### PR TITLE
feat(transport): Implement pluggable transport interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,7 @@ version = "0.1.0"
 dependencies = [
  "aes",
  "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "bincode",
  "botho-wallet",

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -106,6 +106,7 @@ chacha20poly1305 = { workspace = true }
 
 # Async (for future networking)
 tokio = { version = "1", features = ["full"] }
+async-trait = "0.1"
 
 # JSON-RPC server
 hyper = { version = "1", features = ["server", "http1"] }

--- a/botho/src/network/mod.rs
+++ b/botho/src/network/mod.rs
@@ -17,6 +17,7 @@ pub mod privacy;
 mod quorum;
 mod reputation;
 mod sync;
+pub mod transport;
 
 pub use compact_block::{
     BlockTxn, CompactBlock, GetBlockTxn, PrefilledTx, ReconstructionResult, ShortId,

--- a/botho/src/network/transport/error.rs
+++ b/botho/src/network/transport/error.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Transport error types for pluggable transports.
+//!
+//! This module defines the error types used by the transport layer,
+//! covering connection failures, handshake errors, and transport-specific issues.
+
+use std::fmt;
+use std::io;
+
+/// Errors that can occur during transport operations.
+#[derive(Debug)]
+pub enum TransportError {
+    /// Connection to peer failed.
+    ConnectionFailed(String),
+
+    /// Transport handshake failed.
+    HandshakeFailed(String),
+
+    /// Transport type not supported by peer.
+    NotSupported,
+
+    /// Transport negotiation failed.
+    NegotiationFailed(String),
+
+    /// Connection timed out.
+    Timeout,
+
+    /// Connection was closed unexpectedly.
+    ConnectionClosed,
+
+    /// Invalid peer address or identifier.
+    InvalidPeer(String),
+
+    /// Transport configuration error.
+    Configuration(String),
+
+    /// Underlying I/O error.
+    Io(io::Error),
+
+    /// Transport-specific error.
+    Transport(String),
+}
+
+impl fmt::Display for TransportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TransportError::ConnectionFailed(msg) => write!(f, "connection failed: {}", msg),
+            TransportError::HandshakeFailed(msg) => write!(f, "handshake failed: {}", msg),
+            TransportError::NotSupported => write!(f, "transport not supported by peer"),
+            TransportError::NegotiationFailed(msg) => write!(f, "negotiation failed: {}", msg),
+            TransportError::Timeout => write!(f, "connection timed out"),
+            TransportError::ConnectionClosed => write!(f, "connection closed unexpectedly"),
+            TransportError::InvalidPeer(msg) => write!(f, "invalid peer: {}", msg),
+            TransportError::Configuration(msg) => write!(f, "configuration error: {}", msg),
+            TransportError::Io(err) => write!(f, "I/O error: {}", err),
+            TransportError::Transport(msg) => write!(f, "transport error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for TransportError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TransportError::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for TransportError {
+    fn from(err: io::Error) -> Self {
+        TransportError::Io(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn test_error_display() {
+        let err = TransportError::ConnectionFailed("refused".to_string());
+        assert_eq!(err.to_string(), "connection failed: refused");
+
+        let err = TransportError::NotSupported;
+        assert_eq!(err.to_string(), "transport not supported by peer");
+
+        let err = TransportError::Timeout;
+        assert_eq!(err.to_string(), "connection timed out");
+    }
+
+    #[test]
+    fn test_error_from_io() {
+        let io_err = io::Error::new(io::ErrorKind::ConnectionRefused, "refused");
+        let transport_err: TransportError = io_err.into();
+
+        match transport_err {
+            TransportError::Io(e) => assert_eq!(e.kind(), io::ErrorKind::ConnectionRefused),
+            _ => panic!("expected Io variant"),
+        }
+    }
+
+    #[test]
+    fn test_error_source() {
+        let io_err = io::Error::new(io::ErrorKind::Other, "test");
+        let transport_err = TransportError::Io(io_err);
+        assert!(transport_err.source().is_some());
+
+        let other_err = TransportError::Timeout;
+        assert!(other_err.source().is_none());
+    }
+}

--- a/botho/src/network/transport/mod.rs
+++ b/botho/src/network/transport/mod.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Pluggable transport layer for protocol obfuscation.
+//!
+//! This module implements Phase 3.1 of the traffic privacy roadmap:
+//! a pluggable transport interface that allows different transport
+//! implementations to be used interchangeably.
+//!
+//! # Overview
+//!
+//! The transport layer provides an abstraction over the raw network
+//! connection, allowing botho to use different protocols that are
+//! harder to detect and block:
+//!
+//! - **Plain**: Standard TCP + Noise (default, best performance)
+//! - **WebRTC**: Looks like video call traffic (Phase 3.2)
+//! - **TLS Tunnel**: Looks like HTTPS traffic (Phase 3.7)
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                    APPLICATION LAYER                        │
+//! │                    (Gossipsub, SCP)                         │
+//! └──────────────────────────┬──────────────────────────────────┘
+//!                            │
+//! ┌──────────────────────────▼──────────────────────────────────┐
+//! │                  TRANSPORT LAYER                            │
+//! │  ┌─────────────────────────────────────────────────────┐    │
+//! │  │            PluggableTransport Trait                 │    │
+//! │  └─────────────────────────────────────────────────────┘    │
+//! │         │                    │                    │         │
+//! │  ┌──────▼──────┐     ┌───────▼───────┐    ┌───────▼──────┐  │
+//! │  │    Plain    │     │    WebRTC     │    │  TLS Tunnel  │  │
+//! │  │ TCP + Noise │     │ DTLS + SCTP   │    │   TLS 1.3    │  │
+//! │  └─────────────┘     └───────────────┘    └──────────────┘  │
+//! └──────────────────────────┬──────────────────────────────────┘
+//!                            │
+//! ┌──────────────────────────▼──────────────────────────────────┐
+//! │                    NETWORK LAYER                            │
+//! │                    (TCP, UDP)                               │
+//! └─────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Usage
+//!
+//! ```
+//! use botho::network::transport::{
+//!     PlainTransport, PluggableTransport, TransportType,
+//! };
+//!
+//! // Create the default transport
+//! let transport = PlainTransport::new();
+//! assert_eq!(transport.transport_type(), TransportType::Plain);
+//! assert_eq!(transport.name(), "plain");
+//!
+//! // Check transport properties
+//! assert!(!transport.transport_type().is_obfuscated());
+//! assert!(transport.is_available());
+//! ```
+//!
+//! # Transport Selection
+//!
+//! Transport selection is based on:
+//! 1. User preference (configured privacy level)
+//! 2. Peer capabilities (what transports both sides support)
+//! 3. Network conditions (NAT type, firewall rules)
+//!
+//! See the `TransportManager` (Phase 3.8) for automatic selection.
+//!
+//! # Security Considerations
+//!
+//! - All transports provide encryption (Noise, DTLS, or TLS)
+//! - Obfuscated transports (WebRTC, TLS) resist DPI detection
+//! - Transport negotiation is authenticated to prevent downgrade attacks
+//!
+//! # References
+//!
+//! - Design document: `docs/design/traffic-privacy-roadmap.md` (Phase 3)
+//! - Parent issue: #201 (Phase 3: Protocol Obfuscation)
+//! - Implementation issue: #202 (Pluggable transport interface)
+
+mod error;
+mod plain;
+mod traits;
+mod types;
+
+// Re-export error types
+pub use error::TransportError;
+
+// Re-export transport types
+pub use types::{TransportType, TransportTypeParseError};
+
+// Re-export trait and connection types
+pub use traits::{BoxedConnection, ConnectionWrapper, PluggableTransport, TransportConnection};
+
+// Re-export transport implementations
+pub use plain::{PlainConnection, PlainTransport};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_exports() {
+        // Verify all expected types are exported and usable
+        let _: TransportType = TransportType::Plain;
+        let _: PlainTransport = PlainTransport::new();
+
+        // Verify trait is usable
+        fn assert_transport<T: PluggableTransport>(_: &T) {}
+        let transport = PlainTransport::new();
+        assert_transport(&transport);
+    }
+
+    #[test]
+    fn test_plain_transport_is_default() {
+        let transport = PlainTransport::default();
+        assert_eq!(transport.transport_type(), TransportType::Plain);
+    }
+}

--- a/botho/src/network/transport/plain.rs
+++ b/botho/src/network/transport/plain.rs
@@ -1,0 +1,328 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Plain transport implementation using TCP + Noise.
+//!
+//! This is the default transport that wraps the existing libp2p TCP + Noise
+//! connection mechanism. It provides no protocol obfuscation but offers the
+//! best performance.
+//!
+//! # Overview
+//!
+//! The plain transport uses:
+//! - **TCP**: Reliable byte stream transport
+//! - **Noise**: Modern encryption protocol (XX handshake pattern)
+//! - **Yamux**: Stream multiplexing
+//!
+//! This matches the current botho network stack and serves as the baseline
+//! for comparing other transports.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use botho::network::transport::{PlainTransport, PluggableTransport};
+//!
+//! let transport = PlainTransport::new();
+//! assert_eq!(transport.name(), "plain");
+//! assert!(!transport.transport_type().is_obfuscated());
+//! ```
+
+use async_trait::async_trait;
+use libp2p::{Multiaddr, PeerId};
+use std::fmt;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream;
+
+use super::error::TransportError;
+use super::traits::{BoxedConnection, PluggableTransport};
+use super::types::TransportType;
+
+/// Plain transport using TCP + Noise.
+///
+/// This is the baseline transport with no protocol obfuscation.
+/// It provides the best performance but may be detected and blocked
+/// by deep packet inspection.
+///
+/// # Configuration
+///
+/// The plain transport uses the system's TCP stack with default settings.
+/// No additional configuration is required.
+#[derive(Clone)]
+pub struct PlainTransport {
+    /// Connection timeout in seconds.
+    connect_timeout_secs: u64,
+}
+
+impl PlainTransport {
+    /// Create a new plain transport with default settings.
+    pub fn new() -> Self {
+        Self {
+            connect_timeout_secs: 30,
+        }
+    }
+
+    /// Create a new plain transport with custom timeout.
+    pub fn with_timeout(connect_timeout_secs: u64) -> Self {
+        Self {
+            connect_timeout_secs,
+        }
+    }
+
+    /// Get the connection timeout in seconds.
+    pub fn connect_timeout_secs(&self) -> u64 {
+        self.connect_timeout_secs
+    }
+
+    /// Extract TCP address from multiaddr.
+    fn extract_tcp_addr(addr: &Multiaddr) -> Option<std::net::SocketAddr> {
+        use libp2p::multiaddr::Protocol;
+
+        let mut ip = None;
+        let mut port = None;
+
+        for proto in addr.iter() {
+            match proto {
+                Protocol::Ip4(addr) => ip = Some(std::net::IpAddr::V4(addr)),
+                Protocol::Ip6(addr) => ip = Some(std::net::IpAddr::V6(addr)),
+                Protocol::Tcp(p) => port = Some(p),
+                _ => {}
+            }
+        }
+
+        match (ip, port) {
+            (Some(ip), Some(port)) => Some(std::net::SocketAddr::new(ip, port)),
+            _ => None,
+        }
+    }
+}
+
+impl Default for PlainTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for PlainTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PlainTransport")
+            .field("connect_timeout_secs", &self.connect_timeout_secs)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl PluggableTransport for PlainTransport {
+    fn transport_type(&self) -> TransportType {
+        TransportType::Plain
+    }
+
+    fn is_available(&self) -> bool {
+        // Plain transport is always available
+        true
+    }
+
+    async fn connect(
+        &self,
+        peer: &PeerId,
+        addr: Option<&Multiaddr>,
+    ) -> Result<BoxedConnection, TransportError> {
+        let addr = addr.ok_or_else(|| {
+            TransportError::InvalidPeer(format!("no address provided for peer {}", peer))
+        })?;
+
+        let socket_addr = Self::extract_tcp_addr(addr).ok_or_else(|| {
+            TransportError::InvalidPeer(format!("cannot extract TCP address from {}", addr))
+        })?;
+
+        // Connect with timeout
+        let connect_future = TcpStream::connect(socket_addr);
+        let timeout = std::time::Duration::from_secs(self.connect_timeout_secs);
+
+        let stream = tokio::time::timeout(timeout, connect_future)
+            .await
+            .map_err(|_| TransportError::Timeout)?
+            .map_err(|e| TransportError::ConnectionFailed(e.to_string()))?;
+
+        // Configure TCP options
+        stream.set_nodelay(true).map_err(|e| {
+            TransportError::Configuration(format!("failed to set TCP_NODELAY: {}", e))
+        })?;
+
+        // Wrap in PlainConnection for Debug impl
+        let conn = PlainConnection::new(stream, *peer);
+        Ok(Box::new(conn))
+    }
+
+    async fn accept(&self, stream: BoxedConnection) -> Result<BoxedConnection, TransportError> {
+        // For plain transport, we just pass through the connection
+        // The actual Noise handshake is handled by libp2p at a higher level
+        Ok(stream)
+    }
+}
+
+/// A plain TCP connection wrapper.
+///
+/// This wraps a TCP stream with peer information and implements
+/// the required traits for use as a transport connection.
+pub struct PlainConnection {
+    stream: TcpStream,
+    peer: PeerId,
+}
+
+impl PlainConnection {
+    /// Create a new plain connection.
+    pub fn new(stream: TcpStream, peer: PeerId) -> Self {
+        Self { stream, peer }
+    }
+
+    /// Get the peer ID for this connection.
+    pub fn peer(&self) -> &PeerId {
+        &self.peer
+    }
+
+    /// Get a reference to the underlying TCP stream.
+    pub fn stream(&self) -> &TcpStream {
+        &self.stream
+    }
+}
+
+impl fmt::Debug for PlainConnection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PlainConnection")
+            .field("peer", &self.peer)
+            .field("local_addr", &self.stream.local_addr().ok())
+            .field("peer_addr", &self.stream.peer_addr().ok())
+            .finish()
+    }
+}
+
+impl AsyncRead for PlainConnection {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for PlainConnection {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.stream).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stream).poll_shutdown(cx)
+    }
+}
+
+// PlainConnection is Unpin because TcpStream is Unpin
+impl Unpin for PlainConnection {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plain_transport_default() {
+        let transport = PlainTransport::new();
+        assert_eq!(transport.transport_type(), TransportType::Plain);
+        assert_eq!(transport.name(), "plain");
+        assert!(transport.is_available());
+    }
+
+    #[test]
+    fn test_plain_transport_with_timeout() {
+        let transport = PlainTransport::with_timeout(60);
+        assert_eq!(transport.connect_timeout_secs(), 60);
+    }
+
+    #[test]
+    fn test_plain_transport_debug() {
+        let transport = PlainTransport::new();
+        let debug = format!("{:?}", transport);
+        assert!(debug.contains("PlainTransport"));
+        assert!(debug.contains("connect_timeout_secs"));
+    }
+
+    #[test]
+    fn test_extract_tcp_addr_ipv4() {
+        let addr: Multiaddr = "/ip4/127.0.0.1/tcp/8080".parse().unwrap();
+        let socket_addr = PlainTransport::extract_tcp_addr(&addr).unwrap();
+        assert_eq!(socket_addr.to_string(), "127.0.0.1:8080");
+    }
+
+    #[test]
+    fn test_extract_tcp_addr_ipv6() {
+        let addr: Multiaddr = "/ip6/::1/tcp/8080".parse().unwrap();
+        let socket_addr = PlainTransport::extract_tcp_addr(&addr).unwrap();
+        assert_eq!(socket_addr.to_string(), "[::1]:8080");
+    }
+
+    #[test]
+    fn test_extract_tcp_addr_no_port() {
+        let addr: Multiaddr = "/ip4/127.0.0.1".parse().unwrap();
+        assert!(PlainTransport::extract_tcp_addr(&addr).is_none());
+    }
+
+    #[test]
+    fn test_extract_tcp_addr_no_ip() {
+        let addr: Multiaddr = "/tcp/8080".parse().unwrap();
+        assert!(PlainTransport::extract_tcp_addr(&addr).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_connect_no_address() {
+        let transport = PlainTransport::new();
+        let peer = PeerId::random();
+
+        let result = transport.connect(&peer, None).await;
+        assert!(result.is_err());
+
+        match result.unwrap_err() {
+            TransportError::InvalidPeer(msg) => {
+                assert!(msg.contains("no address provided"));
+            }
+            e => panic!("unexpected error: {:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_connect_invalid_address() {
+        let transport = PlainTransport::new();
+        let peer = PeerId::random();
+        let addr: Multiaddr = "/dns4/example.com".parse().unwrap();
+
+        let result = transport.connect(&peer, Some(&addr)).await;
+        assert!(result.is_err());
+
+        match result.unwrap_err() {
+            TransportError::InvalidPeer(msg) => {
+                assert!(msg.contains("cannot extract TCP address"));
+            }
+            e => panic!("unexpected error: {:?}", e),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_connect_unreachable() {
+        let transport = PlainTransport::with_timeout(1); // 1 second timeout
+        let peer = PeerId::random();
+        // Use a non-routable address to trigger connection failure
+        let addr: Multiaddr = "/ip4/10.255.255.1/tcp/12345".parse().unwrap();
+
+        let result = transport.connect(&peer, Some(&addr)).await;
+        assert!(result.is_err());
+        // Could be timeout or connection failed depending on network
+    }
+}

--- a/botho/src/network/transport/traits.rs
+++ b/botho/src/network/transport/traits.rs
@@ -1,0 +1,298 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Pluggable transport trait and related abstractions.
+//!
+//! This module defines the core [`PluggableTransport`] trait that all
+//! transport implementations must satisfy. It provides a unified interface
+//! for establishing connections regardless of the underlying protocol.
+//!
+//! # Architecture
+//!
+//! The transport layer sits between the application (gossipsub) and the
+//! network. Each transport wraps raw connections with its own encryption
+//! and framing:
+//!
+//! ```text
+//! ┌─────────────────┐
+//! │   Application   │
+//! │   (Gossipsub)   │
+//! └────────┬────────┘
+//!          │
+//! ┌────────▼────────┐
+//! │  PluggableTransport │  ← This trait
+//! │  (Plain/WebRTC/TLS) │
+//! └────────┬────────┘
+//!          │
+//! ┌────────▼────────┐
+//! │    Network      │
+//! │   (TCP/UDP)     │
+//! └─────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```ignore
+//! use botho::network::transport::{PluggableTransport, TransportType};
+//!
+//! async fn connect_to_peer(transport: &dyn PluggableTransport, peer: &PeerId) {
+//!     match transport.connect(peer).await {
+//!         Ok(conn) => {
+//!             // Use conn for reading/writing
+//!         }
+//!         Err(e) => {
+//!             eprintln!("Connection failed: {}", e);
+//!         }
+//!     }
+//! }
+//! ```
+
+use async_trait::async_trait;
+use libp2p::PeerId;
+use std::fmt::Debug;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use super::error::TransportError;
+use super::types::TransportType;
+
+/// A connection that can be read from and written to asynchronously.
+///
+/// This trait combines [`AsyncRead`] and [`AsyncWrite`] with [`Send`] and [`Sync`]
+/// bounds required for use across async tasks. All transport connections must
+/// implement this trait.
+pub trait TransportConnection: AsyncRead + AsyncWrite + Send + Sync + Unpin + Debug {}
+
+/// Blanket implementation for any type that satisfies the bounds.
+impl<T> TransportConnection for T where T: AsyncRead + AsyncWrite + Send + Sync + Unpin + Debug {}
+
+/// A boxed transport connection for dynamic dispatch.
+pub type BoxedConnection = Box<dyn TransportConnection>;
+
+/// Pluggable transport interface for protocol obfuscation.
+///
+/// This trait defines the interface that all transport implementations must
+/// satisfy. Each transport provides a different way to establish connections
+/// with peers, with different trade-offs for:
+///
+/// - **Performance**: Connection setup time, throughput
+/// - **Compatibility**: NAT traversal, firewall penetration
+/// - **Obfuscation**: Resistance to deep packet inspection
+///
+/// # Implementors
+///
+/// - [`PlainTransport`]: Standard TCP + Noise (default)
+/// - `WebRtcTransport`: WebRTC data channels (Phase 3)
+/// - `TlsTunnelTransport`: TLS tunnel (Phase 3)
+///
+/// # Thread Safety
+///
+/// All transport implementations must be `Send + Sync` to allow use across
+/// async tasks and threads.
+#[async_trait]
+pub trait PluggableTransport: Send + Sync + Debug {
+    /// Get the transport type identifier.
+    fn transport_type(&self) -> TransportType;
+
+    /// Get the human-readable name of this transport.
+    fn name(&self) -> &'static str {
+        self.transport_type().name()
+    }
+
+    /// Check if this transport is available and ready to use.
+    ///
+    /// This may check for required dependencies, network conditions,
+    /// or configuration. Returns `true` if the transport can be used.
+    fn is_available(&self) -> bool {
+        true
+    }
+
+    /// Establish an outbound connection to a peer.
+    ///
+    /// This creates a new connection to the specified peer using this
+    /// transport's protocol. The returned connection can be used for
+    /// bidirectional communication.
+    ///
+    /// # Arguments
+    ///
+    /// * `peer` - The peer ID to connect to
+    /// * `addr` - Optional multiaddr hint for the peer's address
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection cannot be established, such as:
+    /// - Network unreachable
+    /// - Peer not found
+    /// - Handshake failure
+    /// - Timeout
+    async fn connect(
+        &self,
+        peer: &PeerId,
+        addr: Option<&libp2p::Multiaddr>,
+    ) -> Result<BoxedConnection, TransportError>;
+
+    /// Accept an inbound connection.
+    ///
+    /// This wraps an existing raw connection (e.g., from a TCP listener)
+    /// with this transport's protocol layer.
+    ///
+    /// # Arguments
+    ///
+    /// * `stream` - The raw incoming connection
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the handshake fails or the connection is invalid.
+    async fn accept(&self, stream: BoxedConnection) -> Result<BoxedConnection, TransportError>;
+}
+
+/// A wrapper around a boxed connection that implements the standard I/O traits.
+///
+/// This allows using a `BoxedConnection` with APIs that expect concrete types
+/// rather than trait objects.
+#[derive(Debug)]
+pub struct ConnectionWrapper {
+    inner: BoxedConnection,
+}
+
+impl ConnectionWrapper {
+    /// Create a new connection wrapper.
+    pub fn new(conn: BoxedConnection) -> Self {
+        Self { inner: conn }
+    }
+
+    /// Get a reference to the inner connection.
+    pub fn inner(&self) -> &BoxedConnection {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner connection.
+    pub fn inner_mut(&mut self) -> &mut BoxedConnection {
+        &mut self.inner
+    }
+
+    /// Consume the wrapper and return the inner connection.
+    pub fn into_inner(self) -> BoxedConnection {
+        self.inner
+    }
+}
+
+impl AsyncRead for ConnectionWrapper {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut *self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for ConnectionWrapper {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut *self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut *self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut *self.inner).poll_shutdown(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// A simple in-memory connection for testing.
+    #[derive(Debug)]
+    struct MockConnection {
+        read_buf: Cursor<Vec<u8>>,
+        write_buf: Vec<u8>,
+    }
+
+    impl MockConnection {
+        fn new(data: Vec<u8>) -> Self {
+            Self {
+                read_buf: Cursor::new(data),
+                write_buf: Vec::new(),
+            }
+        }
+
+        fn written(&self) -> &[u8] {
+            &self.write_buf
+        }
+    }
+
+    impl AsyncRead for MockConnection {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            let pos = self.read_buf.position() as usize;
+            let data = self.read_buf.get_ref();
+            let remaining = &data[pos..];
+            let to_read = std::cmp::min(remaining.len(), buf.remaining());
+            buf.put_slice(&remaining[..to_read]);
+            self.read_buf.set_position((pos + to_read) as u64);
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for MockConnection {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            self.write_buf.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_connection_wrapper_read() {
+        let mock = MockConnection::new(b"hello world".to_vec());
+        let mut wrapper = ConnectionWrapper::new(Box::new(mock));
+
+        let mut buf = [0u8; 5];
+        let n = wrapper.read(&mut buf).await.unwrap();
+        assert_eq!(n, 5);
+        assert_eq!(&buf, b"hello");
+    }
+
+    #[tokio::test]
+    async fn test_connection_wrapper_write() {
+        let mock = MockConnection::new(vec![]);
+        let mut wrapper = ConnectionWrapper::new(Box::new(mock));
+
+        wrapper.write_all(b"test data").await.unwrap();
+        wrapper.flush().await.unwrap();
+
+        // The write completed successfully - that's what we're testing
+    }
+
+    // Test that MockConnection implements TransportConnection
+    #[test]
+    fn test_mock_is_transport_connection() {
+        fn assert_transport_connection<T: TransportConnection>() {}
+        assert_transport_connection::<MockConnection>();
+    }
+}

--- a/botho/src/network/transport/types.rs
+++ b/botho/src/network/transport/types.rs
@@ -1,0 +1,216 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Transport type definitions for pluggable transports.
+//!
+//! This module defines the available transport types and their metadata.
+//! Each transport type represents a different method of establishing
+//! connections with peers, with different trade-offs for performance,
+//! compatibility, and protocol obfuscation.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Available transport types for peer connections.
+///
+/// Different transport types offer different trade-offs:
+/// - **Plain**: Standard TCP + Noise, best performance, no obfuscation
+/// - **WebRTC**: Looks like video call traffic, good NAT traversal
+/// - **TlsTunnel**: Looks like HTTPS traffic, good firewall traversal
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TransportType {
+    /// Standard TCP + Noise transport (current default).
+    ///
+    /// This is the baseline transport with:
+    /// - Lowest latency
+    /// - Best throughput
+    /// - No protocol obfuscation
+    /// - May be blocked by DPI
+    #[default]
+    Plain,
+
+    /// WebRTC data channel transport.
+    ///
+    /// Traffic looks like video calls:
+    /// - Uses DTLS encryption
+    /// - Built-in NAT traversal (ICE/STUN)
+    /// - Indistinguishable from legitimate WebRTC
+    /// - Higher connection setup latency
+    WebRTC,
+
+    /// TLS tunnel transport.
+    ///
+    /// Traffic looks like HTTPS:
+    /// - Standard TLS 1.3
+    /// - Good firewall compatibility
+    /// - Alternative when WebRTC is blocked
+    TlsTunnel,
+}
+
+impl TransportType {
+    /// Get all available transport types.
+    pub fn all() -> &'static [TransportType] {
+        &[TransportType::Plain, TransportType::WebRTC, TransportType::TlsTunnel]
+    }
+
+    /// Get the human-readable name of this transport.
+    pub fn name(&self) -> &'static str {
+        match self {
+            TransportType::Plain => "plain",
+            TransportType::WebRTC => "webrtc",
+            TransportType::TlsTunnel => "tls-tunnel",
+        }
+    }
+
+    /// Get a description of this transport type.
+    pub fn description(&self) -> &'static str {
+        match self {
+            TransportType::Plain => "Standard TCP + Noise (no obfuscation)",
+            TransportType::WebRTC => "WebRTC data channels (looks like video calls)",
+            TransportType::TlsTunnel => "TLS tunnel (looks like HTTPS)",
+        }
+    }
+
+    /// Check if this transport provides protocol obfuscation.
+    pub fn is_obfuscated(&self) -> bool {
+        match self {
+            TransportType::Plain => false,
+            TransportType::WebRTC | TransportType::TlsTunnel => true,
+        }
+    }
+
+    /// Get the expected connection setup overhead compared to plain TCP.
+    ///
+    /// Returns a multiplier (1.0 = same as plain, 2.0 = twice as long).
+    pub fn setup_overhead(&self) -> f64 {
+        match self {
+            TransportType::Plain => 1.0,
+            TransportType::WebRTC => 3.0, // ICE + DTLS handshake
+            TransportType::TlsTunnel => 1.5, // TLS handshake
+        }
+    }
+}
+
+impl fmt::Display for TransportType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl std::str::FromStr for TransportType {
+    type Err = TransportTypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "plain" | "tcp" | "noise" => Ok(TransportType::Plain),
+            "webrtc" | "rtc" => Ok(TransportType::WebRTC),
+            "tls-tunnel" | "tls" | "https" => Ok(TransportType::TlsTunnel),
+            _ => Err(TransportTypeParseError(s.to_string())),
+        }
+    }
+}
+
+/// Error when parsing a transport type from string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransportTypeParseError(String);
+
+impl fmt::Display for TransportTypeParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid transport type '{}': expected 'plain', 'webrtc', or 'tls-tunnel'",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for TransportTypeParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transport_type_default() {
+        assert_eq!(TransportType::default(), TransportType::Plain);
+    }
+
+    #[test]
+    fn test_transport_type_name() {
+        assert_eq!(TransportType::Plain.name(), "plain");
+        assert_eq!(TransportType::WebRTC.name(), "webrtc");
+        assert_eq!(TransportType::TlsTunnel.name(), "tls-tunnel");
+    }
+
+    #[test]
+    fn test_transport_type_display() {
+        assert_eq!(TransportType::Plain.to_string(), "plain");
+        assert_eq!(TransportType::WebRTC.to_string(), "webrtc");
+        assert_eq!(TransportType::TlsTunnel.to_string(), "tls-tunnel");
+    }
+
+    #[test]
+    fn test_transport_type_from_str() {
+        assert_eq!("plain".parse::<TransportType>().unwrap(), TransportType::Plain);
+        assert_eq!("webrtc".parse::<TransportType>().unwrap(), TransportType::WebRTC);
+        assert_eq!("tls-tunnel".parse::<TransportType>().unwrap(), TransportType::TlsTunnel);
+
+        // Aliases
+        assert_eq!("tcp".parse::<TransportType>().unwrap(), TransportType::Plain);
+        assert_eq!("rtc".parse::<TransportType>().unwrap(), TransportType::WebRTC);
+        assert_eq!("tls".parse::<TransportType>().unwrap(), TransportType::TlsTunnel);
+        assert_eq!("https".parse::<TransportType>().unwrap(), TransportType::TlsTunnel);
+    }
+
+    #[test]
+    fn test_transport_type_from_str_case_insensitive() {
+        assert_eq!("PLAIN".parse::<TransportType>().unwrap(), TransportType::Plain);
+        assert_eq!("WebRTC".parse::<TransportType>().unwrap(), TransportType::WebRTC);
+    }
+
+    #[test]
+    fn test_transport_type_from_str_invalid() {
+        assert!("invalid".parse::<TransportType>().is_err());
+        assert!("".parse::<TransportType>().is_err());
+    }
+
+    #[test]
+    fn test_is_obfuscated() {
+        assert!(!TransportType::Plain.is_obfuscated());
+        assert!(TransportType::WebRTC.is_obfuscated());
+        assert!(TransportType::TlsTunnel.is_obfuscated());
+    }
+
+    #[test]
+    fn test_setup_overhead() {
+        assert_eq!(TransportType::Plain.setup_overhead(), 1.0);
+        assert!(TransportType::WebRTC.setup_overhead() > 1.0);
+        assert!(TransportType::TlsTunnel.setup_overhead() > 1.0);
+    }
+
+    #[test]
+    fn test_all_types() {
+        let types = TransportType::all();
+        assert_eq!(types.len(), 3);
+        assert!(types.contains(&TransportType::Plain));
+        assert!(types.contains(&TransportType::WebRTC));
+        assert!(types.contains(&TransportType::TlsTunnel));
+    }
+
+    #[test]
+    fn test_serialization() {
+        let t = TransportType::WebRTC;
+        let json = serde_json::to_string(&t).unwrap();
+        assert_eq!(json, "\"webrtc\"");
+
+        let parsed: TransportType = serde_json::from_str(&json).unwrap();
+        assert_eq!(t, parsed);
+    }
+
+    #[test]
+    fn test_description() {
+        assert!(!TransportType::Plain.description().is_empty());
+        assert!(!TransportType::WebRTC.description().is_empty());
+        assert!(!TransportType::TlsTunnel.description().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PluggableTransport` trait as the foundation for Phase 3 protocol obfuscation
- Implement `PlainTransport` wrapping existing TCP + Noise connections
- Define `TransportType` enum (Plain, WebRTC, TlsTunnel) for transport selection
- Add comprehensive error types and connection abstractions

## Implementation Details

This PR implements milestone 3.1 of the Phase 3 Protocol Obfuscation epic (#201). The pluggable transport interface allows different transport implementations to be used interchangeably, enabling:

- **Plain**: Standard TCP + Noise (default, best performance)
- **WebRTC**: Traffic looks like video calls (Phase 3.2)
- **TLS Tunnel**: Traffic looks like HTTPS (Phase 3.7)

### New Files

| File | Purpose |
|------|---------|
| `transport/mod.rs` | Module exports and documentation |
| `transport/traits.rs` | `PluggableTransport` trait definition |
| `transport/types.rs` | `TransportType` enum |
| `transport/error.rs` | `TransportError` types |
| `transport/plain.rs` | `PlainTransport` implementation |

### Key Types

```rust
#[async_trait]
pub trait PluggableTransport: Send + Sync + Debug {
    fn transport_type(&self) -> TransportType;
    fn name(&self) -> &'static str;
    fn is_available(&self) -> bool;
    async fn connect(&self, peer: &PeerId, addr: Option<&Multiaddr>) 
        -> Result<BoxedConnection, TransportError>;
    async fn accept(&self, stream: BoxedConnection) 
        -> Result<BoxedConnection, TransportError>;
}
```

## Test plan

- [x] All 29 new transport unit tests pass
- [x] Existing test suite passes (666 tests)
- [x] `cargo check` clean (only pre-existing warnings)

## Dependencies

This is the foundation for:
- #203: WebRTC data channel transport
- #208: TLS tunnel transport
- #209: Transport selection logic

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)