### PR TITLE
feat(rpc): Add /health and /ready endpoints for load balancer integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "dirs 5.0.1",
  "futures",
  "hex",
+ "libc",
  "rand 0.8.5",
  "reqwest",
  "rpassword",

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -12,7 +12,7 @@ pub mod websocket;
 
 pub use auth::{ApiKeyConfig, ApiPermissions, AuthError, HmacAuthenticator};
 pub use deposit_scanner::{DepositScanner, ScanResult};
-pub use metrics::{check_health, check_ready, HealthResponse, HealthStatus, NodeMetrics};
+pub use metrics::{check_health, check_ready, HealthResponse, HealthStatus, NodeMetrics, ReadyResponse};
 pub use rate_limit::{KeyTier, RateLimitInfo, RateLimiter};
 pub use view_keys::{RegistryError, ViewKeyInfo, ViewKeyRegistry};
 pub use websocket::WsBroadcaster;
@@ -313,13 +313,14 @@ async fn handle_request(
                 ));
             }
             "/ready" => {
-                let is_ready = check_ready(&state);
+                let ready_response = check_ready(&state);
+                let is_ready = ready_response.status == "ready";
                 let status = if is_ready {
                     StatusCode::OK
                 } else {
                     StatusCode::SERVICE_UNAVAILABLE
                 };
-                let body = serde_json::to_string(&json!({ "ready": is_ready })).unwrap_or_default();
+                let body = serde_json::to_string(&ready_response).unwrap_or_default();
                 return Ok(cors_response(
                     Response::builder()
                         .status(status)


### PR DESCRIPTION
## Summary

- Standardizes `/health` endpoint response format with `{status, uptime_seconds}`
- Standardizes `/ready` endpoint response format with `{status, synced, peers, block_height}`  
- Returns 503 SERVICE_UNAVAILABLE when node is not ready (not synced or no peers)
- Adds comprehensive unit tests for response format validation

## Test plan

- [x] Unit tests pass for HealthResponse serialization
- [x] Unit tests pass for ReadyResponse serialization (ready and not_ready states)
- [ ] Manual verification with curl after node startup
- [ ] Kubernetes/load balancer probe compatibility

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)