### PR TITLE
Standardize unit naming (nanoBTH vs picocredits)

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -23,7 +23,11 @@ A collection of transactions bundled together and added to the blockchain. Each 
 The amount of BTH created when a new block is mined. Botho starts at 50 BTH per block, halving every ~2 years until reaching tail emission.
 
 ### BTH
-The native currency unit of Botho. 1 BTH = 1,000,000,000 nanoBTH.
+The native currency unit of Botho. BTH uses a two-tier precision system:
+- **For individual transactions**: 1 BTH = 1,000,000,000,000 picocredits (10^12, internal precision)
+- **For supply tracking/display**: 1 BTH = 1,000,000,000 nanoBTH (10^9, user-facing)
+
+The conversion factor is: 1 nanoBTH = 1,000 picocredits. See [Unit System](tokenomics.md#unit-system) for details.
 
 ### Bulletproofs
 A type of zero-knowledge proof used for range proofs. Ensures transaction amounts are positive without revealing the actual values. Used in Plain, Standard-Private, and PQ-Private transactions (all types except Minting).
@@ -168,7 +172,7 @@ A sequence of words (typically 24) that encodes your wallet's master seed. Used 
 ## N
 
 ### nanoBTH
-The smallest unit of BTH. 1 BTH = 1,000,000,000 nanoBTH.
+A display-friendly unit of BTH used for fee calculations and user interfaces. 1 BTH = 1,000,000,000 nanoBTH (10^9). 1 nanoBTH = 1,000 picocredits. NanoBTH is preferred for user-facing amounts because the numbers are more manageable.
 
 ### Node
 A computer running Botho software that participates in the network. Nodes relay transactions, validate blocks, and optionally mine.
@@ -197,7 +201,7 @@ Another node connected to your node in the P2P network.
 A cryptographic commitment that hides a value while allowing mathematical operations. Used in confidential transactions.
 
 ### Picocredits
-*Deprecated term.* See **nanoBTH** — the smallest unit of BTH. 1 BTH = 1,000,000,000 nanoBTH (10^9).
+The smallest internal unit of BTH, used for transaction amounts and accounting precision. 1 BTH = 1,000,000,000,000 picocredits (10^12). This provides higher precision than nanoBTH for individual transaction calculations. The bridge contracts and core transaction system use picocredits internally, while user interfaces typically display amounts in nanoBTH or BTH for readability.
 
 ### Post-Quantum Cryptography
 Cryptographic algorithms believed to be secure against quantum computer attacks. Botho uses ML-KEM-768 for all stealth addresses (recipient privacy), ML-DSA-65 for minting transaction signatures, and offers LION ring signatures for PQ-Private transactions. Standard-Private uses classical CLSAG for efficiency.

--- a/docs/tokenomics.md
+++ b/docs/tokenomics.md
@@ -7,7 +7,8 @@ Botho (BTH) uses a two-phase emission model designed for long-term sustainabilit
 | Parameter | Value |
 |-----------|-------|
 | Token symbol | BTH |
-| Smallest unit | nanoBTH (10⁻⁹ BTH) |
+| Internal precision | picocredits (10⁻¹² BTH) |
+| Display unit | nanoBTH (10⁻⁹ BTH) |
 | Pre-mine | None (100% mined) |
 | Phase 1 supply | ~100 million BTH |
 | Block time | 3-40 seconds (dynamic based on load) |
@@ -15,7 +16,23 @@ Botho (BTH) uses a two-phase emission model designed for long-term sustainabilit
 
 ## Unit System
 
-BTH uses a 9-decimal precision system:
+BTH uses a **two-tier precision system** for optimal balance between accuracy and usability:
+
+### Internal Precision (12 decimals)
+
+Transaction amounts use picocredits for maximum accounting precision:
+
+| Unit | Picocredits | BTH |
+|------|-------------|-----|
+| 1 picocredit | 1 | 0.000000000001 |
+| 1 nanoBTH | 1,000 | 0.000000001 |
+| 1 microBTH (µBTH) | 1,000,000 | 0.000001 |
+| 1 milliBTH (mBTH) | 1,000,000,000 | 0.001 |
+| 1 BTH | 1,000,000,000,000 | 1 |
+
+### Display Precision (9 decimals)
+
+User interfaces and fee calculations use nanoBTH for manageable numbers:
 
 | Unit | nanoBTH | BTH |
 |------|---------|-----|
@@ -23,6 +40,13 @@ BTH uses a 9-decimal precision system:
 | 1 microBTH (µBTH) | 1,000 | 0.000001 |
 | 1 milliBTH (mBTH) | 1,000,000 | 0.001 |
 | 1 BTH | 1,000,000,000 | 1 |
+
+### Why Two Tiers?
+
+- **Picocredits (10¹²)**: Used by bridge contracts, transaction amounts, and internal accounting. Provides sub-nanoBTH precision for exact calculations.
+- **NanoBTH (10⁹)**: Used for supply tracking, fee calculations, and user display. Fits in u64 for 100M+ BTH totals.
+
+**Conversion**: 1 nanoBTH = 1,000 picocredits
 
 ## Emission Schedule
 


### PR DESCRIPTION
## Summary

Standardize the BTH unit naming by documenting the two-tier precision system:
- **Picocredits (10^12)**: Internal precision for transaction amounts, bridge contracts
- **NanoBTH (10^9)**: User-facing display unit for fees, supply tracking, and UI

## Changes

- Added picocredit constants (`BTH_TO_PICOCREDITS`, `NANOBTH_TO_PICOCREDITS`, etc.) to `transaction/types/src/constants.rs`
- Added comprehensive tests verifying unit conversions and consistency
- Updated `docs/glossary.md` to correctly explain both units (removed incorrect deprecation of picocredits)
- Updated `docs/tokenomics.md` with full unit hierarchy showing both internal and display precision
- Enhanced CLI `balance` command to show amounts in BTH, nanoBTH, and picocredits

## Key Insight

The codebase uses TWO different precision levels for good reasons:
- **12 decimals (picocredits)**: Maximum precision for individual transaction amounts
- **9 decimals (nanoBTH)**: Fits 100M+ BTH in u64 for supply tracking

The conversion factor is: **1 nanoBTH = 1,000 picocredits**

## Test Plan

- [x] All existing tests pass (`cargo test --package bth-transaction-types`)
- [x] New unit conversion tests added and passing
- [x] Code compiles without new errors
- [x] Documentation updated with clear unit hierarchy

Closes #25