### PR TITLE
docs(design): Add entropy proof aggregation research findings

### DIFF
--- a/botho-wallet/src/lib.rs
+++ b/botho-wallet/src/lib.rs
@@ -26,7 +26,7 @@ pub use decoy_selection::{
     DecoySelectionError, DecoySelectionResult, UtxoCandidate,
 };
 pub use discovery::NodeDiscovery;
-pub use fee_estimation::{FeeEstimator, StoredTags};
+pub use fee_estimation::{CachedFeeRate, FeeEstimator, StoredTags};
 pub use keys::WalletKeys;
-pub use rpc_pool::RpcPool;
+pub use rpc_pool::{NetworkFeeRate, RpcPool};
 pub use storage::EncryptedWallet;

--- a/botho-wallet/tests/integration_tests.rs
+++ b/botho-wallet/tests/integration_tests.rs
@@ -1129,11 +1129,13 @@ mod cluster_tags {
 // ============================================================================
 
 mod decoy_selection {
-    use botho_wallet::decoy_selection::{
-        select_decoys, select_decoys_with_fallback, validate_decoys, DecoySelectionConfig,
-        DecoySelectionError, UtxoCandidate,
+    use botho_wallet::{
+        decoy_selection::{
+            select_decoys, select_decoys_with_fallback, validate_decoys, DecoySelectionConfig,
+            DecoySelectionError, UtxoCandidate,
+        },
+        fee_estimation::StoredTags,
     };
-    use botho_wallet::fee_estimation::StoredTags;
     use bth_cluster_tax::{ClusterId, TAG_WEIGHT_SCALE};
     use std::collections::HashMap;
 
@@ -1341,7 +1343,10 @@ mod decoy_selection {
             &config,
         );
         assert!(
-            matches!(strict_result, Err(DecoySelectionError::InsufficientDecoys { .. })),
+            matches!(
+                strict_result,
+                Err(DecoySelectionError::InsufficientDecoys { .. })
+            ),
             "Strict selection should fail"
         );
 
@@ -1394,19 +1399,30 @@ mod decoy_selection {
         );
 
         // Should detect 3 violations (too young, too old, high factor)
-        assert_eq!(violations.len(), 3, "Should detect 3 violations: {:?}", violations);
+        assert_eq!(
+            violations.len(),
+            3,
+            "Should detect 3 violations: {:?}",
+            violations
+        );
 
         // Verify specific violations
         assert!(
-            violations.iter().any(|(idx, msg)| *idx == 0 && msg.contains("young")),
+            violations
+                .iter()
+                .any(|(idx, msg)| *idx == 0 && msg.contains("young")),
             "Should detect 'too young' violation"
         );
         assert!(
-            violations.iter().any(|(idx, msg)| *idx == 2 && msg.contains("old")),
+            violations
+                .iter()
+                .any(|(idx, msg)| *idx == 2 && msg.contains("old")),
             "Should detect 'too old' violation"
         );
         assert!(
-            violations.iter().any(|(idx, msg)| *idx == 3 && msg.contains("factor")),
+            violations
+                .iter()
+                .any(|(idx, msg)| *idx == 3 && msg.contains("factor")),
             "Should detect factor violation"
         );
     }

--- a/cluster-tax/src/entropy_decay.rs
+++ b/cluster-tax/src/entropy_decay.rs
@@ -1,0 +1,987 @@
+//! Entropy-Weighted Decay: Defense against patient wash trading attacks.
+//!
+//! This module implements decay that only applies when cluster entropy actually
+//! changes, indicating genuine commerce rather than self-transfers.
+//!
+//! # Key Insight
+//!
+//! Patient wash trading exploits age-based decay by waiting between each
+//! self-transfer. While each individual transfer is rate-limited, the attacker
+//! eventually achieves full decay without any real commerce.
+//!
+//! Entropy-weighted decay solves this by only allowing decay when the receiver's
+//! cluster entropy increases. Self-transfers don't change entropy, so no decay
+//! applies regardless of timing.
+//!
+//! # Properties
+//!
+//! - **Wash trading (rapid or patient)**: NO decay (entropy unchanged)
+//! - **Sybil wash trading**: NO decay (creating fake counterparties doesn't add
+//!   entropy)
+//! - **Legitimate commerce**: Normal decay (entropy increases from mixing
+//!   sources)
+//! - **Privacy preserved**: Uses existing cluster_entropy() calculation
+//!
+//! # Integration with Age-Based Decay
+//!
+//! Entropy-weighted decay can be used as a gating condition on top of age-based
+//! decay: - Age check: UTXO must be >= min_age_blocks old - Entropy check: Must
+//!   cause entropy delta >= min_entropy_delta - Decay rate: 5% × scaling_factor
+//!   (where scaling_factor depends on entropy delta)
+
+use crate::age_decay::AgeDecayConfig;
+use crate::tag::{TagVector, TagWeight, TAG_WEIGHT_SCALE};
+
+/// Configuration for entropy-weighted decay.
+#[derive(Clone, Debug)]
+pub struct EntropyDecayConfig {
+    /// Minimum entropy delta required to trigger decay.
+    /// Value in bits (e.g., 0.1 means 0.1 bits of entropy increase).
+    pub min_entropy_delta: f64,
+
+    /// Base decay rate (applied when entropy condition is met).
+    /// Uses same scale as TagWeight (e.g., 50_000 = 5%).
+    pub base_decay_rate: TagWeight,
+
+    /// How entropy delta scales the decay rate.
+    pub decay_scaling: EntropyScaling,
+
+    /// Optional: Combine with age-based gating.
+    pub age_config: Option<AgeDecayConfig>,
+}
+
+impl Default for EntropyDecayConfig {
+    fn default() -> Self {
+        Self {
+            min_entropy_delta: 0.1, // Require at least 0.1 bits of entropy increase
+            base_decay_rate: 50_000, // 5% base decay
+            decay_scaling: EntropyScaling::Linear,
+            age_config: Some(AgeDecayConfig::default()),
+        }
+    }
+}
+
+impl EntropyDecayConfig {
+    /// Create a config with custom entropy threshold.
+    pub fn with_threshold(min_entropy_delta: f64) -> Self {
+        Self {
+            min_entropy_delta,
+            ..Default::default()
+        }
+    }
+
+    /// Create a config without age gating (pure entropy-based).
+    pub fn entropy_only() -> Self {
+        Self {
+            age_config: None,
+            ..Default::default()
+        }
+    }
+
+    /// Create a config optimized for wash trading resistance.
+    pub fn anti_wash_trading() -> Self {
+        Self {
+            min_entropy_delta: 0.05, // Low threshold, but still requires real commerce
+            base_decay_rate: 50_000,
+            decay_scaling: EntropyScaling::Sqrt,
+            age_config: Some(AgeDecayConfig::default()),
+        }
+    }
+}
+
+/// How entropy delta scales the decay rate.
+#[derive(Clone, Debug, Default, Copy, PartialEq)]
+pub enum EntropyScaling {
+    /// Full decay when min_entropy_delta is met.
+    #[default]
+    Linear,
+
+    /// Decay proportional to sqrt(entropy_delta).
+    /// More gradual, rewards larger entropy increases less.
+    Sqrt,
+
+    /// Decay proportional to log(1 + entropy_delta).
+    /// Even more gradual, good for large entropy ranges.
+    Log,
+
+    /// Binary: full decay if threshold met, zero otherwise.
+    Binary,
+}
+
+impl EntropyScaling {
+    /// Calculate scaling factor for given entropy delta.
+    /// Returns a value between 0.0 and 1.0.
+    pub fn factor(&self, entropy_delta: f64, min_delta: f64) -> f64 {
+        if entropy_delta < min_delta {
+            return 0.0;
+        }
+
+        match self {
+            EntropyScaling::Binary => 1.0,
+            EntropyScaling::Linear => (entropy_delta / min_delta).min(2.0) / 2.0,
+            EntropyScaling::Sqrt => ((entropy_delta / min_delta).sqrt()).min(2.0) / 2.0,
+            EntropyScaling::Log => ((1.0 + entropy_delta / min_delta).ln()).min(2.0) / 2.0,
+        }
+    }
+}
+
+/// Result of attempting entropy-weighted decay.
+#[derive(Clone, Debug)]
+pub struct EntropyDecayResult {
+    /// Whether decay was applied.
+    pub decay_applied: bool,
+
+    /// Entropy before the transfer.
+    pub entropy_before: f64,
+
+    /// Entropy after the transfer (if decay was applied).
+    pub entropy_after: f64,
+
+    /// The entropy delta that triggered decay.
+    pub entropy_delta: f64,
+
+    /// Scaling factor applied to decay rate.
+    pub scaling_factor: f64,
+
+    /// Actual decay rate applied (0 if no decay).
+    pub effective_decay_rate: TagWeight,
+
+    /// Reason decay was blocked (if applicable).
+    pub block_reason: Option<DecayBlockReason>,
+}
+
+/// Reasons why decay might be blocked.
+#[derive(Clone, Debug, PartialEq)]
+pub enum DecayBlockReason {
+    /// UTXO too young (age check failed).
+    UtxoTooYoung {
+        utxo_age_blocks: u64,
+        required_age: u64,
+    },
+    /// Entropy increase too small.
+    InsufficientEntropy { delta: f64, required: f64 },
+    /// No cluster tags to decay (fully background).
+    FullyDecayed,
+}
+
+/// Calculate entropy-weighted decay for a transfer.
+///
+/// This is the core function that determines whether decay should apply
+/// based on entropy changes from mixing incoming funds.
+pub fn calculate_entropy_decay(
+    receiver_tags_before: &TagVector,
+    receiver_balance: u64,
+    incoming_tags: &TagVector,
+    incoming_amount: u64,
+    config: &EntropyDecayConfig,
+) -> EntropyDecayResult {
+    // Calculate entropy before the mix
+    let entropy_before = receiver_tags_before.cluster_entropy();
+
+    // Simulate the mix to calculate entropy after
+    let mut mixed_tags = receiver_tags_before.clone();
+    mixed_tags.mix(receiver_balance, incoming_tags, incoming_amount);
+    let entropy_after = mixed_tags.cluster_entropy();
+
+    // Calculate entropy delta
+    let entropy_delta = entropy_after - entropy_before;
+
+    // Check if entropy threshold is met
+    if entropy_delta < config.min_entropy_delta {
+        return EntropyDecayResult {
+            decay_applied: false,
+            entropy_before,
+            entropy_after,
+            entropy_delta,
+            scaling_factor: 0.0,
+            effective_decay_rate: 0,
+            block_reason: Some(DecayBlockReason::InsufficientEntropy {
+                delta: entropy_delta,
+                required: config.min_entropy_delta,
+            }),
+        };
+    }
+
+    // Check if there are any cluster tags to decay
+    if receiver_tags_before.total_attributed() == 0 && incoming_tags.total_attributed() == 0 {
+        return EntropyDecayResult {
+            decay_applied: false,
+            entropy_before,
+            entropy_after,
+            entropy_delta,
+            scaling_factor: 0.0,
+            effective_decay_rate: 0,
+            block_reason: Some(DecayBlockReason::FullyDecayed),
+        };
+    }
+
+    // Calculate scaling factor based on entropy delta
+    let scaling_factor = config
+        .decay_scaling
+        .factor(entropy_delta, config.min_entropy_delta);
+
+    // Calculate effective decay rate
+    let effective_decay_rate =
+        (config.base_decay_rate as f64 * scaling_factor).round() as TagWeight;
+
+    EntropyDecayResult {
+        decay_applied: true,
+        entropy_before,
+        entropy_after,
+        entropy_delta,
+        scaling_factor,
+        effective_decay_rate,
+        block_reason: None,
+    }
+}
+
+/// Apply entropy-weighted decay with optional age gating.
+///
+/// Returns the decay result and applies the decay to transferred tags
+/// if all conditions are met.
+pub fn apply_entropy_decay(
+    transferred_tags: &mut TagVector,
+    receiver_tags_before: &TagVector,
+    receiver_balance: u64,
+    incoming_amount: u64,
+    utxo_creation_block: Option<u64>,
+    current_block: Option<u64>,
+    config: &EntropyDecayConfig,
+) -> EntropyDecayResult {
+    // First check age requirement if configured
+    if let (Some(age_config), Some(creation_block), Some(current)) =
+        (&config.age_config, utxo_creation_block, current_block)
+    {
+        let utxo_age = current.saturating_sub(creation_block);
+        if utxo_age < age_config.min_age_blocks {
+            return EntropyDecayResult {
+                decay_applied: false,
+                entropy_before: receiver_tags_before.cluster_entropy(),
+                entropy_after: receiver_tags_before.cluster_entropy(),
+                entropy_delta: 0.0,
+                scaling_factor: 0.0,
+                effective_decay_rate: 0,
+                block_reason: Some(DecayBlockReason::UtxoTooYoung {
+                    utxo_age_blocks: utxo_age,
+                    required_age: age_config.min_age_blocks,
+                }),
+            };
+        }
+    }
+
+    // Calculate entropy-based decay
+    let result = calculate_entropy_decay(
+        receiver_tags_before,
+        receiver_balance,
+        transferred_tags,
+        incoming_amount,
+        config,
+    );
+
+    // Apply decay if conditions met
+    if result.decay_applied {
+        transferred_tags.apply_decay(result.effective_decay_rate);
+    }
+
+    result
+}
+
+// ============================================================================
+// Attack Strategies for Simulation
+// ============================================================================
+
+/// Attack strategies for testing decay resistance.
+#[derive(Clone, Debug)]
+pub enum AttackStrategy {
+    /// Rapid self-transfers without waiting.
+    RapidWash {
+        /// Number of transfers to execute.
+        transfers: u32,
+    },
+
+    /// Patient wash trading: wait between each transfer.
+    PatientWash {
+        /// Blocks to wait between transfers.
+        interval_blocks: u64,
+        /// Total duration in blocks.
+        duration_blocks: u64,
+    },
+
+    /// Create fake counterparty addresses for wash trading.
+    SybilWash {
+        /// Number of fake counterparties to create.
+        fake_counterparties: u32,
+        /// Transfers per counterparty.
+        transfers_per_counterparty: u32,
+    },
+
+    /// Mix real commerce with wash trading.
+    PartialCommerce {
+        /// Fraction of legitimate transactions (0.0 to 1.0).
+        legit_ratio: f64,
+        /// Total transactions.
+        total_transactions: u32,
+    },
+}
+
+/// Result of simulating an attack strategy.
+#[derive(Clone, Debug)]
+pub struct AttackResult {
+    /// Strategy that was executed.
+    pub strategy: String,
+
+    /// Initial cluster tag weight.
+    pub initial_tag: TagWeight,
+
+    /// Final cluster tag weight.
+    pub final_tag: TagWeight,
+
+    /// Tag remaining as fraction (0.0 to 1.0).
+    pub tag_remaining_fraction: f64,
+
+    /// Initial cluster entropy.
+    pub initial_entropy: f64,
+
+    /// Final cluster entropy.
+    pub final_entropy: f64,
+
+    /// Number of decay events that occurred.
+    pub decay_events: u32,
+
+    /// Total decay attempts.
+    pub total_attempts: u32,
+
+    /// Effective decay rate per block.
+    pub effective_decay_rate_per_block: f64,
+
+    /// Time elapsed in blocks.
+    pub blocks_elapsed: u64,
+}
+
+/// Simulated UTXO for attack testing.
+#[derive(Clone, Debug)]
+pub struct SimUtxo {
+    /// UTXO value.
+    pub value: u64,
+    /// Tag vector.
+    pub tags: TagVector,
+    /// Block when UTXO was created.
+    pub creation_block: u64,
+    /// Entropy history for tracking.
+    pub entropy_history: Vec<f64>,
+}
+
+impl SimUtxo {
+    /// Create a new simulated UTXO.
+    pub fn new(value: u64, cluster_id: crate::ClusterId, creation_block: u64) -> Self {
+        Self {
+            value,
+            tags: TagVector::single(cluster_id),
+            creation_block,
+            entropy_history: vec![0.0], // Fresh mint has 0 entropy
+        }
+    }
+
+    /// Record current entropy in history.
+    pub fn record_entropy(&mut self) {
+        self.entropy_history.push(self.tags.cluster_entropy());
+    }
+}
+
+/// Decay mode for comparison simulations.
+#[derive(Clone, Debug, Copy, PartialEq)]
+pub enum DecayMode {
+    /// Age-based decay (current implementation).
+    AgeBased,
+    /// Entropy-weighted decay (proposed).
+    EntropyWeighted,
+    /// No decay (control group).
+    None,
+}
+
+/// Compare decay modes under a given attack strategy.
+pub fn compare_decay_modes(
+    strategy: &AttackStrategy,
+    initial_wealth: u64,
+    initial_factor: f64,
+    duration_blocks: u64,
+) -> Vec<(DecayMode, AttackResult)> {
+    let cluster_id = crate::ClusterId::new(1);
+    let initial_tag = (initial_factor / 6.0 * TAG_WEIGHT_SCALE as f64) as TagWeight;
+
+    vec![
+        (
+            DecayMode::AgeBased,
+            simulate_attack_age_based(
+                strategy,
+                cluster_id,
+                initial_wealth,
+                initial_tag,
+                duration_blocks,
+            ),
+        ),
+        (
+            DecayMode::EntropyWeighted,
+            simulate_attack_entropy_weighted(
+                strategy,
+                cluster_id,
+                initial_wealth,
+                initial_tag,
+                duration_blocks,
+            ),
+        ),
+    ]
+}
+
+/// Simulate attack with age-based decay.
+fn simulate_attack_age_based(
+    strategy: &AttackStrategy,
+    cluster_id: crate::ClusterId,
+    _initial_wealth: u64,
+    initial_tag: TagWeight,
+    duration_blocks: u64,
+) -> AttackResult {
+    let age_config = AgeDecayConfig::default();
+    let mut tags = TagVector::new();
+    tags.set(cluster_id, initial_tag);
+    let initial_entropy = tags.cluster_entropy();
+
+    let mut decay_events = 0u32;
+    let mut total_attempts = 0u32;
+    let mut current_block = 0u64;
+    let mut last_creation_block = 0u64;
+
+    match strategy {
+        AttackStrategy::RapidWash { transfers } => {
+            for _ in 0..*transfers {
+                total_attempts += 1;
+                // Rapid transfers: each output is created 1 block ago
+                current_block += 1;
+                if age_config.is_eligible(last_creation_block, current_block) {
+                    tags.apply_decay(age_config.decay_rate);
+                    decay_events += 1;
+                    last_creation_block = current_block;
+                }
+            }
+        }
+        AttackStrategy::PatientWash {
+            interval_blocks,
+            duration_blocks: attack_duration,
+        } => {
+            let max_transfers = attack_duration / interval_blocks;
+            for _ in 0..max_transfers {
+                total_attempts += 1;
+                current_block += interval_blocks;
+                if current_block > duration_blocks {
+                    break;
+                }
+                if age_config.is_eligible(last_creation_block, current_block) {
+                    tags.apply_decay(age_config.decay_rate);
+                    decay_events += 1;
+                    last_creation_block = current_block;
+                }
+            }
+        }
+        AttackStrategy::SybilWash {
+            fake_counterparties,
+            transfers_per_counterparty,
+        } => {
+            // Sybil attack: create fake addresses, but it's still self-transfer
+            // from the chain's perspective (same cluster tags)
+            let total_transfers = fake_counterparties * transfers_per_counterparty;
+            let interval = duration_blocks / total_transfers as u64;
+            for _ in 0..total_transfers {
+                total_attempts += 1;
+                current_block += interval;
+                if age_config.is_eligible(last_creation_block, current_block) {
+                    tags.apply_decay(age_config.decay_rate);
+                    decay_events += 1;
+                    last_creation_block = current_block;
+                }
+            }
+        }
+        AttackStrategy::PartialCommerce {
+            legit_ratio,
+            total_transactions,
+        } => {
+            let interval = duration_blocks / *total_transactions as u64;
+            let legit_count = (*total_transactions as f64 * legit_ratio) as u32;
+            for i in 0..*total_transactions {
+                total_attempts += 1;
+                current_block += interval;
+                let is_legit = i < legit_count;
+
+                if is_legit {
+                    // Legitimate commerce always triggers decay
+                    tags.apply_decay(age_config.decay_rate);
+                    decay_events += 1;
+                    last_creation_block = current_block;
+                } else if age_config.is_eligible(last_creation_block, current_block) {
+                    // Wash trading only if age allows
+                    tags.apply_decay(age_config.decay_rate);
+                    decay_events += 1;
+                    last_creation_block = current_block;
+                }
+            }
+        }
+    }
+
+    let final_tag = tags.get(cluster_id);
+    let final_entropy = tags.cluster_entropy();
+    let blocks_elapsed = current_block.max(duration_blocks);
+
+    AttackResult {
+        strategy: format!("{strategy:?}"),
+        initial_tag,
+        final_tag,
+        tag_remaining_fraction: final_tag as f64 / initial_tag as f64,
+        initial_entropy,
+        final_entropy,
+        decay_events,
+        total_attempts,
+        effective_decay_rate_per_block: if blocks_elapsed > 0 {
+            1.0 - (final_tag as f64 / initial_tag as f64).powf(1.0 / blocks_elapsed as f64)
+        } else {
+            0.0
+        },
+        blocks_elapsed,
+    }
+}
+
+/// Simulate attack with entropy-weighted decay.
+fn simulate_attack_entropy_weighted(
+    strategy: &AttackStrategy,
+    cluster_id: crate::ClusterId,
+    initial_wealth: u64,
+    initial_tag: TagWeight,
+    duration_blocks: u64,
+) -> AttackResult {
+    let config = EntropyDecayConfig::anti_wash_trading();
+    let mut tags = TagVector::new();
+    tags.set(cluster_id, initial_tag);
+    let initial_entropy = tags.cluster_entropy();
+
+    let mut decay_events = 0u32;
+    let mut total_attempts = 0u32;
+    let mut current_block = 0u64;
+
+    match strategy {
+        AttackStrategy::RapidWash { transfers } => {
+            // Rapid wash: no entropy change on self-transfers
+            for _ in 0..*transfers {
+                total_attempts += 1;
+                current_block += 1;
+
+                // Self-transfer: incoming tags are the same as existing
+                let result = calculate_entropy_decay(
+                    &tags,
+                    initial_wealth,
+                    &tags.clone(),
+                    initial_wealth / *transfers as u64,
+                    &config,
+                );
+
+                if result.decay_applied {
+                    tags.apply_decay(result.effective_decay_rate);
+                    decay_events += 1;
+                }
+            }
+        }
+        AttackStrategy::PatientWash {
+            interval_blocks,
+            duration_blocks: attack_duration,
+        } => {
+            let max_transfers = attack_duration / interval_blocks;
+            for _ in 0..max_transfers {
+                total_attempts += 1;
+                current_block += interval_blocks;
+                if current_block > duration_blocks {
+                    break;
+                }
+
+                // Patient wash: still self-transfer, no entropy change
+                let result = calculate_entropy_decay(
+                    &tags,
+                    initial_wealth,
+                    &tags.clone(),
+                    initial_wealth,
+                    &config,
+                );
+
+                if result.decay_applied {
+                    tags.apply_decay(result.effective_decay_rate);
+                    decay_events += 1;
+                }
+            }
+        }
+        AttackStrategy::SybilWash {
+            fake_counterparties,
+            transfers_per_counterparty,
+        } => {
+            // Sybil attack: fake counterparties still have same-origin tags
+            // Creating a new address doesn't create new cluster entropy
+            let total_transfers = fake_counterparties * transfers_per_counterparty;
+            let interval = duration_blocks / total_transfers as u64;
+
+            for _ in 0..total_transfers {
+                total_attempts += 1;
+                current_block += interval;
+
+                // Fake counterparty has same tags (they received from attacker)
+                let result = calculate_entropy_decay(
+                    &tags,
+                    initial_wealth,
+                    &tags.clone(),
+                    initial_wealth / total_transfers as u64,
+                    &config,
+                );
+
+                if result.decay_applied {
+                    tags.apply_decay(result.effective_decay_rate);
+                    decay_events += 1;
+                }
+            }
+        }
+        AttackStrategy::PartialCommerce {
+            legit_ratio,
+            total_transactions,
+        } => {
+            let interval = duration_blocks / *total_transactions as u64;
+            let legit_count = (*total_transactions as f64 * legit_ratio) as u32;
+
+            // For legitimate commerce, we need a different cluster
+            let other_cluster = crate::ClusterId::new(2);
+
+            for i in 0..*total_transactions {
+                total_attempts += 1;
+                current_block += interval;
+                let is_legit = i < legit_count;
+
+                let incoming = if is_legit {
+                    // Legitimate: incoming from different cluster
+                    TagVector::single(other_cluster)
+                } else {
+                    // Wash: same tags
+                    tags.clone()
+                };
+
+                let result = calculate_entropy_decay(
+                    &tags,
+                    initial_wealth,
+                    &incoming,
+                    initial_wealth / *total_transactions as u64,
+                    &config,
+                );
+
+                if result.decay_applied {
+                    tags.apply_decay(result.effective_decay_rate);
+                    decay_events += 1;
+                }
+            }
+        }
+    }
+
+    let final_tag = tags.get(cluster_id);
+    let final_entropy = tags.cluster_entropy();
+    let blocks_elapsed = current_block.max(duration_blocks);
+
+    AttackResult {
+        strategy: format!("{strategy:?}"),
+        initial_tag,
+        final_tag,
+        tag_remaining_fraction: final_tag as f64 / initial_tag as f64,
+        initial_entropy,
+        final_entropy,
+        decay_events,
+        total_attempts,
+        effective_decay_rate_per_block: if blocks_elapsed > 0 {
+            1.0 - (final_tag as f64 / initial_tag as f64).powf(1.0 / blocks_elapsed as f64)
+        } else {
+            0.0
+        },
+        blocks_elapsed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ClusterId;
+
+    #[test]
+    fn test_self_transfer_no_entropy_change() {
+        let c1 = ClusterId::new(1);
+        let tags = TagVector::single(c1);
+        let config = EntropyDecayConfig::default();
+
+        // Self-transfer: incoming tags same as receiver
+        let result =
+            calculate_entropy_decay(&tags, 1000, &tags, 1000, // Same tags
+                                    &config);
+
+        // No entropy change = no decay
+        assert!(
+            !result.decay_applied,
+            "Self-transfer should not trigger decay"
+        );
+        assert_eq!(result.entropy_delta, 0.0, "Self-transfer has zero entropy delta");
+    }
+
+    #[test]
+    fn test_commerce_increases_entropy() {
+        let c1 = ClusterId::new(1);
+        let c2 = ClusterId::new(2);
+
+        let receiver_tags = TagVector::single(c1);
+        let incoming_tags = TagVector::single(c2);
+        let config = EntropyDecayConfig::default();
+
+        // Commerce: incoming from different cluster
+        let result = calculate_entropy_decay(
+            &receiver_tags,
+            1000,
+            &incoming_tags,
+            1000, // Different cluster
+            &config,
+        );
+
+        // Entropy increases = decay applies
+        assert!(result.decay_applied, "Commerce should trigger decay");
+        assert!(
+            result.entropy_delta > 0.0,
+            "Commerce increases entropy: {}",
+            result.entropy_delta
+        );
+        assert!(
+            result.entropy_after > result.entropy_before,
+            "Entropy should increase: {} -> {}",
+            result.entropy_before,
+            result.entropy_after
+        );
+    }
+
+    #[test]
+    fn test_patient_wash_blocked() {
+        let c1 = ClusterId::new(1);
+        let strategy = AttackStrategy::PatientWash {
+            interval_blocks: 720, // Maximum patience
+            duration_blocks: 60480, // 1 week
+        };
+
+        // With age-based decay: patient attacker succeeds
+        let age_result = simulate_attack_age_based(
+            &strategy,
+            c1,
+            100_000_000,
+            TAG_WEIGHT_SCALE, // 100% initial tag
+            60480,
+        );
+
+        // With entropy-weighted decay: patient attacker blocked
+        let entropy_result = simulate_attack_entropy_weighted(
+            &strategy,
+            c1,
+            100_000_000,
+            TAG_WEIGHT_SCALE,
+            60480,
+        );
+
+        // Age-based allows significant decay
+        assert!(
+            age_result.decay_events > 0,
+            "Age-based should allow some decays"
+        );
+        assert!(
+            age_result.tag_remaining_fraction < 0.5,
+            "Age-based: significant decay ({}%)",
+            age_result.tag_remaining_fraction * 100.0
+        );
+
+        // Entropy-weighted blocks all decay
+        assert_eq!(
+            entropy_result.decay_events, 0,
+            "Entropy-weighted should block patient wash"
+        );
+        assert_eq!(
+            entropy_result.tag_remaining_fraction, 1.0,
+            "Entropy-weighted: no decay"
+        );
+    }
+
+    #[test]
+    fn test_sybil_wash_blocked() {
+        let c1 = ClusterId::new(1);
+        let strategy = AttackStrategy::SybilWash {
+            fake_counterparties: 100,
+            transfers_per_counterparty: 10,
+        };
+
+        let entropy_result = simulate_attack_entropy_weighted(
+            &strategy,
+            c1,
+            100_000_000,
+            TAG_WEIGHT_SCALE,
+            60480,
+        );
+
+        // Sybil attack blocked: fake counterparties don't add entropy
+        assert_eq!(entropy_result.decay_events, 0, "Sybil attack should be blocked");
+        assert_eq!(
+            entropy_result.tag_remaining_fraction, 1.0,
+            "No decay for sybil attack"
+        );
+    }
+
+    #[test]
+    fn test_legitimate_commerce_allows_decay() {
+        let c1 = ClusterId::new(1);
+        let strategy = AttackStrategy::PartialCommerce {
+            legit_ratio: 1.0, // 100% legitimate
+            total_transactions: 100,
+        };
+
+        let entropy_result = simulate_attack_entropy_weighted(
+            &strategy,
+            c1,
+            100_000_000,
+            TAG_WEIGHT_SCALE,
+            60480,
+        );
+
+        // Legitimate commerce allows decay
+        assert!(
+            entropy_result.decay_events > 0,
+            "Legitimate commerce should trigger decay: {} events",
+            entropy_result.decay_events
+        );
+        assert!(
+            entropy_result.tag_remaining_fraction < 1.0,
+            "Should have some decay: {}%",
+            entropy_result.tag_remaining_fraction * 100.0
+        );
+    }
+
+    #[test]
+    fn test_partial_commerce_proportional_decay() {
+        let c1 = ClusterId::new(1);
+
+        // 50% legitimate, 50% wash
+        let partial_strategy = AttackStrategy::PartialCommerce {
+            legit_ratio: 0.5,
+            total_transactions: 100,
+        };
+
+        // 100% legitimate
+        let full_strategy = AttackStrategy::PartialCommerce {
+            legit_ratio: 1.0,
+            total_transactions: 100,
+        };
+
+        let partial_result = simulate_attack_entropy_weighted(
+            &partial_strategy,
+            c1,
+            100_000_000,
+            TAG_WEIGHT_SCALE,
+            60480,
+        );
+
+        let full_result = simulate_attack_entropy_weighted(
+            &full_strategy,
+            c1,
+            100_000_000,
+            TAG_WEIGHT_SCALE,
+            60480,
+        );
+
+        // More legitimate commerce = more decay
+        assert!(
+            partial_result.decay_events < full_result.decay_events,
+            "Partial commerce should have fewer decay events: {} vs {}",
+            partial_result.decay_events,
+            full_result.decay_events
+        );
+    }
+
+    #[test]
+    fn test_scaling_modes() {
+        let c1 = ClusterId::new(1);
+        let c2 = ClusterId::new(2);
+
+        let receiver_tags = TagVector::single(c1);
+        let incoming_tags = TagVector::single(c2);
+
+        // Test all scaling modes
+        for scaling in [
+            EntropyScaling::Binary,
+            EntropyScaling::Linear,
+            EntropyScaling::Sqrt,
+            EntropyScaling::Log,
+        ] {
+            let config = EntropyDecayConfig {
+                decay_scaling: scaling,
+                ..Default::default()
+            };
+
+            let result = calculate_entropy_decay(&receiver_tags, 1000, &incoming_tags, 1000, &config);
+
+            assert!(
+                result.decay_applied,
+                "Commerce should trigger decay with {:?} scaling",
+                scaling
+            );
+            assert!(
+                result.scaling_factor > 0.0,
+                "Scaling factor should be positive for {:?}",
+                scaling
+            );
+        }
+    }
+
+    #[test]
+    fn test_age_gating_with_entropy() {
+        let c1 = ClusterId::new(1);
+        let c2 = ClusterId::new(2);
+
+        let mut transferred_tags = TagVector::single(c1);
+        let receiver_tags = TagVector::new();
+
+        let config = EntropyDecayConfig::default(); // Has age_config with 720 block min
+
+        // Young UTXO should be blocked even with entropy change
+        let result = apply_entropy_decay(
+            &mut transferred_tags,
+            &receiver_tags,
+            0,
+            1000,
+            Some(100),  // Created at block 100
+            Some(500),  // Current block 500 (only 400 blocks old)
+            &config,
+        );
+
+        assert!(
+            !result.decay_applied,
+            "Young UTXO should block decay even with entropy"
+        );
+        assert!(
+            matches!(result.block_reason, Some(DecayBlockReason::UtxoTooYoung { .. })),
+            "Should report UTXO too young"
+        );
+
+        // With commerce (different cluster), should allow decay
+        let mut transferred_tags3 = TagVector::single(c1);
+        let result3 = apply_entropy_decay(
+            &mut transferred_tags3,
+            &TagVector::single(c2), // Receiver has different cluster
+            1000,
+            1000,
+            Some(100),
+            Some(1000),
+            &config,
+        );
+
+        assert!(
+            result3.decay_applied,
+            "Old UTXO with commerce should decay"
+        );
+    }
+}

--- a/cluster-tax/src/lib.rs
+++ b/cluster-tax/src/lib.rs
@@ -46,6 +46,7 @@ pub mod validate;
 mod age_decay;
 mod block_decay;
 mod cluster;
+mod entropy_decay;
 mod fee_curve;
 mod lottery;
 mod tag;
@@ -67,6 +68,11 @@ pub use cluster::{ClusterId, ClusterWealth};
 pub use monetary::{DifficultyController, MonetaryPolicy, MonetaryState, MonetaryStats};
 
 pub use age_decay::{apply_age_decay, ring_cluster_factor, AgeDecayConfig, RingDecayInfo};
+pub use entropy_decay::{
+    apply_entropy_decay, calculate_entropy_decay, compare_decay_modes, AttackResult,
+    AttackStrategy, DecayBlockReason, DecayMode, EntropyDecayConfig, EntropyDecayResult,
+    EntropyScaling, SimUtxo,
+};
 pub use block_decay::{
     AndDecayConfig, AndTagVector, BlockAwareTagVector, BlockDecayConfig, RateLimitedDecayConfig,
     RateLimitedTagVector,

--- a/docs/design/entropy-proof-aggregation-research.md
+++ b/docs/design/entropy-proof-aggregation-research.md
@@ -1,0 +1,487 @@
+# Entropy Proof Aggregation Research
+
+**Status**: Phase A Feasibility Study
+**Issue**: #260
+**Related**: #232 (Phase 2 committed tags), #257 (Entropy-weighted decay)
+
+## Executive Summary
+
+This document presents findings from the Phase A feasibility study on aggregating entropy proofs with Bulletproof range proofs. The goal is to minimize transaction size overhead for Phase 2 committed tags while enabling entropy-weighted decay verification.
+
+**Key Findings**:
+
+1. **Shannon entropy is circuit-hostile** - requires logarithms that don't map well to arithmetic circuits
+2. **Collision entropy (H₂) is a viable alternative** - computable as sum of squared probabilities, circuit-friendly
+3. **Aggregation is feasible** - entropy constraints can share inner-product structure with range proofs
+4. **Estimated savings: ~40-45%** - combined proof ~850-950 bytes vs ~1400-1500 bytes separate
+5. **Recommended approach**: Bulletproofs with auxiliary inner-product constraints
+
+## Background
+
+### The Problem
+
+Phase 2 requires zero-knowledge proofs for:
+1. **Tag conservation**: Output tags derive from input tags (existing Schnorr proofs)
+2. **Fee correctness**: Fee paid matches cluster factor (existing OR-proof structure)
+3. **Entropy delta** (new): Decay credit proportional to genuine entropy increase
+
+Current transaction overhead (Phase 1 baseline):
+- Ring signature (CLSAG, ring=11): ~350 bytes
+- Range proofs: Not yet implemented, estimated ~700 bytes with Bulletproofs
+
+Adding separate entropy proof: ~500-800 bytes additional
+
+**Target**: Combined proof ≤ 1000 bytes total for range + entropy
+
+### Current Crypto Infrastructure
+
+From `cluster-tax/src/crypto/committed_tags.rs`:
+- Pedersen commitments for tag masses: `C = mass * H_k + r * G`
+- Per-cluster generators derived via hash-to-curve
+- Schnorr proofs for tag conservation
+- OR-proof structure for fee segment verification
+
+This provides a foundation for extending with entropy proofs.
+
+## Entropy Reformulation Analysis
+
+### Shannon Entropy: Circuit-Hostile
+
+Standard Shannon entropy:
+```
+H = -Σ (p_i × log₂(p_i))
+```
+
+**Problems for arithmetic circuits**:
+1. **Logarithms**: Not expressible as polynomial constraints
+2. **Lookup tables**: Require pre-computed tables, add significant overhead
+3. **Polynomial approximations**: Taylor series for log₂ needs many terms for accuracy
+4. **Floating point**: Entropy is real-valued, circuits work with field elements
+
+**Estimated circuit cost**: 500+ constraints per tag entry using lookup tables
+
+### Collision Entropy (H₂): Circuit-Friendly
+
+Collision entropy (Rényi entropy of order 2):
+```
+H₂ = -log₂(Σ p_i²)
+```
+
+**Key insight**: We don't need to compute H₂ directly. For threshold comparisons:
+```
+H₂ ≥ threshold  ⟺  Σ p_i² ≤ 2^(-threshold)
+```
+
+The sum of squared probabilities is purely arithmetic:
+```
+collision_sum = Σ (w_i / total)² = Σ w_i² / total²
+```
+
+**Circuit cost**: O(n) multiplications where n = number of clusters
+
+### Comparison: Shannon vs Collision Entropy
+
+| Metric | Shannon H | Collision H₂ |
+|--------|-----------|--------------|
+| Formula | -Σ p log p | -log(Σ p²) |
+| Range | [0, log₂(n)] | [0, log₂(n)] |
+| Single source | 0 | 0 |
+| Uniform (n sources) | log₂(n) | log₂(n) |
+| Decay-invariant | Yes* | Yes* |
+| Circuit-friendly | No | Yes |
+
+*When computed over cluster weights only, excluding background
+
+### Collision Entropy for Wash Trading Detection
+
+**Key question**: Does collision entropy distinguish wash trading from genuine commerce?
+
+**Analysis**:
+
+1. **Wash trading (A→B→C→A)**:
+   - Real input: 100% cluster A, H₂ = 0
+   - Output: 100% cluster A, H₂ = 0
+   - Δ H₂ = 0 → No decay credit ✓
+
+2. **Genuine commerce (receive from diverse sources)**:
+   - Before: 100% cluster A, H₂ = 0
+   - After mixing with 50% B: H₂ = 1 bit
+   - Δ H₂ = 1 → Decay credit granted ✓
+
+3. **Split attack (same entropy preserved)**:
+   - Parent: 60% A, 40% B, H₂ ≈ 0.97 bits
+   - Children (10 outputs): Each 60% A, 40% B, H₂ ≈ 0.97 bits
+   - No entropy gain per split ✓
+
+**Conclusion**: Collision entropy preserves all required properties for decay credit.
+
+### Min-Entropy (H_∞): Even Simpler
+
+Min-entropy:
+```
+H_∞ = -log₂(max(p_i))
+```
+
+**For threshold comparisons**:
+```
+H_∞ ≥ threshold  ⟺  max(p_i) ≤ 2^(-threshold)
+```
+
+**Advantages**:
+- Single comparison instead of sum
+- Even simpler circuit
+
+**Disadvantages**:
+- Less granular than H₂
+- A 51%/49% split has same H_∞ as 51%/24.5%/24.5%
+- May be too coarse for decay credit weighting
+
+**Recommendation**: Use collision entropy (H₂) for better granularity while maintaining circuit-friendliness.
+
+## Bulletproof Aggregation Analysis
+
+### Bulletproofs Background
+
+Bulletproofs (Bünz et al., 2018) provide:
+- **Range proofs**: Prove v ∈ [0, 2^n) without revealing v
+- **Arithmetic circuit proofs**: General constraints (Bulletproofs paper §5)
+- **Aggregation**: Multiple proofs share inner-product argument
+
+**Core structure**:
+```
+Proof = (A, S, T₁, T₂, τ, μ, t̂, L, R)
+Where:
+  A, S, T₁, T₂: Curve points (commitments)
+  τ, μ, t̂: Scalars (blinding, evaluation)
+  L, R: log₂(n) curve point pairs (inner-product argument)
+```
+
+**Size scaling**:
+- Single range proof: ~672 bytes (n=64 bits)
+- Aggregated m proofs: 672 + 64(m-1) bytes (sub-linear!)
+
+### Aggregation Opportunity
+
+The inner-product argument proves:
+```
+⟨a, b⟩ = c  where a, b are vectors
+```
+
+For range proofs:
+- a encodes the bit decomposition of value
+- b encodes powers of 2 and challenges
+- c is the claimed inner product
+
+For entropy constraints:
+- a could encode squared weights (w_i²)
+- b could encode normalization factors (1/total²)
+- c is the collision sum
+
+**Key insight**: Both use the same inner-product structure. They can share:
+- Generator points
+- Challenge derivation
+- Final inner-product argument
+
+### Aggregation Design
+
+**Option A: Sequential Aggregation**
+```
+proof = aggregate([range_proof, entropy_proof])
+```
+- Run range proof, then entropy proof, combine at inner-product stage
+- Savings: ~35-40% (shared generators, combined inner-product)
+
+**Option B: Interleaved Constraints**
+```
+extended_range_proof = range_proof.with_auxiliary(entropy_constraints)
+```
+- Add entropy constraints as auxiliary statements within range proof circuit
+- Savings: ~40-45% (fully integrated)
+
+**Option C: Batch Verification Only**
+```
+batch_verify([range_proof, entropy_proof])
+```
+- Separate proofs, but verify together efficiently
+- Savings: ~20-25% (only verification speedup, same proof size)
+
+**Recommendation**: Option B (interleaved constraints) for maximum size reduction.
+
+## Alternative Approaches Evaluation
+
+### Option 1: Bulletproofs with Auxiliary Constraints
+
+**Description**: Extend Bulletproof range proof to include entropy constraint as additional inner-product argument.
+
+**Implementation sketch**:
+```rust
+struct AugmentedRangeProof {
+    // Standard range proof components
+    range_A: CompressedRistretto,
+    range_S: CompressedRistretto,
+    // Entropy constraint components
+    entropy_commitment: CompressedRistretto,
+    // Shared inner-product argument
+    L: Vec<CompressedRistretto>,
+    R: Vec<CompressedRistretto>,
+    // Combined responses
+    a_range: Scalar,
+    b_range: Scalar,
+    a_entropy: Scalar,
+    b_entropy: Scalar,
+}
+```
+
+**Size estimate**: 850-950 bytes total
+
+**Pros**:
+- Single proof, well-understood security
+- Maximum size reduction
+- Single verification pass
+
+**Cons**:
+- Requires custom Bulletproof variant
+- More complex implementation
+- Needs careful security analysis
+
+**Security considerations**:
+- Soundness: Auxiliary constraints don't weaken range proof
+- Zero-knowledge: Entropy value remains hidden
+- Needs formal security proof or reduction
+
+### Option 2: Groth16 for Entropy Only
+
+**Description**: Use Bulletproofs for range (no trusted setup), Groth16 for entropy (small proof).
+
+**Implementation**:
+```rust
+struct HybridProof {
+    range_proof: Bulletproof,      // ~672 bytes
+    entropy_proof: Groth16Proof,   // ~192 bytes
+}
+```
+
+**Size estimate**: ~864 bytes total
+
+**Pros**:
+- Proven systems, minimal custom work
+- Very small entropy proof
+- Clear security properties
+
+**Cons**:
+- Two proof systems to maintain
+- Groth16 requires trusted setup (ceremony)
+- Trusted setup is per-circuit (changes if constraints change)
+
+**Trusted setup options**:
+1. **Powers of Tau**: Community ceremony (like Zcash)
+2. **Universal setup**: PLONK/Marlin style (one-time, any circuit)
+3. **MPC ceremony**: Distributed trust
+
+### Option 3: PLONK/Halo2 Unified Proof
+
+**Description**: Modern proof system with universal setup, express all constraints in single circuit.
+
+**Implementation**:
+```rust
+struct UnifiedCircuit {
+    // Range constraint: 0 ≤ v < 2^64
+    range_check: RangeGadget,
+    // Entropy constraint: Σ w_i² / total² ≤ threshold
+    entropy_check: EntropyGadget,
+    // Tag conservation (could also include)
+    conservation_check: ConservationGadget,
+}
+```
+
+**Size estimate**: 400-600 bytes (PLONK proofs are very compact)
+
+**Pros**:
+- Clean architecture, single circuit
+- Universal setup (one ceremony for all circuits)
+- Good tooling (halo2, arkworks)
+- Smallest proof size
+
+**Cons**:
+- Larger proving time than Bulletproofs
+- More complex implementation
+- May be overkill if only entropy needed
+- Requires migrating existing proofs
+
+**Consideration**: If planning extensive ZK work beyond entropy, PLONK may be worth the investment.
+
+### Option 4: Commit-and-Prove Separation
+
+**Description**: Commit to entropy at output creation, prove relationship only at spend time.
+
+**Flow**:
+```
+Output Creation:
+  - Compute entropy of output tags
+  - Create entropy_commitment = entropy * G + r * H
+  - Include in output (32 bytes)
+
+Spend Time:
+  - Prove entropy_delta = output_entropy - input_entropy
+  - Prove relationship to committed values
+```
+
+**Implementation**:
+```rust
+struct TaggedOutput {
+    // Existing
+    amount_commitment: CompressedRistretto,
+    tag_commitments: Vec<CommittedTagMass>,
+    // New
+    entropy_commitment: CompressedRistretto,
+}
+
+struct EntropyDeltaProof {
+    // Prove: committed_output_entropy - committed_input_entropy ≥ threshold
+    // Uses homomorphic property of Pedersen commitments
+    delta_commitment: CompressedRistretto,
+    schnorr_proof: SchnorrProof,
+}
+```
+
+**Size estimate**:
+- Output overhead: +32 bytes per output
+- Spend proof: ~128 bytes (Schnorr-style)
+- Total per-spend: ~128 bytes (but outputs are larger)
+
+**Pros**:
+- Amortizes computation over UTXO lifetime
+- Simple proofs at spend time
+- Homomorphic subtraction for delta
+
+**Cons**:
+- Larger outputs (+32 bytes each)
+- More complex state management
+- Entropy is fixed at creation (can't recompute)
+- Requires computing entropy during output creation
+
+## Size Comparison Summary
+
+| Approach | Range | Entropy | Total | Savings vs Separate |
+|----------|-------|---------|-------|---------------------|
+| Separate proofs | 672 | 672 | 1344 | 0% (baseline) |
+| **Option 1: Integrated Bulletproofs** | - | - | **~900** | **~33%** |
+| Option 2: Bulletproofs + Groth16 | 672 | 192 | 864 | ~36% |
+| Option 3: PLONK unified | - | - | ~500 | ~63% |
+| Option 4: Commit-and-prove | 672 | 128 | 800* | ~40% |
+
+*Option 4 adds 32 bytes to every output, which may offset savings for multi-output transactions.
+
+## Verification Cost Analysis
+
+| Approach | Verification Time | Batch Efficiency |
+|----------|-------------------|------------------|
+| Separate proofs | ~8ms × 2 = 16ms | Good (separate batching) |
+| Integrated Bulletproofs | ~10ms | Excellent (single verification) |
+| Bulletproofs + Groth16 | ~8ms + ~2ms = 10ms | Good (pairing batch) |
+| PLONK unified | ~5ms | Excellent |
+| Commit-and-prove | ~8ms + ~1ms = 9ms | Good |
+
+All approaches meet the 15ms verification target.
+
+## Recommendation
+
+**Primary recommendation**: **Option 1 (Integrated Bulletproofs with Auxiliary Constraints)**
+
+**Rationale**:
+1. **Best fit for existing infrastructure**: Already using Pedersen commitments and Schnorr-style proofs
+2. **No trusted setup**: Important for decentralization
+3. **Good size/complexity tradeoff**: ~33% savings without major architectural changes
+4. **Single proof system**: Simpler to audit and maintain
+
+**Implementation path**:
+1. Implement collision entropy computation in existing `TagVector`
+2. Design auxiliary constraint circuit for entropy threshold
+3. Extend Bulletproof generation to include auxiliary constraints
+4. Implement combined verification
+5. Benchmark and optimize
+
+**Fallback**: If Option 1 proves too complex, Option 4 (commit-and-prove) offers good savings with simpler proofs.
+
+## Next Steps (Phase B)
+
+1. **Prototype entropy circuit**:
+   - Implement collision sum computation
+   - Define constraint format for Bulletproofs
+
+2. **Benchmarking**:
+   - Measure actual proof sizes
+   - Profile proving time
+   - Profile verification time
+
+3. **Security analysis**:
+   - Formal reduction to Bulletproofs security
+   - Analyze any additional assumptions
+
+4. **Integration design**:
+   - Transaction format changes
+   - Backward compatibility
+   - Migration path from Phase 1
+
+## Appendix A: Collision Entropy Circuit
+
+**Constraint system for proving H₂ ≥ threshold**:
+
+```
+Public inputs:
+  - threshold_squared = 2^(-2×threshold)  // Pre-computed constant
+  - total_commitment: Commitment to Σ w_i
+
+Private inputs (witness):
+  - weights: [w_1, w_2, ..., w_n]
+  - blinding factors
+
+Constraints:
+  1. Σ w_i = total (sum constraint)
+  2. For each i: sq_i = w_i × w_i (squaring)
+  3. collision_sum = Σ sq_i
+  4. collision_sum × threshold_squared ≤ total² (threshold check)
+
+The final constraint uses the equivalence:
+  H₂ ≥ threshold
+  ⟺ -log₂(Σ p_i²) ≥ threshold
+  ⟺ Σ p_i² ≤ 2^(-threshold)
+  ⟺ Σ (w_i/total)² ≤ 2^(-threshold)
+  ⟺ Σ w_i² ≤ total² × 2^(-threshold)
+```
+
+**Constraint count**: O(n) where n = number of clusters (typically 1-5)
+
+## Appendix B: Alternative Entropy Measures
+
+### Quadratic Rényi Entropy (H₂)
+
+Used in this analysis. Equals Shannon entropy for uniform distributions.
+
+### Tsallis Entropy
+
+```
+S_q = (1 - Σ p_i^q) / (q - 1)
+```
+
+For q=2: S₂ = 1 - Σ p_i², directly related to collision probability.
+
+### Gini-Simpson Index
+
+```
+GS = 1 - Σ p_i²
+```
+
+The "collision probability complement" - also circuit-friendly.
+
+Any of these could substitute for Shannon entropy with similar properties for wash trading detection.
+
+## References
+
+- Bünz et al. (2018). "Bulletproofs: Short Proofs for Confidential Transactions and More." https://eprint.iacr.org/2017/1066
+- Bünz et al. (2020). "Bulletproofs+: Shorter Proofs for Privacy-Enhanced Distributed Ledger." https://eprint.iacr.org/2020/735
+- dalek-cryptography/bulletproofs: https://github.com/dalek-cryptography/bulletproofs
+- Gabizon et al. (2019). "PLONK: Permutations over Lagrange-bases for Oecumenical Noninteractive arguments of Knowledge." https://eprint.iacr.org/2019/953
+- Issue #232: Phase 2 committed tags epic
+- Issue #257: Entropy-weighted decay design
+- `cluster-tax/src/crypto/committed_tags.rs`: Current committed tag infrastructure

--- a/docs/design/entropy-proof-aggregation-research.md
+++ b/docs/design/entropy-proof-aggregation-research.md
@@ -13,7 +13,7 @@ This document presents findings from the Phase A feasibility study on aggregatin
 1. **Shannon entropy is circuit-hostile** - requires logarithms that don't map well to arithmetic circuits
 2. **Collision entropy (H₂) is a viable alternative** - computable as sum of squared probabilities, circuit-friendly
 3. **Aggregation is feasible** - entropy constraints can share inner-product structure with range proofs
-4. **Estimated savings: ~40-45%** - combined proof ~850-950 bytes vs ~1400-1500 bytes separate
+4. **Estimated savings: ~33%** - combined proof ~900 bytes vs ~1344 bytes separate (Option 1)
 5. **Recommended approach**: Bulletproofs with auxiliary inner-product constraints
 
 ## Background

--- a/docs/design/entropy-weighted-decay.md
+++ b/docs/design/entropy-weighted-decay.md
@@ -1,0 +1,462 @@
+# Entropy-Weighted Decay: Design Specification
+
+## Overview
+
+This document specifies **entropy-weighted decay** as Phase 2 of Botho's cluster tag decay mechanism. It addresses the patient wash trading vulnerability in age-based decay by tying decay credit to genuine economic activity as measured by cluster entropy changes.
+
+**Status**: Proposed (Phase 2)
+**Prerequisite**: Age-based decay (Phase 1) - see [cluster-tag-decay.md](cluster-tag-decay.md)
+
+## Problem Statement
+
+### The Patient Wash Trading Attack
+
+Age-based decay (Phase 1) blocks rapid wash trading by requiring UTXOs to be at least 720 blocks (~2 hours) old before decay applies. However, this only **slows** attacks:
+
+| Attack Strategy | Time Required | Decay Events | Tag Remaining |
+|-----------------|---------------|--------------|---------------|
+| 100 rapid self-transfers | Minutes | 0 (blocked) | 100% |
+| Patient attack (1 day) | 24 hours | Max 12 | 54% |
+| **Patient attack (1 week)** | **7 days** | **84** | **1.35%** |
+
+An attacker with patience can reduce their cluster factor from high (15% fees) to low (1% fees) in one week through automated self-transfers.
+
+### The Core Problem
+
+Current decay grants credit for **any** eligible spend:
+```
+decay_effect = 5% per eligible spend (age ≥ 720 blocks)
+```
+
+This doesn't distinguish between:
+- **Wash trading**: A→B→C→A (self-transfers that contribute nothing to economy)
+- **Real commerce**: A→B→C→D→... (genuine economic activity with diverse counterparties)
+
+## The Solution: Entropy-Weighted Decay
+
+### Key Insight
+
+**Cluster entropy is decay-invariant and commerce-sensitive.**
+
+The codebase already has `cluster_entropy()` in `tag.rs`:
+
+```rust
+pub fn cluster_entropy(&self) -> f64 {
+    // Excludes background (decay)
+    // Only counts cluster weights
+    // Increases through genuine mixing with diverse sources
+}
+```
+
+Properties that make it ideal for this use case:
+
+| Event | Shannon Entropy | Cluster Entropy |
+|-------|-----------------|-----------------|
+| Decay (aging) | Increases (background grows) | **Unchanged** |
+| Self-transfer | Unchanged | **Unchanged** |
+| Commerce (new source) | Increases | **Increases** |
+
+### Mathematical Model
+
+#### Entropy Delta Calculation
+
+When spending a UTXO to create outputs, we measure the entropy change:
+
+```
+entropy_before = cluster_entropy(input_tags)
+entropy_after = cluster_entropy(combined_output_tags)
+entropy_delta = max(0, entropy_after - entropy_before)
+```
+
+For transactions with multiple inputs:
+```
+entropy_before = weighted_average(cluster_entropy(input_i), value_i)
+```
+
+#### Entropy Delta Factor
+
+The entropy delta is converted to a multiplicative factor:
+
+```rust
+fn entropy_delta_factor(delta: f64, config: &EntropyDecayConfig) -> f64 {
+    if delta <= config.min_delta_threshold {
+        return config.min_factor; // Minimal decay credit for wash trades
+    }
+
+    // Linear interpolation between min and max
+    let normalized = (delta - config.min_delta_threshold)
+                   / (config.full_credit_delta - config.min_delta_threshold);
+    let clamped = normalized.clamp(0.0, 1.0);
+
+    config.min_factor + clamped * (1.0 - config.min_factor)
+}
+```
+
+#### Decay Application
+
+```rust
+fn apply_entropy_weighted_decay(
+    tags: &mut TagVector,
+    entropy_delta: f64,
+    config: &EntropyDecayConfig,
+) -> f64 {
+    let factor = entropy_delta_factor(entropy_delta, config);
+    let effective_decay = config.base_decay_rate * factor;
+
+    // Apply decay to all cluster tags
+    for (cluster_id, weight) in tags.iter_mut() {
+        let decay_amount = (*weight as f64 * effective_decay) as TagWeight;
+        *weight = weight.saturating_sub(decay_amount);
+    }
+
+    effective_decay
+}
+```
+
+### Configuration Parameters
+
+```rust
+pub struct EntropyDecayConfig {
+    /// Base decay rate per eligible transaction (from Phase 1)
+    pub base_decay_rate: f64,           // 0.05 (5%)
+
+    /// Minimum entropy delta to receive any decay credit
+    pub min_delta_threshold: f64,        // 0.1 bits
+
+    /// Entropy delta for full decay credit
+    pub full_credit_delta: f64,          // 0.5 bits
+
+    /// Minimum decay factor for zero-delta transactions
+    pub min_factor: f64,                 // 0.1 (10% of base)
+
+    /// Age requirement (preserved from Phase 1)
+    pub min_age_blocks: u64,             // 720 blocks
+}
+```
+
+### Parameter Rationale
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| `base_decay_rate` | 5% | Backward compatible with Phase 1 |
+| `min_delta_threshold` | 0.1 bits | Filter out noise from rounding |
+| `full_credit_delta` | 0.5 bits | Typical entropy increase from one new source |
+| `min_factor` | 0.1 | Allow minimal decay for pure consolidation |
+| `min_age_blocks` | 720 | Preserve rapid-attack protection |
+
+## Attack Analysis
+
+### Attack 1: Patient Wash Trading (Primary Target)
+
+**Strategy**: Automated self-transfers spaced by 720 blocks over one week.
+
+**Without entropy weighting (Phase 1)**:
+```
+84 decay events × 5% each = 97% decay
+Tag remaining: 1.35%
+Fees reduced: 15% → ~1%
+```
+
+**With entropy weighting (Phase 2)**:
+```
+Self-transfer: entropy_delta ≈ 0 → factor = 0.1
+84 decay events × (5% × 0.1) = 84 × 0.5% = 42% decay
+Tag remaining: 58%
+Fees reduced: 15% → ~9% (still paying significant fees)
+```
+
+**Improvement**: Attack effectiveness reduced from 97% to 42%.
+
+### Attack 2: Fake Commerce (Secondary Target)
+
+**Strategy**: Create multiple "merchant" wallets, send funds in a circuit.
+
+**Scenario**: A→B→C→D→A with 4 controlled wallets.
+
+**Analysis**:
+- First hop (A→B): entropy_delta = 0 (same source)
+- All hops: Tags identical, no new sources introduced
+- `cluster_entropy()` unchanged throughout circuit
+
+**Result**: Same as wash trading—minimal decay credit.
+
+### Attack 3: Entropy Purchasing
+
+**Strategy**: Buy small amounts from many real merchants to increase entropy.
+
+**Cost**: Each purchase requires:
+1. Finding willing counterparty
+2. Paying market rate + fees
+3. Waiting for age requirement
+
+**Analysis**:
+- Expensive (must actually purchase goods/services)
+- Creates genuine economic activity (not really an attack)
+- Legitimate use of the system
+
+**Verdict**: Not an attack—this IS the intended behavior.
+
+### Attack 4: Entropy Mining via Dust
+
+**Strategy**: Receive many tiny dust payments from diverse sources.
+
+**Defense**: Entropy is weighted by value, not count:
+```rust
+fn cluster_entropy_weighted(&self) -> f64 {
+    // Weight each source by its contribution
+    // Dust sources contribute minimally
+}
+```
+
+**Result**: Receiving 1000 dust payments provides less entropy than one meaningful transaction.
+
+### Attack Comparison Summary
+
+| Attack | Phase 1 (Age-Based) | Phase 2 (Entropy-Weighted) |
+|--------|---------------------|----------------------------|
+| Rapid wash (100 txs) | 0% decay | 0% decay |
+| Patient wash (1 week) | 97% decay | ~42% decay |
+| Fake commerce circuit | 97% decay | ~42% decay |
+| Entropy purchasing | 64% decay | 64% decay |
+| Dust mining | 97% decay | ~10% decay |
+| **Real commerce (20 hops)** | **64% decay** | **64% decay** |
+
+## Privacy Analysis
+
+### Information Leakage
+
+| Information | Phase 1 | Phase 2 | Additional Leakage |
+|-------------|---------|---------|-------------------|
+| UTXO creation block | Public | Public | None |
+| Transaction structure | Public | Public | None |
+| Input values | Public | Public | None |
+| Tag weights | Private | Private | None |
+| **Entropy delta** | N/A | **Computed** | **~0 bits** |
+
+**Key insight**: Entropy delta is computed from tag vectors, but the **result** (decay amount) is private—it modifies internal tag state that is not revealed on-chain.
+
+### Why Zero Privacy Cost?
+
+Unlike lottery selection (which reveals entropy-based preferences publicly), decay happens **internally**:
+
+1. Transaction is processed
+2. Entropy delta computed from private tag data
+3. Decay applied to private tag weights
+4. Only the transaction outputs are visible
+
+An observer sees the same transaction structure regardless of entropy delta.
+
+### Ring Signature Considerations
+
+For ring signatures, decay eligibility must be verifiable:
+
+```rust
+pub struct RingDecayProof {
+    /// Zero-knowledge proof that entropy delta meets threshold
+    pub entropy_threshold_proof: ZkProof,
+
+    /// Commitment to the actual entropy delta (for future auditing)
+    pub entropy_commitment: PedersenCommitment,
+}
+```
+
+**Challenge**: Proving entropy relationships without revealing tag vectors.
+
+**Approach**: Range proofs on entropy delta:
+- Prove `entropy_delta >= min_threshold` without revealing exact value
+- Verifier accepts proof → full decay credit
+- Verifier rejects → minimal decay credit
+
+See [Phase 2 Implementation](#phase-2-implementation) for ZK circuit details.
+
+## Implementation
+
+### State Requirements
+
+No additional state required beyond Phase 1:
+
+```rust
+struct TagDecayState {
+    tag_weights: HashMap<ClusterId, TagWeight>,
+    // entropy computed on-demand from tag_weights
+}
+```
+
+### Core Algorithm
+
+```rust
+impl TagVector {
+    pub fn apply_entropy_weighted_decay(
+        &mut self,
+        other_inputs: &[TagVector],
+        current_block: u64,
+        utxo_creation_block: u64,
+        config: &EntropyDecayConfig,
+    ) -> DecayResult {
+        // Phase 1 check: age requirement
+        if current_block.saturating_sub(utxo_creation_block) < config.min_age_blocks {
+            return DecayResult::NotEligible;
+        }
+
+        // Compute entropy before (this input + others)
+        let entropy_before = self.combined_entropy(other_inputs);
+
+        // Compute entropy after (post-decay state)
+        // Note: This is estimated from input mix, actual may vary
+        let entropy_after = self.estimate_output_entropy(other_inputs);
+
+        let entropy_delta = (entropy_after - entropy_before).max(0.0);
+        let factor = config.entropy_delta_factor(entropy_delta);
+
+        // Apply weighted decay
+        let effective_rate = config.base_decay_rate * factor;
+        self.apply_decay(effective_rate);
+
+        DecayResult::Applied {
+            entropy_delta,
+            factor,
+            effective_rate,
+        }
+    }
+}
+```
+
+### Entropy Calculation
+
+Using the existing `cluster_entropy()` which excludes background:
+
+```rust
+impl TagVector {
+    /// Cluster entropy - decay invariant, commerce sensitive
+    pub fn cluster_entropy(&self) -> f64 {
+        let total_cluster = self.total_attributed();
+        if total_cluster == 0 {
+            return 0.0;
+        }
+
+        let scale = total_cluster as f64;
+        let mut entropy = 0.0;
+
+        for (_, weight) in self.weights.iter() {
+            if *weight > 0 {
+                let p = *weight as f64 / scale;
+                entropy -= p * p.log2();
+            }
+        }
+
+        entropy
+    }
+
+    /// Combined entropy from multiple inputs
+    fn combined_entropy(&self, others: &[TagVector]) -> f64 {
+        if others.is_empty() {
+            return self.cluster_entropy();
+        }
+
+        // Weighted average by total attributed weight
+        let self_weight = self.total_attributed() as f64;
+        let other_weights: Vec<f64> = others.iter()
+            .map(|t| t.total_attributed() as f64)
+            .collect();
+
+        let total_weight = self_weight + other_weights.iter().sum::<f64>();
+        if total_weight == 0.0 {
+            return 0.0;
+        }
+
+        let weighted_sum = self.cluster_entropy() * self_weight
+            + others.iter().zip(other_weights.iter())
+                .map(|(t, w)| t.cluster_entropy() * w)
+                .sum::<f64>();
+
+        weighted_sum / total_weight
+    }
+}
+```
+
+## Migration Path
+
+### Phase 1 → Phase 2 Transition
+
+1. **Deploy Phase 2 code** with feature flag disabled
+2. **Soft fork activation** at predetermined block height
+3. **Gradual ramp-up** of `min_factor`:
+   - Week 1: min_factor = 0.8 (20% reduction for wash trades)
+   - Week 2: min_factor = 0.5 (50% reduction)
+   - Week 3: min_factor = 0.25 (75% reduction)
+   - Week 4+: min_factor = 0.1 (90% reduction, full effect)
+
+### Backward Compatibility
+
+- Transactions remain valid regardless of entropy delta
+- Only decay credit changes, not transaction validity
+- Nodes running old software see normal transactions
+
+## Verification
+
+### Simulation Commands
+
+```bash
+# Compare Phase 1 vs Phase 2 under patient wash attack
+./target/release/cluster-tax-sim entropy-decay-compare \
+  --wealth 100000000 \
+  --base-decay 5.0 \
+  --min-age-blocks 720 \
+  --wash-txs 1000 \
+  --blocks 60480 \
+  --min-factor 0.1
+
+# Test entropy purchasing scenario
+./target/release/cluster-tax-sim entropy-commerce \
+  --wealth 100000000 \
+  --commerce-hops 20 \
+  --sources-per-hop 1
+```
+
+### Expected Results
+
+| Scenario | Phase 1 Remaining | Phase 2 Remaining |
+|----------|-------------------|-------------------|
+| Patient wash (1 week) | 1.35% | 58% |
+| Real commerce (20 hops) | 36% | 36% |
+| Mixed (10 wash + 10 commerce) | 10% | 28% |
+
+## Open Questions
+
+### Q1: Should consolidation receive any decay credit?
+
+**Current design**: Yes, min_factor = 0.1 allows 10% decay credit.
+
+**Alternative**: min_factor = 0.0 for pure consolidation (no entropy increase).
+
+**Trade-off**: Stricter is more secure but may punish legitimate consolidation.
+
+### Q2: How to handle entropy from decoy selection in rings?
+
+**Challenge**: Ring members contribute to apparent entropy but may be decoys.
+
+**Approach**: Use only the real input's entropy (requires ZK proof).
+
+### Q3: Should entropy bonus stack with decay?
+
+**Context**: Lottery already uses entropy for selection weighting.
+
+**Decision**: Keep mechanisms independent—entropy affects both lottery AND decay, creating consistent incentive for genuine commerce.
+
+## Related Documents
+
+- [Cluster Tag Decay](cluster-tag-decay.md) - Phase 1 specification and vulnerability acknowledgment
+- [Provenance-Based Selection](provenance-based-selection.md) - Entropy-weighted lottery (parallel mechanism)
+- [Lottery Redistribution](lottery-redistribution.md) - Fee redistribution overview
+- [Progressive Fees](../concepts/progressive-fees.md) - Overall fee curve design
+
+## References
+
+- GitHub Issue #257 - Patient wash trading vulnerability analysis
+- GitHub Issue #258 - Related entropy analysis
+- GitHub Issue #259 - Implementation tracking (blocked by this spec)
+- GitHub Issue #232 - Phase 2 committed tags
+
+## Changelog
+
+- 2026-01-06: Initial specification (resolves #257)

--- a/docs/design/lottery-redistribution.md
+++ b/docs/design/lottery-redistribution.md
@@ -470,7 +470,8 @@ with legitimate participation rather than gaming.
 
 ## References
 
-- [Provenance-Based Selection](provenance-based-selection.md) - Novel entropy-weighted approach
+- [Provenance-Based Selection](provenance-based-selection.md) - Novel entropy-weighted approach for lottery
+- [Entropy-Weighted Decay](entropy-weighted-decay.md) - Entropy-weighted decay mechanism (parallel to lottery entropy weighting)
 - [Cluster Tag Decay](cluster-tag-decay.md) - How cluster factors decay through trade
 - [Progressive Fees](../concepts/progressive-fees.md) - Fee curve design
 - [Tokenomics](../concepts/tokenomics.md) - Overall economic model

--- a/docs/design/provenance-based-selection.md
+++ b/docs/design/provenance-based-selection.md
@@ -435,6 +435,12 @@ meaningful Sybil resistance reduction without requiring identity.
 - ~~No gaming is possible~~ Gaming is expensive but possible
 - ~~This is a breakthrough~~ It's an incremental improvement
 
+## Related Documents
+
+- [Entropy-Weighted Decay](entropy-weighted-decay.md) - Uses same entropy primitive for decay mechanism
+- [Cluster Tag Decay](cluster-tag-decay.md) - Age-based decay (Phase 1) and entropy-weighted decay (Phase 2)
+- [Lottery Redistribution](lottery-redistribution.md) - Fee redistribution overview
+
 ## References
 
 - Kwon et al. (2019). "Impossibility of Full Decentralization in Permissionless


### PR DESCRIPTION
## Summary

Phase A feasibility study for aggregating entropy proofs with Bulletproof range proofs. This addresses issue #260's research questions about minimizing transaction size overhead for Phase 2 committed tags.

## Key Findings

1. **Shannon entropy is circuit-hostile** - requires logarithms that don't map well to arithmetic circuits
2. **Collision entropy (H₂) is a viable alternative** - computable as sum of squared probabilities, fully circuit-friendly
3. **Aggregation is feasible** - entropy constraints can share inner-product structure with range proofs
4. **Estimated savings: ~33-40%** - combined proof ~900 bytes vs ~1344 bytes separate
5. **Recommended approach**: Bulletproofs with auxiliary inner-product constraints (Option 1)

## Document Contents

- Entropy reformulation analysis (Shannon vs Collision vs Min-entropy)
- Bulletproof aggregation mechanics
- Evaluation of 4 implementation approaches with size/complexity tradeoffs
- Circuit design sketch for collision entropy threshold proofs
- Recommendations for Phase B implementation

## Alternative Approaches Evaluated

| Approach | Size | Pros | Cons |
|----------|------|------|------|
| **Option 1: Integrated Bulletproofs** | ~900 bytes | No trusted setup, single proof | Custom variant needed |
| Option 2: Bulletproofs + Groth16 | ~864 bytes | Proven systems | Trusted setup for Groth16 |
| Option 3: PLONK unified | ~500 bytes | Smallest size | Major architecture change |
| Option 4: Commit-and-prove | ~800 bytes | Simple proofs | Larger outputs |

## Next Steps

This completes Phase A (Feasibility Study). Phase B would involve:
1. Prototype collision entropy circuit
2. Benchmark actual proof sizes and verification times
3. Security analysis with formal reduction

Closes #260