### PR TITLE
fix: update prometheus to 0.14 to fix protobuf vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7317,22 +7317,21 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.10.0",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix 0.38.44",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.10.0",
  "hex",
@@ -7340,9 +7339,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -7352,7 +7351,7 @@ dependencies = [
  "parking_lot",
  "procfs",
  "protobuf",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7445,9 +7444,23 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "ptr_meta"
@@ -10801,7 +10814,7 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix",
+ "rustix 1.1.3",
  "winsafe",
 ]
 

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -104,7 +104,7 @@ sha1 = "0.10"
 base64 = "0.22"
 
 # Metrics
-prometheus = { version = "0.13", features = ["process"] }
+prometheus = { version = "0.14", features = ["process"] }
 lazy_static = "1.4"
 
 # For SCP simulation


### PR DESCRIPTION
## Summary

- Update prometheus from 0.13 to 0.14, which updates protobuf from 2.28.0 to 3.7.2
- Fixes RUSTSEC-2024-0437 (protobuf arbitrary code execution vulnerability)

## Changes

1. **botho/Cargo.toml**: Bump prometheus version from "0.13" to "0.14"
2. **Cargo.lock**: Updated dependencies (prometheus 0.13.4 → 0.14.0, protobuf 2.28.0 → 3.7.2)

## Test plan

- [x] `cargo build -p botho` succeeds
- [x] `cargo test -p botho --lib` passes (280 tests)
- [x] `cargo audit` shows no vulnerabilities
- [x] PR rebased on latest main - no merge conflicts

## Security Advisory

This PR addresses [RUSTSEC-2024-0437](https://rustsec.org/advisories/RUSTSEC-2024-0437) - a vulnerability in protobuf 2.x that could allow arbitrary code execution through maliciously crafted protobuf messages.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)