### PR TITLE
Add clippy deny for unwrap/expect/panic in SCP consensus crate

### DIFF
--- a/consensus/scp/src/ballot.rs
+++ b/consensus/scp/src/ballot.rs
@@ -77,6 +77,7 @@ impl<V: Value> fmt::Display for Ballot<V> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
 

--- a/consensus/scp/src/lib.rs
+++ b/consensus/scp/src/lib.rs
@@ -3,6 +3,9 @@
 #![doc = include_str!("../README.md")]
 #![allow(non_snake_case)]
 #![deny(missing_docs)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
 
 pub mod ballot;
 mod error;

--- a/consensus/scp/src/msg.rs
+++ b/consensus/scp/src/msg.rs
@@ -677,6 +677,7 @@ impl<V: Value, ID: GenericNodeId> fmt::Display for Msg<V, ID> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod msg_tests {
     use super::*;
     use crate::test_utils::test_node_id;

--- a/consensus/scp/src/node/node_impl.rs
+++ b/consensus/scp/src/node/node_impl.rs
@@ -314,6 +314,7 @@ impl<V: Value, ValidationError: Clone + Display + 'static> ScpNode<V> for Node<V
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::{ballot::Ballot, msg::*, slot::MockScpSlot, test_utils::*};

--- a/consensus/scp/src/predicates.rs
+++ b/consensus/scp/src/predicates.rs
@@ -168,6 +168,7 @@ impl<V: Value, ID: GenericNodeId> Predicate<V, ID> for FuncPredicate<'_, V, ID> 
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod predicates_tests {
     use super::*;
     use crate::{msg::*, test_utils::test_node_id, QuorumSet, QuorumSetExt};

--- a/consensus/scp/src/quorum_set_ext.rs
+++ b/consensus/scp/src/quorum_set_ext.rs
@@ -322,6 +322,7 @@ fn findBlockingSetHelper<ID: GenericNodeId, V: Value, P: Predicate<V, ID>>(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::{

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -366,6 +366,7 @@ impl<V: serde::de::DeserializeOwned + Value> Iterator for ScpLogReader<V> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use crate::{node::MockScpNode, scp_log::LoggingScpNode};
     use bth_common::logger::{test_with_logger, Logger};

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -1988,6 +1988,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod nominate_protocol_tests {
     use super::*;
     use crate::test_utils::*;
@@ -2583,6 +2584,7 @@ mod nominate_protocol_tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod ballot_protocol_tests {
     use super::*;
     use crate::test_utils::*;
@@ -4637,6 +4639,7 @@ mod ballot_protocol_tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::test_utils::*;


### PR DESCRIPTION
## Summary
- Add `#![deny(clippy::unwrap_used)]`, `#![deny(clippy::expect_used)]`, and `#![deny(clippy::panic)]` to the SCP consensus crate
- Add `#[allow(...)]` attributes to all test modules to permit these patterns in test code only
- Verified duplicate node detection already exists in `QuorumSet::is_valid()` (lines 168-203 in `consensus/scp/types/src/quorum_set.rs`)
- Audit found all 21 `unwrap()`/`expect()`/`panic!()` calls are in test code, not production paths

## Test plan
- [x] All 98 existing tests pass
- [x] Clippy check passes with no unwrap/expect/panic errors
- [x] Production code compiles without warnings related to these lints
- [ ] Review test modules have appropriate allow attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)