### PR TITLE
Add real-time WebSocket updates to web dashboard

### DIFF
--- a/web/packages/adapters/src/local.ts
+++ b/web/packages/adapters/src/local.ts
@@ -11,9 +11,12 @@ import type {
 import type {
   BlockFetchOptions,
   LocalNodeConfig,
+  MempoolUpdate,
   NodeAdapter,
+  PeerStatus,
   TxHistoryOptions,
   TxSubmitResult,
+  WsConnectionStatus,
 } from './types'
 
 const DEFAULT_CONFIG: Required<LocalNodeConfig> = {
@@ -32,9 +35,13 @@ export class LocalNodeAdapter implements NodeAdapter {
   private connected = false
   private currentNode: NodeInfo | null = null
   private ws: WebSocket | null = null
+  private wsStatus: WsConnectionStatus = 'disconnected'
   private eventSource: EventSource | null = null
   private blockCallbacks: Set<(block: Block) => void> = new Set()
   private txCallbacks: Map<string, Set<(tx: Transaction) => void>> = new Map()
+  private mempoolCallbacks: Set<(update: MempoolUpdate) => void> = new Set()
+  private peerCallbacks: Set<(status: PeerStatus) => void> = new Set()
+  private wsStatusCallbacks: Set<(status: WsConnectionStatus) => void> = new Set()
 
   constructor(config: Partial<LocalNodeConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config }
@@ -77,8 +84,12 @@ export class LocalNodeAdapter implements NodeAdapter {
       this.eventSource.close()
       this.eventSource = null
     }
+    this.setWsStatus('disconnected')
     this.blockCallbacks.clear()
     this.txCallbacks.clear()
+    this.mempoolCallbacks.clear()
+    this.peerCallbacks.clear()
+    this.wsStatusCallbacks.clear()
   }
 
   isConnected(): boolean {
@@ -240,6 +251,36 @@ export class LocalNodeAdapter implements NodeAdapter {
     }
   }
 
+  onMempoolUpdate(callback: (update: MempoolUpdate) => void): () => void {
+    this.mempoolCallbacks.add(callback)
+    return () => this.mempoolCallbacks.delete(callback)
+  }
+
+  onPeerStatus(callback: (status: PeerStatus) => void): () => void {
+    this.peerCallbacks.add(callback)
+    return () => this.peerCallbacks.delete(callback)
+  }
+
+  // =========================================================================
+  // WebSocket Status
+  // =========================================================================
+
+  getWsStatus(): WsConnectionStatus {
+    return this.wsStatus
+  }
+
+  onWsStatusChange(callback: (status: WsConnectionStatus) => void): () => void {
+    this.wsStatusCallbacks.add(callback)
+    return () => this.wsStatusCallbacks.delete(callback)
+  }
+
+  private setWsStatus(status: WsConnectionStatus): void {
+    if (this.wsStatus !== status) {
+      this.wsStatus = status
+      this.wsStatusCallbacks.forEach((cb) => cb(status))
+    }
+  }
+
   // =========================================================================
   // Local-specific methods
   // =========================================================================
@@ -338,11 +379,13 @@ export class LocalNodeAdapter implements NodeAdapter {
     if (!this.currentNode) return
 
     const wsUrl = `ws://${this.currentNode.host}:${this.currentNode.port}/ws`
+    this.setWsStatus('connecting')
 
     try {
       this.ws = new WebSocket(wsUrl)
 
       this.ws.onopen = () => {
+        this.setWsStatus('connected')
         // Subscribe to all events
         this.sendWsMessage({ type: 'subscribe', events: ['blocks', 'transactions', 'mempool', 'peers', 'minting'] })
       }
@@ -359,6 +402,12 @@ export class LocalNodeAdapter implements NodeAdapter {
               this.txCallbacks.forEach((callbacks) => {
                 callbacks.forEach(cb => cb(tx))
               })
+            } else if (msg.event === 'mempool') {
+              const update = this.parseMempoolEvent(msg.data)
+              this.mempoolCallbacks.forEach(cb => cb(update))
+            } else if (msg.event === 'peers') {
+              const status = this.parsePeerEvent(msg.data)
+              this.peerCallbacks.forEach(cb => cb(status))
             }
           }
         } catch {
@@ -367,23 +416,29 @@ export class LocalNodeAdapter implements NodeAdapter {
       }
 
       this.ws.onclose = () => {
+        this.ws = null
         if (this.connected) {
+          this.setWsStatus('reconnecting')
           // Reconnect after delay
           setTimeout(() => {
             if (this.connected) {
               this.setupWebSocket()
             }
           }, 5000)
+        } else {
+          this.setWsStatus('disconnected')
         }
       }
 
       this.ws.onerror = () => {
         // WebSocket failed, fall back to SSE
         this.ws = null
+        this.setWsStatus('disconnected')
         this.setupEventSource()
       }
     } catch {
       // WebSocket not available, use SSE
+      this.setWsStatus('disconnected')
       this.setupEventSource()
     }
   }
@@ -464,6 +519,37 @@ export class LocalNodeAdapter implements NodeAdapter {
       timestamp: Date.now(),
       blockHeight: data.in_block as number | undefined,
       confirmations: data.in_block ? 1 : 0,
+    }
+  }
+
+  /** Parse mempool update from WebSocket event */
+  private parseMempoolEvent(data: Record<string, unknown>): MempoolUpdate {
+    return {
+      size: (data.size as number) || 0,
+      totalFees: BigInt((data.total_fees as number) || 0),
+    }
+  }
+
+  /** Parse peer status from WebSocket event */
+  private parsePeerEvent(data: Record<string, unknown>): PeerStatus {
+    const eventData = data.event as Record<string, unknown> | undefined
+    let event: PeerStatus['event'] = 'count_changed'
+    let peerId: string | undefined
+
+    if (eventData) {
+      if ('Connected' in eventData) {
+        event = 'connected'
+        peerId = (eventData.Connected as Record<string, unknown>)?.peer_id as string
+      } else if ('Disconnected' in eventData) {
+        event = 'disconnected'
+        peerId = (eventData.Disconnected as Record<string, unknown>)?.peer_id as string
+      }
+    }
+
+    return {
+      peerCount: (data.peer_count as number) || 0,
+      event,
+      peerId,
     }
   }
 

--- a/web/packages/adapters/src/remote.ts
+++ b/web/packages/adapters/src/remote.ts
@@ -10,10 +10,13 @@ import type {
 } from '@botho/core'
 import type {
   BlockFetchOptions,
+  MempoolUpdate,
   NodeAdapter,
+  PeerStatus,
   RemoteNodeConfig,
   TxHistoryOptions,
   TxSubmitResult,
+  WsConnectionStatus,
 } from './types'
 
 const DEFAULT_CONFIG: Required<RemoteNodeConfig> = {
@@ -49,8 +52,14 @@ export class RemoteNodeAdapter implements NodeAdapter {
   private currentNode: NodeInfo | null = null
   private currentSeedUrl: string | null = null
   private ws: WebSocket | null = null
+  private wsStatus: WsConnectionStatus = 'disconnected'
+  private wsReconnectAttempt = 0
+  private wsReconnectTimer: ReturnType<typeof setTimeout> | null = null
   private blockCallbacks: Set<(block: Block) => void> = new Set()
   private txCallbacks: Map<string, Set<(tx: Transaction) => void>> = new Map()
+  private mempoolCallbacks: Set<(update: MempoolUpdate) => void> = new Set()
+  private peerCallbacks: Set<(status: PeerStatus) => void> = new Set()
+  private wsStatusCallbacks: Set<(status: WsConnectionStatus) => void> = new Set()
   private rpcId = 0
 
   constructor(config: Partial<RemoteNodeConfig> = {}) {
@@ -101,12 +110,20 @@ export class RemoteNodeAdapter implements NodeAdapter {
     this.connected = false
     this.currentNode = null
     this.currentSeedUrl = null
+    if (this.wsReconnectTimer) {
+      clearTimeout(this.wsReconnectTimer)
+      this.wsReconnectTimer = null
+    }
     if (this.ws) {
       this.ws.close()
       this.ws = null
     }
+    this.setWsStatus('disconnected')
     this.blockCallbacks.clear()
     this.txCallbacks.clear()
+    this.mempoolCallbacks.clear()
+    this.peerCallbacks.clear()
+    this.wsStatusCallbacks.clear()
   }
 
   isConnected(): boolean {
@@ -322,9 +339,39 @@ export class RemoteNodeAdapter implements NodeAdapter {
     }
   }
 
+  onMempoolUpdate(callback: (update: MempoolUpdate) => void): () => void {
+    this.mempoolCallbacks.add(callback)
+    return () => this.mempoolCallbacks.delete(callback)
+  }
+
+  onPeerStatus(callback: (status: PeerStatus) => void): () => void {
+    this.peerCallbacks.add(callback)
+    return () => this.peerCallbacks.delete(callback)
+  }
+
+  // =========================================================================
+  // WebSocket Status
+  // =========================================================================
+
+  getWsStatus(): WsConnectionStatus {
+    return this.wsStatus
+  }
+
+  onWsStatusChange(callback: (status: WsConnectionStatus) => void): () => void {
+    this.wsStatusCallbacks.add(callback)
+    return () => this.wsStatusCallbacks.delete(callback)
+  }
+
   // =========================================================================
   // Private Helpers
   // =========================================================================
+
+  private setWsStatus(status: WsConnectionStatus): void {
+    if (this.wsStatus !== status) {
+      this.wsStatus = status
+      this.wsStatusCallbacks.forEach((cb) => cb(status))
+    }
+  }
 
   private async rpcCall<T>(
     baseUrl: string,
@@ -374,12 +421,21 @@ export class RemoteNodeAdapter implements NodeAdapter {
     // Connect to node WebSocket endpoint for real-time events
     const wsUrl = seedUrl.replace(/^http/, 'ws') + '/ws'
 
+    this.setWsStatus(this.wsReconnectAttempt > 0 ? 'reconnecting' : 'connecting')
+
     try {
       this.ws = new WebSocket(wsUrl)
 
       this.ws.onopen = () => {
-        // Subscribe to block events by default
-        this.sendWsMessage({ type: 'subscribe', events: ['blocks', 'transactions'] })
+        // Reset reconnection state on successful connection
+        this.wsReconnectAttempt = 0
+        this.setWsStatus('connected')
+
+        // Subscribe to all event types
+        this.sendWsMessage({
+          type: 'subscribe',
+          events: ['blocks', 'transactions', 'mempool', 'peers']
+        })
       }
 
       this.ws.onmessage = (event) => {
@@ -395,6 +451,12 @@ export class RemoteNodeAdapter implements NodeAdapter {
               this.txCallbacks.forEach((callbacks) => {
                 callbacks.forEach((cb) => cb(tx))
               })
+            } else if (msg.event === 'mempool') {
+              const update = this.parseMempoolEvent(msg.data)
+              this.mempoolCallbacks.forEach((cb) => cb(update))
+            } else if (msg.event === 'peers') {
+              const status = this.parsePeerEvent(msg.data)
+              this.peerCallbacks.forEach((cb) => cb(status))
             }
           } else if (msg.type === 'subscribed') {
             // Subscription confirmed
@@ -406,23 +468,38 @@ export class RemoteNodeAdapter implements NodeAdapter {
       }
 
       this.ws.onclose = () => {
+        this.ws = null
         if (this.connected) {
-          // Exponential backoff reconnection
-          setTimeout(() => {
+          this.setWsStatus('reconnecting')
+          // Exponential backoff with jitter for reconnection
+          // Base delay: 1s, max delay: 30s
+          const baseDelay = 1000
+          const maxDelay = 30000
+          const delay = Math.min(baseDelay * Math.pow(2, this.wsReconnectAttempt), maxDelay)
+          // Add jitter (±25%)
+          const jitter = delay * 0.25 * (Math.random() * 2 - 1)
+          const finalDelay = Math.round(delay + jitter)
+
+          this.wsReconnectAttempt++
+          this.wsReconnectTimer = setTimeout(() => {
+            this.wsReconnectTimer = null
             if (this.connected) {
               this.setupWebSocket(seedUrl)
             }
-          }, 5000)
+          }, finalDelay)
+        } else {
+          this.setWsStatus('disconnected')
         }
       }
 
       this.ws.onerror = () => {
-        // WebSocket not supported, fall back to polling
-        this.ws = null
+        // WebSocket error - onclose will be called next, which handles reconnection
+        // Don't set ws to null here as onclose handles cleanup
       }
     } catch {
       // WebSocket connection failed, continue without real-time updates
       this.ws = null
+      this.setWsStatus('disconnected')
     }
   }
 
@@ -458,6 +535,37 @@ export class RemoteNodeAdapter implements NodeAdapter {
       timestamp: Date.now(),
       blockHeight: data.in_block as number | undefined,
       confirmations: data.in_block ? 1 : 0,
+    }
+  }
+
+  /** Parse mempool update from WebSocket event */
+  private parseMempoolEvent(data: Record<string, unknown>): MempoolUpdate {
+    return {
+      size: (data.size as number) || 0,
+      totalFees: BigInt((data.total_fees as number) || 0),
+    }
+  }
+
+  /** Parse peer status from WebSocket event */
+  private parsePeerEvent(data: Record<string, unknown>): PeerStatus {
+    const eventData = data.event as Record<string, unknown> | undefined
+    let event: PeerStatus['event'] = 'count_changed'
+    let peerId: string | undefined
+
+    if (eventData) {
+      if ('Connected' in eventData) {
+        event = 'connected'
+        peerId = (eventData.Connected as Record<string, unknown>)?.peer_id as string
+      } else if ('Disconnected' in eventData) {
+        event = 'disconnected'
+        peerId = (eventData.Disconnected as Record<string, unknown>)?.peer_id as string
+      }
+    }
+
+    return {
+      peerCount: (data.peer_count as number) || 0,
+      event,
+      peerId,
     }
   }
 }

--- a/web/packages/adapters/src/types.ts
+++ b/web/packages/adapters/src/types.ts
@@ -10,6 +10,33 @@ import type {
 } from '@botho/core'
 
 /**
+ * WebSocket connection status
+ */
+export type WsConnectionStatus = 'connected' | 'connecting' | 'disconnected' | 'reconnecting'
+
+/**
+ * Mempool update event from WebSocket
+ */
+export interface MempoolUpdate {
+  /** Number of transactions in mempool */
+  size: number
+  /** Total fees in mempool (picocredits) */
+  totalFees: bigint
+}
+
+/**
+ * Peer status event from WebSocket
+ */
+export interface PeerStatus {
+  /** Current peer count */
+  peerCount: number
+  /** Event type */
+  event: 'connected' | 'disconnected' | 'count_changed'
+  /** Peer ID (if connect/disconnect) */
+  peerId?: string
+}
+
+/**
  * Result of submitting a transaction
  */
 export interface TxSubmitResult {
@@ -136,6 +163,30 @@ export interface NodeAdapter {
    * Subscribe to new transactions for watched addresses
    */
   onTransaction(addresses: Address[], callback: (tx: Transaction) => void): () => void
+
+  /**
+   * Subscribe to mempool updates
+   */
+  onMempoolUpdate(callback: (update: MempoolUpdate) => void): () => void
+
+  /**
+   * Subscribe to peer status changes
+   */
+  onPeerStatus(callback: (status: PeerStatus) => void): () => void
+
+  // =========================================================================
+  // WebSocket Status
+  // =========================================================================
+
+  /**
+   * Get current WebSocket connection status
+   */
+  getWsStatus(): WsConnectionStatus
+
+  /**
+   * Subscribe to WebSocket connection status changes
+   */
+  onWsStatusChange(callback: (status: WsConnectionStatus) => void): () => void
 }
 
 /**

--- a/web/packages/ui/src/components/connection-indicator.tsx
+++ b/web/packages/ui/src/components/connection-indicator.tsx
@@ -1,0 +1,67 @@
+import { cn } from '../lib/utils'
+import type { HTMLAttributes } from 'react'
+
+type ConnectionStatus = 'connected' | 'connecting' | 'disconnected' | 'reconnecting'
+
+interface ConnectionIndicatorProps extends HTMLAttributes<HTMLDivElement> {
+  status: ConnectionStatus
+  showLabel?: boolean
+}
+
+const statusConfig: Record<ConnectionStatus, { color: string; label: string; pulse: boolean }> = {
+  connected: {
+    color: 'bg-green-500',
+    label: 'Connected',
+    pulse: false,
+  },
+  connecting: {
+    color: 'bg-yellow-500',
+    label: 'Connecting...',
+    pulse: true,
+  },
+  disconnected: {
+    color: 'bg-red-500',
+    label: 'Disconnected',
+    pulse: false,
+  },
+  reconnecting: {
+    color: 'bg-yellow-500',
+    label: 'Reconnecting...',
+    pulse: true,
+  },
+}
+
+export function ConnectionIndicator({
+  status,
+  showLabel = true,
+  className,
+  ...props
+}: ConnectionIndicatorProps) {
+  const config = statusConfig[status]
+
+  return (
+    <div
+      className={cn('inline-flex items-center gap-2', className)}
+      role="status"
+      aria-label={`Connection status: ${config.label}`}
+      {...props}
+    >
+      <span className="relative flex h-2.5 w-2.5">
+        {config.pulse && (
+          <span
+            className={cn(
+              'absolute inline-flex h-full w-full animate-ping rounded-full opacity-75',
+              config.color
+            )}
+          />
+        )}
+        <span
+          className={cn('relative inline-flex h-2.5 w-2.5 rounded-full', config.color)}
+        />
+      </span>
+      {showLabel && (
+        <span className="text-xs text-[--color-ghost]">{config.label}</span>
+      )}
+    </div>
+  )
+}

--- a/web/packages/ui/src/components/index.ts
+++ b/web/packages/ui/src/components/index.ts
@@ -1,5 +1,6 @@
 export { Card, CardHeader, CardTitle, CardContent } from './card'
 export { Button } from './button'
+export { ConnectionIndicator } from './connection-indicator'
 export { Input } from './input'
 export { Logo } from './logo'
 export { Toast } from './toast'

--- a/web/packages/web-wallet/src/contexts/wallet.test.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.test.tsx
@@ -28,6 +28,12 @@ vi.mock('@botho/adapters', () => ({
     getNodeInfo = vi.fn().mockReturnValue({ version: '1.0.0', network: 'testnet' })
     getBalance = vi.fn().mockResolvedValue({ available: 1000000000000n, pending: 0n, total: 1000000000000n })
     getTransactionHistory = vi.fn().mockResolvedValue([])
+    onNewBlock = vi.fn().mockReturnValue(() => {})
+    onTransaction = vi.fn().mockReturnValue(() => {})
+    onMempoolUpdate = vi.fn().mockReturnValue(() => {})
+    onPeerStatus = vi.fn().mockReturnValue(() => {})
+    getWsStatus = vi.fn().mockReturnValue('connected')
+    onWsStatusChange = vi.fn().mockReturnValue(() => {})
   },
 }))
 


### PR DESCRIPTION
## Summary

- Extends the adapter layer with WebSocket connection status tracking and new event types (mempool, peers)
- Adds exponential backoff with jitter for reliable WebSocket reconnection
- Integrates real-time block events into WalletProvider for automatic balance/transaction refresh
- Falls back to 30-second polling when WebSocket is unavailable
- Adds a ConnectionIndicator UI component for visual status feedback

## Changes

| File | Description |
|------|-------------|
| `web/packages/adapters/src/types.ts` | Add `WsConnectionStatus`, `MempoolUpdate`, `PeerStatus` types; extend `NodeAdapter` interface |
| `web/packages/adapters/src/remote.ts` | Add connection status tracking, mempool/peer events, exponential backoff reconnection |
| `web/packages/adapters/src/local.ts` | Mirror WebSocket status tracking for desktop adapter |
| `web/packages/web-wallet/src/contexts/wallet.tsx` | Subscribe to real-time updates, add fallback polling |
| `web/packages/ui/src/components/connection-indicator.tsx` | New component for WebSocket status display |
| `web/packages/web-wallet/src/contexts/wallet.test.tsx` | Update mock adapter with new methods |

## Test plan

- [x] TypeScript typecheck passes
- [x] All existing tests pass
- [ ] Manual testing: verify real-time updates with running node
- [ ] Manual testing: verify reconnection after node restart
- [ ] Manual testing: verify fallback polling when WebSocket disabled

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)