### PR TITLE
feat(validation): Integrate ring_cluster_factor into transaction fee validation

### DIFF
--- a/transaction/core/src/validation/error.rs
+++ b/transaction/core/src/validation/error.rs
@@ -172,7 +172,8 @@ pub enum TransactionValidationError {
     /// Insufficient progressive fee: required {0}, actual {1}
     InsufficientProgressiveFee(u64, u64),
 
-    /// Insufficient cluster-based fee: required {required}, actual {actual}, cluster_wealth {cluster_wealth}
+    /// Insufficient cluster-based fee: required {required}, actual {actual},
+    /// cluster_wealth {cluster_wealth}
     #[cfg(feature = "cluster-tax")]
     InsufficientClusterFee {
         /// Required minimum fee in nanoBTH

--- a/transaction/core/src/validation/mod.rs
+++ b/transaction/core/src/validation/mod.rs
@@ -27,8 +27,10 @@ pub use self::{
 #[cfg(feature = "cluster-tax")]
 pub use self::cluster_fee::{
     compute_cluster_factor, compute_effective_cluster_wealth,
-    compute_effective_cluster_wealth_from_tags, extract_dominant_cluster, validate_cluster_fee,
-    validate_cluster_fee_dynamic, ClusterWealthMap, ClusterWealthProvider,
+    compute_effective_cluster_wealth_from_tags, compute_ring_max_cluster_wealth,
+    compute_single_utxo_cluster_wealth, extract_dominant_cluster, validate_cluster_fee,
+    validate_cluster_fee_dynamic, validate_ring_cluster_fee, validate_ring_cluster_fee_dynamic,
+    ClusterWealthMap, ClusterWealthProvider,
 };
 
 // Re-export cluster-tax types for convenience


### PR DESCRIPTION
## Summary

- Implements conservative fee validation for ring signatures in Phase 1 (public tags)
- Adds `compute_ring_max_cluster_wealth()` to get the maximum cluster wealth among all ring members
- Adds `validate_ring_cluster_fee()` to validate transactions pay sufficient fees based on max ring member wealth
- The conservative (max) approach prevents fee evasion attacks where wealthy senders select poor decoys

## Changes

- `compute_single_utxo_cluster_wealth()` - Calculate effective cluster wealth for a single UTXO
- `compute_ring_max_cluster_wealth()` - Get max cluster wealth among ring members
- `validate_ring_cluster_fee()` - Validate fee using conservative ring-based approach
- `validate_ring_cluster_fee_dynamic()` - Same with dynamic base fee support
- 21 comprehensive tests covering:
  - Homogeneous rings (all members from same cluster)
  - Heterogeneous rings (members from different clusters)
  - Gaming prevention (attacker with rich coins selecting poor decoys)
  - Edge cases (empty rings, background-only tags)

## Test plan

- [x] All 21 new cluster fee tests pass
- [x] All 117 transaction-core tests pass
- [x] Code formatted with `cargo fmt`
- [ ] Integration test: attacker selecting poor decoys still pays correct fee

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)