### PR TITLE
test(rpc): assert totalMined is a parseable decimal string

### DIFF
--- a/botho/tests/rpc_integration.rs
+++ b/botho/tests/rpc_integration.rs
@@ -171,7 +171,10 @@ async fn test_get_chain_info() {
     assert!(result["height"].is_number());
     assert!(result["tipHash"].is_string());
     assert!(result["difficulty"].is_number());
-    assert!(result["totalMined"].is_number());
+    // totalMined is a u128 picocredit value emitted as a decimal string (PR #342)
+    // to avoid JS 2^53 precision loss; verify it is a well-formed unsigned integer.
+    assert!(result["totalMined"].is_string());
+    assert!(result["totalMined"].as_str().unwrap().parse::<u128>().is_ok());
     assert!(result["mempoolSize"].is_number());
     assert!(result["mempoolFees"].is_number());
 }


### PR DESCRIPTION
## Summary

Test-only fix for the `rpc_integration` regression introduced by PR #342.

PR #342 intentionally changed `getChainInfo` (and the supply-info handler) to emit `totalMined`, `totalFeesBurned`, and `circulatingSupply` as **decimal strings** instead of JSON numbers, because they are now `u128` picocredit values that exceed JavaScript's 2^53 safe-integer limit (`botho/src/rpc/mod.rs:774`). The integration test was not updated to match, so `test_get_chain_info` reliably failed on `main`.

## Change

`botho/tests/rpc_integration.rs:174` — replaced:

```rust
assert!(result["totalMined"].is_number());
```

with:

```rust
assert!(result["totalMined"].is_string());
assert!(result["totalMined"].as_str().unwrap().parse::<u128>().is_ok());
```

This keeps the assertion meaningful: it verifies the field is present and a well-formed decimal `u128`, matching #342's string encoding.

## Audit for siblings

Grepped all of `botho/tests/` and the `#[test]`/`#[tokio::test]` blocks in `botho/src/rpc/` for `is_number()` / numeric assertions on `totalMined`, `totalFeesBurned`, and `circulatingSupply`. The only assertion touching any of the three was line 174 (`getChainInfo` returns only `totalMined` of the three; the supply-info fields have no test assertions). No other changes were required.

Production RPC code is **intentionally unchanged** — #342's string encoding is correct.

## Testing

- `cargo test -p botho --test rpc_integration` — 32 passed, 0 failed (incl. `test_get_chain_info`)
- `cargo build` — green

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)