### PR TITLE
feat(privacy): Add core Onion Gossip data structures (Phase 1)

### DIFF
--- a/botho/src/network/mod.rs
+++ b/botho/src/network/mod.rs
@@ -13,6 +13,7 @@ mod connection_limiter;
 mod discovery;
 mod dns_seeds;
 mod pex;
+pub mod privacy;
 mod quorum;
 mod reputation;
 mod sync;
@@ -26,20 +27,20 @@ pub use connection_limiter::{
 };
 pub use discovery::{
     BothoBehaviour, NetworkDiscovery, NetworkEvent, PeerTableEntry, ProtocolVersion,
-    UpgradeAnnouncement, PROTOCOL_VERSION, MIN_SUPPORTED_PROTOCOL_VERSION,
+    UpgradeAnnouncement, MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION,
 };
 // Re-export rate limit configuration from bth-gossip for network setup
 pub use bth_gossip::{GossipMessageType, MessageTypeLimits, PeerRateLimitConfig};
 pub use dns_seeds::{DnsSeedDiscovery, DnsSeedError};
-pub use quorum::{QuorumBuilder, QuorumValidation};
-pub use reputation::{PeerReputation, ReputationManager};
 pub use pex::{
     PeerSource, PexEntry, PexFilter, PexManager, PexMessage, PexRateLimiter, PexSourceTracker,
-    MAX_PEERS_PER_SUBNET, MAX_PEER_AGE_SECS, MAX_PEX_MESSAGE_SIZE, MAX_PEX_PEERS,
-    MAX_PEX_PER_HOUR, PEX_INTERVAL_SECS,
+    MAX_PEERS_PER_SUBNET, MAX_PEER_AGE_SECS, MAX_PEX_MESSAGE_SIZE, MAX_PEX_PEERS, MAX_PEX_PER_HOUR,
+    PEX_INTERVAL_SECS,
 };
+pub use quorum::{QuorumBuilder, QuorumValidation};
+pub use reputation::{PeerReputation, ReputationManager};
 pub use sync::{
     create_sync_behaviour, ChainSyncManager, SyncAction, SyncCodec, SyncRateLimiter, SyncRequest,
-    SyncResponse, SyncState, BLOCKS_PER_REQUEST, MAX_REQUEST_SIZE, MAX_REQUESTS_PER_MINUTE,
+    SyncResponse, SyncState, BLOCKS_PER_REQUEST, MAX_REQUESTS_PER_MINUTE, MAX_REQUEST_SIZE,
     MAX_RESPONSE_SIZE,
 };

--- a/botho/src/network/privacy/circuit.rs
+++ b/botho/src/network/privacy/circuit.rs
@@ -1,0 +1,534 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Circuit management for onion gossip routing.
+//!
+//! This module provides data structures for managing outbound circuits:
+//! - [`OutboundCircuit`]: A pre-built circuit through 3 relay hops
+//! - [`CircuitPool`]: Pool of active circuits for quick message sending
+//!
+//! # Architecture
+//!
+//! Circuits are 3-hop paths through the relay network. Each hop has a
+//! symmetric key established via a telescoping handshake. When sending
+//! a message, the payload is wrapped in 3 layers of encryption (onion),
+//! with each hop decrypting one layer.
+//!
+//! ```text
+//! Alice -> Hop1 -> Hop2 -> Hop3 (exit) -> Gossipsub
+//! ```
+
+use libp2p::PeerId;
+use std::time::{Duration, Instant};
+
+use super::types::{CircuitId, SymmetricKey};
+
+/// Number of hops in a standard circuit.
+pub const CIRCUIT_HOPS: usize = 3;
+
+/// Default minimum number of circuits to maintain in the pool.
+pub const DEFAULT_MIN_CIRCUITS: usize = 3;
+
+/// Default circuit rotation interval (10 minutes).
+pub const DEFAULT_ROTATION_INTERVAL: Duration = Duration::from_secs(600);
+
+/// Maximum jitter to add to circuit lifetime (3 minutes).
+pub const MAX_LIFETIME_JITTER: Duration = Duration::from_secs(180);
+
+/// An outbound circuit through 3 relay hops.
+///
+/// A circuit represents a pre-built path through the relay network that
+/// can be used to send messages anonymously. The circuit consists of:
+/// - A unique identifier
+/// - Three relay hop peers
+/// - Symmetric keys for each hop (for onion encryption)
+/// - Timing information for expiration
+///
+/// # Example
+///
+/// ```
+/// use botho::network::privacy::{OutboundCircuit, CircuitId, SymmetricKey};
+/// use libp2p::PeerId;
+/// use std::time::{Duration, Instant};
+///
+/// // Create circuit components
+/// let mut rng = rand::thread_rng();
+/// let circuit_id = CircuitId::random(&mut rng);
+/// let hops = [PeerId::random(), PeerId::random(), PeerId::random()];
+/// let keys = [
+///     SymmetricKey::random(&mut rng),
+///     SymmetricKey::random(&mut rng),
+///     SymmetricKey::random(&mut rng),
+/// ];
+///
+/// let circuit = OutboundCircuit::new(
+///     circuit_id,
+///     hops,
+///     keys,
+///     Duration::from_secs(600),
+/// );
+///
+/// assert!(!circuit.is_expired());
+/// ```
+#[derive(Debug)]
+pub struct OutboundCircuit {
+    /// Unique circuit identifier.
+    id: CircuitId,
+
+    /// Ordered relay hops (first hop -> middle hop -> exit hop).
+    hops: [PeerId; CIRCUIT_HOPS],
+
+    /// Symmetric keys for each hop (for onion encryption).
+    /// Each key is used to encrypt/decrypt the layer for that hop.
+    hop_keys: [SymmetricKey; CIRCUIT_HOPS],
+
+    /// When this circuit was built.
+    created_at: Instant,
+
+    /// When this circuit should be rotated (randomized around
+    /// rotation_interval).
+    expires_at: Instant,
+}
+
+impl OutboundCircuit {
+    /// Create a new outbound circuit.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique circuit identifier
+    /// * `hops` - The three relay peers in order [entry, middle, exit]
+    /// * `hop_keys` - Symmetric keys for each hop
+    /// * `lifetime` - Base lifetime before expiration (jitter will be added)
+    pub fn new(
+        id: CircuitId,
+        hops: [PeerId; CIRCUIT_HOPS],
+        hop_keys: [SymmetricKey; CIRCUIT_HOPS],
+        lifetime: Duration,
+    ) -> Self {
+        let now = Instant::now();
+        // Add random jitter to lifetime to prevent timing correlation
+        let jitter =
+            Duration::from_millis(rand::random::<u64>() % MAX_LIFETIME_JITTER.as_millis() as u64);
+        let expires_at = now + lifetime + jitter;
+
+        Self {
+            id,
+            hops,
+            hop_keys,
+            created_at: now,
+            expires_at,
+        }
+    }
+
+    /// Create a new outbound circuit with exact expiration time (for testing).
+    ///
+    /// Unlike `new()`, this method does not add jitter to the lifetime.
+    /// This is primarily useful for testing expiration behavior.
+    #[cfg(test)]
+    pub fn new_exact_lifetime(
+        id: CircuitId,
+        hops: [PeerId; CIRCUIT_HOPS],
+        hop_keys: [SymmetricKey; CIRCUIT_HOPS],
+        lifetime: Duration,
+    ) -> Self {
+        let now = Instant::now();
+        Self {
+            id,
+            hops,
+            hop_keys,
+            created_at: now,
+            expires_at: now + lifetime,
+        }
+    }
+
+    /// Get the circuit's unique identifier.
+    #[inline]
+    pub fn id(&self) -> &CircuitId {
+        &self.id
+    }
+
+    /// Get the relay hops in order [entry, middle, exit].
+    #[inline]
+    pub fn hops(&self) -> &[PeerId; CIRCUIT_HOPS] {
+        &self.hops
+    }
+
+    /// Get the first (entry) hop peer.
+    #[inline]
+    pub fn entry_hop(&self) -> &PeerId {
+        &self.hops[0]
+    }
+
+    /// Get the middle hop peer.
+    #[inline]
+    pub fn middle_hop(&self) -> &PeerId {
+        &self.hops[1]
+    }
+
+    /// Get the exit hop peer.
+    #[inline]
+    pub fn exit_hop(&self) -> &PeerId {
+        &self.hops[2]
+    }
+
+    /// Get the symmetric key for a specific hop (0 = entry, 1 = middle, 2 =
+    /// exit).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `hop_index >= CIRCUIT_HOPS`.
+    #[inline]
+    pub fn hop_key(&self, hop_index: usize) -> &SymmetricKey {
+        &self.hop_keys[hop_index]
+    }
+
+    /// Get when this circuit was created.
+    #[inline]
+    pub fn created_at(&self) -> Instant {
+        self.created_at
+    }
+
+    /// Get when this circuit expires.
+    #[inline]
+    pub fn expires_at(&self) -> Instant {
+        self.expires_at
+    }
+
+    /// Check if this circuit has expired and should be rotated.
+    pub fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+
+    /// Get the age of this circuit.
+    pub fn age(&self) -> Duration {
+        Instant::now().duration_since(self.created_at)
+    }
+
+    /// Get remaining time until expiration.
+    ///
+    /// Returns `Duration::ZERO` if already expired.
+    pub fn time_remaining(&self) -> Duration {
+        let now = Instant::now();
+        if now >= self.expires_at {
+            Duration::ZERO
+        } else {
+            self.expires_at - now
+        }
+    }
+}
+
+/// Configuration for the circuit pool.
+#[derive(Debug, Clone)]
+pub struct CircuitPoolConfig {
+    /// Minimum number of circuits to maintain.
+    pub min_circuits: usize,
+
+    /// Circuit rotation interval (before jitter).
+    pub rotation_interval: Duration,
+}
+
+impl Default for CircuitPoolConfig {
+    fn default() -> Self {
+        Self {
+            min_circuits: DEFAULT_MIN_CIRCUITS,
+            rotation_interval: DEFAULT_ROTATION_INTERVAL,
+        }
+    }
+}
+
+/// Pool of pre-built circuits for quick message sending.
+///
+/// The pool maintains a set of active circuits that can be used immediately
+/// for sending messages. Circuits are rotated based on their expiration time,
+/// and new circuits are built in the background to maintain the minimum count.
+///
+/// # Example
+///
+/// ```
+/// use botho::network::privacy::{CircuitPool, CircuitPoolConfig};
+///
+/// // Create with default configuration
+/// let pool = CircuitPool::new(CircuitPoolConfig::default());
+///
+/// // Check pool status
+/// assert_eq!(pool.active_count(), 0);
+/// assert!(pool.needs_more_circuits());
+/// ```
+#[derive(Debug)]
+pub struct CircuitPool {
+    /// Active circuits ready for use.
+    active: Vec<OutboundCircuit>,
+
+    /// Pool configuration.
+    config: CircuitPoolConfig,
+}
+
+impl CircuitPool {
+    /// Create a new circuit pool with the given configuration.
+    pub fn new(config: CircuitPoolConfig) -> Self {
+        Self {
+            active: Vec::with_capacity(config.min_circuits),
+            config,
+        }
+    }
+
+    /// Get the number of active (non-expired) circuits.
+    pub fn active_count(&self) -> usize {
+        self.active.iter().filter(|c| !c.is_expired()).count()
+    }
+
+    /// Get the total number of circuits (including expired).
+    pub fn total_count(&self) -> usize {
+        self.active.len()
+    }
+
+    /// Check if the pool needs more circuits to meet the minimum.
+    pub fn needs_more_circuits(&self) -> bool {
+        self.active_count() < self.config.min_circuits
+    }
+
+    /// Get the pool configuration.
+    pub fn config(&self) -> &CircuitPoolConfig {
+        &self.config
+    }
+
+    /// Add a circuit to the pool.
+    pub fn add_circuit(&mut self, circuit: OutboundCircuit) {
+        self.active.push(circuit);
+    }
+
+    /// Get a random active circuit for sending a message.
+    ///
+    /// Returns `None` if no active (non-expired) circuits are available.
+    pub fn get_circuit(&self) -> Option<&OutboundCircuit> {
+        let active_circuits: Vec<_> = self.active.iter().filter(|c| !c.is_expired()).collect();
+
+        if active_circuits.is_empty() {
+            return None;
+        }
+
+        // Use random selection for unlinkability
+        let index = rand::random::<usize>() % active_circuits.len();
+        Some(active_circuits[index])
+    }
+
+    /// Remove expired circuits from the pool.
+    ///
+    /// Returns the number of circuits removed.
+    pub fn remove_expired(&mut self) -> usize {
+        let before = self.active.len();
+        self.active.retain(|c| !c.is_expired());
+        before - self.active.len()
+    }
+
+    /// Remove a specific circuit by ID.
+    ///
+    /// Returns `true` if the circuit was found and removed.
+    pub fn remove_circuit(&mut self, circuit_id: &CircuitId) -> bool {
+        let before = self.active.len();
+        self.active.retain(|c| c.id() != circuit_id);
+        self.active.len() < before
+    }
+
+    /// Clear all circuits from the pool.
+    pub fn clear(&mut self) {
+        self.active.clear();
+    }
+
+    /// Iterate over all active circuits.
+    pub fn iter(&self) -> impl Iterator<Item = &OutboundCircuit> {
+        self.active.iter().filter(|c| !c.is_expired())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_circuit(lifetime: Duration) -> OutboundCircuit {
+        let mut rng = rand::thread_rng();
+        OutboundCircuit::new(
+            CircuitId::random(&mut rng),
+            [PeerId::random(), PeerId::random(), PeerId::random()],
+            [
+                SymmetricKey::random(&mut rng),
+                SymmetricKey::random(&mut rng),
+                SymmetricKey::random(&mut rng),
+            ],
+            lifetime,
+        )
+    }
+
+    #[test]
+    fn test_circuit_creation() {
+        let circuit = make_test_circuit(Duration::from_secs(600));
+
+        assert!(!circuit.is_expired());
+        assert!(circuit.time_remaining() > Duration::ZERO);
+        assert!(circuit.age() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_circuit_hops() {
+        let mut rng = rand::thread_rng();
+        let hops = [PeerId::random(), PeerId::random(), PeerId::random()];
+        let circuit = OutboundCircuit::new(
+            CircuitId::random(&mut rng),
+            hops.clone(),
+            [
+                SymmetricKey::random(&mut rng),
+                SymmetricKey::random(&mut rng),
+                SymmetricKey::random(&mut rng),
+            ],
+            Duration::from_secs(600),
+        );
+
+        assert_eq!(circuit.entry_hop(), &hops[0]);
+        assert_eq!(circuit.middle_hop(), &hops[1]);
+        assert_eq!(circuit.exit_hop(), &hops[2]);
+    }
+
+    #[test]
+    fn test_circuit_expiry() {
+        let mut rng = rand::thread_rng();
+        // Create circuit with very short lifetime (using exact lifetime for testing)
+        let circuit = OutboundCircuit::new_exact_lifetime(
+            CircuitId::random(&mut rng),
+            [PeerId::random(), PeerId::random(), PeerId::random()],
+            [
+                SymmetricKey::random(&mut rng),
+                SymmetricKey::random(&mut rng),
+                SymmetricKey::random(&mut rng),
+            ],
+            Duration::from_millis(1),
+        );
+
+        // Wait for expiration
+        std::thread::sleep(Duration::from_millis(10));
+
+        assert!(circuit.is_expired());
+        assert_eq!(circuit.time_remaining(), Duration::ZERO);
+    }
+
+    #[test]
+    fn test_pool_creation() {
+        let pool = CircuitPool::new(CircuitPoolConfig::default());
+
+        assert_eq!(pool.active_count(), 0);
+        assert_eq!(pool.total_count(), 0);
+        assert!(pool.needs_more_circuits());
+    }
+
+    #[test]
+    fn test_pool_add_circuit() {
+        let mut pool = CircuitPool::new(CircuitPoolConfig::default());
+        let circuit = make_test_circuit(Duration::from_secs(600));
+
+        pool.add_circuit(circuit);
+
+        assert_eq!(pool.active_count(), 1);
+        assert!(pool.needs_more_circuits()); // Default min is 3
+    }
+
+    #[test]
+    fn test_pool_get_circuit() {
+        let mut pool = CircuitPool::new(CircuitPoolConfig::default());
+
+        // Empty pool returns None
+        assert!(pool.get_circuit().is_none());
+
+        // Add a circuit
+        pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+
+        // Should get a circuit now
+        assert!(pool.get_circuit().is_some());
+    }
+
+    #[test]
+    fn test_pool_remove_expired() {
+        let mut pool = CircuitPool::new(CircuitPoolConfig::default());
+        let mut rng = rand::thread_rng();
+
+        // Add short-lived circuit (exact lifetime for testing)
+        let short_circuit = OutboundCircuit::new_exact_lifetime(
+            CircuitId::random(&mut rng),
+            [PeerId::random(), PeerId::random(), PeerId::random()],
+            [
+                SymmetricKey::random(&mut rng),
+                SymmetricKey::random(&mut rng),
+                SymmetricKey::random(&mut rng),
+            ],
+            Duration::from_millis(1),
+        );
+        pool.add_circuit(short_circuit);
+
+        // Add long-lived circuit
+        pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+
+        assert_eq!(pool.total_count(), 2);
+
+        // Wait for short-lived circuit to expire
+        std::thread::sleep(Duration::from_millis(10));
+
+        // Remove expired
+        let removed = pool.remove_expired();
+        assert_eq!(removed, 1);
+        assert_eq!(pool.total_count(), 1);
+    }
+
+    #[test]
+    fn test_pool_remove_by_id() {
+        let mut pool = CircuitPool::new(CircuitPoolConfig::default());
+        let circuit = make_test_circuit(Duration::from_secs(600));
+        let circuit_id = *circuit.id();
+
+        pool.add_circuit(circuit);
+        assert_eq!(pool.active_count(), 1);
+
+        assert!(pool.remove_circuit(&circuit_id));
+        assert_eq!(pool.active_count(), 0);
+    }
+
+    #[test]
+    fn test_pool_min_circuits_threshold() {
+        let config = CircuitPoolConfig {
+            min_circuits: 2,
+            ..Default::default()
+        };
+        let mut pool = CircuitPool::new(config);
+
+        // Below threshold
+        pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+        assert!(pool.needs_more_circuits());
+
+        // At threshold
+        pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+        assert!(!pool.needs_more_circuits());
+
+        // Above threshold
+        pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+        assert!(!pool.needs_more_circuits());
+    }
+
+    #[test]
+    fn test_pool_iter() {
+        let mut pool = CircuitPool::new(CircuitPoolConfig::default());
+
+        for _ in 0..5 {
+            pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+        }
+
+        assert_eq!(pool.iter().count(), 5);
+    }
+
+    #[test]
+    fn test_pool_clear() {
+        let mut pool = CircuitPool::new(CircuitPoolConfig::default());
+
+        for _ in 0..3 {
+            pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+        }
+
+        pool.clear();
+        assert_eq!(pool.active_count(), 0);
+    }
+}

--- a/botho/src/network/privacy/mod.rs
+++ b/botho/src/network/privacy/mod.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Privacy layer for traffic analysis resistance using Onion Gossip.
+//!
+//! This module implements the core data structures for Phase 1 of the
+//! traffic analysis resistance roadmap (see
+//! `docs/design/traffic-privacy-roadmap.md`).
+//!
+//! # Overview
+//!
+//! Onion Gossip merges onion routing with gossipsub. Every transaction is
+//! routed through a 3-hop circuit of randomly selected peers before being
+//! broadcast. Every node participates as a potential relay.
+//!
+//! ## Key Concepts
+//!
+//! - **Circuit**: A 3-hop path through the relay network
+//! - **Onion Encryption**: Each hop decrypts one layer of encryption
+//! - **Relay**: Any node can relay traffic for others
+//! - **Exit Hop**: The final hop broadcasts to gossipsub
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                    ONION GOSSIP FLOW                        │
+//! │                                                             │
+//! │   Alice wants to broadcast transaction T                   │
+//! │                                                             │
+//! │   1. Build Circuit: Select 3 random peers [X, Y, Z]        │
+//! │   2. Onion Wrap: Encrypt_X(Encrypt_Y(Encrypt_Z(T)))        │
+//! │   3. Send: Alice → X → Y → Z → Gossipsub                   │
+//! │                                                             │
+//! │   Result: No single node knows both origin AND content     │
+//! └─────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Module Structure
+//!
+//! - [`types`]: Core types (CircuitId, SymmetricKey)
+//! - [`circuit`]: Outbound circuit management (OutboundCircuit, CircuitPool)
+//! - [`relay`]: Relay state management (RelayState, CircuitHopKey)
+//!
+//! # Example
+//!
+//! ```
+//! use botho::network::privacy::{
+//!     CircuitId, SymmetricKey,
+//!     OutboundCircuit, CircuitPool, CircuitPoolConfig,
+//!     RelayState, RelayStateConfig, CircuitHopKey,
+//! };
+//! use libp2p::PeerId;
+//! use std::time::Duration;
+//!
+//! // Create a circuit pool for managing outbound circuits
+//! let mut pool = CircuitPool::new(CircuitPoolConfig::default());
+//!
+//! // Create relay state for handling incoming relay traffic
+//! let mut relay = RelayState::new(RelayStateConfig::default());
+//!
+//! // When we become a relay hop, store the circuit key
+//! let mut rng = rand::thread_rng();
+//! let circuit_id = CircuitId::random(&mut rng);
+//! let hop_key = CircuitHopKey::new_exit(SymmetricKey::random(&mut rng));
+//! relay.add_circuit_key(circuit_id, hop_key);
+//! ```
+//!
+//! # Security Considerations
+//!
+//! - All symmetric keys use [`zeroize`] for secure memory handling
+//! - Circuit IDs are random 16-byte values to prevent prediction
+//! - Per-peer rate limiting prevents relay flooding attacks
+//! - Circuit rotation prevents long-term correlation
+//!
+//! # References
+//!
+//! - Design document: `docs/design/traffic-privacy-roadmap.md`
+//! - Parent issue: #147 (Traffic Analysis Resistance - Phase 1)
+
+mod circuit;
+mod relay;
+mod types;
+
+// Re-export core types
+pub use types::{CircuitId, SymmetricKey, CIRCUIT_ID_LEN, SYMMETRIC_KEY_LEN};
+
+// Re-export circuit management types
+pub use circuit::{
+    CircuitPool, CircuitPoolConfig, OutboundCircuit, CIRCUIT_HOPS, DEFAULT_MIN_CIRCUITS,
+    DEFAULT_ROTATION_INTERVAL, MAX_LIFETIME_JITTER,
+};
+
+// Re-export relay management types
+pub use relay::{
+    CircuitHopKey, RateLimiter, RelayState, RelayStateConfig, DEFAULT_CIRCUIT_KEY_LIFETIME,
+    DEFAULT_MAX_RELAY_PER_WINDOW, DEFAULT_RATE_LIMIT_WINDOW,
+};

--- a/botho/src/network/privacy/relay.rs
+++ b/botho/src/network/privacy/relay.rs
@@ -1,0 +1,530 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Relay state management for onion gossip.
+//!
+//! This module provides data structures for managing relay operations:
+//! - [`CircuitHopKey`]: Key material for a single circuit hop
+//! - [`RelayState`]: Manages circuits where this node acts as a relay
+//! - [`RateLimiter`]: Per-peer rate limiting for relay traffic
+//!
+//! # Relay Architecture
+//!
+//! Every node in the network can act as a relay hop. When a node receives
+//! an onion-wrapped message, it:
+//! 1. Looks up the circuit key in [`RelayState`]
+//! 2. Decrypts one layer of the onion
+//! 3. Forwards to the next hop (or broadcasts if exit)
+
+use libp2p::PeerId;
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
+use super::{
+    circuit::OutboundCircuit,
+    types::{CircuitId, SymmetricKey},
+};
+
+/// Default rate limit window duration.
+pub const DEFAULT_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+
+/// Default maximum relay messages per peer per window.
+pub const DEFAULT_MAX_RELAY_PER_WINDOW: u32 = 100;
+
+/// Default circuit key expiration time.
+pub const DEFAULT_CIRCUIT_KEY_LIFETIME: Duration = Duration::from_secs(900);
+
+/// Key material for one hop of a circuit.
+///
+/// When this node is a relay hop in someone else's circuit, we store
+/// the information needed to process messages for that circuit.
+///
+/// # Fields
+///
+/// - `key`: Symmetric key for decrypting messages on this circuit
+/// - `next_hop`: Where to forward after decryption (`None` if we're the exit)
+/// - `is_exit`: Whether we broadcast the decrypted message (exit hop)
+/// - `created_at`: When this circuit hop was established
+#[derive(Debug)]
+pub struct CircuitHopKey {
+    /// Symmetric key for decrypting this hop's layer.
+    key: SymmetricKey,
+
+    /// Next hop to forward to after decryption.
+    /// `None` if this is the exit hop.
+    next_hop: Option<PeerId>,
+
+    /// When this circuit hop was created.
+    created_at: Instant,
+
+    /// Whether this is an exit hop (we broadcast the decrypted message).
+    is_exit: bool,
+}
+
+impl CircuitHopKey {
+    /// Create a new circuit hop key for a forward (non-exit) hop.
+    pub fn new_forward(key: SymmetricKey, next_hop: PeerId) -> Self {
+        Self {
+            key,
+            next_hop: Some(next_hop),
+            created_at: Instant::now(),
+            is_exit: false,
+        }
+    }
+
+    /// Create a new circuit hop key for an exit hop.
+    pub fn new_exit(key: SymmetricKey) -> Self {
+        Self {
+            key,
+            next_hop: None,
+            created_at: Instant::now(),
+            is_exit: true,
+        }
+    }
+
+    /// Get the symmetric key for this hop.
+    pub fn key(&self) -> &SymmetricKey {
+        &self.key
+    }
+
+    /// Get the next hop peer, if any.
+    pub fn next_hop(&self) -> Option<&PeerId> {
+        self.next_hop.as_ref()
+    }
+
+    /// Check if this is an exit hop.
+    pub fn is_exit(&self) -> bool {
+        self.is_exit
+    }
+
+    /// Get when this circuit hop was created.
+    pub fn created_at(&self) -> Instant {
+        self.created_at
+    }
+
+    /// Get the age of this circuit hop.
+    pub fn age(&self) -> Duration {
+        Instant::now().duration_since(self.created_at)
+    }
+
+    /// Check if this circuit hop key has expired.
+    pub fn is_expired(&self, lifetime: Duration) -> bool {
+        self.age() > lifetime
+    }
+}
+
+/// Per-peer rate limiter for relay traffic.
+///
+/// Prevents any single peer from flooding the relay with messages.
+/// Uses a sliding window algorithm to track request counts.
+#[derive(Debug)]
+pub struct RateLimiter {
+    /// Timestamps of recent relay requests.
+    request_times: Vec<Instant>,
+
+    /// Maximum requests allowed per window.
+    max_requests: u32,
+
+    /// Window duration for rate limiting.
+    window: Duration,
+}
+
+impl Default for RateLimiter {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_RELAY_PER_WINDOW, DEFAULT_RATE_LIMIT_WINDOW)
+    }
+}
+
+impl RateLimiter {
+    /// Create a new rate limiter with the specified limits.
+    pub fn new(max_requests: u32, window: Duration) -> Self {
+        Self {
+            request_times: Vec::new(),
+            max_requests,
+            window,
+        }
+    }
+
+    /// Check if a request should be allowed and record it if so.
+    ///
+    /// Returns `true` if the request is allowed, `false` if rate limited.
+    pub fn check(&mut self) -> bool {
+        let now = Instant::now();
+        let window_start = now - self.window;
+
+        // Remove requests outside the window
+        self.request_times.retain(|&t| t > window_start);
+
+        // Check if under limit
+        if self.request_times.len() >= self.max_requests as usize {
+            return false;
+        }
+
+        // Record this request
+        self.request_times.push(now);
+        true
+    }
+
+    /// Get the current request count within the window.
+    pub fn current_count(&self) -> usize {
+        let now = Instant::now();
+        let window_start = now - self.window;
+        self.request_times
+            .iter()
+            .filter(|&&t| t > window_start)
+            .count()
+    }
+
+    /// Reset the rate limiter.
+    pub fn reset(&mut self) {
+        self.request_times.clear();
+    }
+}
+
+/// Manages relay state for this node.
+///
+/// Tracks:
+/// - Circuit keys for circuits where we're a relay hop
+/// - Circuits we've created (we're the origin)
+/// - Rate limiting per peer
+///
+/// # Example
+///
+/// ```
+/// use botho::network::privacy::{RelayState, RelayStateConfig};
+///
+/// let state = RelayState::new(RelayStateConfig::default());
+/// assert_eq!(state.circuit_count(), 0);
+/// ```
+#[derive(Debug)]
+pub struct RelayState {
+    /// Circuit keys for decryption (we're a relay hop in these circuits).
+    circuit_keys: HashMap<CircuitId, CircuitHopKey>,
+
+    /// Circuits we've created (we're the origin).
+    our_circuits: HashMap<CircuitId, OutboundCircuit>,
+
+    /// Rate limiting per peer.
+    relay_limits: HashMap<PeerId, RateLimiter>,
+
+    /// Configuration.
+    config: RelayStateConfig,
+}
+
+/// Configuration for relay state.
+#[derive(Debug, Clone)]
+pub struct RelayStateConfig {
+    /// Maximum relay messages per peer per window.
+    pub max_relay_per_window: u32,
+
+    /// Rate limit window duration.
+    pub rate_limit_window: Duration,
+
+    /// How long to keep circuit keys.
+    pub circuit_key_lifetime: Duration,
+}
+
+impl Default for RelayStateConfig {
+    fn default() -> Self {
+        Self {
+            max_relay_per_window: DEFAULT_MAX_RELAY_PER_WINDOW,
+            rate_limit_window: DEFAULT_RATE_LIMIT_WINDOW,
+            circuit_key_lifetime: DEFAULT_CIRCUIT_KEY_LIFETIME,
+        }
+    }
+}
+
+impl RelayState {
+    /// Create a new relay state with the given configuration.
+    pub fn new(config: RelayStateConfig) -> Self {
+        Self {
+            circuit_keys: HashMap::new(),
+            our_circuits: HashMap::new(),
+            relay_limits: HashMap::new(),
+            config,
+        }
+    }
+
+    /// Get the configuration.
+    pub fn config(&self) -> &RelayStateConfig {
+        &self.config
+    }
+
+    // ========================================================================
+    // Circuit Key Management (for relaying others' traffic)
+    // ========================================================================
+
+    /// Add a circuit key for relaying.
+    ///
+    /// Called when we accept being a hop in someone else's circuit.
+    pub fn add_circuit_key(&mut self, circuit_id: CircuitId, hop_key: CircuitHopKey) {
+        self.circuit_keys.insert(circuit_id, hop_key);
+    }
+
+    /// Get a circuit key by ID.
+    pub fn get_circuit_key(&self, circuit_id: &CircuitId) -> Option<&CircuitHopKey> {
+        self.circuit_keys.get(circuit_id)
+    }
+
+    /// Remove a circuit key.
+    pub fn remove_circuit_key(&mut self, circuit_id: &CircuitId) -> Option<CircuitHopKey> {
+        self.circuit_keys.remove(circuit_id)
+    }
+
+    /// Get the number of circuit keys we're holding.
+    pub fn circuit_count(&self) -> usize {
+        self.circuit_keys.len()
+    }
+
+    /// Remove expired circuit keys.
+    ///
+    /// Returns the number of keys removed.
+    pub fn cleanup_expired_keys(&mut self) -> usize {
+        let lifetime = self.config.circuit_key_lifetime;
+        let before = self.circuit_keys.len();
+        self.circuit_keys.retain(|_, key| !key.is_expired(lifetime));
+        before - self.circuit_keys.len()
+    }
+
+    // ========================================================================
+    // Our Circuit Management (for our outbound traffic)
+    // ========================================================================
+
+    /// Add a circuit we've created.
+    pub fn add_our_circuit(&mut self, circuit: OutboundCircuit) {
+        self.our_circuits.insert(*circuit.id(), circuit);
+    }
+
+    /// Get one of our circuits by ID.
+    pub fn get_our_circuit(&self, circuit_id: &CircuitId) -> Option<&OutboundCircuit> {
+        self.our_circuits.get(circuit_id)
+    }
+
+    /// Remove one of our circuits.
+    pub fn remove_our_circuit(&mut self, circuit_id: &CircuitId) -> Option<OutboundCircuit> {
+        self.our_circuits.remove(circuit_id)
+    }
+
+    /// Get the number of circuits we've created.
+    pub fn our_circuit_count(&self) -> usize {
+        self.our_circuits.len()
+    }
+
+    /// Remove expired circuits we've created.
+    ///
+    /// Returns the number of circuits removed.
+    pub fn cleanup_expired_circuits(&mut self) -> usize {
+        let before = self.our_circuits.len();
+        self.our_circuits.retain(|_, c| !c.is_expired());
+        before - self.our_circuits.len()
+    }
+
+    // ========================================================================
+    // Rate Limiting
+    // ========================================================================
+
+    /// Check if a relay request from a peer should be allowed.
+    ///
+    /// Returns `true` if allowed, `false` if rate limited.
+    pub fn check_rate_limit(&mut self, peer: &PeerId) -> bool {
+        self.relay_limits
+            .entry(*peer)
+            .or_insert_with(|| {
+                RateLimiter::new(
+                    self.config.max_relay_per_window,
+                    self.config.rate_limit_window,
+                )
+            })
+            .check()
+    }
+
+    /// Get the current relay count for a peer.
+    pub fn peer_relay_count(&self, peer: &PeerId) -> usize {
+        self.relay_limits
+            .get(peer)
+            .map(|r| r.current_count())
+            .unwrap_or(0)
+    }
+
+    /// Clean up rate limiters for peers with no recent activity.
+    pub fn cleanup_rate_limiters(&mut self) {
+        self.relay_limits
+            .retain(|_, limiter| limiter.current_count() > 0);
+    }
+
+    // ========================================================================
+    // Combined Cleanup
+    // ========================================================================
+
+    /// Run all cleanup operations.
+    ///
+    /// Returns (expired_keys, expired_circuits, cleaned_limiters).
+    pub fn cleanup_all(&mut self) -> (usize, usize, usize) {
+        let expired_keys = self.cleanup_expired_keys();
+        let expired_circuits = self.cleanup_expired_circuits();
+        let limiter_count_before = self.relay_limits.len();
+        self.cleanup_rate_limiters();
+        let cleaned_limiters = limiter_count_before - self.relay_limits.len();
+
+        (expired_keys, expired_circuits, cleaned_limiters)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::privacy::{CircuitId, SymmetricKey};
+
+    fn random_symmetric_key() -> SymmetricKey {
+        SymmetricKey::random(&mut rand::thread_rng())
+    }
+
+    fn random_circuit_id() -> CircuitId {
+        CircuitId::random(&mut rand::thread_rng())
+    }
+
+    #[test]
+    fn test_circuit_hop_key_forward() {
+        let key = random_symmetric_key();
+        let next_hop = PeerId::random();
+        let hop_key = CircuitHopKey::new_forward(key, next_hop.clone());
+
+        assert!(!hop_key.is_exit());
+        assert_eq!(hop_key.next_hop(), Some(&next_hop));
+        assert!(hop_key.age() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_circuit_hop_key_exit() {
+        let key = random_symmetric_key();
+        let hop_key = CircuitHopKey::new_exit(key);
+
+        assert!(hop_key.is_exit());
+        assert!(hop_key.next_hop().is_none());
+    }
+
+    #[test]
+    fn test_circuit_hop_key_expiry() {
+        let key = random_symmetric_key();
+        let hop_key = CircuitHopKey::new_exit(key);
+
+        // Not expired with long lifetime
+        assert!(!hop_key.is_expired(Duration::from_secs(600)));
+
+        // Expired with very short lifetime
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(hop_key.is_expired(Duration::from_millis(1)));
+    }
+
+    #[test]
+    fn test_rate_limiter_allows_under_limit() {
+        let mut limiter = RateLimiter::new(10, Duration::from_secs(60));
+
+        for _ in 0..10 {
+            assert!(limiter.check());
+        }
+    }
+
+    #[test]
+    fn test_rate_limiter_blocks_over_limit() {
+        let mut limiter = RateLimiter::new(3, Duration::from_secs(60));
+
+        assert!(limiter.check());
+        assert!(limiter.check());
+        assert!(limiter.check());
+        assert!(!limiter.check()); // Should be blocked
+    }
+
+    #[test]
+    fn test_rate_limiter_reset() {
+        let mut limiter = RateLimiter::new(2, Duration::from_secs(60));
+
+        assert!(limiter.check());
+        assert!(limiter.check());
+        assert!(!limiter.check());
+
+        limiter.reset();
+        assert!(limiter.check()); // Should work after reset
+    }
+
+    #[test]
+    fn test_relay_state_creation() {
+        let state = RelayState::new(RelayStateConfig::default());
+        assert_eq!(state.circuit_count(), 0);
+        assert_eq!(state.our_circuit_count(), 0);
+    }
+
+    #[test]
+    fn test_relay_state_circuit_keys() {
+        let mut state = RelayState::new(RelayStateConfig::default());
+
+        let circuit_id = random_circuit_id();
+        let hop_key = CircuitHopKey::new_exit(random_symmetric_key());
+
+        state.add_circuit_key(circuit_id, hop_key);
+        assert_eq!(state.circuit_count(), 1);
+        assert!(state.get_circuit_key(&circuit_id).is_some());
+
+        state.remove_circuit_key(&circuit_id);
+        assert_eq!(state.circuit_count(), 0);
+    }
+
+    #[test]
+    fn test_relay_state_rate_limiting() {
+        let config = RelayStateConfig {
+            max_relay_per_window: 2,
+            ..Default::default()
+        };
+        let mut state = RelayState::new(config);
+        let peer = PeerId::random();
+
+        assert!(state.check_rate_limit(&peer));
+        assert!(state.check_rate_limit(&peer));
+        assert!(!state.check_rate_limit(&peer)); // Should be rate limited
+    }
+
+    #[test]
+    fn test_relay_state_cleanup_expired_keys() {
+        let config = RelayStateConfig {
+            circuit_key_lifetime: Duration::from_millis(1),
+            ..Default::default()
+        };
+        let mut state = RelayState::new(config);
+
+        // Add a circuit key
+        state.add_circuit_key(
+            random_circuit_id(),
+            CircuitHopKey::new_exit(random_symmetric_key()),
+        );
+        assert_eq!(state.circuit_count(), 1);
+
+        // Wait for expiration
+        std::thread::sleep(Duration::from_millis(10));
+
+        // Cleanup should remove expired key
+        let removed = state.cleanup_expired_keys();
+        assert_eq!(removed, 1);
+        assert_eq!(state.circuit_count(), 0);
+    }
+
+    #[test]
+    fn test_relay_state_multiple_peers_rate_limits() {
+        let config = RelayStateConfig {
+            max_relay_per_window: 1,
+            ..Default::default()
+        };
+        let mut state = RelayState::new(config);
+
+        let peer1 = PeerId::random();
+        let peer2 = PeerId::random();
+
+        // Each peer gets their own limit
+        assert!(state.check_rate_limit(&peer1));
+        assert!(state.check_rate_limit(&peer2));
+
+        // Both should be rate limited now
+        assert!(!state.check_rate_limit(&peer1));
+        assert!(!state.check_rate_limit(&peer2));
+    }
+}

--- a/botho/src/network/privacy/types.rs
+++ b/botho/src/network/privacy/types.rs
@@ -1,0 +1,277 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Core types for the privacy/onion gossip module.
+//!
+//! This module defines foundational types used throughout the privacy layer:
+//! - [`CircuitId`]: Unique identifier for relay circuits
+//! - [`SymmetricKey`]: Secure symmetric key for hop encryption
+//!
+//! # Security
+//!
+//! All key material uses `zeroize` for secure memory handling to prevent
+//! sensitive data from persisting in memory after use.
+
+use rand::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// Length of circuit identifiers in bytes.
+pub const CIRCUIT_ID_LEN: usize = 16;
+
+/// Length of symmetric keys in bytes (256-bit for ChaCha20-Poly1305).
+pub const SYMMETRIC_KEY_LEN: usize = 32;
+
+/// A unique identifier for a relay circuit.
+///
+/// Circuit IDs are 16-byte random values that identify a specific circuit
+/// through the relay network. Each circuit has a unique ID that is used
+/// to route messages through the correct hops.
+///
+/// # Example
+///
+/// ```
+/// use botho::network::privacy::CircuitId;
+///
+/// // Generate a random circuit ID
+/// let mut rng = rand::thread_rng();
+/// let circuit_id = CircuitId::random(&mut rng);
+///
+/// // Convert to bytes for transmission
+/// let bytes = circuit_id.as_bytes();
+/// assert_eq!(bytes.len(), 16);
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CircuitId([u8; CIRCUIT_ID_LEN]);
+
+impl CircuitId {
+    /// Generate a new random circuit ID.
+    ///
+    /// Uses the provided cryptographically secure random number generator
+    /// to create a unique circuit identifier.
+    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        let mut bytes = [0u8; CIRCUIT_ID_LEN];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+
+    /// Create a circuit ID from raw bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the slice length is not exactly [`CIRCUIT_ID_LEN`].
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != CIRCUIT_ID_LEN {
+            return None;
+        }
+        let mut arr = [0u8; CIRCUIT_ID_LEN];
+        arr.copy_from_slice(bytes);
+        Some(Self(arr))
+    }
+
+    /// Get the raw bytes of this circuit ID.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; CIRCUIT_ID_LEN] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for CircuitId {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for CircuitId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CircuitId({})", hex::encode(&self.0[..4]))
+    }
+}
+
+impl fmt::Display for CircuitId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", hex::encode(&self.0[..8]))
+    }
+}
+
+/// A symmetric key for encrypting circuit hop data.
+///
+/// Uses ChaCha20-Poly1305 (256-bit key) for authenticated encryption.
+/// The key is automatically zeroed from memory when dropped.
+///
+/// # Security
+///
+/// - Implements [`Zeroize`] and [`ZeroizeOnDrop`] for secure memory handling
+/// - Debug output shows only a hash of the key, not the key itself
+/// - Clone is intentionally not derived to prevent accidental key duplication
+///
+/// # Example
+///
+/// ```
+/// use botho::network::privacy::SymmetricKey;
+///
+/// // Generate a random key
+/// let mut rng = rand::thread_rng();
+/// let key = SymmetricKey::random(&mut rng);
+///
+/// // Key is zeroed when dropped
+/// drop(key);
+/// ```
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct SymmetricKey([u8; SYMMETRIC_KEY_LEN]);
+
+impl SymmetricKey {
+    /// Generate a new random symmetric key.
+    ///
+    /// Uses the provided cryptographically secure random number generator.
+    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+        let mut bytes = [0u8; SYMMETRIC_KEY_LEN];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+
+    /// Create a symmetric key from raw bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the slice length is not exactly [`SYMMETRIC_KEY_LEN`].
+    ///
+    /// # Security
+    ///
+    /// The input bytes are copied; the caller is responsible for zeroing
+    /// the original source if needed.
+    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != SYMMETRIC_KEY_LEN {
+            return None;
+        }
+        let mut arr = [0u8; SYMMETRIC_KEY_LEN];
+        arr.copy_from_slice(bytes);
+        Some(Self(arr))
+    }
+
+    /// Get the raw bytes of this key.
+    ///
+    /// # Security
+    ///
+    /// Be careful with the returned reference - avoid copying or logging it.
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; SYMMETRIC_KEY_LEN] {
+        &self.0
+    }
+
+    /// Create an explicit copy of this key.
+    ///
+    /// This method exists to make key copying explicit and intentional,
+    /// rather than allowing implicit cloning.
+    ///
+    /// # Security
+    ///
+    /// Only use this when you genuinely need a second copy of the key.
+    /// Both copies will be independently zeroed on drop.
+    pub fn duplicate(&self) -> Self {
+        Self(self.0)
+    }
+}
+
+impl AsRef<[u8]> for SymmetricKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SymmetricKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Never log the actual key - show a hash fingerprint instead
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(&self.0);
+        let hash = hasher.finalize();
+        write!(f, "SymmetricKey(sha256:{})", hex::encode(&hash[..4]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_circuit_id_random_uniqueness() {
+        let mut rng = rand::thread_rng();
+        let id1 = CircuitId::random(&mut rng);
+        let id2 = CircuitId::random(&mut rng);
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_circuit_id_from_bytes() {
+        let bytes = [0x42u8; CIRCUIT_ID_LEN];
+        let id = CircuitId::from_bytes(&bytes).unwrap();
+        assert_eq!(id.as_bytes(), &bytes);
+    }
+
+    #[test]
+    fn test_circuit_id_from_bytes_wrong_length() {
+        let bytes = [0x42u8; 8];
+        assert!(CircuitId::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn test_circuit_id_debug_format() {
+        let id = CircuitId([0xDE, 0xAD, 0xBE, 0xEF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let debug = format!("{:?}", id);
+        assert!(debug.contains("deadbeef"));
+    }
+
+    #[test]
+    fn test_symmetric_key_random_uniqueness() {
+        let mut rng = rand::thread_rng();
+        let key1 = SymmetricKey::random(&mut rng);
+        let key2 = SymmetricKey::random(&mut rng);
+        assert_ne!(key1.as_bytes(), key2.as_bytes());
+    }
+
+    #[test]
+    fn test_symmetric_key_from_bytes() {
+        let bytes = [0x42u8; SYMMETRIC_KEY_LEN];
+        let key = SymmetricKey::from_bytes(&bytes).unwrap();
+        assert_eq!(key.as_bytes(), &bytes);
+    }
+
+    #[test]
+    fn test_symmetric_key_from_bytes_wrong_length() {
+        let bytes = [0x42u8; 16];
+        assert!(SymmetricKey::from_bytes(&bytes).is_none());
+    }
+
+    #[test]
+    fn test_symmetric_key_debug_does_not_leak() {
+        let key = SymmetricKey([0x42u8; SYMMETRIC_KEY_LEN]);
+        let debug = format!("{:?}", key);
+        // Should not contain the actual key bytes
+        assert!(!debug.contains("42424242"));
+        // Should contain a hash fingerprint
+        assert!(debug.contains("sha256:"));
+    }
+
+    #[test]
+    fn test_symmetric_key_duplicate() {
+        let key1 = SymmetricKey([0x42u8; SYMMETRIC_KEY_LEN]);
+        let key2 = key1.duplicate();
+        assert_eq!(key1.as_bytes(), key2.as_bytes());
+    }
+
+    #[test]
+    fn test_circuit_id_hash_impl() {
+        use std::collections::HashSet;
+
+        let mut rng = rand::thread_rng();
+        let mut set = HashSet::new();
+
+        for _ in 0..100 {
+            let id = CircuitId::random(&mut rng);
+            set.insert(id);
+        }
+
+        assert_eq!(set.len(), 100);
+    }
+}


### PR DESCRIPTION
## Summary

- Implements foundational data structures for traffic analysis resistance using Onion Gossip
- Adds `network::privacy` module with core types for circuit management and relay operations
- Part of Epic #147: Traffic Analysis Resistance - Phase 1

## Changes

### New Types (`botho/src/network/privacy/`)

**types.rs:**
- `CircuitId`: 16-byte random circuit identifier with Hash support
- `SymmetricKey`: 256-bit key with zeroize for secure memory handling

**circuit.rs:**
- `OutboundCircuit`: 3-hop circuit with keys, expiration, and jitter
- `CircuitPool`: Pool of pre-built circuits with rotation support
- `CircuitPoolConfig`: Configuration for pool behavior

**relay.rs:**
- `CircuitHopKey`: Per-hop relay key material (forward/exit)
- `RelayState`: Manages circuits where node acts as relay
- `RateLimiter`: Per-peer rate limiting for relay traffic
- `RelayStateConfig`: Configuration for relay behavior

### Key Features

- Secure memory handling with zeroize for all key material
- Circuit expiration with random jitter to prevent timing correlation
- Per-peer rate limiting to prevent relay flooding attacks
- 32 comprehensive unit tests for all components

## Test plan

- [x] All unit tests pass (`cargo test -p botho --lib network::privacy`)
- [x] Library compiles without errors (`cargo check -p botho`)
- [x] Code formatted with `cargo fmt`

## Next Steps (Future PRs)

This is Phase 1, Issue 1 of the Traffic Analysis Resistance epic. Subsequent issues will implement:
- Circuit building and telescoping handshake
- Onion encryption/decryption
- Integration with gossipsub

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)