### PR TITLE
Add observability foundation: /health, /ready, /metrics endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,7 @@ dependencies = [
  "hyper-util",
  "libp2p",
  "num_cpus",
+ "prometheus",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rand_distr",
@@ -1672,6 +1673,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3034,7 +3036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -7065,6 +7067,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7128,6 +7145,12 @@ dependencies = [
  "quote",
  "syn 2.0.112",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -95,6 +95,9 @@ tokio-tungstenite = "0.24"
 sha1 = "0.10"
 base64 = "0.22"
 
+# Observability
+prometheus = "0.13"
+
 # For SCP simulation
 crossbeam-channel = "0.5"
 dashmap = "6"

--- a/botho/src/rpc/metrics.rs
+++ b/botho/src/rpc/metrics.rs
@@ -1,0 +1,237 @@
+//! Observability endpoints for Botho node
+//!
+//! Provides health, readiness, and Prometheus metrics endpoints for
+//! production monitoring and load balancer integration.
+
+use prometheus::{
+    Counter, CounterVec, Encoder, Gauge, Opts, Registry, TextEncoder,
+};
+use serde::Serialize;
+use std::sync::Arc;
+
+use super::RpcState;
+
+/// Prometheus metrics for the Botho node
+pub struct NodeMetrics {
+    registry: Registry,
+    /// Current blockchain height
+    pub block_height: Gauge,
+    /// Number of connected peers
+    pub peer_count: Gauge,
+    /// Number of transactions in mempool
+    pub mempool_size: Gauge,
+    /// Total RPC requests by method
+    pub rpc_requests_total: CounterVec,
+    /// Total RPC errors by method
+    pub rpc_errors_total: CounterVec,
+}
+
+impl NodeMetrics {
+    /// Create a new metrics registry with all metrics registered
+    pub fn new() -> Self {
+        let registry = Registry::new();
+
+        let block_height = Gauge::with_opts(
+            Opts::new("botho_block_height", "Current blockchain height")
+        ).expect("metric can be created");
+
+        let peer_count = Gauge::with_opts(
+            Opts::new("botho_peer_count", "Number of connected peers")
+        ).expect("metric can be created");
+
+        let mempool_size = Gauge::with_opts(
+            Opts::new("botho_mempool_size", "Number of transactions in mempool")
+        ).expect("metric can be created");
+
+        let rpc_requests_total = CounterVec::new(
+            Opts::new("botho_rpc_requests_total", "Total RPC requests"),
+            &["method"],
+        ).expect("metric can be created");
+
+        let rpc_errors_total = CounterVec::new(
+            Opts::new("botho_rpc_errors_total", "Total RPC errors"),
+            &["method"],
+        ).expect("metric can be created");
+
+        // Register all metrics
+        registry.register(Box::new(block_height.clone())).expect("collector can be registered");
+        registry.register(Box::new(peer_count.clone())).expect("collector can be registered");
+        registry.register(Box::new(mempool_size.clone())).expect("collector can be registered");
+        registry.register(Box::new(rpc_requests_total.clone())).expect("collector can be registered");
+        registry.register(Box::new(rpc_errors_total.clone())).expect("collector can be registered");
+
+        Self {
+            registry,
+            block_height,
+            peer_count,
+            mempool_size,
+            rpc_requests_total,
+            rpc_errors_total,
+        }
+    }
+
+    /// Record an RPC request
+    pub fn record_request(&self, method: &str) {
+        self.rpc_requests_total.with_label_values(&[method]).inc();
+    }
+
+    /// Record an RPC error
+    pub fn record_error(&self, method: &str) {
+        self.rpc_errors_total.with_label_values(&[method]).inc();
+    }
+
+    /// Update metrics from current state
+    pub fn update_from_state(&self, state: &RpcState) {
+        // Update block height
+        if let Ok(ledger) = state.ledger.read() {
+            if let Ok(chain_state) = ledger.get_chain_state() {
+                self.block_height.set(chain_state.height as f64);
+            }
+        }
+
+        // Update peer count
+        if let Ok(peers) = state.peer_count.read() {
+            self.peer_count.set(*peers as f64);
+        }
+
+        // Update mempool size
+        if let Ok(mempool) = state.mempool.read() {
+            self.mempool_size.set(mempool.len() as f64);
+        }
+    }
+
+    /// Encode metrics in Prometheus text format
+    pub fn encode(&self) -> Result<String, prometheus::Error> {
+        let encoder = TextEncoder::new();
+        let metric_families = self.registry.gather();
+        let mut buffer = Vec::new();
+        encoder.encode(&metric_families, &mut buffer)?;
+        Ok(String::from_utf8(buffer).unwrap_or_default())
+    }
+}
+
+impl Default for NodeMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Health status of the node
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HealthStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+impl HealthStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HealthStatus::Healthy => "healthy",
+            HealthStatus::Degraded => "degraded",
+            HealthStatus::Unhealthy => "unhealthy",
+        }
+    }
+}
+
+/// Health check response
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    pub status: HealthStatus,
+    pub version: String,
+    pub block_height: u64,
+    pub peer_count: usize,
+    pub synced: bool,
+}
+
+/// Check the health of the node
+pub fn check_health(state: &RpcState) -> HealthResponse {
+    let mut status = HealthStatus::Healthy;
+    let mut block_height = 0u64;
+    let mut peer_count = 0usize;
+    let synced: bool;
+
+    // Get block height
+    match state.ledger.read() {
+        Ok(ledger) => {
+            if let Ok(chain_state) = ledger.get_chain_state() {
+                block_height = chain_state.height;
+            }
+        }
+        Err(_) => {
+            status = HealthStatus::Unhealthy;
+        }
+    }
+
+    // Get peer count
+    match state.peer_count.read() {
+        Ok(peers) => {
+            peer_count = *peers;
+        }
+        Err(_) => {
+            status = HealthStatus::Unhealthy;
+        }
+    }
+
+    // Check if degraded (no peers but otherwise functional)
+    if status == HealthStatus::Healthy && peer_count == 0 {
+        status = HealthStatus::Degraded;
+    }
+
+    // For now, consider synced if we have any blocks
+    // In production, this would compare against known network height
+    synced = block_height > 0;
+
+    HealthResponse {
+        status,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        block_height,
+        peer_count,
+        synced,
+    }
+}
+
+/// Check if the node is ready to accept requests
+///
+/// Returns true if the node is synced and healthy enough to serve requests.
+/// This is used by load balancers to determine if traffic should be routed here.
+pub fn check_ready(state: &RpcState) -> bool {
+    let health = check_health(state);
+
+    // Ready if healthy or degraded (degraded = functional but no peers)
+    // and synced (has at least genesis block)
+    matches!(health.status, HealthStatus::Healthy | HealthStatus::Degraded)
+        && health.synced
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metrics_creation() {
+        let metrics = NodeMetrics::new();
+
+        // Record some requests
+        metrics.record_request("node_getStatus");
+        metrics.record_request("node_getStatus");
+        metrics.record_request("getChainInfo");
+        metrics.record_error("invalid_method");
+
+        // Encode and verify output contains our metrics
+        let output = metrics.encode().unwrap();
+        assert!(output.contains("botho_block_height"));
+        assert!(output.contains("botho_peer_count"));
+        assert!(output.contains("botho_mempool_size"));
+        assert!(output.contains("botho_rpc_requests_total"));
+        assert!(output.contains("node_getStatus"));
+    }
+
+    #[test]
+    fn test_health_status_serialization() {
+        assert_eq!(HealthStatus::Healthy.as_str(), "healthy");
+        assert_eq!(HealthStatus::Degraded.as_str(), "degraded");
+        assert_eq!(HealthStatus::Unhealthy.as_str(), "unhealthy");
+    }
+}


### PR DESCRIPTION
## Summary

Add production-grade observability endpoints for monitoring and load balancer integration:

- **`GET /health`**: Returns JSON health status with version, block height, peer count, and sync status
- **`GET /ready`**: Readiness probe returning 200 when synced, 503 when not ready (for load balancers)
- **`GET /metrics`**: Prometheus-format metrics for block_height, peer_count, mempool_size, and RPC request counts

This addresses the observability requirements from PLAN.md for production monitoring and external audit readiness.

### Changes

- Add prometheus crate dependency (0.13)
- Create `botho/src/rpc/metrics.rs` with `NodeMetrics` struct and health check functions
- Integrate metrics into `RpcState` for automatic updates
- Add HTTP GET handlers in `handle_request` before JSON-RPC routing
- Record RPC request counts and errors per method
- Document endpoints in `docs/api.md`
- Add 4 integration tests for the new endpoints

### Metrics Available

| Metric | Type | Description |
|--------|------|-------------|
| `botho_block_height` | Gauge | Current blockchain height |
| `botho_peer_count` | Gauge | Number of connected peers |
| `botho_mempool_size` | Gauge | Number of transactions in mempool |
| `botho_rpc_requests_total` | Counter | Total RPC requests (labeled by method) |
| `botho_rpc_errors_total` | Counter | Total RPC errors (labeled by method) |

## Test plan

- [x] `cargo check -p botho` compiles without errors
- [x] `cargo test -p botho --test rpc_integration test_health` passes
- [x] `cargo test -p botho --test rpc_integration test_ready` passes
- [x] `cargo test -p botho --test rpc_integration test_metrics` passes
- [ ] Manual verification with curl:
  - `curl http://localhost:7101/health`
  - `curl http://localhost:7101/ready`
  - `curl http://localhost:7101/metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)