### PR TITLE
feat(wallet): Propagate cluster tags to change outputs

### DIFF
--- a/botho-wallet/tests/integration_tests.rs
+++ b/botho-wallet/tests/integration_tests.rs
@@ -1129,11 +1129,13 @@ mod cluster_tags {
 // ============================================================================
 
 mod decoy_selection {
-    use botho_wallet::decoy_selection::{
-        select_decoys, select_decoys_with_fallback, validate_decoys, DecoySelectionConfig,
-        DecoySelectionError, UtxoCandidate,
+    use botho_wallet::{
+        decoy_selection::{
+            select_decoys, select_decoys_with_fallback, validate_decoys, DecoySelectionConfig,
+            DecoySelectionError, UtxoCandidate,
+        },
+        fee_estimation::StoredTags,
     };
-    use botho_wallet::fee_estimation::StoredTags;
     use bth_cluster_tax::{ClusterId, TAG_WEIGHT_SCALE};
     use std::collections::HashMap;
 
@@ -1341,7 +1343,10 @@ mod decoy_selection {
             &config,
         );
         assert!(
-            matches!(strict_result, Err(DecoySelectionError::InsufficientDecoys { .. })),
+            matches!(
+                strict_result,
+                Err(DecoySelectionError::InsufficientDecoys { .. })
+            ),
             "Strict selection should fail"
         );
 
@@ -1394,19 +1399,30 @@ mod decoy_selection {
         );
 
         // Should detect 3 violations (too young, too old, high factor)
-        assert_eq!(violations.len(), 3, "Should detect 3 violations: {:?}", violations);
+        assert_eq!(
+            violations.len(),
+            3,
+            "Should detect 3 violations: {:?}",
+            violations
+        );
 
         // Verify specific violations
         assert!(
-            violations.iter().any(|(idx, msg)| *idx == 0 && msg.contains("young")),
+            violations
+                .iter()
+                .any(|(idx, msg)| *idx == 0 && msg.contains("young")),
             "Should detect 'too young' violation"
         );
         assert!(
-            violations.iter().any(|(idx, msg)| *idx == 2 && msg.contains("old")),
+            violations
+                .iter()
+                .any(|(idx, msg)| *idx == 2 && msg.contains("old")),
             "Should detect 'too old' violation"
         );
         assert!(
-            violations.iter().any(|(idx, msg)| *idx == 3 && msg.contains("factor")),
+            violations
+                .iter()
+                .any(|(idx, msg)| *idx == 3 && msg.contains("factor")),
             "Should detect factor violation"
         );
     }


### PR DESCRIPTION
## Summary

- Implement cluster tag propagation to ensure change outputs maintain accurate attribution
- Add value-weighted tag blending from input UTXOs (`calculate_blended_tags`)
- Store pending tags when transactions are built, apply during sync
- Add encrypted storage for pending change tags in wallet file

## Changes

### New Structures
- `PendingChangeTags`: Tracks pending cluster tags for change outputs by output public key
- `TransferResult`: Extended transaction build result with change output metadata

### Modified Files
- `fee_estimation.rs`: Add `calculate_blended_tags()` and `PendingChangeTags` struct
- `storage.rs`: Add encrypted pending change tags storage to EncryptedWallet
- `transaction.rs`: Add `TransferResult` struct and `build_transfer_with_metadata()` method
- `commands/send.rs`: Store pending change tags after transaction creation
- `commands/sync.rs`: Apply pending tags to discovered change UTXOs

## Test plan

- [x] Added unit tests for `calculate_blended_tags()` with various input scenarios
- [x] Added unit tests for `PendingChangeTags` roundtrip and cleanup
- [x] All existing wallet tests pass (57 tests)
- [ ] Manual testing with wallet send/sync flow

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)