### PR TITLE
feat(faucet): Add node status display to faucet web UI

### DIFF
--- a/infra/faucet/web/index.html
+++ b/infra/faucet/web/index.html
@@ -53,7 +53,7 @@
   <!-- Main Content -->
   <main class="flex-1 max-w-2xl mx-auto w-full px-4 py-8">
     <!-- Faucet Card -->
-    <div class="bg-botho-card rounded-xl border border-botho-border p-6 mb-6">
+    <div id="faucet-card" class="bg-botho-card rounded-xl border border-botho-border p-6 mb-6">
       <h2 class="text-lg font-semibold mb-4">Request Testnet BTH</h2>
 
       <!-- Address Input -->
@@ -92,7 +92,7 @@
     </div>
 
     <!-- Faucet Status Card -->
-    <div class="bg-botho-card rounded-xl border border-botho-border p-6">
+    <div id="faucet-status-card" class="bg-botho-card rounded-xl border border-botho-border p-6 mb-6">
       <h2 class="text-lg font-semibold mb-4">Faucet Status</h2>
 
       <div id="status-loading" class="text-gray-400 text-sm">
@@ -128,6 +128,59 @@
 
       <div id="status-error" class="hidden text-red-400 text-sm">
         Failed to load faucet status
+      </div>
+    </div>
+
+    <!-- Node Status Card -->
+    <div id="node-status-card" class="bg-botho-card rounded-xl border border-botho-border p-6">
+      <h2 class="text-lg font-semibold mb-4">Node Status</h2>
+
+      <div id="node-stats-loading" class="text-gray-400 text-sm">
+        Loading node status...
+      </div>
+
+      <div id="node-stats-content" class="hidden">
+        <!-- Metrics Grid -->
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
+          <div class="text-center p-3 bg-botho-bg rounded-lg border border-botho-border">
+            <p class="text-xs text-gray-500 uppercase tracking-wide mb-1">Uptime</p>
+            <p id="node-uptime" class="text-lg font-semibold text-botho-cyan">—</p>
+          </div>
+          <div class="text-center p-3 bg-botho-bg rounded-lg border border-botho-border">
+            <p class="text-xs text-gray-500 uppercase tracking-wide mb-1">Height</p>
+            <p id="node-height" class="text-lg font-semibold text-botho-cyan">—</p>
+          </div>
+          <div class="text-center p-3 bg-botho-bg rounded-lg border border-botho-border">
+            <p class="text-xs text-gray-500 uppercase tracking-wide mb-1">SCP Peers</p>
+            <p id="node-scp-peers" class="text-lg font-semibold text-botho-cyan">—</p>
+          </div>
+          <div class="text-center p-3 bg-botho-bg rounded-lg border border-botho-border">
+            <p class="text-xs text-gray-500 uppercase tracking-wide mb-1">Transactions</p>
+            <p id="node-transactions" class="text-lg font-semibold text-botho-cyan">—</p>
+          </div>
+        </div>
+
+        <!-- Status Row -->
+        <div class="flex flex-wrap gap-4 text-sm">
+          <div class="flex items-center gap-2">
+            <span class="text-gray-400">Sync:</span>
+            <span id="node-sync-status" class="flex items-center gap-2">
+              <span class="w-2 h-2 rounded-full bg-gray-500"></span>
+              <span class="text-gray-400">Unknown</span>
+            </span>
+          </div>
+          <div class="flex items-center gap-2">
+            <span class="text-gray-400">Minting:</span>
+            <span id="node-minting-status" class="flex items-center gap-2">
+              <span class="w-2 h-2 rounded-full bg-gray-500"></span>
+              <span class="text-gray-400">Unknown</span>
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div id="node-stats-error" class="hidden text-red-400 text-sm">
+        Node status unavailable
       </div>
     </div>
   </main>

--- a/infra/faucet/web/js/faucet.js
+++ b/infra/faucet/web/js/faucet.js
@@ -3,13 +3,48 @@
  *
  * Handles:
  * - Drip amount decay calculation based on time since last request
- * - RPC calls to faucet_request and faucet_getStats
+ * - RPC calls to faucet_request, faucet_getStats, and node_getStatus
  * - localStorage tracking for decay timer
  * - UI state management and error handling
+ * - Configurable section visibility with URL parameter overrides
  */
 
 (function () {
   'use strict';
+
+  // Configuration with defaults
+  const CONFIG = {
+    // Section visibility
+    showFaucetRequest: true,   // Main request form
+    showFaucetStats: true,     // Faucet-specific stats
+    showNodeStats: true,       // Host/node stats
+
+    // Refresh intervals (ms)
+    faucetStatsInterval: 30000,  // 30s
+    nodeStatsInterval: 15000,    // 15s (blocks are ~30s)
+  };
+
+  /**
+   * Parse URL parameters to override config
+   */
+  function parseUrlParams() {
+    const params = new URLSearchParams(window.location.search);
+
+    // faucet=0/1 controls both request form and faucet stats
+    if (params.has('faucet')) {
+      const showFaucet = params.get('faucet') !== '0';
+      CONFIG.showFaucetRequest = showFaucet;
+      CONFIG.showFaucetStats = showFaucet;
+    }
+
+    // nodestats=0/1 controls node stats section
+    if (params.has('nodestats')) {
+      CONFIG.showNodeStats = params.get('nodestats') !== '0';
+    }
+  }
+
+  // Parse URL params on load
+  parseUrlParams();
 
   // Constants
   const STORAGE_KEY = 'botho_faucet_last_request';
@@ -27,6 +62,8 @@
 
   // DOM elements
   const elements = {
+    // Faucet request
+    faucetCard: document.getElementById('faucet-card'),
     addressInput: document.getElementById('address'),
     addressError: document.getElementById('address-error'),
     dripAmount: document.getElementById('drip-amount'),
@@ -34,6 +71,8 @@
     requestBtn: document.getElementById('request-btn'),
     resultBanner: document.getElementById('result-banner'),
     resultContent: document.getElementById('result-content'),
+    // Faucet stats
+    faucetStatusCard: document.getElementById('faucet-status-card'),
     statusLoading: document.getElementById('status-loading'),
     statusContent: document.getElementById('status-content'),
     statusError: document.getElementById('status-error'),
@@ -42,6 +81,17 @@
     dailyLimit: document.getElementById('daily-limit'),
     dailyDispensed: document.getElementById('daily-dispensed'),
     dailyProgress: document.getElementById('daily-progress'),
+    // Node stats
+    nodeStatusCard: document.getElementById('node-status-card'),
+    nodeStatsLoading: document.getElementById('node-stats-loading'),
+    nodeStatsContent: document.getElementById('node-stats-content'),
+    nodeStatsError: document.getElementById('node-stats-error'),
+    nodeUptime: document.getElementById('node-uptime'),
+    nodeHeight: document.getElementById('node-height'),
+    nodeScpPeers: document.getElementById('node-scp-peers'),
+    nodeTransactions: document.getElementById('node-transactions'),
+    nodeSyncStatus: document.getElementById('node-sync-status'),
+    nodeMintingStatus: document.getElementById('node-minting-status'),
   };
 
   // State
@@ -365,36 +415,187 @@
   }
 
   /**
+   * Format uptime in seconds to human readable format
+   */
+  function formatUptime(seconds) {
+    if (typeof seconds !== 'number' || seconds < 0) {
+      return 'Unknown';
+    }
+
+    const days = Math.floor(seconds / 86400);
+    const hours = Math.floor((seconds % 86400) / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+
+    const parts = [];
+    if (days > 0) parts.push(`${days}d`);
+    if (hours > 0) parts.push(`${hours}h`);
+    if (minutes > 0 || parts.length === 0) parts.push(`${minutes}m`);
+
+    return parts.join(' ');
+  }
+
+  /**
+   * Format large numbers with commas
+   */
+  function formatNumber(num) {
+    if (typeof num !== 'number') return '—';
+    return num.toLocaleString();
+  }
+
+  /**
+   * Load node stats
+   */
+  async function loadNodeStats() {
+    if (!CONFIG.showNodeStats || !elements.nodeStatusCard) return;
+
+    try {
+      const status = await rpcCall('node_getStatus', {});
+
+      elements.nodeStatsLoading.classList.add('hidden');
+      elements.nodeStatsError.classList.add('hidden');
+      elements.nodeStatsContent.classList.remove('hidden');
+
+      // Update metrics
+      if (elements.nodeUptime) {
+        elements.nodeUptime.textContent = formatUptime(status.uptime || status.uptimeSeconds);
+      }
+      if (elements.nodeHeight) {
+        elements.nodeHeight.textContent = formatNumber(status.height || status.blockHeight || status.chainHeight);
+      }
+      if (elements.nodeScpPeers) {
+        elements.nodeScpPeers.textContent = formatNumber(status.scpPeers || status.peerCount || status.peers);
+      }
+      if (elements.nodeTransactions) {
+        const txCount = status.transactions || status.transactionCount || status.txCount;
+        elements.nodeTransactions.textContent = txCount !== undefined ? formatNumber(txCount) : '—';
+      }
+
+      // Sync status
+      if (elements.nodeSyncStatus) {
+        const synced = status.synced !== false && status.syncStatus !== 'syncing';
+        if (synced) {
+          elements.nodeSyncStatus.innerHTML = `
+            <span class="w-2 h-2 rounded-full bg-green-500"></span>
+            <span class="text-green-400">Synced</span>
+          `;
+        } else {
+          const syncPercent = status.syncProgress || status.syncPercent || 0;
+          elements.nodeSyncStatus.innerHTML = `
+            <span class="w-2 h-2 rounded-full bg-yellow-500"></span>
+            <span class="text-yellow-400">Syncing ${syncPercent.toFixed(1)}%</span>
+          `;
+        }
+      }
+
+      // Minting status
+      if (elements.nodeMintingStatus) {
+        const minting = status.minting || status.mintingActive;
+        const threads = status.mintingThreads || status.threads || 0;
+        if (minting) {
+          elements.nodeMintingStatus.innerHTML = `
+            <span class="w-2 h-2 rounded-full bg-green-500"></span>
+            <span class="text-green-400">Active${threads > 0 ? ` (${threads} thread${threads > 1 ? 's' : ''})` : ''}</span>
+          `;
+        } else {
+          elements.nodeMintingStatus.innerHTML = `
+            <span class="w-2 h-2 rounded-full bg-gray-500"></span>
+            <span class="text-gray-400">Inactive</span>
+          `;
+        }
+      }
+    } catch (error) {
+      elements.nodeStatsLoading.classList.add('hidden');
+      elements.nodeStatsContent.classList.add('hidden');
+      elements.nodeStatsError.classList.remove('hidden');
+      elements.nodeStatsError.innerHTML = `
+        <div class="flex items-center justify-between">
+          <span>Node status unavailable</span>
+          <button onclick="window.retryNodeStats()" class="px-3 py-1 text-xs bg-botho-border hover:bg-gray-700 rounded transition-colors">
+            Retry
+          </button>
+        </div>
+      `;
+    }
+  }
+
+  // Global function for retry button
+  window.retryNodeStats = function() {
+    if (elements.nodeStatsError) {
+      elements.nodeStatsError.classList.add('hidden');
+    }
+    if (elements.nodeStatsLoading) {
+      elements.nodeStatsLoading.classList.remove('hidden');
+    }
+    loadNodeStats();
+  };
+
+  /**
+   * Apply section visibility based on config
+   */
+  function applySectionVisibility() {
+    // Faucet request section
+    if (elements.faucetCard) {
+      elements.faucetCard.classList.toggle('hidden', !CONFIG.showFaucetRequest);
+    }
+
+    // Faucet stats section
+    if (elements.faucetStatusCard) {
+      elements.faucetStatusCard.classList.toggle('hidden', !CONFIG.showFaucetStats);
+    }
+
+    // Node stats section
+    if (elements.nodeStatusCard) {
+      elements.nodeStatusCard.classList.toggle('hidden', !CONFIG.showNodeStats);
+    }
+  }
+
+  /**
    * Initialize
    */
   function init() {
-    // Update drip display on load
-    updateDripDisplay();
+    // Apply section visibility based on config/URL params
+    applySectionVisibility();
 
-    // Update drip display every minute
-    setInterval(updateDripDisplay, 60000);
+    // Faucet request functionality
+    if (CONFIG.showFaucetRequest) {
+      // Update drip display on load
+      updateDripDisplay();
 
-    // Load faucet stats
-    loadFaucetStats();
+      // Update drip display every minute
+      setInterval(updateDripDisplay, 60000);
 
-    // Refresh stats every 30 seconds
-    setInterval(loadFaucetStats, 30000);
-
-    // Request button handler
-    elements.requestBtn.addEventListener('click', handleRequest);
-
-    // Enter key in address field
-    elements.addressInput.addEventListener('keydown', (e) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        handleRequest();
+      // Request button handler
+      if (elements.requestBtn) {
+        elements.requestBtn.addEventListener('click', handleRequest);
       }
-    });
 
-    // Clear error on input
-    elements.addressInput.addEventListener('input', () => {
-      elements.addressError.classList.add('hidden');
-    });
+      // Enter key in address field
+      if (elements.addressInput) {
+        elements.addressInput.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleRequest();
+          }
+        });
+
+        // Clear error on input
+        elements.addressInput.addEventListener('input', () => {
+          elements.addressError.classList.add('hidden');
+        });
+      }
+    }
+
+    // Faucet stats
+    if (CONFIG.showFaucetStats) {
+      loadFaucetStats();
+      setInterval(loadFaucetStats, CONFIG.faucetStatsInterval);
+    }
+
+    // Node stats
+    if (CONFIG.showNodeStats) {
+      loadNodeStats();
+      setInterval(loadNodeStats, CONFIG.nodeStatsInterval);
+    }
   }
 
   // Global function for copy button


### PR DESCRIPTION
## Summary

- Add node status card to faucet page with key metrics: uptime, chain height, SCP peers, transactions
- Implement JavaScript CONFIG object with section toggles and URL parameter overrides
- Add independent error handling with retry functionality for each section
- Create responsive grid layout (2-column mobile, 4-column desktop)

## Test plan

- [ ] Verify node stats card displays when `node_getStatus` RPC returns data
- [ ] Verify error state with retry button when RPC unavailable (expected until #307 is complete)
- [ ] Test URL parameters: `?faucet=0` hides faucet sections, `?nodestats=0` hides node stats
- [ ] Confirm mobile-responsive grid layout on various screen sizes
- [ ] Check that faucet functionality still works independently of node stats

## Dependencies

- #307: Extend node_getStatus RPC (node stats will show "unavailable" until this is merged)

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)