### PR TITLE
fix(config): Add FaucetConfig and update testnet bootstrap peers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,12 +2,30 @@
 # Copy this file to .env and fill in your values
 # NEVER commit .env to version control
 
-# AWS Credentials (for seed node deployment)
+# =============================================================================
+# AWS Configuration
+# =============================================================================
 AWS_ACCESS_KEY_ID=your-access-key-id
 AWS_SECRET_ACCESS_KEY=your-secret-access-key
 AWS_REGION=us-east-1
 
-# EC2 Seed Node Configuration
-EC2_INSTANCE_ID=i-xxxxxxxxxxxx
-EC2_ELASTIC_IP=x.x.x.x
-EC2_KEY_PATH=~/.ssh/your-key.pem
+# =============================================================================
+# seed.botho.io - Primary relay/discovery node
+# =============================================================================
+SEED_EC2_INSTANCE_ID=i-xxxxxxxxxxxx
+SEED_ELASTIC_IP=x.x.x.x
+SEED_SSH_KEY_PATH=~/.ssh/your-key.pem
+SEED_SSH_USER=ubuntu
+
+# Quick SSH: ssh -i $SEED_SSH_KEY_PATH $SEED_SSH_USER@$SEED_ELASTIC_IP
+# Config location on server: /etc/botho/config.toml
+# Service: sudo systemctl {start|stop|restart|status} botho
+# Logs: journalctl -u botho -f
+
+# =============================================================================
+# faucet.botho.io - Testnet faucet node (future)
+# =============================================================================
+# FAUCET_EC2_INSTANCE_ID=i-xxxxxxxxxxxx
+# FAUCET_ELASTIC_IP=x.x.x.x
+# FAUCET_SSH_KEY_PATH=~/.ssh/your-key.pem
+# FAUCET_SSH_USER=ubuntu

--- a/botho/src/network/dns_seeds.rs
+++ b/botho/src/network/dns_seeds.rs
@@ -242,7 +242,7 @@ impl DnsSeedDiscovery {
                 "/dns4/seed.botho.io/tcp/7100/p2p/12D3KooWBrjTYjNrEwi9MM3AKFenmymyWVXtXbQiSx7eDnDwv9qQ".to_string(),
             ],
             Network::Testnet => vec![
-                "/dns4/testnet.botho.io/tcp/17100/p2p/12D3KooWBrjTYjNrEwi9MM3AKFenmymyWVXtXbQiSx7eDnDwv9qQ".to_string(),
+                "/dns4/seed.botho.io/tcp/17100".to_string(),
             ],
         }
     }
@@ -371,8 +371,8 @@ mod tests {
         let seeds = discovery.hardcoded_seeds();
 
         assert!(!seeds.is_empty());
-        assert!(seeds[0].contains("testnet.botho.io"));
-        assert!(seeds[0].contains("/tcp/17100/"));
+        assert!(seeds[0].contains("seed.botho.io"));
+        assert!(seeds[0].contains("/tcp/17100"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `FaucetConfig` struct with rate limiting fields for testnet faucet functionality
- Add `faucet` field to `Config` struct (defaults to disabled)
- Fix `Config::new` and `Config::new_relay` constructors to include the faucet field
- Update hardcoded testnet bootstrap peer from `testnet.botho.io` to `seed.botho.io`

## Background
The seed.botho.io and faucet.botho.io infrastructure has been set up:
- **seed.botho.io** (35.163.89.16): Relay node with faucet disabled
- **faucet.botho.io** (44.236.60.66): Minting node with faucet enabled

The `testnet.botho.io` domain no longer exists, so bootstrap peers needed to be updated to use `seed.botho.io`.

## Test plan
- [x] `cargo check -p botho` passes
- [x] Both testnet nodes are running and syncing blocks
- [x] Nodes connect using the updated bootstrap peer addresses

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)