### PR TITLE
feat(wallet): Implement PQ UTXO scanning for balance tracking

### DIFF
--- a/botho-wallet/Cargo.toml
+++ b/botho-wallet/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = { workspace = true }
 
 [features]
 default = ["pq"]
-pq = ["bth-account-keys/pq", "bth-crypto-pq", "botho/pq"]
+pq = ["bth-account-keys/pq", "bth-crypto-pq", "bth-crypto-ring-signature/pq", "botho/pq"]
 
 [[bin]]
 name = "botho-wallet"

--- a/botho-wallet/src/commands/balance.rs
+++ b/botho-wallet/src/commands/balance.rs
@@ -7,7 +7,13 @@ use crate::discovery::NodeDiscovery;
 use crate::keys::WalletKeys;
 use crate::rpc_pool::RpcPool;
 use crate::storage::EncryptedWallet;
-use crate::transaction::{format_amount, sync_wallet};
+use crate::transaction::format_amount;
+
+#[cfg(not(feature = "pq"))]
+use crate::transaction::sync_wallet;
+
+#[cfg(feature = "pq")]
+use crate::transaction::sync_wallet_all;
 
 use super::{decrypt_wallet_with_rate_limiting, print_error, print_success};
 
@@ -37,9 +43,29 @@ pub async fn run(wallet_path: &Path, detailed: bool) -> Result<()> {
 
     println!("Connected to {} nodes", rpc.connected_count());
 
-    // Sync wallet
+    // Sync wallet and display balance
     println!("Syncing wallet...");
-    let (utxos, height) = sync_wallet(&mut rpc, &keys, wallet.sync_height).await?;
+
+    #[cfg(feature = "pq")]
+    {
+        display_balance_pq(&mut rpc, &keys, &wallet, detailed).await
+    }
+
+    #[cfg(not(feature = "pq"))]
+    {
+        display_balance_classical(&mut rpc, &keys, &wallet, detailed).await
+    }
+}
+
+/// Display balance for classical-only mode (no PQ feature)
+#[cfg(not(feature = "pq"))]
+async fn display_balance_classical(
+    rpc: &mut RpcPool,
+    keys: &WalletKeys,
+    wallet: &EncryptedWallet,
+    detailed: bool,
+) -> Result<()> {
+    let (utxos, height) = sync_wallet(rpc, keys, wallet.sync_height).await?;
 
     // Calculate balance
     let total: u64 = utxos.iter().map(|u| u.amount).sum();
@@ -59,6 +85,76 @@ pub async fn run(wallet_path: &Path, detailed: bool) -> Result<()> {
                 format_amount(utxo.amount),
                 utxo.created_at
             );
+        }
+    }
+
+    Ok(())
+}
+
+/// Display balance with PQ UTXO scanning
+#[cfg(feature = "pq")]
+async fn display_balance_pq(
+    rpc: &mut RpcPool,
+    keys: &WalletKeys,
+    wallet: &EncryptedWallet,
+    detailed: bool,
+) -> Result<()> {
+    let result = sync_wallet_all(rpc, keys, wallet.sync_height).await?;
+
+    // Calculate balances
+    let classical_total: u64 = result.classical_utxos.iter().map(|u| u.amount).sum();
+    let pq_total: u64 = result.pq_utxos.iter().map(|u| u.amount).sum();
+    let total = classical_total + pq_total;
+
+    println!();
+
+    // Show combined balance prominently
+    print_success(&format!("Total Balance: {}", format_amount(total)));
+
+    // Show breakdown if there are both types or if detailed mode
+    if pq_total > 0 || detailed {
+        println!();
+        println!("Balance Breakdown:");
+        println!("  Classical:    {}", format_amount(classical_total));
+        println!("  Quantum-safe: {}", format_amount(pq_total));
+    }
+
+    println!();
+    println!("Synced to block {}", result.height);
+
+    if detailed {
+        // Show classical UTXOs
+        if !result.classical_utxos.is_empty() {
+            println!();
+            println!("Classical UTXOs ({}):", result.classical_utxos.len());
+            for (i, utxo) in result.classical_utxos.iter().enumerate() {
+                println!(
+                    "  {}. {} (block {})",
+                    i + 1,
+                    format_amount(utxo.amount),
+                    utxo.created_at
+                );
+            }
+        }
+
+        // Show PQ UTXOs
+        if !result.pq_utxos.is_empty() {
+            println!();
+            println!("Quantum-safe UTXOs ({}):", result.pq_utxos.len());
+            for (i, utxo) in result.pq_utxos.iter().enumerate() {
+                println!(
+                    "  {}. {} (block {}) [PQ]",
+                    i + 1,
+                    format_amount(utxo.amount),
+                    utxo.created_at
+                );
+            }
+        }
+
+        // Show summary if no UTXOs at all
+        if result.classical_utxos.is_empty() && result.pq_utxos.is_empty() {
+            println!();
+            println!("No UTXOs found.");
         }
     }
 

--- a/botho-wallet/src/rpc_pool.rs
+++ b/botho-wallet/src/rpc_pool.rs
@@ -453,6 +453,13 @@ pub struct TxOutput {
     /// Amount commitment (or plaintext amount)
     #[serde(rename = "amountCommitment")]
     pub amount_commitment: String,
+    /// ML-KEM-768 ciphertext for PQ outputs (1088 bytes, hex-encoded)
+    /// Only present for QuantumPrivateTxOut outputs
+    #[serde(rename = "pqCiphertext")]
+    pub pq_ciphertext: Option<String>,
+    /// Indicates if this is a quantum-private output
+    #[serde(rename = "isPqOutput", default)]
+    pub is_pq_output: bool,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary

- Implements quantum-private UTXO scanning for wallet balance tracking
- Users can now see their quantum-safe balance from funds migrated via `migrate-to-pq`
- Displays dual balances (classical + quantum-safe) with breakdown in `--detailed` mode

## Changes

- **PqOwnedUtxo struct**: New type for storing PQ UTXOs with ML-KEM-768 ciphertext (1088 bytes) and target key
- **PqWalletScanner**: Uses `check_pq_output_ownership()` from `pq_onetime_keys` to identify owned outputs
- **sync_wallet_all()**: Returns both classical and PQ UTXOs in a single sync pass
- **Balance command**: Shows total, classical, and quantum-safe balances with `[PQ]` markers in detailed view
- **TxOutput extension**: Added optional `pq_ciphertext` and `is_pq_output` fields for RPC

## Test plan

- [x] `PqOwnedUtxo` serialization roundtrip
- [x] `PqOwnedUtxo::id()` creates correct UTXO identifier
- [x] Scanner skips non-PQ outputs (`is_pq_output: false`)
- [x] Scanner rejects invalid ciphertext size
- [x] `SyncResult` correctly separates classical and PQ UTXOs

## Related

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)