### PR TITLE
Implement cluster wealth tracking for progressive fees

### DIFF
--- a/botho/src/ledger/mod.rs
+++ b/botho/src/ledger/mod.rs
@@ -1,6 +1,6 @@
 mod store;
 
-pub use store::{Ledger, TxLocation};
+pub use store::{ClusterWealthInfo, Ledger, TxLocation};
 
 use thiserror::Error;
 


### PR DESCRIPTION
## Summary

- Add persistent cluster wealth tracking in the ledger's LMDB database
- Track cluster contributions automatically when new outputs are created
- Expose RPC endpoints for wallets to query their cluster wealth for accurate fee estimation
- Update `estimate_fee` RPC to accept optional `cluster_wealth` parameter

## Key Changes

### Ledger Store (`botho/src/ledger/store.rs`)
- Add `cluster_wealth_db` to LMDB for tracking wealth by cluster ID
- `update_cluster_wealth_for_output()` - Updates wealth when outputs are created
- `get_cluster_wealth()` - Query wealth for a specific cluster
- `compute_cluster_wealth_for_utxos()` - Compute wealth from target keys (primary wallet API)
- `get_all_cluster_wealth()` - Network-wide wealth distribution analytics
- `rebuild_cluster_wealth_index()` - Database repair/migration utility

### RPC Endpoints (`botho/src/rpc/mod.rs`)
- `cluster_getWealth` - Get total wealth for a cluster ID
- `cluster_getWealthByTargetKeys` - Primary wallet API for fee estimation
- `cluster_getAllWealth` - Network analytics
- Updated `estimate_fee` to accept optional `cluster_wealth` param

### Mempool (`botho/src/mempool.rs`)
- Add `estimate_fee_with_wealth()` for accurate progressive fee calculation

## Privacy Implications (documented in code)

1. **Cluster tags are public** - visible on-chain, this API just makes lookup efficient
2. **Wealth aggregates visible** - reveals concentration but not individual wallet balances
3. **Ring signatures protect spending** - which UTXO was spent remains hidden
4. **Approximation** - spent UTXOs continue contributing until pruned (ring signature privacy)
5. **Decay over time** - 5% decay per transaction dilutes wealth attribution

## Test Plan

- [x] `cargo check --package botho` passes
- [x] `cargo test --package botho --lib ledger` passes (9 tests)
- [ ] Manual testing of RPC endpoints

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)