### PR TITLE
feat(botho): add botho-testnet binary for local multi-node testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "libp2p",
+ "nix 0.29.0",
  "num_cpus",
  "parking_lot",
  "prometheus",
@@ -1403,6 +1404,7 @@ dependencies = [
  "toml 0.9.10+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
+ "which",
  "zeroize",
 ]
 
@@ -1473,6 +1475,7 @@ dependencies = [
  "dirs 5.0.1",
  "futures",
  "hex",
+ "libc",
  "rand 0.8.5",
  "reqwest",
  "rpassword",
@@ -3489,6 +3492,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -6013,6 +6022,18 @@ checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -10387,6 +10408,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11022,6 +11055,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -21,6 +21,10 @@ path = "src/main.rs"
 name = "scp_sim"
 path = "src/bin/scp_sim.rs"
 
+[[bin]]
+name = "botho-testnet"
+path = "src/bin/botho_testnet.rs"
+
 [dependencies]
 # CLI
 clap = { version = "4", features = ["derive"] }
@@ -105,6 +109,12 @@ dashmap = "6"
 # Connection rate limiting
 parking_lot = "0.12"
 
+# For botho-testnet harness
+chrono = "0.4"
+nix = { version = "0.29", features = ["signal"] }
+which = "7"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking"] }
+
 [build-dependencies]
 chrono = "0.4"
 
@@ -112,5 +122,4 @@ chrono = "0.4"
 tempfile = "3"
 botho-wallet = { path = "../botho-wallet" }
 bth-transaction-core = { path = "../transaction/core", features = ["pq"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 futures = "0.3"

--- a/botho/src/bin/botho_testnet.rs
+++ b/botho/src/bin/botho_testnet.rs
@@ -1,0 +1,913 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Local Testnet Harness
+//!
+//! This tool spawns and manages a local multi-node Botho network for testing.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Start a 5-node local testnet
+//! cargo run --release --bin botho-testnet -- start --nodes 5
+//!
+//! # Check status of running nodes
+//! cargo run --release --bin botho-testnet -- status
+//!
+//! # Send test transaction between nodes
+//! cargo run --release --bin botho-testnet -- send --from 0 --to 1 --amount 100
+//!
+//! # Stop all nodes
+//! cargo run --release --bin botho-testnet -- stop
+//! ```
+//!
+//! # Architecture
+//!
+//! The testnet harness spawns N independent botho node processes, each with:
+//! - Unique gossip and RPC ports (base_port + N, base_port + 100 + N)
+//! - Isolated ledger directory (/tmp/botho-testnet/node-N/)
+//! - Pre-funded wallet from deterministic seed
+//! - Auto-configured quorum set for BFT consensus
+//!
+//! All nodes connect to each other via localhost bootstrap peers.
+
+use std::{
+    fs::{self, File},
+    net::TcpStream,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use anyhow::{anyhow, Context, Result};
+use bip39::{Language, Mnemonic};
+use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// Base directory for testnet data
+const TESTNET_DIR: &str = "/tmp/botho-testnet";
+
+/// Default number of nodes
+const DEFAULT_NODES: usize = 5;
+
+/// Default base port for gossip
+const DEFAULT_BASE_PORT: u16 = 27100;
+
+/// RPC port offset from gossip port
+const RPC_PORT_OFFSET: u16 = 100;
+
+/// Timeout for node startup (seconds)
+const STARTUP_TIMEOUT_SECS: u64 = 30;
+
+/// Timeout for RPC requests (seconds)
+const RPC_TIMEOUT_SECS: u64 = 10;
+
+#[derive(Parser)]
+#[command(name = "botho-testnet")]
+#[command(about = "Local multi-node testnet harness for Botho")]
+struct Args {
+    #[command(subcommand)]
+    command: Commands,
+
+    /// Enable verbose output
+    #[arg(short, long, global = true)]
+    verbose: bool,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Start a local testnet with N nodes
+    Start {
+        /// Number of nodes to spawn (2-10)
+        #[arg(short, long, default_value_t = DEFAULT_NODES)]
+        nodes: usize,
+
+        /// Base port for gossip connections (RPC = base + 100)
+        #[arg(long, default_value_t = DEFAULT_BASE_PORT)]
+        base_port: u16,
+
+        /// Clean existing data before starting
+        #[arg(long)]
+        clean: bool,
+
+        /// Wait for consensus before returning
+        #[arg(long)]
+        wait_consensus: bool,
+    },
+
+    /// Stop all running testnet nodes
+    Stop,
+
+    /// Show status of testnet nodes
+    Status,
+
+    /// Send a test transaction between nodes
+    Send {
+        /// Source node index (0-based)
+        #[arg(long)]
+        from: usize,
+
+        /// Destination node index (0-based)
+        #[arg(long)]
+        to: usize,
+
+        /// Amount to send in BTH
+        #[arg(long)]
+        amount: u64,
+    },
+
+    /// Kill a specific node (for chaos testing)
+    KillNode {
+        /// Node index to kill (0-based)
+        #[arg(long)]
+        node: usize,
+    },
+
+    /// Restart a killed node
+    RestartNode {
+        /// Node index to restart (0-based)
+        #[arg(long)]
+        node: usize,
+    },
+
+    /// Clean all testnet data
+    Clean,
+}
+
+/// Testnet state persisted to disk
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TestnetState {
+    /// Number of nodes
+    node_count: usize,
+    /// Base gossip port
+    base_port: u16,
+    /// Node configurations
+    nodes: Vec<NodeState>,
+    /// Timestamp when started
+    started_at: String,
+}
+
+/// Per-node state
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct NodeState {
+    /// Node index
+    index: usize,
+    /// Gossip port
+    gossip_port: u16,
+    /// RPC port
+    rpc_port: u16,
+    /// Data directory
+    data_dir: PathBuf,
+    /// PID file path
+    pid_file: PathBuf,
+    /// Log file path
+    log_file: PathBuf,
+    /// Node's public address (for receiving funds)
+    address: Option<String>,
+}
+
+impl TestnetState {
+    fn state_file() -> PathBuf {
+        PathBuf::from(TESTNET_DIR).join("state.json")
+    }
+
+    fn load() -> Result<Option<Self>> {
+        let path = Self::state_file();
+        if !path.exists() {
+            return Ok(None);
+        }
+        let contents = fs::read_to_string(&path)?;
+        Ok(Some(serde_json::from_str(&contents)?))
+    }
+
+    fn save(&self) -> Result<()> {
+        let path = Self::state_file();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let contents = serde_json::to_string_pretty(self)?;
+        fs::write(&path, contents)?;
+        Ok(())
+    }
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    match args.command {
+        Commands::Start {
+            nodes,
+            base_port,
+            clean,
+            wait_consensus,
+        } => cmd_start(nodes, base_port, clean, wait_consensus, args.verbose),
+        Commands::Stop => cmd_stop(args.verbose),
+        Commands::Status => cmd_status(args.verbose),
+        Commands::Send { from, to, amount } => cmd_send(from, to, amount, args.verbose),
+        Commands::KillNode { node } => cmd_kill_node(node, args.verbose),
+        Commands::RestartNode { node } => cmd_restart_node(node, args.verbose),
+        Commands::Clean => cmd_clean(args.verbose),
+    }
+}
+
+/// Start the testnet
+fn cmd_start(
+    node_count: usize,
+    base_port: u16,
+    clean: bool,
+    wait_consensus: bool,
+    verbose: bool,
+) -> Result<()> {
+    // Validate node count
+    if !(2..=10).contains(&node_count) {
+        return Err(anyhow!("Node count must be between 2 and 10"));
+    }
+
+    // Check for existing testnet
+    if let Some(state) = TestnetState::load()? {
+        // Check if any nodes are still running
+        let running = state
+            .nodes
+            .iter()
+            .filter(|n| is_node_running(n))
+            .count();
+        if running > 0 {
+            return Err(anyhow!(
+                "Testnet already running with {} nodes. Use 'stop' first.",
+                running
+            ));
+        }
+    }
+
+    // Clean if requested
+    if clean {
+        cmd_clean(verbose)?;
+    }
+
+    println!("Starting {} node testnet...", node_count);
+    println!("  Base port: {} (gossip), {} (RPC)", base_port, base_port + RPC_PORT_OFFSET);
+    println!("  Data dir: {}", TESTNET_DIR);
+
+    // Create testnet directory
+    fs::create_dir_all(TESTNET_DIR)?;
+
+    // Generate node configurations
+    let mut nodes = Vec::with_capacity(node_count);
+    for i in 0..node_count {
+        let gossip_port = base_port + i as u16;
+        let rpc_port = base_port + RPC_PORT_OFFSET + i as u16;
+        let data_dir = PathBuf::from(TESTNET_DIR).join(format!("node-{}", i));
+
+        nodes.push(NodeState {
+            index: i,
+            gossip_port,
+            rpc_port,
+            data_dir: data_dir.clone(),
+            pid_file: data_dir.join("botho.pid"),
+            log_file: data_dir.join("botho.log"),
+            address: None,
+        });
+    }
+
+    // Initialize and start each node
+    let mut children: Vec<Child> = Vec::new();
+
+    for i in 0..nodes.len() {
+        let node = &nodes[i];
+        println!("\n[Node {}] Initializing...", node.index);
+
+        // Create node data directory
+        fs::create_dir_all(&node.data_dir)?;
+
+        // Generate deterministic mnemonic for this node
+        let mnemonic = generate_deterministic_mnemonic(node.index)?;
+
+        // Create config file
+        let config = create_node_config(node, &nodes, &mnemonic)?;
+        let config_path = node.data_dir.join("config.toml");
+        fs::write(&config_path, config)?;
+
+        if verbose {
+            println!("  Config: {}", config_path.display());
+            println!("  Gossip: {}, RPC: {}", node.gossip_port, node.rpc_port);
+        }
+
+        // Start the node process
+        let child = start_node_process(node, &config_path, verbose)?;
+        let pid = child.id();
+
+        // Save PID
+        fs::write(&node.pid_file, pid.to_string())?;
+
+        children.push(child);
+        println!("[Node {}] Started (PID: {})", node.index, pid);
+    }
+
+    // Wait for nodes to be ready
+    println!("\nWaiting for nodes to initialize...");
+    let start = Instant::now();
+    let mut ready_count = 0;
+
+    while start.elapsed().as_secs() < STARTUP_TIMEOUT_SECS {
+        ready_count = 0;
+        for node in &nodes {
+            if check_node_rpc(node) {
+                ready_count += 1;
+            }
+        }
+        if ready_count == node_count {
+            break;
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+
+    if ready_count < node_count {
+        println!(
+            "Warning: Only {}/{} nodes responded to RPC within timeout",
+            ready_count, node_count
+        );
+    } else {
+        println!("All {} nodes ready!", node_count);
+    }
+
+    // Get addresses for each node
+    for node in &mut nodes {
+        if let Ok(addr) = get_node_address(node) {
+            node.address = Some(addr.clone());
+            if verbose {
+                println!("[Node {}] Address: {}", node.index, addr);
+            }
+        }
+    }
+
+    // Save state
+    let state = TestnetState {
+        node_count,
+        base_port,
+        nodes: nodes.clone(),
+        started_at: chrono::Utc::now().to_rfc3339(),
+    };
+    state.save()?;
+
+    // Wait for consensus if requested
+    if wait_consensus {
+        println!("\nWaiting for consensus...");
+        wait_for_consensus(&nodes, STARTUP_TIMEOUT_SECS)?;
+    }
+
+    println!("\nTestnet started successfully!");
+    println!("\nUseful commands:");
+    println!("  botho-testnet status              # Check node status");
+    println!("  botho-testnet send --from 0 --to 1 --amount 100");
+    println!("  botho-testnet stop                # Stop all nodes");
+
+    Ok(())
+}
+
+/// Stop all testnet nodes
+fn cmd_stop(verbose: bool) -> Result<()> {
+    let state = TestnetState::load()?.ok_or_else(|| anyhow!("No testnet state found"))?;
+
+    println!("Stopping {} nodes...", state.nodes.len());
+
+    for node in &state.nodes {
+        if let Some(pid) = read_pid(&node.pid_file) {
+            if verbose {
+                println!("[Node {}] Sending SIGTERM to PID {}", node.index, pid);
+            }
+
+            // Send SIGTERM
+            #[cfg(unix)]
+            {
+                use nix::sys::signal::{kill, Signal};
+                use nix::unistd::Pid;
+                let _ = kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
+            }
+
+            #[cfg(not(unix))]
+            {
+                // On non-Unix, try to kill via taskkill
+                let _ = Command::new("taskkill")
+                    .args(["/PID", &pid.to_string(), "/F"])
+                    .output();
+            }
+        }
+    }
+
+    // Wait a moment for graceful shutdown
+    thread::sleep(Duration::from_secs(2));
+
+    // Force kill any remaining
+    for node in &state.nodes {
+        if let Some(pid) = read_pid(&node.pid_file) {
+            if is_process_running(pid) {
+                if verbose {
+                    println!("[Node {}] Force killing PID {}", node.index, pid);
+                }
+                #[cfg(unix)]
+                {
+                    use nix::sys::signal::{kill, Signal};
+                    use nix::unistd::Pid;
+                    let _ = kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
+                }
+            }
+        }
+        // Clean up PID file
+        let _ = fs::remove_file(&node.pid_file);
+    }
+
+    println!("All nodes stopped.");
+    Ok(())
+}
+
+/// Show testnet status
+fn cmd_status(verbose: bool) -> Result<()> {
+    let state = TestnetState::load()?;
+
+    match state {
+        None => {
+            println!("No testnet running.");
+            println!("Use 'botho-testnet start' to create one.");
+            return Ok(());
+        }
+        Some(state) => {
+            println!("Testnet Status");
+            println!("==============");
+            println!("Started: {}", state.started_at);
+            println!("Nodes: {}", state.node_count);
+            println!("Base port: {}", state.base_port);
+            println!();
+
+            for node in &state.nodes {
+                let running = is_node_running(node);
+                let rpc_ok = if running { check_node_rpc(node) } else { false };
+
+                let status = if running && rpc_ok {
+                    "✓ Running"
+                } else if running {
+                    "⚠ Running (RPC unresponsive)"
+                } else {
+                    "✗ Stopped"
+                };
+
+                println!(
+                    "[Node {}] {} (gossip:{}, rpc:{})",
+                    node.index, status, node.gossip_port, node.rpc_port
+                );
+
+                if verbose {
+                    if let Some(addr) = &node.address {
+                        println!("         Address: {}", addr);
+                    }
+                    if let Some(pid) = read_pid(&node.pid_file) {
+                        println!("         PID: {}", pid);
+                    }
+
+                    // Try to get block height
+                    if rpc_ok {
+                        if let Ok(height) = get_block_height(node) {
+                            println!("         Block height: {}", height);
+                        }
+                    }
+                }
+            }
+
+            // Show consensus status
+            println!();
+            let running_count = state.nodes.iter().filter(|n| is_node_running(n)).count();
+            let quorum_threshold = (state.node_count + 1) / 2 + 1; // BFT threshold
+            if running_count >= quorum_threshold {
+                println!(
+                    "Quorum: {}/{} nodes running (threshold: {})",
+                    running_count, state.node_count, quorum_threshold
+                );
+            } else {
+                println!(
+                    "Warning: Only {}/{} nodes running, need {} for quorum",
+                    running_count, state.node_count, quorum_threshold
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Send a test transaction
+fn cmd_send(from: usize, to: usize, amount: u64, verbose: bool) -> Result<()> {
+    let state = TestnetState::load()?.ok_or_else(|| anyhow!("No testnet running"))?;
+
+    if from >= state.nodes.len() {
+        return Err(anyhow!("Invalid 'from' node index: {}", from));
+    }
+    if to >= state.nodes.len() {
+        return Err(anyhow!("Invalid 'to' node index: {}", to));
+    }
+    if from == to {
+        return Err(anyhow!("Cannot send to same node"));
+    }
+
+    let from_node = &state.nodes[from];
+    let to_node = &state.nodes[to];
+
+    // Get destination address
+    let to_address = to_node
+        .address
+        .as_ref()
+        .ok_or_else(|| anyhow!("Node {} has no address", to))?;
+
+    println!(
+        "Sending {} BTH from node {} to node {}...",
+        amount, from, to
+    );
+    if verbose {
+        println!("  To address: {}", to_address);
+    }
+
+    // Make RPC call to send
+    let rpc_url = format!("http://127.0.0.1:{}", from_node.rpc_port);
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "send_transaction",
+        "params": {
+            "to": to_address,
+            "amount": amount,
+            "private": false
+        }
+    });
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(RPC_TIMEOUT_SECS))
+        .build()?;
+
+    let response = client.post(&rpc_url).json(&request).send()?;
+
+    if response.status().is_success() {
+        let result: serde_json::Value = response.json()?;
+        if let Some(tx_hash) = result.get("result").and_then(|r| r.get("tx_hash")) {
+            println!("Transaction submitted: {}", tx_hash);
+        } else if let Some(error) = result.get("error") {
+            return Err(anyhow!("RPC error: {}", error));
+        } else {
+            println!("Transaction submitted successfully");
+        }
+    } else {
+        return Err(anyhow!("RPC request failed: {}", response.status()));
+    }
+
+    Ok(())
+}
+
+/// Kill a specific node (for chaos testing)
+fn cmd_kill_node(node_idx: usize, verbose: bool) -> Result<()> {
+    let state = TestnetState::load()?.ok_or_else(|| anyhow!("No testnet running"))?;
+
+    if node_idx >= state.nodes.len() {
+        return Err(anyhow!("Invalid node index: {}", node_idx));
+    }
+
+    let node = &state.nodes[node_idx];
+    if let Some(pid) = read_pid(&node.pid_file) {
+        if verbose {
+            println!("Killing node {} (PID: {})", node_idx, pid);
+        }
+
+        #[cfg(unix)]
+        {
+            use nix::sys::signal::{kill, Signal};
+            use nix::unistd::Pid;
+            kill(Pid::from_raw(pid as i32), Signal::SIGKILL)?;
+        }
+
+        // Remove PID file
+        let _ = fs::remove_file(&node.pid_file);
+        println!("Node {} killed", node_idx);
+    } else {
+        println!("Node {} is not running", node_idx);
+    }
+
+    Ok(())
+}
+
+/// Restart a killed node
+fn cmd_restart_node(node_idx: usize, verbose: bool) -> Result<()> {
+    let mut state = TestnetState::load()?.ok_or_else(|| anyhow!("No testnet running"))?;
+
+    if node_idx >= state.nodes.len() {
+        return Err(anyhow!("Invalid node index: {}", node_idx));
+    }
+
+    let node = &state.nodes[node_idx];
+    if is_node_running(node) {
+        return Err(anyhow!("Node {} is already running", node_idx));
+    }
+
+    let config_path = node.data_dir.join("config.toml");
+    if !config_path.exists() {
+        return Err(anyhow!(
+            "Config not found for node {}. Was it initialized?",
+            node_idx
+        ));
+    }
+
+    println!("Restarting node {}...", node_idx);
+
+    let child = start_node_process(node, &config_path, verbose)?;
+    let pid = child.id();
+
+    // Save PID
+    fs::write(&node.pid_file, pid.to_string())?;
+
+    // Wait for node to be ready
+    let start = Instant::now();
+    while start.elapsed().as_secs() < STARTUP_TIMEOUT_SECS {
+        if check_node_rpc(node) {
+            break;
+        }
+        thread::sleep(Duration::from_millis(500));
+    }
+
+    if check_node_rpc(node) {
+        println!("Node {} restarted (PID: {})", node_idx, pid);
+
+        // Update address if needed
+        if let Ok(addr) = get_node_address(node) {
+            state.nodes[node_idx].address = Some(addr);
+            state.save()?;
+        }
+    } else {
+        println!(
+            "Node {} started but RPC not responding (PID: {})",
+            node_idx, pid
+        );
+    }
+
+    Ok(())
+}
+
+/// Clean all testnet data
+fn cmd_clean(verbose: bool) -> Result<()> {
+    // First stop any running nodes
+    if let Ok(Some(_)) = TestnetState::load() {
+        let _ = cmd_stop(verbose);
+    }
+
+    // Remove testnet directory
+    let testnet_dir = PathBuf::from(TESTNET_DIR);
+    if testnet_dir.exists() {
+        if verbose {
+            println!("Removing {}", testnet_dir.display());
+        }
+        fs::remove_dir_all(&testnet_dir)?;
+    }
+
+    println!("Testnet data cleaned.");
+    Ok(())
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Generate a deterministic mnemonic for a node index
+fn generate_deterministic_mnemonic(node_index: usize) -> Result<String> {
+    // Use a fixed seed phrase pattern for reproducibility
+    let seed = format!("testnet-node-{}-seed-phrase-entropy", node_index);
+    let entropy = sha256_hash(seed.as_bytes());
+
+    // Create mnemonic from entropy (first 16 bytes = 128 bits = 12 words)
+    let mnemonic = Mnemonic::from_entropy(&entropy[..16], Language::English)
+        .map_err(|e| anyhow!("Failed to create mnemonic: {}", e))?;
+
+    Ok(mnemonic.phrase().to_string())
+}
+
+/// Simple SHA256 hash
+fn sha256_hash(data: &[u8]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher.finalize().into()
+}
+
+/// Create node config TOML
+fn create_node_config(
+    node: &NodeState,
+    all_nodes: &[NodeState],
+    mnemonic: &str,
+) -> Result<String> {
+    // Build bootstrap peers list (all other nodes)
+    let bootstrap_peers: Vec<String> = all_nodes
+        .iter()
+        .filter(|n| n.index != node.index)
+        .map(|n| format!("/ip4/127.0.0.1/tcp/{}", n.gossip_port))
+        .collect();
+
+    // Calculate quorum threshold (BFT optimal)
+    let n = all_nodes.len();
+    let threshold = (n + 1) / 2 + 1; // ceil((n+1)/2)
+
+    let config = format!(
+        r#"# Auto-generated config for testnet node {}
+network_type = "testnet"
+
+[wallet]
+mnemonic = "{}"
+
+[network]
+gossip_port = {}
+rpc_port = {}
+cors_origins = ["*"]
+bootstrap_peers = {:?}
+max_connections_per_ip = 100
+
+[network.quorum]
+mode = "recommended"
+threshold = {}
+min_peers = 1
+
+[minting]
+enabled = true
+threads = 1
+"#,
+        node.index,
+        mnemonic,
+        node.gossip_port,
+        node.rpc_port,
+        bootstrap_peers,
+        threshold
+    );
+
+    Ok(config)
+}
+
+/// Start a node process
+fn start_node_process(node: &NodeState, config_path: &Path, verbose: bool) -> Result<Child> {
+    // Open log file
+    let log_file = File::create(&node.log_file)?;
+
+    // Find the botho binary
+    let botho_bin = find_botho_binary()?;
+
+    if verbose {
+        println!("  Using binary: {}", botho_bin.display());
+        println!("  Log file: {}", node.log_file.display());
+    }
+
+    let child = Command::new(&botho_bin)
+        .args([
+            "--testnet",
+            "--config",
+            config_path.to_str().unwrap(),
+            "run",
+            "--mint",
+        ])
+        .stdout(Stdio::from(log_file.try_clone()?))
+        .stderr(Stdio::from(log_file))
+        .spawn()
+        .with_context(|| format!("Failed to spawn botho process for node {}", node.index))?;
+
+    Ok(child)
+}
+
+/// Find the botho binary (either in target/release or target/debug)
+fn find_botho_binary() -> Result<PathBuf> {
+    // Try release first
+    let release_bin = PathBuf::from("target/release/botho");
+    if release_bin.exists() {
+        return Ok(release_bin);
+    }
+
+    // Try debug
+    let debug_bin = PathBuf::from("target/debug/botho");
+    if debug_bin.exists() {
+        return Ok(debug_bin);
+    }
+
+    // Try system PATH
+    if let Ok(path) = which::which("botho") {
+        return Ok(path);
+    }
+
+    Err(anyhow!(
+        "Could not find botho binary. Run 'cargo build --release' first."
+    ))
+}
+
+/// Read PID from file
+fn read_pid(pid_file: &Path) -> Option<u32> {
+    fs::read_to_string(pid_file)
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+}
+
+/// Check if a process is running
+fn is_process_running(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::kill;
+        use nix::unistd::Pid;
+        // Sending signal 0 checks if process exists
+        kill(Pid::from_raw(pid as i32), None).is_ok()
+    }
+
+    #[cfg(not(unix))]
+    {
+        // On Windows, try to open the process
+        false // Simplified for now
+    }
+}
+
+/// Check if a node is running
+fn is_node_running(node: &NodeState) -> bool {
+    if let Some(pid) = read_pid(&node.pid_file) {
+        is_process_running(pid)
+    } else {
+        false
+    }
+}
+
+/// Check if node RPC is responding
+fn check_node_rpc(node: &NodeState) -> bool {
+    let addr = format!("127.0.0.1:{}", node.rpc_port);
+    TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_secs(1)).is_ok()
+}
+
+/// Get block height from node RPC
+fn get_block_height(node: &NodeState) -> Result<u64> {
+    let rpc_url = format!("http://127.0.0.1:{}", node.rpc_port);
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "get_block_count",
+        "params": {}
+    });
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(RPC_TIMEOUT_SECS))
+        .build()?;
+
+    let response: serde_json::Value = client.post(&rpc_url).json(&request).send()?.json()?;
+
+    response
+        .get("result")
+        .and_then(|r| r.as_u64())
+        .ok_or_else(|| anyhow!("Invalid response"))
+}
+
+/// Get node's receiving address via RPC
+fn get_node_address(node: &NodeState) -> Result<String> {
+    let rpc_url = format!("http://127.0.0.1:{}", node.rpc_port);
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "get_address",
+        "params": {}
+    });
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(RPC_TIMEOUT_SECS))
+        .build()?;
+
+    let response: serde_json::Value = client.post(&rpc_url).json(&request).send()?.json()?;
+
+    response
+        .get("result")
+        .and_then(|r| r.get("address"))
+        .and_then(|a| a.as_str())
+        .map(String::from)
+        .ok_or_else(|| anyhow!("Could not get address from RPC"))
+}
+
+/// Wait for consensus to be achieved
+fn wait_for_consensus(nodes: &[NodeState], timeout_secs: u64) -> Result<()> {
+    let start = Instant::now();
+
+    while start.elapsed().as_secs() < timeout_secs {
+        // Check if all responsive nodes have the same block height > 0
+        let heights: Vec<u64> = nodes
+            .iter()
+            .filter_map(|n| get_block_height(n).ok())
+            .collect();
+
+        if heights.len() >= 2 && heights.iter().all(|h| *h > 0) {
+            let min = heights.iter().min().unwrap();
+            let max = heights.iter().max().unwrap();
+
+            // Allow small variance (1 block difference is OK)
+            if max - min <= 1 {
+                println!(
+                    "Consensus achieved! Block height: {}-{}",
+                    min, max
+                );
+                return Ok(());
+            }
+        }
+
+        thread::sleep(Duration::from_secs(1));
+    }
+
+    Err(anyhow!("Timeout waiting for consensus"))
+}


### PR DESCRIPTION
## Summary

Add a new `botho-testnet` binary that spawns and manages a local multi-node Botho network for testing consensus, transactions, and network behavior.

## Features

- **Multi-node spawning**: Start 2-10 nodes with unique ports and isolated ledger directories
- **Auto-configured quorum sets**: Uses BFT-optimal threshold (ceil((n+1)/2))
- **Deterministic test wallets**: Reproducible testing with seeded mnemonics
- **Process management**: PID tracking, graceful shutdown, and force kill
- **Test transactions**: Send BTH between nodes via JSON-RPC
- **Chaos testing**: Kill individual nodes and restart them
- **Status monitoring**: Show node health, RPC responsiveness, and block height

## Commands

```bash
# Start a 5-node local testnet
botho-testnet start --nodes 5

# Check status of running nodes
botho-testnet status

# Send test transaction between nodes
botho-testnet send --from 0 --to 1 --amount 100

# Kill a specific node (chaos testing)
botho-testnet kill-node --node 2

# Restart a killed node
botho-testnet restart-node --node 2

# Stop all nodes
botho-testnet stop

# Clean all testnet data
botho-testnet clean
```

## Test Plan

- [ ] `botho-testnet start --nodes 3` spawns 3 nodes with unique ports
- [ ] `botho-testnet status` shows all nodes running
- [ ] Nodes produce blocks (visible in logs or via RPC)
- [ ] `botho-testnet send --from 0 --to 1 --amount 100` completes successfully
- [ ] `botho-testnet stop` cleanly shuts down all nodes
- [ ] Ledger directories contain valid LMDB databases

Closes #34