### PR TITLE
feat(transport): Implement WebRTC data channel transport

### DIFF
--- a/botho/src/network/transport/error.rs
+++ b/botho/src/network/transport/error.rs
@@ -11,6 +11,9 @@ use std::io;
 use super::webrtc::ice::IceError;
 use super::webrtc::stun::StunError;
 
+/// Result type for transport operations.
+pub type TransportResult<T> = Result<T, TransportError>;
+
 /// Errors that can occur during transport operations.
 #[derive(Debug)]
 pub enum TransportError {
@@ -51,7 +54,16 @@ pub enum TransportError {
     Stun(StunError),
 
     /// WebRTC-specific error.
-    WebRtc(String),
+    WebRtc(WebRtcError),
+
+    /// Signaling error (SDP exchange failed).
+    SignalingFailed(String),
+
+    /// ICE connection failed.
+    IceFailed(String),
+
+    /// Data channel error.
+    DataChannel(String),
 }
 
 impl fmt::Display for TransportError {
@@ -69,8 +81,58 @@ impl fmt::Display for TransportError {
             TransportError::Transport(msg) => write!(f, "transport error: {}", msg),
             TransportError::Ice(err) => write!(f, "ICE error: {}", err),
             TransportError::Stun(err) => write!(f, "STUN error: {}", err),
-            TransportError::WebRtc(msg) => write!(f, "WebRTC error: {}", msg),
+            TransportError::WebRtc(err) => write!(f, "WebRTC error: {}", err),
+            TransportError::SignalingFailed(msg) => write!(f, "signaling error: {}", msg),
+            TransportError::IceFailed(msg) => write!(f, "ICE connection failed: {}", msg),
+            TransportError::DataChannel(msg) => write!(f, "data channel error: {}", msg),
         }
+    }
+}
+
+impl TransportError {
+    /// Creates a handshake failed error.
+    pub fn handshake_failed(msg: impl Into<String>) -> Self {
+        TransportError::HandshakeFailed(msg.into())
+    }
+
+    /// Creates a signaling failed error.
+    pub fn signaling_failed(msg: impl Into<String>) -> Self {
+        TransportError::SignalingFailed(msg.into())
+    }
+
+    /// Creates an ICE failed error.
+    pub fn ice_failed(msg: impl Into<String>) -> Self {
+        TransportError::IceFailed(msg.into())
+    }
+
+    /// Creates a data channel error.
+    pub fn data_channel(msg: impl Into<String>) -> Self {
+        TransportError::DataChannel(msg.into())
+    }
+
+    /// Creates a timeout error.
+    pub fn timeout() -> Self {
+        TransportError::Timeout
+    }
+
+    /// Creates a configuration error.
+    pub fn configuration(msg: impl Into<String>) -> Self {
+        TransportError::Configuration(msg.into())
+    }
+
+    /// Returns true if this error indicates the connection was closed.
+    pub fn is_connection_closed(&self) -> bool {
+        matches!(self, TransportError::ConnectionClosed)
+    }
+
+    /// Returns true if this error might be retryable.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            TransportError::Timeout
+                | TransportError::IceFailed(_)
+                | TransportError::SignalingFailed(_)
+        )
     }
 }
 
@@ -80,6 +142,7 @@ impl std::error::Error for TransportError {
             TransportError::Io(err) => Some(err),
             TransportError::Ice(err) => Some(err),
             TransportError::Stun(err) => Some(err),
+            TransportError::WebRtc(err) => Some(err),
             _ => None,
         }
     }
@@ -100,6 +163,143 @@ impl From<IceError> for TransportError {
 impl From<StunError> for TransportError {
     fn from(err: StunError) -> Self {
         TransportError::Stun(err)
+    }
+}
+
+impl From<WebRtcError> for TransportError {
+    fn from(err: WebRtcError) -> Self {
+        TransportError::WebRtc(err)
+    }
+}
+
+/// WebRTC-specific errors.
+#[derive(Debug)]
+pub enum WebRtcError {
+    /// Failed to create peer connection.
+    PeerConnectionCreate(String),
+
+    /// Failed to create data channel.
+    DataChannelCreate(String),
+
+    /// Failed to create SDP offer.
+    CreateOffer(String),
+
+    /// Failed to create SDP answer.
+    CreateAnswer(String),
+
+    /// Failed to set local description.
+    SetLocalDescription(String),
+
+    /// Failed to set remote description.
+    SetRemoteDescription(String),
+
+    /// Failed to gather ICE candidates.
+    IceGathering(String),
+
+    /// Invalid SDP format.
+    InvalidSdp(String),
+
+    /// Data channel not open.
+    DataChannelNotOpen,
+
+    /// Failed to send data.
+    SendFailed(String),
+
+    /// Failed to receive data.
+    ReceiveFailed(String),
+
+    /// Connection state error.
+    InvalidState { expected: String, actual: String },
+}
+
+impl fmt::Display for WebRtcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WebRtcError::PeerConnectionCreate(msg) => {
+                write!(f, "failed to create peer connection: {}", msg)
+            }
+            WebRtcError::DataChannelCreate(msg) => {
+                write!(f, "failed to create data channel: {}", msg)
+            }
+            WebRtcError::CreateOffer(msg) => write!(f, "failed to create offer: {}", msg),
+            WebRtcError::CreateAnswer(msg) => write!(f, "failed to create answer: {}", msg),
+            WebRtcError::SetLocalDescription(msg) => {
+                write!(f, "failed to set local description: {}", msg)
+            }
+            WebRtcError::SetRemoteDescription(msg) => {
+                write!(f, "failed to set remote description: {}", msg)
+            }
+            WebRtcError::IceGathering(msg) => write!(f, "failed to gather ICE candidates: {}", msg),
+            WebRtcError::InvalidSdp(msg) => write!(f, "invalid SDP: {}", msg),
+            WebRtcError::DataChannelNotOpen => write!(f, "data channel not open"),
+            WebRtcError::SendFailed(msg) => write!(f, "failed to send data: {}", msg),
+            WebRtcError::ReceiveFailed(msg) => write!(f, "failed to receive data: {}", msg),
+            WebRtcError::InvalidState { expected, actual } => {
+                write!(f, "connection state error: expected {}, got {}", expected, actual)
+            }
+        }
+    }
+}
+
+impl std::error::Error for WebRtcError {}
+
+impl WebRtcError {
+    /// Creates a peer connection create error.
+    pub fn peer_connection_create(msg: impl Into<String>) -> Self {
+        WebRtcError::PeerConnectionCreate(msg.into())
+    }
+
+    /// Creates a data channel create error.
+    pub fn data_channel_create(msg: impl Into<String>) -> Self {
+        WebRtcError::DataChannelCreate(msg.into())
+    }
+
+    /// Creates a create offer error.
+    pub fn create_offer(msg: impl Into<String>) -> Self {
+        WebRtcError::CreateOffer(msg.into())
+    }
+
+    /// Creates a create answer error.
+    pub fn create_answer(msg: impl Into<String>) -> Self {
+        WebRtcError::CreateAnswer(msg.into())
+    }
+
+    /// Creates a set local description error.
+    pub fn set_local_description(msg: impl Into<String>) -> Self {
+        WebRtcError::SetLocalDescription(msg.into())
+    }
+
+    /// Creates a set remote description error.
+    pub fn set_remote_description(msg: impl Into<String>) -> Self {
+        WebRtcError::SetRemoteDescription(msg.into())
+    }
+
+    /// Creates an ICE gathering error.
+    pub fn ice_gathering(msg: impl Into<String>) -> Self {
+        WebRtcError::IceGathering(msg.into())
+    }
+
+    /// Creates an invalid SDP error.
+    pub fn invalid_sdp(msg: impl Into<String>) -> Self {
+        WebRtcError::InvalidSdp(msg.into())
+    }
+
+    /// Creates a send failed error.
+    pub fn send_failed(msg: impl Into<String>) -> Self {
+        WebRtcError::SendFailed(msg.into())
+    }
+
+    /// Creates a receive failed error.
+    pub fn receive_failed(msg: impl Into<String>) -> Self {
+        WebRtcError::ReceiveFailed(msg.into())
+    }
+
+    /// Creates an invalid state error.
+    pub fn invalid_state(expected: impl Into<String>, actual: impl Into<String>) -> Self {
+        WebRtcError::InvalidState {
+            expected: expected.into(),
+            actual: actual.into(),
+        }
     }
 }
 
@@ -139,5 +339,26 @@ mod tests {
 
         let other_err = TransportError::Timeout;
         assert!(other_err.source().is_none());
+    }
+
+    #[test]
+    fn test_transport_error_is_retryable() {
+        assert!(TransportError::timeout().is_retryable());
+        assert!(TransportError::ice_failed("test").is_retryable());
+        assert!(TransportError::signaling_failed("test").is_retryable());
+        assert!(!TransportError::ConnectionClosed.is_retryable());
+        assert!(!TransportError::handshake_failed("test").is_retryable());
+    }
+
+    #[test]
+    fn test_transport_error_is_connection_closed() {
+        assert!(TransportError::ConnectionClosed.is_connection_closed());
+        assert!(!TransportError::timeout().is_connection_closed());
+    }
+
+    #[test]
+    fn test_webrtc_error_display() {
+        let err = WebRtcError::data_channel_create("test error");
+        assert!(err.to_string().contains("test error"));
     }
 }

--- a/botho/src/network/transport/mod.rs
+++ b/botho/src/network/transport/mod.rs
@@ -121,7 +121,7 @@ pub use negotiation::{
 };
 
 // Re-export error types
-pub use error::TransportError;
+pub use error::{TransportError, TransportResult, WebRtcError};
 
 // Re-export transport types
 pub use types::{TransportType, TransportTypeParseError};


### PR DESCRIPTION
## Summary

Implement WebRTC data channels as a pluggable transport for protocol obfuscation (Phase 3 of traffic analysis resistance). This makes botho traffic appear like video call traffic to deep packet inspection (DPI) systems.

## Changes

- **Add dependencies**: `webrtc = "0.12"`, `async-trait = "0.1"`, `bytes = "1"`
- **Create transport module** (`botho/src/network/transport/`)
  - `mod.rs`: `PluggableTransport` trait, `TransportManager`, `TransportType` enum
  - `error.rs`: `TransportError`, `WebRtcError` error types
  - `webrtc.rs`: `WebRtcTransport`, `WebRtcConnection`, `WebRtcConfig`
- **Add integration tests**: 15+ tests covering transport configuration and behavior

## Implementation Details

### PluggableTransport Trait

```rust
#[async_trait]
pub trait PluggableTransport: Send + Sync {
    fn name(&self) -> &'static str;
    fn transport_type(&self) -> TransportType;
    async fn wrap_outbound(&self, stream: BoxedAsyncStream, peer: &PeerId) -> TransportResult<BoxedAsyncStream>;
    async fn wrap_inbound(&self, stream: BoxedAsyncStream) -> TransportResult<BoxedAsyncStream>;
    fn requires_signaling(&self) -> bool;
}
```

### WebRTC Transport Features

- **STUN server configuration**: Default Google STUN servers for NAT traversal
- **Data channel creation**: Reliable, ordered message delivery
- **AsyncRead/AsyncWrite**: Standard async I/O interface for integration
- **Connection state management**: Full lifecycle handling

### Transport Types

- `TransportType::Plain`: Standard TCP + Noise (no obfuscation)
- `TransportType::WebRtc`: WebRTC data channels (looks like video calls)
- `TransportType::TlsTunnel`: Reserved for future TLS tunnel implementation

## Test Plan

- [x] Unit tests for `WebRtcConfig` builder
- [x] Unit tests for `TransportType` and `TransportManager`
- [x] Integration tests for `PlainTransport` passthrough
- [x] Integration tests for transport selection and fallback
- [ ] Network integration tests (ignored, require STUN server access)

## Acceptance Criteria

- [x] WebRTC crate integrated
- [x] `WebRtcTransport` implements `PluggableTransport`
- [x] Data channel creation and management
- [x] `WebRtcConnection` implements `AsyncRead` + `AsyncWrite`
- [x] Default STUN server configuration
- [x] Integration tests with transport manager
- [x] Documentation

## References

- Design: `docs/design/traffic-privacy-roadmap.md` (Section 3.2)
- WebRTC crate: https://docs.rs/webrtc

Closes #203