### PR TITLE
Add per-peer rate limiting on gossipsub messages

### DIFF
--- a/gossip/src/analyzer.rs
+++ b/gossip/src/analyzer.rs
@@ -7,10 +7,7 @@
 //! join the network by recommending trust configurations based on
 //! what other nodes in the network are doing.
 
-use crate::{
-    messages::NodeAnnouncement,
-    store::SharedPeerStore,
-};
+use crate::{messages::NodeAnnouncement, store::SharedPeerStore};
 use bth_common::{HashMap, HashSet, ResponderId};
 use bth_consensus_scp_types::{QuorumSet, QuorumSetMember};
 use std::sync::Arc;
@@ -381,15 +378,8 @@ impl TopologyAnalyzer {
     }
 
     /// Validate a proposed quorum set against the known network.
-    pub fn validate_quorum_set(
-        &self,
-        quorum_set: &QuorumSet<ResponderId>,
-    ) -> QuorumSetValidation {
-        let known_nodes: HashSet<_> = self
-            .store
-            .get_responder_ids()
-            .into_iter()
-            .collect();
+    pub fn validate_quorum_set(&self, quorum_set: &QuorumSet<ResponderId>) -> QuorumSetValidation {
+        let known_nodes: HashSet<_> = self.store.get_responder_ids().into_iter().collect();
 
         let qs_nodes = quorum_set.nodes();
         let unknown_nodes: Vec<_> = qs_nodes
@@ -490,11 +480,7 @@ mod tests {
         }
     }
 
-    fn make_announcement(
-        name: &str,
-        trusted: Vec<&str>,
-        timestamp: u64,
-    ) -> NodeAnnouncement {
+    fn make_announcement(name: &str, trusted: Vec<&str>, timestamp: u64) -> NodeAnnouncement {
         let node_id = make_node_id(name);
         let quorum_set = QuorumSet::new(
             ((trusted.len() as u32 * 67) / 100).max(1),
@@ -576,10 +562,7 @@ mod tests {
 
         assert!(!popular.is_empty());
         // node1 should be most popular (trusted by 2)
-        assert_eq!(
-            popular[0].0,
-            ResponderId::from_str("node1:8443").unwrap()
-        );
+        assert_eq!(popular[0].0, ResponderId::from_str("node1:8443").unwrap());
         assert_eq!(popular[0].1, 2);
     }
 
@@ -822,7 +805,10 @@ mod tests {
 
         let validation = analyzer.validate_quorum_set(&quorum_set);
         assert!(!validation.is_valid);
-        assert!(validation.warnings.iter().any(|w| w.contains("fewer than 3")));
+        assert!(validation
+            .warnings
+            .iter()
+            .any(|w| w.contains("fewer than 3")));
     }
 
     #[test]

--- a/gossip/src/behaviour.rs
+++ b/gossip/src/behaviour.rs
@@ -11,8 +11,8 @@ use crate::{
     config::GossipConfig,
     error::{GossipError, GossipResult},
     messages::{
-        BlockBroadcast, NodeAnnouncement, TransactionBroadcast,
-        ANNOUNCEMENTS_TOPIC, BLOCKS_TOPIC, TRANSACTIONS_TOPIC, TOPOLOGY_SYNC_PROTOCOL,
+        BlockBroadcast, NodeAnnouncement, TransactionBroadcast, ANNOUNCEMENTS_TOPIC, BLOCKS_TOPIC,
+        TOPOLOGY_SYNC_PROTOCOL, TRANSACTIONS_TOPIC,
     },
     store::SharedPeerStore,
 };
@@ -26,12 +26,7 @@ use libp2p::{
     swarm::{NetworkBehaviour, SwarmEvent},
     tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
-use std::{
-    collections::HashSet,
-    io,
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashSet, io, sync::Arc, time::Duration};
 use tokio::sync::mpsc;
 
 /// Events emitted by the gossip behaviour.
@@ -53,10 +48,7 @@ pub enum GossipEvent {
     BlockReceived(BlockBroadcast),
 
     /// Received a topology sync request
-    TopologySyncRequest {
-        peer: PeerId,
-        since_timestamp: u64,
-    },
+    TopologySyncRequest { peer: PeerId, since_timestamp: u64 },
 
     /// Received a topology sync response
     TopologySyncResponse {
@@ -97,11 +89,7 @@ impl Codec for TopologySyncCodec {
         _protocol: &'life1 Self::Protocol,
         io: &'life2 mut T,
     ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = io::Result<Self::Request>>
-                + Send
-                + 'async_trait,
-        >,
+        Box<dyn std::future::Future<Output = io::Result<Self::Request>> + Send + 'async_trait>,
     >
     where
         T: futures::AsyncRead + Unpin + Send + 'async_trait,
@@ -114,8 +102,7 @@ impl Codec for TopologySyncCodec {
             use futures::AsyncReadExt;
             let mut buf = Vec::new();
             io.read_to_end(&mut buf).await?;
-            serde_json::from_slice(&buf)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+            serde_json::from_slice(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
         })
     }
 
@@ -124,11 +111,7 @@ impl Codec for TopologySyncCodec {
         _protocol: &'life1 Self::Protocol,
         io: &'life2 mut T,
     ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = io::Result<Self::Response>>
-                + Send
-                + 'async_trait,
-        >,
+        Box<dyn std::future::Future<Output = io::Result<Self::Response>> + Send + 'async_trait>,
     >
     where
         T: futures::AsyncRead + Unpin + Send + 'async_trait,
@@ -141,8 +124,7 @@ impl Codec for TopologySyncCodec {
             use futures::AsyncReadExt;
             let mut buf = Vec::new();
             io.read_to_end(&mut buf).await?;
-            serde_json::from_slice(&buf)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+            serde_json::from_slice(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
         })
     }
 
@@ -151,9 +133,7 @@ impl Codec for TopologySyncCodec {
         _protocol: &'life1 Self::Protocol,
         io: &'life2 mut T,
         req: Self::Request,
-    ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = io::Result<()>> + Send + 'async_trait>,
-    >
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = io::Result<()>> + Send + 'async_trait>>
     where
         T: futures::AsyncWrite + Unpin + Send + 'async_trait,
         'life0: 'async_trait,
@@ -176,9 +156,7 @@ impl Codec for TopologySyncCodec {
         _protocol: &'life1 Self::Protocol,
         io: &'life2 mut T,
         resp: Self::Response,
-    ) -> std::pin::Pin<
-        Box<dyn std::future::Future<Output = io::Result<()>> + Send + 'async_trait>,
-    >
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = io::Result<()>> + Send + 'async_trait>>
     where
         T: futures::AsyncWrite + Unpin + Send + 'async_trait,
         'life0: 'async_trait,
@@ -249,8 +227,7 @@ impl GossipBehaviour {
         // Configure request-response
         let topology_sync = request_response::Behaviour::new(
             [(TOPOLOGY_SYNC_PROTOCOL, ProtocolSupport::Full)],
-            request_response::Config::default()
-                .with_request_timeout(config.request_timeout()),
+            request_response::Config::default().with_request_timeout(config.request_timeout()),
         );
 
         Ok(Self {

--- a/gossip/src/consensus_integration.rs
+++ b/gossip/src/consensus_integration.rs
@@ -33,7 +33,8 @@ pub struct ConsensusGossipConfig {
     /// Announce interval in seconds
     pub announce_interval_secs: u64,
 
-    /// Whether to automatically update peer connections based on discovered topology
+    /// Whether to automatically update peer connections based on discovered
+    /// topology
     pub auto_connect_peers: bool,
 
     /// Maximum peers to auto-connect to
@@ -135,7 +136,8 @@ pub async fn start_consensus_gossip(
         .sync_interval_secs(30)
         .build();
 
-    let capabilities = NodeCapabilities::CONSENSUS | NodeCapabilities::GOSSIP | NodeCapabilities::RELAY;
+    let capabilities =
+        NodeCapabilities::CONSENSUS | NodeCapabilities::GOSSIP | NodeCapabilities::RELAY;
 
     let mut service = GossipService::new(
         node_id.clone(),
@@ -157,7 +159,10 @@ pub async fn start_consensus_gossip(
 
     // Spawn task to forward events
     let task_handle = tokio::spawn(async move {
-        info!("Gossip integration started for node {}", node_id.responder_id);
+        info!(
+            "Gossip integration started for node {}",
+            node_id.responder_id
+        );
 
         loop {
             match service.next_event().await {

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -61,15 +61,15 @@
 //!
 //! The gossip protocol uses several message types:
 //!
-//! - [`NodeAnnouncement`]: Signed advertisement of a node's identity, endpoints,
-//!   quorum set, and capabilities
+//! - [`NodeAnnouncement`]: Signed advertisement of a node's identity,
+//!   endpoints, quorum set, and capabilities
 //! - [`GossipMessage`]: Wrapper enum for all protocol messages
 //! - [`PeerInfo`]: Lightweight peer information for peer exchange
 //!
 //! # Peer Store
 //!
-//! The [`PeerStore`] maintains the view of known peers and their configurations.
-//! It provides:
+//! The [`PeerStore`] maintains the view of known peers and their
+//! configurations. It provides:
 //!
 //! - Signature verification for announcements
 //! - Deduplication and freshness checks
@@ -104,16 +104,21 @@ pub use analyzer::{
     TrustCluster,
 };
 pub use behaviour::{GossipBehaviour, GossipCommand, GossipEvent, GossipHandle};
+pub use config::{
+    GossipConfig, GossipConfigBuilder, MessageTypeLimits, NetworkId, PeerRateLimitConfig,
+};
 pub use consensus_integration::{
     start_consensus_gossip, ConsensusGossipConfig, ConsensusGossipHandle,
 };
-pub use config::{GossipConfig, GossipConfigBuilder, NetworkId, PeerRateLimitConfig};
-pub use rate_limit::{PeerRateLimiter, PeerRateStats, RateLimitResult};
 pub use error::{GossipError, GossipResult};
 pub use messages::{
     BlockBroadcast, GossipMessage, NodeAnnouncement, NodeCapabilities, PeerInfo,
     TransactionBroadcast, ANNOUNCEMENTS_TOPIC, BLOCKS_TOPIC, PEER_EXCHANGE_TOPIC,
     TOPOLOGY_SYNC_PROTOCOL, TRANSACTIONS_TOPIC,
+};
+pub use rate_limit::{
+    GossipMessageType, PeerRateLimiter, PeerRateStats, RateLimitMetrics, RateLimitMetricsSnapshot,
+    RateLimitResult,
 };
 pub use service::GossipService;
 pub use store::{new_shared_store, PeerStore, PeerStoreConfig, PeerStoreStats, SharedPeerStore};

--- a/gossip/src/messages.rs
+++ b/gossip/src/messages.rs
@@ -127,7 +127,10 @@ impl NodeAnnouncement {
     pub fn verify_signature(&self) -> bool {
         use bth_crypto_keys::Verifier;
         let bytes = self.signing_bytes();
-        self.node_id.public_key.verify(&bytes, &self.signature).is_ok()
+        self.node_id
+            .public_key
+            .verify(&bytes, &self.signature)
+            .is_ok()
     }
 
     /// Check if this announcement is newer than another.
@@ -334,7 +337,9 @@ mod tests {
 
         assert_eq!(announcement.node_id, node_id);
         assert_eq!(announcement.endpoints.len(), 1);
-        assert!(announcement.capabilities.contains(NodeCapabilities::CONSENSUS));
+        assert!(announcement
+            .capabilities
+            .contains(NodeCapabilities::CONSENSUS));
     }
 
     #[test]

--- a/gossip/src/rate_limit.rs
+++ b/gossip/src/rate_limit.rs
@@ -3,18 +3,66 @@
 //! Per-peer rate limiting for gossipsub messages.
 //!
 //! This module implements sliding window rate limiting to protect against
-//! message flooding attacks from individual peers.
+//! message flooding attacks from individual peers. It tracks message rates
+//! per message type to enforce different limits for:
+//!
+//! - Transaction announcements: 100/min (frequent, lightweight)
+//! - Block announcements: 10/min (infrequent, important)
+//! - Consensus messages: 50/min (critical but bounded)
+//! - Node announcements: 20/min (periodic discovery)
+//!
+//! # Security
+//!
+//! Rate limiting prevents DoS attacks where malicious peers flood the network
+//! with messages. Peers that repeatedly exceed limits are flagged for
+//! disconnection.
 
 use crate::config::PeerRateLimitConfig;
 use libp2p::PeerId;
-use std::collections::HashMap;
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+
+/// Types of gossipsub messages for rate limiting purposes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GossipMessageType {
+    /// Transaction broadcasts
+    Transaction,
+    /// Block broadcasts
+    Block,
+    /// Consensus (SCP) messages
+    Consensus,
+    /// Node announcements for discovery
+    Announcement,
+    /// Peer exchange messages
+    PeerExchange,
+    /// Unknown/other message types
+    Other,
+}
+
+impl GossipMessageType {
+    /// Get the rate limit (messages per minute) for this message type.
+    pub fn rate_limit(&self, config: &PeerRateLimitConfig) -> u32 {
+        match self {
+            GossipMessageType::Transaction => config.message_limits.transactions_per_minute,
+            GossipMessageType::Block => config.message_limits.blocks_per_minute,
+            GossipMessageType::Consensus => config.message_limits.consensus_per_minute,
+            GossipMessageType::Announcement => config.message_limits.announcements_per_minute,
+            GossipMessageType::PeerExchange => config.message_limits.announcements_per_minute,
+            GossipMessageType::Other => config.max_messages_per_second * 60, // Use global limit
+        }
+    }
+}
 
 /// Tracks rate limiting state for a single peer.
 #[derive(Debug, Clone)]
 pub struct PeerRateState {
-    /// Timestamps of recent messages (within burst window)
-    message_times: Vec<Instant>,
+    /// Timestamps of recent messages by type (within 1-minute window)
+    message_times_by_type: HashMap<GossipMessageType, Vec<Instant>>,
+    /// Global message times for overall rate limiting
+    global_message_times: Vec<Instant>,
     /// Number of rate limit violations
     violations: u32,
     /// Last time the peer was warned
@@ -31,7 +79,8 @@ impl PeerRateState {
     /// Create a new rate state.
     pub fn new() -> Self {
         Self {
-            message_times: Vec::with_capacity(100),
+            message_times_by_type: HashMap::new(),
+            global_message_times: Vec::with_capacity(100),
             violations: 0,
             last_warning: None,
         }
@@ -56,33 +105,56 @@ impl PeerRateState {
     /// Record a message and check if it exceeds rate limits.
     /// Returns true if the message should be allowed, false if rate limited.
     pub fn record_message(&mut self, config: &PeerRateLimitConfig) -> bool {
+        self.record_message_typed(config, GossipMessageType::Other)
+    }
+
+    /// Record a typed message and check if it exceeds rate limits.
+    /// Returns true if the message should be allowed, false if rate limited.
+    pub fn record_message_typed(
+        &mut self,
+        config: &PeerRateLimitConfig,
+        msg_type: GossipMessageType,
+    ) -> bool {
         let now = Instant::now();
-        let window = Duration::from_millis(config.burst_window_ms);
+        let one_minute = Duration::from_secs(60);
+        let burst_window = Duration::from_millis(config.burst_window_ms);
 
-        // Remove old messages outside the window
-        self.message_times.retain(|t| now.duration_since(*t) < window);
+        // Clean up old global messages
+        self.global_message_times
+            .retain(|t| now.duration_since(*t) < burst_window);
 
-        // Check if we're over the burst limit
-        if self.message_times.len() >= config.burst_limit as usize {
+        // Check global burst limit
+        if self.global_message_times.len() >= config.burst_limit as usize {
             self.record_violation();
             return false;
         }
 
-        // Check messages per second (using 1-second sliding window)
+        // Check global per-second limit
         let one_second_ago = now - Duration::from_secs(1);
-        let recent_count = self
-            .message_times
+        let recent_global_count = self
+            .global_message_times
             .iter()
             .filter(|t| **t > one_second_ago)
             .count();
 
-        if recent_count >= config.max_messages_per_second as usize {
+        if recent_global_count >= config.max_messages_per_second as usize {
             self.record_violation();
             return false;
         }
 
-        // Message is allowed
-        self.message_times.push(now);
+        // Check per-message-type limit (messages per minute)
+        let type_times = self.message_times_by_type.entry(msg_type).or_default();
+        type_times.retain(|t| now.duration_since(*t) < one_minute);
+
+        let type_limit = msg_type.rate_limit(config) as usize;
+        if type_times.len() >= type_limit {
+            self.record_violation();
+            return false;
+        }
+
+        // Message is allowed - record it
+        type_times.push(now);
+        self.global_message_times.push(now);
         true
     }
 
@@ -94,10 +166,25 @@ impl PeerRateState {
     /// Get message count in the current window.
     pub fn current_message_count(&self, window: Duration) -> usize {
         let now = Instant::now();
-        self.message_times
+        self.global_message_times
             .iter()
             .filter(|t| now.duration_since(**t) < window)
             .count()
+    }
+
+    /// Get message count by type in the last minute.
+    pub fn message_count_by_type(&self, msg_type: GossipMessageType) -> usize {
+        let now = Instant::now();
+        let one_minute = Duration::from_secs(60);
+        self.message_times_by_type
+            .get(&msg_type)
+            .map(|times| {
+                times
+                    .iter()
+                    .filter(|t| now.duration_since(**t) < one_minute)
+                    .count()
+            })
+            .unwrap_or(0)
     }
 }
 
@@ -110,6 +197,8 @@ pub struct PeerRateLimiter {
     peers: HashMap<PeerId, PeerRateState>,
     /// Peers that have been flagged for disconnection
     flagged_peers: Vec<PeerId>,
+    /// Metrics for monitoring
+    metrics: RateLimitMetrics,
 }
 
 impl PeerRateLimiter {
@@ -119,6 +208,7 @@ impl PeerRateLimiter {
             config,
             peers: HashMap::new(),
             flagged_peers: Vec::new(),
+            metrics: RateLimitMetrics::new(),
         }
     }
 
@@ -127,24 +217,42 @@ impl PeerRateLimiter {
         self.config.enabled
     }
 
-    /// Record a message from a peer.
+    /// Record a message from a peer (untyped, uses Other type).
     /// Returns RateLimitResult indicating if the message should be processed.
     pub fn record_message(&mut self, peer: &PeerId) -> RateLimitResult {
+        self.record_message_typed(peer, GossipMessageType::Other)
+    }
+
+    /// Record a typed message from a peer.
+    /// Returns RateLimitResult indicating if the message should be processed.
+    pub fn record_message_typed(
+        &mut self,
+        peer: &PeerId,
+        msg_type: GossipMessageType,
+    ) -> RateLimitResult {
+        // Always count messages for metrics
+        self.metrics.record_message(msg_type);
+
         if !self.config.enabled {
             return RateLimitResult::Allowed;
         }
 
         let state = self.peers.entry(*peer).or_default();
-        let allowed = state.record_message(&self.config);
+        let allowed = state.record_message_typed(&self.config, msg_type);
 
         if !allowed {
+            // Record rate limit hit
+            self.metrics.record_rate_limit_hit(msg_type);
+
             if state.should_disconnect(self.config.disconnect_threshold) {
                 self.flagged_peers.push(*peer);
+                self.metrics.record_peer_ban();
                 RateLimitResult::Disconnect
             } else {
                 RateLimitResult::RateLimited {
                     violations: state.violations(),
                     remaining: self.config.disconnect_threshold - state.violations(),
+                    message_type: msg_type,
                 }
             }
         } else {
@@ -170,6 +278,10 @@ impl PeerRateLimiter {
                 violations: state.violations(),
                 messages_in_window: state.current_message_count(window),
                 should_disconnect: state.should_disconnect(self.config.disconnect_threshold),
+                transactions_per_minute: state
+                    .message_count_by_type(GossipMessageType::Transaction),
+                blocks_per_minute: state.message_count_by_type(GossipMessageType::Block),
+                consensus_per_minute: state.message_count_by_type(GossipMessageType::Consensus),
             }
         })
     }
@@ -185,6 +297,16 @@ impl PeerRateLimiter {
     pub fn tracked_peer_count(&self) -> usize {
         self.peers.len()
     }
+
+    /// Get rate limiting metrics for monitoring.
+    pub fn metrics(&self) -> &RateLimitMetrics {
+        &self.metrics
+    }
+
+    /// Get a snapshot of current metrics.
+    pub fn metrics_snapshot(&self) -> RateLimitMetricsSnapshot {
+        self.metrics.snapshot()
+    }
 }
 
 /// Result of a rate limit check.
@@ -198,6 +320,8 @@ pub enum RateLimitResult {
         violations: u32,
         /// Remaining violations before disconnect.
         remaining: u32,
+        /// The message type that was rate limited.
+        message_type: GossipMessageType,
     },
     /// Peer should be disconnected due to repeated violations.
     Disconnect,
@@ -224,11 +348,143 @@ pub struct PeerRateStats {
     pub messages_in_window: usize,
     /// Whether the peer should be disconnected.
     pub should_disconnect: bool,
+    /// Transaction messages in the last minute.
+    pub transactions_per_minute: usize,
+    /// Block messages in the last minute.
+    pub blocks_per_minute: usize,
+    /// Consensus messages in the last minute.
+    pub consensus_per_minute: usize,
+}
+
+/// Metrics for rate limiting monitoring.
+///
+/// These metrics can be exposed to monitoring systems (Prometheus, etc.)
+/// to track rate limiting effectiveness and detect potential attacks.
+#[derive(Debug)]
+pub struct RateLimitMetrics {
+    /// Total messages received (by type)
+    messages_total: HashMap<GossipMessageType, AtomicU64>,
+    /// Rate limit hits (by type)
+    rate_limit_hits: HashMap<GossipMessageType, AtomicU64>,
+    /// Peers banned for rate limit violations
+    peers_banned: AtomicU64,
+}
+
+impl RateLimitMetrics {
+    /// Create new metrics tracker.
+    pub fn new() -> Self {
+        let mut messages_total = HashMap::new();
+        let mut rate_limit_hits = HashMap::new();
+
+        // Initialize counters for each message type
+        for msg_type in [
+            GossipMessageType::Transaction,
+            GossipMessageType::Block,
+            GossipMessageType::Consensus,
+            GossipMessageType::Announcement,
+            GossipMessageType::PeerExchange,
+            GossipMessageType::Other,
+        ] {
+            messages_total.insert(msg_type, AtomicU64::new(0));
+            rate_limit_hits.insert(msg_type, AtomicU64::new(0));
+        }
+
+        Self {
+            messages_total,
+            rate_limit_hits,
+            peers_banned: AtomicU64::new(0),
+        }
+    }
+
+    /// Record a message received.
+    pub fn record_message(&self, msg_type: GossipMessageType) {
+        if let Some(counter) = self.messages_total.get(&msg_type) {
+            counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Record a rate limit hit.
+    pub fn record_rate_limit_hit(&self, msg_type: GossipMessageType) {
+        if let Some(counter) = self.rate_limit_hits.get(&msg_type) {
+            counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Record a peer ban.
+    pub fn record_peer_ban(&self) {
+        self.peers_banned.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Get total messages received for a type.
+    pub fn messages_total(&self, msg_type: GossipMessageType) -> u64 {
+        self.messages_total
+            .get(&msg_type)
+            .map(|c| c.load(Ordering::Relaxed))
+            .unwrap_or(0)
+    }
+
+    /// Get rate limit hits for a type.
+    pub fn rate_limit_hits(&self, msg_type: GossipMessageType) -> u64 {
+        self.rate_limit_hits
+            .get(&msg_type)
+            .map(|c| c.load(Ordering::Relaxed))
+            .unwrap_or(0)
+    }
+
+    /// Get total peers banned.
+    pub fn peers_banned(&self) -> u64 {
+        self.peers_banned.load(Ordering::Relaxed)
+    }
+
+    /// Get a snapshot of all metrics.
+    pub fn snapshot(&self) -> RateLimitMetricsSnapshot {
+        RateLimitMetricsSnapshot {
+            transactions_total: self.messages_total(GossipMessageType::Transaction),
+            transactions_rate_limited: self.rate_limit_hits(GossipMessageType::Transaction),
+            blocks_total: self.messages_total(GossipMessageType::Block),
+            blocks_rate_limited: self.rate_limit_hits(GossipMessageType::Block),
+            consensus_total: self.messages_total(GossipMessageType::Consensus),
+            consensus_rate_limited: self.rate_limit_hits(GossipMessageType::Consensus),
+            announcements_total: self.messages_total(GossipMessageType::Announcement),
+            announcements_rate_limited: self.rate_limit_hits(GossipMessageType::Announcement),
+            peers_banned: self.peers_banned(),
+        }
+    }
+}
+
+impl Default for RateLimitMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Snapshot of rate limiting metrics for export.
+#[derive(Debug, Clone, Default)]
+pub struct RateLimitMetricsSnapshot {
+    /// Total transaction messages received.
+    pub transactions_total: u64,
+    /// Transaction messages rate limited.
+    pub transactions_rate_limited: u64,
+    /// Total block messages received.
+    pub blocks_total: u64,
+    /// Block messages rate limited.
+    pub blocks_rate_limited: u64,
+    /// Total consensus messages received.
+    pub consensus_total: u64,
+    /// Consensus messages rate limited.
+    pub consensus_rate_limited: u64,
+    /// Total announcement messages received.
+    pub announcements_total: u64,
+    /// Announcement messages rate limited.
+    pub announcements_rate_limited: u64,
+    /// Total peers banned for rate limit violations.
+    pub peers_banned: u64,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::MessageTypeLimits;
 
     fn test_config() -> PeerRateLimitConfig {
         PeerRateLimitConfig {
@@ -237,6 +493,12 @@ mod tests {
             burst_window_ms: 1000,
             disconnect_threshold: 3,
             enabled: true,
+            message_limits: MessageTypeLimits {
+                transactions_per_minute: 10,
+                blocks_per_minute: 5,
+                consensus_per_minute: 8,
+                announcements_per_minute: 5,
+            },
         }
     }
 
@@ -260,6 +522,7 @@ mod tests {
         let mut config = test_config();
         config.max_messages_per_second = 100; // High per-second limit
         config.burst_limit = 10;
+        config.message_limits.transactions_per_minute = 100; // High type limit
 
         let mut state = PeerRateState::new();
 
@@ -271,6 +534,28 @@ mod tests {
         // Next message should be rate limited (burst limit reached)
         assert!(!state.record_message(&config));
         assert_eq!(state.violations(), 1);
+    }
+
+    #[test]
+    fn test_per_type_rate_limiting() {
+        let mut config = test_config();
+        config.max_messages_per_second = 100; // High global limit
+        config.burst_limit = 100;
+        config.message_limits.transactions_per_minute = 3; // Low transaction limit
+
+        let mut state = PeerRateState::new();
+
+        // Should allow 3 transaction messages
+        for _ in 0..3 {
+            assert!(state.record_message_typed(&config, GossipMessageType::Transaction));
+        }
+
+        // 4th transaction should be rate limited
+        assert!(!state.record_message_typed(&config, GossipMessageType::Transaction));
+        assert_eq!(state.violations(), 1);
+
+        // But block messages should still be allowed (different type)
+        assert!(state.record_message_typed(&config, GossipMessageType::Block));
     }
 
     #[test]
@@ -287,7 +572,6 @@ mod tests {
             }
             // This one triggers violation
             limiter.record_message(&peer);
-            // Wait conceptually (in real test we'd use time control)
         }
 
         // After 3 violations, peer should be flagged for disconnect
@@ -345,5 +629,113 @@ mod tests {
 
         // List should be cleared
         assert!(limiter.take_flagged_peers().is_empty());
+    }
+
+    #[test]
+    fn test_typed_rate_limiter() {
+        let mut config = test_config();
+        config.max_messages_per_second = 100;
+        config.burst_limit = 100;
+        config.message_limits.blocks_per_minute = 2;
+
+        let mut limiter = PeerRateLimiter::new(config);
+        let peer = PeerId::random();
+
+        // Allow 2 block messages
+        assert!(limiter
+            .record_message_typed(&peer, GossipMessageType::Block)
+            .is_allowed());
+        assert!(limiter
+            .record_message_typed(&peer, GossipMessageType::Block)
+            .is_allowed());
+
+        // 3rd block should be rate limited
+        let result = limiter.record_message_typed(&peer, GossipMessageType::Block);
+        assert!(!result.is_allowed());
+        assert!(matches!(
+            result,
+            RateLimitResult::RateLimited {
+                message_type: GossipMessageType::Block,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_metrics_tracking() {
+        let config = test_config();
+        let mut limiter = PeerRateLimiter::new(config);
+        let peer = PeerId::random();
+
+        // Record some messages
+        limiter.record_message_typed(&peer, GossipMessageType::Transaction);
+        limiter.record_message_typed(&peer, GossipMessageType::Transaction);
+        limiter.record_message_typed(&peer, GossipMessageType::Block);
+
+        let snapshot = limiter.metrics_snapshot();
+        assert_eq!(snapshot.transactions_total, 2);
+        assert_eq!(snapshot.blocks_total, 1);
+        assert_eq!(snapshot.transactions_rate_limited, 0);
+    }
+
+    #[test]
+    fn test_metrics_rate_limit_hits() {
+        let mut config = test_config();
+        config.max_messages_per_second = 100;
+        config.burst_limit = 100;
+        config.message_limits.transactions_per_minute = 1;
+
+        let mut limiter = PeerRateLimiter::new(config);
+        let peer = PeerId::random();
+
+        // First allowed
+        limiter.record_message_typed(&peer, GossipMessageType::Transaction);
+        // Second rate limited
+        limiter.record_message_typed(&peer, GossipMessageType::Transaction);
+
+        let snapshot = limiter.metrics_snapshot();
+        assert_eq!(snapshot.transactions_total, 2);
+        assert_eq!(snapshot.transactions_rate_limited, 1);
+    }
+
+    #[test]
+    fn test_peer_stats_by_type() {
+        let mut config = test_config();
+        config.max_messages_per_second = 100;
+        config.burst_limit = 100;
+
+        let mut limiter = PeerRateLimiter::new(config);
+        let peer = PeerId::random();
+
+        // Send different message types
+        for _ in 0..3 {
+            limiter.record_message_typed(&peer, GossipMessageType::Transaction);
+        }
+        for _ in 0..2 {
+            limiter.record_message_typed(&peer, GossipMessageType::Block);
+        }
+
+        let stats = limiter.get_peer_stats(&peer).unwrap();
+        assert_eq!(stats.transactions_per_minute, 3);
+        assert_eq!(stats.blocks_per_minute, 2);
+    }
+
+    #[test]
+    fn test_message_type_rate_limits() {
+        let config = PeerRateLimitConfig::default();
+
+        // Verify default rate limits from audit requirements
+        assert_eq!(
+            GossipMessageType::Transaction.rate_limit(&config),
+            100 // 100/min for transactions
+        );
+        assert_eq!(
+            GossipMessageType::Block.rate_limit(&config),
+            10 // 10/min for blocks
+        );
+        assert_eq!(
+            GossipMessageType::Consensus.rate_limit(&config),
+            50 // 50/min for consensus
+        );
     }
 }

--- a/gossip/src/store.rs
+++ b/gossip/src/store.rs
@@ -84,7 +84,8 @@ impl PeerStore {
 
     /// Insert or update an announcement.
     ///
-    /// Returns `true` if the announcement was accepted (new or newer than existing).
+    /// Returns `true` if the announcement was accepted (new or newer than
+    /// existing).
     pub fn insert(&self, announcement: NodeAnnouncement) -> bool {
         // Verify signature before accepting
         if !announcement.verify_signature() {
@@ -234,10 +235,16 @@ impl PeerStore {
         };
 
         for announcement in announcements.values() {
-            if announcement.capabilities.contains(NodeCapabilities::CONSENSUS) {
+            if announcement
+                .capabilities
+                .contains(NodeCapabilities::CONSENSUS)
+            {
                 stats.consensus_nodes += 1;
             }
-            if announcement.capabilities.contains(NodeCapabilities::ARCHIVE) {
+            if announcement
+                .capabilities
+                .contains(NodeCapabilities::ARCHIVE)
+            {
                 stats.archive_nodes += 1;
             }
             if announcement.capabilities.contains(NodeCapabilities::RELAY) {
@@ -377,7 +384,8 @@ mod tests {
         // In real usage, announcements would be signed
 
         // For testing, we need to bypass signature verification
-        // This is a limitation of the test - in production, all announcements are signed
+        // This is a limitation of the test - in production, all announcements are
+        // signed
         let announcements = &store.announcements;
         {
             let mut guard = announcements.write().unwrap();
@@ -455,10 +463,7 @@ mod tests {
 
             let mut consensus_node = make_test_announcement("consensus", 1000);
             consensus_node.capabilities = NodeCapabilities::CONSENSUS;
-            guard.insert(
-                consensus_node.node_id.responder_id.clone(),
-                consensus_node,
-            );
+            guard.insert(consensus_node.node_id.responder_id.clone(), consensus_node);
 
             let mut relay_node = make_test_announcement("relay", 1000);
             relay_node.capabilities = NodeCapabilities::RELAY;


### PR DESCRIPTION
## Summary

Implements per-peer rate limiting on gossipsub messages to protect against flooding attacks from malicious peers (security hardening from audit).

- Add `GossipMessageType` enum to categorize messages (Transaction, Block, Consensus, Announcement)
- Add `MessageTypeLimits` config with per-type rate limits matching audit requirements:
  - Transaction announcements: 100/min
  - Block announcements: 10/min
  - Consensus messages: 50/min
  - Node announcements: 20/min
- Extend `PeerRateLimiter` to track rates per message type using sliding window algorithm
- Add `RateLimitMetrics` for monitoring rate limit hits and peer bans
- Integrate typed rate limiting in service.rs message handlers
- Add comprehensive tests for new functionality

## Test plan

- [x] All existing tests pass (61 tests)
- [x] New tests for per-type rate limiting
- [x] Tests for metrics tracking
- [x] Tests for peer banning on repeated violations
- [x] Code compiles with no new warnings from rate_limit.rs
- [x] Formatting passes

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)