### PR TITLE
Remove unsafe code from LRU cache and add panic prevention to SCP consensus

### DIFF
--- a/consensus/scp/src/ballot.rs
+++ b/consensus/scp/src/ballot.rs
@@ -77,6 +77,7 @@ impl<V: Value> fmt::Display for Ballot<V> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
 

--- a/consensus/scp/src/lib.rs
+++ b/consensus/scp/src/lib.rs
@@ -3,6 +3,9 @@
 #![doc = include_str!("../README.md")]
 #![allow(non_snake_case)]
 #![deny(missing_docs)]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
 
 pub mod ballot;
 mod error;

--- a/consensus/scp/src/msg.rs
+++ b/consensus/scp/src/msg.rs
@@ -677,6 +677,7 @@ impl<V: Value, ID: GenericNodeId> fmt::Display for Msg<V, ID> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod msg_tests {
     use super::*;
     use crate::test_utils::test_node_id;

--- a/consensus/scp/src/node/node_impl.rs
+++ b/consensus/scp/src/node/node_impl.rs
@@ -314,6 +314,7 @@ impl<V: Value, ValidationError: Clone + Display + 'static> ScpNode<V> for Node<V
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::{ballot::Ballot, msg::*, slot::MockScpSlot, test_utils::*};

--- a/consensus/scp/src/predicates.rs
+++ b/consensus/scp/src/predicates.rs
@@ -168,6 +168,7 @@ impl<V: Value, ID: GenericNodeId> Predicate<V, ID> for FuncPredicate<'_, V, ID> 
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod predicates_tests {
     use super::*;
     use crate::{msg::*, test_utils::test_node_id, QuorumSet, QuorumSetExt};

--- a/consensus/scp/src/quorum_set_ext.rs
+++ b/consensus/scp/src/quorum_set_ext.rs
@@ -322,6 +322,7 @@ fn findBlockingSetHelper<ID: GenericNodeId, V: Value, P: Predicate<V, ID>>(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::{

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -366,6 +366,7 @@ impl<V: serde::de::DeserializeOwned + Value> Iterator for ScpLogReader<V> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use crate::{node::MockScpNode, scp_log::LoggingScpNode};
     use bth_common::logger::{test_with_logger, Logger};

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -1988,6 +1988,7 @@ impl<V: Value, ValidationError: Display> Slot<V, ValidationError> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod nominate_protocol_tests {
     use super::*;
     use crate::test_utils::*;
@@ -2583,6 +2584,7 @@ mod nominate_protocol_tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod ballot_protocol_tests {
     use super::*;
     use crate::test_utils::*;
@@ -4637,6 +4639,7 @@ mod ballot_protocol_tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use super::*;
     use crate::test_utils::*;


### PR DESCRIPTION
## Summary

### LRU Cache Safety
- Replace unsafe `iter_mut()` with safe `for_each_mut()` callback pattern
- Add `#![forbid(unsafe_code)]` to prevent future unsafe additions
- Remove `LruCacheMutIterator` struct and unsafe Iterator implementation

### SCP Consensus Robustness
- Add `#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]` to consensus/scp crate
- Add `#[allow(...)]` annotations to test modules (tests can use unwrap/expect/panic)
- Prevents accidental panics in consensus-critical code paths

## Motivation

### LRU Cache

The unsafe code in `LruCacheMutIterator::next()` was required because Rust's `Iterator` trait demands that items returned from `next()` can all exist simultaneously. For mutable references, this would create aliasing that the borrow checker cannot verify is sound.

The callback-based `for_each_mut()` approach is inherently safe: each mutable reference is scoped to the closure invocation and dropped before the next one is obtained—no aliasing is possible.

### SCP Consensus

The SCP consensus implementation is safety-critical. Using `unwrap()`, `expect()`, or `panic!()` in production code paths can cause node crashes, potentially disrupting network consensus. By denying these patterns at compile time (while still allowing them in tests), we ensure consensus code handles errors gracefully.

## API Change

**Before:**
```rust
for (key, val) in cache.iter_mut() {
    *val *= 2;
}
```

**After:**
```rust
cache.for_each_mut(|key, val| {
    *val *= 2;
});
```

## Test plan
- [x] All 13 LRU cache tests pass
- [x] All 98 SCP consensus tests pass (2 ignored)
- [x] No clippy warnings in lru.rs
- [x] `#![forbid(unsafe_code)]` enforces no unsafe code can be added
- [x] `#![deny(clippy::unwrap_used)]` enforces no unwrap in SCP production code

Resolves:
- "Unsafe Code Cleanup" high-priority item in PLAN.md Section 4
- "Consensus Robustness" high-priority item in PLAN.md Section 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
