### PR TITLE
feat(wallet): Integrate DecryptionRateLimiter into all CLI commands

### DIFF
--- a/botho-wallet/src/commands/address.rs
+++ b/botho-wallet/src/commands/address.rs
@@ -1,12 +1,12 @@
 //! Address display command
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::path::Path;
 
 use crate::keys::WalletKeys;
 use crate::storage::EncryptedWallet;
 
-use super::{print_error, prompt_password};
+use super::{decrypt_wallet_with_rate_limiting, print_error};
 
 /// Run the address command
 pub async fn run(wallet_path: &Path, show_pq: bool) -> Result<()> {
@@ -16,12 +16,8 @@ pub async fn run(wallet_path: &Path, show_pq: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Load and decrypt wallet
-    let wallet = EncryptedWallet::load(wallet_path)?;
-    let password = prompt_password("Enter wallet password: ")?;
-
-    let mnemonic = wallet.decrypt(&password)
-        .map_err(|_| anyhow!("Failed to decrypt wallet - wrong password?"))?;
+    // Load and decrypt wallet with rate limiting protection
+    let (_wallet, mnemonic, _password) = decrypt_wallet_with_rate_limiting(wallet_path)?;
 
     let keys = WalletKeys::from_mnemonic(&mnemonic)?;
 

--- a/botho-wallet/src/commands/history.rs
+++ b/botho-wallet/src/commands/history.rs
@@ -1,11 +1,11 @@
 //! Transaction history command
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::path::Path;
 
 use crate::storage::EncryptedWallet;
 
-use super::{print_error, print_warning, prompt_password};
+use super::{decrypt_wallet_with_rate_limiting, print_error, print_warning};
 
 /// Run the history command
 pub async fn run(wallet_path: &Path, limit: usize) -> Result<()> {
@@ -15,12 +15,8 @@ pub async fn run(wallet_path: &Path, limit: usize) -> Result<()> {
         return Ok(());
     }
 
-    // Load wallet (just to verify password)
-    let wallet = EncryptedWallet::load(wallet_path)?;
-    let password = prompt_password("Enter wallet password: ")?;
-
-    wallet.decrypt(&password)
-        .map_err(|_| anyhow!("Failed to decrypt wallet - wrong password?"))?;
+    // Load and decrypt wallet with rate limiting protection (verify password)
+    let (_wallet, _mnemonic, _password) = decrypt_wallet_with_rate_limiting(wallet_path)?;
 
     println!();
     print_warning("Transaction history is not yet implemented.");

--- a/botho-wallet/src/commands/mod.rs
+++ b/botho-wallet/src/commands/mod.rs
@@ -14,6 +14,10 @@ pub mod sync;
 
 use anyhow::Result;
 use std::io::{self, Write};
+use std::path::Path;
+use zeroize::Zeroizing;
+
+use crate::storage::{DecryptionRateLimiter, EncryptedWallet};
 
 /// Prompt for password input (hidden)
 pub fn prompt_password(prompt: &str) -> Result<String> {
@@ -48,4 +52,74 @@ pub fn print_success(message: &str) {
 /// Print a warning message
 pub fn print_warning(message: &str) {
     println!("\x1b[33mWarning:\x1b[0m {}", message);
+}
+
+/// Load and decrypt a wallet with rate limiting protection.
+///
+/// This function handles the complete workflow for secure wallet decryption:
+/// 1. Loads or creates rate limiter state
+/// 2. Checks if currently rate limited (and displays error if so)
+/// 3. Prompts for password
+/// 4. Attempts decryption with rate limiting
+/// 5. Saves rate limiter state (success resets, failure increments)
+///
+/// # Arguments
+/// * `wallet_path` - Path to the encrypted wallet file
+///
+/// # Returns
+/// * `Ok((EncryptedWallet, Zeroizing<String>, String))` - The wallet, decrypted mnemonic, and password
+/// * `Err` - If rate limited, wallet not found, or decryption failed
+///
+/// # Security
+/// The returned mnemonic is wrapped in `Zeroizing<String>` which automatically
+/// overwrites memory when dropped, preventing sensitive data from persisting.
+pub fn decrypt_wallet_with_rate_limiting(
+    wallet_path: &Path,
+) -> Result<(EncryptedWallet, Zeroizing<String>, String)> {
+    // Load rate limiter state
+    let mut rate_limiter = DecryptionRateLimiter::load_for_wallet(wallet_path);
+
+    // Check if we're currently rate limited before prompting for password
+    if let Err(e) = rate_limiter.check_rate_limit() {
+        print_error(&e.to_string());
+        return Err(e);
+    }
+
+    // Check for lockout
+    if rate_limiter.is_locked_out() {
+        if let Some(remaining) = rate_limiter.remaining_lockout_time() {
+            let msg = format!(
+                "Account temporarily locked due to too many failed attempts. Try again in {}",
+                remaining
+            );
+            print_error(&msg);
+            return Err(anyhow::anyhow!("{}", msg));
+        }
+    }
+
+    // Load wallet
+    let wallet = EncryptedWallet::load(wallet_path)?;
+
+    // Prompt for password
+    let password = prompt_password("Enter wallet password: ")?;
+
+    // Attempt decryption with rate limiting
+    match wallet.decrypt_with_rate_limit(&password, &mut rate_limiter) {
+        Ok(mnemonic) => {
+            // Save updated rate limiter state (success resets failures)
+            if let Err(e) = rate_limiter.save_for_wallet(wallet_path) {
+                // Log but don't fail - decryption succeeded
+                eprintln!("Warning: Failed to save rate limiter state: {}", e);
+            }
+            Ok((wallet, mnemonic, password))
+        }
+        Err(e) => {
+            // Save updated rate limiter state (failure increments counter)
+            if let Err(save_err) = rate_limiter.save_for_wallet(wallet_path) {
+                eprintln!("Warning: Failed to save rate limiter state: {}", save_err);
+            }
+            print_error(&e.to_string());
+            Err(e)
+        }
+    }
 }

--- a/botho-wallet/src/commands/sync.rs
+++ b/botho-wallet/src/commands/sync.rs
@@ -1,6 +1,6 @@
 //! Wallet sync command
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::path::Path;
 
 use crate::discovery::NodeDiscovery;
@@ -9,7 +9,7 @@ use crate::rpc_pool::RpcPool;
 use crate::storage::EncryptedWallet;
 use crate::transaction::{format_amount, sync_wallet};
 
-use super::{print_error, print_success, prompt_password};
+use super::{decrypt_wallet_with_rate_limiting, print_error, print_success};
 
 /// Run the sync command
 pub async fn run(wallet_path: &Path, full: bool) -> Result<()> {
@@ -19,12 +19,8 @@ pub async fn run(wallet_path: &Path, full: bool) -> Result<()> {
         return Ok(());
     }
 
-    // Load and decrypt wallet
-    let mut wallet = EncryptedWallet::load(wallet_path)?;
-    let password = prompt_password("Enter wallet password: ")?;
-
-    let mnemonic = wallet.decrypt(&password)
-        .map_err(|_| anyhow!("Failed to decrypt wallet - wrong password?"))?;
+    // Load and decrypt wallet with rate limiting protection
+    let (mut wallet, mnemonic, password) = decrypt_wallet_with_rate_limiting(wallet_path)?;
 
     let keys = WalletKeys::from_mnemonic(&mnemonic)?;
 


### PR DESCRIPTION
## Summary

- Integrates the existing `DecryptionRateLimiter` into all wallet CLI commands
- Adds persistent rate limiter state across CLI invocations
- Creates shared helper function to avoid code duplication
- Adds comprehensive unit tests for persistence

Closes #114

## Problem

The `DecryptionRateLimiter` was implemented in `storage.rs` but **not used** by any wallet CLI commands. All 8 commands called `.decrypt()` directly, bypassing rate limiting protection.

**Security Risk**: Without integration, an attacker could brute-force wallet passwords without any delay or lockout.

## Solution

### 1. Persistent Rate Limiter State
- Added `Serialize`/`Deserialize` to `DecryptionRateLimiter`
- State stored in `~/.botho-wallet/rate_limiter.json`
- Persists across CLI invocations

### 2. Shared Helper Function
Created `decrypt_wallet_with_rate_limiting()` in `commands/mod.rs`:
- Loads/creates rate limiter state
- Checks rate limit before password prompt
- Uses `decrypt_with_rate_limit()` for decryption
- Saves state after each attempt

### 3. Updated All Commands
- `address.rs` - display wallet address
- `balance.rs` - check balance
- `export.rs` - export mnemonic
- `history.rs` - transaction history
- `nodes.rs` - node management
- `send.rs` - send transactions (2 places: classical + PQ)
- `sync.rs` - sync wallet
- `migrate_to_pq.rs` - PQ migration (new file from merge)

### 4. Comprehensive Tests
Added 8 new unit tests:
- `test_rate_limiter_serialization`
- `test_rate_limiter_save_and_load`
- `test_rate_limiter_load_nonexistent`
- `test_rate_limiter_load_invalid_json`
- `test_rate_limiter_default_path`
- `test_rate_limiter_for_wallet`
- `test_rate_limiter_persistence_across_sessions`
- `test_rate_limiter_success_resets_persisted_state`

## Test plan

- [x] All existing tests pass (97 tests)
- [x] New persistence tests pass (8 tests)
- [x] Build succeeds without errors
- [ ] Manual test: verify rate limiting works across CLI invocations
- [ ] Manual test: verify each command respects rate limiting

## Security Properties

| Property | Status |
|----------|--------|
| Exponential backoff (1s, 2s, 4s, 8s...) | ✅ |
| Max delay capped at 5 minutes | ✅ |
| 5 consecutive failures → lockout | ✅ |
| Success resets counter | ✅ |
| State persists across invocations | ✅ |
| Clear error messages with remaining time | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)