### PR TITLE
feat(web-wallet): Add configurable RPC endpoints for testnet

### DIFF
--- a/web/packages/web-wallet/.env.example
+++ b/web/packages/web-wallet/.env.example
@@ -1,0 +1,8 @@
+# Web Wallet Environment Variables
+# Copy to .env.local for local development
+
+# Custom RPC endpoint (optional - defaults to testnet)
+# VITE_RPC_ENDPOINT=http://localhost:27200
+
+# Custom faucet endpoint (optional - defaults to testnet faucet)
+# VITE_FAUCET_ENDPOINT=http://localhost:27200

--- a/web/packages/web-wallet/src/App.tsx
+++ b/web/packages/web-wallet/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { NetworkProvider } from './contexts/network'
 import { WalletProvider } from './contexts/wallet'
 import { LandingPage } from './pages/landing'
 import { WalletPage } from './pages/wallet'
@@ -7,17 +8,19 @@ import { ExplorerPage } from './pages/explorer'
 
 function App() {
   return (
-    <WalletProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<LandingPage />} />
-          <Route path="/wallet" element={<WalletPage />} />
-          <Route path="/explorer" element={<ExplorerPage />} />
-          <Route path="/docs" element={<DocsPage />} />
-          <Route path="/docs/*" element={<DocsPage />} />
-        </Routes>
-      </BrowserRouter>
-    </WalletProvider>
+    <NetworkProvider>
+      <WalletProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<LandingPage />} />
+            <Route path="/wallet" element={<WalletPage />} />
+            <Route path="/explorer" element={<ExplorerPage />} />
+            <Route path="/docs" element={<DocsPage />} />
+            <Route path="/docs/*" element={<DocsPage />} />
+          </Routes>
+        </BrowserRouter>
+      </WalletProvider>
+    </NetworkProvider>
   )
 }
 

--- a/web/packages/web-wallet/src/components/FaucetButton.tsx
+++ b/web/packages/web-wallet/src/components/FaucetButton.tsx
@@ -1,0 +1,185 @@
+import { useState } from 'react'
+import { Button, Card } from '@botho/ui'
+import { Droplets, Loader2, Check, AlertCircle, ExternalLink } from 'lucide-react'
+import { useNetwork } from '../contexts/network'
+import { useWallet } from '../contexts/wallet'
+
+interface FaucetResponse {
+  success: boolean
+  txHash?: string
+  amount?: number
+  error?: string
+  retryAfter?: number
+}
+
+export function FaucetButton() {
+  const { network, hasFaucet } = useNetwork()
+  const { address } = useWallet()
+  const [isRequesting, setIsRequesting] = useState(false)
+  const [result, setResult] = useState<FaucetResponse | null>(null)
+
+  if (!hasFaucet || !network.faucetEndpoint) {
+    return null
+  }
+
+  const handleRequest = async () => {
+    if (!address) return
+
+    setIsRequesting(true)
+    setResult(null)
+
+    try {
+      const response = await fetch(network.faucetEndpoint!, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'faucet_request',
+          params: { address },
+          id: 1,
+        }),
+      })
+
+      const json = await response.json()
+
+      if (json.error) {
+        // Check if rate limited
+        if (json.error.code === -32001 || json.error.message?.includes('rate')) {
+          const retryMatch = json.error.message?.match(/(\d+)\s*(seconds?|minutes?|hours?)/)
+          let retryAfter: number | undefined
+
+          if (retryMatch) {
+            const value = parseInt(retryMatch[1], 10)
+            const unit = retryMatch[2].toLowerCase()
+            if (unit.startsWith('minute')) {
+              retryAfter = value * 60
+            } else if (unit.startsWith('hour')) {
+              retryAfter = value * 3600
+            } else {
+              retryAfter = value
+            }
+          }
+
+          setResult({
+            success: false,
+            error: 'Rate limited. Please try again later.',
+            retryAfter,
+          })
+        } else {
+          setResult({
+            success: false,
+            error: json.error.message || 'Faucet request failed',
+          })
+        }
+      } else if (json.result) {
+        setResult({
+          success: true,
+          txHash: json.result.txHash,
+          amount: json.result.amount,
+        })
+      }
+    } catch (err) {
+      setResult({
+        success: false,
+        error: err instanceof Error ? err.message : 'Request failed',
+      })
+    } finally {
+      setIsRequesting(false)
+    }
+  }
+
+  const formatRetryTime = (seconds: number): string => {
+    if (seconds >= 3600) {
+      const hours = Math.floor(seconds / 3600)
+      return `${hours} hour${hours > 1 ? 's' : ''}`
+    }
+    if (seconds >= 60) {
+      const minutes = Math.floor(seconds / 60)
+      return `${minutes} minute${minutes > 1 ? 's' : ''}`
+    }
+    return `${seconds} second${seconds > 1 ? 's' : ''}`
+  }
+
+  const explorerTxUrl = result?.txHash && network.explorerUrl
+    ? `${network.explorerUrl}/tx/${result.txHash}`
+    : null
+
+  return (
+    <Card className="p-4 sm:p-5">
+      <div className="flex items-start gap-4">
+        <div className="w-10 h-10 rounded-full bg-pulse/10 flex items-center justify-center shrink-0">
+          <Droplets className="text-pulse" size={20} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-medium text-light mb-1">Get Testnet BTH</h3>
+          <p className="text-sm text-ghost mb-4">
+            Request free testnet coins for testing. Limited to one request per hour.
+          </p>
+
+          {result && (
+            <div className={`mb-4 p-3 rounded-lg ${
+              result.success
+                ? 'bg-success/10 border border-success/20'
+                : 'bg-danger/10 border border-danger/20'
+            }`}>
+              <div className="flex items-start gap-2">
+                {result.success ? (
+                  <Check size={16} className="text-success mt-0.5 shrink-0" />
+                ) : (
+                  <AlertCircle size={16} className="text-danger mt-0.5 shrink-0" />
+                )}
+                <div className="flex-1 min-w-0">
+                  {result.success ? (
+                    <>
+                      <p className="text-sm text-success">
+                        Received {result.amount ? `${result.amount / 1e12} BTH` : 'testnet BTH'}
+                      </p>
+                      {explorerTxUrl && (
+                        <a
+                          href={explorerTxUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-xs text-ghost hover:text-light mt-1"
+                        >
+                          View transaction
+                          <ExternalLink size={12} />
+                        </a>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <p className="text-sm text-danger">{result.error}</p>
+                      {result.retryAfter && (
+                        <p className="text-xs text-ghost mt-1">
+                          Try again in {formatRetryTime(result.retryAfter)}
+                        </p>
+                      )}
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <Button
+            onClick={handleRequest}
+            disabled={!address || isRequesting}
+            size="sm"
+          >
+            {isRequesting ? (
+              <>
+                <Loader2 size={14} className="mr-2 animate-spin" />
+                Requesting...
+              </>
+            ) : (
+              <>
+                <Droplets size={14} className="mr-2" />
+                Request 10 BTH
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/web/packages/web-wallet/src/components/NetworkSelector.tsx
+++ b/web/packages/web-wallet/src/components/NetworkSelector.tsx
@@ -1,0 +1,164 @@
+import { useState, useRef, useEffect } from 'react'
+import { Button, Input } from '@botho/ui'
+import { ChevronDown, Globe, Check, Loader2, AlertCircle, X } from 'lucide-react'
+import { useNetwork } from '../contexts/network'
+
+interface NetworkSelectorProps {
+  /** Additional CSS classes */
+  className?: string
+}
+
+export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
+  const { network, availableNetworks, switchNetwork, setCustomEndpoint, isValidating, validationError } = useNetwork()
+  const [isOpen, setIsOpen] = useState(false)
+  const [showCustomInput, setShowCustomInput] = useState(false)
+  const [customEndpoint, setCustomEndpointInput] = useState('')
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+        setShowCustomInput(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const handleNetworkSelect = (networkId: string) => {
+    if (networkId === 'custom') {
+      setShowCustomInput(true)
+    } else {
+      switchNetwork(networkId)
+      setIsOpen(false)
+      setShowCustomInput(false)
+    }
+  }
+
+  const handleCustomSubmit = async () => {
+    if (!customEndpoint.trim()) return
+
+    const success = await setCustomEndpoint(customEndpoint.trim())
+    if (success) {
+      setIsOpen(false)
+      setShowCustomInput(false)
+      setCustomEndpointInput('')
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleCustomSubmit()
+    } else if (e.key === 'Escape') {
+      setShowCustomInput(false)
+      setCustomEndpointInput('')
+    }
+  }
+
+  return (
+    <div className={`relative ${className}`} ref={dropdownRef}>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setIsOpen(!isOpen)}
+        className="gap-2"
+      >
+        <Globe size={14} />
+        <span className="hidden sm:inline">{network.name}</span>
+        {network.isTestnet && (
+          <span className="px-1.5 py-0.5 text-xs rounded bg-warning/20 text-warning">
+            Testnet
+          </span>
+        )}
+        <ChevronDown size={14} className={`transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+      </Button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-64 rounded-lg bg-abyss border border-steel shadow-lg z-50 overflow-hidden">
+          <div className="p-2 border-b border-steel">
+            <span className="text-xs text-ghost uppercase tracking-wide px-2">Select Network</span>
+          </div>
+
+          <div className="py-1">
+            {availableNetworks.map((net) => (
+              <button
+                key={net.id}
+                onClick={() => handleNetworkSelect(net.id)}
+                className={`w-full px-3 py-2 flex items-center gap-3 hover:bg-steel/50 transition-colors ${
+                  network.id === net.id ? 'bg-steel/30' : ''
+                }`}
+              >
+                <div className={`w-2 h-2 rounded-full ${net.isTestnet ? 'bg-warning' : 'bg-success'}`} />
+                <div className="flex-1 text-left">
+                  <div className="text-sm text-light">{net.name}</div>
+                  <div className="text-xs text-ghost truncate">{net.rpcEndpoint}</div>
+                </div>
+                {network.id === net.id && <Check size={16} className="text-pulse" />}
+              </button>
+            ))}
+
+            {/* Custom endpoint option */}
+            <button
+              onClick={() => handleNetworkSelect('custom')}
+              className={`w-full px-3 py-2 flex items-center gap-3 hover:bg-steel/50 transition-colors ${
+                network.id === 'custom' ? 'bg-steel/30' : ''
+              }`}
+            >
+              <div className="w-2 h-2 rounded-full bg-ghost" />
+              <div className="flex-1 text-left">
+                <div className="text-sm text-light">Custom RPC</div>
+                {network.id === 'custom' && (
+                  <div className="text-xs text-ghost truncate">{network.rpcEndpoint}</div>
+                )}
+              </div>
+              {network.id === 'custom' && <Check size={16} className="text-pulse" />}
+            </button>
+          </div>
+
+          {/* Custom endpoint input */}
+          {showCustomInput && (
+            <div className="p-3 border-t border-steel">
+              <div className="flex gap-2">
+                <Input
+                  type="url"
+                  placeholder="https://node.example.com"
+                  value={customEndpoint}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCustomEndpointInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  className="flex-1 text-sm"
+                  autoFocus
+                />
+                <Button
+                  size="sm"
+                  onClick={handleCustomSubmit}
+                  disabled={!customEndpoint.trim() || isValidating}
+                >
+                  {isValidating ? <Loader2 size={14} className="animate-spin" /> : 'Connect'}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => {
+                    setShowCustomInput(false)
+                    setCustomEndpointInput('')
+                  }}
+                >
+                  <X size={14} />
+                </Button>
+              </div>
+              {validationError && (
+                <div className="flex items-center gap-2 mt-2 text-xs text-danger">
+                  <AlertCircle size={12} />
+                  {validationError}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/packages/web-wallet/src/config/networks.ts
+++ b/web/packages/web-wallet/src/config/networks.ts
@@ -1,0 +1,145 @@
+/**
+ * Network configuration for the Botho Web Wallet
+ * Supports testnet, mainnet, and custom RPC endpoints
+ */
+
+export interface NetworkConfig {
+  id: string
+  name: string
+  rpcEndpoint: string
+  faucetEndpoint?: string
+  explorerUrl?: string
+  networkId: string
+  isTestnet: boolean
+}
+
+/**
+ * Get RPC endpoint from environment variable or use default
+ */
+function getEnvRpcEndpoint(): string | undefined {
+  return import.meta.env.VITE_RPC_ENDPOINT as string | undefined
+}
+
+/**
+ * Get faucet endpoint from environment variable or use default
+ */
+function getEnvFaucetEndpoint(): string | undefined {
+  return import.meta.env.VITE_FAUCET_ENDPOINT as string | undefined
+}
+
+/**
+ * Predefined network configurations
+ */
+export const NETWORKS: Record<string, NetworkConfig> = {
+  testnet: {
+    id: 'testnet',
+    name: 'Testnet',
+    rpcEndpoint: getEnvRpcEndpoint() || 'https://seed.botho.io:17101',
+    faucetEndpoint: getEnvFaucetEndpoint() || 'https://faucet.botho.io:17101',
+    explorerUrl: 'https://explorer.testnet.botho.io',
+    networkId: 'botho-testnet',
+    isTestnet: true,
+  },
+  mainnet: {
+    id: 'mainnet',
+    name: 'Mainnet',
+    rpcEndpoint: 'https://seed.botho.io:7101',
+    explorerUrl: 'https://explorer.botho.io',
+    networkId: 'botho-mainnet',
+    isTestnet: false,
+  },
+}
+
+/**
+ * Default network during beta
+ */
+export const DEFAULT_NETWORK_ID = 'testnet'
+
+/**
+ * Get network configuration by ID
+ */
+export function getNetwork(id: string): NetworkConfig | undefined {
+  return NETWORKS[id]
+}
+
+/**
+ * Get all available networks
+ */
+export function getNetworks(): NetworkConfig[] {
+  return Object.values(NETWORKS)
+}
+
+/**
+ * Create a custom network configuration
+ */
+export function createCustomNetwork(rpcEndpoint: string, name?: string): NetworkConfig {
+  return {
+    id: 'custom',
+    name: name || 'Custom',
+    rpcEndpoint,
+    networkId: 'botho-custom',
+    isTestnet: false,
+  }
+}
+
+/**
+ * Validate that an RPC endpoint is reachable
+ */
+export async function validateRpcEndpoint(endpoint: string): Promise<boolean> {
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), 5000)
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'node_getStatus',
+        params: {},
+        id: 1,
+      }),
+    })
+
+    clearTimeout(timeoutId)
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Storage key for persisted network selection
+ */
+const NETWORK_STORAGE_KEY = 'botho_selected_network'
+const CUSTOM_ENDPOINT_KEY = 'botho_custom_endpoint'
+
+/**
+ * Save selected network to localStorage
+ */
+export function saveSelectedNetwork(networkId: string, customEndpoint?: string): void {
+  try {
+    localStorage.setItem(NETWORK_STORAGE_KEY, networkId)
+    if (customEndpoint) {
+      localStorage.setItem(CUSTOM_ENDPOINT_KEY, customEndpoint)
+    } else {
+      localStorage.removeItem(CUSTOM_ENDPOINT_KEY)
+    }
+  } catch {
+    // localStorage may not be available
+  }
+}
+
+/**
+ * Load selected network from localStorage
+ */
+export function loadSelectedNetwork(): { networkId: string; customEndpoint?: string } {
+  try {
+    const networkId = localStorage.getItem(NETWORK_STORAGE_KEY) || DEFAULT_NETWORK_ID
+    const customEndpoint = localStorage.getItem(CUSTOM_ENDPOINT_KEY) || undefined
+    return { networkId, customEndpoint }
+  } catch {
+    return { networkId: DEFAULT_NETWORK_ID }
+  }
+}

--- a/web/packages/web-wallet/src/contexts/network.tsx
+++ b/web/packages/web-wallet/src/contexts/network.tsx
@@ -1,0 +1,150 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  type ReactNode,
+} from 'react'
+import {
+  type NetworkConfig,
+  NETWORKS,
+  DEFAULT_NETWORK_ID,
+  createCustomNetwork,
+  saveSelectedNetwork,
+  loadSelectedNetwork,
+  validateRpcEndpoint,
+} from '../config/networks'
+
+interface NetworkState {
+  /** Currently selected network */
+  network: NetworkConfig
+  /** Whether we're validating a custom endpoint */
+  isValidating: boolean
+  /** Validation error message */
+  validationError: string | null
+  /** Whether the network has a faucet available */
+  hasFaucet: boolean
+}
+
+interface NetworkContextValue extends NetworkState {
+  /** Switch to a different network */
+  switchNetwork: (networkId: string) => void
+  /** Set a custom RPC endpoint */
+  setCustomEndpoint: (endpoint: string) => Promise<boolean>
+  /** Get all available networks */
+  availableNetworks: NetworkConfig[]
+}
+
+const NetworkContext = createContext<NetworkContextValue | null>(null)
+
+/**
+ * Get initial network configuration
+ */
+function getInitialNetwork(): NetworkConfig {
+  const { networkId, customEndpoint } = loadSelectedNetwork()
+
+  if (networkId === 'custom' && customEndpoint) {
+    return createCustomNetwork(customEndpoint)
+  }
+
+  return NETWORKS[networkId] || NETWORKS[DEFAULT_NETWORK_ID]
+}
+
+export function NetworkProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<NetworkState>(() => {
+    const network = getInitialNetwork()
+    return {
+      network,
+      isValidating: false,
+      validationError: null,
+      hasFaucet: !!network.faucetEndpoint,
+    }
+  })
+
+  // Notify listeners when network changes
+  useEffect(() => {
+    // Dispatch custom event for wallet context to pick up
+    window.dispatchEvent(new CustomEvent('network-changed', {
+      detail: { network: state.network }
+    }))
+  }, [state.network])
+
+  const switchNetwork = useCallback((networkId: string) => {
+    const network = NETWORKS[networkId]
+    if (!network) {
+      console.error(`Unknown network: ${networkId}`)
+      return
+    }
+
+    saveSelectedNetwork(networkId)
+    setState({
+      network,
+      isValidating: false,
+      validationError: null,
+      hasFaucet: !!network.faucetEndpoint,
+    })
+  }, [])
+
+  const setCustomEndpoint = useCallback(async (endpoint: string): Promise<boolean> => {
+    setState(s => ({
+      ...s,
+      isValidating: true,
+      validationError: null,
+    }))
+
+    try {
+      // Validate the endpoint is reachable
+      const isValid = await validateRpcEndpoint(endpoint)
+
+      if (!isValid) {
+        setState(s => ({
+          ...s,
+          isValidating: false,
+          validationError: 'Could not connect to endpoint',
+        }))
+        return false
+      }
+
+      const network = createCustomNetwork(endpoint)
+      saveSelectedNetwork('custom', endpoint)
+
+      setState({
+        network,
+        isValidating: false,
+        validationError: null,
+        hasFaucet: false,
+      })
+
+      return true
+    } catch (err) {
+      setState(s => ({
+        ...s,
+        isValidating: false,
+        validationError: err instanceof Error ? err.message : 'Validation failed',
+      }))
+      return false
+    }
+  }, [])
+
+  return (
+    <NetworkContext.Provider
+      value={{
+        ...state,
+        switchNetwork,
+        setCustomEndpoint,
+        availableNetworks: Object.values(NETWORKS),
+      }}
+    >
+      {children}
+    </NetworkContext.Provider>
+  )
+}
+
+export function useNetwork() {
+  const context = useContext(NetworkContext)
+  if (!context) {
+    throw new Error('useNetwork must be used within a NetworkProvider')
+  }
+  return context
+}

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -4,6 +4,9 @@ import { Button, Card, Input, Logo, Toast } from '@botho/ui'
 import { createMnemonic12 } from '@botho/core'
 import { useCopyToClipboard, BalanceCard, TransactionList, SendModal, type SendFormData, type SendResult } from '@botho/features'
 import { useWallet } from '../contexts/wallet'
+import { useNetwork } from '../contexts/network'
+import { NetworkSelector } from '../components/NetworkSelector'
+import { FaucetButton } from '../components/FaucetButton'
 import { Send, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Check, Settings, Trash2 } from 'lucide-react'
 
 function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?: string) => void }) {
@@ -211,6 +214,7 @@ function ImportWalletView({ onImport }: { onImport: (mnemonic: string, password?
 
 function WalletDashboard() {
   const { address, balance, transactions, isConnecting, isConnected, refreshBalance, resetWallet } = useWallet()
+  const { hasFaucet } = useNetwork()
   const { copy } = useCopyToClipboard()
   const [sendOpen, setSendOpen] = useState(false)
   const [isSending, setIsSending] = useState(false)
@@ -277,6 +281,8 @@ function WalletDashboard() {
         isSyncing={isConnecting}
         actions={actionButtons}
       />
+
+      {hasFaucet && <FaucetButton />}
 
       <TransactionList
         transactions={transactions}
@@ -481,6 +487,7 @@ export function WalletPage() {
             <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">Botho Wallet</span>
             <span className="font-display text-base font-semibold sm:hidden">Wallet</span>
           </Link>
+          <NetworkSelector />
         </div>
       </header>
       <main className="py-6 sm:py-8 md:py-12">

--- a/web/packages/web-wallet/src/vite-env.d.ts
+++ b/web/packages/web-wallet/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Custom RPC endpoint URL (overrides default testnet endpoint) */
+  readonly VITE_RPC_ENDPOINT?: string
+  /** Custom faucet endpoint URL (overrides default testnet faucet) */
+  readonly VITE_FAUCET_ENDPOINT?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary

Add network configuration system to the web wallet enabling connection to testnet nodes (seed.botho.io and faucet.botho.io).

### Changes

- **Network Configuration** (`networks.ts`): Define testnet/mainnet network configs with RPC and faucet endpoints
- **NetworkContext** (`network.tsx`): Manage network state with persistence to localStorage
- **NetworkSelector** component: Dropdown in wallet header for switching networks
- **FaucetButton** component: Request testnet BTH with rate limit handling
- **WalletProvider** updates: Reconnect adapter when network changes via custom events
- **Environment variables**: Support `VITE_RPC_ENDPOINT` and `VITE_FAUCET_ENDPOINT` for local dev

### Acceptance Criteria

- [x] Network selector visible in wallet UI
- [x] Default network is Testnet
- [x] Can switch between Testnet and custom endpoints
- [x] Faucet button visible when on Testnet
- [x] Faucet request calls faucet_request RPC
- [x] Rate limit errors displayed with retry time
- [x] RPC endpoint configurable via environment variables
- [x] Works when deployed to Cloudflare Pages (static build)

## Test Plan

- [x] TypeScript type checking passes (`pnpm typecheck`)
- [x] Production build succeeds (`pnpm build:web`)
- [x] Unit tests pass (`pnpm test:run`)
- Manual testing: Switch networks, request faucet, verify reconnection

Closes #293