### PR TITLE
docs(spec): Update protocol specification to v0.2.0

### DIFF
--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -6,16 +6,17 @@ This directory contains the formal specification of the Botho protocol.
 
 | Version | Status | Date | Description |
 |---------|--------|------|-------------|
-| [v0.1.0](protocol-v0.1.0.md) | Draft | 2024-12-31 | Initial specification |
+| [v0.2.0](protocol-v0.2.0.md) | Draft | 2025-01-03 | Current specification (LION removed) |
+| [v0.1.0](protocol-v0.1.0.md) | Superseded | 2024-12-31 | Initial specification (includes deprecated LION) |
 
 ## Overview
 
 The Botho protocol specification provides complete documentation for:
 
-- **Transaction Format**: Classical and post-quantum transaction structures
+- **Transaction Format**: Minting and Private transaction structures
 - **Consensus (SCP)**: Stellar Consensus Protocol implementation
 - **Network Protocol**: P2P messaging and synchronization
-- **Cryptographic Primitives**: CLSAG, ML-KEM, ML-DSA, Bulletproofs (LION deprecated per ADR-0001)
+- **Cryptographic Primitives**: CLSAG, ML-KEM, ML-DSA, Bulletproofs
 - **Block Structure**: Headers, PoW, and minting transactions
 - **Monetary System**: Units, supply schedule, and fee structure
 - **Network Configuration**: Ports, addresses, and parameters


### PR DESCRIPTION
## Summary

- Created protocol-v0.2.0.md as the current specification (LION removed)
- Updated v0.1.0.md with superseded notice pointing to v0.2.0
- Updated specification/README.md version table

## Changes

- **Removed** all LION/PQ-Private transaction type documentation
- **Updated** to two-transaction model: Minting (ML-DSA) + Private (CLSAG)
- **Added** hybrid security rationale explaining why classical sender privacy is sufficient while recipient privacy needs post-quantum protection
- **Updated** cryptographic primitives section (removed LION ring signatures)
- **Updated** security considerations (removed quantum sender privacy claims)
- **Added** changelog documenting LION deprecation

## Test plan

- [x] All internal links verified
- [x] Version table updated correctly
- [x] Superseded notice added to v0.1.0
- [x] No references to LION in v0.2.0

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)