### PR TITLE
Revert to block-based halving with 5s block assumption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1672,6 +1672,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/botho/src/block.rs
+++ b/botho/src/block.rs
@@ -1024,7 +1024,7 @@ mod tests {
         assert_eq!(hash1, hash2);
     }
 
-    // Note: Tests for block-height-based halving (calculate_block_reward_v2) were removed.
-    // Halving is now based on transaction count via EmissionController.
-    // See difficulty::EmissionController tests for tx-based halving tests.
+    // Note: Block reward calculation uses calculate_block_reward() which is based on
+    // block height via MonetaryPolicy (5s block assumption). Tests for the halving
+    // schedule are in the monetary.rs and validation.rs test modules.
 }

--- a/botho/src/consensus/validation.rs
+++ b/botho/src/consensus/validation.rs
@@ -6,7 +6,7 @@
 //! - Minting transactions (PoW-based coinbase rewards)
 //! - Transfer transactions (UTXO-based value transfers)
 
-use crate::block::{calculate_block_reward_v2, MintingTx};
+use crate::block::MintingTx;
 use crate::ledger::ChainState;
 use crate::transaction::Transaction;
 #[cfg(feature = "pq")]
@@ -153,8 +153,10 @@ impl TransactionValidator {
             return Err(ValidationError::WrongDifficulty);
         }
 
-        // 4. Check reward matches Two-Phase emission schedule
-        let expected_reward = calculate_block_reward_v2(tx.block_height, state.total_mined);
+        // 4. Check reward matches tx-based emission schedule
+        // The expected reward comes from EmissionController's current_reward,
+        // which is based on cumulative transaction count (tx-based halving).
+        let expected_reward = state.current_reward;
         if tx.reward != expected_reward {
             warn!(
                 expected = expected_reward,

--- a/botho/src/consensus/validation.rs
+++ b/botho/src/consensus/validation.rs
@@ -6,7 +6,7 @@
 //! - Minting transactions (PoW-based coinbase rewards)
 //! - Transfer transactions (UTXO-based value transfers)
 
-use crate::block::MintingTx;
+use crate::block::{calculate_block_reward, MintingTx};
 use crate::ledger::ChainState;
 use crate::transaction::Transaction;
 #[cfg(feature = "pq")]
@@ -153,10 +153,10 @@ impl TransactionValidator {
             return Err(ValidationError::WrongDifficulty);
         }
 
-        // 4. Check reward matches tx-based emission schedule
-        // The expected reward comes from EmissionController's current_reward,
-        // which is based on cumulative transaction count (tx-based halving).
-        let expected_reward = state.current_reward;
+        // 4. Check reward matches block-based emission schedule
+        // Block reward is calculated from height and total supply using
+        // MonetaryPolicy with 5s block assumption.
+        let expected_reward = calculate_block_reward(tx.block_height, state.total_mined);
         if tx.reward != expected_reward {
             warn!(
                 expected = expected_reward,

--- a/docs/monetary-policy.md
+++ b/docs/monetary-policy.md
@@ -17,6 +17,18 @@ The key insight is that **block production and emission are decoupled**:
 
 This separation allows precise monetary targeting without affecting transaction throughput.
 
+### Transaction-Based Halving (Implementation)
+
+> **Note**: The halving schedule is tied to **cumulative transaction count**, not block height.
+> This ties the monetary schedule to network adoption rather than wall-clock time.
+>
+> - Halving occurs every 10 million transactions (`HALVING_TX_INTERVAL`)
+> - 5 halvings total before tail emission (~50M transactions)
+> - See `block.rs::difficulty::EmissionController` for the authoritative implementation
+>
+> The block-height-based schedule in this document is for approximate timing reference only.
+> The actual halving trigger is transaction count, managed by `EmissionController`.
+
 ## The Economic Loop
 
 ```

--- a/docs/monetary-policy.md
+++ b/docs/monetary-policy.md
@@ -17,17 +17,26 @@ The key insight is that **block production and emission are decoupled**:
 
 This separation allows precise monetary targeting without affecting transaction throughput.
 
-### Transaction-Based Halving (Implementation)
+### Block-Based Halving (Design Decision)
 
-> **Note**: The halving schedule is tied to **cumulative transaction count**, not block height.
-> This ties the monetary schedule to network adoption rather than wall-clock time.
+> **Block-Based Monetary Schedule**: The halving schedule is tied to **block height**,
+> using a 5-second block assumption for monetary calculations.
 >
-> - Halving occurs every 10 million transactions (`HALVING_TX_INTERVAL`)
-> - 5 halvings total before tail emission (~50M transactions)
-> - See `block.rs::difficulty::EmissionController` for the authoritative implementation
+> - Halving occurs every 12,614,400 blocks (~2 years at 5s blocks)
+> - 5 halvings total before tail emission (~10 years at 5s blocks)
+> - See `monetary.rs::mainnet_policy()` for the authoritative implementation
 >
-> The block-height-based schedule in this document is for approximate timing reference only.
-> The actual halving trigger is transaction count, managed by `EmissionController`.
+> **Adaptive Inflation**: Since actual block times vary (5-40s based on network load),
+> effective inflation scales with network activity:
+>
+> | Block Time | Effective Inflation | Halving Period |
+> |------------|--------------------:|---------------:|
+> | 5s (high load) | 2.0%/year | 2 years |
+> | 20s (normal) | 0.5%/year | 8 years |
+> | 40s (idle) | 0.25%/year | 16 years |
+>
+> This creates a natural inflation dampener: busy network = full inflation,
+> idle network = reduced inflation.
 
 ## The Economic Loop
 


### PR DESCRIPTION
## Summary

This PR reverts from tx-based halving to block-height-based halving, using a 5-second block assumption for all monetary calculations.

### Key Changes
- Update `MonetaryPolicy` to use 5s block time (`mainnet_policy`, `testnet_policy`)
- Restore `calculate_block_reward()` function using block height
- Revert minter and validation to use `calculate_block_reward()`
- Remove `current_reward` from `MintingWork` (now calculated from height)
- Simplify `EmissionController` to focus on difficulty adjustment only
- Update `phase()` method to use u128 for overflow-safe calculations
- Update documentation to reflect block-based design

### Design Rationale
Block-based halving with 5s assumption is simpler than tx-based and creates a natural inflation dampener:

| Block Time | Effective Inflation | Halving Period |
|------------|--------------------:|---------------:|
| 5s (high load) | 2.0%/year | 2 years |
| 20s (normal) | 0.5%/year | 8 years |
| 40s (idle) | 0.25%/year | 16 years |

Fee burn compensation is handled by difficulty adjustment, not the halving schedule.

## Test plan
- [x] All 241 library tests pass
- [x] Build succeeds without errors
- [x] Documentation updated

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)