### PR TITLE
feat(cluster-tax): Add ring signature support for entropy-weighted decay

### DIFF
--- a/cluster-tax/src/lib.rs
+++ b/cluster-tax/src/lib.rs
@@ -69,9 +69,10 @@ pub use monetary::{DifficultyController, MonetaryPolicy, MonetaryState, Monetary
 
 pub use age_decay::{apply_age_decay, ring_cluster_factor, AgeDecayConfig, RingDecayInfo};
 pub use entropy_decay::{
-    apply_entropy_decay, calculate_entropy_decay, compare_decay_modes, AttackResult,
-    AttackStrategy, DecayBlockReason, DecayMode, EntropyDecayConfig, EntropyDecayResult,
-    EntropyScaling, SimUtxo,
+    apply_entropy_decay, calculate_entropy_decay, compare_decay_modes,
+    conservative_entropy_delta, ring_entropy_decay, AttackResult, AttackStrategy, DecayBlockReason,
+    DecayMode, EntropyDecayConfig, EntropyDecayResult, EntropyScaling, RingDecayBlockReason,
+    RingEntropyDecayInfo, SimUtxo,
 };
 pub use block_decay::{
     AndDecayConfig, AndTagVector, BlockAwareTagVector, BlockDecayConfig, RateLimitedDecayConfig,


### PR DESCRIPTION
## Summary

Add ring signature support to the entropy-weighted decay system. This enables proper decay handling for ring signature transactions where the real input is unknown among decoys.

### Key Changes

- **`conservative_entropy_delta()`**: Calculates entropy delta using MAX input entropy among all ring members, defending against high-entropy decoy attacks
- **`ring_entropy_decay()`**: Ring-aware decay function that requires ALL ring members to be age-eligible for decay to apply
- **`RingEntropyDecayInfo`**: Comprehensive analysis struct for debugging and auditing ring signature decay decisions

### Security Properties

- **High-entropy decoy attack**: Blocked - attacker can't pick high-entropy decoys to inflate their delta
- **Young decoy attack**: Blocked - all ring members must be age-eligible, so attacker can't pick old decoys to force decay on young coins  
- **Self-transfer with decoys**: Blocked - even with decoys, self-transfers don't increase entropy

## Changes

- `cluster-tax/src/entropy_decay.rs`: Added ring signature support functions and comprehensive tests (+849 lines)
- `cluster-tax/src/lib.rs`: Exported new types (+4 lines)

## Test Plan

- [x] All existing entropy decay tests pass
- [x] 17 new ring signature tests covering:
  - Conservative entropy delta calculation
  - Ring decay with all-eligible members
  - Ring decay blocked by young members
  - Self-transfer detection
  - High-entropy decoy attack prevention
  - RingEntropyDecayInfo analysis edge cases
  - Typical ring sizes (11 members like Monero)
- [x] Doc test for usage example passes
- [x] No new clippy warnings introduced

Closes #275