### PR TITLE
feat(faucet): Add historical metrics daemon for node stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.3.4",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -501,6 +501,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "axum-core"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +549,27 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -853,6 +908,26 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 0.9.10+spec-1.1.0",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "botho-metrics-daemon"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum 0.7.9",
+ "chrono",
+ "clap",
+ "reqwest",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -7270,7 +7345,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7955,6 +8030,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -9255,7 +9341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.6.20",
  "base64 0.21.7",
  "bytes",
  "futures-core",
@@ -9309,6 +9395,23 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -9347,6 +9450,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "util/zip-exact",
     "web/packages/desktop/src-tauri",
     "mobile/rust-bridge",
+    "infra/faucet/metrics-daemon",
 ]
 exclude = [
     "contracts",

--- a/infra/faucet/botho-metrics-daemon.service
+++ b/infra/faucet/botho-metrics-daemon.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=Botho Metrics Daemon
+Documentation=https://github.com/botho-project/botho
+After=network-online.target botho-faucet.service
+Wants=network-online.target
+Requires=botho-faucet.service
+
+[Service]
+Type=simple
+User=botho
+Group=botho
+WorkingDirectory=/home/botho
+
+# Collect metrics from local node and serve API
+ExecStart=/usr/local/bin/botho-metrics-daemon \
+    --node-url http://127.0.0.1:17101 \
+    --db /var/lib/botho-faucet/metrics.db \
+    --api-port 17102 \
+    --interval 300
+
+Restart=always
+RestartSec=10
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/var/lib/botho-faucet
+
+# Resource limits
+LimitNOFILE=65535
+MemoryMax=256M
+
+# Environment
+Environment=RUST_LOG=info
+Environment=RUST_BACKTRACE=1
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=botho-metrics-daemon
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/faucet/faucet-nginx.conf
+++ b/infra/faucet/faucet-nginx.conf
@@ -111,6 +111,41 @@ server {
         client_max_body_size 64k;
     }
 
+    # Metrics API proxy to metrics daemon
+    location /api/metrics {
+        # Handle CORS preflight
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Content-Type' always;
+            add_header 'Access-Control-Max-Age' 86400 always;
+            add_header 'Content-Length' 0;
+            add_header 'Content-Type' 'text/plain';
+            return 204;
+        }
+
+        # Proxy to metrics daemon
+        proxy_pass http://127.0.0.1:17102;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Timeout settings
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+
+        # CORS headers
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Content-Type' always;
+
+        # Cache metrics responses for 1 minute
+        proxy_cache_valid 200 1m;
+    }
+
     # Health check endpoint
     location /health {
         access_log off;

--- a/infra/faucet/metrics-daemon/Cargo.toml
+++ b/infra/faucet/metrics-daemon/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "botho-metrics-daemon"
+version = "0.1.0"
+edition = "2021"
+description = "Historical metrics collection daemon for Botho faucet"
+license = "MIT"
+
+[[bin]]
+name = "botho-metrics-daemon"
+path = "src/main.rs"
+
+[dependencies]
+# Async runtime
+tokio = { version = "1", features = ["full"] }
+
+# HTTP client for polling node
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+# HTTP server for API
+axum = { version = "0.7", features = ["json"] }
+tower-http = { version = "0.5", features = ["cors"] }
+
+# Database
+rusqlite = { version = "0.31", features = ["bundled"] }
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Time handling
+chrono = { version = "0.4", features = ["serde"] }
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Error handling
+anyhow = "1"
+thiserror = "1"
+
+# Configuration
+clap = { version = "4", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/infra/faucet/metrics-daemon/src/api.rs
+++ b/infra/faucet/metrics-daemon/src/api.rs
@@ -1,0 +1,151 @@
+//! HTTP API for serving historical metrics
+//!
+//! Endpoints:
+//! - GET /api/metrics/history?metric=height&period=24h&granularity=5min
+//! - GET /api/metrics/latest
+//! - GET /health
+
+use std::sync::{Arc, Mutex};
+use anyhow::Result;
+use axum::{
+    Router,
+    Json,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::get,
+};
+use serde::{Deserialize, Serialize};
+use tower_http::cors::{CorsLayer, Any};
+
+use crate::db::{MetricsDb, HistoryQuery, DataPoint};
+
+/// Shared application state
+type AppState = Arc<Mutex<MetricsDb>>;
+
+/// History response
+#[derive(Serialize)]
+struct HistoryResponse {
+    metric: String,
+    period: String,
+    granularity: String,
+    data: Vec<DataPoint>,
+}
+
+/// Latest metrics response
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LatestResponse {
+    timestamp: i64,
+    height: u64,
+    peer_count: f64,
+    scp_peer_count: f64,
+    mempool_size: f64,
+    tx_delta: i64,
+    uptime_seconds: u64,
+    minting_active: bool,
+}
+
+/// Error response
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+/// Start the API server
+pub async fn serve(addr: String, db: Arc<Mutex<MetricsDb>>) -> Result<()> {
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/api/metrics/history", get(history))
+        .route("/api/metrics/latest", get(latest))
+        .layer(cors)
+        .with_state(db);
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+/// Health check endpoint
+async fn health() -> impl IntoResponse {
+    "OK"
+}
+
+/// Query parameters for history endpoint
+#[derive(Debug, Deserialize)]
+struct HistoryParams {
+    metric: Option<String>,
+    period: Option<String>,
+    granularity: Option<String>,
+}
+
+/// Get historical metrics
+async fn history(
+    State(db): State<AppState>,
+    Query(params): Query<HistoryParams>,
+) -> impl IntoResponse {
+    let query = HistoryQuery {
+        metric: params.metric.unwrap_or_else(|| "height".to_string()),
+        period: params.period.unwrap_or_else(|| "24h".to_string()),
+        granularity: params.granularity.unwrap_or_else(|| "5min".to_string()),
+    };
+
+    let db_lock = db.lock().unwrap();
+
+    match db_lock.query_history(&query) {
+        Ok(data) => {
+            let response = HistoryResponse {
+                metric: query.metric,
+                period: query.period,
+                granularity: query.granularity,
+                data,
+            };
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        Err(e) => {
+            let response = ErrorResponse {
+                error: e.to_string(),
+            };
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(response)).into_response()
+        }
+    }
+}
+
+/// Get latest metrics sample
+async fn latest(State(db): State<AppState>) -> impl IntoResponse {
+    let db_lock = db.lock().unwrap();
+
+    match db_lock.get_latest() {
+        Ok(Some(sample)) => {
+            let response = LatestResponse {
+                timestamp: sample.timestamp,
+                height: sample.height,
+                peer_count: sample.peer_count,
+                scp_peer_count: sample.scp_peer_count,
+                mempool_size: sample.mempool_size,
+                tx_delta: sample.tx_delta,
+                uptime_seconds: sample.uptime_seconds,
+                minting_active: sample.minting_active,
+            };
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        Ok(None) => {
+            let response = ErrorResponse {
+                error: "No data available".to_string(),
+            };
+            (StatusCode::NOT_FOUND, Json(response)).into_response()
+        }
+        Err(e) => {
+            let response = ErrorResponse {
+                error: e.to_string(),
+            };
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(response)).into_response()
+        }
+    }
+}

--- a/infra/faucet/metrics-daemon/src/collector.rs
+++ b/infra/faucet/metrics-daemon/src/collector.rs
@@ -1,0 +1,110 @@
+//! Metrics collection from Botho node
+
+use std::sync::{Arc, Mutex};
+use anyhow::{Result, Context};
+use serde::Deserialize;
+use tracing::debug;
+
+use crate::db::{MetricsDb, MetricsSample};
+
+/// JSON-RPC request structure
+#[derive(serde::Serialize)]
+struct RpcRequest {
+    jsonrpc: &'static str,
+    method: &'static str,
+    params: serde_json::Value,
+    id: u32,
+}
+
+/// JSON-RPC response structure
+#[derive(Deserialize)]
+struct RpcResponse {
+    result: Option<NodeStatus>,
+    error: Option<RpcError>,
+}
+
+#[derive(Deserialize)]
+struct RpcError {
+    code: i32,
+    message: String,
+}
+
+/// Node status from node_getStatus RPC
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NodeStatus {
+    chain_height: u64,
+    peer_count: u64,
+    scp_peer_count: u64,
+    mempool_size: u64,
+    total_transactions: u64,
+    uptime_seconds: u64,
+    minting_active: bool,
+}
+
+/// Collect metrics from the node and store in database
+pub async fn collect_metrics(node_url: &str, db: &Arc<Mutex<MetricsDb>>) -> Result<()> {
+    // Build RPC request
+    let request = RpcRequest {
+        jsonrpc: "2.0",
+        method: "node_getStatus",
+        params: serde_json::json!({}),
+        id: 1,
+    };
+
+    // Call node RPC
+    let client = reqwest::Client::new();
+    let response = client
+        .post(node_url)
+        .json(&request)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+        .context("Failed to connect to node")?;
+
+    let rpc_response: RpcResponse = response
+        .json()
+        .await
+        .context("Failed to parse RPC response")?;
+
+    // Check for RPC error
+    if let Some(error) = rpc_response.error {
+        anyhow::bail!("RPC error {}: {}", error.code, error.message);
+    }
+
+    let status = rpc_response.result
+        .context("No result in RPC response")?;
+
+    debug!("Received node status: height={}, peers={}", status.chain_height, status.peer_count);
+
+    // Calculate tx_delta
+    let mut db_lock = db.lock().unwrap();
+    let last_tx = db_lock.get_last_tx_count()?.unwrap_or(status.total_transactions);
+    let tx_delta = status.total_transactions.saturating_sub(last_tx) as i64;
+
+    // Update last tx count
+    db_lock.set_last_tx_count(status.total_transactions)?;
+
+    // Create sample
+    let now = chrono::Utc::now().timestamp();
+    // Round to nearest 5 minutes for consistent timestamps
+    let rounded_ts = (now / 300) * 300;
+
+    let sample = MetricsSample {
+        timestamp: rounded_ts,
+        height: status.chain_height,
+        peer_count: status.peer_count as f64,
+        scp_peer_count: status.scp_peer_count as f64,
+        mempool_size: status.mempool_size as f64,
+        tx_delta,
+        uptime_seconds: status.uptime_seconds,
+        minting_active: status.minting_active,
+    };
+
+    // Store sample
+    db_lock.insert_sample(&sample)?;
+
+    debug!("Stored metrics sample: {:?}", sample);
+
+    Ok(())
+}

--- a/infra/faucet/metrics-daemon/src/db.rs
+++ b/infra/faucet/metrics-daemon/src/db.rs
@@ -1,0 +1,303 @@
+//! SQLite database for metrics storage
+//!
+//! Schema:
+//! - metrics_5min: Raw 5-minute samples (24h retention)
+//! - metrics_hourly: Hourly aggregates (30d retention)
+//! - metrics_daily: Daily aggregates (1y retention)
+
+use std::path::Path;
+use anyhow::Result;
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+
+/// A single metrics sample
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricsSample {
+    pub timestamp: i64,
+    pub height: u64,
+    pub peer_count: f64,
+    pub scp_peer_count: f64,
+    pub mempool_size: f64,
+    pub tx_delta: i64,
+    pub uptime_seconds: u64,
+    pub minting_active: bool,
+}
+
+/// Query parameters for historical data
+#[derive(Debug, Clone, Deserialize)]
+pub struct HistoryQuery {
+    pub metric: String,
+    pub period: String,      // "1h", "24h", "7d", "30d"
+    pub granularity: String, // "5min", "hourly", "daily"
+}
+
+/// A data point for API response
+#[derive(Debug, Clone, Serialize)]
+pub struct DataPoint {
+    pub timestamp: i64,
+    pub value: f64,
+}
+
+/// Metrics database wrapper
+pub struct MetricsDb {
+    conn: Connection,
+}
+
+impl MetricsDb {
+    /// Open or create the metrics database
+    pub fn open(path: &Path) -> Result<Self> {
+        let conn = Connection::open(path)?;
+
+        // Create tables
+        conn.execute_batch(r#"
+            -- 5-minute samples (raw data, 24h retention)
+            CREATE TABLE IF NOT EXISTS metrics_5min (
+                timestamp INTEGER PRIMARY KEY,
+                height INTEGER NOT NULL,
+                peer_count REAL NOT NULL,
+                scp_peer_count REAL NOT NULL,
+                mempool_size REAL NOT NULL,
+                tx_delta INTEGER NOT NULL,
+                uptime_seconds INTEGER NOT NULL,
+                minting_active INTEGER NOT NULL
+            );
+
+            -- Hourly aggregates (30d retention)
+            CREATE TABLE IF NOT EXISTS metrics_hourly (
+                timestamp INTEGER PRIMARY KEY,
+                height INTEGER NOT NULL,
+                peer_count_avg REAL NOT NULL,
+                scp_peer_count_avg REAL NOT NULL,
+                mempool_size_avg REAL NOT NULL,
+                tx_total INTEGER NOT NULL,
+                samples INTEGER NOT NULL
+            );
+
+            -- Daily aggregates (1y retention)
+            CREATE TABLE IF NOT EXISTS metrics_daily (
+                timestamp INTEGER PRIMARY KEY,
+                height INTEGER NOT NULL,
+                peer_count_avg REAL NOT NULL,
+                scp_peer_count_avg REAL NOT NULL,
+                mempool_size_avg REAL NOT NULL,
+                tx_total INTEGER NOT NULL,
+                samples INTEGER NOT NULL
+            );
+
+            -- Indexes for efficient queries
+            CREATE INDEX IF NOT EXISTS idx_5min_ts ON metrics_5min(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_hourly_ts ON metrics_hourly(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_daily_ts ON metrics_daily(timestamp);
+
+            -- Track last known height for delta calculation
+            CREATE TABLE IF NOT EXISTS state (
+                key TEXT PRIMARY KEY,
+                value INTEGER NOT NULL
+            );
+        "#)?;
+
+        Ok(Self { conn })
+    }
+
+    /// Insert a 5-minute sample
+    pub fn insert_sample(&mut self, sample: &MetricsSample) -> Result<()> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO metrics_5min
+             (timestamp, height, peer_count, scp_peer_count, mempool_size, tx_delta, uptime_seconds, minting_active)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                sample.timestamp,
+                sample.height as i64,
+                sample.peer_count,
+                sample.scp_peer_count,
+                sample.mempool_size,
+                sample.tx_delta,
+                sample.uptime_seconds as i64,
+                sample.minting_active as i32,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Get the last recorded total_tx for delta calculation
+    pub fn get_last_tx_count(&self) -> Result<Option<u64>> {
+        let result: Option<i64> = self.conn.query_row(
+            "SELECT value FROM state WHERE key = 'last_tx_count'",
+            [],
+            |row| row.get(0),
+        ).ok();
+        Ok(result.map(|v| v as u64))
+    }
+
+    /// Update the last recorded total_tx
+    pub fn set_last_tx_count(&mut self, count: u64) -> Result<()> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO state (key, value) VALUES ('last_tx_count', ?1)",
+            params![count as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Aggregate 5min data into hourly (for a specific hour)
+    pub fn aggregate_to_hourly(&mut self, hour_start: i64) -> Result<()> {
+        let hour_end = hour_start + 3600;
+
+        self.conn.execute(
+            r#"
+            INSERT OR REPLACE INTO metrics_hourly
+            (timestamp, height, peer_count_avg, scp_peer_count_avg, mempool_size_avg, tx_total, samples)
+            SELECT
+                ?1 as timestamp,
+                MAX(height) as height,
+                AVG(peer_count) as peer_count_avg,
+                AVG(scp_peer_count) as scp_peer_count_avg,
+                AVG(mempool_size) as mempool_size_avg,
+                SUM(tx_delta) as tx_total,
+                COUNT(*) as samples
+            FROM metrics_5min
+            WHERE timestamp >= ?1 AND timestamp < ?2
+            "#,
+            params![hour_start, hour_end],
+        )?;
+        Ok(())
+    }
+
+    /// Aggregate hourly data into daily (for a specific day)
+    pub fn aggregate_to_daily(&mut self, day_start: i64) -> Result<()> {
+        let day_end = day_start + 86400;
+
+        self.conn.execute(
+            r#"
+            INSERT OR REPLACE INTO metrics_daily
+            (timestamp, height, peer_count_avg, scp_peer_count_avg, mempool_size_avg, tx_total, samples)
+            SELECT
+                ?1 as timestamp,
+                MAX(height) as height,
+                AVG(peer_count_avg) as peer_count_avg,
+                AVG(scp_peer_count_avg) as scp_peer_count_avg,
+                AVG(mempool_size_avg) as mempool_size_avg,
+                SUM(tx_total) as tx_total,
+                SUM(samples) as samples
+            FROM metrics_hourly
+            WHERE timestamp >= ?1 AND timestamp < ?2
+            "#,
+            params![day_start, day_end],
+        )?;
+        Ok(())
+    }
+
+    /// Delete old 5min samples (older than 24h)
+    pub fn cleanup_5min(&mut self, before: i64) -> Result<usize> {
+        let count = self.conn.execute(
+            "DELETE FROM metrics_5min WHERE timestamp < ?1",
+            params![before],
+        )?;
+        Ok(count)
+    }
+
+    /// Delete old hourly samples (older than 30d)
+    pub fn cleanup_hourly(&mut self, before: i64) -> Result<usize> {
+        let count = self.conn.execute(
+            "DELETE FROM metrics_hourly WHERE timestamp < ?1",
+            params![before],
+        )?;
+        Ok(count)
+    }
+
+    /// Delete old daily samples (older than 1y)
+    pub fn cleanup_daily(&mut self, before: i64) -> Result<usize> {
+        let count = self.conn.execute(
+            "DELETE FROM metrics_daily WHERE timestamp < ?1",
+            params![before],
+        )?;
+        Ok(count)
+    }
+
+    /// Query historical data for a specific metric
+    pub fn query_history(&self, query: &HistoryQuery) -> Result<Vec<DataPoint>> {
+        let now = chrono::Utc::now().timestamp();
+
+        // Parse period to seconds
+        let period_secs = match query.period.as_str() {
+            "1h" => 3600,
+            "6h" => 21600,
+            "24h" => 86400,
+            "7d" => 604800,
+            "30d" => 2592000,
+            _ => 86400, // Default to 24h
+        };
+
+        let since = now - period_secs;
+
+        // Select table based on granularity
+        let (table, column) = match (query.granularity.as_str(), query.metric.as_str()) {
+            ("5min", "height") => ("metrics_5min", "height"),
+            ("5min", "peerCount") => ("metrics_5min", "peer_count"),
+            ("5min", "scpPeerCount") => ("metrics_5min", "scp_peer_count"),
+            ("5min", "mempoolSize") => ("metrics_5min", "mempool_size"),
+            ("5min", "txDelta") => ("metrics_5min", "tx_delta"),
+
+            ("hourly", "height") => ("metrics_hourly", "height"),
+            ("hourly", "peerCount") => ("metrics_hourly", "peer_count_avg"),
+            ("hourly", "scpPeerCount") => ("metrics_hourly", "scp_peer_count_avg"),
+            ("hourly", "mempoolSize") => ("metrics_hourly", "mempool_size_avg"),
+            ("hourly", "txTotal") => ("metrics_hourly", "tx_total"),
+
+            ("daily", "height") => ("metrics_daily", "height"),
+            ("daily", "peerCount") => ("metrics_daily", "peer_count_avg"),
+            ("daily", "scpPeerCount") => ("metrics_daily", "scp_peer_count_avg"),
+            ("daily", "mempoolSize") => ("metrics_daily", "mempool_size_avg"),
+            ("daily", "txTotal") => ("metrics_daily", "tx_total"),
+
+            // Default to 5min height
+            _ => ("metrics_5min", "height"),
+        };
+
+        let sql = format!(
+            "SELECT timestamp, {} as value FROM {} WHERE timestamp >= ?1 ORDER BY timestamp ASC",
+            column, table
+        );
+
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt.query_map(params![since], |row| {
+            Ok(DataPoint {
+                timestamp: row.get(0)?,
+                value: row.get(1)?,
+            })
+        })?;
+
+        let mut data = Vec::new();
+        for row in rows {
+            data.push(row?);
+        }
+
+        Ok(data)
+    }
+
+    /// Get latest sample for current status
+    pub fn get_latest(&self) -> Result<Option<MetricsSample>> {
+        let result = self.conn.query_row(
+            "SELECT timestamp, height, peer_count, scp_peer_count, mempool_size, tx_delta, uptime_seconds, minting_active
+             FROM metrics_5min ORDER BY timestamp DESC LIMIT 1",
+            [],
+            |row| {
+                Ok(MetricsSample {
+                    timestamp: row.get(0)?,
+                    height: row.get::<_, i64>(1)? as u64,
+                    peer_count: row.get(2)?,
+                    scp_peer_count: row.get(3)?,
+                    mempool_size: row.get(4)?,
+                    tx_delta: row.get(5)?,
+                    uptime_seconds: row.get::<_, i64>(6)? as u64,
+                    minting_active: row.get::<_, i32>(7)? != 0,
+                })
+            },
+        );
+
+        match result {
+            Ok(sample) => Ok(Some(sample)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/infra/faucet/metrics-daemon/src/main.rs
+++ b/infra/faucet/metrics-daemon/src/main.rs
@@ -1,0 +1,135 @@
+//! Botho Metrics Daemon
+//!
+//! Collects historical node metrics for the faucet web UI.
+//!
+//! Features:
+//! - Polls node_getStatus every 5 minutes
+//! - Stores metrics in SQLite with automatic rollup
+//! - Serves historical data via HTTP API
+//!
+//! Usage:
+//!   botho-metrics-daemon --node-url http://127.0.0.1:17101 --db /var/lib/botho-faucet/metrics.db
+
+mod db;
+mod collector;
+mod api;
+mod rollup;
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::Parser;
+use tracing::{info, error, Level};
+use tracing_subscriber::FmtSubscriber;
+
+use db::MetricsDb;
+
+/// Botho Metrics Daemon - Historical metrics collection for faucet
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    /// URL of the Botho node RPC endpoint
+    #[arg(long, default_value = "http://127.0.0.1:17101")]
+    node_url: String,
+
+    /// Path to the SQLite database file
+    #[arg(long, default_value = "/var/lib/botho-faucet/metrics.db")]
+    db: PathBuf,
+
+    /// Port for the metrics API server
+    #[arg(long, default_value = "17102")]
+    api_port: u16,
+
+    /// Collection interval in seconds (default: 300 = 5 minutes)
+    #[arg(long, default_value = "300")]
+    interval: u64,
+
+    /// Run once and exit (for cron-based operation)
+    #[arg(long)]
+    once: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .init();
+
+    let args = Args::parse();
+
+    info!("Botho Metrics Daemon starting");
+    info!("Node URL: {}", args.node_url);
+    info!("Database: {:?}", args.db);
+
+    // Ensure parent directory exists
+    if let Some(parent) = args.db.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // Initialize database
+    let db = Arc::new(Mutex::new(MetricsDb::open(&args.db)?));
+    info!("Database initialized");
+
+    // If --once flag is set, collect once and exit
+    if args.once {
+        info!("Running single collection (--once mode)");
+        if let Err(e) = collector::collect_metrics(&args.node_url, &db).await {
+            error!("Failed to collect metrics: {}", e);
+            return Err(e);
+        }
+
+        // Run rollup
+        {
+            let mut db_lock = db.lock().unwrap();
+            rollup::run_rollup(&mut db_lock)?;
+        }
+
+        info!("Collection complete, exiting");
+        return Ok(());
+    }
+
+    // Start API server
+    let db_clone = db.clone();
+    let api_addr = format!("0.0.0.0:{}", args.api_port);
+    info!("Starting API server on {}", api_addr);
+
+    tokio::spawn(async move {
+        if let Err(e) = api::serve(api_addr, db_clone).await {
+            error!("API server error: {}", e);
+        }
+    });
+
+    // Start collection loop
+    let collection_interval = Duration::from_secs(args.interval);
+    info!("Starting collection loop (interval: {:?})", collection_interval);
+
+    let mut interval_timer = tokio::time::interval(collection_interval);
+
+    // Run rollup every hour
+    let mut rollup_counter = 0u32;
+    let rollups_per_hour = 3600 / args.interval as u32;
+
+    loop {
+        interval_timer.tick().await;
+
+        // Collect metrics
+        match collector::collect_metrics(&args.node_url, &db).await {
+            Ok(()) => info!("Metrics collected successfully"),
+            Err(e) => error!("Failed to collect metrics: {}", e),
+        }
+
+        // Run rollup every hour
+        rollup_counter += 1;
+        if rollup_counter >= rollups_per_hour {
+            rollup_counter = 0;
+            let mut db_lock = db.lock().unwrap();
+            match rollup::run_rollup(&mut db_lock) {
+                Ok(()) => info!("Rollup completed successfully"),
+                Err(e) => error!("Rollup failed: {}", e),
+            }
+        }
+    }
+}

--- a/infra/faucet/metrics-daemon/src/rollup.rs
+++ b/infra/faucet/metrics-daemon/src/rollup.rs
@@ -1,0 +1,152 @@
+//! Rollup and retention management
+//!
+//! Aggregates fine-grained data into coarser granularities and
+//! enforces retention policies.
+//!
+//! Retention policy:
+//! - 5-minute samples: 24 hours
+//! - Hourly aggregates: 30 days
+//! - Daily aggregates: 1 year
+
+use anyhow::Result;
+use chrono::{Utc, Duration, Timelike};
+use tracing::{info, debug};
+
+use crate::db::MetricsDb;
+
+/// Retention periods in seconds
+const RETENTION_5MIN: i64 = 24 * 3600;           // 24 hours
+const RETENTION_HOURLY: i64 = 30 * 24 * 3600;    // 30 days
+const RETENTION_DAILY: i64 = 365 * 24 * 3600;    // 1 year
+
+/// Run the complete rollup process
+pub fn run_rollup(db: &mut MetricsDb) -> Result<()> {
+    let now = Utc::now();
+
+    // Aggregate to hourly
+    aggregate_hourly(db, now)?;
+
+    // Aggregate to daily
+    aggregate_daily(db, now)?;
+
+    // Cleanup old data
+    cleanup_old_data(db, now)?;
+
+    Ok(())
+}
+
+/// Aggregate 5min samples from the last 2 hours into hourly buckets
+fn aggregate_hourly(db: &mut MetricsDb, now: chrono::DateTime<Utc>) -> Result<()> {
+    // Process last 2 hours to ensure we catch any late data
+    let current_hour = now
+        .with_minute(0)
+        .and_then(|t| t.with_second(0))
+        .and_then(|t| t.with_nanosecond(0))
+        .unwrap_or(now);
+
+    for hours_ago in 1..=2 {
+        let hour_start = (current_hour - Duration::hours(hours_ago)).timestamp();
+        db.aggregate_to_hourly(hour_start)?;
+        debug!("Aggregated hour starting at {}", hour_start);
+    }
+
+    info!("Hourly aggregation complete");
+    Ok(())
+}
+
+/// Aggregate hourly samples from yesterday into daily buckets
+fn aggregate_daily(db: &mut MetricsDb, now: chrono::DateTime<Utc>) -> Result<()> {
+    // Process yesterday's data
+    let today_start = now
+        .with_hour(0)
+        .and_then(|t| t.with_minute(0))
+        .and_then(|t| t.with_second(0))
+        .and_then(|t| t.with_nanosecond(0))
+        .unwrap_or(now);
+
+    let yesterday_start = (today_start - Duration::days(1)).timestamp();
+
+    db.aggregate_to_daily(yesterday_start)?;
+    debug!("Aggregated day starting at {}", yesterday_start);
+
+    info!("Daily aggregation complete");
+    Ok(())
+}
+
+/// Clean up data older than retention period
+fn cleanup_old_data(db: &mut MetricsDb, now: chrono::DateTime<Utc>) -> Result<()> {
+    let now_ts = now.timestamp();
+
+    // Cleanup 5min samples older than 24h
+    let cleanup_5min_before = now_ts - RETENTION_5MIN;
+    let deleted_5min = db.cleanup_5min(cleanup_5min_before)?;
+    if deleted_5min > 0 {
+        info!("Deleted {} old 5min samples", deleted_5min);
+    }
+
+    // Cleanup hourly samples older than 30d
+    let cleanup_hourly_before = now_ts - RETENTION_HOURLY;
+    let deleted_hourly = db.cleanup_hourly(cleanup_hourly_before)?;
+    if deleted_hourly > 0 {
+        info!("Deleted {} old hourly samples", deleted_hourly);
+    }
+
+    // Cleanup daily samples older than 1y
+    let cleanup_daily_before = now_ts - RETENTION_DAILY;
+    let deleted_daily = db.cleanup_daily(cleanup_daily_before)?;
+    if deleted_daily > 0 {
+        info!("Deleted {} old daily samples", deleted_daily);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+    use crate::db::MetricsSample;
+
+    #[test]
+    fn test_rollup_aggregation() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let mut db = MetricsDb::open(&db_path).unwrap();
+
+        // Use current time rounded to start of hour
+        let now = Utc::now();
+        let base_time = now
+            .with_minute(0)
+            .and_then(|t| t.with_second(0))
+            .and_then(|t| t.with_nanosecond(0))
+            .unwrap_or(now)
+            .timestamp();
+
+        // Insert 12 samples (one per 5 minutes = 1 hour of data)
+        for i in 0..12 {
+            let sample = MetricsSample {
+                timestamp: base_time + i * 300, // Every 5 minutes
+                height: 1000 + i as u64,
+                peer_count: 5.0,
+                scp_peer_count: 3.0,
+                mempool_size: 10.0 + i as f64,
+                tx_delta: 10,
+                uptime_seconds: 1000,
+                minting_active: true,
+            };
+            db.insert_sample(&sample).unwrap();
+        }
+
+        // Aggregate to hourly
+        db.aggregate_to_hourly(base_time).unwrap();
+
+        // Query should return data within the last 24h
+        let query = crate::db::HistoryQuery {
+            metric: "height".to_string(),
+            period: "24h".to_string(),
+            granularity: "5min".to_string(),
+        };
+        let data = db.query_history(&query).unwrap();
+        assert_eq!(data.len(), 12);
+    }
+}


### PR DESCRIPTION
## Summary

- Implements standalone Rust daemon (`botho-metrics-daemon`) that polls `node_getStatus` RPC every 5 minutes
- Stores metrics in SQLite with automatic rollup to hourly (30d) and daily (1y) aggregates
- Serves historical data via HTTP API at `/api/metrics/history` and `/api/metrics/latest`
- Adds systemd service and nginx config for deployment

## Test plan

- [x] Build passes: `cargo build -p botho-metrics-daemon`
- [x] Tests pass: `cargo test -p botho-metrics-daemon`
- [ ] Manual testing against running node
- [ ] Deploy to testnet faucet server

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)