### PR TITLE
docs: mark wallet decryption rate limiting as complete

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -59,7 +59,7 @@ Performance benchmarks ─────────→ v0.2.0 Release
    - [x] Add `#![deny(unsafe_code)]` to crypto crates (10/10 crates complete)
 
 5. **Rate Limiting & DoS Protection**
-   - [ ] Add wallet decryption rate limiting (exponential backoff)
+   - [x] Add wallet decryption rate limiting (exponential backoff)
    - [ ] Add per-peer rate limiting on gossipsub messages
    - [ ] Add per-IP connection rate limiting (max 10 connections/IP)
    - [ ] Add RPC rate limiting per API key (100 req/min default)


### PR DESCRIPTION
## Summary

Updates PLAN.md to mark wallet decryption rate limiting as complete - the feature was already implemented in commit bdf4ff7.

## Evidence of Implementation

The rate limiting feature exists in `botho-wallet/src/storage.rs`:

- **DecryptionRateLimiter struct** (lines 41-160): Tracks consecutive failures, implements exponential backoff
- **decrypt_with_rate_limit() method** (lines 276-321): Wraps decrypt() with rate limiting protection
- **Constants**: `MAX_FAILED_ATTEMPTS = 5`, `BASE_DELAY_MS = 1000`, `MAX_DELAY_MS = 300_000`
- **7 unit tests** all passing:
  - `test_rate_limiter_initial_state`
  - `test_rate_limiter_records_failures`
  - `test_rate_limiter_resets_on_success`
  - `test_rate_limiter_lockout_after_max_attempts`
  - `test_decrypt_with_rate_limit_success`
  - `test_decrypt_with_rate_limit_failure_increments`
  - `test_decrypt_with_rate_limit_success_after_failure`

## Requirements Met

From issue #13:
- ✅ Exponential backoff after failed attempts (1s, 2s, 4s, 8s, 16s...)
- ✅ Track attempt count (in-memory)
- ✅ Reset counter after successful decryption
- ✅ Lockout after 5 failed attempts
- ✅ Unit tests for rate limiting behavior

## Changes

- PLAN.md: Mark "Add wallet decryption rate limiting (exponential backoff)" as complete

Closes #13