### PR TITLE
feat(consensus): Add lottery result validation to block verification

### DIFF
--- a/botho/src/consensus/mod.rs
+++ b/botho/src/consensus/mod.rs
@@ -18,8 +18,9 @@ mod value;
 
 pub use block_builder::{BlockBuildError, BlockBuilder, BuiltBlock};
 pub use lottery::{
-    draw_lottery_winners, split_fees, verify_lottery_result, utxo_to_candidate,
-    BlockLotteryResult, LotteryFeeConfig, LotteryStats,
+    draw_lottery_winners, split_fees, validate_block_lottery, verify_lottery_result,
+    utxo_to_candidate, BlockLotteryResult, LotteryFeeConfig, LotteryStats,
+    LotteryValidationError,
 };
 pub use service::{ConsensusConfig, ConsensusEvent, ConsensusService, ScpMessage};
 pub use validation::{BatchValidationResult, TransactionValidator, ValidationError};

--- a/botho/src/ledger/mod.rs
+++ b/botho/src/ledger/mod.rs
@@ -23,6 +23,27 @@ pub enum LedgerError {
 
     #[error("Block already exists at height {0}")]
     BlockExists(u64),
+
+    // Lottery validation errors
+    #[error("Invalid lottery fee split: expected pool={expected_pool}, burn={expected_burn}, got pool={actual_pool}, burn={actual_burn}")]
+    InvalidLotteryFeeSplit {
+        expected_pool: u64,
+        expected_burn: u64,
+        actual_pool: u64,
+        actual_burn: u64,
+    },
+
+    #[error("Invalid lottery drawing: verification failed")]
+    InvalidLotteryDrawing,
+
+    #[error("Lottery payout mismatch: expected {expected}, got {actual}")]
+    LotteryPayoutMismatch { expected: u64, actual: u64 },
+
+    #[error("Lottery output mismatch: expected {expected} outputs, got {actual}")]
+    LotteryOutputCountMismatch { expected: usize, actual: usize },
+
+    #[error("Lottery winner not found in candidates: {0}")]
+    LotteryWinnerNotEligible(String),
 }
 
 /// Information about the current chain state

--- a/botho/src/transaction.rs
+++ b/botho/src/transaction.rs
@@ -1100,6 +1100,22 @@ pub struct Utxo {
 }
 
 #[cfg(test)]
+impl Transaction {
+    /// Create a stub transaction for testing with a given fee.
+    ///
+    /// This creates an empty transaction (no inputs/outputs) with the specified fee.
+    /// Used for testing fee-related logic like lottery validation.
+    pub fn new_stub_with_fee(fee: u64) -> Self {
+        Self {
+            inputs: TxInputs::new(vec![]),
+            outputs: vec![],
+            fee,
+            created_at_height: 0,
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Summary
- Implements lottery validation during block consensus to prevent invalid lottery results from being accepted
- Adds `validate_block_lottery()` function that verifies fee splitting (80/20), winner selection, and payout amounts
- Adds `get_lottery_candidates()` method to Ledger for retrieving eligible UTXOs
- Integrates validation into `add_block()` to reject blocks with invalid lottery data

## Test plan
- [x] Unit tests pass for all validation scenarios (13 lottery tests)
- [x] Tests cover: no fees/winners, invalid fee split, payout mismatch, ineligible winners
- [ ] Integration testing with live network (manual verification)
- [ ] Verify blocks with manipulated lottery data are rejected

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)