### PR TITLE
feat(infra): Add nginx caching for RPC responses

### DIFF
--- a/infra/faucet/faucet-nginx.conf
+++ b/infra/faucet/faucet-nginx.conf
@@ -5,13 +5,39 @@
 # - Proxies /rpc requests to the local Botho node on port 17101
 # - Handles SSL/TLS termination
 # - Provides CORS headers for fetch() API calls
+# - Caches RPC responses for stats endpoints (see #309)
 #
 # Installation:
 #   1. Copy this file to /etc/nginx/sites-available/faucet.botho.io
 #   2. Create symlink: ln -s /etc/nginx/sites-available/faucet.botho.io /etc/nginx/sites-enabled/
-#   3. Copy web files: cp -r web/* /var/www/faucet/
-#   4. Test config: nginx -t
-#   5. Reload: systemctl reload nginx
+#   3. Create cache directory: mkdir -p /var/cache/nginx/rpc && chown www-data:www-data /var/cache/nginx/rpc
+#   4. Copy web files: cp -r web/* /var/www/faucet/
+#   5. Test config: nginx -t
+#   6. Reload: systemctl reload nginx
+
+# =============================================================================
+# RPC Response Caching
+# =============================================================================
+# Cache zone for RPC responses (stats endpoints only)
+# - 10m keys_zone = ~80,000 cache keys in shared memory
+# - 100m max_size = 100MB on disk
+# - 60m inactive = purge entries not accessed for 60 minutes
+proxy_cache_path /var/cache/nginx/rpc levels=1:2 keys_zone=rpc_cache:10m
+                 max_size=100m inactive=60m use_temp_path=off;
+
+# Map RPC method to cache bypass flag
+# - 0 = cache the response (stats endpoints)
+# - 1 = bypass cache (all other methods, especially faucet_request)
+#
+# Note: Standard nginx doesn't support per-method TTLs with proxy_cache_valid.
+# We use a conservative 10s TTL for all cached methods. For method-specific
+# TTLs (10s for node_getStatus, 30s for faucet_getStats), use the OpenResty
+# configuration in the documentation below.
+map $request_body $rpc_cache_bypass {
+    default                                       1;
+    "~*\"method\"\\s*:\\s*\"node_getStatus\""     0;
+    "~*\"method\"\\s*:\\s*\"faucet_getStats\""    0;
+}
 
 # Redirect HTTP to HTTPS
 server {
@@ -102,6 +128,34 @@ server {
         proxy_send_timeout 30s;
         proxy_read_timeout 30s;
 
+        # =========================================================================
+        # RPC Response Caching (see #309)
+        # =========================================================================
+        # Ensure request body is buffered for cache key (must fit in memory)
+        client_body_buffer_size 64k;
+
+        # Enable caching for stats endpoints only
+        proxy_cache rpc_cache;
+        proxy_cache_methods POST;
+        proxy_cache_key "$request_body";
+
+        # Cache successful responses for 10 seconds (conservative TTL)
+        # Note: Standard nginx doesn't support per-method TTLs. Both
+        # node_getStatus and faucet_getStats use 10s. For method-specific
+        # TTLs, use OpenResty (see infra/faucet/README.md).
+        proxy_cache_valid 200 10s;
+
+        # Bypass cache for non-stats methods (faucet_request, etc.)
+        # $rpc_cache_bypass is set by the map directive above:
+        # - 0 for node_getStatus and faucet_getStats (cache)
+        # - 1 for all other methods (bypass)
+        proxy_cache_bypass $rpc_cache_bypass;
+        proxy_no_cache $rpc_cache_bypass;
+
+        # Add cache status header for debugging
+        # Values: MISS, HIT, EXPIRED, STALE, UPDATING, REVALIDATED, BYPASS
+        add_header X-Cache-Status $upstream_cache_status always;
+
         # CORS headers
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS' always;
@@ -143,7 +197,10 @@ server {
         add_header 'Access-Control-Allow-Headers' 'Content-Type' always;
 
         # Cache metrics responses for 1 minute
+        proxy_cache rpc_cache;
+        proxy_cache_key "$uri$is_args$args";
         proxy_cache_valid 200 1m;
+        add_header X-Cache-Status $upstream_cache_status always;
     }
 
     # Health check endpoint


### PR DESCRIPTION
## Summary

Implement nginx-level caching for `node_getStatus` and `faucet_getStats` RPC responses to reduce load on the Botho node and improve response times for the faucet web UI.

## Changes

- **Cache zone**: Added `proxy_cache_path` zone (100MB max, 60m inactive cleanup)
- **Method detection**: Map directive identifies cacheable RPC methods via request body regex
- **Caching policy**:
  - `node_getStatus`: 10s cache
  - `faucet_getStats`: 10s cache (conservative; use OpenResty for 30s)
  - `faucet_request`: bypass (never cached)
  - `/api/metrics`: 60s cache (fixed previous broken config)
- **Debugging**: X-Cache-Status header shows HIT/MISS/BYPASS
- **Documentation**: Updated README with caching section and acceptance criteria

## Technical Notes

Standard nginx doesn't support per-method TTLs with `proxy_cache_valid`. The implementation uses:
1. A `map` directive to detect RPC method from request body
2. `proxy_cache_bypass` and `proxy_no_cache` to conditionally bypass cache
3. A conservative 10s TTL for all cached methods

For exact per-method TTLs (10s/30s), the README documents an OpenResty/Lua alternative.

## Test Plan

After deployment:

```bash
# Verify node_getStatus is cached (second request should show HIT)
curl -s -X POST https://faucet.botho.io/rpc \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"node_getStatus","params":{},"id":1}' \
  -D - -o /dev/null | grep X-Cache-Status

# Verify faucet_request bypasses cache (should show BYPASS)
curl -s -X POST https://faucet.botho.io/rpc \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"faucet_request","params":{"address":"test"},"id":1}' \
  -D - -o /dev/null | grep X-Cache-Status
```

Closes #309