### PR TITLE
feat(infra): Add faucet.botho.io deployment infrastructure

### DIFF
--- a/infra/faucet/README.md
+++ b/infra/faucet/README.md
@@ -1,0 +1,369 @@
+# Botho Faucet Node Deployment
+
+Deploy and operate the testnet faucet node at `faucet.botho.io`.
+
+## Architecture
+
+```
+┌─────────────────────────────────┐      ┌─────────────────────────────────┐
+│        seed.botho.io            │      │       faucet.botho.io           │
+│         (existing)              │◄────►│          (new)                  │
+├─────────────────────────────────┤      ├─────────────────────────────────┤
+│  • Bootstrap/discovery          │      │  • Minting enabled              │
+│  • Relay blocks & txns          │      │  • Faucet endpoint enabled      │
+│  • No wallet (relay-only)       │      │  • Wallet accumulates BTH       │
+│  • Minting: OFF                 │      │  • Connects to seed as peer     │
+│  • Faucet: OFF                  │      │                                 │
+└─────────────────────────────────┘      └─────────────────────────────────┘
+```
+
+## Prerequisites
+
+### EC2 Instance Requirements
+
+| Component | Specification |
+|-----------|--------------|
+| Instance Type | `t3.medium` (2 vCPU, 4GB RAM) |
+| Storage | 50GB gp3 SSD |
+| OS | Ubuntu 22.04 LTS |
+| Region | us-east-1 (or existing region) |
+
+### Security Group Configuration
+
+| Port | Protocol | Source | Purpose |
+|------|----------|--------|---------|
+| 22 | TCP | Admin IPs | SSH access |
+| 17100 | TCP | 0.0.0.0/0 | P2P gossip |
+| 17101 | TCP | 0.0.0.0/0 | RPC + Faucet |
+| 19090 | TCP | Admin IPs | Prometheus metrics |
+
+### DNS Configuration
+
+Add an A record pointing `faucet.botho.io` to the EC2 Elastic IP.
+
+## Quick Start
+
+### Option 1: Automated Deployment
+
+```bash
+# SSH into the EC2 instance
+ssh -i your-key.pem ubuntu@<ec2-ip>
+
+# Clone the repository
+git clone https://github.com/botho-project/botho.git
+cd botho/infra/faucet
+
+# Run the deployment script
+sudo ./deploy-faucet.sh
+```
+
+### Option 2: Manual Deployment
+
+See [Manual Deployment Steps](#manual-deployment-steps) below.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `deploy-faucet.sh` | Automated deployment script |
+| `botho-faucet.service` | systemd service file |
+| `faucet-config.toml.template` | Configuration template |
+
+## Configuration
+
+The faucet node uses the following configuration:
+
+```toml
+network_type = "testnet"
+
+[wallet]
+mnemonic = "... 24 words ..."  # Generated on init
+
+[network]
+gossip_port = 17100
+rpc_port = 17101
+metrics_port = 19090
+cors_origins = ["*"]
+bootstrap_peers = ["/dns4/seed.botho.io/tcp/17100"]
+max_connections_per_ip = 50
+
+[network.dns_seeds]
+enabled = false
+
+[network.quorum]
+mode = "recommended"
+min_peers = 1
+
+[minting]
+enabled = true
+threads = 2
+
+[faucet]
+enabled = true
+amount = 10_000_000_000_000        # 10 BTH per request
+per_ip_hourly_limit = 5
+per_address_daily_limit = 3
+daily_limit = 10_000_000_000_000_000  # 10,000 BTH/day
+cooldown_secs = 60
+```
+
+### Rate Limiting
+
+The faucet includes built-in rate limiting to prevent abuse:
+
+- **Per IP**: 5 requests per hour
+- **Per Address**: 3 requests per 24 hours
+- **Cooldown**: 60 seconds minimum between requests from same IP
+- **Daily Total**: 10,000 BTH maximum per day
+
+## Manual Deployment Steps
+
+### 1. Launch EC2 Instance
+
+1. Launch a `t3.medium` instance with Ubuntu 22.04 LTS
+2. Attach a 50GB gp3 SSD
+3. Allocate and associate an Elastic IP
+4. Configure the security group with the ports listed above
+
+### 2. Install Dependencies
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential curl git pkg-config libssl-dev
+
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source ~/.cargo/env
+```
+
+### 3. Build Botho
+
+```bash
+git clone https://github.com/botho-project/botho.git
+cd botho
+cargo build --release --bin botho
+sudo cp target/release/botho /usr/local/bin/
+```
+
+### 4. Create Service User
+
+```bash
+sudo useradd -r -m -s /bin/bash botho
+sudo mkdir -p /home/botho/.botho/testnet
+sudo chown -R botho:botho /home/botho/.botho
+sudo chmod 700 /home/botho/.botho
+```
+
+### 5. Initialize Wallet
+
+```bash
+sudo -u botho /usr/local/bin/botho --testnet init
+```
+
+**Important**: Back up the generated mnemonic from `/home/botho/.botho/testnet/config.toml`!
+
+### 6. Configure Faucet
+
+Edit `/home/botho/.botho/testnet/config.toml` to add:
+
+```toml
+[faucet]
+enabled = true
+amount = 10_000_000_000_000
+per_ip_hourly_limit = 5
+per_address_daily_limit = 3
+daily_limit = 10_000_000_000_000_000
+cooldown_secs = 60
+```
+
+And update the `[minting]` section:
+
+```toml
+[minting]
+enabled = true
+threads = 2
+```
+
+Set secure permissions:
+
+```bash
+sudo chmod 600 /home/botho/.botho/testnet/config.toml
+```
+
+### 7. Install systemd Service
+
+```bash
+sudo cp botho-faucet.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable botho-faucet
+sudo systemctl start botho-faucet
+```
+
+### 8. Configure DNS
+
+Add an A record for `faucet.botho.io` pointing to the Elastic IP.
+
+### 9. Verify Deployment
+
+```bash
+# Check service status
+sudo systemctl status botho-faucet
+
+# Check logs
+sudo journalctl -u botho-faucet -f
+
+# Test RPC endpoint
+curl -X POST http://localhost:17101/ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"node_getStatus","params":{},"id":1}'
+
+# Test faucet endpoint
+curl -X POST http://localhost:17101/ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"faucet_request","params":{"address":"YOUR_TESTNET_ADDRESS"},"id":1}'
+```
+
+## Operations
+
+### View Logs
+
+```bash
+sudo journalctl -u botho-faucet -f
+```
+
+### Restart Service
+
+```bash
+sudo systemctl restart botho-faucet
+```
+
+### Check Node Status
+
+```bash
+curl -s -X POST http://localhost:17101/ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"node_getStatus","params":{},"id":1}' | jq
+```
+
+### Check Faucet Balance
+
+```bash
+curl -s -X POST http://localhost:17101/ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"wallet_getBalance","params":{},"id":1}' | jq
+```
+
+## Monitoring
+
+### Set Up CloudWatch Monitoring
+
+```bash
+cd ../monitoring
+sudo ./setup-monitoring.sh
+```
+
+### Key Metrics to Monitor
+
+- **Chain height**: Should increase over time
+- **Peer count**: Should be >= 1 (connected to seed)
+- **Minting status**: Should be active
+- **Faucet balance**: Monitor for depletion
+
+### Health Check Script
+
+```bash
+#!/bin/bash
+RESPONSE=$(curl -s -X POST http://localhost:17101/ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"node_getStatus","params":{},"id":1}')
+
+if echo "$RESPONSE" | jq -e '.result.chainHeight' > /dev/null 2>&1; then
+    HEIGHT=$(echo "$RESPONSE" | jq '.result.chainHeight')
+    PEERS=$(echo "$RESPONSE" | jq '.result.peerCount')
+    MINTING=$(echo "$RESPONSE" | jq '.result.mintingActive')
+    echo "OK - Height: $HEIGHT, Peers: $PEERS, Minting: $MINTING"
+    exit 0
+else
+    echo "CRITICAL - Node not responding"
+    exit 2
+fi
+```
+
+## Security Considerations
+
+1. **Mnemonic Protection**: The config file contains the wallet mnemonic. Keep it secure:
+   - File permissions: `chmod 600 config.toml`
+   - Back up securely (encrypted, offline)
+   - Never commit to version control
+
+2. **SSH Access**: Restrict SSH to known admin IPs only
+
+3. **Metrics Port**: Keep port 19090 internal-only (not publicly exposed)
+
+4. **Rate Limiting**: The built-in rate limiting prevents abuse, but monitor for patterns
+
+5. **Future Enhancement**: Consider adding nginx reverse proxy with TLS
+
+## Troubleshooting
+
+### Node Won't Start
+
+```bash
+# Check logs for errors
+sudo journalctl -u botho-faucet -n 100
+
+# Check config syntax
+cat /home/botho/.botho/testnet/config.toml
+
+# Check port availability
+sudo lsof -i :17100
+sudo lsof -i :17101
+```
+
+### No Peers Connected
+
+```bash
+# Check network connectivity to seed
+nc -zv seed.botho.io 17100
+
+# Check firewall
+sudo ufw status
+```
+
+### Faucet Not Working
+
+```bash
+# Check if faucet is enabled in config
+grep -A5 '\[faucet\]' /home/botho/.botho/testnet/config.toml
+
+# Check wallet balance
+curl -s -X POST http://localhost:17101/ \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"wallet_getBalance","params":{},"id":1}' | jq
+```
+
+### High Resource Usage
+
+```bash
+# Check memory
+ps aux | grep botho
+
+# Check disk usage
+df -h /home/botho/.botho
+
+# Limit minting threads if needed (edit config.toml)
+# [minting]
+# threads = 1
+```
+
+## Acceptance Criteria Checklist
+
+- [ ] EC2 instance running Ubuntu 22.04
+- [ ] Botho node running with minting enabled
+- [ ] Faucet endpoint responding at `http://faucet.botho.io:17101`
+- [ ] Node connected to seed.botho.io as peer
+- [ ] Blocks being minted (check block height increasing)
+- [ ] Faucet dispenses testnet BTH correctly
+- [ ] Systemd service configured for auto-restart
+- [ ] Metrics available on port 19090 (internal only)
+- [ ] DNS resolves faucet.botho.io correctly

--- a/infra/faucet/botho-faucet.service
+++ b/infra/faucet/botho-faucet.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=Botho Testnet Faucet Node
+Documentation=https://github.com/botho-project/botho
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=botho
+Group=botho
+WorkingDirectory=/home/botho
+
+# Run with minting enabled for testnet faucet
+ExecStart=/usr/local/bin/botho --testnet run --mint
+Restart=always
+RestartSec=10
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/home/botho/.botho
+
+# Resource limits
+LimitNOFILE=65535
+MemoryMax=4G
+
+# Environment
+Environment=RUST_LOG=info
+Environment=RUST_BACKTRACE=1
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=botho-faucet
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/faucet/deploy-faucet.sh
+++ b/infra/faucet/deploy-faucet.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+#
+# Deploy Botho Faucet Node
+#
+# This script sets up a Botho faucet node on an Ubuntu 22.04 EC2 instance.
+# It installs dependencies, builds the Botho binary, configures the node,
+# and sets up systemd for auto-restart.
+#
+# Prerequisites:
+#   - Ubuntu 22.04 LTS
+#   - Run as root or with sudo
+#   - Internet access for package installation
+#   - SSH access configured
+#
+# Usage:
+#   sudo ./deploy-faucet.sh [--build-from-source|--use-binary PATH]
+#
+# Options:
+#   --build-from-source   Clone and build Botho from GitHub (default)
+#   --use-binary PATH     Use a pre-built binary from the specified path
+#
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_step() { echo -e "${BLUE}[STEP]${NC} $1"; }
+
+# Configuration
+BOTHO_USER="botho"
+BOTHO_HOME="/home/$BOTHO_USER"
+BOTHO_DATA="$BOTHO_HOME/.botho/testnet"
+BOTHO_CONFIG="$BOTHO_DATA/config.toml"
+BOTHO_BIN="/usr/local/bin/botho"
+SERVICE_FILE="/etc/systemd/system/botho-faucet.service"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_FROM_SOURCE=true
+BINARY_PATH=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --build-from-source)
+            BUILD_FROM_SOURCE=true
+            shift
+            ;;
+        --use-binary)
+            BUILD_FROM_SOURCE=false
+            BINARY_PATH="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--build-from-source|--use-binary PATH]"
+            echo ""
+            echo "Options:"
+            echo "  --build-from-source   Clone and build Botho from GitHub (default)"
+            echo "  --use-binary PATH     Use a pre-built binary from the specified path"
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Check if running as root
+if [[ $EUID -ne 0 ]]; then
+    log_error "This script must be run as root (use sudo)"
+    exit 1
+fi
+
+log_info "Starting Botho Faucet Node deployment..."
+
+# Step 1: Update system and install dependencies
+log_step "Installing system dependencies..."
+apt-get update
+apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    pkg-config \
+    libssl-dev \
+    jq
+
+# Step 2: Install Rust if building from source
+if $BUILD_FROM_SOURCE; then
+    log_step "Installing Rust toolchain..."
+    if ! command -v rustc &> /dev/null; then
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        source "$HOME/.cargo/env"
+    else
+        log_info "Rust already installed: $(rustc --version)"
+    fi
+fi
+
+# Step 3: Create botho user
+log_step "Creating botho user..."
+if ! id "$BOTHO_USER" &>/dev/null; then
+    useradd -r -m -s /bin/bash "$BOTHO_USER"
+    log_info "Created user: $BOTHO_USER"
+else
+    log_info "User $BOTHO_USER already exists"
+fi
+
+# Step 4: Build or copy Botho binary
+if $BUILD_FROM_SOURCE; then
+    log_step "Building Botho from source..."
+    cd /tmp
+    if [[ -d "botho" ]]; then
+        rm -rf botho
+    fi
+    git clone https://github.com/botho-project/botho.git
+    cd botho
+    source "$HOME/.cargo/env"
+    cargo build --release --bin botho
+    cp target/release/botho "$BOTHO_BIN"
+    cd /
+    rm -rf /tmp/botho
+else
+    log_step "Installing pre-built binary..."
+    if [[ ! -f "$BINARY_PATH" ]]; then
+        log_error "Binary not found: $BINARY_PATH"
+        exit 1
+    fi
+    cp "$BINARY_PATH" "$BOTHO_BIN"
+fi
+
+chmod 755 "$BOTHO_BIN"
+log_info "Installed Botho binary: $BOTHO_BIN"
+
+# Step 5: Create data directories
+log_step "Creating data directories..."
+mkdir -p "$BOTHO_DATA"
+chown -R "$BOTHO_USER:$BOTHO_USER" "$BOTHO_HOME/.botho"
+chmod 700 "$BOTHO_HOME/.botho"
+
+# Step 6: Generate wallet mnemonic if not exists
+if [[ ! -f "$BOTHO_CONFIG" ]]; then
+    log_step "Initializing wallet (generating mnemonic)..."
+    sudo -u "$BOTHO_USER" "$BOTHO_BIN" --testnet init
+    log_info "Wallet initialized"
+
+    # Backup the mnemonic (IMPORTANT: secure this!)
+    log_warn "IMPORTANT: Back up the mnemonic from $BOTHO_CONFIG"
+    log_warn "Store it securely - it controls the faucet wallet!"
+else
+    log_info "Config already exists, skipping wallet initialization"
+fi
+
+# Step 7: Configure faucet settings
+log_step "Configuring faucet node..."
+
+# Read existing config and update faucet settings
+if [[ -f "$BOTHO_CONFIG" ]]; then
+    # Create a temporary config with faucet enabled
+    # We preserve the existing mnemonic and add faucet config
+
+    # Check if faucet section exists
+    if ! grep -q '\[faucet\]' "$BOTHO_CONFIG"; then
+        cat >> "$BOTHO_CONFIG" << 'EOF'
+
+[faucet]
+enabled = true
+amount = 10_000_000_000_000
+per_ip_hourly_limit = 5
+per_address_daily_limit = 3
+daily_limit = 10_000_000_000_000_000
+cooldown_secs = 60
+EOF
+        log_info "Added faucet configuration"
+    else
+        log_info "Faucet configuration already present"
+    fi
+
+    # Check if minting section has enabled = true
+    if grep -q 'enabled = false' "$BOTHO_CONFIG" | head -1; then
+        sed -i 's/enabled = false/enabled = true/' "$BOTHO_CONFIG"
+        log_info "Enabled minting"
+    fi
+
+    # Update CORS to allow all origins for testnet
+    if grep -q 'cors_origins' "$BOTHO_CONFIG"; then
+        log_info "CORS already configured"
+    else
+        # Add CORS config in network section
+        sed -i '/\[network\]/a cors_origins = ["*"]' "$BOTHO_CONFIG" 2>/dev/null || true
+    fi
+fi
+
+# Set secure permissions on config (contains mnemonic)
+chown "$BOTHO_USER:$BOTHO_USER" "$BOTHO_CONFIG"
+chmod 600 "$BOTHO_CONFIG"
+log_info "Config permissions set to 600"
+
+# Step 8: Install systemd service
+log_step "Installing systemd service..."
+cp "$SCRIPT_DIR/botho-faucet.service" "$SERVICE_FILE"
+chmod 644 "$SERVICE_FILE"
+
+# Step 9: Enable and start service
+log_step "Starting Botho faucet service..."
+systemctl daemon-reload
+systemctl enable botho-faucet
+systemctl start botho-faucet
+
+# Wait for service to start
+sleep 5
+
+# Step 10: Verify service is running
+log_step "Verifying service status..."
+if systemctl is-active --quiet botho-faucet; then
+    log_info "Botho faucet service is running"
+else
+    log_error "Botho faucet service failed to start"
+    log_info "Check logs: journalctl -u botho-faucet -n 50"
+    exit 1
+fi
+
+# Step 11: Test faucet endpoint
+log_step "Testing faucet endpoint..."
+sleep 5  # Give the RPC server time to start
+
+RESPONSE=$(curl -s -X POST http://localhost:17101/ \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"node_getStatus","params":{},"id":1}' 2>/dev/null || echo "FAILED")
+
+if echo "$RESPONSE" | jq -e '.result.chainHeight' > /dev/null 2>&1; then
+    HEIGHT=$(echo "$RESPONSE" | jq '.result.chainHeight')
+    log_info "Node responding - Chain height: $HEIGHT"
+else
+    log_warn "Node not responding yet - may still be initializing"
+    log_info "Check status with: curl -X POST http://localhost:17101/ -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"node_getStatus\",\"params\":{},\"id\":1}'"
+fi
+
+echo ""
+log_info "Botho Faucet Node deployment complete!"
+echo ""
+echo "==========================================="
+echo "  Faucet Node Summary"
+echo "==========================================="
+echo ""
+echo "  Service:    botho-faucet"
+echo "  User:       $BOTHO_USER"
+echo "  Config:     $BOTHO_CONFIG"
+echo "  Data:       $BOTHO_DATA"
+echo "  Binary:     $BOTHO_BIN"
+echo ""
+echo "  Ports:"
+echo "    P2P:      17100/tcp"
+echo "    RPC:      17101/tcp"
+echo "    Metrics:  19090/tcp"
+echo ""
+echo "  Useful commands:"
+echo "    View logs:      journalctl -u botho-faucet -f"
+echo "    Check status:   systemctl status botho-faucet"
+echo "    Restart:        systemctl restart botho-faucet"
+echo "    Test endpoint:  curl -X POST http://localhost:17101/ \\"
+echo "                    -H 'Content-Type: application/json' \\"
+echo "                    -d '{\"jsonrpc\":\"2.0\",\"method\":\"node_getStatus\",\"params\":{},\"id\":1}'"
+echo ""
+echo "  Next steps:"
+echo "    1. Configure DNS: Add A record for faucet.botho.io"
+echo "    2. Configure firewall: Open ports 17100, 17101"
+echo "    3. Set up monitoring (optional): ./setup-monitoring.sh"
+echo "    4. Back up the mnemonic from $BOTHO_CONFIG"
+echo ""

--- a/infra/faucet/faucet-config.toml.template
+++ b/infra/faucet/faucet-config.toml.template
@@ -1,0 +1,58 @@
+# Botho Faucet Node Configuration
+#
+# This is a template for faucet.botho.io configuration.
+# Copy this file to ~/.botho/testnet/config.toml and update the mnemonic.
+#
+# SECURITY: This file contains the wallet mnemonic!
+#   - Set permissions: chmod 600 config.toml
+#   - Back up the mnemonic securely
+#   - Never commit this file with a real mnemonic
+
+network_type = "testnet"
+
+[wallet]
+# Generate a new mnemonic with: botho --testnet init
+# Then copy it here, or let the init command create the config
+mnemonic = "YOUR_24_WORD_MNEMONIC_HERE"
+
+[network]
+# Testnet ports (default for testnet, explicit for clarity)
+gossip_port = 17100
+rpc_port = 17101
+metrics_port = 19090
+
+# Allow all origins for testnet faucet access
+cors_origins = ["*"]
+
+# Bootstrap peers - connect to seed node
+bootstrap_peers = [
+    "/dns4/seed.botho.io/tcp/17100"
+]
+
+# Disable DNS discovery (using explicit bootstrap peer)
+[network.dns_seeds]
+enabled = false
+
+# Quorum configuration
+[network.quorum]
+mode = "recommended"
+min_peers = 1
+
+# Higher connection limit for faucet (public service)
+max_connections_per_ip = 50
+
+[minting]
+enabled = true
+threads = 2
+
+[faucet]
+enabled = true
+# 10 BTH per request (in picocredits)
+amount = 10_000_000_000_000
+# Rate limiting
+per_ip_hourly_limit = 5
+per_address_daily_limit = 3
+# 10,000 BTH per day total (in picocredits)
+daily_limit = 10_000_000_000_000_000
+# Minimum 60 seconds between requests from same IP
+cooldown_secs = 60


### PR DESCRIPTION
## Summary

Add deployment scripts and configuration for the faucet.botho.io EC2 server with minting enabled and faucet endpoint active.

## Changes

- `infra/faucet/deploy-faucet.sh` - Automated deployment script for Ubuntu 22.04 EC2 instances
- `infra/faucet/botho-faucet.service` - systemd service file with security hardening
- `infra/faucet/faucet-config.toml.template` - Configuration template with faucet rate limiting
- `infra/faucet/README.md` - Comprehensive deployment and operations guide

## Architecture

```
┌─────────────────────────────────┐      ┌─────────────────────────────────┐
│        seed.botho.io            │      │       faucet.botho.io           │
│         (existing)              │◄────►│          (new)                  │
├─────────────────────────────────┤      ├─────────────────────────────────┤
│  • Bootstrap/discovery          │      │  • Minting enabled              │
│  • Relay blocks & txns          │      │  • Faucet endpoint enabled      │
│  • No wallet (relay-only)       │      │  • Wallet accumulates BTH       │
│  • Minting: OFF                 │      │  • Connects to seed as peer     │
│  • Faucet: OFF                  │      │                                 │
└─────────────────────────────────┘      └─────────────────────────────────┘
```

## Faucet Configuration

- **Amount**: 10 BTH per request
- **Rate Limits**: 5 requests/IP/hour, 3 requests/address/day
- **Daily Cap**: 10,000 BTH total
- **Cooldown**: 60 seconds between requests from same IP

## Test Plan

- [ ] Deploy to test EC2 instance
- [ ] Verify node connects to seed.botho.io
- [ ] Verify minting produces blocks
- [ ] Test faucet endpoint responds
- [ ] Verify rate limiting works
- [ ] Test systemd service restart

Closes #292