### PR TITLE
Add CloudWatch monitoring for seed node

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -350,6 +350,8 @@ sudo nginx -t && sudo systemctl reload nginx
 
 ## Monitoring
 
+> **CloudWatch Monitoring**: For AWS CloudWatch setup (EC2 instances), see [docs/monitoring.md](monitoring.md).
+
 ### Health Check Script
 
 ```bash

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,441 @@
+# CloudWatch Monitoring
+
+Set up AWS CloudWatch monitoring for Botho seed nodes.
+
+## Overview
+
+This guide covers:
+- Installing the CloudWatch agent
+- Collecting system and application metrics
+- Setting up alarms and notifications
+- Troubleshooting monitoring issues
+
+## Prerequisites
+
+- EC2 instance running the Botho seed node
+- IAM role with `CloudWatchAgentServerPolicy` attached
+- SNS topic for alarm notifications
+- AWS CLI configured (for alarm creation)
+
+## Quick Start
+
+```bash
+# 1. SSH to seed node
+ssh ec2-user@seed.botho.io
+
+# 2. Run setup script
+sudo ./infra/monitoring/setup-monitoring.sh
+
+# 3. Create alarms (from local machine with AWS CLI)
+./infra/monitoring/create-alarms.sh \
+    i-03f2b4b35fa7e86ce \
+    arn:aws:sns:us-east-1:123456789:botho-ops \
+    us-east-1
+```
+
+---
+
+## Installation
+
+### Step 1: Attach IAM Role
+
+The EC2 instance needs an IAM role with CloudWatch permissions.
+
+**Create IAM Role** (if not exists):
+1. Go to IAM Console → Roles → Create Role
+2. Select "AWS service" → EC2
+3. Attach policy: `CloudWatchAgentServerPolicy`
+4. Name: `BothoSeedNodeRole`
+
+**Attach to Instance**:
+```bash
+aws ec2 associate-iam-instance-profile \
+    --instance-id i-03f2b4b35fa7e86ce \
+    --iam-instance-profile Name=BothoSeedNodeRole
+```
+
+### Step 2: Install CloudWatch Agent
+
+**Amazon Linux / RHEL**:
+```bash
+sudo yum install -y amazon-cloudwatch-agent
+```
+
+**Ubuntu / Debian**:
+```bash
+wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+sudo dpkg -i amazon-cloudwatch-agent.deb
+```
+
+### Step 3: Configure Agent
+
+Copy the configuration file:
+```bash
+sudo cp infra/monitoring/cloudwatch-agent-config.json \
+    /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+```
+
+### Step 4: Start Agent
+
+```bash
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+    -a fetch-config \
+    -m ec2 \
+    -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json \
+    -s
+
+# Enable on boot
+sudo systemctl enable amazon-cloudwatch-agent
+```
+
+---
+
+## Metrics Collected
+
+### System Metrics (Namespace: `Botho/SeedNode`)
+
+| Metric | Description | Unit |
+|--------|-------------|------|
+| `cpu_usage_active` | CPU utilization | Percent |
+| `mem_used_percent` | Memory utilization | Percent |
+| `disk_used_percent` | Disk usage for `/` | Percent |
+| `bytes_sent` / `bytes_recv` | Network I/O | Bytes |
+| `tcp_established` | Active TCP connections | Count |
+
+### Process Metrics (Botho-specific)
+
+| Metric | Description | Unit |
+|--------|-------------|------|
+| `pid_count` | Number of Botho processes | Count |
+| `cpu_usage` | Botho CPU usage | Percent |
+| `memory_rss` | Botho memory (RSS) | Bytes |
+| `num_threads` | Thread count | Count |
+
+---
+
+## Alarms
+
+### Configured Alarms
+
+| Alarm | Threshold | Severity | Action |
+|-------|-----------|----------|--------|
+| `botho-seed-cpu-high` | CPU > 80% for 10 min | WARNING | SNS notification |
+| `botho-seed-memory-high` | Memory > 90% for 10 min | WARNING | SNS notification |
+| `botho-seed-disk-high` | Disk > 80% for 10 min | WARNING | SNS notification |
+| `botho-seed-process-down` | Process count < 1 for 2 min | CRITICAL | SNS notification |
+| `botho-seed-status-check-failed` | EC2 status check failed | CRITICAL | SNS notification |
+| `botho-seed-network-isolation` | No network traffic for 15 min | WARNING | SNS notification |
+
+### Create Alarms
+
+```bash
+./infra/monitoring/create-alarms.sh <instance-id> <sns-topic-arn> [region]
+
+# Example
+./infra/monitoring/create-alarms.sh \
+    i-03f2b4b35fa7e86ce \
+    arn:aws:sns:us-east-1:123456789:botho-ops \
+    us-east-1
+```
+
+### Custom Alarm Thresholds
+
+To modify thresholds, edit `create-alarms.sh` or create alarms manually:
+
+```bash
+# Example: More aggressive CPU alarm (70% threshold)
+aws cloudwatch put-metric-alarm \
+    --alarm-name "botho-seed-cpu-warning" \
+    --metric-name CPUUtilization \
+    --namespace AWS/EC2 \
+    --threshold 70 \
+    --comparison-operator GreaterThanThreshold \
+    --evaluation-periods 2 \
+    --period 300 \
+    --statistic Average \
+    --dimensions "Name=InstanceId,Value=i-03f2b4b35fa7e86ce" \
+    --alarm-actions "arn:aws:sns:us-east-1:123456789:botho-ops"
+```
+
+---
+
+## SNS Notifications
+
+### Create SNS Topic
+
+```bash
+# Create topic
+aws sns create-topic --name botho-ops --region us-east-1
+
+# Subscribe email
+aws sns subscribe \
+    --topic-arn arn:aws:sns:us-east-1:123456789:botho-ops \
+    --protocol email \
+    --notification-endpoint ops@botho.io
+
+# Subscribe SMS (optional)
+aws sns subscribe \
+    --topic-arn arn:aws:sns:us-east-1:123456789:botho-ops \
+    --protocol sms \
+    --notification-endpoint +1234567890
+```
+
+### PagerDuty Integration
+
+```bash
+# Create HTTPS subscription to PagerDuty
+aws sns subscribe \
+    --topic-arn arn:aws:sns:us-east-1:123456789:botho-ops \
+    --protocol https \
+    --notification-endpoint https://events.pagerduty.com/integration/YOUR_KEY/enqueue
+```
+
+---
+
+## CloudWatch Dashboard
+
+### Create Dashboard
+
+```bash
+aws cloudwatch put-dashboard \
+    --dashboard-name BothoSeedNode \
+    --dashboard-body file://dashboard.json
+```
+
+**Sample Dashboard JSON** (`dashboard.json`):
+
+```json
+{
+    "widgets": [
+        {
+            "type": "metric",
+            "x": 0, "y": 0, "width": 12, "height": 6,
+            "properties": {
+                "title": "CPU & Memory",
+                "region": "us-east-1",
+                "metrics": [
+                    ["AWS/EC2", "CPUUtilization", "InstanceId", "i-03f2b4b35fa7e86ce"],
+                    ["Botho/SeedNode", "mem_used_percent", "InstanceId", "i-03f2b4b35fa7e86ce"]
+                ],
+                "period": 300,
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12, "y": 0, "width": 12, "height": 6,
+            "properties": {
+                "title": "Disk Usage",
+                "region": "us-east-1",
+                "metrics": [
+                    ["Botho/SeedNode", "disk_used_percent", "InstanceId", "i-03f2b4b35fa7e86ce", "path", "/"]
+                ],
+                "period": 300,
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0, "y": 6, "width": 12, "height": 6,
+            "properties": {
+                "title": "Botho Process",
+                "region": "us-east-1",
+                "metrics": [
+                    ["Botho/SeedNode", "pid_count", "InstanceId", "i-03f2b4b35fa7e86ce", "pattern", "botho"],
+                    [".", "cpu_usage", ".", ".", ".", "."],
+                    [".", "memory_rss", ".", ".", ".", "."]
+                ],
+                "period": 60,
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12, "y": 6, "width": 12, "height": 6,
+            "properties": {
+                "title": "Network",
+                "region": "us-east-1",
+                "metrics": [
+                    ["AWS/EC2", "NetworkIn", "InstanceId", "i-03f2b4b35fa7e86ce"],
+                    [".", "NetworkOut", ".", "."]
+                ],
+                "period": 300,
+                "stat": "Sum"
+            }
+        }
+    ]
+}
+```
+
+---
+
+## Log Collection
+
+The CloudWatch agent also collects logs from:
+
+| Log File | Log Group | Retention |
+|----------|-----------|-----------|
+| `/var/log/botho/botho.log` | `/botho/seed-node` | 30 days |
+| `/var/log/syslog` | `/botho/seed-node` | 14 days |
+
+### View Logs
+
+```bash
+# Via AWS CLI
+aws logs tail /botho/seed-node --follow
+
+# Filter for errors
+aws logs filter-log-events \
+    --log-group-name /botho/seed-node \
+    --filter-pattern "ERROR"
+```
+
+---
+
+## Verification
+
+### Test Plan
+
+After setup, verify monitoring works:
+
+1. **Verify metrics collection**:
+   - Go to CloudWatch Console → Metrics → Botho/SeedNode
+   - Confirm metrics appear within 5 minutes
+
+2. **Test CPU alarm**:
+   ```bash
+   # On seed node
+   stress --cpu 4 --timeout 300
+   ```
+   - Verify WARNING alert triggers within 10 minutes
+
+3. **Test process alarm**:
+   ```bash
+   # Stop Botho temporarily
+   sudo systemctl stop botho
+   # Wait 2 minutes, verify CRITICAL alert
+   sudo systemctl start botho
+   ```
+
+4. **Verify SNS delivery**:
+   - Check email/SMS for test alerts
+   - Verify OK notifications when conditions clear
+
+5. **Check dashboard**:
+   - Open CloudWatch Dashboard
+   - Verify all widgets show data
+
+---
+
+## Troubleshooting
+
+### Agent Not Starting
+
+```bash
+# Check agent status
+amazon-cloudwatch-agent-ctl -a status
+
+# View agent logs
+tail -100 /var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log
+
+# Common issues:
+# - Missing IAM role: Attach CloudWatchAgentServerPolicy
+# - Config syntax error: Validate JSON
+# - Permission denied: Run as root
+```
+
+### Metrics Not Appearing
+
+```bash
+# Verify agent is collecting
+cat /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log | grep -i error
+
+# Check namespace
+aws cloudwatch list-metrics --namespace Botho/SeedNode
+
+# Verify dimensions
+aws cloudwatch list-metrics \
+    --namespace Botho/SeedNode \
+    --dimensions Name=InstanceId,Value=i-03f2b4b35fa7e86ce
+```
+
+### Alarms Not Triggering
+
+```bash
+# Check alarm state
+aws cloudwatch describe-alarms --alarm-names botho-seed-cpu-high
+
+# Verify metric data exists
+aws cloudwatch get-metric-statistics \
+    --namespace AWS/EC2 \
+    --metric-name CPUUtilization \
+    --dimensions Name=InstanceId,Value=i-03f2b4b35fa7e86ce \
+    --start-time $(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ) \
+    --end-time $(date -u +%Y-%m-%dT%H:%M:%SZ) \
+    --period 300 \
+    --statistics Average
+```
+
+### Process Monitoring Issues
+
+If `pid_count` always shows 0:
+
+```bash
+# Verify process name matches
+ps aux | grep botho
+
+# Test procstat pattern
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent -test \
+    -config /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+```
+
+---
+
+## Configuration Reference
+
+### CloudWatch Agent Config
+
+Location: `/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json`
+
+Source: `infra/monitoring/cloudwatch-agent-config.json`
+
+Key sections:
+- `agent`: Global settings (collection interval, run user)
+- `metrics.metrics_collected`: System metrics (CPU, memory, disk, network)
+- `metrics.metrics_collected.procstat`: Process-specific metrics
+- `logs`: Log file collection
+
+### Alarm Scripts
+
+Location: `infra/monitoring/`
+
+| Script | Purpose |
+|--------|---------|
+| `setup-monitoring.sh` | Install and configure CloudWatch agent |
+| `create-alarms.sh` | Create CloudWatch alarms |
+| `cloudwatch-agent-config.json` | Agent configuration |
+
+---
+
+## Cost Optimization
+
+CloudWatch costs can add up. Optimize by:
+
+1. **Reduce metric frequency**: Change `metrics_collection_interval` from 60 to 300 seconds
+2. **Limit log retention**: Set appropriate retention periods
+3. **Use alarm actions wisely**: Avoid excessive SNS notifications
+4. **Clean up unused alarms**: Delete alarms for terminated instances
+
+**Estimated monthly cost** (us-east-1):
+- Custom metrics (10): ~$3.00
+- Alarms (6): ~$0.60
+- Logs (10 GB): ~$5.00
+- **Total**: ~$10/month per node
+
+---
+
+## See Also
+
+- [Deployment Guide](deployment.md) - Full production setup
+- [Backup Strategy](backup.md) - Data protection
+- [AWS CloudWatch Documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/)

--- a/infra/monitoring/README.md
+++ b/infra/monitoring/README.md
@@ -1,0 +1,25 @@
+# CloudWatch Monitoring for Seed Node
+
+Scripts and configuration for AWS CloudWatch monitoring of the Botho seed node.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `cloudwatch-agent-config.json` | CloudWatch agent configuration |
+| `setup-monitoring.sh` | Install and configure agent on EC2 |
+| `create-alarms.sh` | Create CloudWatch alarms |
+
+## Quick Start
+
+```bash
+# On seed node (requires sudo)
+sudo ./setup-monitoring.sh
+
+# From local machine (requires AWS CLI)
+./create-alarms.sh <instance-id> <sns-topic-arn> [region]
+```
+
+## Documentation
+
+See [docs/monitoring.md](../../docs/monitoring.md) for full documentation.

--- a/infra/monitoring/cloudwatch-agent-config.json
+++ b/infra/monitoring/cloudwatch-agent-config.json
@@ -1,0 +1,107 @@
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root",
+    "logfile": "/var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log"
+  },
+  "metrics": {
+    "namespace": "Botho/SeedNode",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "cpu": {
+        "measurement": [
+          "cpu_usage_active",
+          "cpu_usage_idle",
+          "cpu_usage_iowait"
+        ],
+        "totalcpu": true,
+        "metrics_collection_interval": 60
+      },
+      "mem": {
+        "measurement": [
+          "mem_used_percent",
+          "mem_available_percent"
+        ],
+        "metrics_collection_interval": 60
+      },
+      "disk": {
+        "measurement": [
+          "disk_used_percent",
+          "disk_free",
+          "disk_inodes_free"
+        ],
+        "resources": [
+          "/"
+        ],
+        "metrics_collection_interval": 60
+      },
+      "diskio": {
+        "measurement": [
+          "reads",
+          "writes",
+          "read_bytes",
+          "write_bytes"
+        ],
+        "resources": [
+          "*"
+        ],
+        "metrics_collection_interval": 60
+      },
+      "net": {
+        "measurement": [
+          "bytes_sent",
+          "bytes_recv",
+          "packets_sent",
+          "packets_recv"
+        ],
+        "resources": [
+          "eth0"
+        ],
+        "metrics_collection_interval": 60
+      },
+      "netstat": {
+        "measurement": [
+          "tcp_established",
+          "tcp_time_wait"
+        ],
+        "metrics_collection_interval": 60
+      },
+      "procstat": [
+        {
+          "pattern": "botho",
+          "measurement": [
+            "pid_count",
+            "cpu_usage",
+            "memory_rss",
+            "memory_vms",
+            "read_bytes",
+            "write_bytes",
+            "num_threads"
+          ]
+        }
+      ]
+    }
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/botho/botho.log",
+            "log_group_name": "/botho/seed-node",
+            "log_stream_name": "{instance_id}/botho",
+            "retention_in_days": 30
+          },
+          {
+            "file_path": "/var/log/syslog",
+            "log_group_name": "/botho/seed-node",
+            "log_stream_name": "{instance_id}/syslog",
+            "retention_in_days": 14
+          }
+        ]
+      }
+    }
+  }
+}

--- a/infra/monitoring/create-alarms.sh
+++ b/infra/monitoring/create-alarms.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Create CloudWatch alarms for Botho seed node monitoring
+#
+# Prerequisites:
+#   - AWS CLI configured with appropriate permissions
+#   - SNS topic created for notifications
+#
+# Usage:
+#   ./create-alarms.sh <instance-id> <sns-topic-arn> [region]
+#
+# Example:
+#   ./create-alarms.sh i-03f2b4b35fa7e86ce arn:aws:sns:us-east-1:123456789:botho-ops us-east-1
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Validate arguments
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <instance-id> <sns-topic-arn> [region]"
+    echo ""
+    echo "Arguments:"
+    echo "  instance-id    EC2 instance ID (e.g., i-03f2b4b35fa7e86ce)"
+    echo "  sns-topic-arn  SNS topic ARN for alarm notifications"
+    echo "  region         AWS region (default: us-east-1)"
+    exit 1
+fi
+
+INSTANCE_ID="$1"
+SNS_TOPIC_ARN="$2"
+AWS_REGION="${3:-us-east-1}"
+
+log_info "Creating CloudWatch alarms for instance: $INSTANCE_ID"
+log_info "SNS Topic: $SNS_TOPIC_ARN"
+log_info "Region: $AWS_REGION"
+
+# Alarm: CPU Utilization > 80% (WARNING)
+log_info "Creating CPU utilization alarm..."
+aws cloudwatch put-metric-alarm \
+    --region "$AWS_REGION" \
+    --alarm-name "botho-seed-cpu-high" \
+    --alarm-description "WARNING: Seed node CPU utilization exceeds 80%" \
+    --metric-name CPUUtilization \
+    --namespace AWS/EC2 \
+    --statistic Average \
+    --period 300 \
+    --threshold 80 \
+    --comparison-operator GreaterThanThreshold \
+    --dimensions "Name=InstanceId,Value=$INSTANCE_ID" \
+    --evaluation-periods 2 \
+    --alarm-actions "$SNS_TOPIC_ARN" \
+    --ok-actions "$SNS_TOPIC_ARN" \
+    --treat-missing-data notBreaching
+
+# Alarm: Memory Usage > 90% (WARNING)
+log_info "Creating memory utilization alarm..."
+aws cloudwatch put-metric-alarm \
+    --region "$AWS_REGION" \
+    --alarm-name "botho-seed-memory-high" \
+    --alarm-description "WARNING: Seed node memory utilization exceeds 90%" \
+    --metric-name mem_used_percent \
+    --namespace Botho/SeedNode \
+    --statistic Average \
+    --period 300 \
+    --threshold 90 \
+    --comparison-operator GreaterThanThreshold \
+    --dimensions "Name=InstanceId,Value=$INSTANCE_ID" \
+    --evaluation-periods 2 \
+    --alarm-actions "$SNS_TOPIC_ARN" \
+    --ok-actions "$SNS_TOPIC_ARN" \
+    --treat-missing-data notBreaching
+
+# Alarm: Disk Usage > 80% (WARNING)
+log_info "Creating disk utilization alarm..."
+aws cloudwatch put-metric-alarm \
+    --region "$AWS_REGION" \
+    --alarm-name "botho-seed-disk-high" \
+    --alarm-description "WARNING: Seed node disk utilization exceeds 80%" \
+    --metric-name disk_used_percent \
+    --namespace Botho/SeedNode \
+    --statistic Average \
+    --period 300 \
+    --threshold 80 \
+    --comparison-operator GreaterThanThreshold \
+    --dimensions "Name=InstanceId,Value=$INSTANCE_ID" "Name=path,Value=/" \
+    --evaluation-periods 2 \
+    --alarm-actions "$SNS_TOPIC_ARN" \
+    --ok-actions "$SNS_TOPIC_ARN" \
+    --treat-missing-data notBreaching
+
+# Alarm: Botho process not running (CRITICAL)
+log_info "Creating process monitoring alarm..."
+aws cloudwatch put-metric-alarm \
+    --region "$AWS_REGION" \
+    --alarm-name "botho-seed-process-down" \
+    --alarm-description "CRITICAL: Botho process is not running on seed node" \
+    --metric-name pid_count \
+    --namespace Botho/SeedNode \
+    --statistic Minimum \
+    --period 60 \
+    --threshold 1 \
+    --comparison-operator LessThanThreshold \
+    --dimensions "Name=InstanceId,Value=$INSTANCE_ID" "Name=pattern,Value=botho" \
+    --evaluation-periods 2 \
+    --alarm-actions "$SNS_TOPIC_ARN" \
+    --ok-actions "$SNS_TOPIC_ARN" \
+    --treat-missing-data breaching
+
+# Alarm: StatusCheckFailed (EC2 health check)
+log_info "Creating EC2 status check alarm..."
+aws cloudwatch put-metric-alarm \
+    --region "$AWS_REGION" \
+    --alarm-name "botho-seed-status-check-failed" \
+    --alarm-description "CRITICAL: EC2 status check failed for seed node" \
+    --metric-name StatusCheckFailed \
+    --namespace AWS/EC2 \
+    --statistic Maximum \
+    --period 60 \
+    --threshold 1 \
+    --comparison-operator GreaterThanOrEqualToThreshold \
+    --dimensions "Name=InstanceId,Value=$INSTANCE_ID" \
+    --evaluation-periods 2 \
+    --alarm-actions "$SNS_TOPIC_ARN" \
+    --ok-actions "$SNS_TOPIC_ARN" \
+    --treat-missing-data notBreaching
+
+# Alarm: Network connectivity (bytes received)
+log_info "Creating network connectivity alarm..."
+aws cloudwatch put-metric-alarm \
+    --region "$AWS_REGION" \
+    --alarm-name "botho-seed-network-isolation" \
+    --alarm-description "WARNING: Seed node appears network isolated (no incoming traffic)" \
+    --metric-name NetworkIn \
+    --namespace AWS/EC2 \
+    --statistic Sum \
+    --period 300 \
+    --threshold 1000 \
+    --comparison-operator LessThanThreshold \
+    --dimensions "Name=InstanceId,Value=$INSTANCE_ID" \
+    --evaluation-periods 3 \
+    --alarm-actions "$SNS_TOPIC_ARN" \
+    --ok-actions "$SNS_TOPIC_ARN" \
+    --treat-missing-data notBreaching
+
+log_info "All alarms created successfully!"
+echo ""
+echo "Created alarms:"
+echo "  - botho-seed-cpu-high (WARNING: CPU > 80%)"
+echo "  - botho-seed-memory-high (WARNING: Memory > 90%)"
+echo "  - botho-seed-disk-high (WARNING: Disk > 80%)"
+echo "  - botho-seed-process-down (CRITICAL: Process not running)"
+echo "  - botho-seed-status-check-failed (CRITICAL: EC2 health check)"
+echo "  - botho-seed-network-isolation (WARNING: No network traffic)"
+echo ""
+echo "Verify alarms in CloudWatch Console:"
+echo "  https://$AWS_REGION.console.aws.amazon.com/cloudwatch/home?region=$AWS_REGION#alarmsV2:"

--- a/infra/monitoring/setup-monitoring.sh
+++ b/infra/monitoring/setup-monitoring.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# Setup CloudWatch monitoring on Botho seed node
+#
+# This script installs and configures the CloudWatch agent on an EC2 instance
+# running the Botho seed node.
+#
+# Prerequisites:
+#   - Run as root or with sudo
+#   - EC2 instance with IAM role including CloudWatchAgentServerPolicy
+#   - Internet access for package installation
+#
+# Usage:
+#   sudo ./setup-monitoring.sh
+#
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_step() { echo -e "${BLUE}[STEP]${NC} $1"; }
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+    log_error "This script must be run as root (use sudo)"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="$SCRIPT_DIR/cloudwatch-agent-config.json"
+
+# Verify config file exists
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    log_error "CloudWatch agent config not found: $CONFIG_FILE"
+    exit 1
+fi
+
+# Detect OS
+detect_os() {
+    if [[ -f /etc/os-release ]]; then
+        . /etc/os-release
+        echo "$ID"
+    elif [[ -f /etc/redhat-release ]]; then
+        echo "rhel"
+    else
+        echo "unknown"
+    fi
+}
+
+OS=$(detect_os)
+log_info "Detected OS: $OS"
+
+# Step 1: Install CloudWatch Agent
+log_step "Installing CloudWatch Agent..."
+
+case "$OS" in
+    "amzn"|"rhel"|"centos"|"fedora")
+        if command -v amazon-cloudwatch-agent &> /dev/null; then
+            log_info "CloudWatch Agent already installed"
+        else
+            yum install -y amazon-cloudwatch-agent
+        fi
+        ;;
+    "ubuntu"|"debian")
+        if command -v amazon-cloudwatch-agent &> /dev/null; then
+            log_info "CloudWatch Agent already installed"
+        else
+            wget -q https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+            dpkg -i amazon-cloudwatch-agent.deb
+            rm -f amazon-cloudwatch-agent.deb
+        fi
+        ;;
+    *)
+        log_error "Unsupported OS: $OS"
+        log_info "Please install CloudWatch Agent manually:"
+        log_info "  https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Agent-on-EC2-Instance.html"
+        exit 1
+        ;;
+esac
+
+# Step 2: Create log directory for Botho
+log_step "Creating log directories..."
+mkdir -p /var/log/botho
+chown -R botho:botho /var/log/botho 2>/dev/null || true
+
+# Step 3: Configure CloudWatch Agent
+log_step "Configuring CloudWatch Agent..."
+cp "$CONFIG_FILE" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+# Step 4: Start CloudWatch Agent
+log_step "Starting CloudWatch Agent..."
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+    -a fetch-config \
+    -m ec2 \
+    -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json \
+    -s
+
+# Step 5: Enable CloudWatch Agent to start on boot
+log_step "Enabling CloudWatch Agent on boot..."
+systemctl enable amazon-cloudwatch-agent
+
+# Step 6: Verify agent is running
+log_step "Verifying CloudWatch Agent status..."
+if systemctl is-active --quiet amazon-cloudwatch-agent; then
+    log_info "CloudWatch Agent is running"
+else
+    log_error "CloudWatch Agent failed to start"
+    log_info "Check logs: /var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log"
+    exit 1
+fi
+
+# Step 7: Verify metrics are being collected
+log_step "Waiting for initial metrics collection..."
+sleep 10
+
+# Check agent status
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a status
+
+echo ""
+log_info "CloudWatch monitoring setup complete!"
+echo ""
+echo "Next steps:"
+echo "  1. Create CloudWatch alarms (run create-alarms.sh)"
+echo "  2. Verify metrics in CloudWatch Console"
+echo "  3. Subscribe to SNS topic for notifications"
+echo ""
+echo "Useful commands:"
+echo "  Check agent status:  amazon-cloudwatch-agent-ctl -a status"
+echo "  View agent logs:     tail -f /var/log/amazon/amazon-cloudwatch-agent/amazon-cloudwatch-agent.log"
+echo "  Restart agent:       systemctl restart amazon-cloudwatch-agent"


### PR DESCRIPTION
## Summary

Configure AWS CloudWatch monitoring for the Botho seed node (seed.botho.io) to enable proactive alerting and operational visibility.

## Changes

### Infrastructure (`infra/monitoring/`)
- **cloudwatch-agent-config.json**: CloudWatch agent configuration collecting:
  - System metrics: CPU, memory, disk, network I/O
  - Process metrics: Botho process count, CPU, memory, threads
  - Logs: `/var/log/botho/botho.log` and syslog

- **setup-monitoring.sh**: Installation script supporting Amazon Linux, RHEL, Ubuntu, Debian

- **create-alarms.sh**: Creates 6 CloudWatch alarms:
  - CPU > 80% (WARNING)
  - Memory > 90% (WARNING)
  - Disk > 80% (WARNING)
  - Process not running (CRITICAL)
  - EC2 status check failed (CRITICAL)
  - Network isolation (WARNING)

### Documentation (`docs/monitoring.md`)
- Complete setup guide
- Metrics reference table
- Alarm configuration
- Dashboard creation
- SNS notification setup
- Troubleshooting guide

### Updated (`docs/deployment.md`)
- Added cross-reference to new monitoring documentation

## Test Plan

- [ ] Verify CloudWatch agent config is valid JSON
- [ ] Test setup-monitoring.sh on Amazon Linux EC2
- [ ] Verify metrics appear in CloudWatch console within 5 minutes
- [ ] Test CPU alarm with `stress --cpu 4`
- [ ] Test process alarm by stopping botho service
- [ ] Verify SNS notifications are received

Closes #40