### PR TITLE
Add Prometheus metrics endpoint for node monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.3",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -1427,6 +1427,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
+ "lazy_static",
  "libp2p",
  "num_cpus",
  "opentelemetry",
@@ -5666,6 +5667,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -7086,7 +7093,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -7289,6 +7296,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.10.0",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.10.0",
+ "hex",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7297,8 +7327,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot",
+ "procfs",
  "protobuf",
  "thiserror 1.0.69",
 ]
@@ -8071,6 +8103,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -8078,7 +8123,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -9549,7 +9594,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -99,8 +99,9 @@ tokio-tungstenite = "0.24"
 sha1 = "0.10"
 base64 = "0.22"
 
-# Observability
-prometheus = "0.13"
+# Metrics
+prometheus = { version = "0.13", features = ["process"] }
+lazy_static = "1.4"
 
 # For SCP simulation
 crossbeam-channel = "0.5"

--- a/botho/src/main.rs
+++ b/botho/src/main.rs
@@ -57,6 +57,10 @@ enum Commands {
         /// Enable minting
         #[arg(long)]
         mint: bool,
+
+        /// Port for Prometheus metrics endpoint (overrides config, 0 to disable)
+        #[arg(long)]
+        metrics_port: Option<u16>,
     },
 
     /// Show node and wallet status
@@ -148,8 +152,8 @@ fn main() -> Result<()> {
         Commands::Init { recover, relay } => {
             commands::init::run(&config_path, recover, relay, network)
         }
-        Commands::Run { mint } => {
-            commands::run::run(&config_path, mint)
+        Commands::Run { mint, metrics_port } => {
+            commands::run::run(&config_path, mint, metrics_port)
         }
         Commands::Status => {
             commands::status::run(&config_path)

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -12,7 +12,7 @@ pub mod websocket;
 
 pub use auth::{ApiKeyConfig, ApiPermissions, AuthError, HmacAuthenticator};
 pub use deposit_scanner::{DepositScanner, ScanResult};
-pub use metrics::{check_health, check_ready, HealthResponse, HealthStatus, NodeMetrics, ReadyResponse};
+pub use metrics::{check_health, check_ready, HealthResponse, HealthStatus, NodeMetrics, ReadyResponse, init_metrics, start_metrics_server, MetricsUpdater};
 pub use rate_limit::{KeyTier, RateLimitInfo, RateLimiter};
 pub use view_keys::{RegistryError, ViewKeyInfo, ViewKeyRegistry};
 pub use websocket::WsBroadcaster;


### PR DESCRIPTION
## Summary

- Adds Prometheus-compatible metrics endpoint at `/metrics` for node monitoring and observability
- Exposes key operational metrics (gauges, histograms, counters) for peer count, mempool, block height, TPS, minting status, validation latency, and more
- Configurable via `network.metrics_port` in config.toml or `--metrics-port` CLI flag
- Default ports: 9090 (mainnet), 19090 (testnet); set to 0 to disable

## Test plan

- [x] `cargo build -p botho` compiles successfully
- [x] `cargo test -p botho --lib -- metrics` - all 4 unit tests pass
- [x] `cargo test -p botho --lib -- config` - all 11 config tests pass
- [ ] Manual verification: start node and verify `curl http://localhost:19090/metrics` returns Prometheus-format metrics

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)