### PR TITLE
feat(wallet): Add dynamic network fee rate fetching

### DIFF
--- a/botho-wallet/src/lib.rs
+++ b/botho-wallet/src/lib.rs
@@ -26,7 +26,7 @@ pub use decoy_selection::{
     DecoySelectionError, DecoySelectionResult, UtxoCandidate,
 };
 pub use discovery::NodeDiscovery;
-pub use fee_estimation::{FeeEstimator, StoredTags};
+pub use fee_estimation::{CachedFeeRate, FeeEstimator, StoredTags};
 pub use keys::WalletKeys;
-pub use rpc_pool::RpcPool;
+pub use rpc_pool::{NetworkFeeRate, RpcPool};
 pub use storage::EncryptedWallet;


### PR DESCRIPTION
## Summary

- Add `fee_getRate` RPC method on node to expose dynamic fee state
- Add `get_fee_rate()` method to RpcPool for wallet clients  
- Add `NetworkFeeRate` response type with congestion information
- Add `CachedFeeRate` struct with TTL-based caching (60s default)
- Add graceful fallback to minimum rate when network unavailable

This enables wallets to use accurate fee estimates based on real-time network congestion instead of relying on the hardcoded minimum base rate.

## Test plan

- [x] New unit tests for `CachedFeeRate` (expiry, update, fallback)
- [x] Integration test for `FeeEstimator` with dynamic rates
- [x] All existing fee estimation tests pass
- [x] Manual verification that RPC endpoint returns expected fields

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)