### PR TITLE
feat(cluster-tax): Add entropy proof structures for Phase 2B decay

### DIFF
--- a/cluster-tax/src/crypto/serialization.rs
+++ b/cluster-tax/src/crypto/serialization.rs
@@ -383,6 +383,7 @@ impl ExtendedTxSignature {
         Ok(Self {
             pseudo_tag_outputs,
             conservation_proof,
+            entropy_proof: None,
         })
     }
 }

--- a/cluster-tax/src/lib.rs
+++ b/cluster-tax/src/lib.rs
@@ -90,6 +90,15 @@ pub use crypto::{
     ExtendedTxSignature,
     RingTagData,
     SegmentOrProof,
+    // Phase 2B: Entropy proofs
+    EntropyLinkageProof,
+    EntropyProof,
+    EntropyProofBuilder,
+    EntropyProofVerifier,
+    EntropyRangeProof,
+    TransactionVersion,
+    ENTROPY_SCALE,
+    MIN_ENTROPY_THRESHOLD_SCALED,
 };
 pub use dynamic_fee::{DynamicFeeBase, DynamicFeeState, FeeSuggestion};
 pub use fee_curve::{


### PR DESCRIPTION
## Summary

- Add `EntropyProof` struct to `cluster-tax/src/crypto/` with entropy commitments and Bulletproof range proofs
- Add `entropy_proof: Option<EntropyProof>` to `ExtendedTxSignature`
- Add `TransactionVersion` enum (V1, V2, V3) for versioned transaction formats
- Update serialization/deserialization with versioned format and backward compatibility
- Add `ExtendedTxSignature::detected_version()` method for version detection

## Test plan

- [x] All 35 crypto module tests pass
- [x] Entropy proof creation and verification tests
- [x] Bulletproof placeholder verification tests
- [x] Linkage proof verification tests
- [x] Serialization roundtrip tests for new structures
- [x] `cargo check --all` passes

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)