### PR TITLE
style: rustfmt baseline + CI fmt check on pinned nightly

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,68 @@
+name: Format Check
+
+# Enforces the repo-wide rustfmt baseline so the tree never drifts out of
+# compliance again. rustfmt.toml uses nightly-only options (wrap_comments,
+# imports_granularity = "Crate"), so this MUST run on the pinned nightly the
+# repo builds against -- stable rustfmt silently ignores those options and
+# would let drift through.
+
+on:
+  pull_request:
+    paths:
+      - '**.rs'
+      - 'rustfmt.toml'
+      - 'rust-toolchain'
+      - '.github/workflows/fmt.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.rs'
+      - 'rustfmt.toml'
+      - 'rust-toolchain'
+      - '.github/workflows/fmt.yml'
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt-check:
+    name: rustfmt --check (pinned nightly)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pin to the same nightly as rust-toolchain (channel = nightly-2025-12-03).
+      # We pin explicitly here -- NOT @stable -- because the unstable rustfmt
+      # options only take effect on nightly. Keep this in sync with
+      # rust-toolchain when bumping the channel.
+      - name: Install pinned Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-12-03
+          components: rustfmt
+
+      # Workspace members (root Cargo.toml). `--all` honors the rustfmt.toml
+      # `ignore` list (sgx/types, sgx/urts, sgx/sync) automatically.
+      - name: Check workspace formatting
+        run: cargo +nightly-2025-12-03 fmt --all -- --check
+
+      # Members listed under `exclude` in the root Cargo.toml are not reached by
+      # `--all`, so check them individually. fuzz especially: the strict fuzz
+      # build guard compiles every target, and drift there is otherwise invisible.
+      - name: Check fuzz crate formatting
+        working-directory: fuzz
+        run: cargo +nightly-2025-12-03 fmt -- --check
+
+      - name: Check util/serial crate formatting
+        working-directory: util/serial
+        run: cargo +nightly-2025-12-03 fmt -- --check
+
+      - name: Check contracts/solana crate formatting
+        working-directory: contracts/solana
+        run: cargo +nightly-2025-12-03 fmt -- --check

--- a/botho/src/block.rs
+++ b/botho/src/block.rs
@@ -346,7 +346,12 @@ impl LotteryOutput {
     }
 
     /// Create from a 36-byte UTXO ID.
-    pub fn from_utxo_id(utxo_id: [u8; 36], payout: u64, target_key: [u8; 32], public_key: [u8; 32]) -> Self {
+    pub fn from_utxo_id(
+        utxo_id: [u8; 36],
+        payout: u64,
+        target_key: [u8; 32],
+        public_key: [u8; 32],
+    ) -> Self {
         let mut tx_hash = [0u8; 32];
         tx_hash.copy_from_slice(&utxo_id[..32]);
         let output_index = u32::from_le_bytes(utxo_id[32..36].try_into().unwrap());
@@ -478,7 +483,8 @@ impl Block {
     /// Create a new block template for minting with transactions.
     ///
     /// The minting reward output uses stealth addressing for minter privacy.
-    /// Note: Lottery outputs should be added separately via `set_lottery_result`.
+    /// Note: Lottery outputs should be added separately via
+    /// `set_lottery_result`.
     pub fn new_template_with_txs(
         prev_block: &Block,
         minter_address: &PublicAddress,
@@ -617,8 +623,7 @@ fn calculate_tail_reward_u128(
     // Target annual NET emission.
     let target_net = supply_at_transition * policy.tail_inflation_bps as u128 / 10_000;
     // Expected annual fee burns.
-    let expected_burns =
-        supply_at_transition * policy.expected_fee_burn_rate_bps as u128 / 10_000;
+    let expected_burns = supply_at_transition * policy.expected_fee_burn_rate_bps as u128 / 10_000;
     // Gross emission needed.
     let gross_needed = target_net + expected_burns;
     // Blocks per year at target rate.
@@ -1290,8 +1295,7 @@ mod tests {
 
         // Recompute the expected reward independently in u128.
         let target_net = real_supply * policy.tail_inflation_bps as u128 / 10_000;
-        let expected_burns =
-            real_supply * policy.expected_fee_burn_rate_bps as u128 / 10_000;
+        let expected_burns = real_supply * policy.expected_fee_burn_rate_bps as u128 / 10_000;
         let secs_per_year: u128 = 365 * 24 * 3600;
         let blocks_per_year = secs_per_year / policy.target_block_time_secs as u128;
         let expected = ((target_net + expected_burns) / blocks_per_year).max(1) as u64;
@@ -1337,7 +1341,10 @@ mod tests {
 
         let expected = near_max as u128 + reward as u128;
         assert_eq!(ctrl.total_emitted, expected);
-        assert!(ctrl.total_emitted > u64::MAX as u128, "must have crossed u64::MAX");
+        assert!(
+            ctrl.total_emitted > u64::MAX as u128,
+            "must have crossed u64::MAX"
+        );
 
         // net_supply also computed in u128 without wrapping.
         assert_eq!(ctrl.net_supply(), expected);

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -26,18 +26,17 @@ use crate::{
         BlockBuilder, ConsensusConfig, ConsensusEvent, ConsensusService, LotteryFeeConfig,
         TransactionValidator,
     },
-    node::SharedLedger,
-    wallet::Wallet,
     network::{
         BlockTxn, CompactBlock, GetBlockTxn, NetworkDiscovery, NetworkEvent, QuorumBuilder,
         ReconstructionResult,
     },
-    node::{MintedMintingTx, Node},
+    node::{MintedMintingTx, Node, SharedLedger},
     rpc::{
         calculate_dir_size, init_metrics, start_metrics_server, start_rpc_server, FaucetState,
         MetricsUpdater, RpcState, WsBroadcaster, DATA_DIR_USAGE_BYTES,
     },
     transaction::Transaction,
+    wallet::Wallet,
 };
 
 /// Timeout for initial peer discovery (seconds)
@@ -259,8 +258,12 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                 // Initialize faucet if enabled in config (testnet only)
                 if config.faucet.enabled {
                     if !config.network_type.is_production() {
-                        info!("Faucet enabled: {} BTH per request", config.faucet.amount as f64 / 1_000_000_000_000.0);
-                        rpc_state = rpc_state.with_faucet(FaucetState::new(config.faucet.clone()), wallet);
+                        info!(
+                            "Faucet enabled: {} BTH per request",
+                            config.faucet.amount as f64 / 1_000_000_000_000.0
+                        );
+                        rpc_state =
+                            rpc_state.with_faucet(FaucetState::new(config.faucet.clone()), wallet);
                     } else {
                         warn!("Faucet is configured but disabled on mainnet for safety");
                         rpc_state = rpc_state.with_wallet(wallet);
@@ -1373,5 +1376,11 @@ fn apply_lottery_to_block(
         ledger.get_utxo_by_id(utxo_id).ok().flatten()
     };
 
-    BlockBuilder::apply_lottery(block, &candidates, stored_pool, utxo_lookup, &lottery_config)
+    BlockBuilder::apply_lottery(
+        block,
+        &candidates,
+        stored_pool,
+        utxo_lookup,
+        &lottery_config,
+    )
 }

--- a/botho/src/config.rs
+++ b/botho/src/config.rs
@@ -181,7 +181,8 @@ fn default_bootstrap_peers(network: Network) -> Vec<String> {
     match network {
         Network::Mainnet => vec![
             // Mainnet seed node
-            "/dns4/seed.botho.io/tcp/7100/p2p/12D3KooWBrjTYjNrEwi9MM3AKFenmymyWVXtXbQiSx7eDnDwv9qQ".to_string(),
+            "/dns4/seed.botho.io/tcp/7100/p2p/12D3KooWBrjTYjNrEwi9MM3AKFenmymyWVXtXbQiSx7eDnDwv9qQ"
+                .to_string(),
         ],
         Network::Testnet => vec![
             // Testnet seed node (no peer ID - resolved dynamically)

--- a/botho/src/consensus/block_builder.rs
+++ b/botho/src/consensus/block_builder.rs
@@ -211,11 +211,12 @@ impl BlockBuilder {
     /// # Arguments
     /// * `block` - The block to add lottery results to
     /// * `candidates` - Lottery candidates with real cluster factors, from
-    ///   `Ledger::get_lottery_validation_candidates` — the SAME function
-    ///   block validation uses. Verification re-runs the draw, so proposer
-    ///   and validator candidate sets (values, factors, order) must match.
+    ///   `Ledger::get_lottery_validation_candidates` — the SAME function block
+    ///   validation uses. Verification re-runs the draw, so proposer and
+    ///   validator candidate sets (values, factors, order) must match.
     /// * `stored_pool` - Carryover lottery pool balance from the ledger
-    /// * `utxo_lookup` - Function to look up UTXO details by ID for key recovery
+    /// * `utxo_lookup` - Function to look up UTXO details by ID for key
+    ///   recovery
     /// * `lottery_config` - Configuration for fee splitting and lottery drawing
     ///
     /// # Returns
@@ -338,7 +339,8 @@ impl BlockBuilder {
         outputs
     }
 
-    /// Convert ClusterTagVector (on-chain format) to TagVector (cluster-tax format).
+    /// Convert ClusterTagVector (on-chain format) to TagVector (cluster-tax
+    /// format).
     ///
     /// Both represent the same concept but in different crate contexts.
     fn cluster_tags_to_tag_vector(
@@ -484,7 +486,13 @@ mod tests {
         };
 
         let lottery_config = LotteryFeeConfig::default();
-        let result = BlockBuilder::apply_lottery(block.clone(), &candidates, 0, utxo_lookup, &lottery_config);
+        let result = BlockBuilder::apply_lottery(
+            block.clone(),
+            &candidates,
+            0,
+            utxo_lookup,
+            &lottery_config,
+        );
 
         // No fees means no lottery
         assert!(result.lottery_outputs.is_empty());
@@ -502,7 +510,13 @@ mod tests {
         let utxo_lookup = |_: &[u8; 36]| None;
 
         let lottery_config = LotteryFeeConfig::default();
-        let result = BlockBuilder::apply_lottery(block.clone(), &candidates, 0, utxo_lookup, &lottery_config);
+        let result = BlockBuilder::apply_lottery(
+            block.clone(),
+            &candidates,
+            0,
+            utxo_lookup,
+            &lottery_config,
+        );
 
         // No candidates: the fee burn share (20%) is burned; the pool share
         // carries over via the persistent lottery pool
@@ -525,17 +539,21 @@ mod tests {
             mock_candidate([3u8; 36], 50_000_000, 30),  // 50M value, 70 blocks old
         ];
 
-        let utxo_lookup = |id: &[u8; 36]| {
-            match id[0] {
-                1 => Some(mock_utxo([1u8; 36], 100_000_000, 50)),
-                2 => Some(mock_utxo([2u8; 36], 200_000_000, 40)),
-                3 => Some(mock_utxo([3u8; 36], 50_000_000, 30)),
-                _ => None,
-            }
+        let utxo_lookup = |id: &[u8; 36]| match id[0] {
+            1 => Some(mock_utxo([1u8; 36], 100_000_000, 50)),
+            2 => Some(mock_utxo([2u8; 36], 200_000_000, 40)),
+            3 => Some(mock_utxo([3u8; 36], 50_000_000, 30)),
+            _ => None,
         };
 
         let lottery_config = LotteryFeeConfig::default();
-        let result = BlockBuilder::apply_lottery(block.clone(), &candidates, 0, utxo_lookup, &lottery_config);
+        let result = BlockBuilder::apply_lottery(
+            block.clone(),
+            &candidates,
+            0,
+            utxo_lookup,
+            &lottery_config,
+        );
 
         // Should have applied lottery - total_fees should be recorded
         assert_eq!(result.lottery_summary.total_fees, 10_000_000);
@@ -551,17 +569,16 @@ mod tests {
         } else {
             // Winners drawn: payout = min(fee pool share, block reward cap)
             let cap = result.minting_tx.reward;
-            assert_eq!(
-                result.lottery_summary.pool_distributed,
-                8_000_000.min(cap)
-            );
+            assert_eq!(result.lottery_summary.pool_distributed, 8_000_000.min(cap));
         }
     }
 
     #[test]
     fn test_cluster_tags_to_tag_vector_conversion() {
-        use bth_transaction_types::{ClusterId as TypesClusterId, ClusterTagEntry, ClusterTagVector};
         use bth_cluster_tax::ClusterId as TaxClusterId;
+        use bth_transaction_types::{
+            ClusterId as TypesClusterId, ClusterTagEntry, ClusterTagVector,
+        };
 
         // Create a ClusterTagVector with multiple entries
         let mut tags = ClusterTagVector::empty();

--- a/botho/src/consensus/lottery.rs
+++ b/botho/src/consensus/lottery.rs
@@ -69,8 +69,7 @@ impl LotteryFeeConfig {
     ///
     /// Returns (pool_amount, burn_amount).
     pub fn split_fees(&self, total_fees: u64) -> (u64, u64) {
-        let pool_amount =
-            (total_fees as u128 * self.pool_fraction_permille as u128 / 1000) as u64;
+        let pool_amount = (total_fees as u128 * self.pool_fraction_permille as u128 / 1000) as u64;
         let burn_amount = total_fees.saturating_sub(pool_amount);
         (pool_amount, burn_amount)
     }
@@ -114,7 +113,11 @@ impl BlockLotteryResult {
     ///
     /// Only the fee burn share is burned; the pool share (fees + emission)
     /// carries over to future blocks via the persistent lottery pool.
-    pub fn no_winners(block_height: u64, total_fees: u64, accounting: &LotteryPoolAccounting) -> Self {
+    pub fn no_winners(
+        block_height: u64,
+        total_fees: u64,
+        accounting: &LotteryPoolAccounting,
+    ) -> Self {
         Self {
             block_height,
             total_fees,
@@ -193,8 +196,8 @@ impl LotteryPoolAccounting {
 /// * `emission_share` - Lottery share of the block reward
 ///   (`MintingTx::lottery_emission_share`)
 /// * `stored_pool` - Carryover pool balance before this block
-/// * `payout_cap` - Maximum payout per block (the block reward;
-///   anti-grinding bound)
+/// * `payout_cap` - Maximum payout per block (the block reward; anti-grinding
+///   bound)
 pub fn compute_pool_accounting(
     total_fees: u64,
     emission_share: u64,
@@ -288,7 +291,8 @@ pub fn draw_lottery_winners(
 
 /// Verify a lottery drawing result.
 ///
-/// Re-runs the drawing with the same parameters and verifies the result matches.
+/// Re-runs the drawing with the same parameters and verifies the result
+/// matches.
 ///
 /// # Arguments
 /// * `candidates` - Eligible UTXOs (must match what was used in draw)
@@ -473,7 +477,8 @@ impl std::error::Error for LotteryValidationError {}
 ///
 /// # Arguments
 /// * `block` - The block to validate
-/// * `candidates` - Eligible UTXOs from the UTXO set (must be at state before block)
+/// * `candidates` - Eligible UTXOs from the UTXO set (must be at state before
+///   block)
 /// * `prev_block_hash` - Hash of the previous block (for verifiable randomness)
 /// * `config` - Lottery configuration
 ///
@@ -562,7 +567,13 @@ pub fn validate_block_lottery(
     };
 
     // 3. Verify the lottery drawing
-    if !verify_lottery_result(candidates, &block_result, &accounting, prev_block_hash, config) {
+    if !verify_lottery_result(
+        candidates,
+        &block_result,
+        &accounting,
+        prev_block_hash,
+        config,
+    ) {
         return Err(LotteryValidationError::InvalidDrawing);
     }
 
@@ -785,8 +796,7 @@ mod tests {
         ];
 
         let accounting = compute_pool_accounting(1000, 0, 0, 1000, &config);
-        let result =
-            draw_lottery_winners(&candidates, 1000, &accounting, 100, &prev_hash, &config);
+        let result = draw_lottery_winners(&candidates, 1000, &accounting, 100, &prev_hash, &config);
 
         assert!(result.has_winners());
         assert_eq!(result.winners.len(), 2);
@@ -815,8 +825,7 @@ mod tests {
         ];
 
         let accounting = compute_pool_accounting(1000, 0, 0, 1000, &config);
-        let result =
-            draw_lottery_winners(&candidates, 1000, &accounting, 100, &prev_hash, &config);
+        let result = draw_lottery_winners(&candidates, 1000, &accounting, 100, &prev_hash, &config);
 
         // Verification should pass with same parameters
         assert!(verify_lottery_result(
@@ -911,7 +920,9 @@ mod tests {
 
         // Create transactions that sum to total_fees
         let transactions = if total_fees > 0 {
-            vec![crate::transaction::Transaction::new_stub_with_fee(total_fees)]
+            vec![crate::transaction::Transaction::new_stub_with_fee(
+                total_fees,
+            )]
         } else {
             vec![]
         };
@@ -951,10 +962,7 @@ mod tests {
         let prev_hash = [0u8; 32];
 
         // Create candidates that are eligible (old enough)
-        let candidates = vec![
-            make_candidate(1, 10_000, 0),
-            make_candidate(2, 20_000, 0),
-        ];
+        let candidates = vec![make_candidate(1, 10_000, 0), make_candidate(2, 20_000, 0)];
 
         // Create a lottery summary with incorrect split
         // Total fees = 1000, so expected: pool=800, burn=200
@@ -998,10 +1006,7 @@ mod tests {
         };
         let prev_hash = [42u8; 32];
 
-        let candidates = vec![
-            make_candidate(1, 10_000, 0),
-            make_candidate(2, 20_000, 0),
-        ];
+        let candidates = vec![make_candidate(1, 10_000, 0), make_candidate(2, 20_000, 0)];
 
         // First draw to get a valid result
         let accounting = compute_pool_accounting(1000, 0, 0, 1000, &config);
@@ -1038,11 +1043,9 @@ mod tests {
         let block = create_test_block(100, prev_hash, 1000, lottery_summary, lottery_outputs);
 
         let result = validate_block_lottery(&block, &candidates, 0, &prev_hash, &config);
-        // Should fail either with PayoutMismatch or InvalidDrawing depending on validation order
-        assert!(
-            result.is_err(),
-            "Payout mismatch should fail validation"
-        );
+        // Should fail either with PayoutMismatch or InvalidDrawing depending on
+        // validation order
+        assert!(result.is_err(), "Payout mismatch should fail validation");
     }
 
     #[test]
@@ -1189,8 +1192,7 @@ mod tests {
             amount_burned: expected_burn,
             lottery_seed: [0u8; 32],
         };
-        let valid_block =
-            create_test_block(100, prev_hash, total_fees, valid_summary, vec![]);
+        let valid_block = create_test_block(100, prev_hash, total_fees, valid_summary, vec![]);
         let candidates: Vec<LotteryCandidate> = vec![];
 
         let r1 = validate_block_lottery(&valid_block, &candidates, 0, &prev_hash, &config);
@@ -1206,13 +1208,19 @@ mod tests {
                 valid_block.minting_tx.reward,
                 &config,
             );
-            assert_eq!(valid_block.lottery_summary.amount_burned, accounting.fee_burn);
+            assert_eq!(
+                valid_block.lottery_summary.amount_burned,
+                accounting.fee_burn
+            );
             // No-winner block: the pool share carries over (returned new pool),
             // so the summary's pool_distributed is 0 even though payout > 0.
             if valid_block.lottery_outputs.is_empty() {
                 assert_eq!(valid_block.lottery_summary.pool_distributed, 0);
             } else {
-                assert_eq!(valid_block.lottery_summary.pool_distributed, accounting.payout);
+                assert_eq!(
+                    valid_block.lottery_summary.pool_distributed,
+                    accounting.payout
+                );
             }
         }
 
@@ -1236,8 +1244,10 @@ mod tests {
         // Mirrors fuzz_cluster_tax_math: cluster factor in documented bounds,
         // demurrage exempt for factor-1, emission share <= reward, and the
         // monetary primitives never panic on extreme inputs.
-        use bth_cluster_tax::demurrage::{FACTOR_SCALE, MAX_FACTOR_SCALED};
-        use bth_cluster_tax::{demurrage_charge, ClusterFactorCurve, MonetaryPolicy};
+        use bth_cluster_tax::{
+            demurrage::{FACTOR_SCALE, MAX_FACTOR_SCALED},
+            demurrage_charge, ClusterFactorCurve, MonetaryPolicy,
+        };
 
         let curve = ClusterFactorCurve::default_params();
         // Valid mid-range wealth and the u64 extremes all stay in [1000, 6000].

--- a/botho/src/consensus/mod.rs
+++ b/botho/src/consensus/mod.rs
@@ -18,8 +18,8 @@ mod value;
 
 pub use block_builder::{BlockBuildError, BlockBuilder, BuiltBlock};
 pub use lottery::{
-    draw_lottery_winners, split_fees, validate_block_lottery, verify_lottery_result,
-    utxo_to_candidate, BlockLotteryResult, LotteryFeeConfig, LotteryStats,
+    draw_lottery_winners, split_fees, utxo_to_candidate, validate_block_lottery,
+    verify_lottery_result, BlockLotteryResult, LotteryFeeConfig, LotteryStats,
     LotteryValidationError,
 };
 pub use service::{ConsensusConfig, ConsensusEvent, ConsensusService, ScpMessage};

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -502,7 +502,10 @@ impl ConsensusService {
         }
 
         // Fill remaining slots with transfer txs
-        let remaining_slots = self.config.max_txs_per_slot.saturating_sub(to_propose.len());
+        let remaining_slots = self
+            .config
+            .max_txs_per_slot
+            .saturating_sub(to_propose.len());
         let transfer_txs: Vec<ConsensusValue> = self
             .pending_values
             .iter()

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -484,9 +484,7 @@ impl Ledger {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
-            .map_err(|_| {
-                LedgerError::InvalidBlock("System time before UNIX epoch".to_string())
-            })?;
+            .map_err(|_| LedgerError::InvalidBlock("System time before UNIX epoch".to_string()))?;
         if block.header.timestamp > now.saturating_add(MAX_FUTURE_TIMESTAMP_SECS) {
             return Err(LedgerError::InvalidBlock(format!(
                 "Block timestamp {} is too far in the future (now={})",
@@ -534,7 +532,8 @@ impl Ledger {
             || stored_lottery_pool > 0
         {
             let lottery_config = LotteryFeeConfig::default();
-            let candidates = self.get_lottery_validation_candidates(block.height(), &lottery_config.draw_config)?;
+            let candidates = self
+                .get_lottery_validation_candidates(block.height(), &lottery_config.draw_config)?;
 
             // prev_block_hash is used for verifiable randomness
             let prev_block_hash = &block.header.prev_block_hash;
@@ -922,7 +921,10 @@ impl Ledger {
     /// target_key against the account's view key. This is necessary because
     /// stealth outputs use one-time addresses that can only be identified
     /// by the recipient.
-    pub fn scan_utxos_for_account(&self, account_key: &AccountKey) -> Result<Vec<Utxo>, LedgerError> {
+    pub fn scan_utxos_for_account(
+        &self,
+        account_key: &AccountKey,
+    ) -> Result<Vec<Utxo>, LedgerError> {
         let rtxn = self
             .env
             .read_txn()
@@ -1178,8 +1180,10 @@ impl Ledger {
         height: u64,
     ) -> Result<(), LedgerError> {
         // Check if already exists
-        if let Ok(Some(existing_height_bytes)) = self.key_images_db.get(wtxn, key_image.as_slice()) {
-            let existing_height = u64::from_le_bytes(existing_height_bytes.try_into().unwrap_or([0u8; 8]));
+        if let Ok(Some(existing_height_bytes)) = self.key_images_db.get(wtxn, key_image.as_slice())
+        {
+            let existing_height =
+                u64::from_le_bytes(existing_height_bytes.try_into().unwrap_or([0u8; 8]));
             warn!(
                 "Key image collision: {} already spent at height {}, trying to spend at height {}",
                 hex::encode(&key_image[0..8]),
@@ -2076,7 +2080,8 @@ impl Ledger {
     /// with different age/value thresholds — a latent consensus bug.)
     ///
     /// # Arguments
-    /// * `block_height` - The block height being validated (UTXOs must be older)
+    /// * `block_height` - The block height being validated (UTXOs must be
+    ///   older)
     /// * `config` - Lottery draw configuration with age/value thresholds
     ///
     /// # Returns
@@ -2124,7 +2129,8 @@ impl Ledger {
                     let age = block_height.saturating_sub(utxo.created_at);
                     if age >= config.min_utxo_age && utxo.output.amount >= config.min_utxo_value {
                         // Convert ClusterTagVector to TagVector for entropy calculation
-                        let tag_vector = Self::cluster_tags_to_tag_vector(&utxo.output.cluster_tags);
+                        let tag_vector =
+                            Self::cluster_tags_to_tag_vector(&utxo.output.cluster_tags);
 
                         // Create candidate with UTXO ID (36 bytes: tx_hash || output_index)
                         let utxo_id = utxo.id.to_bytes();
@@ -2182,7 +2188,8 @@ impl Ledger {
         Ok(candidates)
     }
 
-    /// Convert ClusterTagVector (on-chain format) to TagVector (cluster-tax format).
+    /// Convert ClusterTagVector (on-chain format) to TagVector (cluster-tax
+    /// format).
     ///
     /// This conversion is needed for entropy calculation in lottery selection.
     fn cluster_tags_to_tag_vector(
@@ -2192,10 +2199,7 @@ impl Ledger {
 
         for entry in &cluster_tags.entries {
             // ClusterTagVector uses u32 weights, TagVector also uses u32 weights
-            tag_vector.set(
-                bth_cluster_tax::ClusterId(entry.cluster_id.0),
-                entry.weight,
-            );
+            tag_vector.set(bth_cluster_tax::ClusterId(entry.cluster_id.0), entry.weight);
         }
 
         tag_vector
@@ -2281,7 +2285,12 @@ mod tests {
             // 16-byte LE on disk (consensus-state format change, 8 -> 16).
             let rtxn = ledger.env.read_txn().unwrap();
             assert_eq!(
-                ledger.meta_db.get(&rtxn, META_TOTAL_MINED).unwrap().unwrap().len(),
+                ledger
+                    .meta_db
+                    .get(&rtxn, META_TOTAL_MINED)
+                    .unwrap()
+                    .unwrap()
+                    .len(),
                 16
             );
         }
@@ -2308,7 +2317,10 @@ mod tests {
 
         // Monetary fields are u64 (8 bytes), not u128 (16 bytes).
         assert_eq!(genesis.minting_tx.reward.to_le_bytes().len(), 8);
-        assert_eq!(genesis.minting_tx.to_tx_output().amount.to_le_bytes().len(), 8);
+        assert_eq!(
+            genesis.minting_tx.to_tx_output().amount.to_le_bytes().len(),
+            8
+        );
         for tx in &genesis.transactions {
             assert_eq!(tx.fee.to_le_bytes().len(), 8);
             for output in &tx.outputs {
@@ -2609,7 +2621,10 @@ mod tests {
 
         // Post-state unchanged and still conserved.
         let post_height = conserved(&ledger);
-        assert_eq!(prev_height, post_height, "rejected block must not advance height");
+        assert_eq!(
+            prev_height, post_height,
+            "rejected block must not advance height"
+        );
     }
 
     // The cumulative lottery carryover persists as 16-byte LE u128. A value

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -275,10 +275,11 @@ pub struct PendingTx {
     pub tx: Transaction,
     pub received_at: std::time::Instant,
     pub fee_per_byte: u64,
-    /// Fee density accounting for cluster factor: fee / (size × cluster_factor).
-    /// Higher values get priority. This ensures wealthy clusters (high factor)
-    /// must pay more to achieve the same priority as smaller clusters.
-    /// Stored as scaled integer (×1000) to avoid floating point.
+    /// Fee density accounting for cluster factor: fee / (size ×
+    /// cluster_factor). Higher values get priority. This ensures wealthy
+    /// clusters (high factor) must pay more to achieve the same priority as
+    /// smaller clusters. Stored as scaled integer (×1000) to avoid floating
+    /// point.
     pub fee_density: u64,
     /// The cluster wealth used for fee calculation.
     pub cluster_wealth: u64,
@@ -351,7 +352,8 @@ pub struct Mempool {
     /// Spent key images with timestamps (for double-spend prevention).
     /// Maps key image -> time when first seen.
     /// Key images are kept even after transaction eviction to prevent race
-    /// conditions with consensus pending_values. Cleaned up after MAX_KEY_IMAGE_AGE_SECS.
+    /// conditions with consensus pending_values. Cleaned up after
+    /// MAX_KEY_IMAGE_AGE_SECS.
     spent_key_images: HashMap<[u8; 32], std::time::Instant>,
     /// Fee configuration for computing minimum fees
     fee_config: FeeConfig,
@@ -359,7 +361,8 @@ pub struct Mempool {
     dynamic_fee: DynamicFeeBase,
     /// Whether we're at minimum block time (triggers dynamic fee adjustment)
     at_min_block_time: bool,
-    /// Whether to enforce minimum fee requirements (can be disabled for testnet)
+    /// Whether to enforce minimum fee requirements (can be disabled for
+    /// testnet)
     enforce_minimum_fee: bool,
     /// Metrics tracking for fee enforcement
     fee_metrics: MempoolFeeMetrics,
@@ -627,7 +630,8 @@ impl Mempool {
             .map_err(|e| MempoolError::InvalidTransaction(e.to_string()))?;
 
         // Validate inputs (all transactions use CLSAG ring signatures)
-        let (input_sum, ring_members) = self.validate_clsag_inputs(tx.inputs.clsag(), &tx, ledger)?;
+        let (input_sum, ring_members) =
+            self.validate_clsag_inputs(tx.inputs.clsag(), &tx, ledger)?;
 
         // Validate outputs + fee <= inputs
         // Use checked arithmetic to detect overflow from malicious transactions
@@ -683,14 +687,9 @@ impl Mempool {
         // See docs/design/cluster-tilted-redistribution.md.
         let demurrage = {
             let policy = crate::monetary::mainnet_policy();
-            let chain_height = ledger
-                .get_chain_state()
-                .map(|s| s.height)
-                .unwrap_or(0);
-            let elapsed =
-                bth_cluster_tax::ring_elapsed_centroid(&ring_members, chain_height);
-            let blocks_per_year =
-                (365 * 24 * 60 * 60) / policy.target_block_time_secs.max(1);
+            let chain_height = ledger.get_chain_state().map(|s| s.height).unwrap_or(0);
+            let elapsed = bth_cluster_tax::ring_elapsed_centroid(&ring_members, chain_height);
+            let blocks_per_year = (365 * 24 * 60 * 60) / policy.target_block_time_secs.max(1);
             bth_cluster_tax::demurrage_charge(
                 output_sum,
                 self.fee_config.cluster_factor(cluster_wealth),
@@ -706,10 +705,11 @@ impl Mempool {
 
             // Track metrics for all insufficient fees (even if not enforced)
             self.fee_metrics.fee_rejections += 1;
-            self.fee_metrics.total_fee_shortfall =
-                self.fee_metrics.total_fee_shortfall.saturating_add(shortfall);
-            self.fee_metrics.max_fee_shortfall =
-                self.fee_metrics.max_fee_shortfall.max(shortfall);
+            self.fee_metrics.total_fee_shortfall = self
+                .fee_metrics
+                .total_fee_shortfall
+                .saturating_add(shortfall);
+            self.fee_metrics.max_fee_shortfall = self.fee_metrics.max_fee_shortfall.max(shortfall);
 
             if self.enforce_minimum_fee {
                 debug!(
@@ -861,8 +861,9 @@ impl Mempool {
 
     /// Remove a transaction from the mempool and clear its key images.
     ///
-    /// Use this when a transaction is confirmed in a block or explicitly invalidated.
-    /// For eviction (space/age), use `evict_tx` instead to preserve key image tracking.
+    /// Use this when a transaction is confirmed in a block or explicitly
+    /// invalidated. For eviction (space/age), use `evict_tx` instead to
+    /// preserve key image tracking.
     pub fn remove_tx(&mut self, tx_hash: &[u8; 32]) -> Option<Transaction> {
         if let Some(pending) = self.txs.remove(tx_hash) {
             // Remove spent key images - safe because tx is confirmed/invalid
@@ -878,8 +879,8 @@ impl Mempool {
     /// Evict a transaction from the mempool but KEEP its key images tracked.
     ///
     /// This is used for space/age eviction where we want to prevent the same
-    /// key images from being re-submitted (which could cause double-spend issues
-    /// if the evicted tx is still in consensus pending_values).
+    /// key images from being re-submitted (which could cause double-spend
+    /// issues if the evicted tx is still in consensus pending_values).
     ///
     /// Key images are only cleared when a transaction is:
     /// - Confirmed in a block (via `remove_tx`)
@@ -1024,7 +1025,12 @@ impl Mempool {
             if now.duration_since(*added_at).as_secs() > MAX_KEY_IMAGE_AGE_SECS {
                 // Check if any transaction in the mempool uses this key image
                 let still_in_use = self.txs.values().any(|pending| {
-                    pending.tx.inputs.clsag().iter().any(|input| &input.key_image == key_image)
+                    pending
+                        .tx
+                        .inputs
+                        .clsag()
+                        .iter()
+                        .any(|input| &input.key_image == key_image)
                 });
 
                 if !still_in_use {
@@ -1423,7 +1429,9 @@ mod tests {
 
         let key_image: [u8; 32] = [0xDE; 32];
 
-        mempool.spent_key_images.insert(key_image, std::time::Instant::now());
+        mempool
+            .spent_key_images
+            .insert(key_image, std::time::Instant::now());
 
         assert!(mempool.spent_key_images.contains_key(&key_image));
         assert_eq!(mempool.spent_key_images.len(), 1);

--- a/botho/src/network/compact_block.rs
+++ b/botho/src/network/compact_block.rs
@@ -54,7 +54,8 @@ pub struct CompactBlock {
     pub short_ids: Vec<ShortId>,
     /// Pre-filled transactions (for txs unlikely to be in mempool)
     pub prefilled_txs: Vec<PrefilledTx>,
-    /// Lottery payout outputs (always included - deterministic from block state)
+    /// Lottery payout outputs (always included - deterministic from block
+    /// state)
     #[serde(default)]
     pub lottery_outputs: Vec<LotteryOutput>,
     /// Lottery summary for validation

--- a/botho/src/network/discovery.rs
+++ b/botho/src/network/discovery.rs
@@ -179,10 +179,7 @@ impl ProtocolVersion {
     /// valid protocol version cannot be assumed to share our consensus
     /// rules, and honest-but-misconfigured peers are exactly what this
     /// check exists to exclude.
-    pub fn consensus_incompatibility(
-        peer_version: &Option<Self>,
-        local: &Self,
-    ) -> Option<Self> {
+    pub fn consensus_incompatibility(peer_version: &Option<Self>, local: &Self) -> Option<Self> {
         match peer_version {
             Some(pv) => (!pv.is_consensus_compatible(local)).then(|| pv.clone()),
             None => Some(Self {
@@ -1155,8 +1152,9 @@ impl NetworkDiscovery {
                 };
 
                 // Parse transport capabilities from agent_version
-                let transport_caps =
-                    super::transport::TransportCapabilities::from_agent_version(&info.agent_version);
+                let transport_caps = super::transport::TransportCapabilities::from_agent_version(
+                    &info.agent_version,
+                );
 
                 // Update peer entry with version and transport information
                 if let Some(entry) = self.peers.get_mut(&peer_id) {
@@ -1172,8 +1170,7 @@ impl NetworkDiscovery {
                 // what makes coordinated upgrades enforceable instead of
                 // silently divergent.
                 if let Some(lv) = &local_version {
-                    if let Some(pv) =
-                        ProtocolVersion::consensus_incompatibility(&peer_version, lv)
+                    if let Some(pv) = ProtocolVersion::consensus_incompatibility(&peer_version, lv)
                     {
                         warn!(
                             %peer_id,
@@ -1359,7 +1356,10 @@ mod tests {
 
         let peer_id = PeerId::random();
         let caps = TransportCapabilities::new(
-            vec![CapabilityTransportType::WebRTC, CapabilityTransportType::Plain],
+            vec![
+                CapabilityTransportType::WebRTC,
+                CapabilityTransportType::Plain,
+            ],
             CapabilityTransportType::WebRTC,
             NegotiationNatType::Open,
         );

--- a/botho/src/network/mod.rs
+++ b/botho/src/network/mod.rs
@@ -46,10 +46,23 @@ pub use sync::{
     MAX_RESPONSE_SIZE,
 };
 pub use transport::{
-    negotiate_transport_initiator, negotiate_transport_responder, select_transport,
-    CapabilityTransportType, NegotiationConfig, NegotiationError, NegotiationMessage,
-    NegotiationNatType, TransportCapabilities, TransportError, TransportManager,
-    TransportManagerConfig, TransportType, UpgradeResult,
+    negotiate_transport_initiator,
+    negotiate_transport_responder,
+    select_transport,
+    CapabilityTransportType,
     // WebRTC types
-    NatType, StunClient, StunConfig, StunError,
+    NatType,
+    NegotiationConfig,
+    NegotiationError,
+    NegotiationMessage,
+    NegotiationNatType,
+    StunClient,
+    StunConfig,
+    StunError,
+    TransportCapabilities,
+    TransportError,
+    TransportManager,
+    TransportManagerConfig,
+    TransportType,
+    UpgradeResult,
 };

--- a/botho/src/network/transport/capabilities.rs
+++ b/botho/src/network/transport/capabilities.rs
@@ -338,10 +338,22 @@ mod tests {
 
     #[test]
     fn test_transport_type_from_str() {
-        assert_eq!(TransportType::from_str("webrtc"), Some(TransportType::WebRTC));
-        assert_eq!(TransportType::from_str("WEBRTC"), Some(TransportType::WebRTC));
-        assert_eq!(TransportType::from_str("tls"), Some(TransportType::TlsTunnel));
-        assert_eq!(TransportType::from_str("tlstunnel"), Some(TransportType::TlsTunnel));
+        assert_eq!(
+            TransportType::from_str("webrtc"),
+            Some(TransportType::WebRTC)
+        );
+        assert_eq!(
+            TransportType::from_str("WEBRTC"),
+            Some(TransportType::WebRTC)
+        );
+        assert_eq!(
+            TransportType::from_str("tls"),
+            Some(TransportType::TlsTunnel)
+        );
+        assert_eq!(
+            TransportType::from_str("tlstunnel"),
+            Some(TransportType::TlsTunnel)
+        );
         assert_eq!(TransportType::from_str("plain"), Some(TransportType::Plain));
         assert_eq!(TransportType::from_str("tcp"), Some(TransportType::Plain));
         assert_eq!(TransportType::from_str("invalid"), None);
@@ -349,8 +361,12 @@ mod tests {
 
     #[test]
     fn test_transport_type_preference_score() {
-        assert!(TransportType::WebRTC.preference_score() > TransportType::TlsTunnel.preference_score());
-        assert!(TransportType::TlsTunnel.preference_score() > TransportType::Plain.preference_score());
+        assert!(
+            TransportType::WebRTC.preference_score() > TransportType::TlsTunnel.preference_score()
+        );
+        assert!(
+            TransportType::TlsTunnel.preference_score() > TransportType::Plain.preference_score()
+        );
     }
 
     #[test]
@@ -458,7 +474,10 @@ mod tests {
     #[test]
     fn test_capabilities_from_multiaddr_suffix_invalid() {
         assert!(TransportCapabilities::from_multiaddr_suffix("invalid").is_none());
-        assert!(TransportCapabilities::from_multiaddr_suffix("/transport-caps/999/webrtc/open").is_none());
+        assert!(
+            TransportCapabilities::from_multiaddr_suffix("/transport-caps/999/webrtc/open")
+                .is_none()
+        );
         assert!(TransportCapabilities::from_multiaddr_suffix("/transport-caps/1//open").is_none());
     }
 

--- a/botho/src/network/transport/error.rs
+++ b/botho/src/network/transport/error.rs
@@ -3,13 +3,12 @@
 //! Transport error types for pluggable transports.
 //!
 //! This module defines the error types used by the transport layer,
-//! covering connection failures, handshake errors, and transport-specific issues.
+//! covering connection failures, handshake errors, and transport-specific
+//! issues.
 
-use std::fmt;
-use std::io;
+use std::{fmt, io};
 
-use super::webrtc::ice::IceError;
-use super::webrtc::stun::StunError;
+use super::webrtc::{ice::IceError, stun::StunError};
 
 /// Result type for transport operations.
 pub type TransportResult<T> = Result<T, TransportError>;
@@ -235,7 +234,11 @@ impl fmt::Display for WebRtcError {
             WebRtcError::SendFailed(msg) => write!(f, "failed to send data: {}", msg),
             WebRtcError::ReceiveFailed(msg) => write!(f, "failed to receive data: {}", msg),
             WebRtcError::InvalidState { expected, actual } => {
-                write!(f, "connection state error: expected {}, got {}", expected, actual)
+                write!(
+                    f,
+                    "connection state error: expected {}, got {}",
+                    expected, actual
+                )
             }
         }
     }

--- a/botho/src/network/transport/fingerprint.rs
+++ b/botho/src/network/transport/fingerprint.rs
@@ -3,7 +3,8 @@
 //! Fingerprinting resistance testing utilities.
 //!
 //! This module provides tools for verifying that botho WebRTC traffic is
-//! statistically indistinguishable from legitimate WebRTC traffic (video calls).
+//! statistically indistinguishable from legitimate WebRTC traffic (video
+//! calls).
 //!
 //! # Overview
 //!
@@ -121,11 +122,7 @@ impl TrafficPattern {
         if self.inter_arrival_times.is_empty() {
             return 0.0;
         }
-        let total_us: u128 = self
-            .inter_arrival_times
-            .iter()
-            .map(|d| d.as_micros())
-            .sum();
+        let total_us: u128 = self.inter_arrival_times.iter().map(|d| d.as_micros()).sum();
         total_us as f64 / self.inter_arrival_times.len() as f64
     }
 
@@ -174,7 +171,8 @@ pub struct KsTestResult {
 }
 
 impl KsTestResult {
-    /// Check if the samples are indistinguishable at the given significance level.
+    /// Check if the samples are indistinguishable at the given significance
+    /// level.
     ///
     /// Returns true if p_value > significance_level, meaning we cannot reject
     /// the null hypothesis that the samples come from the same distribution.
@@ -609,7 +607,9 @@ pub fn generate_synthetic_webrtc_pattern(packet_count: usize) -> TrafficPattern 
 
         let iat = if i > 0 {
             let iat_us: f64 = iat_dist.sample(&mut rng);
-            Some(Duration::from_micros(iat_us.max(1000.0).min(100_000.0) as u64))
+            Some(Duration::from_micros(
+                iat_us.max(1000.0).min(100_000.0) as u64
+            ))
         } else {
             None
         };

--- a/botho/src/network/transport/negotiation.rs
+++ b/botho/src/network/transport/negotiation.rs
@@ -498,13 +498,15 @@ mod tests {
         let peer_caps = TransportCapabilities::full(NatType::FullCone);
 
         // Run initiator and responder concurrently
-        let initiator = tokio::spawn(async move {
-            negotiate_transport_initiator(&mut client, &our_caps).await
-        });
+        let initiator =
+            tokio::spawn(
+                async move { negotiate_transport_initiator(&mut client, &our_caps).await },
+            );
 
-        let responder = tokio::spawn(async move {
-            negotiate_transport_responder(&mut server, &peer_caps).await
-        });
+        let responder =
+            tokio::spawn(
+                async move { negotiate_transport_responder(&mut server, &peer_caps).await },
+            );
 
         let (init_result, resp_result) = tokio::join!(initiator, responder);
 
@@ -523,13 +525,15 @@ mod tests {
         let our_caps = TransportCapabilities::plain_only();
         let peer_caps = TransportCapabilities::full(NatType::Open);
 
-        let initiator = tokio::spawn(async move {
-            negotiate_transport_initiator(&mut client, &our_caps).await
-        });
+        let initiator =
+            tokio::spawn(
+                async move { negotiate_transport_initiator(&mut client, &our_caps).await },
+            );
 
-        let responder = tokio::spawn(async move {
-            negotiate_transport_responder(&mut server, &peer_caps).await
-        });
+        let responder =
+            tokio::spawn(
+                async move { negotiate_transport_responder(&mut server, &peer_caps).await },
+            );
 
         let (init_result, resp_result) = tokio::join!(initiator, responder);
 
@@ -557,13 +561,15 @@ mod tests {
             NatType::Open,
         );
 
-        let initiator = tokio::spawn(async move {
-            negotiate_transport_initiator(&mut client, &our_caps).await
-        });
+        let initiator =
+            tokio::spawn(
+                async move { negotiate_transport_initiator(&mut client, &our_caps).await },
+            );
 
-        let responder = tokio::spawn(async move {
-            negotiate_transport_responder(&mut server, &peer_caps).await
-        });
+        let responder =
+            tokio::spawn(
+                async move { negotiate_transport_responder(&mut server, &peer_caps).await },
+            );
 
         let (init_result, resp_result) = tokio::join!(initiator, responder);
 

--- a/botho/src/network/transport/plain.rs
+++ b/botho/src/network/transport/plain.rs
@@ -28,16 +28,21 @@
 
 use async_trait::async_trait;
 use libp2p::{Multiaddr, PeerId};
-use std::fmt;
-use std::io;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::net::TcpStream;
+use std::{
+    fmt, io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::TcpStream,
+};
 
-use super::error::TransportError;
-use super::traits::{BoxedConnection, PluggableTransport};
-use super::types::TransportType;
+use super::{
+    error::TransportError,
+    traits::{BoxedConnection, PluggableTransport},
+    types::TransportType,
+};
 
 /// Plain transport using TCP + Noise.
 ///

--- a/botho/src/network/transport/signaling.rs
+++ b/botho/src/network/transport/signaling.rs
@@ -10,7 +10,8 @@
 //! # Overview
 //!
 //! WebRTC requires out-of-band signaling to exchange:
-//! - **SDP Offer**: Initiator's session description (codecs, ICE candidates, fingerprint)
+//! - **SDP Offer**: Initiator's session description (codecs, ICE candidates,
+//!   fingerprint)
 //! - **SDP Answer**: Responder's session description
 //! - **ICE Candidates**: Trickle ICE updates for NAT traversal
 //!
@@ -50,12 +51,16 @@ use futures::{SinkExt, StreamExt};
 use libp2p::PeerId;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::fmt;
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    fmt,
+    time::{Duration, Instant},
+};
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::time::timeout;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    time::timeout,
+};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 
 /// Length of session identifiers in bytes.
@@ -231,8 +236,8 @@ impl SignalingMessage {
 
     /// Deserialize a message from bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, SignalingError> {
-        let msg: Self =
-            bincode::deserialize(bytes).map_err(|e| SignalingError::Io(std::io::Error::other(e)))?;
+        let msg: Self = bincode::deserialize(bytes)
+            .map_err(|e| SignalingError::Io(std::io::Error::other(e)))?;
         msg.validate()?;
         Ok(msg)
     }
@@ -525,8 +530,9 @@ where
 
     /// Complete an SDP offer/answer exchange.
     ///
-    /// If `is_offerer` is true, sends the local SDP as an offer and waits for an answer.
-    /// If `is_offerer` is false, waits for an offer and sends the local SDP as an answer.
+    /// If `is_offerer` is true, sends the local SDP as an offer and waits for
+    /// an answer. If `is_offerer` is false, waits for an offer and sends
+    /// the local SDP as an answer.
     ///
     /// Returns the remote SDP on success.
     pub async fn exchange_sdp(
@@ -546,7 +552,10 @@ where
             // Wait for answer
             let response = self.recv().await?;
             match response {
-                SignalingMessage::Answer { sdp, session_id: resp_id } => {
+                SignalingMessage::Answer {
+                    sdp,
+                    session_id: resp_id,
+                } => {
                     if resp_id != session_id {
                         return Err(SignalingError::Protocol(format!(
                             "Session ID mismatch: expected {}, got {}",
@@ -564,7 +573,10 @@ where
             // Wait for offer
             let offer = self.recv().await?;
             let (remote_sdp, offer_session_id) = match offer {
-                SignalingMessage::Offer { sdp, session_id: offer_id } => (sdp, offer_id),
+                SignalingMessage::Offer {
+                    sdp,
+                    session_id: offer_id,
+                } => (sdp, offer_id),
                 _ => {
                     return Err(SignalingError::Protocol(
                         "Expected Offer message".to_string(),
@@ -912,7 +924,9 @@ mod tests {
 
         // Spawn offerer
         let offerer_task = tokio::spawn(async move {
-            offerer.exchange_sdp(offer_sdp_clone, session_id, true).await
+            offerer
+                .exchange_sdp(offer_sdp_clone, session_id, true)
+                .await
         });
 
         // Run answerer

--- a/botho/src/network/transport/traits.rs
+++ b/botho/src/network/transport/traits.rs
@@ -48,20 +48,21 @@
 
 use async_trait::async_trait;
 use libp2p::PeerId;
-use std::fmt::Debug;
-use std::io;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    fmt::Debug,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-use super::error::TransportError;
-use super::types::TransportType;
+use super::{error::TransportError, types::TransportType};
 
 /// A connection that can be read from and written to asynchronously.
 ///
-/// This trait combines [`AsyncRead`] and [`AsyncWrite`] with [`Send`] and [`Sync`]
-/// bounds required for use across async tasks. All transport connections must
-/// implement this trait.
+/// This trait combines [`AsyncRead`] and [`AsyncWrite`] with [`Send`] and
+/// [`Sync`] bounds required for use across async tasks. All transport
+/// connections must implement this trait.
 pub trait TransportConnection: AsyncRead + AsyncWrite + Send + Sync + Unpin + Debug {}
 
 /// Blanket implementation for any type that satisfies the bounds.

--- a/botho/src/network/transport/types.rs
+++ b/botho/src/network/transport/types.rs
@@ -50,7 +50,11 @@ pub enum TransportType {
 impl TransportType {
     /// Get all available transport types.
     pub fn all() -> &'static [TransportType] {
-        &[TransportType::Plain, TransportType::WebRTC, TransportType::TlsTunnel]
+        &[
+            TransportType::Plain,
+            TransportType::WebRTC,
+            TransportType::TlsTunnel,
+        ]
     }
 
     /// Get the human-readable name of this transport.
@@ -85,7 +89,7 @@ impl TransportType {
     pub fn setup_overhead(&self) -> f64 {
         match self {
             TransportType::Plain => 1.0,
-            TransportType::WebRTC => 3.0, // ICE + DTLS handshake
+            TransportType::WebRTC => 3.0,    // ICE + DTLS handshake
             TransportType::TlsTunnel => 1.5, // TLS handshake
         }
     }
@@ -151,21 +155,48 @@ mod tests {
 
     #[test]
     fn test_transport_type_from_str() {
-        assert_eq!("plain".parse::<TransportType>().unwrap(), TransportType::Plain);
-        assert_eq!("webrtc".parse::<TransportType>().unwrap(), TransportType::WebRTC);
-        assert_eq!("tls-tunnel".parse::<TransportType>().unwrap(), TransportType::TlsTunnel);
+        assert_eq!(
+            "plain".parse::<TransportType>().unwrap(),
+            TransportType::Plain
+        );
+        assert_eq!(
+            "webrtc".parse::<TransportType>().unwrap(),
+            TransportType::WebRTC
+        );
+        assert_eq!(
+            "tls-tunnel".parse::<TransportType>().unwrap(),
+            TransportType::TlsTunnel
+        );
 
         // Aliases
-        assert_eq!("tcp".parse::<TransportType>().unwrap(), TransportType::Plain);
-        assert_eq!("rtc".parse::<TransportType>().unwrap(), TransportType::WebRTC);
-        assert_eq!("tls".parse::<TransportType>().unwrap(), TransportType::TlsTunnel);
-        assert_eq!("https".parse::<TransportType>().unwrap(), TransportType::TlsTunnel);
+        assert_eq!(
+            "tcp".parse::<TransportType>().unwrap(),
+            TransportType::Plain
+        );
+        assert_eq!(
+            "rtc".parse::<TransportType>().unwrap(),
+            TransportType::WebRTC
+        );
+        assert_eq!(
+            "tls".parse::<TransportType>().unwrap(),
+            TransportType::TlsTunnel
+        );
+        assert_eq!(
+            "https".parse::<TransportType>().unwrap(),
+            TransportType::TlsTunnel
+        );
     }
 
     #[test]
     fn test_transport_type_from_str_case_insensitive() {
-        assert_eq!("PLAIN".parse::<TransportType>().unwrap(), TransportType::Plain);
-        assert_eq!("WebRTC".parse::<TransportType>().unwrap(), TransportType::WebRTC);
+        assert_eq!(
+            "PLAIN".parse::<TransportType>().unwrap(),
+            TransportType::Plain
+        );
+        assert_eq!(
+            "WebRTC".parse::<TransportType>().unwrap(),
+            TransportType::WebRTC
+        );
     }
 
     #[test]

--- a/botho/src/network/transport/webrtc/dtls.rs
+++ b/botho/src/network/transport/webrtc/dtls.rs
@@ -1,16 +1,19 @@
 // Copyright (c) 2024 Botho Foundation
 
-//! DTLS (Datagram Transport Layer Security) configuration and helpers for WebRTC transport.
+//! DTLS (Datagram Transport Layer Security) configuration and helpers for
+//! WebRTC transport.
 //!
-//! This module implements Phase 3.3 of the traffic privacy roadmap: DTLS integration
-//! for secure, encrypted communication that matches legitimate WebRTC traffic patterns.
+//! This module implements Phase 3.3 of the traffic privacy roadmap: DTLS
+//! integration for secure, encrypted communication that matches legitimate
+//! WebRTC traffic patterns.
 //!
 //! # Overview
 //!
 //! DTLS is the UDP equivalent of TLS and is mandatory for WebRTC data channels.
 //! Proper DTLS integration ensures:
 //! - All traffic is encrypted end-to-end
-//! - Traffic patterns are indistinguishable from legitimate WebRTC (video calls)
+//! - Traffic patterns are indistinguishable from legitimate WebRTC (video
+//!   calls)
 //! - Certificate handling matches browser behavior
 //!
 //! # Example
@@ -33,8 +36,10 @@
 //! - Design: `docs/design/traffic-privacy-roadmap.md` (Section 3.3)
 
 use sha2::{Digest, Sha256};
-use std::fmt;
-use std::time::{Duration, Instant};
+use std::{
+    fmt,
+    time::{Duration, Instant},
+};
 use thiserror::Error;
 
 /// Default certificate lifetime for ephemeral certificates.
@@ -199,9 +204,8 @@ impl CertificateFingerprint {
             .map(|hex| u8::from_str_radix(hex, 16))
             .collect();
 
-        let bytes = bytes.map_err(|_| {
-            DtlsError::InvalidFingerprint("invalid hex in fingerprint".to_string())
-        })?;
+        let bytes = bytes
+            .map_err(|_| DtlsError::InvalidFingerprint("invalid hex in fingerprint".to_string()))?;
 
         Ok(Self { algorithm, bytes })
     }
@@ -352,7 +356,8 @@ impl DtlsConfig {
     /// Generate ephemeral certificate configuration for a session.
     ///
     /// Creates a new self-signed certificate suitable for WebRTC DTLS.
-    /// This matches browser behavior where each session uses a fresh certificate.
+    /// This matches browser behavior where each session uses a fresh
+    /// certificate.
     pub fn generate_ephemeral() -> Result<Self, DtlsError> {
         let certificate = EphemeralCertificate::generate()?;
 
@@ -416,7 +421,8 @@ impl DtlsConfig {
 
     /// Rotate to a new certificate.
     ///
-    /// Returns a new config with a fresh certificate while preserving other settings.
+    /// Returns a new config with a fresh certificate while preserving other
+    /// settings.
     pub fn rotate(&self) -> Result<Self, DtlsError> {
         let certificate = EphemeralCertificate::generate()?;
 
@@ -565,10 +571,8 @@ mod tests {
 
     #[test]
     fn test_fingerprint_sdp_format() {
-        let fingerprint = CertificateFingerprint::new(
-            "sha-256",
-            vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF],
-        );
+        let fingerprint =
+            CertificateFingerprint::new("sha-256", vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
 
         let sdp = fingerprint.to_sdp_value();
         assert_eq!(sdp, "sha-256 AA:BB:CC:DD:EE:FF");
@@ -599,8 +603,7 @@ mod tests {
 
     #[test]
     fn test_certificate_with_short_lifetime() {
-        let cert =
-            EphemeralCertificate::generate_with_lifetime(Duration::from_secs(30)).unwrap();
+        let cert = EphemeralCertificate::generate_with_lifetime(Duration::from_secs(30)).unwrap();
 
         // With only 30 seconds, should recommend rotation
         assert!(cert.should_rotate());
@@ -635,10 +638,7 @@ mod tests {
         let config2 = config1.rotate().unwrap();
 
         // New config should have different fingerprint
-        assert_ne!(
-            config1.fingerprint().bytes,
-            config2.fingerprint().bytes
-        );
+        assert_ne!(config1.fingerprint().bytes, config2.fingerprint().bytes);
 
         // But same role setting
         assert_eq!(config1.role(), config2.role());

--- a/botho/src/network/transport/webrtc/ice.rs
+++ b/botho/src/network/transport/webrtc/ice.rs
@@ -27,16 +27,17 @@
 //!   │═══════════════[4. Selected Pair]═══════════════════│
 //! ```
 
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 use thiserror::Error;
-use tokio::sync::{mpsc, Mutex};
-use tokio::time::timeout;
+use tokio::{
+    sync::{mpsc, Mutex},
+    time::timeout,
+};
 use tracing::{debug, info, warn};
-use webrtc::ice_transport::ice_candidate::RTCIceCandidate;
-use webrtc::ice_transport::ice_gathering_state::RTCIceGatheringState;
-use webrtc::peer_connection::RTCPeerConnection;
+use webrtc::{
+    ice_transport::{ice_candidate::RTCIceCandidate, ice_gathering_state::RTCIceGatheringState},
+    peer_connection::RTCPeerConnection,
+};
 
 /// Errors that can occur during ICE operations.
 #[derive(Debug, Error)]
@@ -202,9 +203,14 @@ impl IceCandidate {
     }
 
     /// Calculate priority for this candidate.
-    pub fn calculate_priority(candidate_type: IceCandidateType, component: u16, local_pref: u32) -> u32 {
+    pub fn calculate_priority(
+        candidate_type: IceCandidateType,
+        component: u16,
+        local_pref: u32,
+    ) -> u32 {
         // RFC 8445 priority formula:
-        // priority = (2^24) * type_preference + (2^8) * local_preference + (256 - component_id)
+        // priority = (2^24) * type_preference + (2^8) * local_preference + (256 -
+        // component_id)
         let type_pref = candidate_type.priority_modifier() as u32;
         (1 << 24) * type_pref + (1 << 8) * local_pref + (256 - component as u32)
     }
@@ -232,7 +238,8 @@ impl IceCandidate {
     /// Parse from SDP candidate attribute.
     pub fn from_sdp_attribute(sdp: &str) -> Result<Self, IceError> {
         // Parse SDP candidate line
-        // Format: candidate:foundation component protocol priority address port typ type [raddr addr rport port]
+        // Format: candidate:foundation component protocol priority address port typ
+        // type [raddr addr rport port]
         let parts: Vec<&str> = sdp.split_whitespace().collect();
         if parts.len() < 8 {
             return Err(IceError::InvalidCandidate(format!(

--- a/botho/src/network/transport/webrtc/mod.rs
+++ b/botho/src/network/transport/webrtc/mod.rs
@@ -2,9 +2,9 @@
 
 //! WebRTC transport for protocol obfuscation.
 //!
-//! This module implements Phase 3 of the traffic privacy roadmap: Protocol Obfuscation
-//! using WebRTC data channels to make botho traffic indistinguishable from legitimate
-//! video calling applications.
+//! This module implements Phase 3 of the traffic privacy roadmap: Protocol
+//! Obfuscation using WebRTC data channels to make botho traffic
+//! indistinguishable from legitimate video calling applications.
 //!
 //! # Overview
 //!
@@ -47,9 +47,11 @@
 //!
 //! # Features
 //!
-//! - **NAT Traversal**: ICE with STUN/TURN support for connectivity through NATs
+//! - **NAT Traversal**: ICE with STUN/TURN support for connectivity through
+//!   NATs
 //! - **Protocol Obfuscation**: Traffic looks like WebRTC video calls
-//! - **Trickle ICE**: Candidates sent as gathered for faster connection establishment
+//! - **Trickle ICE**: Candidates sent as gathered for faster connection
+//!   establishment
 //! - **DTLS Security**: Ephemeral certificates for authenticated encryption
 //!
 //! # References
@@ -76,18 +78,18 @@ pub use stun::{NatType, StunClient, StunConfig, StunError};
 
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use webrtc::api::interceptor_registry::register_default_interceptors;
-use webrtc::api::media_engine::MediaEngine;
-use webrtc::api::APIBuilder;
-use webrtc::data_channel::data_channel_message::DataChannelMessage;
-use webrtc::data_channel::RTCDataChannel;
-use webrtc::ice_transport::ice_connection_state::RTCIceConnectionState;
-use webrtc::ice_transport::ice_server::RTCIceServer;
-use webrtc::interceptor::registry::Registry;
-use webrtc::peer_connection::configuration::RTCConfiguration;
-use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
-use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
-use webrtc::peer_connection::RTCPeerConnection;
+use webrtc::{
+    api::{
+        interceptor_registry::register_default_interceptors, media_engine::MediaEngine, APIBuilder,
+    },
+    data_channel::{data_channel_message::DataChannelMessage, RTCDataChannel},
+    ice_transport::{ice_connection_state::RTCIceConnectionState, ice_server::RTCIceServer},
+    interceptor::registry::Registry,
+    peer_connection::{
+        configuration::RTCConfiguration, peer_connection_state::RTCPeerConnectionState,
+        sdp::session_description::RTCSessionDescription, RTCPeerConnection,
+    },
+};
 
 use super::{TransportError, WebRtcError};
 
@@ -158,14 +160,17 @@ impl WebRtcTransport {
                 urls: vec![url.clone()],
                 ..Default::default()
             })
-            .chain(self.ice_config.turn_servers.iter().map(|turn| {
-                RTCIceServer {
-                    urls: vec![turn.url.clone()],
-                    username: turn.username.clone(),
-                    credential: turn.credential.clone(),
-                    ..Default::default()
-                }
-            }))
+            .chain(
+                self.ice_config
+                    .turn_servers
+                    .iter()
+                    .map(|turn| RTCIceServer {
+                        urls: vec![turn.url.clone()],
+                        username: turn.username.clone(),
+                        credential: turn.credential.clone(),
+                        ..Default::default()
+                    }),
+            )
             .collect();
 
         let config = RTCConfiguration {
@@ -282,10 +287,7 @@ pub struct WebRtcConnection {
 
 impl WebRtcConnection {
     /// Create a new WebRTC connection.
-    pub fn new(
-        peer_connection: Arc<RTCPeerConnection>,
-        data_channel: Arc<RTCDataChannel>,
-    ) -> Self {
+    pub fn new(peer_connection: Arc<RTCPeerConnection>, data_channel: Arc<RTCDataChannel>) -> Self {
         let recv_buffer = Arc::new(Mutex::new(Vec::new()));
         let buffer_clone = recv_buffer.clone();
 

--- a/botho/src/network/transport/webrtc/stun.rs
+++ b/botho/src/network/transport/webrtc/stun.rs
@@ -12,7 +12,8 @@
 //! - **Open/Full Cone**: Any external host can send to the mapped port
 //! - **Restricted Cone**: Only hosts the internal host has contacted can send
 //! - **Port Restricted Cone**: Must match both host and port
-//! - **Symmetric**: Different mapping for each destination (hardest to traverse)
+//! - **Symmetric**: Different mapping for each destination (hardest to
+//!   traverse)
 //!
 //! # Protocol (RFC 5389)
 //!
@@ -30,11 +31,12 @@
 //! +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 //! ```
 
-use std::net::{IpAddr, SocketAddr};
-use std::time::Duration;
+use std::{
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
 use thiserror::Error;
-use tokio::net::UdpSocket;
-use tokio::time::timeout;
+use tokio::{net::UdpSocket, time::timeout};
 use tracing::{debug, info, trace, warn};
 
 /// STUN magic cookie (RFC 5389)
@@ -305,10 +307,7 @@ impl StunClient {
 
         if mapped1.ip() != mapped2.ip() || mapped1.port() != mapped2.port() {
             // Different mappings for different destinations = Symmetric NAT
-            info!(
-                "Symmetric NAT detected: {} vs {}",
-                mapped1, mapped2
-            );
+            info!("Symmetric NAT detected: {} vs {}", mapped1, mapped2);
             return Ok(NatType::Symmetric);
         }
 
@@ -331,9 +330,7 @@ impl StunClient {
 /// Parse STUN server URL or address.
 fn parse_stun_server(server: &str) -> Result<SocketAddr, StunError> {
     // Handle stun: URL prefix
-    let addr_str = server
-        .strip_prefix("stun:")
-        .unwrap_or(server);
+    let addr_str = server.strip_prefix("stun:").unwrap_or(server);
 
     // Parse as socket address
     if let Ok(addr) = addr_str.parse() {
@@ -403,12 +400,16 @@ fn parse_binding_response(
     // Check magic cookie
     let cookie = u32::from_be_bytes([data[4], data[5], data[6], data[7]]);
     if cookie != STUN_MAGIC_COOKIE {
-        return Err(StunError::InvalidResponse("invalid magic cookie".to_string()));
+        return Err(StunError::InvalidResponse(
+            "invalid magic cookie".to_string(),
+        ));
     }
 
     // Check transaction ID
     if &data[8..20] != expected_transaction_id {
-        return Err(StunError::InvalidResponse("transaction ID mismatch".to_string()));
+        return Err(StunError::InvalidResponse(
+            "transaction ID mismatch".to_string(),
+        ));
     }
 
     // Get message length
@@ -539,7 +540,10 @@ mod tests {
     #[test]
     fn test_nat_type_relay_score() {
         assert!(NatType::Open.relay_score_modifier() > NatType::Symmetric.relay_score_modifier());
-        assert!(NatType::FullCone.relay_score_modifier() > NatType::PortRestricted.relay_score_modifier());
+        assert!(
+            NatType::FullCone.relay_score_modifier()
+                > NatType::PortRestricted.relay_score_modifier()
+        );
     }
 
     #[test]
@@ -574,7 +578,10 @@ mod tests {
         let request = build_binding_request(&tx_id);
 
         assert_eq!(request.len(), 20);
-        assert_eq!(u16::from_be_bytes([request[0], request[1]]), STUN_BINDING_REQUEST);
+        assert_eq!(
+            u16::from_be_bytes([request[0], request[1]]),
+            STUN_BINDING_REQUEST
+        );
         assert_eq!(u16::from_be_bytes([request[2], request[3]]), 0); // No attributes
         assert_eq!(
             u32::from_be_bytes([request[4], request[5], request[6], request[7]]),

--- a/botho/src/rpc/faucet.rs
+++ b/botho/src/rpc/faucet.rs
@@ -4,6 +4,7 @@
 //! The faucet is only available on testnet and must be explicitly enabled.
 
 use dashmap::DashMap;
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
@@ -12,7 +13,6 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::Mutex;
-use parking_lot::RwLock;
 
 use crate::config::FaucetConfig;
 
@@ -94,10 +94,7 @@ impl FaucetError {
                 requests_today, limit, retry_after_secs
             ),
             Self::CooldownActive { retry_after_secs } => {
-                format!(
-                    "Please wait {} seconds between requests.",
-                    retry_after_secs
-                )
+                format!("Please wait {} seconds between requests.", retry_after_secs)
             }
             Self::DailyLimitReached {
                 retry_after_secs, ..
@@ -220,7 +217,8 @@ impl FaucetState {
     /// Acquire the transaction build lock.
     ///
     /// This must be held during UTXO selection and transaction submission
-    /// to prevent race conditions where concurrent requests select the same UTXO.
+    /// to prevent race conditions where concurrent requests select the same
+    /// UTXO.
     pub async fn acquire_tx_lock(&self) -> tokio::sync::MutexGuard<'_, ()> {
         self.tx_build_mutex.lock().await
     }
@@ -237,7 +235,8 @@ impl FaucetState {
 
     /// Check rate limits for a request
     ///
-    /// Returns Ok(()) if the request is allowed, Err with the specific limit hit.
+    /// Returns Ok(()) if the request is allowed, Err with the specific limit
+    /// hit.
     pub fn check_rate_limit(&self, ip: IpAddr, address: &str) -> Result<(), FaucetError> {
         // Reset daily counter if we've crossed into a new day
         self.maybe_reset_daily_counter();
@@ -539,7 +538,10 @@ mod tests {
 
         // Third request to same address should be rate limited
         let result = state.check_rate_limit(ip3, address);
-        assert!(matches!(result, Err(FaucetError::AddressRateLimited { .. })));
+        assert!(matches!(
+            result,
+            Err(FaucetError::AddressRateLimited { .. })
+        ));
     }
 
     #[test]
@@ -587,7 +589,10 @@ mod tests {
         // Third request should be limited (same normalized address)
         let ip3: IpAddr = "192.168.1.3".parse().unwrap();
         let result = state.check_rate_limit(ip3, addr1);
-        assert!(matches!(result, Err(FaucetError::AddressRateLimited { .. })));
+        assert!(matches!(
+            result,
+            Err(FaucetError::AddressRateLimited { .. })
+        ));
     }
 
     #[test]

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -65,9 +65,15 @@ use std::{
 use tokio::net::TcpListener;
 use tracing::{debug, error, info, warn};
 
+use crate::{
+    address::Address,
+    ledger::Ledger,
+    mempool::Mempool,
+    transaction::{TxOutput, MIN_TX_FEE},
+    wallet::Wallet,
+};
 use bth_cluster_tax::{FeeConfig, TransactionType};
 use bth_transaction_types::constants::Network;
-use crate::{address::Address, ledger::Ledger, mempool::Mempool, transaction::{TxOutput, MIN_TX_FEE}, wallet::Wallet};
 
 /// JSON-RPC request
 #[derive(Debug, Deserialize)]
@@ -151,7 +157,8 @@ pub struct RpcState {
     pub rate_limiter: Arc<RateLimiter>,
     /// Faucet state (None if faucet is disabled)
     pub faucet: Option<Arc<FaucetState>>,
-    /// Wallet for signing faucet transactions (None if no wallet or faucet disabled)
+    /// Wallet for signing faucet transactions (None if no wallet or faucet
+    /// disabled)
     pub wallet: Option<Arc<Wallet>>,
 }
 
@@ -642,17 +649,19 @@ fn get_entropy_proof_from_tx(tx: &crate::transaction::Transaction) -> Option<Val
     // if let Some(ref extended_sig) = tx.extended_signature {
     //     if let Some(ref proof) = extended_sig.entropy_proof {
     //         return Some(json!({
-    //             "entropyBeforeCommitment": hex::encode(proof.entropy_before_commitment.as_bytes()),
-    //             "entropyAfterCommitment": hex::encode(proof.entropy_after_commitment.as_bytes()),
-    //             "proofSize": proof.serialized_size(),
-    //         }));
+    //             "entropyBeforeCommitment":
+    // hex::encode(proof.entropy_before_commitment.as_bytes()),
+    // "entropyAfterCommitment":
+    // hex::encode(proof.entropy_after_commitment.as_bytes()),
+    // "proofSize": proof.serialized_size(),         }));
     //     }
     // }
     let _ = tx; // Suppress unused variable warning
     None
 }
 
-/// Compute the entropy validation result based on proof presence and block height.
+/// Compute the entropy validation result based on proof presence and block
+/// height.
 ///
 /// Returns one of:
 /// - "valid": Proof provided and verified
@@ -1019,8 +1028,9 @@ async fn handle_wallet_balance(id: Value, state: &RpcState) -> JsonRpcResponse {
         // Check if this output belongs to us and get subaddress index
         if let Some(subaddress_index) = utxo.output.belongs_to(wallet.account_key()) {
             // Recover the one-time private key to compute key image
-            if let Some(onetime_private) =
-                utxo.output.recover_spend_key(wallet.account_key(), subaddress_index)
+            if let Some(onetime_private) = utxo
+                .output
+                .recover_spend_key(wallet.account_key(), subaddress_index)
             {
                 let key_image = bth_crypto_ring_signature::KeyImage::from(&onetime_private);
                 let key_image_bytes = key_image.as_bytes();
@@ -1031,7 +1041,11 @@ async fn handle_wallet_balance(id: Value, state: &RpcState) -> JsonRpcResponse {
                 }
 
                 // Skip if already spent on-chain
-                if ledger.is_key_image_spent(&key_image_bytes).unwrap_or(None).is_some() {
+                if ledger
+                    .is_key_image_spent(&key_image_bytes)
+                    .unwrap_or(None)
+                    .is_some()
+                {
                     continue;
                 }
 
@@ -1186,9 +1200,11 @@ async fn handle_submit_pq_tx(id: Value, _params: &Value, _state: &RpcState) -> J
 ///
 /// The response includes entropy proof information when available:
 /// - `entropyProof`: Entropy proof data (null if not provided)
-/// - `entropyValidationResult`: Validation status ("valid", "not_provided", "no_decay_credit", "invalid")
+/// - `entropyValidationResult`: Validation status ("valid", "not_provided",
+///   "no_decay_credit", "invalid")
 /// - `effectiveDecayRate`: Computed decay rate based on entropy proof
-/// - `entropyProofRequired`: Whether entropy proof is required at this block height
+/// - `entropyProofRequired`: Whether entropy proof is required at this block
+///   height
 async fn handle_get_transaction(id: Value, params: &Value, state: &RpcState) -> JsonRpcResponse {
     // Parse tx_hash parameter
     let tx_hash_hex = match params
@@ -1292,8 +1308,10 @@ async fn handle_get_transaction(id: Value, params: &Value, state: &RpcState) -> 
 ///
 /// # Entropy Validation Fields (Phase 2)
 ///
-/// - `entropyValidationResult`: Validation status ("valid", "not_provided", "no_decay_credit")
-/// - `entropyProofRequired`: Whether entropy proof is required at this block height
+/// - `entropyValidationResult`: Validation status ("valid", "not_provided",
+///   "no_decay_credit")
+/// - `entropyProofRequired`: Whether entropy proof is required at this block
+///   height
 async fn handle_get_transaction_status(
     id: Value,
     params: &Value,
@@ -1349,9 +1367,10 @@ async fn handle_get_transaction_status(
     // Look up in blockchain
     match ledger.get_transaction_confirmations(&tx_hash) {
         Ok(Some(confirmations)) => {
-            // For confirmed transactions, we need the block height to determine entropy status
-            // Since this is the lightweight endpoint, we use chain height as approximation
-            // Full entropy info is available via getTransaction
+            // For confirmed transactions, we need the block height to determine entropy
+            // status Since this is the lightweight endpoint, we use chain
+            // height as approximation Full entropy info is available via
+            // getTransaction
             let entropy_proof_required = is_entropy_proof_required(chain_state.height);
             let entropy_validation_result = if entropy_proof_required {
                 "no_decay_credit" // Default without proof after required height
@@ -2267,7 +2286,10 @@ async fn handle_faucet_request(
         // Check if this output belongs to us and get subaddress index
         if let Some(subaddress_index) = utxo.output.belongs_to(wallet.account_key()) {
             // Recover the one-time private key
-            if let Some(onetime_private) = utxo.output.recover_spend_key(wallet.account_key(), subaddress_index) {
+            if let Some(onetime_private) = utxo
+                .output
+                .recover_spend_key(wallet.account_key(), subaddress_index)
+            {
                 // Compute the key image
                 let key_image = bth_crypto_ring_signature::KeyImage::from(&onetime_private);
                 let key_image_bytes = key_image.as_bytes();
@@ -2368,11 +2390,21 @@ async fn handle_faucet_request(
     }
 
     // Create the transaction
-    let tx = match wallet.create_private_transaction(&selected_utxos, outputs, fee, current_height, &ledger) {
+    let tx = match wallet.create_private_transaction(
+        &selected_utxos,
+        outputs,
+        fee,
+        current_height,
+        &ledger,
+    ) {
         Ok(t) => t,
         Err(e) => {
             error!("Faucet: failed to create transaction: {}", e);
-            return JsonRpcResponse::error(id, -32000, &format!("Failed to create transaction: {}", e));
+            return JsonRpcResponse::error(
+                id,
+                -32000,
+                &format!("Failed to create transaction: {}", e),
+            );
         }
     };
 
@@ -2388,7 +2420,11 @@ async fn handle_faucet_request(
         let ledger = read_lock!(state.ledger, id);
         if let Err(e) = mempool.add_tx(tx.clone(), &ledger) {
             error!("Faucet: failed to add transaction to mempool: {}", e);
-            return JsonRpcResponse::error(id, -32000, &format!("Failed to submit transaction: {}", e));
+            return JsonRpcResponse::error(
+                id,
+                -32000,
+                &format!("Failed to submit transaction: {}", e),
+            );
         }
     }
 
@@ -2412,7 +2448,9 @@ async fn handle_faucet_request(
     let response = faucet::FaucetResponse::success(tx_hash_hex, amount);
     match serde_json::to_value(&response) {
         Ok(value) => JsonRpcResponse::success(id, value),
-        Err(e) => JsonRpcResponse::error(id, -32000, &format!("Failed to serialize response: {}", e)),
+        Err(e) => {
+            JsonRpcResponse::error(id, -32000, &format!("Failed to serialize response: {}", e))
+        }
     }
 }
 
@@ -2467,7 +2505,11 @@ fn calculate_dispensed_from_blockchain(
     // Step 1: Update the key image cache with any new blocks.
     // We only scan blocks that haven't been processed yet.
     let cached_height = faucet.key_image_cache().cached_height;
-    let start_height = if cached_height == 0 { 0 } else { cached_height + 1 };
+    let start_height = if cached_height == 0 {
+        0
+    } else {
+        cached_height + 1
+    };
 
     if chain_state.height >= start_height {
         let mut cache = faucet.key_image_cache_mut();
@@ -2558,7 +2600,8 @@ fn calculate_dispensed_from_blockchain(
 /// Handle faucet status request
 ///
 /// Returns information about the faucet configuration and current stats.
-/// Daily and lifetime dispensed are calculated from the blockchain for accuracy.
+/// Daily and lifetime dispensed are calculated from the blockchain for
+/// accuracy.
 async fn handle_faucet_status(id: Value, state: &RpcState) -> JsonRpcResponse {
     match &state.faucet {
         Some(faucet) => {
@@ -2576,7 +2619,12 @@ async fn handle_faucet_status(id: Value, state: &RpcState) -> JsonRpcResponse {
                         );
                     }
                 };
-                let dispense_stats = calculate_dispensed_from_blockchain(&wallet, &ledger, faucet, stats.amount_per_request);
+                let dispense_stats = calculate_dispensed_from_blockchain(
+                    &wallet,
+                    &ledger,
+                    faucet,
+                    stats.amount_per_request,
+                );
                 // The blockchain reflects only *confirmed* dispenses. Faucet
                 // transactions sit in the mempool until mined, so a freshly
                 // dispensed request would otherwise report zero. The in-memory

--- a/botho/src/telemetry.rs
+++ b/botho/src/telemetry.rs
@@ -70,8 +70,8 @@ impl Default for TelemetryConfig {
 pub fn init_tracing(config: &TelemetryConfig, verbose: bool) -> Result<Option<TelemetryGuard>> {
     // Use RUST_LOG if set, otherwise default based on verbose flag
     let default_level = if verbose { "debug" } else { "warn" };
-    let env_filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(default_level));
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
 
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_target(false)

--- a/botho/src/transaction.rs
+++ b/botho/src/transaction.rs
@@ -654,7 +654,8 @@ pub struct ClsagRingInput {
     /// In the current transparent-amount model (trivial zero-blinding Pedersen
     /// commitments), each input's CLSAG balance proof asserts that the real
     /// ring member's committed amount equals this value. The transaction-level
-    /// balance check then requires `sum(pseudo_output_amount) == outputs + fee`.
+    /// balance check then requires `sum(pseudo_output_amount) == outputs +
+    /// fee`.
     ///
     /// This replaces the previous (broken) model where every input was checked
     /// against the *full* output total, which made any honest multi-input
@@ -1092,9 +1093,9 @@ impl Transaction {
     ///    binds that member's committed amount to the claimed pseudo-output
     ///    amount.
     /// 2. **Balance equation**: the sum of all per-input pseudo-output amounts
-    ///    must equal `outputs + fee`. All arithmetic is exact integer
-    ///    (checked) — there are no floating-point operations in this path, and
-    ///    any overflow is treated as invalid.
+    ///    must equal `outputs + fee`. All arithmetic is exact integer (checked)
+    ///    — there are no floating-point operations in this path, and any
+    ///    overflow is treated as invalid.
     ///
     /// This replaces the previous (broken) model where every input was checked
     /// against the full `outputs + fee` total, which made any honest
@@ -1122,13 +1123,13 @@ impl Transaction {
                 .ok_or("Input amount sum overflow")?;
         }
 
-        // 2. Balance equation: sum(inputs) == sum(outputs) + fee (exact).
-        //    Accumulate the output sum with checked arithmetic — do NOT route
-        //    through `total_output()`, whose internal sum would wrap silently
-        //    in release (overflow-checks = false). An overflowing output sum
-        //    must REJECT the transaction, never wrap: a wrapped output total
-        //    could equal a small honest input total and let a tx mint outputs
-        //    far exceeding its inputs (inflation). See audit finding #340.
+        // 2. Balance equation: sum(inputs) == sum(outputs) + fee (exact). Accumulate
+        //    the output sum with checked arithmetic — do NOT route through
+        //    `total_output()`, whose internal sum would wrap silently in release
+        //    (overflow-checks = false). An overflowing output sum must REJECT the
+        //    transaction, never wrap: a wrapped output total could equal a small honest
+        //    input total and let a tx mint outputs far exceeding its inputs
+        //    (inflation). See audit finding #340.
         let mut output_total: u64 = 0;
         for output in &self.outputs {
             output_total = output_total
@@ -1197,8 +1198,8 @@ pub struct Utxo {
 impl Transaction {
     /// Create a stub transaction for testing with a given fee.
     ///
-    /// This creates an empty transaction (no inputs/outputs) with the specified fee.
-    /// Used for testing fee-related logic like lottery validation.
+    /// This creates an empty transaction (no inputs/outputs) with the specified
+    /// fee. Used for testing fee-related logic like lottery validation.
     pub fn new_stub_with_fee(fee: u64) -> Self {
         Self {
             inputs: TxInputs::new(vec![]),
@@ -1430,7 +1431,9 @@ mod tests {
         let onetime_public = RistrettoPublic::from(&onetime_private);
 
         let real_member = RingMember {
-            target_key: CompressedRistrettoPublic::from(&onetime_public).to_bytes().into(),
+            target_key: CompressedRistrettoPublic::from(&onetime_public)
+                .to_bytes()
+                .into(),
             public_key: CompressedRistrettoPublic::from(&RistrettoPublic::from(
                 &RistrettoPrivate::from_random(&mut rng),
             ))
@@ -1452,8 +1455,12 @@ mod tests {
             let decoy_amount: u64 = rng.gen_range(1..1_000_000);
             let g = generators(0);
             ring.push(RingMember {
-                target_key: CompressedRistrettoPublic::from(&decoy_target).to_bytes().into(),
-                public_key: CompressedRistrettoPublic::from(&decoy_public).to_bytes().into(),
+                target_key: CompressedRistrettoPublic::from(&decoy_target)
+                    .to_bytes()
+                    .into(),
+                public_key: CompressedRistrettoPublic::from(&decoy_public)
+                    .to_bytes()
+                    .into(),
                 commitment: g
                     .commit(Scalar::from(decoy_amount), Scalar::ZERO)
                     .compress()
@@ -1478,9 +1485,10 @@ mod tests {
 
     /// Assemble a transaction whose inputs sum to `outputs + fee`.
     ///
-    /// `input_amounts` are the per-input spent amounts; the outputs are a single
-    /// recipient output plus an implicit balance — here we simply emit a single
-    /// output equal to `sum(inputs) - fee` so the balance equation holds.
+    /// `input_amounts` are the per-input spent amounts; the outputs are a
+    /// single recipient output plus an implicit balance — here we simply
+    /// emit a single output equal to `sum(inputs) - fee` so the balance
+    /// equation holds.
     fn balanced_tx(input_amounts: &[u64], fee: u64) -> Transaction {
         let total_input: u64 = input_amounts.iter().sum();
         let output_amount = total_input - fee;

--- a/botho/src/wallet.rs
+++ b/botho/src/wallet.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
 use bip39::{Language, Mnemonic, Seed};
 use bth_account_keys::{AccountKey, PublicAddress};
-use bth_cluster_tax::crypto::{CommittedTagVectorSecret, EntropyProof, EntropyProofBuilder};
-use bth_cluster_tax::ClusterId as TaxClusterId;
+use bth_cluster_tax::{
+    crypto::{CommittedTagVectorSecret, EntropyProof, EntropyProofBuilder},
+    ClusterId as TaxClusterId,
+};
 use bth_core::slip10::Slip10KeyGenerator;
 use bth_transaction_types::{ClusterTagVector, TAG_WEIGHT_SCALE};
 use rand::{rngs::OsRng, seq::SliceRandom};
@@ -121,7 +123,8 @@ impl TransactionConfig {
 pub enum EntropyProofResult {
     /// Proof generated successfully.
     Generated(EntropyProof),
-    /// Proof generation skipped (V2 transaction or not enough entropy increase).
+    /// Proof generation skipped (V2 transaction or not enough entropy
+    /// increase).
     Skipped,
     /// Proof generation failed, fell back to V2.
     Fallback(String),
@@ -591,10 +594,10 @@ impl Wallet {
 
     /// Create a V3 transaction with entropy proof for full decay credit.
     ///
-    /// This method creates a transaction with an entropy proof that demonstrates
-    /// the transaction creates sufficient entropy increase to qualify for full
-    /// decay credit. If entropy proof generation fails and fallback is enabled,
-    /// returns a V2 transaction without the proof.
+    /// This method creates a transaction with an entropy proof that
+    /// demonstrates the transaction creates sufficient entropy increase to
+    /// qualify for full decay credit. If entropy proof generation fails and
+    /// fallback is enabled, returns a V2 transaction without the proof.
     ///
     /// # Arguments
     /// * `utxos_to_spend` - The wallet's UTXOs to spend
@@ -606,7 +609,8 @@ impl Wallet {
     ///
     /// # Returns
     /// A tuple of (Transaction, EntropyProofResult) where the proof result
-    /// indicates whether the entropy proof was generated, skipped, or fell back.
+    /// indicates whether the entropy proof was generated, skipped, or fell
+    /// back.
     pub fn create_transaction_v3(
         &self,
         utxos_to_spend: &[Utxo],
@@ -691,26 +695,22 @@ impl Wallet {
         // Convert input UTXOs to CommittedTagVectorSecrets
         let input_secrets: Vec<CommittedTagVectorSecret> = utxos
             .iter()
-            .map(|utxo| {
-                Self::utxo_to_committed_tag_secret(utxo)
-            })
+            .map(|utxo| Self::utxo_to_committed_tag_secret(utxo))
             .collect();
 
         // Convert outputs to CommittedTagVectorSecrets (with decay applied)
         let output_secrets: Vec<CommittedTagVectorSecret> = outputs
             .iter()
-            .map(|output| {
-                Self::output_to_committed_tag_secret(output)
-            })
+            .map(|output| Self::output_to_committed_tag_secret(output))
             .collect();
 
         // Build the entropy proof
         let builder = EntropyProofBuilder::new(input_secrets, output_secrets);
-        builder
-            .prove(&mut rng)
-            .ok_or_else(|| anyhow::anyhow!(
+        builder.prove(&mut rng).ok_or_else(|| {
+            anyhow::anyhow!(
                 "Entropy delta below threshold - transaction does not qualify for decay credit"
-            ))
+            )
+        })
     }
 
     /// Convert a UTXO's tags to a CommittedTagVectorSecret.
@@ -1019,15 +1019,23 @@ mod tests {
         let base_fee_per_byte = 10u64;
 
         // V2 fee (no entropy proof)
-        let fee_v2 =
-            Wallet::estimate_fee_with_entropy_proof(&utxos, 2, base_fee_per_byte, TransactionVersion::V2);
+        let fee_v2 = Wallet::estimate_fee_with_entropy_proof(
+            &utxos,
+            2,
+            base_fee_per_byte,
+            TransactionVersion::V2,
+        );
         // Size: 100 + 700 + 200 + 500 = 1500
         // Fee: 1500 * 10 * 1 (no multiplier for < 1M) = 15000
         assert_eq!(fee_v2, 15000);
 
         // V3 fee (with entropy proof)
-        let fee_v3 =
-            Wallet::estimate_fee_with_entropy_proof(&utxos, 2, base_fee_per_byte, TransactionVersion::V3);
+        let fee_v3 = Wallet::estimate_fee_with_entropy_proof(
+            &utxos,
+            2,
+            base_fee_per_byte,
+            TransactionVersion::V3,
+        );
         // Size: 1500 + 1024 = 2524
         // Fee: 2524 * 10 * 1 = 25240
         assert_eq!(fee_v3, 25240);

--- a/botho/tests/common/constants.rs
+++ b/botho/tests/common/constants.rs
@@ -24,7 +24,8 @@ pub const TEST_RING_SIZE: usize = 20;
 
 /// Trivial PoW difficulty for fast testing.
 ///
-/// Must match the chain's initial difficulty (`block::difficulty::INITIAL_DIFFICULTY`
+/// Must match the chain's initial difficulty
+/// (`block::difficulty::INITIAL_DIFFICULTY`
 /// / `node::minter::INITIAL_DIFFICULTY` = `0x00FF_FFFF_FFFF_FFFF`) — block
 /// acceptance now enforces `header.difficulty == chain.difficulty` (audit
 /// cycle 6, C1). A trivially-easy difficulty here is fine for tests because

--- a/botho/tests/common/network.rs
+++ b/botho/tests/common/network.rs
@@ -595,8 +595,7 @@ fn apply_lottery_to_block(block: Block, ledger: &Arc<RwLock<Ledger>>) -> Block {
                 Ok(p) => p,
                 Err(_) => return burn_fee_share(block),
             };
-            match led
-                .get_lottery_validation_candidates(block.height(), &lottery_config.draw_config)
+            match led.get_lottery_validation_candidates(block.height(), &lottery_config.draw_config)
             {
                 Ok(c) => (pool, c),
                 Err(_) => return burn_fee_share(block),
@@ -616,5 +615,11 @@ fn apply_lottery_to_block(block: Block, ledger: &Arc<RwLock<Ledger>>) -> Block {
         led.get_utxo_by_id(utxo_id).ok().flatten()
     };
 
-    BlockBuilder::apply_lottery(block, &candidates, stored_pool, utxo_lookup, &lottery_config)
+    BlockBuilder::apply_lottery(
+        block,
+        &candidates,
+        stored_pool,
+        utxo_lookup,
+        &lottery_config,
+    )
 }

--- a/botho/tests/e2e_consensus_integration.rs
+++ b/botho/tests/e2e_consensus_integration.rs
@@ -305,7 +305,10 @@ fn test_e2e_5_node_consensus_with_mining_and_transactions() {
         "  Final total mined: {} BTH",
         final_state.total_mined / PICOCREDITS_PER_CREDIT as u128
     );
-    println!("  Fees burned (20% share): {} picocredits", final_state.total_fees_burned);
+    println!(
+        "  Fees burned (20% share): {} picocredits",
+        final_state.total_fees_burned
+    );
     println!("  Lottery pool (carryover): {} picocredits", lottery_pool);
 
     // All four transfers were confirmed (asserted by confirm_transaction
@@ -375,7 +378,10 @@ fn test_e2e_5_node_consensus_with_mining_and_transactions() {
     println!("  - {} nodes reached consensus", DEFAULT_NUM_NODES);
     println!("  - {} blocks mined", final_state.height);
     println!("  - {} transactions confirmed", num_tx_blocks);
-    println!("  - {} picocredits destroyed (burn share)", final_state.total_fees_burned);
+    println!(
+        "  - {} picocredits destroyed (burn share)",
+        final_state.total_fees_burned
+    );
     println!("  - {} picocredits in redistribution pool", lottery_pool);
     println!("  - All nodes have consistent ledger state");
     println!("  - Supply conservation verified: mined = wallets + burned + pool");

--- a/botho/tests/e2e_faucet_workflow.rs
+++ b/botho/tests/e2e_faucet_workflow.rs
@@ -12,7 +12,11 @@
 
 mod common;
 
-use std::{net::SocketAddr, sync::Arc, time::Duration, time::SystemTime};
+use std::{
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -20,8 +24,6 @@ use serial_test::serial;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 
-use bth_account_keys::PublicAddress;
-use bth_transaction_types::constants::Network;
 use botho::{
     address::Address,
     block::{Block, BlockHeader, BlockLotterySummary, MintingTx},
@@ -33,6 +35,8 @@ use botho::{
     transaction::PICOCREDITS_PER_CREDIT,
     wallet::Wallet,
 };
+use bth_account_keys::PublicAddress;
+use bth_transaction_types::constants::Network;
 
 // ============================================================================
 // Test Helpers
@@ -137,7 +141,13 @@ fn apply_lottery_to_block(block: Block, ledger: &Ledger) -> Block {
     }
 
     let utxo_lookup = |utxo_id: &[u8; 36]| ledger.get_utxo_by_id(utxo_id).ok().flatten();
-    BlockBuilder::apply_lottery(block, &candidates, stored_pool, utxo_lookup, &lottery_config)
+    BlockBuilder::apply_lottery(
+        block,
+        &candidates,
+        stored_pool,
+        utxo_lookup,
+        &lottery_config,
+    )
 }
 
 /// Mine a single block crediting `minter_address` and append it to the ledger.

--- a/botho/tests/e2e_transfer_patterns.rs
+++ b/botho/tests/e2e_transfer_patterns.rs
@@ -22,8 +22,10 @@ use std::{thread, time::Duration};
 use bth_account_keys::PublicAddress;
 use serial_test::serial;
 
-use botho::consensus::split_fees;
-use botho::transaction::{Utxo, MIN_TX_FEE, PICOCREDITS_PER_CREDIT};
+use botho::{
+    consensus::split_fees,
+    transaction::{Utxo, MIN_TX_FEE, PICOCREDITS_PER_CREDIT},
+};
 
 use crate::common::{
     confirm_transaction, create_multi_input_transaction, create_signed_transaction,
@@ -444,7 +446,10 @@ fn test_stress_load_patterns() {
                 }
             }
             Err(e) => {
-                println!("    {} -> {}: create FAILED ({})", sender_idx, recipient_idx, e);
+                println!(
+                    "    {} -> {}: create FAILED ({})",
+                    sender_idx, recipient_idx, e
+                );
             }
         }
     }
@@ -462,7 +467,10 @@ fn test_stress_load_patterns() {
     println!("  Total blocks: {}", final_state.height);
     println!("  Transactions created: {}", total_transactions);
     println!("  Transactions confirmed: {}", confirmed_tx_count);
-    println!("  Fees burned (20% share): {} picocredits", final_state.total_fees_burned);
+    println!(
+        "  Fees burned (20% share): {} picocredits",
+        final_state.total_fees_burned
+    );
 
     // confirm_transaction is reliable, so every created tx should confirm.
     assert_eq!(
@@ -470,7 +478,10 @@ fn test_stress_load_patterns() {
         "All created transactions should confirm ({} of {})",
         confirmed_tx_count, total_transactions
     );
-    assert!(total_transactions > 0, "Stress test created no transactions");
+    assert!(
+        total_transactions > 0,
+        "Stress test created no transactions"
+    );
 
     // Each confirmed transfer lands in its own block, so the destroyed amount
     // is confirmed * burn(MIN_TX_FEE) (audit cycle 6, M4).

--- a/botho/tests/ice_stun_integration.rs
+++ b/botho/tests/ice_stun_integration.rs
@@ -64,25 +64,21 @@ fn test_ice_config_builder() {
 #[test]
 fn test_ice_candidate_priority() {
     // Host candidates should have highest priority
-    let host_priority =
-        IceCandidate::calculate_priority(IceCandidateType::Host, 1, 65535);
+    let host_priority = IceCandidate::calculate_priority(IceCandidateType::Host, 1, 65535);
 
     // Server reflexive candidates have lower priority
     let srflx_priority =
         IceCandidate::calculate_priority(IceCandidateType::ServerReflexive, 1, 65535);
 
     // Relay candidates have lowest priority
-    let relay_priority =
-        IceCandidate::calculate_priority(IceCandidateType::Relay, 1, 65535);
+    let relay_priority = IceCandidate::calculate_priority(IceCandidateType::Relay, 1, 65535);
 
     assert!(host_priority > srflx_priority);
     assert!(srflx_priority > relay_priority);
 
     // Component 1 should have higher priority than component 2
-    let comp1_priority =
-        IceCandidate::calculate_priority(IceCandidateType::Host, 1, 65535);
-    let comp2_priority =
-        IceCandidate::calculate_priority(IceCandidateType::Host, 2, 65535);
+    let comp1_priority = IceCandidate::calculate_priority(IceCandidateType::Host, 1, 65535);
+    let comp2_priority = IceCandidate::calculate_priority(IceCandidateType::Host, 2, 65535);
     assert!(comp1_priority > comp2_priority);
 }
 

--- a/botho/tests/ledger_consistency_integration.rs
+++ b/botho/tests/ledger_consistency_integration.rs
@@ -1089,8 +1089,7 @@ fn test_c3_block_rejected_when_ring_member_target_key_not_in_utxo_set() {
         .expect_err("Block with counterfeit ring member must be rejected");
     let msg = format!("{}", err);
     assert!(
-        msg.contains("target_key not in UTXO set")
-            || msg.contains("ring member"),
+        msg.contains("target_key not in UTXO set") || msg.contains("ring member"),
         "Error should identify the counterfeit ring member, got: {}",
         msg
     );

--- a/botho/tests/rpc_integration.rs
+++ b/botho/tests/rpc_integration.rs
@@ -17,12 +17,12 @@ use serial_test::serial;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 
-use bth_transaction_types::constants::Network;
 use botho::{
     ledger::Ledger,
     mempool::Mempool,
     rpc::{RpcState, WsBroadcaster},
 };
+use bth_transaction_types::constants::Network;
 
 // ============================================================================
 // Test Helpers
@@ -174,7 +174,11 @@ async fn test_get_chain_info() {
     // totalMined is a u128 picocredit value emitted as a decimal string (PR #342)
     // to avoid JS 2^53 precision loss; verify it is a well-formed unsigned integer.
     assert!(result["totalMined"].is_string());
-    assert!(result["totalMined"].as_str().unwrap().parse::<u128>().is_ok());
+    assert!(result["totalMined"]
+        .as_str()
+        .unwrap()
+        .parse::<u128>()
+        .is_ok());
     assert!(result["mempoolSize"].is_number());
     assert!(result["mempoolFees"].is_number());
 }

--- a/botho/tests/signaling_integration.rs
+++ b/botho/tests/signaling_integration.rs
@@ -148,7 +148,12 @@ async fn test_full_signaling_flow_with_ice() {
     // Offerer sends ICE candidates
     for (candidate, sdp_mid, sdp_mline_index) in &candidates {
         offerer
-            .send_ice_candidate(session_id, candidate.clone(), sdp_mid.clone(), *sdp_mline_index)
+            .send_ice_candidate(
+                session_id,
+                candidate.clone(),
+                sdp_mid.clone(),
+                *sdp_mline_index,
+            )
             .await
             .expect("Should send ICE candidate");
     }
@@ -309,21 +314,16 @@ async fn test_concurrent_signaling_sessions() {
             let mut offerer = SignalingChannel::new(client);
             let mut answerer = SignalingChannel::new(server);
 
-            let offer_sdp = format!(
-                "v=0\r\no=session{} 0 0 IN IP4 127.0.0.1\r\ns=-\r\n",
-                i
-            );
-            let answer_sdp = format!(
-                "v=0\r\no=answer{} 0 0 IN IP4 127.0.0.1\r\ns=-\r\n",
-                i
-            );
+            let offer_sdp = format!("v=0\r\no=session{} 0 0 IN IP4 127.0.0.1\r\ns=-\r\n", i);
+            let answer_sdp = format!("v=0\r\no=answer{} 0 0 IN IP4 127.0.0.1\r\ns=-\r\n", i);
 
             let offer_clone = offer_sdp.clone();
             let answer_clone = answer_sdp.clone();
 
-            let offerer_task = tokio::spawn(async move {
-                offerer.exchange_sdp(offer_clone, session_id, true).await
-            });
+            let offerer_task =
+                tokio::spawn(
+                    async move { offerer.exchange_sdp(offer_clone, session_id, true).await },
+                );
 
             let answerer_task = tokio::spawn(async move {
                 answerer.exchange_sdp(answer_clone, session_id, false).await

--- a/botho/tests/transport_negotiation_integration.rs
+++ b/botho/tests/transport_negotiation_integration.rs
@@ -10,8 +10,7 @@
 //! - Fallback behavior when no common transport exists
 
 use std::time::Duration;
-use tokio::io::duplex;
-use tokio::time::timeout;
+use tokio::{io::duplex, time::timeout};
 
 use botho::network::{
     negotiate_transport_initiator, negotiate_transport_responder, select_transport,
@@ -67,7 +66,10 @@ async fn test_e2e_negotiate_falls_back_to_plain() {
 
     // Client only supports WebRTC
     let client_caps = TransportCapabilities::new(
-        vec![CapabilityTransportType::WebRTC, CapabilityTransportType::Plain],
+        vec![
+            CapabilityTransportType::WebRTC,
+            CapabilityTransportType::Plain,
+        ],
         CapabilityTransportType::WebRTC,
         NegotiationNatType::Open,
     );
@@ -189,19 +191,28 @@ fn test_select_transport_prefers_higher_score() {
     let peer_caps = TransportCapabilities::full(NegotiationNatType::Open);
 
     let selected = select_transport(&our_caps, &peer_caps);
-    assert_eq!(selected, CapabilityTransportType::WebRTC); // Highest preference score
+    assert_eq!(selected, CapabilityTransportType::WebRTC); // Highest preference
+                                                           // score
 }
 
 #[test]
 fn test_select_transport_considers_preference_order() {
     // We prefer TLS, peer prefers WebRTC
     let our_caps = TransportCapabilities::new(
-        vec![CapabilityTransportType::TlsTunnel, CapabilityTransportType::WebRTC, CapabilityTransportType::Plain],
+        vec![
+            CapabilityTransportType::TlsTunnel,
+            CapabilityTransportType::WebRTC,
+            CapabilityTransportType::Plain,
+        ],
         CapabilityTransportType::TlsTunnel,
         NegotiationNatType::Open,
     );
     let peer_caps = TransportCapabilities::new(
-        vec![CapabilityTransportType::WebRTC, CapabilityTransportType::TlsTunnel, CapabilityTransportType::Plain],
+        vec![
+            CapabilityTransportType::WebRTC,
+            CapabilityTransportType::TlsTunnel,
+            CapabilityTransportType::Plain,
+        ],
         CapabilityTransportType::WebRTC,
         NegotiationNatType::Open,
     );
@@ -376,8 +387,14 @@ fn test_nat_webrtc_compatibility_matrix() {
 #[test]
 fn test_transport_type_preference_ordering() {
     // Verify preference scores are ordered correctly
-    assert!(CapabilityTransportType::WebRTC.preference_score() > CapabilityTransportType::TlsTunnel.preference_score());
-    assert!(CapabilityTransportType::TlsTunnel.preference_score() > CapabilityTransportType::Plain.preference_score());
+    assert!(
+        CapabilityTransportType::WebRTC.preference_score()
+            > CapabilityTransportType::TlsTunnel.preference_score()
+    );
+    assert!(
+        CapabilityTransportType::TlsTunnel.preference_score()
+            > CapabilityTransportType::Plain.preference_score()
+    );
 }
 
 // ============================================================================
@@ -387,7 +404,8 @@ fn test_transport_type_preference_ordering() {
 #[test]
 fn test_negotiation_message_bincode_size() {
     // Verify messages are reasonably sized
-    let propose = NegotiationMessage::propose(&TransportCapabilities::full(NegotiationNatType::Open));
+    let propose =
+        NegotiationMessage::propose(&TransportCapabilities::full(NegotiationNatType::Open));
     let accept = NegotiationMessage::accept(CapabilityTransportType::WebRTC);
     let reject = NegotiationMessage::reject("No common transport available");
 

--- a/botho/tests/tx_lifecycle_integration.rs
+++ b/botho/tests/tx_lifecycle_integration.rs
@@ -178,7 +178,8 @@ fn mine_block(
 }
 
 /// Apply the lottery fee-split / draw to a block using the ledger's pool and
-/// candidate set (single-ledger analogue of commands/run.rs::apply_lottery_to_block).
+/// candidate set (single-ledger analogue of
+/// commands/run.rs::apply_lottery_to_block).
 fn apply_lottery_to_block(block: Block, ledger: &Ledger) -> Block {
     let total_fees: u64 = block.transactions.iter().map(|tx| tx.fee).sum();
     let emission_share = block.minting_tx.lottery_emission_share();
@@ -195,7 +196,13 @@ fn apply_lottery_to_block(block: Block, ledger: &Ledger) -> Block {
     }
 
     let utxo_lookup = |utxo_id: &[u8; 36]| ledger.get_utxo_by_id(utxo_id).ok().flatten();
-    BlockBuilder::apply_lottery(block, &candidates, stored_pool, utxo_lookup, &lottery_config)
+    BlockBuilder::apply_lottery(
+        block,
+        &candidates,
+        stored_pool,
+        utxo_lookup,
+        &lottery_config,
+    )
 }
 
 /// Scan wallet for unspent UTXOs

--- a/cluster-tax/benches/committed_tags_benchmarks.rs
+++ b/cluster-tax/benches/committed_tags_benchmarks.rs
@@ -2,7 +2,8 @@
 //!
 //! These benchmarks measure proof sizes and performance characteristics
 //! for the integrated Bulletproof + entropy approach, validating estimates
-//! from the Phase A feasibility study (docs/design/entropy-proof-aggregation-research.md).
+//! from the Phase A feasibility study
+//! (docs/design/entropy-proof-aggregation-research.md).
 //!
 //! ## Phase A Target Metrics
 //!
@@ -55,7 +56,8 @@ fn create_test_secret(num_clusters: usize, value: u64) -> CommittedTagVectorSecr
     CommittedTagVectorSecret::from_plaintext(value, &tags, &mut OsRng)
 }
 
-/// Create a TagVector with N equal-weight clusters (for collision entropy benchmarks).
+/// Create a TagVector with N equal-weight clusters (for collision entropy
+/// benchmarks).
 fn create_tag_vector(num_clusters: usize) -> TagVector {
     let mut tags = TagVector::new();
     if num_clusters == 0 {
@@ -188,7 +190,12 @@ fn bench_proof_sizes(c: &mut Criterion) {
                     let output_vector_size = output_secret.commit().to_bytes().len();
                     let total = conservation_size + input_vector_size + output_vector_size;
 
-                    black_box((conservation_size, input_vector_size, output_vector_size, total))
+                    black_box((
+                        conservation_size,
+                        input_vector_size,
+                        output_vector_size,
+                        total,
+                    ))
                 });
             },
         );

--- a/cluster-tax/src/age_decay.rs
+++ b/cluster-tax/src/age_decay.rs
@@ -135,9 +135,11 @@ impl RingDecayInfo {
     /// This returns `true` only if ALL ring members are eligible for decay.
     /// This is the conservative choice because:
     /// - If the real input is young (not eligible), decay shouldn't apply
-    /// - If ANY decoy is young, we conservatively assume it might be the real one
+    /// - If ANY decoy is young, we conservatively assume it might be the real
+    ///   one
     ///
-    /// This prevents attackers from using old decoys to force decay on young coins.
+    /// This prevents attackers from using old decoys to force decay on young
+    /// coins.
     ///
     /// For Phase 1 (public tags), this is the recommended approach as it
     /// provides safety without requiring ZK proofs.
@@ -467,7 +469,11 @@ mod tests {
         let factor = ring_cluster_factor(&ring_tags, &cluster_wealth, total_supply);
 
         // Background-only = 0 cluster factor
-        assert!(factor < 0.001, "Background should have ~0 factor, got {}", factor);
+        assert!(
+            factor < 0.001,
+            "Background should have ~0 factor, got {}",
+            factor
+        );
     }
 
     #[test]

--- a/cluster-tax/src/bin/sim.rs
+++ b/cluster-tax/src/bin/sim.rs
@@ -482,9 +482,10 @@ mod cli {
         },
 
         /// Emission-schedule sweep (issue #350): run a fixed grid of candidate
-        /// MonetaryPolicy schedules (S1..S5) through the agent-based sim plus an
-        /// analytic monetary model, and emit a neutral comparison report
-        /// (markdown + CSV). Presents data only; recommends nothing.
+        /// MonetaryPolicy schedules (S1..S5) through the agent-based sim plus
+        /// an analytic monetary model, and emit a neutral comparison
+        /// report (markdown + CSV). Presents data only; recommends
+        /// nothing.
         EmissionSweep {
             /// Number of simulated rounds for the distribution track
             #[arg(long, default_value = "4000")]
@@ -1188,7 +1189,10 @@ mod cli {
         };
 
         if show_progress {
-            eprintln!("(progress display not available; running {} rounds...)", rounds);
+            eprintln!(
+                "(progress display not available; running {} rounds...)",
+                rounds
+            );
         }
         let result = run_simulation(&mut agents, &config);
         let summary = result.metrics.summary();
@@ -2946,10 +2950,7 @@ mod cli {
         use bth_cluster_tax::{compare_decay_modes, AttackStrategy, DecayMode};
 
         let strategies = vec![
-            (
-                "rapid-wash",
-                AttackStrategy::RapidWash { transfers: 100 },
-            ),
+            ("rapid-wash", AttackStrategy::RapidWash { transfers: 100 }),
             (
                 "patient-wash-720",
                 AttackStrategy::PatientWash {
@@ -3004,18 +3005,29 @@ mod cli {
         println!("├───────────────────────┼─────────┼───────┼───────┼─────────┼───────┼───────┤");
 
         for (name, strategy) in &strategies {
-            let comparison = compare_decay_modes(strategy, initial_wealth, initial_factor, duration_blocks);
+            let comparison =
+                compare_decay_modes(strategy, initial_wealth, initial_factor, duration_blocks);
 
-            let age_result = comparison.iter()
+            let age_result = comparison
+                .iter()
                 .find(|(m, _)| *m == DecayMode::AgeBased)
                 .map(|(_, r)| r);
-            let entropy_result = comparison.iter()
+            let entropy_result = comparison
+                .iter()
                 .find(|(m, _)| *m == DecayMode::EntropyWeighted)
                 .map(|(_, r)| r);
 
             if let (Some(age), Some(entropy)) = (age_result, entropy_result) {
-                let age_resist = if age.tag_remaining_fraction > 0.5 { "✓" } else { "✗" };
-                let entropy_resist = if entropy.tag_remaining_fraction > 0.5 { "✓" } else { "✗" };
+                let age_resist = if age.tag_remaining_fraction > 0.5 {
+                    "✓"
+                } else {
+                    "✗"
+                };
+                let entropy_resist = if entropy.tag_remaining_fraction > 0.5 {
+                    "✓"
+                } else {
+                    "✗"
+                };
 
                 println!(
                     "│ {:<21} │ {:>6.1}% │ {:>5} │   {}   │ {:>6.1}% │ {:>5} │   {}   │",
@@ -3040,15 +3052,21 @@ mod cli {
         println!("ANALYSIS");
         println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
         println!();
-        println!("Key Insight: Entropy-weighted decay only applies when cluster_entropy() increases.");
+        println!(
+            "Key Insight: Entropy-weighted decay only applies when cluster_entropy() increases."
+        );
         println!();
         println!("  • SELF-TRANSFERS: Same tags in, same tags out → entropy unchanged → NO decay");
         println!("  • SYBIL ATTACK: Fake counterparties have attacker's tags → entropy unchanged → NO decay");
-        println!("  • REAL COMMERCE: Different cluster tags mix → entropy increases → decay applies");
+        println!(
+            "  • REAL COMMERCE: Different cluster tags mix → entropy increases → decay applies"
+        );
         println!();
         println!("Advantages of entropy-weighted decay:");
         println!("  1. ✓ Resistant to rapid wash trading (no entropy change)");
-        println!("  2. ✓ Resistant to patient wash trading (no entropy change regardless of timing)");
+        println!(
+            "  2. ✓ Resistant to patient wash trading (no entropy change regardless of timing)"
+        );
         println!("  3. ✓ Resistant to sybil wash trading (fake identities don't add entropy)");
         println!("  4. ✓ Allows natural decay through legitimate commerce");
         println!("  5. ✓ Privacy preserved (uses existing cluster_entropy() calculation)");
@@ -3091,12 +3109,16 @@ mod cli {
         };
 
         let initial_factor = 6.0; // Maximum cluster factor
-        let comparison = compare_decay_modes(&strategy, initial_wealth, initial_factor, duration_blocks);
+        let comparison =
+            compare_decay_modes(&strategy, initial_wealth, initial_factor, duration_blocks);
 
         println!("╔════════════════════════════════════════════════════════════════════════════════════════╗");
         println!("║                     ATTACK RESISTANCE ANALYSIS                                         ║");
         println!("╠════════════════════════════════════════════════════════════════════════════════════════╣");
-        println!("║  Strategy:           {:<30}                                    ║", strategy_name);
+        println!(
+            "║  Strategy:           {:<30}                                    ║",
+            strategy_name
+        );
         println!("║  Initial Wealth:     {:>12}                                                         ║", initial_wealth);
         println!("║  Duration:           {:>6} blocks (~{:.1} days)                                          ║",
             duration_blocks, duration_blocks as f64 / 8640.0);
@@ -3111,14 +3133,21 @@ mod cli {
             };
 
             let attack_success = result.tag_remaining_fraction < 0.5;
-            let status = if attack_success { "VULNERABLE ✗" } else { "RESISTANT ✓" };
+            let status = if attack_success {
+                "VULNERABLE ✗"
+            } else {
+                "RESISTANT ✓"
+            };
 
             println!("┌─────────────────────────────────────────────────┐");
             println!("│ {:^47} │", mode_name);
             println!("├─────────────────────────────────────────────────┤");
             println!("│ Initial tag weight:     {:>20}  │", result.initial_tag);
             println!("│ Final tag weight:       {:>20}  │", result.final_tag);
-            println!("│ Tag remaining:          {:>19.2}%  │", result.tag_remaining_fraction * 100.0);
+            println!(
+                "│ Tag remaining:          {:>19.2}%  │",
+                result.tag_remaining_fraction * 100.0
+            );
             println!("│ Decay events:           {:>20}  │", result.decay_events);
             println!("│ Total attempts:         {:>20}  │", result.total_attempts);
             println!("│ Attack status:          {:>20}  │", status);
@@ -3127,20 +3156,36 @@ mod cli {
         }
 
         // Summary
-        let age_result = comparison.iter().find(|(m, _)| *m == DecayMode::AgeBased).map(|(_, r)| r);
-        let entropy_result = comparison.iter().find(|(m, _)| *m == DecayMode::EntropyWeighted).map(|(_, r)| r);
+        let age_result = comparison
+            .iter()
+            .find(|(m, _)| *m == DecayMode::AgeBased)
+            .map(|(_, r)| r);
+        let entropy_result = comparison
+            .iter()
+            .find(|(m, _)| *m == DecayMode::EntropyWeighted)
+            .map(|(_, r)| r);
 
         if let (Some(age), Some(entropy)) = (age_result, entropy_result) {
             println!("Summary:");
-            println!("  Age-based:        {:.1}% remaining ({} decay events)",
-                age.tag_remaining_fraction * 100.0, age.decay_events);
-            println!("  Entropy-weighted: {:.1}% remaining ({} decay events)",
-                entropy.tag_remaining_fraction * 100.0, entropy.decay_events);
+            println!(
+                "  Age-based:        {:.1}% remaining ({} decay events)",
+                age.tag_remaining_fraction * 100.0,
+                age.decay_events
+            );
+            println!(
+                "  Entropy-weighted: {:.1}% remaining ({} decay events)",
+                entropy.tag_remaining_fraction * 100.0,
+                entropy.decay_events
+            );
 
             if entropy.tag_remaining_fraction > age.tag_remaining_fraction {
-                let improvement = (entropy.tag_remaining_fraction - age.tag_remaining_fraction) * 100.0;
+                let improvement =
+                    (entropy.tag_remaining_fraction - age.tag_remaining_fraction) * 100.0;
                 println!();
-                println!("  ✓ Entropy-weighted decay provides {:.1}% better attack resistance!", improvement);
+                println!(
+                    "  ✓ Entropy-weighted decay provides {:.1}% better attack resistance!",
+                    improvement
+                );
             }
         }
     }
@@ -3178,12 +3223,26 @@ mod cli {
             };
             let comparison = compare_decay_modes(&strategy, initial_wealth, 6.0, duration_blocks);
 
-            let age_result = comparison.iter().find(|(m, _)| *m == DecayMode::AgeBased).map(|(_, r)| r);
-            let entropy_result = comparison.iter().find(|(m, _)| *m == DecayMode::EntropyWeighted).map(|(_, r)| r);
+            let age_result = comparison
+                .iter()
+                .find(|(m, _)| *m == DecayMode::AgeBased)
+                .map(|(_, r)| r);
+            let entropy_result = comparison
+                .iter()
+                .find(|(m, _)| *m == DecayMode::EntropyWeighted)
+                .map(|(_, r)| r);
 
             if let (Some(age), Some(entropy)) = (age_result, entropy_result) {
-                let age_status = if age.tag_remaining_fraction > 0.5 { "Resistant" } else { "Vulnerable" };
-                let entropy_status = if entropy.tag_remaining_fraction > 0.5 { "Resistant" } else { "Vulnerable" };
+                let age_status = if age.tag_remaining_fraction > 0.5 {
+                    "Resistant"
+                } else {
+                    "Vulnerable"
+                };
+                let entropy_status = if entropy.tag_remaining_fraction > 0.5 {
+                    "Resistant"
+                } else {
+                    "Vulnerable"
+                };
 
                 println!(
                     "│   {:>5.1}   │  {:>6.1}%  │ {:^11} │  {:>6.1}%  │ {:^11} │",
@@ -3216,8 +3275,14 @@ mod cli {
             };
             let comparison = compare_decay_modes(&strategy, initial_wealth, 6.0, duration_blocks);
 
-            let age_result = comparison.iter().find(|(m, _)| *m == DecayMode::AgeBased).map(|(_, r)| r);
-            let entropy_result = comparison.iter().find(|(m, _)| *m == DecayMode::EntropyWeighted).map(|(_, r)| r);
+            let age_result = comparison
+                .iter()
+                .find(|(m, _)| *m == DecayMode::AgeBased)
+                .map(|(_, r)| r);
+            let entropy_result = comparison
+                .iter()
+                .find(|(m, _)| *m == DecayMode::EntropyWeighted)
+                .map(|(_, r)| r);
 
             if let (Some(age), Some(entropy)) = (age_result, entropy_result) {
                 println!(
@@ -3245,12 +3310,16 @@ mod cli {
         println!("     • Entropy-weighted decay remains resistant regardless of timing");
         println!();
         println!("  2. Partial Commerce:");
-        println!("     • Age-based: All transactions (legit or not) cause decay after age requirement");
+        println!(
+            "     • Age-based: All transactions (legit or not) cause decay after age requirement"
+        );
         println!("     • Entropy-weighted: Only legitimate commerce causes decay (proportional to ratio)");
         println!();
         println!("  3. Key Insight:");
         println!("     Entropy-weighted decay provides resistance proportional to the attacker's");
-        println!("     legitimate commerce ratio. Pure wash trading = 0% decay, regardless of patience.");
+        println!(
+            "     legitimate commerce ratio. Pure wash trading = 0% decay, regardless of patience."
+        );
     }
 
     /// Parameter sweep for the combined progressive mechanism.
@@ -3271,9 +3340,21 @@ mod cli {
         const SYBIL_ACCOUNTS: u32 = 10;
         let total_wealth: u64 = 100_000_000 * BTH;
 
-        let decays: Vec<f64> = if quick { vec![0.03] } else { vec![0.01, 0.03, 0.10] };
-        let thresholds_bth: Vec<u64> = if quick { vec![1_000] } else { vec![100, 1_000, 5_000] };
-        let penalties: Vec<f64> = if quick { vec![1.0] } else { vec![0.5, 1.0, 2.0] };
+        let decays: Vec<f64> = if quick {
+            vec![0.03]
+        } else {
+            vec![0.01, 0.03, 0.10]
+        };
+        let thresholds_bth: Vec<u64> = if quick {
+            vec![1_000]
+        } else {
+            vec![100, 1_000, 5_000]
+        };
+        let penalties: Vec<f64> = if quick {
+            vec![1.0]
+        } else {
+            vec![0.5, 1.0, 2.0]
+        };
 
         let make_config = |decay: f64, threshold_bth: u64| -> LotteryConfig {
             let mut config = LotteryConfig::combined_mechanism();
@@ -3301,11 +3382,15 @@ mod cli {
                 .collect();
             let parker = sim.add_owner(
                 total_wealth * 5 / 100,
-                SybilStrategy::ParkingAttack { split_target: PARKER_SPLIT },
+                SybilStrategy::ParkingAttack {
+                    split_target: PARKER_SPLIT,
+                },
             );
             let sybil = sim.add_owner(
                 total_wealth * 5 / 100,
-                SybilStrategy::MultiAccount { num_accounts: SYBIL_ACCOUNTS },
+                SybilStrategy::MultiAccount {
+                    num_accounts: SYBIL_ACCOUNTS,
+                },
             );
             (sim, parker, sybil, whales)
         };
@@ -3331,7 +3416,11 @@ mod cli {
         baseline_config.pool_fraction = 0.0;
         let (mut baseline_sim, _, _, _) = build(baseline_config);
         let baseline_initial = baseline_sim.calculate_gini();
-        baseline_sim.advance_blocks_immediate(blocks, txs_per_block, TransactionModel::ValueWeighted);
+        baseline_sim.advance_blocks_immediate(
+            blocks,
+            txs_per_block,
+            TransactionModel::ValueWeighted,
+        );
         let baseline_final = baseline_sim.calculate_gini();
         println!(
             "Baseline (burn-only, no lottery): Gini {:.4} -> {:.4} (delta {:+.4})",
@@ -3362,10 +3451,13 @@ mod cli {
                 let initial_gini = sim.calculate_gini();
                 let parker_wealth = sim.owner_value(parker) as f64;
                 let sybil_wealth = sim.owner_value(sybil) as f64;
-                let whale_wealth: f64 =
-                    whales.iter().map(|id| sim.owner_value(*id) as f64).sum();
+                let whale_wealth: f64 = whales.iter().map(|id| sim.owner_value(*id) as f64).sum();
 
-                sim.advance_blocks_immediate(blocks, txs_per_block, TransactionModel::ValueWeighted);
+                sim.advance_blocks_immediate(
+                    blocks,
+                    txs_per_block,
+                    TransactionModel::ValueWeighted,
+                );
 
                 let final_gini = sim.calculate_gini();
                 let whale_winnings: u64 = whales
@@ -3374,10 +3466,16 @@ mod cli {
                     .sum();
                 // Winnings per unit of initial wealth, honest whales = reference.
                 let honest_rate = whale_winnings as f64 / whale_wealth;
-                let parker_winnings =
-                    sim.owners.get(&parker).map(|o| o.total_winnings).unwrap_or(0);
-                let sybil_winnings =
-                    sim.owners.get(&sybil).map(|o| o.total_winnings).unwrap_or(0);
+                let parker_winnings = sim
+                    .owners
+                    .get(&parker)
+                    .map(|o| o.total_winnings)
+                    .unwrap_or(0);
+                let sybil_winnings = sim
+                    .owners
+                    .get(&sybil)
+                    .map(|o| o.total_winnings)
+                    .unwrap_or(0);
                 let parking_adv = if honest_rate > 0.0 {
                     (parker_winnings as f64 / parker_wealth) / honest_rate
                 } else {
@@ -3424,11 +3522,9 @@ mod cli {
                 let mut cfg = make_config(run.decay, run.threshold_bth);
                 cfg.split_penalty_multiplier = penalty;
                 let split_factor = cfg.structure_factor(1, PARKER_SPLIT);
-                let split_cost =
-                    cfg.base_fee as f64 * run.parker_cluster_factor * split_factor;
+                let split_cost = cfg.base_fee as f64 * run.parker_cluster_factor * split_factor;
                 let parker_wealth = (total_wealth * 5 / 100) as f64;
-                let extra_winnings =
-                    run.parker_winnings as f64 - run.honest_rate * parker_wealth;
+                let extra_winnings = run.parker_winnings as f64 - run.honest_rate * parker_wealth;
                 let parking_roi = if split_cost > 0.0 {
                     extra_winnings / split_cost
                 } else {
@@ -3453,7 +3549,8 @@ mod cli {
                 );
 
                 if penalty == 1.0 && run.decay == 0.03 && run.threshold_bth == 1_000 {
-                    sweet_spot = Some((gini_delta, vs_baseline, run.final_utxos as u64, parking_roi));
+                    sweet_spot =
+                        Some((gini_delta, vs_baseline, run.final_utxos as u64, parking_roi));
                 }
             }
         }
@@ -3482,10 +3579,7 @@ mod cli {
                 if vs_baseline > 0.05 { "PASS" } else { "FAIL" },
                 vs_baseline
             );
-            println!(
-                "- Absolute Gini reduction: {:+.4}",
-                gini_delta
-            );
+            println!("- Absolute Gini reduction: {:+.4}", gini_delta);
             println!(
                 "- Parking attack defeated (ROI < 1.0): {} ({:.2})",
                 if parking_roi < 1.0 { "PASS" } else { "FAIL" },
@@ -3505,10 +3599,10 @@ mod cli {
     /// Structural Gini-reduction experiment.
     ///
     /// Seven scenarios isolating each redistribution lever:
-    ///   A. Status quo: value-weighted payout, fees only (known: zero Gini effect)
-    ///   B. Uniform-per-UTXO payout, fees only (payout progressivity alone)
-    ///   C. Value-weighted payout + emission (control: proportional payout of
-    ///      emission should be Gini-neutral)
+    ///   A. Status quo: value-weighted payout, fees only (known: zero Gini
+    /// effect)   B. Uniform-per-UTXO payout, fees only (payout
+    /// progressivity alone)   C. Value-weighted payout + emission (control:
+    /// proportional payout of      emission should be Gini-neutral)
     ///   D. Uniform payout + emission (the naive full proposal, honest whale)
     ///   E. D with a strategic whale: splits into N UTXOs and churns them to
     ///      stay lottery-eligible (gamed equilibrium for uniform payouts)
@@ -3574,19 +3668,97 @@ mod cli {
             demurrage: Demurrage,
         }
         let scenarios = [
-            Scenario { name: "A: status quo (VW payout, fees only)", payout: Payout::Vw, emission: false, whale: Whale::Honest, demurrage: Demurrage::None },
-            Scenario { name: "B: uniform payout, fees only", payout: Payout::Uniform, emission: false, whale: Whale::Honest, demurrage: Demurrage::None },
-            Scenario { name: "C: VW payout + emission", payout: Payout::Vw, emission: true, whale: Whale::Honest, demurrage: Demurrage::None },
-            Scenario { name: "D: uniform payout + emission", payout: Payout::Uniform, emission: true, whale: Whale::Honest, demurrage: Demurrage::None },
-            Scenario { name: "E: D + whale split+churn (gamed)", payout: Payout::Uniform, emission: true, whale: Whale::SplitChurn, demurrage: Demurrage::None },
-            Scenario { name: "F: VW payout + emission + demurrage", payout: Payout::Vw, emission: true, whale: Whale::Honest, demurrage: Demurrage::Daily },
-            Scenario { name: "G: F + whale split+churn (gaming attempt)", payout: Payout::Vw, emission: true, whale: Whale::SplitChurn, demurrage: Demurrage::Daily },
-            Scenario { name: "H: cluster-tilted payout + emission", payout: Payout::ClusterTilted, emission: true, whale: Whale::Honest, demurrage: Demurrage::None },
-            Scenario { name: "I: H + whale split+churn (gaming attempt)", payout: Payout::ClusterTilted, emission: true, whale: Whale::SplitChurn, demurrage: Demurrage::None },
-            Scenario { name: "J: H + demurrage daily (original model)", payout: Payout::ClusterTilted, emission: true, whale: Whale::Honest, demurrage: Demurrage::Daily },
-            Scenario { name: "K: H + demurrage AT SPEND (as implemented)", payout: Payout::ClusterTilted, emission: true, whale: Whale::Honest, demurrage: Demurrage::AtSpend },
-            Scenario { name: "L: K + whale split+churn (gaming attempt)", payout: Payout::ClusterTilted, emission: true, whale: Whale::SplitChurn, demurrage: Demurrage::AtSpend },
-            Scenario { name: "M: K + whale PARKS FOREVER (escape attempt)", payout: Payout::ClusterTilted, emission: true, whale: Whale::Parker, demurrage: Demurrage::AtSpend },
+            Scenario {
+                name: "A: status quo (VW payout, fees only)",
+                payout: Payout::Vw,
+                emission: false,
+                whale: Whale::Honest,
+                demurrage: Demurrage::None,
+            },
+            Scenario {
+                name: "B: uniform payout, fees only",
+                payout: Payout::Uniform,
+                emission: false,
+                whale: Whale::Honest,
+                demurrage: Demurrage::None,
+            },
+            Scenario {
+                name: "C: VW payout + emission",
+                payout: Payout::Vw,
+                emission: true,
+                whale: Whale::Honest,
+                demurrage: Demurrage::None,
+            },
+            Scenario {
+                name: "D: uniform payout + emission",
+                payout: Payout::Uniform,
+                emission: true,
+                whale: Whale::Honest,
+                demurrage: Demurrage::None,
+            },
+            Scenario {
+                name: "E: D + whale split+churn (gamed)",
+                payout: Payout::Uniform,
+                emission: true,
+                whale: Whale::SplitChurn,
+                demurrage: Demurrage::None,
+            },
+            Scenario {
+                name: "F: VW payout + emission + demurrage",
+                payout: Payout::Vw,
+                emission: true,
+                whale: Whale::Honest,
+                demurrage: Demurrage::Daily,
+            },
+            Scenario {
+                name: "G: F + whale split+churn (gaming attempt)",
+                payout: Payout::Vw,
+                emission: true,
+                whale: Whale::SplitChurn,
+                demurrage: Demurrage::Daily,
+            },
+            Scenario {
+                name: "H: cluster-tilted payout + emission",
+                payout: Payout::ClusterTilted,
+                emission: true,
+                whale: Whale::Honest,
+                demurrage: Demurrage::None,
+            },
+            Scenario {
+                name: "I: H + whale split+churn (gaming attempt)",
+                payout: Payout::ClusterTilted,
+                emission: true,
+                whale: Whale::SplitChurn,
+                demurrage: Demurrage::None,
+            },
+            Scenario {
+                name: "J: H + demurrage daily (original model)",
+                payout: Payout::ClusterTilted,
+                emission: true,
+                whale: Whale::Honest,
+                demurrage: Demurrage::Daily,
+            },
+            Scenario {
+                name: "K: H + demurrage AT SPEND (as implemented)",
+                payout: Payout::ClusterTilted,
+                emission: true,
+                whale: Whale::Honest,
+                demurrage: Demurrage::AtSpend,
+            },
+            Scenario {
+                name: "L: K + whale split+churn (gaming attempt)",
+                payout: Payout::ClusterTilted,
+                emission: true,
+                whale: Whale::SplitChurn,
+                demurrage: Demurrage::AtSpend,
+            },
+            Scenario {
+                name: "M: K + whale PARKS FOREVER (escape attempt)",
+                payout: Payout::ClusterTilted,
+                emission: true,
+                whale: Whale::Parker,
+                demurrage: Demurrage::AtSpend,
+            },
         ];
 
         println!("Structural Gini Reduction Experiment");
@@ -3654,19 +3826,16 @@ mod cli {
                 sim.add_owner_with_factor(total_wealth / 4 / 30, SybilStrategy::Normal, 2.0);
             }
             for _ in 0..9 {
-                sim.add_owner_with_factor(
-                    total_wealth * 65 / 100 / 9,
-                    SybilStrategy::Normal,
-                    6.0,
-                );
+                sim.add_owner_with_factor(total_wealth * 65 / 100 / 9, SybilStrategy::Normal, 6.0);
             }
             let whale_strategy = match sc.whale {
                 Whale::Honest => SybilStrategy::Normal,
-                Whale::SplitChurn => SybilStrategy::MultiAccount { num_accounts: split },
+                Whale::SplitChurn => SybilStrategy::MultiAccount {
+                    num_accounts: split,
+                },
                 Whale::Parker => SybilStrategy::PermanentParker,
             };
-            let whale_id =
-                sim.add_owner_with_factor(total_wealth * 5 / 100, whale_strategy, 6.0);
+            let whale_id = sim.add_owner_with_factor(total_wealth * 5 / 100, whale_strategy, 6.0);
 
             let owner_ids: Vec<u64> = sim.owners.keys().copied().collect();
             let total_value = |sim: &LotterySimulation| -> u64 {
@@ -3675,10 +3844,7 @@ mod cli {
 
             let gini0 = sim.calculate_gini();
             let whale_share0 = sim.owner_value(whale_id) as f64 / total_value(&sim) as f64;
-            let poor_share0 = poor_ids
-                .iter()
-                .map(|id| sim.owner_value(*id))
-                .sum::<u64>() as f64
+            let poor_share0 = poor_ids.iter().map(|id| sim.owner_value(*id)).sum::<u64>() as f64
                 / total_value(&sim) as f64;
 
             for b in 1..=blocks {
@@ -3705,8 +3871,7 @@ mod cli {
                         .iter()
                         .filter_map(|(id, u)| {
                             let progressivity = ((u.cluster_factor - 1.0) / 5.0).clamp(0.0, 1.0);
-                            let charge =
-                                (u.value as f64 * daily_demurrage * progressivity) as u64;
+                            let charge = (u.value as f64 * daily_demurrage * progressivity) as u64;
                             (charge > 0).then_some((*id, charge))
                         })
                         .collect();
@@ -3741,8 +3906,7 @@ mod cli {
             let poor_share_f =
                 poor_ids.iter().map(|id| sim.owner_value(*id)).sum::<u64>() as f64 / total_f;
             let whale = sim.owners.get(&whale_id).unwrap();
-            let whale_net =
-                whale.total_winnings as i64 - whale.total_fees_paid as i64;
+            let whale_net = whale.total_winnings as i64 - whale.total_fees_paid as i64;
 
             println!(
                 "| {} | {:.4} | {:.4} | {:+.4} | {:+.4} | {:.2}% -> {:.2}% | {:+} | {:.2}% -> {:.2}% |",
@@ -3767,7 +3931,9 @@ mod cli {
         println!("- G vs F tests whether demurrage-based redistribution is split-proof.");
         println!("- I vs H tests whether cluster-tilted payouts are split-proof.");
         println!("- J is the combined candidate: progressive intake (fees+demurrage) and");
-        println!("  progressive payout (cluster-tilted), both anchored to split-proof cluster tags.");
+        println!(
+            "  progressive payout (cluster-tilted), both anchored to split-proof cluster tags."
+        );
         println!("- K vs J compares spend-time demurrage (as implemented in the node) to the");
         println!("  daily balance charge the original validation assumed (issue #314).");
         println!("- M measures the permanent-parker escape: never spending avoids spend-time");

--- a/cluster-tax/src/crypto/entropy_proof.rs
+++ b/cluster-tax/src/crypto/entropy_proof.rs
@@ -1,7 +1,8 @@
 //! Entropy proof generation for Phase 2 entropy-weighted decay.
 //!
 //! This module implements zero-knowledge proofs that demonstrate entropy delta
-//! meets the threshold for decay credit, without revealing actual entropy values.
+//! meets the threshold for decay credit, without revealing actual entropy
+//! values.
 //!
 //! # Overview
 //!
@@ -16,10 +17,12 @@
 //! # Security Properties
 //!
 //! - **Soundness**: Cannot prove false entropy claims (DLOG assumption)
-//! - **Zero-Knowledge**: Reveals only threshold satisfaction, not actual entropy
+//! - **Zero-Knowledge**: Reveals only threshold satisfaction, not actual
+//!   entropy
 //! - **Binding**: Entropy commitments cannot be opened to multiple values
 //!
-//! See `docs/design/entropy-proof-security-analysis.md` for full security analysis.
+//! See `docs/design/entropy-proof-security-analysis.md` for full security
+//! analysis.
 
 use super::{blinding_generator, CommittedTagVectorSecret, SchnorrProof};
 use crate::ClusterId;
@@ -71,7 +74,8 @@ pub struct EntropyProof {
     pub entropy_after_commitment: CompressedRistretto,
 
     /// Range proof: entropy_delta = entropy_after - entropy_before >= threshold
-    /// Uses simplified Schnorr-based range proof (Bulletproof integration planned).
+    /// Uses simplified Schnorr-based range proof (Bulletproof integration
+    /// planned).
     pub threshold_range_proof: EntropyRangeProof,
 
     /// Linkage proof: ties entropy commitments to tag commitments.
@@ -165,7 +169,8 @@ impl EntropyProofBuilder {
     ///
     /// H2 = -log2(sum(p_k^2)) where p_k = m_k / total_mass
     ///
-    /// Returns the entropy value scaled by ENTROPY_SCALE for integer arithmetic.
+    /// Returns the entropy value scaled by ENTROPY_SCALE for integer
+    /// arithmetic.
     fn compute_collision_entropy(secrets: &[CommittedTagVectorSecret]) -> u64 {
         // Aggregate all tag masses by cluster
         let mut cluster_masses: std::collections::HashMap<ClusterId, u64> =
@@ -630,9 +635,7 @@ impl EntropyLinkageProof {
 
     /// Serialized size in bytes.
     pub fn serialized_size(&self) -> usize {
-        4 + (32 * self.intermediate_commitments.len())
-            + (64 * self.step_proofs.len())
-            + 64
+        4 + (32 * self.intermediate_commitments.len()) + (64 * self.step_proofs.len()) + 64
     }
 }
 
@@ -643,8 +646,7 @@ impl EntropyLinkageProof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto::CommittedTagVectorSecret;
-    use crate::{TagWeight, TAG_WEIGHT_SCALE};
+    use crate::{crypto::CommittedTagVectorSecret, TagWeight, TAG_WEIGHT_SCALE};
     use rand_core::OsRng;
     use std::collections::HashMap;
 
@@ -671,7 +673,10 @@ mod tests {
     fn test_entropy_generator_unique() {
         let h_e = entropy_generator();
         let g = blinding_generator();
-        assert_ne!(h_e, g, "Entropy generator should differ from blinding generator");
+        assert_ne!(
+            h_e, g,
+            "Entropy generator should differ from blinding generator"
+        );
     }
 
     #[test]
@@ -726,7 +731,10 @@ mod tests {
         let builder = EntropyProofBuilder::new(vec![input_secret], vec![output_secret]);
         let proof = builder.prove(&mut OsRng);
 
-        assert!(proof.is_some(), "Should generate proof when entropy increases");
+        assert!(
+            proof.is_some(),
+            "Should generate proof when entropy increases"
+        );
     }
 
     #[test]
@@ -871,10 +879,7 @@ mod tests {
         let input_secret = create_test_secret(1_000_000, &[(ClusterId(1), TAG_WEIGHT_SCALE)]);
         let output_secret = create_test_secret(
             1_000_000,
-            &[
-                (ClusterId(1), 900_000),
-                (ClusterId(2), 100_000),
-            ],
+            &[(ClusterId(1), 900_000), (ClusterId(2), 100_000)],
         );
 
         // Very high threshold - should fail

--- a/cluster-tax/src/crypto/entropy_validation.rs
+++ b/cluster-tax/src/crypto/entropy_validation.rs
@@ -1,21 +1,25 @@
-//! Consensus-level entropy proof validation for Phase 2B entropy-weighted decay.
+//! Consensus-level entropy proof validation for Phase 2B entropy-weighted
+//! decay.
 //!
 //! This module provides the consensus validation layer for entropy proofs,
 //! implementing version-aware validation and phase-based requirements.
 //!
 //! ## Relationship with `entropy_proof` module
 //!
-//! - `entropy_proof`: Provides proof structures (`EntropyProof`) and cryptographic
-//!   verification (`EntropyProofBuilder`, `EntropyProofVerifier`)
-//! - `entropy_validation` (this module): Provides consensus-level validation with
-//!   version awareness, phase transitions, and decay rate computation
+//! - `entropy_proof`: Provides proof structures (`EntropyProof`) and
+//!   cryptographic verification (`EntropyProofBuilder`, `EntropyProofVerifier`)
+//! - `entropy_validation` (this module): Provides consensus-level validation
+//!   with version awareness, phase transitions, and decay rate computation
 //!
 //! ## Version-Aware Validation
 //!
 //! The validation behavior depends on the current phase:
-//! - **Phase 1 (Optional)**: Entropy proofs optional, minimal decay credit if not provided
-//! - **Phase 2 (Recommended)**: Same as Phase 1, but signals upcoming requirement
-//! - **Phase 3 (RequiredForCredit)**: Required for decay credit, but tx still valid without
+//! - **Phase 1 (Optional)**: Entropy proofs optional, minimal decay credit if
+//!   not provided
+//! - **Phase 2 (Recommended)**: Same as Phase 1, but signals upcoming
+//!   requirement
+//! - **Phase 3 (RequiredForCredit)**: Required for decay credit, but tx still
+//!   valid without
 //! - **Phase 4 (Mandatory)**: Consensus rejection without proof
 
 use super::entropy_proof::{EntropyProof, EntropyProofVerifier, MIN_ENTROPY_THRESHOLD_SCALED};
@@ -172,8 +176,8 @@ impl Default for EntropyConsensusConfig {
             entropy_recommended_height: 1_000_000,
             entropy_required_height: 2_000_000,
             entropy_mandatory_height: 3_000_000,
-            base_decay_rate: 50_000,      // 5%
-            minimal_decay_rate: 5_000,    // 0.5%
+            base_decay_rate: 50_000,   // 5%
+            minimal_decay_rate: 5_000, // 0.5%
             min_entropy_threshold: MIN_ENTROPY_THRESHOLD_SCALED,
         }
     }
@@ -236,7 +240,8 @@ pub enum EntropyPhase {
 ///
 /// # Returns
 /// * `Ok(EntropyValidationResult)` - Validation result indicating decay credit
-/// * `Err(EntropyValidationError)` - If proof is invalid or missing when required
+/// * `Err(EntropyValidationError)` - If proof is invalid or missing when
+///   required
 pub fn validate_entropy_proof(
     entropy_proof: Option<&EntropyProof>,
     config: &EntropyConsensusConfig,
@@ -270,9 +275,7 @@ pub fn validate_entropy_proof(
         }
 
         // Phase 3: No proof - no decay credit (but tx valid)
-        (EntropyPhase::RequiredForCredit, None) => {
-            Ok(EntropyValidationResult::NoDecayCredit)
-        }
+        (EntropyPhase::RequiredForCredit, None) => Ok(EntropyValidationResult::NoDecayCredit),
 
         // Phase 4 (Mandatory): Proof provided - validate it
         (EntropyPhase::Mandatory, Some(proof)) => {
@@ -284,9 +287,7 @@ pub fn validate_entropy_proof(
         }
 
         // Phase 4 (Mandatory): No proof - consensus rejection
-        (EntropyPhase::Mandatory, None) => {
-            Err(EntropyValidationError::MissingEntropyProof)
-        }
+        (EntropyPhase::Mandatory, None) => Err(EntropyValidationError::MissingEntropyProof),
     }
 }
 
@@ -329,8 +330,10 @@ pub fn compute_decay_rate(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crypto::{CommittedTagVectorSecret, EntropyProofBuilder};
-    use crate::{ClusterId, TAG_WEIGHT_SCALE};
+    use crate::{
+        crypto::{CommittedTagVectorSecret, EntropyProofBuilder},
+        ClusterId, TAG_WEIGHT_SCALE,
+    };
     use rand_core::OsRng;
     use std::collections::HashMap;
 
@@ -349,10 +352,7 @@ mod tests {
         // Output: two clusters (>0 entropy)
         let output_secret = create_test_secret(
             1_000_000,
-            &[
-                (1, TAG_WEIGHT_SCALE / 2),
-                (2, TAG_WEIGHT_SCALE / 2),
-            ],
+            &[(1, TAG_WEIGHT_SCALE / 2), (2, TAG_WEIGHT_SCALE / 2)],
         );
 
         EntropyProofBuilder::new(vec![input_secret], vec![output_secret])
@@ -380,7 +380,11 @@ mod tests {
 
     #[test]
     fn test_transaction_version_byte_roundtrip() {
-        for version in [TransactionVersion::V1, TransactionVersion::V2, TransactionVersion::V3] {
+        for version in [
+            TransactionVersion::V1,
+            TransactionVersion::V2,
+            TransactionVersion::V3,
+        ] {
             let byte = version.to_byte();
             let restored = TransactionVersion::from_byte(byte);
             assert_eq!(restored, Some(version));

--- a/cluster-tax/src/crypto/extended_signature.rs
+++ b/cluster-tax/src/crypto/extended_signature.rs
@@ -29,12 +29,14 @@
 //! - V2: Phase 1 committed tags (pseudo-tag-outputs + conservation proof)
 //! - V3: Phase 2 entropy proofs (adds optional entropy proof for decay credit)
 
-use super::committed_tags::{
-    CommittedTagMass, CommittedTagVector, CommittedTagVectorSecret, SchnorrProof,
-    TagConservationProof, TagConservationProver, TagConservationVerifier,
+use super::{
+    committed_tags::{
+        CommittedTagMass, CommittedTagVector, CommittedTagVectorSecret, SchnorrProof,
+        TagConservationProof, TagConservationProver, TagConservationVerifier,
+    },
+    entropy_proof::EntropyProof,
+    entropy_validation::TransactionVersion,
 };
-use super::entropy_proof::EntropyProof;
-use super::entropy_validation::TransactionVersion;
 use crate::{ClusterId, TagWeight};
 use curve25519_dalek::scalar::Scalar;
 

--- a/cluster-tax/src/crypto/mod.rs
+++ b/cluster-tax/src/crypto/mod.rs
@@ -68,17 +68,17 @@ pub use entropy_proof::{
 
 // Phase 2B: Consensus-level entropy validation
 pub use entropy_validation::{
-    // Core validation function
-    validate_entropy_proof,
     // Decay rate computation
     compute_decay_rate,
-    // Result and error types
-    EntropyValidationResult,
-    EntropyValidationError,
-    // Version and configuration
-    TransactionVersion,
+    // Core validation function
+    validate_entropy_proof,
     EntropyConsensusConfig,
     EntropyPhase,
+    EntropyValidationError,
+    // Result and error types
+    EntropyValidationResult,
+    // Version and configuration
+    TransactionVersion,
 };
 
 pub use serialization::DeserializeError;

--- a/cluster-tax/src/crypto/serialization.rs
+++ b/cluster-tax/src/crypto/serialization.rs
@@ -351,7 +351,8 @@ impl ExtendedTxSignature {
     /// Serialize to bytes.
     ///
     /// Format:
-    /// - Version byte (1 byte): 2 = V2 (no entropy proof), 3 = V3 (with entropy proof)
+    /// - Version byte (1 byte): 2 = V2 (no entropy proof), 3 = V3 (with entropy
+    ///   proof)
     /// - Pseudo-tag-output count (4 bytes)
     /// - Pseudo-tag-outputs (variable)
     /// - Conservation proof (variable)
@@ -555,7 +556,8 @@ mod tests {
         let input_commitment = input_secret.commit();
         let ring_tags = vec![input_commitment.clone()];
 
-        // Create output using apply_decay (preserves cluster structure for conservation proof)
+        // Create output using apply_decay (preserves cluster structure for conservation
+        // proof)
         let output_secret = input_secret.apply_decay(decay_rate, &mut OsRng);
 
         // Build V2 signature first
@@ -630,7 +632,10 @@ mod tests {
         let bytes = signature.to_bytes();
 
         // First byte should be version 2
-        assert_eq!(bytes[0], EXTENDED_SIG_VERSION_V2, "V2 signature version byte");
+        assert_eq!(
+            bytes[0], EXTENDED_SIG_VERSION_V2,
+            "V2 signature version byte"
+        );
     }
 
     #[test]

--- a/cluster-tax/src/demurrage.rs
+++ b/cluster-tax/src/demurrage.rs
@@ -14,15 +14,15 @@
 //! ```
 //!
 //! - `factor` is the cluster factor already used for progressive fees
-//!   (1.0x..6.0x in FACTOR_SCALE units). Factor-1 (background/commerce)
-//!   coins pay exactly zero — demurrage only binds wealthy clusters.
-//! - `elapsed` is how long the spent coins sat idle. Under ring signatures
-//!   the real input is hidden, so the elapsed value is the value-weighted
-//!   centroid of the PUBLIC creation heights of all ring members: a large
-//!   real input dominates its own ring's centroid, while the factor term
-//!   protects small spenders from old decoys entirely.
-//! - The charge is added to the transaction's minimum fee and flows through
-//!   the standard fee split into the redistribution lottery pool.
+//!   (1.0x..6.0x in FACTOR_SCALE units). Factor-1 (background/commerce) coins
+//!   pay exactly zero — demurrage only binds wealthy clusters.
+//! - `elapsed` is how long the spent coins sat idle. Under ring signatures the
+//!   real input is hidden, so the elapsed value is the value-weighted centroid
+//!   of the PUBLIC creation heights of all ring members: a large real input
+//!   dominates its own ring's centroid, while the factor term protects small
+//!   spenders from old decoys entirely.
+//! - The charge is added to the transaction's minimum fee and flows through the
+//!   standard fee split into the redistribution lottery pool.
 //!
 //! ## Why churning doesn't escape
 //!
@@ -50,8 +50,8 @@ pub const MAX_FACTOR_SCALED: u64 = 6 * FACTOR_SCALE;
 ///   from the same computation the progressive fee uses
 /// * `elapsed_blocks` - Holding duration in blocks (value-weighted ring
 ///   centroid of public UTXO creation heights)
-/// * `rate_bps` - Annual demurrage rate at maximum factor, in basis points
-///   (200 = 2%/year); use `MonetaryPolicy::demurrage_rate_bps(height)`
+/// * `rate_bps` - Annual demurrage rate at maximum factor, in basis points (200
+///   = 2%/year); use `MonetaryPolicy::demurrage_rate_bps(height)`
 /// * `blocks_per_year` - Blocks per year at the policy's assumed block time
 ///
 /// # Returns
@@ -75,15 +75,15 @@ pub fn demurrage_charge(
         return 0;
     }
 
-    // charge = value × rate_bps/10_000 × progressivity/5000 × elapsed/blocks_per_year
+    // charge = value × rate_bps/10_000 × progressivity/5000 ×
+    // elapsed/blocks_per_year
     //
     // Multiply before dividing to preserve precision; u128 bounds:
     // value (2^64) × rate_bps (2^14) × progressivity (2^13) ≈ 2^91, then
     // × elapsed (2^64) would overflow — so fold elapsed/blocks_per_year in
     // a separate u128 stage with a precision scale.
     const TIME_SCALE: u128 = 1_000_000;
-    let time_fraction =
-        (elapsed_blocks as u128 * TIME_SCALE) / blocks_per_year as u128;
+    let time_fraction = (elapsed_blocks as u128 * TIME_SCALE) / blocks_per_year as u128;
 
     let charge = transfer_value as u128 * rate_bps as u128 * progressivity as u128
         / 10_000
@@ -132,7 +132,13 @@ mod tests {
     fn test_factor_one_pays_zero() {
         // Background/commerce coins are exempt regardless of age or value
         assert_eq!(
-            demurrage_charge(u64::MAX, FACTOR_SCALE, BLOCKS_PER_YEAR * 10, 200, BLOCKS_PER_YEAR),
+            demurrage_charge(
+                u64::MAX,
+                FACTOR_SCALE,
+                BLOCKS_PER_YEAR * 10,
+                200,
+                BLOCKS_PER_YEAR
+            ),
             0
         );
     }
@@ -142,34 +148,62 @@ mod tests {
         // Factor 6.0, one year: exactly rate_bps of value
         // 1M × 2% = 20_000
         assert_eq!(
-            demurrage_charge(1_000_000, MAX_FACTOR_SCALED, BLOCKS_PER_YEAR, 200, BLOCKS_PER_YEAR),
+            demurrage_charge(
+                1_000_000,
+                MAX_FACTOR_SCALED,
+                BLOCKS_PER_YEAR,
+                200,
+                BLOCKS_PER_YEAR
+            ),
             20_000
         );
     }
 
     #[test]
     fn test_linear_in_factor_time_and_value() {
-        let full = demurrage_charge(1_000_000, MAX_FACTOR_SCALED, BLOCKS_PER_YEAR, 200, BLOCKS_PER_YEAR);
+        let full = demurrage_charge(
+            1_000_000,
+            MAX_FACTOR_SCALED,
+            BLOCKS_PER_YEAR,
+            200,
+            BLOCKS_PER_YEAR,
+        );
 
         // Half the progressivity range: factor 3.5 → (3500-1000)/5000 = 1/2
         let half_factor = demurrage_charge(1_000_000, 3_500, BLOCKS_PER_YEAR, 200, BLOCKS_PER_YEAR);
         assert_eq!(half_factor, full / 2);
 
         // Half the time
-        let half_time =
-            demurrage_charge(1_000_000, MAX_FACTOR_SCALED, BLOCKS_PER_YEAR / 2, 200, BLOCKS_PER_YEAR);
+        let half_time = demurrage_charge(
+            1_000_000,
+            MAX_FACTOR_SCALED,
+            BLOCKS_PER_YEAR / 2,
+            200,
+            BLOCKS_PER_YEAR,
+        );
         assert_eq!(half_time, full / 2);
 
         // Double the value
-        let double_value =
-            demurrage_charge(2_000_000, MAX_FACTOR_SCALED, BLOCKS_PER_YEAR, 200, BLOCKS_PER_YEAR);
+        let double_value = demurrage_charge(
+            2_000_000,
+            MAX_FACTOR_SCALED,
+            BLOCKS_PER_YEAR,
+            200,
+            BLOCKS_PER_YEAR,
+        );
         assert_eq!(double_value, full * 2);
     }
 
     #[test]
     fn test_zero_inputs() {
-        assert_eq!(demurrage_charge(1_000_000, 6_000, 0, 200, BLOCKS_PER_YEAR), 0);
-        assert_eq!(demurrage_charge(1_000_000, 6_000, 1000, 0, BLOCKS_PER_YEAR), 0);
+        assert_eq!(
+            demurrage_charge(1_000_000, 6_000, 0, 200, BLOCKS_PER_YEAR),
+            0
+        );
+        assert_eq!(
+            demurrage_charge(1_000_000, 6_000, 1000, 0, BLOCKS_PER_YEAR),
+            0
+        );
         assert_eq!(demurrage_charge(1_000_000, 6_000, 1000, 200, 0), 0);
         assert_eq!(demurrage_charge(0, 6_000, 1000, 200, BLOCKS_PER_YEAR), 0);
     }
@@ -187,9 +221,9 @@ mod tests {
         // decoys barely reduce the elapsed value.
         let current = 1_000_000u64;
         let members = [
-            (100_000_000, 0),       // real input: 100M, 1M blocks old
-            (1_000, current),        // fresh small decoy
-            (1_000, current),        // fresh small decoy
+            (100_000_000, 0), // real input: 100M, 1M blocks old
+            (1_000, current), // fresh small decoy
+            (1_000, current), // fresh small decoy
         ];
         let elapsed = ring_elapsed_centroid(&members, current);
         // 100M×1M / 100.002M ≈ 999_980
@@ -210,8 +244,7 @@ mod tests {
     fn test_churn_invariance() {
         // Paying demurrage at every churn sums to the same total as paying
         // once at the end: charge(T) = charge(T/2) + charge(T/2).
-        let one_year =
-            demurrage_charge(1_000_000, 6_000, BLOCKS_PER_YEAR, 200, BLOCKS_PER_YEAR);
+        let one_year = demurrage_charge(1_000_000, 6_000, BLOCKS_PER_YEAR, 200, BLOCKS_PER_YEAR);
         let half = demurrage_charge(1_000_000, 6_000, BLOCKS_PER_YEAR / 2, 200, BLOCKS_PER_YEAR);
         assert_eq!(one_year, half * 2);
     }

--- a/cluster-tax/src/entropy_decay.rs
+++ b/cluster-tax/src/entropy_decay.rs
@@ -9,9 +9,9 @@
 //! self-transfer. While each individual transfer is rate-limited, the attacker
 //! eventually achieves full decay without any real commerce.
 //!
-//! Entropy-weighted decay solves this by only allowing decay when the receiver's
-//! cluster entropy increases. Self-transfers don't change entropy, so no decay
-//! applies regardless of timing.
+//! Entropy-weighted decay solves this by only allowing decay when the
+//! receiver's cluster entropy increases. Self-transfers don't change entropy,
+//! so no decay applies regardless of timing.
 //!
 //! # Properties
 //!
@@ -32,10 +32,13 @@
 //! # Ring Signature Support
 //!
 //! For ring signatures where we don't know which ring member is the real input,
-//! this module provides conservative calculations that defend against manipulation:
+//! this module provides conservative calculations that defend against
+//! manipulation:
 //!
-//! - **Conservative entropy delta**: Uses MAX input entropy among all ring members
-//! - **Age eligibility**: ALL ring members must be old enough for decay to apply
+//! - **Conservative entropy delta**: Uses MAX input entropy among all ring
+//!   members
+//! - **Age eligibility**: ALL ring members must be old enough for decay to
+//!   apply
 //! - **Attack prevention**: Blocks high-entropy decoy and young decoy attacks
 //!
 //! ## Ring Signature Usage Example
@@ -97,14 +100,17 @@
 //! 1. **High-entropy decoy attack**: Blocked by using MAX input entropy
 //!    - Attacker can't pick high-entropy decoys to inflate their delta
 //!
-//! 2. **Young decoy attack**: Blocked by requiring ALL members to be age-eligible
+//! 2. **Young decoy attack**: Blocked by requiring ALL members to be
+//!    age-eligible
 //!    - Attacker can't pick old decoys to force decay on young coins
 //!
 //! 3. **Self-transfer with decoys**: Blocked by entropy check
 //!    - Even with decoys, self-transfer doesn't increase entropy
 
-use crate::age_decay::AgeDecayConfig;
-use crate::tag::{TagVector, TagWeight, TAG_WEIGHT_SCALE};
+use crate::{
+    age_decay::AgeDecayConfig,
+    tag::{TagVector, TagWeight, TAG_WEIGHT_SCALE},
+};
 
 /// Configuration for entropy-weighted decay.
 #[derive(Clone, Debug)]
@@ -127,7 +133,7 @@ pub struct EntropyDecayConfig {
 impl Default for EntropyDecayConfig {
     fn default() -> Self {
         Self {
-            min_entropy_delta: 0.1, // Require at least 0.1 bits of entropy increase
+            min_entropy_delta: 0.1,  // Require at least 0.1 bits of entropy increase
             base_decay_rate: 50_000, // 5% base decay
             decay_scaling: EntropyScaling::Linear,
             age_config: Some(AgeDecayConfig::default()),
@@ -790,7 +796,8 @@ fn simulate_attack_entropy_weighted(
 /// # Security Properties
 ///
 /// - **High-entropy decoy attack**: Blocked by using MAX input entropy
-///   (attacker can't inflate their output entropy relative to low-entropy input)
+///   (attacker can't inflate their output entropy relative to low-entropy
+///   input)
 /// - **Young decoy attack**: Handled separately via age checking
 /// - **Conservative approach**: Assumes sender is trying to minimize decay
 ///
@@ -801,7 +808,8 @@ fn simulate_attack_entropy_weighted(
 ///
 /// # Returns
 ///
-/// The conservative entropy delta (output entropy - max input entropy), clamped to >= 0.
+/// The conservative entropy delta (output entropy - max input entropy), clamped
+/// to >= 0.
 pub fn conservative_entropy_delta(ring_member_tags: &[TagVector], output_tags: &TagVector) -> f64 {
     if ring_member_tags.is_empty() {
         return 0.0;
@@ -946,7 +954,8 @@ impl RingEntropyDecayInfo {
     ///
     /// * `ring_member_tags` - Tag vectors for each ring member
     /// * `output_tags` - Tag vector for the mixed output
-    /// * `ring_creation_blocks` - Block heights when each ring member was created
+    /// * `ring_creation_blocks` - Block heights when each ring member was
+    ///   created
     /// * `current_block` - Current block height
     /// * `config` - Entropy decay configuration
     ///
@@ -999,9 +1008,7 @@ impl RingEntropyDecayInfo {
             .map(|tv| tv.collision_entropy())
             .collect();
 
-        let max_input_entropy = member_entropies
-            .iter()
-            .fold(0.0_f64, |a, &b| a.max(b));
+        let max_input_entropy = member_entropies.iter().fold(0.0_f64, |a, &b| a.max(b));
 
         let output_entropy = output_tags.collision_entropy();
         let conservative_delta = (output_entropy - max_input_entropy).max(0.0);
@@ -1094,16 +1101,20 @@ mod tests {
         let config = EntropyDecayConfig::default();
 
         // Self-transfer: incoming tags same as receiver
-        let result =
-            calculate_entropy_decay(&tags, 1000, &tags, 1000, // Same tags
-                                    &config);
+        let result = calculate_entropy_decay(
+            &tags, 1000, &tags, 1000, // Same tags
+            &config,
+        );
 
         // No entropy change = no decay
         assert!(
             !result.decay_applied,
             "Self-transfer should not trigger decay"
         );
-        assert_eq!(result.entropy_delta, 0.0, "Self-transfer has zero entropy delta");
+        assert_eq!(
+            result.entropy_delta, 0.0,
+            "Self-transfer has zero entropy delta"
+        );
     }
 
     #[test]
@@ -1143,7 +1154,7 @@ mod tests {
     fn test_patient_wash_blocked() {
         let c1 = ClusterId::new(1);
         let strategy = AttackStrategy::PatientWash {
-            interval_blocks: 720, // Maximum patience
+            interval_blocks: 720,   // Maximum patience
             duration_blocks: 60480, // 1 week
         };
 
@@ -1157,13 +1168,8 @@ mod tests {
         );
 
         // With entropy-weighted decay: patient attacker blocked
-        let entropy_result = simulate_attack_entropy_weighted(
-            &strategy,
-            c1,
-            100_000_000,
-            TAG_WEIGHT_SCALE,
-            60480,
-        );
+        let entropy_result =
+            simulate_attack_entropy_weighted(&strategy, c1, 100_000_000, TAG_WEIGHT_SCALE, 60480);
 
         // Age-based allows significant decay
         assert!(
@@ -1195,16 +1201,14 @@ mod tests {
             transfers_per_counterparty: 10,
         };
 
-        let entropy_result = simulate_attack_entropy_weighted(
-            &strategy,
-            c1,
-            100_000_000,
-            TAG_WEIGHT_SCALE,
-            60480,
-        );
+        let entropy_result =
+            simulate_attack_entropy_weighted(&strategy, c1, 100_000_000, TAG_WEIGHT_SCALE, 60480);
 
         // Sybil attack blocked: fake counterparties don't add entropy
-        assert_eq!(entropy_result.decay_events, 0, "Sybil attack should be blocked");
+        assert_eq!(
+            entropy_result.decay_events, 0,
+            "Sybil attack should be blocked"
+        );
         assert_eq!(
             entropy_result.tag_remaining_fraction, 1.0,
             "No decay for sybil attack"
@@ -1219,13 +1223,8 @@ mod tests {
             total_transactions: 100,
         };
 
-        let entropy_result = simulate_attack_entropy_weighted(
-            &strategy,
-            c1,
-            100_000_000,
-            TAG_WEIGHT_SCALE,
-            60480,
-        );
+        let entropy_result =
+            simulate_attack_entropy_weighted(&strategy, c1, 100_000_000, TAG_WEIGHT_SCALE, 60480);
 
         // Legitimate commerce allows decay
         assert!(
@@ -1301,7 +1300,8 @@ mod tests {
                 ..Default::default()
             };
 
-            let result = calculate_entropy_decay(&receiver_tags, 1000, &incoming_tags, 1000, &config);
+            let result =
+                calculate_entropy_decay(&receiver_tags, 1000, &incoming_tags, 1000, &config);
 
             assert!(
                 result.decay_applied,
@@ -1332,8 +1332,8 @@ mod tests {
             &receiver_tags,
             0,
             1000,
-            Some(100),  // Created at block 100
-            Some(500),  // Current block 500 (only 400 blocks old)
+            Some(100), // Created at block 100
+            Some(500), // Current block 500 (only 400 blocks old)
             &config,
         );
 
@@ -1342,7 +1342,10 @@ mod tests {
             "Young UTXO should block decay even with entropy"
         );
         assert!(
-            matches!(result.block_reason, Some(DecayBlockReason::UtxoTooYoung { .. })),
+            matches!(
+                result.block_reason,
+                Some(DecayBlockReason::UtxoTooYoung { .. })
+            ),
             "Should report UTXO too young"
         );
 
@@ -1358,10 +1361,7 @@ mod tests {
             &config,
         );
 
-        assert!(
-            result3.decay_applied,
-            "Old UTXO with commerce should decay"
-        );
+        assert!(result3.decay_applied, "Old UTXO with commerce should decay");
     }
 
     // ========================================================================
@@ -1592,10 +1592,7 @@ mod tests {
         // Conservative approach uses MAX input entropy (from high-entropy decoys)
         // Output entropy is likely lower than max input, so delta <= 0
         // Decay should be 0 (attack blocked)
-        assert_eq!(
-            decay, 0,
-            "High-entropy decoy attack should be blocked"
-        );
+        assert_eq!(decay, 0, "High-entropy decoy attack should be blocked");
     }
 
     #[test]
@@ -1661,7 +1658,10 @@ mod tests {
         assert_eq!(info.member_age_eligible, vec![true, false]);
         assert!(matches!(
             info.block_reason,
-            Some(RingDecayBlockReason::SomeUtxosTooYoung { ineligible_count: 1, total_count: 2 })
+            Some(RingDecayBlockReason::SomeUtxosTooYoung {
+                ineligible_count: 1,
+                total_count: 2
+            })
         ));
     }
 
@@ -1675,7 +1675,10 @@ mod tests {
         let info = RingEntropyDecayInfo::analyze(&[], &output_tags, &[], 1000, &config);
 
         assert!(!info.decay_applied());
-        assert!(matches!(info.block_reason, Some(RingDecayBlockReason::EmptyRing)));
+        assert!(matches!(
+            info.block_reason,
+            Some(RingDecayBlockReason::EmptyRing)
+        ));
     }
 
     #[test]

--- a/cluster-tax/src/fee_curve.rs
+++ b/cluster-tax/src/fee_curve.rs
@@ -21,8 +21,8 @@
 //! 1. **Size-based fee**: Larger transactions pay more (proportional to bytes)
 //! 2. **Progressive multiplier**: Cluster factor ranges from 1x to 6x based on
 //!    the sender's cluster wealth, ensuring wealthy clusters pay more
-//! 3. **Superlinear output fee**: Quadratic penalty for multiple outputs prevents
-//!    UTXO farming (splitting coins to game lottery systems)
+//! 3. **Superlinear output fee**: Quadratic penalty for multiple outputs
+//!    prevents UTXO farming (splitting coins to game lottery systems)
 //! 4. **Memo fees**: Flat fee per encrypted memo
 //!
 //! ## Superlinear Output Fees
@@ -115,7 +115,8 @@ pub enum TransactionType {
 /// fee = fee_per_byte × tx_size × cluster_factor × output_penalty + memo_fees
 /// ```
 ///
-/// where `output_penalty = min(output_count, output_count_cap)^output_fee_exponent`
+/// where `output_penalty = min(output_count,
+/// output_count_cap)^output_fee_exponent`
 ///
 /// This superlinear output fee prevents UTXO farming attacks where attackers
 /// split coins into many small UTXOs to game lottery systems.
@@ -141,8 +142,9 @@ pub struct FeeConfig {
     /// - 1.0 = linear (no penalty for multiple outputs)
     /// - 2.0 = quadratic (default, 10 outputs costs 100x)
     ///
-    /// Stored as fixed-point: actual_exponent = output_fee_exponent_scaled / 1000
-    /// Default: 2000 (= 2.0 quadratic) to prevent UTXO farming attacks.
+    /// Stored as fixed-point: actual_exponent = output_fee_exponent_scaled /
+    /// 1000 Default: 2000 (= 2.0 quadratic) to prevent UTXO farming
+    /// attacks.
     pub output_fee_exponent_scaled: u32,
 
     /// Maximum output count to apply the exponent to.
@@ -169,12 +171,12 @@ pub const OUTPUT_FEE_EXPONENT_SCALE: u32 = 1000;
 impl Default for FeeConfig {
     fn default() -> Self {
         Self {
-            fee_per_byte: 1,                            // 1 nanoBTH per byte
+            fee_per_byte: 1, // 1 nanoBTH per byte
             cluster_curve: ClusterFactorCurve::default(),
-            fee_per_memo: 100,                          // 100 nanoBTH per memo
-            output_fee_exponent_scaled: 2000,           // 2.0 (quadratic)
-            output_count_cap: 10,                       // Cap at 10 outputs
-            min_output_value: 1_000_000,                // 0.001 BTH minimum
+            fee_per_memo: 100,                // 100 nanoBTH per memo
+            output_fee_exponent_scaled: 2000, // 2.0 (quadratic)
+            output_count_cap: 10,             // Cap at 10 outputs
+            min_output_value: 1_000_000,      // 0.001 BTH minimum
         }
     }
 }
@@ -207,7 +209,8 @@ impl FeeConfig {
         (penalty * OUTPUT_FEE_EXPONENT_SCALE as f64) as u64
     }
 
-    /// Compute the fee for a transaction based on size, cluster wealth, and output count.
+    /// Compute the fee for a transaction based on size, cluster wealth, and
+    /// output count.
     ///
     /// Formula:
     /// ```text
@@ -220,7 +223,8 @@ impl FeeConfig {
     /// * `tx_type` - The transaction type (Minting pays no fee)
     /// * `tx_size_bytes` - Size of the transaction in bytes
     /// * `cluster_wealth` - Total wealth of sender's cluster
-    /// * `num_outputs` - Number of transaction outputs (for superlinear penalty)
+    /// * `num_outputs` - Number of transaction outputs (for superlinear
+    ///   penalty)
     /// * `num_memos` - Number of outputs with encrypted memos
     ///
     /// # Returns
@@ -263,8 +267,8 @@ impl FeeConfig {
     /// This method assumes 2 outputs (standard transfer with change).
     /// For full control, use `compute_fee_with_outputs`.
     ///
-    /// Formula: `fee = (fee_per_byte × tx_size_bytes × cluster_factor × output_penalty) +
-    /// memo_fees`
+    /// Formula: `fee = (fee_per_byte × tx_size_bytes × cluster_factor ×
+    /// output_penalty) + memo_fees`
     ///
     /// # Arguments
     /// * `tx_type` - The transaction type (Minting pays no fee)
@@ -350,12 +354,19 @@ impl FeeConfig {
             }
             TransactionType::Minting => 1_500, // ~1.5 KB for minting
         };
-        self.compute_fee_with_outputs(tx_type, typical_size, cluster_wealth, num_outputs, num_memos)
+        self.compute_fee_with_outputs(
+            tx_type,
+            typical_size,
+            cluster_wealth,
+            num_outputs,
+            num_memos,
+        )
     }
 
     /// Compute the minimum fee for a transaction (alias for validation).
     ///
-    /// Assumes 2 outputs. For multi-output validation, use `minimum_fee_with_outputs`.
+    /// Assumes 2 outputs. For multi-output validation, use
+    /// `minimum_fee_with_outputs`.
     pub fn minimum_fee(
         &self,
         tx_type: TransactionType,
@@ -375,7 +386,13 @@ impl FeeConfig {
         num_outputs: usize,
         num_memos: usize,
     ) -> u64 {
-        self.compute_fee_with_outputs(tx_type, tx_size_bytes, cluster_wealth, num_outputs, num_memos)
+        self.compute_fee_with_outputs(
+            tx_type,
+            tx_size_bytes,
+            cluster_wealth,
+            num_outputs,
+            num_memos,
+        )
     }
 
     /// Compute fee with dynamic base adjustment for congestion control.
@@ -385,7 +402,8 @@ impl FeeConfig {
     /// fee = dynamic_base × tx_size × cluster_factor × output_penalty + memo_fees
     /// ```
     ///
-    /// Assumes 2 outputs. For multi-output, use `compute_fee_with_dynamic_base_and_outputs`.
+    /// Assumes 2 outputs. For multi-output, use
+    /// `compute_fee_with_dynamic_base_and_outputs`.
     ///
     /// # Arguments
     /// * `tx_type` - Transaction type (Minting pays no fee)
@@ -467,7 +485,8 @@ impl FeeConfig {
 
     /// Compute minimum fee with dynamic base (alias for validation).
     ///
-    /// Assumes 2 outputs. For multi-output, use `minimum_fee_dynamic_with_outputs`.
+    /// Assumes 2 outputs. For multi-output, use
+    /// `minimum_fee_dynamic_with_outputs`.
     pub fn minimum_fee_dynamic(
         &self,
         tx_type: TransactionType,
@@ -1035,26 +1054,18 @@ mod tests {
         let config = FeeConfig::default();
 
         // Single 2-output transaction (normal)
-        let fee_normal = config.compute_fee_with_outputs(
-            TransactionType::Hidden,
-            4_000,
-            0,
-            2,
-            0,
-        );
+        let fee_normal = config.compute_fee_with_outputs(TransactionType::Hidden, 4_000, 0, 2, 0);
 
         // Splitting into 10 outputs costs 25x more
-        let fee_split = config.compute_fee_with_outputs(
-            TransactionType::Hidden,
-            4_000,
-            0,
-            10,
-            0,
-        );
+        let fee_split = config.compute_fee_with_outputs(TransactionType::Hidden, 4_000, 0, 10, 0);
 
         // 10 outputs = 100x penalty, 2 outputs = 4x penalty
         // So splitting should cost 100/4 = 25x more
-        assert_eq!(fee_split, fee_normal * 25, "10-output tx should cost 25x more");
+        assert_eq!(
+            fee_split,
+            fee_normal * 25,
+            "10-output tx should cost 25x more"
+        );
     }
 
     // ========================================================================

--- a/cluster-tax/src/lib.rs
+++ b/cluster-tax/src/lib.rs
@@ -69,13 +69,6 @@ pub use cluster::{ClusterId, ClusterWealth};
 pub use monetary::{DifficultyController, MonetaryPolicy, MonetaryState, MonetaryStats};
 
 pub use age_decay::{apply_age_decay, ring_cluster_factor, AgeDecayConfig, RingDecayInfo};
-pub use demurrage::{demurrage_charge, ring_elapsed_centroid};
-pub use entropy_decay::{
-    apply_entropy_decay, calculate_entropy_decay, compare_decay_modes,
-    conservative_entropy_delta, ring_entropy_decay, AttackResult, AttackStrategy, DecayBlockReason,
-    DecayMode, EntropyDecayConfig, EntropyDecayResult, EntropyScaling, RingDecayBlockReason,
-    RingEntropyDecayInfo, SimUtxo,
-};
 pub use block_decay::{
     AndDecayConfig, AndTagVector, BlockAwareTagVector, BlockDecayConfig, RateLimitedDecayConfig,
     RateLimitedTagVector,
@@ -89,20 +82,27 @@ pub use crypto::{
     CommittedFeeVerifier,
     CommittedTagVector,
     CommittedTagVectorSecret,
-    ExtendedTxSignature,
-    RingTagData,
-    SegmentOrProof,
     // Phase 2B: Entropy proofs
     EntropyLinkageProof,
     EntropyProof,
     EntropyProofBuilder,
     EntropyProofVerifier,
     EntropyRangeProof,
+    ExtendedTxSignature,
+    RingTagData,
+    SegmentOrProof,
     TransactionVersion,
     ENTROPY_SCALE,
     MIN_ENTROPY_THRESHOLD_SCALED,
 };
+pub use demurrage::{demurrage_charge, ring_elapsed_centroid};
 pub use dynamic_fee::{DynamicFeeBase, DynamicFeeState, FeeSuggestion};
+pub use entropy_decay::{
+    apply_entropy_decay, calculate_entropy_decay, compare_decay_modes, conservative_entropy_delta,
+    ring_entropy_decay, AttackResult, AttackStrategy, DecayBlockReason, DecayMode,
+    EntropyDecayConfig, EntropyDecayResult, EntropyScaling, RingDecayBlockReason,
+    RingEntropyDecayInfo, SimUtxo,
+};
 pub use fee_curve::{
     count_outputs_with_memos,
     ClusterFactorCurve,

--- a/cluster-tax/src/lottery.rs
+++ b/cluster-tax/src/lottery.rs
@@ -1,8 +1,8 @@
 //! Production lottery draw implementation.
 //!
-//! This module provides the core lottery selection logic for fee redistribution.
-//! Unlike the simulation module, this is designed for actual use in block production
-//! and validation with verifiable randomness.
+//! This module provides the core lottery selection logic for fee
+//! redistribution. Unlike the simulation module, this is designed for actual
+//! use in block production and validation with verifiable randomness.
 //!
 //! ## Selection Mode
 //!
@@ -171,8 +171,7 @@ impl LotteryCandidate {
                 // config constant must be identical across nodes, so the
                 // f64→bps conversion is deterministic).
                 let alpha_bps = (alpha.clamp(0.0, 1.0) * 10_000.0).round() as u128;
-                alpha_bps * max_value.max(1) as u128
-                    + (10_000 - alpha_bps) * self.value as u128
+                alpha_bps * max_value.max(1) as u128 + (10_000 - alpha_bps) * self.value as u128
             }
 
             SelectionMode::ClusterWeighted => {
@@ -227,7 +226,8 @@ pub struct LotteryWinner {
 /// * `config` - Lottery configuration
 ///
 /// # Returns
-/// `LotteryResult` with winners and payouts, or `None` if no eligible candidates.
+/// `LotteryResult` with winners and payouts, or `None` if no eligible
+/// candidates.
 pub fn draw_winners(
     candidates: &[LotteryCandidate],
     pool_amount: u64,
@@ -374,7 +374,13 @@ mod tests {
     use super::*;
 
     /// `factor` is in FACTOR_SCALE units (1000 = 1.0x .. 6000 = 6.0x).
-    fn make_candidate(id: u8, value: u64, factor: u64, entropy: f64, block: u64) -> LotteryCandidate {
+    fn make_candidate(
+        id: u8,
+        value: u64,
+        factor: u64,
+        entropy: f64,
+        block: u64,
+    ) -> LotteryCandidate {
         let mut utxo_id = [0u8; 36];
         utxo_id[0] = id;
         LotteryCandidate {
@@ -508,7 +514,10 @@ mod tests {
         let roll0 = verifiable_random_u128(&seed, 0);
         let roll1 = verifiable_random_u128(&seed, 1);
 
-        assert_ne!(roll0, roll1, "Different indices should produce different rolls");
+        assert_ne!(
+            roll0, roll1,
+            "Different indices should produce different rolls"
+        );
     }
 
     #[test]

--- a/cluster-tax/src/monetary.rs
+++ b/cluster-tax/src/monetary.rs
@@ -216,9 +216,9 @@ impl MonetaryPolicy {
     ///   would be miner coinbases, so routing emission would be circular at
     ///   best. Miners keep the full (large) reward while security depends
     ///   entirely on emission.
-    /// - The ramp counteracts the absolute decay of f x reward across
-    ///   halvings, maintaining redistribution intensity as wealth
-    ///   concentration accumulates.
+    /// - The ramp counteracts the absolute decay of f x reward across halvings,
+    ///   maintaining redistribution intensity as wealth concentration
+    ///   accumulates.
     /// - The cap preserves at least half of tail emission as the permanent
     ///   mining security budget.
     ///
@@ -513,8 +513,7 @@ impl DifficultyController {
         // CONSENSUS-CRITICAL: pure integer arithmetic — difficulty is
         // validated state (minting txs are rejected on mismatch), so every
         // node must compute the identical value.
-        let proposed =
-            (self.state.difficulty as u128 * expected as u128) / elapsed as u128;
+        let proposed = (self.state.difficulty as u128 * expected as u128) / elapsed as u128;
 
         self.apply_bounded_adjustment(proposed)
     }

--- a/cluster-tax/src/simulation/constrained_analysis.rs
+++ b/cluster-tax/src/simulation/constrained_analysis.rs
@@ -8,11 +8,11 @@
 //! 1. **Effective Anonymity Set Size**: How do age and factor constraints
 //!    reduce the anonymity set compared to unconstrained selection?
 //!
-//! 2. **Tag Distribution Impact**: Do certain tag profiles suffer more
-//!    privacy loss than others under constraints?
+//! 2. **Tag Distribution Impact**: Do certain tag profiles suffer more privacy
+//!    loss than others under constraints?
 //!
-//! 3. **Optimal Parameters**: What constraint thresholds balance privacy
-//!    with fee accuracy?
+//! 3. **Optimal Parameters**: What constraint thresholds balance privacy with
+//!    fee accuracy?
 //!
 //! # Reference
 //!
@@ -24,8 +24,8 @@ use rand::Rng;
 use std::collections::HashMap;
 
 use super::privacy::{
-    calculate_privacy_metrics, AgeAdversary, Adversary, ClusterAdversary, CombinedAdversary,
-    DistributionStats, NaiveAdversary, OutputType, OutputPoolGenerator, PoolConfig,
+    calculate_privacy_metrics, Adversary, AgeAdversary, ClusterAdversary, CombinedAdversary,
+    DistributionStats, NaiveAdversary, OutputPoolGenerator, OutputType, PoolConfig,
     RingPrivacyMetrics, SimulatedOutput, MIN_AGE_BLOCKS,
 };
 use crate::tag::TAG_WEIGHT_SCALE;
@@ -72,7 +72,8 @@ impl ConstraintConfig {
 
 /// Calculate the cluster factor for a simulated output.
 ///
-/// This replicates the logic from wallet decoy_selection for simulation purposes.
+/// This replicates the logic from wallet decoy_selection for simulation
+/// purposes.
 pub fn calculate_cluster_factor(output: &SimulatedOutput) -> f64 {
     let total_attributed: u64 = output.cluster_tags.values().map(|&w| w as u64).sum();
     let attribution_pct = total_attributed as f64 / TAG_WEIGHT_SCALE as f64;
@@ -423,7 +424,7 @@ pub fn run_comparative_analysis<R: Rng>(
     // Collect unconstrained results (using very relaxed constraints)
     let unconstrained_config = ConstraintConfig {
         ring_size: config.ring_size,
-        max_age_ratio: 1000.0, // Effectively no age constraint
+        max_age_ratio: 1000.0,    // Effectively no age constraint
         max_factor_ratio: 1000.0, // Effectively no factor constraint
     };
 
@@ -449,7 +450,10 @@ pub fn run_comparative_analysis<R: Rng>(
     }
 }
 
-fn compute_selection_stats(results: &[ConstrainedRingResult], fallback_count: usize) -> SelectionStats {
+fn compute_selection_stats(
+    results: &[ConstrainedRingResult],
+    fallback_count: usize,
+) -> SelectionStats {
     let success_count = results.iter().filter(|r| r.selection_succeeded).count();
     let success_rate = success_count as f64 / results.len() as f64;
     let fallback_rate = fallback_count as f64 / results.len() as f64;
@@ -461,8 +465,14 @@ fn compute_selection_stats(results: &[ConstrainedRingResult], fallback_count: us
     for result in results {
         if let Some(metrics) = &result.metrics_by_adversary {
             for (name, m) in metrics {
-                bits_samples.entry(name.clone()).or_default().push(m.bits_of_privacy);
-                anonymity_samples.entry(name.clone()).or_default().push(m.effective_anonymity);
+                bits_samples
+                    .entry(name.clone())
+                    .or_default()
+                    .push(m.bits_of_privacy);
+                anonymity_samples
+                    .entry(name.clone())
+                    .or_default()
+                    .push(m.effective_anonymity);
                 if m.real_signer_rank == 1 {
                     *identified_counts.entry(name.clone()).or_default() += 1;
                 }
@@ -621,9 +631,15 @@ pub fn parameter_sweep<R: Rng>(
 pub fn format_comparative_report(analysis: &ComparativeAnalysis) -> String {
     let mut report = String::new();
 
-    report.push_str("╔══════════════════════════════════════════════════════════════════════════════╗\n");
-    report.push_str("║           CONSTRAINED VS UNCONSTRAINED DECOY SELECTION ANALYSIS              ║\n");
-    report.push_str("╠══════════════════════════════════════════════════════════════════════════════╣\n");
+    report.push_str(
+        "╔══════════════════════════════════════════════════════════════════════════════╗\n",
+    );
+    report.push_str(
+        "║           CONSTRAINED VS UNCONSTRAINED DECOY SELECTION ANALYSIS              ║\n",
+    );
+    report.push_str(
+        "╠══════════════════════════════════════════════════════════════════════════════╣\n",
+    );
     report.push_str(&format!(
         "║  Simulations: {:>6}  Ring Size: {:>2}  Age Ratio: {:.1}x  Factor Ratio: {:.1}x    ║\n",
         analysis.num_simulations,
@@ -631,10 +647,14 @@ pub fn format_comparative_report(analysis: &ComparativeAnalysis) -> String {
         analysis.config.max_age_ratio,
         analysis.config.max_factor_ratio
     ));
-    report.push_str("╚══════════════════════════════════════════════════════════════════════════════╝\n\n");
+    report.push_str(
+        "╚══════════════════════════════════════════════════════════════════════════════╝\n\n",
+    );
 
     report.push_str("SUCCESS RATES\n");
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
     report.push_str(&format!(
         "Constrained:   Success: {:>5.1}%   Fallback: {:>5.1}%\n",
         analysis.constrained.success_rate * 100.0,
@@ -646,15 +666,34 @@ pub fn format_comparative_report(analysis: &ComparativeAnalysis) -> String {
     ));
 
     report.push_str("\nBITS OF PRIVACY BY ADVERSARY\n");
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
     report.push_str("Adversary            Constrained    Unconstrained    Reduction\n");
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
 
     let adversaries = ["Naive", "Age-Heuristic", "Cluster-Fingerprint", "Combined"];
     for adv in adversaries {
-        let c_bits = analysis.constrained.bits_by_adversary.get(adv).map(|s| s.mean).unwrap_or(0.0);
-        let u_bits = analysis.unconstrained.bits_by_adversary.get(adv).map(|s| s.mean).unwrap_or(0.0);
-        let reduction = analysis.privacy_reduction.bits_reduction.get(adv).copied().unwrap_or(0.0);
+        let c_bits = analysis
+            .constrained
+            .bits_by_adversary
+            .get(adv)
+            .map(|s| s.mean)
+            .unwrap_or(0.0);
+        let u_bits = analysis
+            .unconstrained
+            .bits_by_adversary
+            .get(adv)
+            .map(|s| s.mean)
+            .unwrap_or(0.0);
+        let reduction = analysis
+            .privacy_reduction
+            .bits_reduction
+            .get(adv)
+            .copied()
+            .unwrap_or(0.0);
 
         report.push_str(&format!(
             "{:<20} {:>6.2}          {:>6.2}          {:>+6.2}\n",
@@ -663,27 +702,53 @@ pub fn format_comparative_report(analysis: &ComparativeAnalysis) -> String {
     }
 
     report.push_str("\nIDENTIFICATION RATES (lower is better)\n");
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
     report.push_str("Adversary            Constrained    Unconstrained    Change\n");
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
 
     for adv in adversaries {
-        let c_rate = analysis.constrained.identification_rate.get(adv).copied().unwrap_or(0.0);
-        let u_rate = analysis.unconstrained.identification_rate.get(adv).copied().unwrap_or(0.0);
-        let increase = analysis.privacy_reduction.identification_increase.get(adv).copied().unwrap_or(0.0);
+        let c_rate = analysis
+            .constrained
+            .identification_rate
+            .get(adv)
+            .copied()
+            .unwrap_or(0.0);
+        let u_rate = analysis
+            .unconstrained
+            .identification_rate
+            .get(adv)
+            .copied()
+            .unwrap_or(0.0);
+        let increase = analysis
+            .privacy_reduction
+            .identification_increase
+            .get(adv)
+            .copied()
+            .unwrap_or(0.0);
 
         report.push_str(&format!(
             "{:<20} {:>5.1}%          {:>5.1}%           {:>+5.1}%\n",
-            adv, c_rate * 100.0, u_rate * 100.0, increase * 100.0
+            adv,
+            c_rate * 100.0,
+            u_rate * 100.0,
+            increase * 100.0
         ));
     }
 
-    report.push_str("\n─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "\n─────────────────────────────────────────────────────────────────────────────────\n",
+    );
     report.push_str("INTERPRETATION:\n");
     report.push_str("  • Negative reduction = constraints IMPROVE privacy (unlikely)\n");
     report.push_str("  • Positive reduction = constraints REDUCE privacy\n");
     report.push_str("  • Ideal: small reduction with high success rate and no fallbacks\n");
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
 
     report
 }
@@ -692,13 +757,21 @@ pub fn format_comparative_report(analysis: &ComparativeAnalysis) -> String {
 pub fn format_parameter_sweep(results: &[ParameterSweepResult]) -> String {
     let mut report = String::new();
 
-    report.push_str("╔══════════════════════════════════════════════════════════════════════════════╗\n");
-    report.push_str("║                    CONSTRAINT PARAMETER SWEEP RESULTS                        ║\n");
-    report.push_str("╚══════════════════════════════════════════════════════════════════════════════╝\n\n");
+    report.push_str(
+        "╔══════════════════════════════════════════════════════════════════════════════╗\n",
+    );
+    report.push_str(
+        "║                    CONSTRAINT PARAMETER SWEEP RESULTS                        ║\n",
+    );
+    report.push_str(
+        "╚══════════════════════════════════════════════════════════════════════════════╝\n\n",
+    );
 
     report.push_str("Age    Factor   Eligible    Insufficient   Success    Bits of\n");
     report.push_str("Ratio  Ratio    Pool Size   Fraction       Rate       Privacy\n");
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
 
     for r in results {
         report.push_str(&format!(
@@ -712,13 +785,17 @@ pub fn format_parameter_sweep(results: &[ParameterSweepResult]) -> String {
         ));
     }
 
-    report.push_str("\n─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "\n─────────────────────────────────────────────────────────────────────────────────\n",
+    );
     report.push_str("INTERPRETATION:\n");
     report.push_str("  • Higher eligible pool = more decoy choices\n");
     report.push_str("  • Lower insufficient fraction = fewer fallbacks needed\n");
     report.push_str("  • Higher bits of privacy = better anonymity\n");
     report.push_str("  • Optimal: balance between eligible pool size and privacy bits\n");
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
 
     report
 }
@@ -839,18 +916,34 @@ pub fn analyze_ring_sizes<R: Rng>(
 pub fn format_ring_size_report(rec: &RingSizeRecommendation) -> String {
     let mut report = String::new();
 
-    report.push_str("╔══════════════════════════════════════════════════════════════════════════════╗\n");
-    report.push_str("║                        RING SIZE ANALYSIS REPORT                             ║\n");
-    report.push_str("╚══════════════════════════════════════════════════════════════════════════════╝\n\n");
+    report.push_str(
+        "╔══════════════════════════════════════════════════════════════════════════════╗\n",
+    );
+    report.push_str(
+        "║                        RING SIZE ANALYSIS REPORT                             ║\n",
+    );
+    report.push_str(
+        "╚══════════════════════════════════════════════════════════════════════════════╝\n\n",
+    );
 
-    report.push_str(&format!("MINIMUM RING SIZE:     {}\n", rec.minimum_ring_size));
-    report.push_str(&format!("RECOMMENDED RING SIZE: {}\n\n", rec.recommended_ring_size));
+    report.push_str(&format!(
+        "MINIMUM RING SIZE:     {}\n",
+        rec.minimum_ring_size
+    ));
+    report.push_str(&format!(
+        "RECOMMENDED RING SIZE: {}\n\n",
+        rec.recommended_ring_size
+    ));
 
     report.push_str("ANALYSIS BY RING SIZE\n");
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
     report.push_str("Ring    Mean     5th%     Success    Eligible\n");
     report.push_str("Size    Bits     Bits     Rate       Pool Size\n");
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
 
     for a in &rec.by_ring_size {
         let marker = if a.ring_size == rec.recommended_ring_size {
@@ -872,10 +965,14 @@ pub fn format_ring_size_report(rec: &RingSizeRecommendation) -> String {
         ));
     }
 
-    report.push_str("\n─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "\n─────────────────────────────────────────────────────────────────────────────────\n",
+    );
     report.push_str("RATIONALE:\n");
     report.push_str(&format!("{}\n", rec.rationale));
-    report.push_str("─────────────────────────────────────────────────────────────────────────────────\n");
+    report.push_str(
+        "─────────────────────────────────────────────────────────────────────────────────\n",
+    );
 
     report
 }
@@ -983,20 +1080,17 @@ mod tests {
         let pool = create_test_pool();
         let mut rng = rand::thread_rng();
 
-        let results = parameter_sweep(
-            &pool,
-            11,
-            &[1.5, 2.0, 3.0],
-            &[1.25, 1.5, 2.0],
-            50,
-            &mut rng,
-        );
+        let results = parameter_sweep(&pool, 11, &[1.5, 2.0, 3.0], &[1.25, 1.5, 2.0], 50, &mut rng);
 
         assert_eq!(results.len(), 9); // 3 x 3
 
         // Looser constraints should have higher eligible pool sizes
-        let tight = results.iter().find(|r| r.age_ratio == 1.5 && r.factor_ratio == 1.25);
-        let loose = results.iter().find(|r| r.age_ratio == 3.0 && r.factor_ratio == 2.0);
+        let tight = results
+            .iter()
+            .find(|r| r.age_ratio == 1.5 && r.factor_ratio == 1.25);
+        let loose = results
+            .iter()
+            .find(|r| r.age_ratio == 3.0 && r.factor_ratio == 2.0);
 
         if let (Some(t), Some(l)) = (tight, loose) {
             assert!(

--- a/cluster-tax/src/simulation/emission_sweep.rs
+++ b/cluster-tax/src/simulation/emission_sweep.rs
@@ -13,12 +13,13 @@
 //!
 //! 1. **Analytic monetary track** (real-world scale). The emission curve is a
 //!    pure deterministic function of the policy parameters
-//!    ([`MonetaryPolicy::halving_reward`] / [`MonetaryPolicy::calculate_tail_reward`]),
-//!    so quantities like derived total supply, time-to-tail, %-issued-by-year,
-//!    steady-state inflation and the early-vs-late issuance share are computed
-//!    *exactly* over the real Phase-1 block counts
-//!    (`BLOCKS_PER_YEAR = 6_307_200` at 5s blocks). No simulation is needed or
-//!    desirable here — simulating ~60M blocks would add noise, not signal.
+//!    ([`MonetaryPolicy::halving_reward`] /
+//!    [`MonetaryPolicy::calculate_tail_reward`]), so quantities like derived
+//!    total supply, time-to-tail, %-issued-by-year, steady-state inflation and
+//!    the early-vs-late issuance share are computed *exactly* over the real
+//!    Phase-1 block counts (`BLOCKS_PER_YEAR = 6_307_200` at 5s blocks). No
+//!    simulation is needed or desirable here — simulating ~60M blocks would add
+//!    noise, not signal.
 //!
 //! 2. **Agent-based distribution track** (sim scale). Wealth-distribution
 //!    outcomes (Gini trajectory, top-1%/10% share), the recycled-value
@@ -35,11 +36,13 @@
 //! RNG seeded from agent IDs (no global/thread RNG), and an identical agent
 //! population is used for every schedule.
 
-use crate::simulation::{
-    run_simulation, Agent, AgentId, MerchantAgent, Metrics, MinterAgent, RetailUserAgent,
-    SimulationConfig, WhaleAgent, WhaleStrategy,
+use crate::{
+    simulation::{
+        run_simulation, Agent, AgentId, MerchantAgent, Metrics, MinterAgent, RetailUserAgent,
+        SimulationConfig, WhaleAgent, WhaleStrategy,
+    },
+    MonetaryPolicy,
 };
-use crate::MonetaryPolicy;
 
 /// 1 BTH expressed in nanoBTH (the smallest unit used by the policy).
 const NANOBTH_PER_BTH: u128 = 1_000_000_000;
@@ -227,7 +230,8 @@ pub fn pct_issued_by_year(policy: &MonetaryPolicy, year: u64) -> f64 {
     }
     // Cap Phase-1 portion at 100%; tail emission beyond that is reported
     // separately as steady-state inflation.
-    let p1_at = cumulative_supply_at(policy, height.min(policy.tail_emission_start_height())) as f64;
+    let p1_at =
+        cumulative_supply_at(policy, height.min(policy.tail_emission_start_height())) as f64;
     (p1_at / total) * 100.0
 }
 
@@ -783,7 +787,11 @@ fn neutral_observations(results: &[ScheduleResult]) -> String {
 driven entirely by the halving interval H.\n",
         min_supply,
         max_supply,
-        if min_supply > 0.0 { max_supply / min_supply } else { 0.0 },
+        if min_supply > 0.0 {
+            max_supply / min_supply
+        } else {
+            0.0
+        },
     ));
 
     // Time-to-tail spread.
@@ -803,14 +811,12 @@ front-load issuance into fewer years.\n",
 
     // Early-issuance comparison (concentration proxy): contrast the schedules
     // with the highest and lowest early-10% share.
-    let high_early = results
-        .iter()
-        .max_by(|a, b| {
-            a.monetary
-                .early_share_10pct
-                .partial_cmp(&b.monetary.early_share_10pct)
-                .unwrap()
-        });
+    let high_early = results.iter().max_by(|a, b| {
+        a.monetary
+            .early_share_10pct
+            .partial_cmp(&b.monetary.early_share_10pct)
+            .unwrap()
+    });
     let low_early = results.iter().min_by(|a, b| {
         a.monetary
             .early_share_10pct

--- a/cluster-tax/src/simulation/lottery.rs
+++ b/cluster-tax/src/simulation/lottery.rs
@@ -178,7 +178,6 @@ pub struct LotteryConfig {
     // === Asymmetric Structure Fees (from asymmetric-utxo-fees.md) ===
 
     // === Spend-Time Demurrage (issue #314, matches node implementation) ===
-
     /// Annual demurrage rate at max cluster factor, in basis points.
     /// 0 disables spend-time demurrage. When enabled, each spend charges
     /// accrual on the spender's full UTXO value since its demurrage anchor,
@@ -404,11 +403,17 @@ impl LotteryUtxo {
         } else {
             1.0 // Floor: everyone gets at least 1 ticket
         };
-        let elig = self.eligibility(current_block, decay_rate_per_day, min_eligibility, blocks_per_day);
+        let elig = self.eligibility(
+            current_block,
+            decay_rate_per_day,
+            min_eligibility,
+            blocks_per_day,
+        );
         base_tickets * elig
     }
 
-    /// Update last activity block (called when UTXO participates in transaction).
+    /// Update last activity block (called when UTXO participates in
+    /// transaction).
     pub fn refresh_activity(&mut self, current_block: u64) {
         self.last_activity_block = current_block;
     }
@@ -1118,12 +1123,7 @@ impl LotterySimulation {
     /// which is dramatically faster than repeated `select_winner_by_mode`
     /// calls for multi-year simulations. Other modes fall back to per-winner
     /// selection.
-    pub fn select_winners_by_mode(
-        &self,
-        utxo_ids: &[u64],
-        n: u32,
-        rng: &mut impl Rng,
-    ) -> Vec<u64> {
+    pub fn select_winners_by_mode(&self, utxo_ids: &[u64], n: u32, rng: &mut impl Rng) -> Vec<u64> {
         if utxo_ids.is_empty() || n == 0 {
             return Vec::new();
         }
@@ -2077,10 +2077,11 @@ mod tests {
 
     #[test]
     fn test_sybil_not_profitable() {
-        // This test validates value-weighted selection's Sybil resistance via simulation.
-        // ValueWeighted has theoretical ~1x gaming ratio (splitting doesn't help).
-        // Threshold is 20% to account for simulation variance over 10k blocks.
-        // Key comparison: Uniform would show ~10x advantage, ValueWeighted should be ~1x.
+        // This test validates value-weighted selection's Sybil resistance via
+        // simulation. ValueWeighted has theoretical ~1x gaming ratio (splitting
+        // doesn't help). Threshold is 20% to account for simulation variance
+        // over 10k blocks. Key comparison: Uniform would show ~10x advantage,
+        // ValueWeighted should be ~1x.
         //
         // The measurement is a Monte Carlo estimate over 10k blocks, so it carries
         // simulation noise. Previously the simulation drew from `thread_rng` (system
@@ -6603,7 +6604,10 @@ mod tests {
 
         eprintln!("  Small holder (100 BTH): {:.4} tickets/BTH", small_tpb);
         eprintln!("  Large holder (1M BTH):  {:.4} tickets/BTH", large_tpb);
-        eprintln!("  Ratio: {:.1}x more tickets/BTH for small", small_tpb / large_tpb);
+        eprintln!(
+            "  Ratio: {:.1}x more tickets/BTH for small",
+            small_tpb / large_tpb
+        );
 
         assert!(
             small_tpb > large_tpb * 5.0,
@@ -6702,7 +6706,10 @@ mod tests {
         let total_tickets_day0 = tickets_per_utxo * split_count;
 
         eprintln!("  Attacker: 100K BTH split into 100 UTXOs");
-        eprintln!("  Day 0 tickets: {} (100 UTXOs × 1 floor ticket)", total_tickets_day0);
+        eprintln!(
+            "  Day 0 tickets: {} (100 UTXOs × 1 floor ticket)",
+            total_tickets_day0
+        );
 
         // After 30 days of parking
         let elig_30 = (1.0 - decay_rate).powf(30.0).max(min_eligibility);
@@ -6738,7 +6745,10 @@ mod tests {
             "After refresh, eligibility should be 100%: got {:.4}",
             elig_after_refresh
         );
-        eprintln!("  After refresh at day 50: {:.0}% eligibility", elig_after_refresh * 100.0);
+        eprintln!(
+            "  After refresh at day 50: {:.0}% eligibility",
+            elig_after_refresh * 100.0
+        );
 
         eprintln!("");
         eprintln!("✓ VERIFIED: Eligibility decays over time");
@@ -6760,8 +6770,14 @@ mod tests {
 
         let config = LotteryConfig::combined_mechanism();
         eprintln!("Parameters:");
-        eprintln!("  Split penalty multiplier: {}", config.split_penalty_multiplier);
-        eprintln!("  Consolidation discount: {}", config.consolidation_discount);
+        eprintln!(
+            "  Split penalty multiplier: {}",
+            config.split_penalty_multiplier
+        );
+        eprintln!(
+            "  Consolidation discount: {}",
+            config.consolidation_discount
+        );
         eprintln!("  Allowed extra outputs: {}", config.allowed_extra_outputs);
         eprintln!("");
 
@@ -6843,7 +6859,10 @@ mod tests {
         }
 
         // Add parking attacker
-        let attacker_id = sim.add_owner(attacker_wealth, SybilStrategy::ParkingAttack { split_target: 100 });
+        let attacker_id = sim.add_owner(
+            attacker_wealth,
+            SybilStrategy::ParkingAttack { split_target: 100 },
+        );
 
         sim.current_block = 1000;
 
@@ -6854,7 +6873,11 @@ mod tests {
         eprintln!("Initial state:");
         eprintln!("  Total wealth: {} BTH", total_wealth / 1000);
         eprintln!("  Normal users: 100 × {} BTH", user_wealth / 1000);
-        eprintln!("  Attacker: {} BTH ({} UTXOs)", attacker_wealth / 1000, initial_attacker_utxos);
+        eprintln!(
+            "  Attacker: {} BTH ({} UTXOs)",
+            attacker_wealth / 1000,
+            initial_attacker_utxos
+        );
         eprintln!("");
 
         // Simulate attacker splitting (manually for this test)
@@ -6901,7 +6924,10 @@ mod tests {
         };
         let avg_effective_tickets = initial_tickets as f64 * avg_eligibility;
 
-        eprintln!("  Average eligibility over 30 days: {:.1}%", avg_eligibility * 100.0);
+        eprintln!(
+            "  Average eligibility over 30 days: {:.1}%",
+            avg_eligibility * 100.0
+        );
         eprintln!("  Average effective tickets: {:.0}", avg_effective_tickets);
 
         // Compare to unsplit scenario
@@ -6910,27 +6936,45 @@ mod tests {
         eprintln!("Comparison to unsplit (honest) strategy:");
         eprintln!("  Unsplit tickets: {}", unsplit_tickets);
         eprintln!("  Split tickets (day 0): {}", initial_tickets);
-        eprintln!("  Split advantage ratio: {:.2}x", initial_tickets as f64 / unsplit_tickets as f64);
-        eprintln!("  After decay (avg): {:.2}x", avg_effective_tickets / unsplit_tickets as f64);
+        eprintln!(
+            "  Split advantage ratio: {:.2}x",
+            initial_tickets as f64 / unsplit_tickets as f64
+        );
+        eprintln!(
+            "  After decay (avg): {:.2}x",
+            avg_effective_tickets / unsplit_tickets as f64
+        );
 
         // The split advantage should be bounded by min_utxo constraint
         let max_split_advantage = (attacker_wealth / config.min_utxo_value) as f64
             / (attacker_wealth / ticket_threshold) as f64;
         eprintln!("");
-        eprintln!("Max theoretical split advantage (from min UTXO): {:.1}x", max_split_advantage);
+        eprintln!(
+            "Max theoretical split advantage (from min UTXO): {:.1}x",
+            max_split_advantage
+        );
 
         eprintln!("");
         eprintln!("Attack profitability analysis:");
         eprintln!("  Split cost: {} BTH", split_cost / 1000);
-        eprintln!("  Ticket advantage: {:.1}x (before decay)", initial_tickets as f64 / unsplit_tickets as f64);
-        eprintln!("  Ticket advantage: {:.1}x (after 30d decay avg)", avg_effective_tickets / unsplit_tickets as f64);
+        eprintln!(
+            "  Ticket advantage: {:.1}x (before decay)",
+            initial_tickets as f64 / unsplit_tickets as f64
+        );
+        eprintln!(
+            "  Ticket advantage: {:.1}x (after 30d decay avg)",
+            avg_effective_tickets / unsplit_tickets as f64
+        );
 
         // Key insight: with eligibility decay, the advantage diminishes over time
         // Combined with split cost, the attack becomes unprofitable
         eprintln!("");
         eprintln!("Key insights:");
         eprintln!("  1. Value-weighted floor limits max splitting advantage");
-        eprintln!("  2. Min UTXO size caps splitting to ~{}x", max_split_advantage as u64);
+        eprintln!(
+            "  2. Min UTXO size caps splitting to ~{}x",
+            max_split_advantage as u64
+        );
         eprintln!("  3. Eligibility decay reduces effective tickets over time");
         eprintln!("  4. Split penalty adds upfront cost");
         eprintln!("  5. Combined: Parking attack ROI < 1.0 (unprofitable)");
@@ -6940,5 +6984,3 @@ mod tests {
         eprintln!("{}", "=".repeat(80));
     }
 }
-
-

--- a/cluster-tax/src/simulation/mod.rs
+++ b/cluster-tax/src/simulation/mod.rs
@@ -13,8 +13,8 @@
 //! ## Constrained Analysis
 //!
 //! The `constrained_analysis` submodule extends privacy simulation to analyze
-//! the impact of wallet-side tag-based constraints (age similarity, factor ceiling)
-//! on ring signature anonymity.
+//! the impact of wallet-side tag-based constraints (age similarity, factor
+//! ceiling) on ring signature anonymity.
 //!
 //! ## Lottery Simulation
 //!

--- a/cluster-tax/src/tag.rs
+++ b/cluster-tax/src/tag.rs
@@ -294,11 +294,7 @@ impl TagVector {
             return (0, 0);
         }
 
-        let sum_sq: u128 = self
-            .tags
-            .values()
-            .map(|&w| (w as u128) * (w as u128))
-            .sum();
+        let sum_sq: u128 = self.tags.values().map(|&w| (w as u128) * (w as u128)).sum();
 
         let total_sq = (total as u128) * (total as u128);
 
@@ -415,10 +411,12 @@ impl TagVector {
         (sum_sq as f64 / total_sq as f64) <= threshold_inv
     }
 
-    /// Compute collision sum for the cluster-only distribution (excluding background).
+    /// Compute collision sum for the cluster-only distribution (excluding
+    /// background).
     ///
     /// This is the collision entropy equivalent of `cluster_entropy()` - it
-    /// only considers the attributed cluster weights, making it decay-invariant.
+    /// only considers the attributed cluster weights, making it
+    /// decay-invariant.
     ///
     /// # Returns
     ///
@@ -991,7 +989,10 @@ mod tests {
         // total_sq = 1_000_000² = 1_000_000_000_000
         // collision_prob = 1.0, H₂ = 0 bits
         assert_eq!(sum_sq, total_sq);
-        assert_eq!(sum_sq, (TAG_WEIGHT_SCALE as u128) * (TAG_WEIGHT_SCALE as u128));
+        assert_eq!(
+            sum_sq,
+            (TAG_WEIGHT_SCALE as u128) * (TAG_WEIGHT_SCALE as u128)
+        );
     }
 
     #[test]
@@ -1331,10 +1332,7 @@ mod tests {
 
         let h2_equal = equal.collision_entropy();
         let h1_equal = equal.cluster_entropy();
-        assert!(
-            (h2_equal - h1_equal).abs() < 0.01,
-            "Equal split: H₂ = H₁"
-        );
+        assert!((h2_equal - h1_equal).abs() < 0.01, "Equal split: H₂ = H₁");
 
         // Unequal split: H₂ < H₁
         let mut unequal = TagVector::new();

--- a/contracts/solana/programs/wbth/src/lib.rs
+++ b/contracts/solana/programs/wbth/src/lib.rs
@@ -31,11 +31,7 @@ pub mod wbth_bridge {
     /// Mint wBTH to a user when BTH is deposited to the bridge.
     ///
     /// Only callable by the bridge authority.
-    pub fn bridge_mint(
-        ctx: Context<BridgeMint>,
-        amount: u64,
-        bth_tx_hash: [u8; 32],
-    ) -> Result<()> {
+    pub fn bridge_mint(ctx: Context<BridgeMint>, amount: u64, bth_tx_hash: [u8; 32]) -> Result<()> {
         let bridge = &mut ctx.accounts.bridge;
 
         require!(!bridge.paused, BridgeError::Paused);
@@ -93,11 +89,7 @@ pub mod wbth_bridge {
     /// Burn wBTH to redeem BTH on the native chain.
     ///
     /// The bridge service monitors these events and releases BTH.
-    pub fn bridge_burn(
-        ctx: Context<BridgeBurn>,
-        amount: u64,
-        bth_address: String,
-    ) -> Result<()> {
+    pub fn bridge_burn(ctx: Context<BridgeBurn>, amount: u64, bth_address: String) -> Result<()> {
         let bridge = &ctx.accounts.bridge;
 
         require!(!bridge.paused, BridgeError::Paused);

--- a/fuzz/fuzz_targets/fuzz_address_parsing.rs
+++ b/fuzz/fuzz_targets/fuzz_address_parsing.rs
@@ -2,9 +2,9 @@
 
 //! Fuzzing target for address parsing.
 //!
-//! Security rationale: Address parsing accepts user input (from wallets, exchanges,
-//! command line). Invalid addresses must be rejected gracefully without panics or
-//! undefined behavior.
+//! Security rationale: Address parsing accepts user input (from wallets,
+//! exchanges, command line). Invalid addresses must be rejected gracefully
+//! without panics or undefined behavior.
 //!
 //! Botho supports both classical (Ristretto-based) and quantum-safe addresses.
 

--- a/fuzz/fuzz_targets/fuzz_clsag.rs
+++ b/fuzz/fuzz_targets/fuzz_clsag.rs
@@ -2,9 +2,9 @@
 
 //! Fuzzing target for CLSAG ring signature sign/verify.
 //!
-//! Security rationale: CLSAG signatures are cryptographically complex and provide
-//! unlinkability for transaction inputs. Invalid signatures must NEVER verify,
-//! and the implementation must handle malformed data gracefully.
+//! Security rationale: CLSAG signatures are cryptographically complex and
+//! provide unlinkability for transaction inputs. Invalid signatures must NEVER
+//! verify, and the implementation must handle malformed data gracefully.
 //!
 //! CLSAG is an improvement over MLSAG that reduces signature size by ~50%.
 
@@ -179,7 +179,6 @@ fn create_test_ring(
     )
 }
 
-
 // ============================================================================
 // Fuzz Target
 // ============================================================================
@@ -235,7 +234,9 @@ fn fuzz_valid_sign(valid: &ValidSignFuzz) {
 
     // Valid signature must verify
     assert!(
-        signature.verify(&message, &ring, &output_commitment).is_ok(),
+        signature
+            .verify(&message, &ring, &output_commitment)
+            .is_ok(),
         "Valid CLSAG signature must verify"
     );
 
@@ -303,10 +304,14 @@ fn fuzz_malformed_sig(malformed: &MalformedSigFuzz) {
             }
         }
         SigCorruption::CorruptKeyImage(bytes) => {
-            signature.key_image = KeyImage { point: curve25519_dalek::ristretto::CompressedRistretto(*bytes) };
+            signature.key_image = KeyImage {
+                point: curve25519_dalek::ristretto::CompressedRistretto(*bytes),
+            };
         }
         SigCorruption::CorruptCommitmentKeyImage(bytes) => {
-            signature.commitment_key_image = KeyImage { point: curve25519_dalek::ristretto::CompressedRistretto(*bytes) };
+            signature.commitment_key_image = KeyImage {
+                point: curve25519_dalek::ristretto::CompressedRistretto(*bytes),
+            };
         }
         SigCorruption::WrongResponseCount(count) => {
             let new_len = (*count as usize).min(100);

--- a/fuzz/fuzz_targets/fuzz_mlkem_decapsulation.rs
+++ b/fuzz/fuzz_targets/fuzz_mlkem_decapsulation.rs
@@ -118,7 +118,10 @@ fn fuzz_decapsulate(decap: &FuzzDecapsulation) {
         if let Ok(ct) = MlKem768Ciphertext::from_bytes(&decap.ciphertext) {
             if let Ok(shared_secret) = keypair.decapsulate(&ct) {
                 // Shared secret should always be 32 bytes.
-                assert_eq!(shared_secret.as_bytes().len(), ML_KEM_768_SHARED_SECRET_BYTES);
+                assert_eq!(
+                    shared_secret.as_bytes().len(),
+                    ML_KEM_768_SHARED_SECRET_BYTES
+                );
             }
         }
     }

--- a/fuzz/fuzz_targets/fuzz_pq_keys.rs
+++ b/fuzz/fuzz_targets/fuzz_pq_keys.rs
@@ -3,15 +3,16 @@
 use libfuzzer_sys::fuzz_target;
 
 use bth_crypto_pq::{
-    MlKem768Ciphertext, MlKem768PublicKey, MlDsa65PublicKey, MlDsa65Signature,
-    ML_KEM_768_CIPHERTEXT_BYTES, ML_KEM_768_PUBLIC_KEY_BYTES,
-    ML_DSA_65_PUBLIC_KEY_BYTES, ML_DSA_65_SIGNATURE_BYTES,
+    MlDsa65PublicKey, MlDsa65Signature, MlKem768Ciphertext, MlKem768PublicKey,
+    ML_DSA_65_PUBLIC_KEY_BYTES, ML_DSA_65_SIGNATURE_BYTES, ML_KEM_768_CIPHERTEXT_BYTES,
+    ML_KEM_768_PUBLIC_KEY_BYTES,
 };
 
 // Fuzz target for PQ cryptographic type parsing.
 //
-// Tests that malformed PQ key material cannot cause panics or undefined behavior.
-// These types are parsed from untrusted network data in transaction outputs and inputs.
+// Tests that malformed PQ key material cannot cause panics or undefined
+// behavior. These types are parsed from untrusted network data in transaction
+// outputs and inputs.
 //
 // Security rationale:
 // - ML-KEM public keys (1184 bytes) are in every PQ address
@@ -55,7 +56,8 @@ fuzz_target!(|data: &[u8]| {
     // (verification with random data should fail gracefully, not panic)
     if data.len() >= ML_DSA_65_PUBLIC_KEY_BYTES + ML_DSA_65_SIGNATURE_BYTES {
         let pk_bytes = &data[..ML_DSA_65_PUBLIC_KEY_BYTES];
-        let sig_bytes = &data[ML_DSA_65_PUBLIC_KEY_BYTES..ML_DSA_65_PUBLIC_KEY_BYTES + ML_DSA_65_SIGNATURE_BYTES];
+        let sig_bytes = &data
+            [ML_DSA_65_PUBLIC_KEY_BYTES..ML_DSA_65_PUBLIC_KEY_BYTES + ML_DSA_65_SIGNATURE_BYTES];
 
         if let (Ok(pk), Ok(sig)) = (
             MlDsa65PublicKey::from_bytes(pk_bytes),

--- a/fuzz/fuzz_targets/fuzz_pq_transaction.rs
+++ b/fuzz/fuzz_targets/fuzz_pq_transaction.rs
@@ -2,7 +2,9 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use botho::transaction_pq::{QuantumPrivateTxInput, QuantumPrivateTxOutput, QuantumPrivateTransaction};
+use botho::transaction_pq::{
+    QuantumPrivateTransaction, QuantumPrivateTxInput, QuantumPrivateTxOutput,
+};
 
 // Fuzz target for Quantum-Private Transaction deserialization.
 //

--- a/fuzz/fuzz_targets/fuzz_ring_signature.rs
+++ b/fuzz/fuzz_targets/fuzz_ring_signature.rs
@@ -2,19 +2,20 @@
 
 //! Fuzzing target for MLSAG ring signature verification.
 //!
-//! Security rationale: Ring signatures are cryptographically complex and provide
-//! unlinkability for transaction inputs. Invalid signatures must NEVER verify,
-//! and malformed signature data must never cause panics or undefined behavior.
+//! Security rationale: Ring signatures are cryptographically complex and
+//! provide unlinkability for transaction inputs. Invalid signatures must NEVER
+//! verify, and malformed signature data must never cause panics or undefined
+//! behavior.
 //!
-//! The ring signature implementation uses MLSAG (Multilayer Linkable Spontaneous
-//! Anonymous Group signatures) with Ristretto points.
+//! The ring signature implementation uses MLSAG (Multilayer Linkable
+//! Spontaneous Anonymous Group signatures) with Ristretto points.
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 
 use bth_crypto_hashes::Digest;
-use bth_crypto_ring_signature::{KeyImage, RingMLSAG, Commitment};
 use bth_crypto_keys::RistrettoPublic;
+use bth_crypto_ring_signature::{Commitment, KeyImage, RingMLSAG};
 use bth_util_repr_bytes::ReprBytes;
 
 // ============================================================================

--- a/fuzz/fuzz_targets/fuzz_rpc_request.rs
+++ b/fuzz/fuzz_targets/fuzz_rpc_request.rs
@@ -2,9 +2,9 @@
 
 //! Fuzzing target for JSON-RPC request parsing.
 //!
-//! Security rationale: The RPC endpoint is exposed to external clients (exchanges,
-//! wallets, web interfaces). Malformed requests must not crash the server, leak
-//! information, or cause resource exhaustion.
+//! Security rationale: The RPC endpoint is exposed to external clients
+//! (exchanges, wallets, web interfaces). Malformed requests must not crash the
+//! server, leak information, or cause resource exhaustion.
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;

--- a/fuzz/fuzz_targets/fuzz_subaddress.rs
+++ b/fuzz/fuzz_targets/fuzz_subaddress.rs
@@ -2,9 +2,10 @@
 
 //! Fuzzing target for subaddress derivation and view key scanning.
 //!
-//! Security rationale: Subaddress derivation must be deterministic and consistent.
-//! The same account key must always produce the same subaddresses. View key scanning
-//! must correctly identify owned outputs without false positives or negatives.
+//! Security rationale: Subaddress derivation must be deterministic and
+//! consistent. The same account key must always produce the same subaddresses.
+//! View key scanning must correctly identify owned outputs without false
+//! positives or negatives.
 //!
 //! This target tests:
 //! - Subaddress derivation consistency
@@ -18,8 +19,8 @@ use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 
 use bth_account_keys::{
-    AccountKey, ViewAccountKey, PublicAddress,
-    DEFAULT_SUBADDRESS_INDEX, CHANGE_SUBADDRESS_INDEX, GIFT_CODE_SUBADDRESS_INDEX,
+    AccountKey, PublicAddress, ViewAccountKey, CHANGE_SUBADDRESS_INDEX, DEFAULT_SUBADDRESS_INDEX,
+    GIFT_CODE_SUBADDRESS_INDEX,
 };
 use bth_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use bth_util_from_random::FromRandom;

--- a/fuzz/fuzz_targets/fuzz_transaction.rs
+++ b/fuzz/fuzz_targets/fuzz_transaction.rs
@@ -2,8 +2,9 @@
 
 //! Fuzzing target for Transaction parsing and validation.
 //!
-//! Security rationale: Transactions are received from untrusted peers over the network.
-//! A malformed transaction must never cause a crash, memory corruption, or infinite loop.
+//! Security rationale: Transactions are received from untrusted peers over the
+//! network. A malformed transaction must never cause a crash, memory
+//! corruption, or infinite loop.
 //!
 //! This target uses both:
 //! 1. Raw byte fuzzing for deserialization edge cases
@@ -19,7 +20,8 @@ use botho::transaction::{Transaction, TxInput, TxOutput, Utxo};
 // ============================================================================
 
 /// Structured representation of a transaction for fuzzing.
-/// This generates semantically meaningful transactions rather than random bytes.
+/// This generates semantically meaningful transactions rather than random
+/// bytes.
 #[derive(Debug, Arbitrary)]
 struct FuzzTransaction {
     /// Number of inputs (0-16)
@@ -108,7 +110,8 @@ fn fuzz_raw_bytes(data: &[u8]) {
     let _ = bincode::deserialize::<TxOutput>(data);
     let _ = bincode::deserialize::<Utxo>(data);
 
-    // If deserialization succeeds, verify the transaction doesn't panic on validation
+    // If deserialization succeeds, verify the transaction doesn't panic on
+    // validation
     if let Ok(tx) = bincode::deserialize::<Transaction>(data) {
         validate_transaction(&tx);
     }
@@ -124,7 +127,9 @@ fn fuzz_structured(fuzz_tx: &FuzzTransaction) {
     // but we can test that the types handle edge cases properly.
 
     // Test output amount overflow
-    let total: u128 = fuzz_tx.output_seeds.iter()
+    let total: u128 = fuzz_tx
+        .output_seeds
+        .iter()
         .take(num_outputs)
         .map(|o| o.amount as u128)
         .sum();

--- a/infra/faucet/metrics-daemon/src/api.rs
+++ b/infra/faucet/metrics-daemon/src/api.rs
@@ -5,20 +5,19 @@
 //! - GET /api/metrics/latest
 //! - GET /health
 
-use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use axum::{
-    Router,
-    Json,
     extract::{Query, State},
     http::StatusCode,
     response::IntoResponse,
     routing::get,
+    Json, Router,
 };
 use serde::{Deserialize, Serialize};
-use tower_http::cors::{CorsLayer, Any};
+use std::sync::{Arc, Mutex};
+use tower_http::cors::{Any, CorsLayer};
 
-use crate::db::{MetricsDb, HistoryQuery, DataPoint};
+use crate::db::{DataPoint, HistoryQuery, MetricsDb};
 
 /// Shared application state
 type AppState = Arc<Mutex<MetricsDb>>;

--- a/infra/faucet/metrics-daemon/src/collector.rs
+++ b/infra/faucet/metrics-daemon/src/collector.rs
@@ -1,8 +1,8 @@
 //! Metrics collection from Botho node
 
-use std::sync::{Arc, Mutex};
-use anyhow::{Result, Context};
+use anyhow::{Context, Result};
 use serde::Deserialize;
+use std::sync::{Arc, Mutex};
 use tracing::debug;
 
 use crate::db::{MetricsDb, MetricsSample};
@@ -72,14 +72,18 @@ pub async fn collect_metrics(node_url: &str, db: &Arc<Mutex<MetricsDb>>) -> Resu
         anyhow::bail!("RPC error {}: {}", error.code, error.message);
     }
 
-    let status = rpc_response.result
-        .context("No result in RPC response")?;
+    let status = rpc_response.result.context("No result in RPC response")?;
 
-    debug!("Received node status: height={}, peers={}", status.chain_height, status.peer_count);
+    debug!(
+        "Received node status: height={}, peers={}",
+        status.chain_height, status.peer_count
+    );
 
     // Calculate tx_delta
     let mut db_lock = db.lock().unwrap();
-    let last_tx = db_lock.get_last_tx_count()?.unwrap_or(status.total_transactions);
+    let last_tx = db_lock
+        .get_last_tx_count()?
+        .unwrap_or(status.total_transactions);
     let tx_delta = status.total_transactions.saturating_sub(last_tx) as i64;
 
     // Update last tx count

--- a/infra/faucet/metrics-daemon/src/db.rs
+++ b/infra/faucet/metrics-daemon/src/db.rs
@@ -5,10 +5,10 @@
 //! - metrics_hourly: Hourly aggregates (30d retention)
 //! - metrics_daily: Daily aggregates (1y retention)
 
-use std::path::Path;
 use anyhow::Result;
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 /// A single metrics sample
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,7 +49,8 @@ impl MetricsDb {
         let conn = Connection::open(path)?;
 
         // Create tables
-        conn.execute_batch(r#"
+        conn.execute_batch(
+            r#"
             -- 5-minute samples (raw data, 24h retention)
             CREATE TABLE IF NOT EXISTS metrics_5min (
                 timestamp INTEGER PRIMARY KEY,
@@ -94,7 +95,8 @@ impl MetricsDb {
                 key TEXT PRIMARY KEY,
                 value INTEGER NOT NULL
             );
-        "#)?;
+        "#,
+        )?;
 
         Ok(Self { conn })
     }
@@ -121,11 +123,14 @@ impl MetricsDb {
 
     /// Get the last recorded total_tx for delta calculation
     pub fn get_last_tx_count(&self) -> Result<Option<u64>> {
-        let result: Option<i64> = self.conn.query_row(
-            "SELECT value FROM state WHERE key = 'last_tx_count'",
-            [],
-            |row| row.get(0),
-        ).ok();
+        let result: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT value FROM state WHERE key = 'last_tx_count'",
+                [],
+                |row| row.get(0),
+            )
+            .ok();
         Ok(result.map(|v| v as u64))
     }
 

--- a/infra/faucet/metrics-daemon/src/main.rs
+++ b/infra/faucet/metrics-daemon/src/main.rs
@@ -10,18 +10,20 @@
 //! Usage:
 //!   botho-metrics-daemon --node-url http://127.0.0.1:17101 --db /var/lib/botho-faucet/metrics.db
 
-mod db;
-mod collector;
 mod api;
+mod collector;
+mod db;
 mod rollup;
 
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use anyhow::Result;
 use clap::Parser;
-use tracing::{info, error, Level};
+use tracing::{error, info, Level};
 use tracing_subscriber::FmtSubscriber;
 
 use db::MetricsDb;
@@ -54,9 +56,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     // Initialize logging
-    FmtSubscriber::builder()
-        .with_max_level(Level::INFO)
-        .init();
+    FmtSubscriber::builder().with_max_level(Level::INFO).init();
 
     let args = Args::parse();
 
@@ -104,7 +104,10 @@ async fn main() -> Result<()> {
 
     // Start collection loop
     let collection_interval = Duration::from_secs(args.interval);
-    info!("Starting collection loop (interval: {:?})", collection_interval);
+    info!(
+        "Starting collection loop (interval: {:?})",
+        collection_interval
+    );
 
     let mut interval_timer = tokio::time::interval(collection_interval);
 

--- a/infra/faucet/metrics-daemon/src/rollup.rs
+++ b/infra/faucet/metrics-daemon/src/rollup.rs
@@ -9,15 +9,15 @@
 //! - Daily aggregates: 1 year
 
 use anyhow::Result;
-use chrono::{Utc, Duration, Timelike};
-use tracing::{info, debug};
+use chrono::{Duration, Timelike, Utc};
+use tracing::{debug, info};
 
 use crate::db::MetricsDb;
 
 /// Retention periods in seconds
-const RETENTION_5MIN: i64 = 24 * 3600;           // 24 hours
-const RETENTION_HOURLY: i64 = 30 * 24 * 3600;    // 30 days
-const RETENTION_DAILY: i64 = 365 * 24 * 3600;    // 1 year
+const RETENTION_5MIN: i64 = 24 * 3600; // 24 hours
+const RETENTION_HOURLY: i64 = 30 * 24 * 3600; // 30 days
+const RETENTION_DAILY: i64 = 365 * 24 * 3600; // 1 year
 
 /// Run the complete rollup process
 pub fn run_rollup(db: &mut MetricsDb) -> Result<()> {
@@ -104,8 +104,8 @@ fn cleanup_old_data(db: &mut MetricsDb, now: chrono::DateTime<Utc>) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
     use crate::db::MetricsSample;
+    use tempfile::TempDir;
 
     #[test]
     fn test_rollup_aggregation() {

--- a/transaction/core/src/validation/validate.rs
+++ b/transaction/core/src/validation/validate.rs
@@ -610,7 +610,9 @@ pub fn compute_progressive_fee(
 /// bit-identical on every platform; floating-point here was a fork risk
 /// (audits/2026-01-03-cycle5.md).
 fn compute_cluster_fee_rate(wealth: u64, config: &ProgressiveFeeConfig) -> u32 {
-    let rate_range = config.max_rate_bps.saturating_sub(config.background_rate_bps);
+    let rate_range = config
+        .max_rate_bps
+        .saturating_sub(config.background_rate_bps);
     let denominator = (config.steepness as u128).saturating_add(wealth as u128);
     if denominator == 0 {
         // steepness == 0 and wealth == 0: degenerate config, charge max


### PR DESCRIPTION
## Summary

The repo had a `rustfmt.toml` but no CI enforcement, so the tree had drifted out of compliance (the recurring "giant abandoned `cargo fmt` stash" failure mode). This fixes it once: a clean repo-wide rustfmt baseline plus a CI check so it never drifts again.

All formatting was run with the **pinned nightly** (`cargo +nightly-2025-12-03 fmt`), NOT stable. This is required because `rustfmt.toml` uses nightly-only options (`wrap_comments = true`, `imports_granularity = "Crate"`) that stable rustfmt silently ignores — running stable would produce a different/wrong result. `rustfmt.toml` is unchanged.

## Changes

Three cleanly separable commits:

1. **`style:` workspace baseline** — `cargo +nightly-2025-12-03 fmt --all` over the workspace (65 files). The `rustfmt.toml` `ignore` list (`sgx/types`, `sgx/urts`, `sgx/sync`) is honored automatically.
2. **`style:` excluded-crate baseline** — `--all` does not reach members under `exclude` in the root `Cargo.toml`, so formatted them individually with the same pinned nightly:
   - `fuzz/` (10 files) — matters most; the strict fuzz build guard compiles every target.
   - `contracts/solana/` (1 file).
   - `util/serial/` — already conformant, no diff.
   - `contracts/ethereum` has no Rust; nothing to format.
3. **`ci:` `.github/workflows/fmt.yml`** — fmt-check only (no build/test, stays fast). Triggers on `pull_request` and `push` to `main`. Installs the pinned `nightly-2025-12-03` + `rustfmt` component via `dtolnay/rust-toolchain@master` (matching the `fuzz.yml` pattern, **not** `@stable`), then runs `cargo +nightly-2025-12-03 fmt --all -- --check` for the workspace plus the equivalent in `fuzz`, `util/serial`, and `contracts/solana`. Fails on any diff.

**Dirs baselined:** workspace (`--all`) + `fuzz` + `contracts/solana` + `util/serial`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Single mechanical baseline; `fmt --all -- --check` exits 0 for workspace | done | `cargo +nightly-2025-12-03 fmt --all -- --check` → exit 0 |
| `fuzz/` baselined too | done | `cargo +nightly-2025-12-03 fmt -- --check` in `fuzz/` → exit 0 (also `util/serial`, `contracts/solana`) |
| CI fmt job on pinned nightly (not stable), fails on diff | done | `fmt.yml` pins `nightly-2025-12-03` + `rustfmt`; runs `fmt -- --check`; YAML validated |
| No logic changes; `cargo build` + `cargo test -p botho --lib` green | done | build Finished OK; 937 tests pass (single-threaded; the 4 failures under default parallelism are a pre-existing LMDB tempdir flake — reproduced on clean main, unrelated to fmt) |
| `rustfmt.toml` unchanged | done | `git diff` on `rustfmt.toml` → empty |

## Test Plan

- `cargo +nightly-2025-12-03 fmt --all -- --check` → exit 0 (workspace).
- Same in `fuzz/`, `util/serial/`, `contracts/solana/` → all exit 0.
- `cargo build` → green. `cargo test -p botho --lib -- --test-threads=1` → 937 passed, 0 failed.
- Reformat commits are `cargo fmt` output only — zero logic changes; the workflow file is isolated in its own commit.

Closes #354