### PR TITLE
Migrate println! to tracing/eprintln! in library crates

### DIFF
--- a/botho/src/decoy_selection.rs
+++ b/botho/src/decoy_selection.rs
@@ -1123,8 +1123,8 @@ mod tests {
 
         // Similar ages should provide better anonymity
         assert!(similar_anon > diverse_anon);
-        println!("Similar ages anonymity: {:.2}", similar_anon);
-        println!("Diverse ages anonymity: {:.2}", diverse_anon);
+        eprintln!("Similar ages anonymity: {:.2}", similar_anon);
+        eprintln!("Diverse ages anonymity: {:.2}", diverse_anon);
     }
 
     #[test]
@@ -1137,9 +1137,9 @@ mod tests {
         let weight_medium = selector.weight_for_age(21600); // 30 days
         let weight_old = selector.weight_for_age(525600);   // 2 years
 
-        println!("Weight at 100 blocks: {}", weight_young);
-        println!("Weight at 21600 blocks: {}", weight_medium);
-        println!("Weight at 525600 blocks: {}", weight_old);
+        eprintln!("Weight at 100 blocks: {}", weight_young);
+        eprintln!("Weight at 21600 blocks: {}", weight_medium);
+        eprintln!("Weight at 525600 blocks: {}", weight_old);
 
         // Medium-aged outputs should be preferred
         assert!(weight_medium > weight_young);
@@ -1285,7 +1285,7 @@ mod tests {
             .filter(|d| d.target_key[0] < 10)
             .count();
 
-        println!("Selected {} decoys from similar cluster group", similar_count);
+        eprintln!("Selected {} decoys from similar cluster group", similar_count);
         assert!(similar_count >= 4, "Expected at least 4 similar, got {similar_count}");
     }
 
@@ -1311,7 +1311,7 @@ mod tests {
             .collect();
 
         let anon = selector.effective_anonymity_with_clusters(&similar_ring, &real_input);
-        println!("Similar clusters effective anonymity: {:.2}", anon);
+        eprintln!("Similar clusters effective anonymity: {:.2}", anon);
 
         // With 20 similar-cluster ring members, effective anonymity should be high (>10)
         // Note: 12+ indicates excellent anonymity set (more than half the ring is plausible)
@@ -1323,7 +1323,7 @@ mod tests {
         let high_sim = real_tags.combined_similarity(&high_match);
         let low_sim = real_tags.combined_similarity(&low_match);
 
-        println!("High match similarity: {:.2}, Low match: {:.2}", high_sim, low_sim);
+        eprintln!("High match similarity: {:.2}, Low match: {:.2}", high_sim, low_sim);
         assert!(high_sim > low_sim, "Matching cluster should have higher similarity");
     }
 }

--- a/botho/src/lib.rs
+++ b/botho/src/lib.rs
@@ -5,6 +5,8 @@
 //! This library provides the core functionality for the Botho node,
 //! including blockchain types, networking, consensus, and wallet support.
 
+#![deny(clippy::print_stdout)]
+
 pub mod address;
 pub mod block;
 pub mod config;

--- a/botho/src/node/mod.rs
+++ b/botho/src/node/mod.rs
@@ -121,33 +121,34 @@ impl Node {
         };
         let current_reward = crate::block::calculate_block_reward_v2(state.height + 1, net_supply);
 
-        println!();
-        println!("=== Botho Node ===");
+        info!("=== Botho Node ===");
         if let Some(ref wallet) = self.wallet {
-            println!(
-                "Address: {}",
-                wallet.address_string().replace('\n', ", ")
+            info!(
+                address = %wallet.address_string().replace('\n', ", "),
+                "Wallet configured"
             );
         } else {
-            println!("Mode: Relay (no wallet)");
+            info!("Mode: Relay (no wallet)");
         }
-        println!("Chain height: {}", state.height);
-        println!("Phase: {}", phase);
-        println!(
+        info!(height = state.height, phase = phase, "Chain status");
+        info!(
+            block_reward_bth = current_reward as f64 / 1_000_000_000_000.0,
             "Block reward: {:.6} BTH",
             current_reward as f64 / 1_000_000_000_000.0
         );
-        println!(
+        info!(
+            net_supply_bth = net_supply as f64 / 1_000_000_000_000.0,
+            mined_bth = state.total_mined as f64 / 1_000_000_000_000.0,
+            burned_bth = state.total_fees_burned as f64 / 1_000_000_000_000.0,
             "Net supply: {:.6} BTH (mined: {:.6}, burned: {:.6})",
             net_supply as f64 / 1_000_000_000_000.0,
             state.total_mined as f64 / 1_000_000_000_000.0,
             state.total_fees_burned as f64 / 1_000_000_000_000.0
         );
-        println!("Bootstrap peers: {} configured", self.config.network.bootstrap_peers.len());
+        info!(peer_count = self.config.network.bootstrap_peers.len(), "Bootstrap peers configured");
         if self.config.network.bootstrap_peers.is_empty() {
             warn!("No bootstrap peers configured - add bootstrap_peers to config.toml");
         }
-        println!();
         Ok(())
     }
 

--- a/cluster-tax/src/lib.rs
+++ b/cluster-tax/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::print_stdout)]
+
 //! Botho fee system with size-based progressive pricing.
 //!
 //! This module implements Botho's fee model with two key features:

--- a/cluster-tax/src/simulation/runner.rs
+++ b/cluster-tax/src/simulation/runner.rs
@@ -404,7 +404,7 @@ pub fn run_simulation(
             metrics.record_snapshot(snapshot);
 
             if config.verbose {
-                println!(
+                eprintln!(
                     "Round {}: {} txs, {} fees, Gini={:.4}",
                     round,
                     round_transactions,
@@ -636,8 +636,8 @@ mod tests {
 
         // Net supply change can be positive or negative depending on fee burn rate
         // The key is the system adapts difficulty in response
-        println!("Net supply change: {}", stats.net_supply_change);
-        println!("Difficulty: {}", stats.difficulty);
+        eprintln!("Net supply change: {}", stats.net_supply_change);
+        eprintln!("Difficulty: {}", stats.difficulty);
     }
 
     #[test]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -3,6 +3,7 @@
 //! Common types and methods. no_std-compatible crate.
 
 #![deny(missing_docs)]
+#![deny(clippy::print_stdout)]
 #![warn(unused_extern_crates)]
 #![no_std]
 

--- a/common/src/panic_handler.rs
+++ b/common/src/panic_handler.rs
@@ -4,9 +4,10 @@ use super::logger;
 use backtrace::Backtrace;
 use std::{
     boxed::Box,
-    env, format,
+    env,
+    eprintln, format,
     panic::{self, PanicHookInfo},
-    println, process,
+    process,
     string::ToString,
     thread, time,
 };
@@ -24,10 +25,10 @@ fn handle_panic(panic_info: &PanicHookInfo<'_>) {
     let thread_name = thread::current().name().unwrap_or("?").to_string();
     let process_name = env::args().next().unwrap_or_else(|| "?".to_string());
 
-    // First, print the crash details.
-    println!("OH NO, WE CRASHED :( thread {thread_name} on {process_name}");
-    println!("Details: {details}");
-    println!("{backtrace}");
+    // First, print the crash details to stderr (more reliable than tracing during panics).
+    eprintln!("OH NO, WE CRASHED :( thread {thread_name} on {process_name}");
+    eprintln!("Details: {details}");
+    eprintln!("{backtrace}");
 
     // Also attempt to log using the logger.
     logger::global_log::crit!(

--- a/consensus/scp/src/lib.rs
+++ b/consensus/scp/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
 #![deny(clippy::panic)]
+#![deny(clippy::print_stdout)]
 
 pub mod ballot;
 mod error;

--- a/consensus/scp/src/slot.rs
+++ b/consensus/scp/src/slot.rs
@@ -2509,7 +2509,7 @@ mod nominate_protocol_tests {
             logger,
         );
 
-        println!("max_priority_peers: {:?}", slot.max_priority_peers);
+        eprintln!("max_priority_peers: {:?}", slot.max_priority_peers);
         // Ensure that the local node **is not** in max_priority_peers.
         assert!(!slot.max_priority_peers.contains(&local_node.0));
 
@@ -2535,7 +2535,7 @@ mod nominate_protocol_tests {
             logger,
         );
 
-        println!("max_priority_peers: {:?}", slot.max_priority_peers);
+        eprintln!("max_priority_peers: {:?}", slot.max_priority_peers);
         // Ensure that the local node **is** in max_priority_peers.
         slot.max_priority_peers.insert(local_node.0.clone());
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![warn(missing_docs)]
 #![deny(unsafe_code)]
+#![deny(clippy::print_stdout)]
 
 // Re-export shared type modules
 pub use bth_core_types::{account, keys};

--- a/crypto/keys/src/lib.rs
+++ b/crypto/keys/src/lib.rs
@@ -48,6 +48,7 @@
 
 #![no_std]
 #![deny(unsafe_code)]
+#![deny(clippy::print_stdout)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/crypto/lion/src/lib.rs
+++ b/crypto/lion/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(unsafe_code)]
+#![deny(clippy::print_stdout)]
 
 //! Lion: Lattice-based Linkable Ring Signatures for Botho
 //!

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -87,6 +87,7 @@
 
 #![warn(missing_docs)]
 #![warn(unused_extern_crates)]
+#![deny(clippy::print_stdout)]
 
 pub mod analyzer;
 pub mod behaviour;


### PR DESCRIPTION
## Summary

Migrate println! statements to structured logging in library crates and add clippy lint to prevent future regressions.

## Changes

**Migrated output:**
- `common/panic_handler.rs`: Use `eprintln!` for reliable panic output
- `consensus/scp/slot.rs`: Convert test debug output to `eprintln!`
- `botho/decoy_selection.rs`: Convert test debug output to `eprintln!`
- `botho/node/mod.rs`: Convert startup banner to `tracing::info!`
- `cluster-tax/simulation/runner.rs`: Convert verbose output to `eprintln!`

**Added `#![deny(clippy::print_stdout)]` lint to:**
- common
- consensus/scp
- core
- crypto/keys
- crypto/lion
- gossip
- cluster-tax
- botho

**Preserved exceptions:**
- `build.rs`: Required for cargo build script output
- `core/slip10/mod.rs`: Test vector generation (intentional stdout)
- `botho-exchange-scanner/stdout.rs`: Intentional stdout OutputWriter

## Test Plan

- [x] `cargo check` passes for all modified library crates
- [ ] CI passes

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)