### PR TITLE
feat: Integrate onion gossip with transaction broadcast

### DIFF
--- a/botho/src/network/privacy/broadcaster.rs
+++ b/botho/src/network/privacy/broadcaster.rs
@@ -1,0 +1,398 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Privacy-preserving transaction broadcaster using onion gossip.
+//!
+//! This module implements the broadcast integration for Phase 1 of the
+//! traffic analysis resistance roadmap. Transactions are routed through
+//! 3-hop circuits before being broadcast, hiding the originating node.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────────────────────┐
+//! │                    PRIVATE BROADCAST FLOW                         │
+//! │                                                                   │
+//! │   User submits transaction                                        │
+//! │       │                                                           │
+//! │       ▼                                                           │
+//! │   OnionBroadcaster.broadcast_private(tx)                          │
+//! │       │                                                           │
+//! │       ├─── Get circuit from CircuitPool                           │
+//! │       │         │                                                 │
+//! │       │         ├─── Circuit available                            │
+//! │       │         │         │                                       │
+//! │       │         │         ▼                                       │
+//! │       │         │    Wrap tx in InnerMessage::Transaction         │
+//! │       │         │         │                                       │
+//! │       │         │         ▼                                       │
+//! │       │         │    wrap_onion(inner, hops, keys)                │
+//! │       │         │         │                                       │
+//! │       │         │         ▼                                       │
+//! │       │         │    GossipHandle.send_onion_relay()              │
+//! │       │         │         │                                       │
+//! │       │         │         ▼                                       │
+//! │       │         │    → Hop1 → Hop2 → Exit → gossipsub             │
+//! │       │         │                                                 │
+//! │       │         └─── No circuit (fallback behavior)               │
+//! │       │                   │                                       │
+//! │       │                   ▼                                       │
+//! │       │              Queue or return error                        │
+//! │       │                                                           │
+//! │       ▼                                                           │
+//! │   Return tx_hash                                                  │
+//! └──────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Security Properties
+//!
+//! - Transactions exit from a different node than the origin
+//! - No single relay knows both origin and transaction content
+//! - Cover traffic normalizes message patterns (Phase 2)
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use bth_gossip::{GossipHandle, InnerMessage, OnionRelayMessage};
+use libp2p::PeerId;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tracing::{debug, trace, warn};
+
+use super::{wrap_onion, CircuitPool, OutboundCircuit};
+use crate::transaction::Transaction;
+
+/// Errors that can occur during private broadcast.
+#[derive(Debug, Error)]
+pub enum BroadcastError {
+    /// No circuit available for routing.
+    #[error("no circuit available for private broadcast")]
+    NoCircuit,
+
+    /// Failed to serialize transaction.
+    #[error("failed to serialize transaction: {0}")]
+    SerializationError(String),
+
+    /// Failed to serialize inner message.
+    #[error("failed to serialize inner message: {0}")]
+    InnerSerializationError(String),
+
+    /// Failed to send to gossip network.
+    #[error("gossip network error: {0}")]
+    GossipError(String),
+}
+
+/// Metrics for private broadcast operations.
+#[derive(Debug, Default)]
+pub struct BroadcastMetrics {
+    /// Transactions sent via onion circuit.
+    pub tx_broadcast_private: AtomicU64,
+
+    /// Transactions queued because no circuit available.
+    pub tx_queued_no_circuit: AtomicU64,
+
+    /// Transactions that failed to broadcast.
+    pub tx_broadcast_failed: AtomicU64,
+
+    /// Transactions we broadcast as exit node (received via relay).
+    pub tx_exit_broadcast: AtomicU64,
+}
+
+impl BroadcastMetrics {
+    /// Create new metrics instance.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Get a snapshot of current metrics.
+    pub fn snapshot(&self) -> BroadcastMetricsSnapshot {
+        BroadcastMetricsSnapshot {
+            tx_broadcast_private: self.tx_broadcast_private.load(Ordering::Relaxed),
+            tx_queued_no_circuit: self.tx_queued_no_circuit.load(Ordering::Relaxed),
+            tx_broadcast_failed: self.tx_broadcast_failed.load(Ordering::Relaxed),
+            tx_exit_broadcast: self.tx_exit_broadcast.load(Ordering::Relaxed),
+        }
+    }
+
+    fn inc_private(&self) {
+        self.tx_broadcast_private.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn inc_queued(&self) {
+        self.tx_queued_no_circuit.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn inc_failed(&self) {
+        self.tx_broadcast_failed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment exit broadcast counter (called when we're the exit node).
+    pub fn inc_exit_broadcast(&self) {
+        self.tx_exit_broadcast.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Snapshot of broadcast metrics (for RPC/monitoring).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BroadcastMetricsSnapshot {
+    /// Transactions sent via onion circuit.
+    pub tx_broadcast_private: u64,
+    /// Transactions queued because no circuit available.
+    pub tx_queued_no_circuit: u64,
+    /// Transactions that failed to broadcast.
+    pub tx_broadcast_failed: u64,
+    /// Transactions we broadcast as exit node.
+    pub tx_exit_broadcast: u64,
+}
+
+/// Privacy-preserving transaction broadcaster.
+///
+/// Wraps transactions in onion layers and routes them through circuits
+/// before broadcast. This ensures the exit node (not the origin) appears
+/// as the source of the transaction.
+#[derive(Debug)]
+pub struct OnionBroadcaster {
+    /// Metrics for monitoring broadcast operations.
+    metrics: Arc<BroadcastMetrics>,
+}
+
+impl OnionBroadcaster {
+    /// Create a new broadcaster.
+    pub fn new() -> Self {
+        Self {
+            metrics: Arc::new(BroadcastMetrics::new()),
+        }
+    }
+
+    /// Create a new broadcaster with shared metrics.
+    pub fn with_metrics(metrics: Arc<BroadcastMetrics>) -> Self {
+        Self { metrics }
+    }
+
+    /// Get the broadcaster's metrics.
+    pub fn metrics(&self) -> &Arc<BroadcastMetrics> {
+        &self.metrics
+    }
+
+    /// Broadcast a transaction privately through an onion circuit.
+    ///
+    /// The transaction is:
+    /// 1. Serialized to bytes
+    /// 2. Wrapped in an InnerMessage::Transaction
+    /// 3. Onion-encrypted with 3 layers
+    /// 4. Sent to the first hop via gossipsub
+    ///
+    /// # Arguments
+    ///
+    /// * `tx` - The transaction to broadcast
+    /// * `circuit_pool` - Pool of available circuits
+    /// * `gossip_handle` - Handle to the gossip network
+    ///
+    /// # Returns
+    ///
+    /// The transaction hash on success, or an error if broadcast failed.
+    pub async fn broadcast_private(
+        &self,
+        tx: &Transaction,
+        circuit_pool: &CircuitPool,
+        gossip_handle: &GossipHandle,
+    ) -> Result<[u8; 32], BroadcastError> {
+        // Get a circuit from the pool
+        let circuit = match circuit_pool.get_circuit() {
+            Some(c) => c,
+            None => {
+                self.metrics.inc_queued();
+                warn!("No circuit available for private broadcast");
+                return Err(BroadcastError::NoCircuit);
+            }
+        };
+
+        self.broadcast_via_circuit(tx, circuit, gossip_handle).await
+    }
+
+    /// Broadcast a transaction through a specific circuit.
+    ///
+    /// This is the core broadcast logic, factored out to allow testing
+    /// with specific circuits.
+    pub async fn broadcast_via_circuit(
+        &self,
+        tx: &Transaction,
+        circuit: &OutboundCircuit,
+        gossip_handle: &GossipHandle,
+    ) -> Result<[u8; 32], BroadcastError> {
+        // Serialize transaction
+        let tx_data =
+            bincode::serialize(tx).map_err(|e| BroadcastError::SerializationError(e.to_string()))?;
+
+        // Compute transaction hash
+        let tx_hash = tx.hash();
+
+        debug!(
+            tx_hash = hex::encode(&tx_hash[..8]),
+            circuit_id = %circuit.id(),
+            first_hop = %circuit.entry_hop(),
+            "Broadcasting transaction via onion circuit"
+        );
+
+        // Create inner message
+        let inner = InnerMessage::Transaction {
+            tx_data,
+            tx_hash,
+        };
+
+        // Serialize inner message
+        let inner_bytes = bth_util_serial::serialize(&inner)
+            .map_err(|e| BroadcastError::InnerSerializationError(e.to_string()))?;
+
+        // Wrap in onion layers
+        let hops = *circuit.hops();
+        let keys = [
+            circuit.hop_key(0).duplicate(),
+            circuit.hop_key(1).duplicate(),
+            circuit.hop_key(2).duplicate(),
+        ];
+        let wrapped = wrap_onion(&inner_bytes, &hops, &keys);
+
+        // Create gossip circuit ID from our circuit ID
+        let gossip_circuit_id = bth_gossip::CircuitId(*circuit.id().as_bytes());
+
+        // Create onion relay message
+        let msg = OnionRelayMessage {
+            circuit_id: gossip_circuit_id,
+            payload: wrapped,
+        };
+
+        // Send to gossip network
+        gossip_handle
+            .send_onion_relay(msg)
+            .await
+            .map_err(|e| {
+                self.metrics.inc_failed();
+                BroadcastError::GossipError(e.to_string())
+            })?;
+
+        self.metrics.inc_private();
+
+        trace!(
+            tx_hash = hex::encode(&tx_hash[..8]),
+            "Transaction successfully routed through circuit"
+        );
+
+        Ok(tx_hash)
+    }
+
+    /// Check if a transaction hash matches the transaction data.
+    ///
+    /// Used by exit nodes to validate transactions before broadcast.
+    pub fn validate_tx_hash(tx_data: &[u8], expected_hash: &[u8; 32]) -> bool {
+        if tx_data.is_empty() {
+            return false;
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(tx_data);
+        let computed = hasher.finalize();
+
+        computed.as_slice() == expected_hash
+    }
+}
+
+impl Default for OnionBroadcaster {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::privacy::{CircuitId, CircuitPoolConfig, SymmetricKey};
+    use std::time::Duration;
+
+    fn make_test_circuit() -> OutboundCircuit {
+        let mut rng = rand::thread_rng();
+        OutboundCircuit::new(
+            CircuitId::random(&mut rng),
+            [PeerId::random(), PeerId::random(), PeerId::random()],
+            [
+                SymmetricKey::random(&mut rng),
+                SymmetricKey::random(&mut rng),
+                SymmetricKey::random(&mut rng),
+            ],
+            Duration::from_secs(600),
+        )
+    }
+
+    #[test]
+    fn test_broadcaster_creation() {
+        let broadcaster = OnionBroadcaster::new();
+        let snapshot = broadcaster.metrics().snapshot();
+
+        assert_eq!(snapshot.tx_broadcast_private, 0);
+        assert_eq!(snapshot.tx_queued_no_circuit, 0);
+        assert_eq!(snapshot.tx_broadcast_failed, 0);
+        assert_eq!(snapshot.tx_exit_broadcast, 0);
+    }
+
+    #[test]
+    fn test_metrics_increment() {
+        let metrics = BroadcastMetrics::new();
+
+        metrics.inc_private();
+        metrics.inc_private();
+        metrics.inc_queued();
+        metrics.inc_failed();
+        metrics.inc_exit_broadcast();
+
+        let snapshot = metrics.snapshot();
+        assert_eq!(snapshot.tx_broadcast_private, 2);
+        assert_eq!(snapshot.tx_queued_no_circuit, 1);
+        assert_eq!(snapshot.tx_broadcast_failed, 1);
+        assert_eq!(snapshot.tx_exit_broadcast, 1);
+    }
+
+    #[test]
+    fn test_validate_tx_hash() {
+        use sha2::{Digest, Sha256};
+
+        let tx_data = b"test transaction data";
+
+        // Compute correct hash
+        let mut hasher = Sha256::new();
+        hasher.update(tx_data);
+        let hash = hasher.finalize();
+        let mut correct_hash = [0u8; 32];
+        correct_hash.copy_from_slice(&hash);
+
+        // Valid hash should pass
+        assert!(OnionBroadcaster::validate_tx_hash(tx_data, &correct_hash));
+
+        // Wrong hash should fail
+        let wrong_hash = [0u8; 32];
+        assert!(!OnionBroadcaster::validate_tx_hash(tx_data, &wrong_hash));
+
+        // Empty data should fail
+        assert!(!OnionBroadcaster::validate_tx_hash(&[], &correct_hash));
+    }
+
+    #[test]
+    fn test_no_circuit_increments_queued() {
+        let broadcaster = OnionBroadcaster::new();
+        let pool = CircuitPool::new(CircuitPoolConfig::default());
+
+        // Pool is empty, so we can't test the full broadcast without a mock
+        // But we can verify the pool reports no circuits
+        assert!(pool.get_circuit().is_none());
+    }
+
+    #[test]
+    fn test_shared_metrics() {
+        let metrics = Arc::new(BroadcastMetrics::new());
+        let broadcaster = OnionBroadcaster::with_metrics(metrics.clone());
+
+        // Increment via broadcaster's metrics
+        broadcaster.metrics().inc_private();
+
+        // Should be visible via shared reference
+        assert_eq!(metrics.snapshot().tx_broadcast_private, 1);
+    }
+}

--- a/botho/src/network/privacy/mod.rs
+++ b/botho/src/network/privacy/mod.rs
@@ -82,6 +82,7 @@
 //! - Design document: `docs/design/traffic-privacy-roadmap.md`
 //! - Parent issue: #147 (Traffic Analysis Resistance - Phase 1)
 
+mod broadcaster;
 mod circuit;
 mod crypto;
 pub mod handshake;
@@ -120,3 +121,6 @@ pub use handshake::{
 pub use relay_handler::{
     RelayAction, RelayHandler, RelayHandlerError, RelayMetrics, RelayMetricsSnapshot,
 };
+
+// Re-export broadcaster types
+pub use broadcaster::{BroadcastError, BroadcastMetrics, BroadcastMetricsSnapshot, OnionBroadcaster};

--- a/botho/tests/onion_broadcast_integration.rs
+++ b/botho/tests/onion_broadcast_integration.rs
@@ -1,0 +1,283 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Integration tests for private transaction broadcasting via onion gossip.
+//!
+//! These tests verify the full broadcast pipeline from transaction creation
+//! through onion wrapping and message creation.
+
+use botho::network::privacy::{
+    decrypt_layer, wrap_onion, BroadcastMetrics, CircuitId, CircuitPool, CircuitPoolConfig,
+    DecryptedLayer, OnionBroadcaster, OutboundCircuit, SymmetricKey,
+};
+use bth_gossip::InnerMessage;
+use libp2p::PeerId;
+use std::sync::Arc;
+use std::time::Duration;
+
+fn random_symmetric_key() -> SymmetricKey {
+    SymmetricKey::random(&mut rand::thread_rng())
+}
+
+fn make_test_circuit(lifetime: Duration) -> OutboundCircuit {
+    let mut rng = rand::thread_rng();
+    OutboundCircuit::new(
+        CircuitId::random(&mut rng),
+        [PeerId::random(), PeerId::random(), PeerId::random()],
+        [
+            SymmetricKey::random(&mut rng),
+            SymmetricKey::random(&mut rng),
+            SymmetricKey::random(&mut rng),
+        ],
+        lifetime,
+    )
+}
+
+/// Test that broadcaster can be created with default configuration.
+#[test]
+fn test_broadcaster_creation() {
+    let broadcaster = OnionBroadcaster::new();
+    let snapshot = broadcaster.metrics().snapshot();
+
+    assert_eq!(snapshot.tx_broadcast_private, 0);
+    assert_eq!(snapshot.tx_queued_no_circuit, 0);
+}
+
+/// Test that broadcaster can be created with shared metrics.
+#[test]
+fn test_broadcaster_shared_metrics() {
+    let metrics = Arc::new(BroadcastMetrics::new());
+    let broadcaster = OnionBroadcaster::with_metrics(metrics.clone());
+
+    broadcaster.metrics().inc_exit_broadcast();
+
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.tx_exit_broadcast, 1);
+}
+
+/// Test that all metrics counters increment correctly.
+#[test]
+fn test_metrics_counters() {
+    let metrics = BroadcastMetrics::new();
+
+    // Increment all counters
+    for _ in 0..3 {
+        metrics.tx_broadcast_private.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    for _ in 0..2 {
+        metrics.tx_queued_no_circuit.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+    metrics.tx_broadcast_failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    for _ in 0..5 {
+        metrics.inc_exit_broadcast();
+    }
+
+    let snapshot = metrics.snapshot();
+    assert_eq!(snapshot.tx_broadcast_private, 3);
+    assert_eq!(snapshot.tx_queued_no_circuit, 2);
+    assert_eq!(snapshot.tx_broadcast_failed, 1);
+    assert_eq!(snapshot.tx_exit_broadcast, 5);
+}
+
+/// Test onion wrapping produces valid layered encryption.
+#[test]
+fn test_onion_wrap_and_unwrap() {
+    let keys = [random_symmetric_key(), random_symmetric_key(), random_symmetric_key()];
+    let hops = [PeerId::random(), PeerId::random(), PeerId::random()];
+
+    // Create inner message
+    let tx_data = b"test transaction data".to_vec();
+    let tx_hash = [42u8; 32];
+    let inner = InnerMessage::Transaction {
+        tx_data: tx_data.clone(),
+        tx_hash,
+    };
+    let inner_bytes = bth_util_serial::serialize(&inner).unwrap();
+
+    // Wrap in onion layers
+    let wrapped = wrap_onion(&inner_bytes, &hops, &keys);
+
+    // Unwrap layer by layer
+    // First hop
+    let layer1 = decrypt_layer(&keys[0], &wrapped).expect("layer 1 decryption failed");
+    let (next1, inner1) = match layer1 {
+        DecryptedLayer::Forward { next_hop, inner } => (next_hop, inner),
+        _ => panic!("expected Forward layer at hop 1"),
+    };
+    assert_eq!(next1, hops[1]);
+
+    // Second hop
+    let layer2 = decrypt_layer(&keys[1], &inner1).expect("layer 2 decryption failed");
+    let (next2, inner2) = match layer2 {
+        DecryptedLayer::Forward { next_hop, inner } => (next_hop, inner),
+        _ => panic!("expected Forward layer at hop 2"),
+    };
+    assert_eq!(next2, hops[2]);
+
+    // Third hop (exit)
+    let layer3 = decrypt_layer(&keys[2], &inner2).expect("layer 3 decryption failed");
+    match layer3 {
+        DecryptedLayer::Exit { payload } => {
+            // Deserialize inner message
+            let inner_msg: InnerMessage = bth_util_serial::deserialize(&payload).unwrap();
+            match inner_msg {
+                InnerMessage::Transaction { tx_data: td, tx_hash: th } => {
+                    assert_eq!(td, tx_data);
+                    assert_eq!(th, tx_hash);
+                }
+                _ => panic!("expected Transaction inner message"),
+            }
+        }
+        _ => panic!("expected Exit layer at hop 3"),
+    }
+}
+
+/// Test that circuit pool reports no circuits when empty.
+#[test]
+fn test_empty_circuit_pool() {
+    let pool = CircuitPool::new(CircuitPoolConfig::default());
+
+    assert!(pool.get_circuit().is_none());
+    assert!(pool.needs_more_circuits());
+    assert_eq!(pool.active_count(), 0);
+}
+
+/// Test that circuit pool returns circuits when available.
+#[test]
+fn test_circuit_pool_with_circuits() {
+    let mut pool = CircuitPool::new(CircuitPoolConfig {
+        min_circuits: 2,
+        ..Default::default()
+    });
+
+    // Add circuits
+    pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+    pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+
+    assert_eq!(pool.active_count(), 2);
+    assert!(!pool.needs_more_circuits());
+    assert!(pool.get_circuit().is_some());
+}
+
+/// Test transaction hash validation.
+#[test]
+fn test_tx_hash_validation() {
+    use sha2::{Digest, Sha256};
+
+    let tx_data = b"valid transaction data";
+
+    // Compute correct hash
+    let mut hasher = Sha256::new();
+    hasher.update(tx_data);
+    let hash = hasher.finalize();
+    let mut correct_hash = [0u8; 32];
+    correct_hash.copy_from_slice(&hash);
+
+    // Valid hash should pass
+    assert!(OnionBroadcaster::validate_tx_hash(tx_data, &correct_hash));
+
+    // Wrong hash should fail
+    let wrong_hash = [0u8; 32];
+    assert!(!OnionBroadcaster::validate_tx_hash(tx_data, &wrong_hash));
+
+    // Empty data should fail
+    assert!(!OnionBroadcaster::validate_tx_hash(&[], &correct_hash));
+}
+
+/// Test circuit expiration removes circuits from pool.
+#[test]
+fn test_circuit_expiration() {
+    let mut pool = CircuitPool::new(CircuitPoolConfig::default());
+
+    // Add a short-lived circuit (1ms lifetime + max jitter of 180s)
+    // Since jitter is random, we can't guarantee expiration timing in integration tests.
+    // Instead, test that remove_expired doesn't panic and works with fresh circuits.
+    pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+    pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+
+    assert_eq!(pool.total_count(), 2);
+
+    // Fresh circuits shouldn't be removed
+    let removed = pool.remove_expired();
+    assert_eq!(removed, 0);
+    assert_eq!(pool.total_count(), 2);
+}
+
+/// Test InnerMessage serialization round-trip.
+#[test]
+fn test_inner_message_serialization() {
+    // Transaction
+    let tx_inner = InnerMessage::Transaction {
+        tx_data: vec![1, 2, 3, 4, 5],
+        tx_hash: [99u8; 32],
+    };
+    let tx_bytes = bth_util_serial::serialize(&tx_inner).unwrap();
+    let tx_decoded: InnerMessage = bth_util_serial::deserialize(&tx_bytes).unwrap();
+    match tx_decoded {
+        InnerMessage::Transaction { tx_data, tx_hash } => {
+            assert_eq!(tx_data, vec![1, 2, 3, 4, 5]);
+            assert_eq!(tx_hash, [99u8; 32]);
+        }
+        _ => panic!("expected Transaction"),
+    }
+
+    // SyncRequest
+    let sync_inner = InnerMessage::SyncRequest {
+        from_height: 12345,
+        max_blocks: 100,
+    };
+    let sync_bytes = bth_util_serial::serialize(&sync_inner).unwrap();
+    let sync_decoded: InnerMessage = bth_util_serial::deserialize(&sync_bytes).unwrap();
+    match sync_decoded {
+        InnerMessage::SyncRequest { from_height, max_blocks } => {
+            assert_eq!(from_height, 12345);
+            assert_eq!(max_blocks, 100);
+        }
+        _ => panic!("expected SyncRequest"),
+    }
+
+    // Cover
+    let cover_inner = InnerMessage::Cover;
+    let cover_bytes = bth_util_serial::serialize(&cover_inner).unwrap();
+    let cover_decoded: InnerMessage = bth_util_serial::deserialize(&cover_bytes).unwrap();
+    assert!(matches!(cover_decoded, InnerMessage::Cover));
+}
+
+/// Test that multiple circuits provide random selection.
+#[test]
+fn test_random_circuit_selection() {
+    let mut pool = CircuitPool::new(CircuitPoolConfig::default());
+
+    // Add several circuits with different IDs
+    for _ in 0..10 {
+        pool.add_circuit(make_test_circuit(Duration::from_secs(600)));
+    }
+
+    // Get circuits multiple times - should get different ones sometimes
+    let mut seen_ids = std::collections::HashSet::new();
+    for _ in 0..20 {
+        if let Some(circuit) = pool.get_circuit() {
+            seen_ids.insert(*circuit.id().as_bytes());
+        }
+    }
+
+    // We should see more than one circuit (random selection)
+    // With 10 circuits and 20 selections, probability of seeing only 1 is (1/10)^19 ≈ 0
+    assert!(seen_ids.len() > 1, "Expected random selection to hit multiple circuits");
+}
+
+/// Test broadcast error types.
+#[test]
+fn test_broadcast_error_display() {
+    use botho::network::privacy::BroadcastError;
+
+    let err = BroadcastError::NoCircuit;
+    assert!(format!("{}", err).contains("no circuit"));
+
+    let err = BroadcastError::SerializationError("test error".to_string());
+    assert!(format!("{}", err).contains("serialize"));
+    assert!(format!("{}", err).contains("test error"));
+
+    let err = BroadcastError::GossipError("network down".to_string());
+    assert!(format!("{}", err).contains("gossip"));
+    assert!(format!("{}", err).contains("network down"));
+}

--- a/gossip/src/service.rs
+++ b/gossip/src/service.rs
@@ -354,6 +354,12 @@ async fn run_swarm(
                         }
                     }
 
+                    GossipCommand::SendOnionRelay(onion_msg) => {
+                        if let Err(e) = swarm.behaviour_mut().publish_onion_relay(&onion_msg) {
+                            warn!(?e, "Failed to send onion relay message");
+                        }
+                    }
+
                     GossipCommand::RequestTopology { peer, since_timestamp } => {
                         swarm.behaviour_mut().request_topology(
                             peer,


### PR DESCRIPTION
## Summary

- Adds `SendOnionRelay` command to `GossipHandle` for sending onion relay messages
- Adds `publish_onion_relay` method to `GossipBehaviour` for gossipsub publishing
- Creates `OnionBroadcaster` for wrapping transactions in 3 onion layers
- Adds `BroadcastMetrics` for monitoring private broadcast operations
- Adds comprehensive integration tests for the broadcast pipeline

## Changes

### Gossip Crate (bth-gossip)
- `behaviour.rs`: Added `GossipCommand::SendOnionRelay` variant
- `behaviour.rs`: Added `send_onion_relay()` method to `GossipHandle`
- `behaviour.rs`: Added `publish_onion_relay()` method to `GossipBehaviour`
- `service.rs`: Handle `SendOnionRelay` command in the swarm loop

### Botho Crate
- `network/privacy/broadcaster.rs`: New `OnionBroadcaster` module
  - `OnionBroadcaster` - wraps transactions in onion layers and sends to circuits
  - `BroadcastError` - error types for private broadcast failures
  - `BroadcastMetrics` - atomic counters for monitoring
- `network/privacy/mod.rs`: Export broadcaster types

### Tests
- `tests/onion_broadcast_integration.rs`: 11 integration tests covering:
  - Broadcaster creation and metrics
  - Onion wrap/unwrap round-trip
  - Circuit pool operations
  - Transaction hash validation
  - InnerMessage serialization
  - Random circuit selection

## Test plan

- [x] All 11 new integration tests pass
- [x] Existing relay_handler tests pass
- [x] `cargo check` passes for all crates
- [x] Library compiles without errors

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)