### PR TITLE
web: verify & harden web wallet + ledger browser (build, e2e, RPC wiring)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,38 @@ http://localhost:7101/
 ws://localhost:7101/ws
 ```
 
+### Public testnet endpoint
+
+The seed node exposes a CORS-enabled, read-only JSON-RPC endpoint for the
+public testnet. This is the endpoint the web wallet and ledger browser use:
+
+```bash
+# HTTPS JSON-RPC (read-only, CORS-enabled for browser fetch())
+https://seed.botho.io/rpc
+
+# WebSocket (real-time block/tx events)
+wss://seed.botho.io/rpc/ws
+```
+
+Example:
+
+```bash
+curl -s -X POST https://seed.botho.io/rpc \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"node_getStatus","params":{},"id":1}'
+```
+
+CORS for this endpoint is terminated at nginx (see
+`infra/seed/seed-nginx.conf`). nginx is the single CORS authority: it hides the
+upstream node's `Access-Control-Allow-Origin` header and emits a single `*`
+value. Both the wildcard `add_header` and the `proxy_hide_header` directives
+must be present in the deployed config — otherwise browsers reject responses
+that carry two `Access-Control-Allow-Origin` values.
+
+> Note: `faucet_request` / `faucet_getStatus` are only served by a node with the
+> faucet enabled (the separate `faucet.botho.io` deployment), not by the seed
+> node.
+
 ## Request Format
 
 All requests use JSON-RPC 2.0:

--- a/infra/seed/seed-nginx.conf
+++ b/infra/seed/seed-nginx.conf
@@ -154,11 +154,21 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
-        # Hide upstream CORS headers to prevent duplicates
-        # (Botho node sets its own, nginx adds ours below)
+        # Hide upstream CORS headers to prevent duplicates.
+        #
+        # IMPORTANT: The Botho node sets its own Access-Control-Allow-Origin
+        # (echoing the request Origin, plus "Vary: Origin"). nginx adds a
+        # wildcard "*" below. If the upstream headers are NOT hidden, the
+        # browser receives TWO Access-Control-Allow-Origin values
+        # (e.g. "https://botho.io, *") and rejects the response with:
+        #   "The 'Access-Control-Allow-Origin' header contains multiple
+        #    values ... but only one is allowed."
+        # These proxy_hide_header directives MUST be present (and the conf
+        # redeployed) for the web wallet/explorer to reach this RPC.
         proxy_hide_header 'Access-Control-Allow-Origin';
         proxy_hide_header 'Access-Control-Allow-Methods';
         proxy_hide_header 'Access-Control-Allow-Headers';
+        proxy_hide_header 'Vary';
 
         # Timeout settings
         proxy_connect_timeout 10s;

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,104 @@
+# Botho Web
+
+Monorepo for Botho's web apps:
+
+- **`packages/web-wallet`** (`@botho/web-wallet`) — the public web wallet and
+  ledger browser / block explorer served at `https://botho.io`. Routes:
+  `/` (landing), `/wallet`, `/explorer`, `/explorer/block/:hash`,
+  `/explorer/tx/:hash`, `/docs`.
+- **`packages/desktop`** (`@botho/desktop`) — the desktop (Tauri) wallet UI.
+- **`packages/features`** — shared feature components, including the explorer
+  (`src/explorer/*`).
+- **`packages/adapters`** — node adapters, including the JSON-RPC
+  `RemoteNodeAdapter`.
+- **`packages/core`**, **`packages/ui`** — shared core logic and UI components.
+
+## Prerequisites
+
+- Node.js 20+
+- [pnpm](https://pnpm.io/) (the workspace uses pnpm workspaces)
+
+## Install & build
+
+```bash
+cd web
+pnpm install
+pnpm build        # builds all packages
+pnpm typecheck    # type-checks all packages
+pnpm test:run     # vitest unit tests
+```
+
+## RPC endpoint configuration
+
+The web wallet and explorer read chain data over JSON-RPC 2.0. The default
+testnet endpoint is the seed node's CORS-enabled read RPC:
+
+```
+https://seed.botho.io/rpc
+```
+
+This is configured in `packages/web-wallet/src/config/networks.ts` and can be
+overridden at build time:
+
+```bash
+# Point the wallet/explorer at a different RPC (absolute or same-origin path)
+VITE_RPC_ENDPOINT=https://my-node.example/rpc pnpm build:web
+
+# Use a same-origin proxy path (recommended for local dev / e2e to avoid CORS).
+# The wallet's vite config proxies /rpc -> https://seed.botho.io.
+VITE_RPC_ENDPOINT=/rpc pnpm build:web
+```
+
+See `docs/api.md` ("Public testnet endpoint") for endpoint details and the CORS
+requirements enforced by `infra/seed/seed-nginx.conf`.
+
+The `RemoteNodeAdapter` accepts both absolute endpoints
+(`https://seed.botho.io/rpc`) and relative same-origin paths (`/rpc`); the
+latter is resolved against the page origin.
+
+## End-to-end tests (Playwright)
+
+E2E specs live under `e2e/` (smoke, wallet, explorer, faucet).
+
+By default the suite is **self-contained**: it builds the web wallet (with
+`VITE_RPC_ENDPOINT=/rpc`), serves it via `vite preview` on
+`http://localhost:4173`, serves the faucet static site
+(`infra/faucet/web`) on `http://localhost:4174`, and points the wallet/explorer
+at the live seed node through the same-origin `/rpc` proxy. This means the suite
+does not depend on `https://botho.io` / `https://faucet.botho.io` being up.
+
+```bash
+# Install the Playwright browser once
+npx playwright install chromium
+
+# Run the smoke suite
+pnpm test:e2e:smoke
+
+# Run everything
+pnpm test:e2e
+```
+
+### Running options (env vars)
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `E2E_WEB_BASE_URL` | `http://localhost:4173` | Point wallet/explorer specs at a remote deployment (e.g. `https://botho.io`). Disables the local web server. |
+| `E2E_FAUCET_BASE_URL` | `http://localhost:4174` | Point faucet specs at a remote deployment. Disables the local faucet server. |
+| `E2E_BROWSER_CHANNEL` | _(bundled chromium)_ | Set to `chrome` to use the system-installed Google Chrome instead of Playwright's bundled browser (useful where the bundled browser cannot be downloaded). |
+| `E2E_VIDEO` | `retain-on-failure` | Set to `off` in environments without Playwright's ffmpeg build. |
+
+Example (run against the live deployment using system Chrome):
+
+```bash
+E2E_WEB_BASE_URL=https://botho.io \
+E2E_FAUCET_BASE_URL=https://faucet.botho.io \
+E2E_BROWSER_CHANNEL=chrome \
+  pnpm test:e2e
+```
+
+## Deploy
+
+```bash
+pnpm deploy           # build web wallet + deploy to Cloudflare Pages
+pnpm deploy:preview   # deploy a preview build
+```

--- a/web/e2e/fixtures/test-data.ts
+++ b/web/e2e/fixtures/test-data.ts
@@ -5,11 +5,22 @@
  */
 
 // Service URLs
+//
+// By default the e2e suite runs against locally-served builds (started by the
+// Playwright `webServer` config) so it is deterministic and CI-friendly:
+//   - Web wallet / explorer: http://localhost:4173  (vite preview of web-wallet)
+//   - Faucet static site:    http://localhost:4174  (infra/faucet/web)
+//
+// To run against the live deployment instead, set the env vars:
+//   E2E_WEB_BASE_URL=https://botho.io E2E_FAUCET_BASE_URL=https://faucet.botho.io
+const WEB_BASE = process.env.E2E_WEB_BASE_URL ?? 'http://localhost:4173'
+const FAUCET_BASE = process.env.E2E_FAUCET_BASE_URL ?? 'http://localhost:4174'
+
 export const URLS = {
-  WALLET: 'https://botho.io/wallet',
-  EXPLORER: 'https://botho.io/explorer',
-  FAUCET: 'https://faucet.botho.io',
-  LANDING: 'https://botho.io',
+  WALLET: `${WEB_BASE}/wallet`,
+  EXPLORER: `${WEB_BASE}/explorer`,
+  FAUCET: FAUCET_BASE,
+  LANDING: WEB_BASE,
 } as const
 
 // Standard BIP39 test mnemonics - produce deterministic addresses

--- a/web/e2e/playwright.config.ts
+++ b/web/e2e/playwright.config.ts
@@ -1,4 +1,20 @@
 import { defineConfig, devices } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Base URLs for the apps under test.
+ *
+ * By default the suite spins up local servers (see `webServer` below) so the
+ * tests are deterministic and do not depend on the live deployment being up.
+ * Set E2E_WEB_BASE_URL / E2E_FAUCET_BASE_URL to point at a remote deployment
+ * (e.g. https://botho.io); in that case the local servers are not started.
+ */
+const WEB_BASE_URL = process.env.E2E_WEB_BASE_URL ?? 'http://localhost:4173'
+const FAUCET_BASE_URL = process.env.E2E_FAUCET_BASE_URL ?? 'http://localhost:4174'
+const useLocalServers = !process.env.E2E_WEB_BASE_URL && !process.env.E2E_FAUCET_BASE_URL
 
 /**
  * Playwright E2E test configuration for Botho web services.
@@ -12,11 +28,14 @@ import { defineConfig, devices } from '@playwright/test'
  */
 export default defineConfig({
   testDir: './tests',
-  fullyParallel: true,
+  // Run serially by default: the wallet/explorer specs share a single
+  // vite-preview /rpc proxy to a live seed node, and running many browser
+  // contexts in parallel against it caused intermittent "connecting" flakes.
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
-  // Limit workers to avoid network issues with external services
-  workers: process.env.CI ? 1 : 2,
+  // A couple of retries absorb transient slowness from the shared public RPC.
+  retries: process.env.CI ? 2 : 1,
+  workers: 1,
   timeout: 60_000, // 60s default timeout for blockchain operations
 
   outputDir: '../test-results/artifacts',
@@ -30,8 +49,43 @@ export default defineConfig({
   use: {
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    // Video recording requires Playwright's ffmpeg build. Default to capturing
+    // on failure; set E2E_VIDEO=off for environments where ffmpeg is unavailable.
+    video: (process.env.E2E_VIDEO as 'off' | 'retain-on-failure') || 'retain-on-failure',
+    // Browser channel. Defaults to Playwright's bundled chromium (works in CI
+    // after `npx playwright install chromium`). For local runs where the
+    // bundled browser cannot be downloaded, set E2E_BROWSER_CHANNEL=chrome to
+    // use the system-installed Google Chrome instead.
+    channel: process.env.E2E_BROWSER_CHANNEL || undefined,
   },
+
+  // Start local servers for the web wallet/explorer and the faucet site unless
+  // the suite is pointed at a remote deployment via env vars.
+  webServer: useLocalServers
+    ? [
+        {
+          // Build the web wallet with the RPC endpoint pointed at the
+          // same-origin /rpc proxy (configured in the wallet's vite preview
+          // config to forward to https://seed.botho.io), then serve
+          // landing/wallet/explorer as a SPA via vite preview on port 4173.
+          // This lets the explorer perform a real RPC read in e2e without
+          // depending on cross-origin CORS.
+          command:
+            'VITE_RPC_ENDPOINT=/rpc pnpm --filter @botho/web-wallet build && pnpm --filter @botho/web-wallet preview --port 4173 --strictPort',
+          cwd: path.resolve(__dirname, '..'),
+          url: 'http://localhost:4173/',
+          reuseExistingServer: !process.env.CI,
+          timeout: 180_000,
+        },
+        {
+          command: 'node e2e/serve-faucet.mjs',
+          cwd: path.resolve(__dirname, '..'),
+          url: 'http://localhost:4174/',
+          reuseExistingServer: !process.env.CI,
+          timeout: 30_000,
+        },
+      ]
+    : undefined,
 
   projects: [
     // Smoke tests - run first, quick sanity check
@@ -39,6 +93,7 @@ export default defineConfig({
       name: 'smoke',
       use: {
         ...devices['Desktop Chrome'],
+        baseURL: WEB_BASE_URL,
       },
       testMatch: /smoke\.spec\.ts/,
     },
@@ -48,7 +103,7 @@ export default defineConfig({
       name: 'web-wallet',
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: 'https://botho.io',
+        baseURL: WEB_BASE_URL,
       },
       testMatch: /wallet\/.*\.spec\.ts/,
     },
@@ -58,7 +113,7 @@ export default defineConfig({
       name: 'explorer',
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: 'https://botho.io',
+        baseURL: WEB_BASE_URL,
       },
       testMatch: /explorer\/.*\.spec\.ts/,
     },
@@ -68,7 +123,7 @@ export default defineConfig({
       name: 'faucet',
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: 'https://faucet.botho.io',
+        baseURL: FAUCET_BASE_URL,
       },
       testMatch: /faucet\/.*\.spec\.ts/,
     },

--- a/web/e2e/serve-faucet.mjs
+++ b/web/e2e/serve-faucet.mjs
@@ -1,0 +1,91 @@
+/**
+ * Minimal static file server for the faucet site (infra/faucet/web).
+ *
+ * Used by the Playwright `webServer` config to serve the faucet site locally
+ * during e2e runs, so the faucet specs do not depend on the live
+ * faucet.botho.io deployment being up.
+ *
+ * No external dependencies — uses only Node's built-in http/fs modules.
+ */
+import { createServer } from 'node:http'
+import { readFile, stat } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '../../infra/faucet/web')
+const PORT = Number(process.env.FAUCET_PORT ?? 4174)
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url ?? '/', `http://localhost:${PORT}`)
+    let pathname = decodeURIComponent(url.pathname)
+
+    // The faucet site issues same-origin POSTs to /rpc. There is no faucet
+    // backend in local e2e, so respond with a JSON-RPC error the client
+    // handles gracefully (renders #status-error / #result-banner).
+    if (pathname === '/rpc') {
+      res.writeHead(503, { 'Content-Type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Faucet backend not available in local e2e' },
+          id: null,
+        })
+      )
+      return
+    }
+
+    if (pathname === '/' || pathname.endsWith('/')) {
+      pathname += 'index.html'
+    }
+
+    const filePath = path.join(ROOT, path.normalize(pathname))
+    if (!filePath.startsWith(ROOT)) {
+      res.writeHead(403)
+      res.end('Forbidden')
+      return
+    }
+
+    const info = await stat(filePath).catch(() => null)
+    if (!info || !info.isFile()) {
+      // SPA-style fallback to index.html
+      const fallback = await readFile(path.join(ROOT, 'index.html')).catch(() => null)
+      if (fallback) {
+        res.writeHead(200, { 'Content-Type': MIME['.html'] })
+        res.end(fallback)
+        return
+      }
+      res.writeHead(404)
+      res.end('Not found')
+      return
+    }
+
+    const ext = path.extname(filePath)
+    const body = await readFile(filePath)
+    res.writeHead(200, { 'Content-Type': MIME[ext] ?? 'application/octet-stream' })
+    res.end(body)
+  } catch (err) {
+    res.writeHead(500)
+    res.end(`Server error: ${err instanceof Error ? err.message : String(err)}`)
+  }
+})
+
+server.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Faucet static server listening on http://localhost:${PORT} (root: ${ROOT})`)
+})

--- a/web/e2e/tests/explorer/blocks.spec.ts
+++ b/web/e2e/tests/explorer/blocks.spec.ts
@@ -1,15 +1,15 @@
 import { test, expect } from '@playwright/test'
 import { URLS, TIMEOUTS } from '../../fixtures/test-data'
 
-// Helper to wait for explorer to be ready (either block list or connecting message)
+// Helper to wait for the explorer to finish connecting. The search bar renders
+// once connected to the node; wait for it so subsequent block-list assertions
+// are not racing the connection handshake.
 async function waitForExplorerReady(page: import('@playwright/test').Page) {
-  // Wait for either blocks to load or connecting message
-  await Promise.race([
-    expect(page.getByText('Recent Blocks')).toBeVisible({ timeout: TIMEOUTS.NETWORK_REQUEST }),
-    expect(page.getByText('Connecting to network')).toBeVisible({ timeout: 5000 }),
-  ]).catch(() => {
-    // Ignore - we'll check in the test
-  })
+  await expect(page.getByPlaceholder(/Search by block height or hash/i))
+    .toBeVisible({ timeout: TIMEOUTS.WALLET_SYNC })
+    .catch(() => {
+      // If it never connects the individual tests handle the unconnected state.
+    })
 }
 
 test.describe('Explorer - Block List', () => {

--- a/web/e2e/tests/explorer/search.spec.ts
+++ b/web/e2e/tests/explorer/search.spec.ts
@@ -1,12 +1,13 @@
 import { test, expect } from '@playwright/test'
 import { URLS, TIMEOUTS, INVALID } from '../../fixtures/test-data'
 
-// Helper to wait for explorer to be ready
+// Helper to wait for the explorer to finish connecting. The search bar is only
+// rendered once connected to the node, so waiting for it is a reliable signal
+// that the explorer is ready for search interactions.
 async function waitForExplorerReady(page: import('@playwright/test').Page) {
-  await Promise.race([
-    expect(page.getByText('Recent Blocks')).toBeVisible({ timeout: TIMEOUTS.NETWORK_REQUEST }),
-    expect(page.getByText('Connecting to network')).toBeVisible({ timeout: 5000 }),
-  ]).catch(() => {})
+  await expect(page.getByPlaceholder(/Search by block height or hash/i)).toBeVisible({
+    timeout: TIMEOUTS.WALLET_SYNC,
+  })
 }
 
 test.describe('Explorer - Search', () => {

--- a/web/packages/adapters/src/remote.ts
+++ b/web/packages/adapters/src/remote.ts
@@ -21,10 +21,32 @@ import type {
 } from './types'
 
 const DEFAULT_CONFIG: Required<RemoteNodeConfig> = {
-  seedNodes: ['https://faucet.botho.io/rpc'],
-  networkId: 'botho-mainnet',
+  // Seed node read RPC (CORS-enabled, see infra/seed/seed-nginx.conf).
+  seedNodes: ['https://seed.botho.io/rpc'],
+  networkId: 'botho-testnet',
   timeout: 10000,
   useWebSocket: true,
+}
+
+/**
+ * Resolve an RPC endpoint (which may be absolute, e.g.
+ * "https://seed.botho.io/rpc", or relative, e.g. "/rpc" when served behind a
+ * same-origin proxy) into a URL object. Returns null if it cannot be parsed.
+ */
+function resolveUrl(endpoint: string): URL | null {
+  try {
+    return new URL(endpoint)
+  } catch {
+    // Relative endpoint - resolve against the page origin if available.
+    if (typeof window !== 'undefined' && window.location?.origin) {
+      try {
+        return new URL(endpoint, window.location.origin)
+      } catch {
+        return null
+      }
+    }
+    return null
+  }
 }
 
 /** JSON-RPC 2.0 request */
@@ -80,10 +102,11 @@ export class RemoteNodeAdapter implements NodeAdapter {
 
         if (result) {
           this.currentSeedUrl = seedUrl
+          const resolvedUrl = resolveUrl(seedUrl)
           this.currentNode = {
             id: seedUrl,
-            host: new URL(seedUrl).hostname,
-            port: 443,
+            host: resolvedUrl?.hostname ?? seedUrl,
+            port: resolvedUrl ? Number(resolvedUrl.port) || (resolvedUrl.protocol === 'http:' ? 80 : 443) : 443,
             version: result.version,
             blockHeight: result.chainHeight,
             networkId: result.network || this.config.networkId,
@@ -428,8 +451,16 @@ export class RemoteNodeAdapter implements NodeAdapter {
   }
 
   private setupWebSocket(seedUrl: string): void {
-    // Connect to node WebSocket endpoint for real-time events
-    const wsUrl = seedUrl.replace(/^http/, 'ws') + '/ws'
+    // Connect to node WebSocket endpoint for real-time events.
+    // Handle both absolute (https://host/rpc) and relative (/rpc) endpoints.
+    const resolved = resolveUrl(seedUrl)
+    if (!resolved) {
+      // Cannot derive a WebSocket URL; fall back to polling.
+      this.setWsStatus('disconnected')
+      return
+    }
+    const wsProtocol = resolved.protocol === 'https:' ? 'wss:' : 'ws:'
+    const wsUrl = `${wsProtocol}//${resolved.host}${resolved.pathname}/ws`
 
     this.setWsStatus(this.wsReconnectAttempt > 0 ? 'reconnecting' : 'connecting')
 

--- a/web/packages/features/src/explorer/components/search-bar.tsx
+++ b/web/packages/features/src/explorer/components/search-bar.tsx
@@ -25,12 +25,18 @@ export function SearchBar({
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && search()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  // Pass the current input value to avoid racing the async
+                  // searchQuery state update.
+                  search((e.target as HTMLInputElement).value)
+                }
+              }}
               placeholder={placeholder}
               className="w-full rounded-lg border border-[--color-slate]/50 bg-[--color-void]/50 py-2.5 pl-10 pr-4 font-mono text-sm text-[--color-light] placeholder:text-[--color-dim] focus:border-[--color-pulse] focus:outline-none focus:ring-1 focus:ring-[--color-pulse]"
             />
           </div>
-          <Button onClick={search} disabled={loading}>
+          <Button onClick={() => search()} disabled={loading}>
             {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Search'}
           </Button>
         </div>

--- a/web/packages/features/src/explorer/context.tsx
+++ b/web/packages/features/src/explorer/context.tsx
@@ -88,27 +88,23 @@ export function ExplorerProvider({ dataSource, isReady = true, initialQuery, onV
     }
   }, [dataSource, isReady, blocks, loadingMore])
 
-  // Search by height or hash
-  const search = useCallback(async () => {
-    if (!isReady || !searchQuery.trim()) return
+  // Search by height or hash. Accepts an optional query override so callers
+  // (e.g. pressing Enter immediately after typing) can pass the current input
+  // value without racing the async searchQuery state update.
+  const search = useCallback(async (queryOverride?: string) => {
+    const raw = queryOverride ?? searchQuery
+    if (!isReady || !raw.trim()) return
 
     setLoading(true)
     setError(null)
 
-    const query = searchQuery.trim()
+    const query = raw.trim()
 
     try {
-      // Check if it's a block height (number)
-      if (/^\d+$/.test(query)) {
-        const block = await dataSource.getBlock(parseInt(query, 10))
-        if (block) {
-          setView({ mode: 'block', block })
-        } else {
-          setError(`Block at height ${query} not found`)
-        }
-      }
-      // Check if it's a hash (64 hex chars)
-      else if (/^[0-9a-fA-F]{64}$/.test(query)) {
+      // Check if it's a hash (64 hex chars) FIRST. An all-numeric 64-char
+      // value (e.g. an all-zeros hash) is a hash, not a block height, so the
+      // hash check must take precedence over the numeric-height check below.
+      if (/^[0-9a-fA-F]{64}$/.test(query)) {
         // Try as block hash first
         const block = await dataSource.getBlock(query)
         if (block) {
@@ -121,6 +117,15 @@ export function ExplorerProvider({ dataSource, isReady = true, initialQuery, onV
           } else {
             setError('Block or transaction not found')
           }
+        }
+      }
+      // Otherwise check if it's a block height (number)
+      else if (/^\d+$/.test(query)) {
+        const block = await dataSource.getBlock(parseInt(query, 10))
+        if (block) {
+          setView({ mode: 'block', block })
+        } else {
+          setError(`Block at height ${query} not found`)
         }
       } else {
         setError('Invalid search query. Enter a block height or hash.')

--- a/web/packages/features/src/explorer/types.ts
+++ b/web/packages/features/src/explorer/types.ts
@@ -53,8 +53,9 @@ export interface ExplorerContextValue {
   /** Set search query */
   setSearchQuery: (query: string) => void
 
-  /** Execute search */
-  search: () => Promise<void>
+  /** Execute search. Optionally pass the query to search directly (avoids a
+   *  race with the async searchQuery state update on rapid input + Enter). */
+  search: (queryOverride?: string) => Promise<void>
 
   /** View a specific block */
   viewBlock: (blockOrHeightOrHash: Block | number | string) => Promise<void>

--- a/web/packages/web-wallet/src/config/networks.ts
+++ b/web/packages/web-wallet/src/config/networks.ts
@@ -34,7 +34,10 @@ export const NETWORKS: Record<string, NetworkConfig> = {
   testnet: {
     id: 'testnet',
     name: 'Testnet',
-    rpcEndpoint: getEnvRpcEndpoint() || 'https://faucet.botho.io/rpc',
+    // Read RPC is served by the seed node at https://seed.botho.io/rpc
+    // (CORS-enabled via infra/seed/seed-nginx.conf). The faucet endpoint is a
+    // separate deployment used only for faucet_request / faucet_getStatus.
+    rpcEndpoint: getEnvRpcEndpoint() || 'https://seed.botho.io/rpc',
     faucetEndpoint: getEnvFaucetEndpoint() || 'https://faucet.botho.io/rpc',
     explorerUrl: 'https://botho.io/explorer',
     networkId: 'botho-testnet',

--- a/web/packages/web-wallet/vite.config.ts
+++ b/web/packages/web-wallet/vite.config.ts
@@ -74,6 +74,23 @@ export default defineConfig({
         target: 'https://seed.botho.io',
         changeOrigin: true,
       },
+      // Same-origin proxy to the seed node read RPC. Used during local dev and
+      // e2e (build with VITE_RPC_ENDPOINT=/rpc) so the app reaches a real node
+      // without depending on cross-origin CORS.
+      '/rpc': {
+        target: 'https://seed.botho.io',
+        changeOrigin: true,
+      },
+    },
+  },
+  // `vite preview` (used by the e2e webServer) needs the same /rpc proxy as the
+  // dev server so the served production build can reach the seed node RPC.
+  preview: {
+    proxy: {
+      '/rpc': {
+        target: 'https://seed.botho.io',
+        changeOrigin: true,
+      },
     },
   },
   build: {


### PR DESCRIPTION
Closes #322

## Summary

Verified and hardened the web wallet and ledger browser (block explorer). The deployed app was **non-functional**, and this PR fixes the root causes and makes the e2e suite deterministic.

### Functional verdict (before this PR)
- **Build**: clean (no build errors found).
- **Wallet**: created/loaded fine in the UI, but **never read a balance** — the configured testnet RPC pointed at `https://faucet.botho.io/rpc`, which is **down** (connection refused).
- **Ledger browser**: stuck on "Connecting to network..." (true on the live https://botho.io site as well), so it showed **no blocks**.
- **e2e**: pointed at production URLs (`https://botho.io`, `https://faucet.botho.io`); the faucet site is down so faucet specs could never pass; not runnable in CI.

### Root causes fixed
1. **Dead RPC endpoint.** Testnet RPC defaulted to the unreachable `faucet.botho.io/rpc`. Repointed wallet config + adapter defaults to the verified, CORS-enabled seed read RPC `https://seed.botho.io/rpc` (`node_getStatus` returns chainHeight 1320, synced).
2. **Adapter crashed on relative URLs.** `RemoteNodeAdapter.connect()` did `new URL(seedUrl)`, which **throws** for a relative `/rpc` endpoint (used behind a same-origin proxy). The throw was swallowed by `catch { continue }`, so `connect()` always reported failure → explorer/wallet permanently "Connecting". Added `resolveUrl()` to handle absolute and relative endpoints, and fixed WebSocket URL derivation the same way.
3. **Explorer search bugs.** An all-zeros 64-char hash was matched by the numeric-height check first and resolved to genesis **block #0** instead of "not found" — fixed by checking the hash pattern first. Also fixed an Enter-key race that searched a stale query (button worked, Enter didn't).

### Verified real RPC reads (acceptance criteria)
- Ledger browser loads **recent blocks from RPC** (heights 1320..1311 with real hashes/rewards) and opens **block detail** from RPC.
- Web wallet performs a real **`wallet_getBalance`** read (plus `chain_getOutputs`) against the seed node after wallet load.

### e2e (Playwright) — now deterministic
- Serves the built wallet via `vite preview` (port 4173) and the faucet static site `infra/faucet/web` (port 4174) locally; proxies `/rpc` to the seed node so the explorer/wallet do real RPC reads without cross-origin CORS.
- Base URLs are env-overridable (`E2E_WEB_BASE_URL` / `E2E_FAUCET_BASE_URL`) to target the live deployment; browser channel and video are env-configurable for restricted environments.
- Runs serially (the specs share one live public RPC; parallel runs flaked on "connecting").

**Result:** `56 passed, 3 skipped, 0 failed` across smoke + wallet + explorer + faucet. (The 3 skips are pre-existing `test.skip()` guards in block-detail specs.) Unit tests: `75 passed`. Build + typecheck: clean.

### RPC endpoint documentation
- `docs/api.md`: added a "Public testnet endpoint" section (`https://seed.botho.io/rpc`, `wss://.../rpc/ws`) and the CORS contract.
- `web/README.md`: build, RPC config (`VITE_RPC_ENDPOINT`), and e2e instructions.
- `infra/seed/seed-nginx.conf`: documented/strengthened the single-CORS-authority setup (hide upstream `Vary`; explain why duplicate `Access-Control-Allow-Origin` headers break browsers).

## What still doesn't work (filed as focused follow-ups)
- **#329** — the **deployed** `seed.botho.io/rpc` still returns **two** `Access-Control-Allow-Origin` headers (stale nginx conf), so the **live** botho.io app remains broken until the updated conf is redeployed; `/rpc/ws` returns 400. (Operational/redeploy fix.)
- **#330** — explorer **block-by-hash** (no RPC method) and **tx-by-hash** (adapter stub) lookups; deep links / hash search show "not found".
- **#331** — `faucet.botho.io` is **down** and the faucet RPC is disabled on the seed node; the web faucet flow can't work end-to-end until redeployed.

## Test plan
- [x] `pnpm install && pnpm build` clean for all `web/packages/*`
- [x] `pnpm typecheck` clean; `pnpm test:run` 75 passed
- [x] `pnpm test:e2e` (smoke + wallet + explorer + faucet): 56 passed, 3 skipped, 0 failed
- [x] Explorer loads recent blocks + block detail from RPC; wallet does a real balance read
- [ ] Redeploy `infra/seed/seed-nginx.conf` so the live site connects (tracked in #329)

🤖 Generated with [Claude Code](https://claude.com/claude-code)