### PR TITLE
Clarify dual block timing architecture (60s vs dynamic)

### DIFF
--- a/botho/src/block.rs
+++ b/botho/src/block.rs
@@ -469,6 +469,20 @@ pub fn calculate_block_reward_v2(height: u64, total_supply: u64) -> u64 {
 /// - Finality latency (faster under load)
 ///
 /// Uses discrete levels for stability and predictability.
+///
+/// # Relationship to Monetary Policy
+///
+/// This module controls **actual block production timing** (5-40s range) and is
+/// separate from `MonetaryPolicy::target_block_time_secs` (60s), which is used
+/// for **economic calculations** (difficulty adjustment, halving schedules).
+///
+/// The two systems serve different purposes:
+/// - **MonetaryPolicy (60s)**: Long-term emission schedule, reward calculations
+/// - **dynamic_timing (5-40s)**: Short-term network efficiency optimization
+///
+/// Dynamic timing does NOT affect monetary policy calculations. The emission
+/// schedule assumes 60s blocks for predictable economics, regardless of actual
+/// block production speed. See `docs/architecture.md` for the full explanation.
 pub mod dynamic_timing {
     use super::Block;
 

--- a/botho/src/monetary.rs
+++ b/botho/src/monetary.rs
@@ -207,7 +207,12 @@ pub fn mainnet_policy() -> MonetaryPolicy {
         // Phase 2: 2% target net inflation
         tail_inflation_bps: 200,
 
-        // Block time: 60 seconds target, 45-90s bounds
+        // Block time: 60 seconds target, 45-90s bounds.
+        //
+        // NOTE: This is the **authoritative** block time for monetary policy calculations
+        // (difficulty adjustment, halving schedules, inflation targeting). It does NOT
+        // control actual block production timing, which uses `block::dynamic_timing`
+        // (5-40s range based on network load). See docs/architecture.md for details.
         target_block_time_secs: 60,
         min_block_time_secs: 45,
         max_block_time_secs: 90,


### PR DESCRIPTION
## Summary

Document the relationship between the two block timing systems in Botho:

1. **MonetaryPolicy (60s)**: Used for economic calculations (difficulty adjustment, halving schedules, inflation targeting)
2. **dynamic_timing (5-40s)**: Used for actual block production timing based on network load

## Changes

- **botho/src/monetary.rs**: Added code comment explaining `target_block_time_secs` is authoritative for monetary policy only
- **botho/src/block.rs**: Added doc comment to `dynamic_timing` module explaining relationship to MonetaryPolicy
- **docs/architecture.md**: Added "Block Timing Architecture" section with diagram and explanation

## Why Two Systems?

- **Predictable Economics**: 60s assumption ensures stable halving schedules regardless of network conditions
- **Network Efficiency**: Dynamic timing (5-40s) adapts to transaction load for optimal performance

## Test Plan

- [x] Code compiles without errors (`cargo check --package botho`)
- [x] Documentation is clear and addresses the original confusion
- [x] Code comments reference architecture docs for full explanation

Closes #26