### PR TITLE
fix(consensus): widen cumulative lottery-pool balance to u128 (conservation at scale)

### DIFF
--- a/botho/src/consensus/block_builder.rs
+++ b/botho/src/consensus/block_builder.rs
@@ -223,7 +223,7 @@ impl BlockBuilder {
     pub fn apply_lottery<F>(
         mut block: Block,
         candidates: &[LotteryCandidate],
-        stored_pool: u64,
+        stored_pool: u128,
         utxo_lookup: F,
         lottery_config: &LotteryFeeConfig,
     ) -> Block

--- a/botho/src/consensus/lottery.rs
+++ b/botho/src/consensus/lottery.rs
@@ -141,6 +141,14 @@ impl BlockLotteryResult {
 /// CONSENSUS-CRITICAL: every field is a deterministic integer function of
 /// (block fees, block reward, height schedule, stored pool balance), all of
 /// which are consensus state — proposer and validators must agree exactly.
+///
+/// Width note: the per-block amounts (`fee_pool`, `fee_burn`, `emission_share`,
+/// `payout`) stay `u64`. Each is bounded by a single block: fee shares are a
+/// split of one block's `total_fees` (itself `u64`), `emission_share` is a
+/// fraction of one block reward, and `payout` is capped at one block reward.
+/// None can approach `u64::MAX` within a single block. Only the cumulative
+/// `available` carryover can grow unbounded across blocks, so it alone is
+/// widened to `u128`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LotteryPoolAccounting {
     /// Pool share of this block's transaction fees (80% by default).
@@ -151,7 +159,15 @@ pub struct LotteryPoolAccounting {
     /// the block reward; the miner receives the remainder).
     pub emission_share: u64,
     /// Total available to distribute: carryover + emission share + fee pool.
-    pub available: u64,
+    ///
+    /// This is the cumulative carryover balance and is the one field here that
+    /// can grow without bound: the pool drains at most one block reward per
+    /// block (the anti-grinding `payout` cap) but inflow per block is
+    /// `emission_share + fee_pool`, so sustained high-fee blocks accumulate.
+    /// It is therefore `u128` (the per-block amounts below stay `u64`): a `u64`
+    /// would saturate at `u64::MAX` (~18.4M BTH in picocredits) under sustained
+    /// inflow, silently losing value from supply conservation.
+    pub available: u128,
     /// Amount actually paid out this block: min(available, payout cap).
     ///
     /// The cap (one block reward) makes seed-grinding unprofitable by
@@ -162,8 +178,11 @@ pub struct LotteryPoolAccounting {
 
 impl LotteryPoolAccounting {
     /// Pool balance carried to the next block if `distributed` was paid out.
-    pub fn carryover_after(&self, distributed: u64) -> u64 {
-        self.available.saturating_sub(distributed)
+    ///
+    /// Returns the cumulative carryover as `u128`; `distributed` (a single
+    /// block's payout) is `u64` and widened for the subtraction.
+    pub fn carryover_after(&self, distributed: u64) -> u128 {
+        self.available.saturating_sub(distributed as u128)
     }
 }
 
@@ -179,15 +198,19 @@ impl LotteryPoolAccounting {
 pub fn compute_pool_accounting(
     total_fees: u64,
     emission_share: u64,
-    stored_pool: u64,
+    stored_pool: u128,
     payout_cap: u64,
     config: &LotteryFeeConfig,
 ) -> LotteryPoolAccounting {
     let (fee_pool, fee_burn) = config.split_fees(total_fees);
+    // Cumulative carryover: widened to u128 so sustained high-fee inflow can
+    // never saturate (see LotteryPoolAccounting::available).
     let available = stored_pool
-        .saturating_add(emission_share)
-        .saturating_add(fee_pool);
-    let payout = available.min(payout_cap);
+        .saturating_add(emission_share as u128)
+        .saturating_add(fee_pool as u128);
+    // payout is capped at one block reward (u64), so the min result always
+    // fits in u64; the cast is lossless by construction.
+    let payout = available.min(payout_cap as u128) as u64;
 
     LotteryPoolAccounting {
         fee_pool,
@@ -459,10 +482,10 @@ impl std::error::Error for LotteryValidationError {}
 pub fn validate_block_lottery(
     block: &crate::block::Block,
     candidates: &[LotteryCandidate],
-    stored_pool: u64,
+    stored_pool: u128,
     prev_block_hash: &[u8; 32],
     config: &LotteryFeeConfig,
-) -> Result<u64, LotteryValidationError> {
+) -> Result<u128, LotteryValidationError> {
     let total_fees = block.total_fees();
 
     // 1. Compute the expected pool accounting from consensus state: fees,
@@ -652,6 +675,79 @@ mod tests {
         let accounting = compute_pool_accounting(1000, 0, 0, 10_000, &config);
         assert_eq!(accounting.payout, 800);
         assert_eq!(accounting.carryover_after(accounting.payout), 0);
+    }
+
+    // Drive the cumulative carryover past u64::MAX by feeding sustained
+    // per-block fee inflow that exceeds the anti-grinding payout cap. The
+    // carryover must accumulate EXACTLY in u128 with no saturation or wrap,
+    // and the payout cap must still hold at that scale.
+    //
+    // Per block the maximum fee inflow is one block's `total_fees` (a u64);
+    // its 80% pool share is `0.8 * u64::MAX`, so a single block cannot push
+    // the carryover past u64::MAX, but a handful of sustained max-fee blocks
+    // do — exactly the regime where a u64 carryover would have saturated.
+    #[test]
+    fn test_pool_carryover_accumulates_past_u64_max_without_saturation() {
+        let config = LotteryFeeConfig::default();
+
+        // Largest possible single-block fee inflow.
+        let total_fees: u64 = u64::MAX;
+        let (fee_pool, _) = config.split_fees(total_fees);
+        let emission_share: u64 = 0;
+        let reward: u64 = 5_000_000; // payout cap = one block reward
+
+        // Net per-block growth of the carryover: inflow - payout cap. With a
+        // max-fee block this is ~0.8 * u64::MAX, so just a few blocks cross
+        // u64::MAX (and overflow a u64, which u128 must absorb exactly).
+        let inflow_per_block = fee_pool as u128 + emission_share as u128;
+        assert!(
+            inflow_per_block > reward as u128,
+            "test requires inflow above the payout cap so the pool grows"
+        );
+
+        // Reference carryover computed independently in u128.
+        let mut expected: u128 = 0;
+        let mut pool: u128 = 0;
+        let blocks = 4; // 4 * (0.8 * u64::MAX) far exceeds u64::MAX
+        for _ in 0..blocks {
+            let accounting =
+                compute_pool_accounting(total_fees, emission_share, pool, reward, &config);
+
+            // Anti-grinding cap preserved: payout == min(available, reward).
+            assert_eq!(
+                accounting.payout as u128,
+                accounting.available.min(reward as u128),
+                "payout must equal min(available, reward) at all scales"
+            );
+            // The pool always dwarfs the reward here, so the cap binds exactly.
+            assert_eq!(
+                accounting.payout, reward,
+                "payout must be capped at one block reward"
+            );
+
+            // Independent u128 reference: available = pool + emission + fee_pool,
+            // carryover = available - capped payout. No saturation expected.
+            let available_ref = pool + emission_share as u128 + fee_pool as u128;
+            assert_eq!(
+                accounting.available, available_ref,
+                "available must accumulate exactly in u128 (no saturation)"
+            );
+            expected = available_ref - reward as u128;
+
+            pool = accounting.carryover_after(accounting.payout);
+            assert_eq!(
+                pool, expected,
+                "carryover must accumulate exactly with no saturation/wrap"
+            );
+        }
+
+        // The pool has grown past what u64 could represent — proving the
+        // widening prevents the u64::MAX saturation this fix targets.
+        assert!(
+            pool > u64::MAX as u128,
+            "carryover ({pool}) should exceed u64::MAX ({})",
+            u64::MAX
+        );
     }
 
     #[test]

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -740,14 +740,19 @@ impl Ledger {
     /// Consensus state: the pool accumulates the fee pool share plus the
     /// height-scheduled emission share, and drains via capped per-block
     /// payouts. Missing key (fresh/pre-upgrade ledger) means zero.
-    pub fn get_lottery_pool(&self) -> Result<u64, LedgerError> {
+    ///
+    /// The balance is the cumulative carryover and can grow without bound under
+    /// sustained high-fee inflow, so it is `u128` (persisted as 16-byte LE).
+    pub fn get_lottery_pool(&self) -> Result<u128, LedgerError> {
         let rtxn = self
             .env
             .read_txn()
             .map_err(|e| LedgerError::Database(format!("Failed to start read txn: {}", e)))?;
         match self.meta_db.get(&rtxn, META_LOTTERY_POOL) {
-            Ok(Some(bytes)) if bytes.len() == 8 => {
-                Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
+            // Cumulative carryover persists as 16-byte LE u128 (widened from
+            // 8-byte u64 to prevent saturation; rides the testnet reset #323).
+            Ok(Some(bytes)) if bytes.len() == 16 => {
+                Ok(u128::from_le_bytes(bytes.try_into().unwrap_or([0u8; 16])))
             }
             Ok(_) => Ok(0),
             Err(e) => Err(LedgerError::Database(format!(
@@ -2584,7 +2589,7 @@ mod tests {
                 .sum();
             assert_eq!(
                 state.total_mined,
-                utxo_sum + state.total_fees_burned + pool as u128,
+                utxo_sum + state.total_fees_burned + pool,
                 "supply conservation violated"
             );
             state.height
@@ -2605,5 +2610,38 @@ mod tests {
         // Post-state unchanged and still conserved.
         let post_height = conserved(&ledger);
         assert_eq!(prev_height, post_height, "rejected block must not advance height");
+    }
+
+    // The cumulative lottery carryover persists as 16-byte LE u128. A value
+    // above u64::MAX must round-trip exactly through META_LOTTERY_POOL — this
+    // is the on-disk half of the u64->u128 widening (the saturation fix).
+    #[test]
+    fn test_lottery_pool_u128_persist_reload_roundtrip() {
+        let dir = tempdir().unwrap();
+
+        // A balance that no longer fits in u64 (would have saturated before).
+        let big_pool: u128 = (u64::MAX as u128) + 1_234_567;
+
+        {
+            let ledger = Ledger::open(dir.path()).unwrap();
+            let mut wtxn = ledger.env.write_txn().unwrap();
+            ledger
+                .meta_db
+                .put(&mut wtxn, META_LOTTERY_POOL, &big_pool.to_le_bytes())
+                .unwrap();
+            wtxn.commit().unwrap();
+
+            // Same handle reads it back exactly (16-byte LE decode).
+            assert_eq!(ledger.get_lottery_pool().unwrap(), big_pool);
+        }
+
+        // Reopen from disk: value survives a reload with no truncation.
+        let reopened = Ledger::open(dir.path()).unwrap();
+        assert_eq!(reopened.get_lottery_pool().unwrap(), big_pool);
+
+        // A fresh ledger (missing key) reads as zero.
+        let fresh_dir = tempdir().unwrap();
+        let fresh = Ledger::open(fresh_dir.path()).unwrap();
+        assert_eq!(fresh.get_lottery_pool().unwrap(), 0u128);
     }
 }

--- a/fuzz/fuzz_targets/fuzz_add_block.rs
+++ b/fuzz/fuzz_targets/fuzz_add_block.rs
@@ -121,7 +121,7 @@ fuzz_target!(|data: &[u8]| {
                 .get_lottery_pool()
                 .expect("lottery pool readable after successful add_block");
             let utxo_sum = sum_utxo_values(&ledger);
-            let accounted = utxo_sum + post.total_fees_burned + lottery_pool as u128;
+            let accounted = utxo_sum + post.total_fees_burned + lottery_pool;
             assert_eq!(
                 post.total_mined, accounted,
                 "supply conservation violated after accepted block: \

--- a/fuzz/fuzz_targets/fuzz_lottery_validation.rs
+++ b/fuzz/fuzz_targets/fuzz_lottery_validation.rs
@@ -52,7 +52,10 @@ struct FuzzData {
     /// Raw bytes decoded into a Block (arbitrary lottery_summary / outputs).
     block_bytes: Vec<u8>,
     candidates: Vec<FuzzCandidate>,
-    stored_pool: u64,
+    // Cumulative carryover pool is u128 (widened from u64 to prevent
+    // saturation under sustained inflow); fuzz the full range, including
+    // values above u64::MAX.
+    stored_pool: u128,
     prev_block_hash: [u8; 32],
 }
 


### PR DESCRIPTION
## Summary

The cumulative lottery-pool carryover was `u64` with `saturating_add`, so under sustained high-fee volume it grows toward `u64::MAX` and **saturates** — a supply-conservation failure (the pool balance silently stops tracking real value). The pool drains at most one block reward per block (the anti-grinding payout cap) but inflow per block is `emission_share + fee_pool`; whenever per-block fee inflow exceeds `(reward - emission_share)` the carryover grows without bound. Lower-severity sibling of #333 / PR #342: it saturates rather than wrapping, so it is conservation/liveness, not active inflation — but still wrong consensus accounting at scale. Same medicine: widen the cumulative balance to `u128`, keep per-block amounts `u64`.

## Changes

- `LotteryPoolAccounting.available` and `carryover_after()` return are now `u128`; `compute_pool_accounting`'s `stored_pool` param is `u128`. `payout = available.min(payout_cap as u128) as u64` — lossless because the cap is one block reward (u64).
- `validate_block_lottery` and `BlockBuilder::apply_lottery` take/return the carryover as `u128`.
- `Ledger::get_lottery_pool()` returns `u128`; `META_LOTTERY_POOL` persists as **16-byte LE** (was 8-byte), decoding `unwrap_or([0;16])`. Missing key still reads as 0.
- Dropped now-redundant `lottery_pool as u128` cast in `fuzz_add_block.rs` and the matching `pool as u128` in the ledger conservation test (clippy `unnecessary_cast`).
- Widened `fuzz_lottery_validation.rs` `FuzzData.stored_pool` to `u128` to match the signatures and fuzz the full range.

### Fields widened to u128 vs kept u64

| Field | Width | Justification |
|---|---|---|
| `available` / carryover / `META_LOTTERY_POOL` / `get_lottery_pool` | **u128** | Cumulative carryover; grows unbounded across blocks when inflow > payout cap; u64 would saturate at u64::MAX (~18.4M BTH in pico). |
| `fee_pool`, `fee_burn`, `emission_share`, `payout`, `payout_cap`, `total_fees` | u64 | Bounded by a single block: fee shares split one block's `total_fees`; emission share / payout / cap are fractions of one block reward. None can approach u64::MAX within a block. |

### Anti-grinding cap preserved

`payout == min(available, reward)` is computed in `u128` and cast back to `u64`; the new test asserts this holds even when `available > u64::MAX`.

### Serialization

`META_LOTTERY_POOL` on-disk encoding changes 8 -> 16 bytes. This is **consensus-state format**; it rides the planned testnet reset (#323) alongside #333, so no migration path is needed.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Carryover is u128; test drives pool past u64::MAX, accumulates exactly, cap still binds | done | `test_pool_carryover_accumulates_past_u64_max_without_saturation` (lottery.rs) asserts exact u128 accumulation + `payout == min(available, reward)` past u64::MAX |
| `META_LOTTERY_POOL` persists/reloads as 16-byte LE; round-trip green | done | `test_lottery_pool_u128_persist_reload_roundtrip` (store.rs): writes a value > u64::MAX, reads back, reopens from disk, fresh ledger reads 0 |
| Per-block amounts remain u64; single-block bound documented | done | doc-comment on `LotteryPoolAccounting`; see table above |
| Existing lottery/consensus tests pass; `cargo test -p botho`; `cargo build --release` | done | lib: 937 passed, 0 failed; release build green |
| Fuzz redundant cast removed; `cargo fuzz build` clean | done | `cd fuzz && cargo +nightly-2025-12-03 fuzz build` (cargo-fuzz 0.13.1) finished, all 15 targets, 0 errors/cast warnings |

## Test Plan

- `cargo test -p botho --lib` -> 937 passed, 0 failed (includes the two new tests).
- `cargo build --release -p botho` -> green.
- `cd fuzz && cargo +nightly-2025-12-03 fuzz build` -> green (Fuzz Build Guard).
- `cargo clippy -p botho --lib` -> no new warnings on changed files (no `unnecessary_cast` in lottery.rs / store.rs / block_builder.rs).

## Notes

- One pre-existing integration-test failure unrelated to this change: `rpc_integration::test_get_chain_info` asserts `totalMined.is_number()`, but PR #342 (#333) intentionally emits it as a decimal string. Filed separately as #345 to stay in scope.
- Picocredit unit unchanged.

Closes #343