### PR TITLE
ci: add cargo-deny security scanning workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,39 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/security.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'deny.toml'
+      - '.github/workflows/security.yml'
+  # Allow manual trigger for on-demand security audits
+  workflow_dispatch:
+  # Run weekly to catch newly disclosed vulnerabilities
+  schedule:
+    - cron: '0 9 * * 1'  # 9 AM UTC every Monday
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+          arguments: --all-features


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to run `cargo deny check` for automated security and license scanning.

## Changes

- Add `.github/workflows/security.yml` with cargo-deny-action v2
- Workflow triggers on:
  - Push/PR to main when Cargo files or deny.toml change
  - Weekly schedule (Monday 9 AM UTC) to catch newly disclosed vulnerabilities  
  - Manual trigger via workflow_dispatch for on-demand audits

## Implementation Notes

The `deny.toml` configuration already exists (135 lines) with:
- Advisory scanning with documented RUSTSEC exceptions (Tauri/GTK transitive deps)
- License allowlist (MIT, Apache-2.0, BSD-*, GPL-3.0, etc.)
- Duplicate version warnings with skip rules
- Source restrictions (crates.io + 2 MobileCoin git repos)

This PR completes the CI integration - the only missing piece identified in the Curator review.

## Test Plan

- [ ] Workflow triggers on this PR
- [ ] `cargo deny check` passes in CI
- [ ] Workflow appears in Actions tab

Closes #22