### PR TITLE
test: serialize privacy-metrics tests racing on process-global Prometheus metrics

### DIFF
--- a/botho/src/network/privacy/metrics.rs
+++ b/botho/src/network/privacy/metrics.rs
@@ -681,8 +681,20 @@ impl AlertingThresholds {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    // NOTE: Several tests below mutate process-global Prometheus metrics
+    // (CIRCUITS_ACTIVE, CIRCUITS_BUILT, RELAY_*, TX_*, HANDSHAKE_*, ...).
+    // Those globals are shared across the whole test process, so running these
+    // tests concurrently races (e.g. an absolute `set`/`get` on a shared gauge,
+    // or a counter incremented by a sibling test between `before` and `after`).
+    // They are annotated `#[serial(privacy_metrics)]` so they never interleave
+    // with each other while still running in parallel with unrelated tests.
+    // Tests that only operate on local PrivacyMetricsSnapshot values (no global
+    // access) intentionally remain unserialized.
 
     #[test]
+    #[serial(privacy_metrics)]
     fn test_metrics_updater_circuits() {
         let updater = PrivacyMetricsUpdater::new();
 
@@ -699,6 +711,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(privacy_metrics)]
     fn test_metrics_updater_relay() {
         let updater = PrivacyMetricsUpdater::new();
 
@@ -715,6 +728,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(privacy_metrics)]
     fn test_metrics_updater_path() {
         let updater = PrivacyMetricsUpdater::new();
 
@@ -728,6 +742,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(privacy_metrics)]
     fn test_metrics_updater_handshake() {
         let updater = PrivacyMetricsUpdater::new();
 
@@ -741,6 +756,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(privacy_metrics)]
     fn test_snapshot_capture() {
         // Reset some metrics to known state for testing
         CIRCUITS_ACTIVE.set(3);


### PR DESCRIPTION
## Summary

`network::privacy::metrics::tests::test_metrics_updater_circuits` was flaky under default test parallelism (~10-20% failure rate; passed reliably with `--test-threads=1`). The root cause is a shared-process-global hazard: the privacy-metrics tests assert on **process-global Prometheus metrics** (`CIRCUITS_ACTIVE`, `CIRCUITS_BUILT`, `RELAY_*`, `TX_*`, `HANDSHAKE_*`). There is one instance of each per process, so sibling tests mutating them concurrently race:

- `test_metrics_updater_circuits` does `set_active_circuits(5); assert_eq!(CIRCUITS_ACTIVE.get(), 5)` — an absolute assertion on a shared gauge another test can overwrite between the `set` and the `get`.
- The relay/path/handshake tests use `before + 1` counter deltas, which still race because a sibling test can increment the same shared counter between the two reads.

## Changes

- Added `use serial_test::serial;` to the test module (`serial_test` was already a `botho` dev-dependency, used by `tests/rpc_integration.rs`).
- Annotated every test that touches the shared globals with `#[serial(privacy_metrics)]` so they never interleave with each other, while still running in parallel with unrelated tests:
  - `test_metrics_updater_circuits`
  - `test_metrics_updater_relay`
  - `test_metrics_updater_path`
  - `test_metrics_updater_handshake`
  - `test_snapshot_capture` (does `CIRCUITS_ACTIVE.set(3)` then asserts the snapshot)
- Left the pure snapshot-math tests (`test_circuit_build_success_rate`, `test_private_path_ratio`, `test_handshake_success_rate`, `test_alerting_thresholds`, and the `_no_attempts`/`_no_transactions` variants) **unserialized** — they only operate on local `PrivacyMetricsSnapshot` structs and never read the globals.
- Added a module comment documenting the shared-global hazard and the serialization rationale.
- **No assertions were deleted or weakened.** Serialization removes the race without reducing coverage; the tests still verify the updater moves the metrics.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `serial_test` dev-dep present | ✅ | Already in `botho/Cargo.toml` `[dev-dependencies]` (`serial_test = { workspace = true }`) |
| All shared-global privacy-metrics tests annotated `#[serial(privacy_metrics)]` | ✅ | 5 globals-mutating tests annotated; snapshot-math tests intentionally left alone |
| Assertions unchanged in intent | ✅ | Only added attributes + a comment; no assertion bodies touched |
| `cargo build -p botho` green | ✅ | Builds clean (pre-existing warnings only) |
| 15+ parallel lib-test runs, zero `test_metrics_updater_*` flake | ✅ | 15/15 clean full `cargo test -p botho --lib` runs under default parallelism; 0 metrics flakes, 0 unrelated failures. Also 20/20 clean on the module filter. |

## Test Plan

- `cargo build -p botho` — green.
- `cargo test -p botho --lib` run 15 times under default parallelism: **15/15 clean**, zero `test_metrics_updater_*` failures, zero other failures.
- `cargo test -p botho --lib network::privacy::metrics` run 20 times: **20/20 clean**.

Closes #357