### PR TITLE
fix(cluster-tax): make agents_by_wealth() a total order to remove cross-process drift

### DIFF
--- a/cluster-tax/src/simulation/agent.rs
+++ b/cluster-tax/src/simulation/agent.rs
@@ -3,7 +3,7 @@
 use crate::tag::TagVector;
 
 /// Unique identifier for an agent in the simulation.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct AgentId(pub u64);
 
 impl AgentId {

--- a/cluster-tax/src/simulation/state.rs
+++ b/cluster-tax/src/simulation/state.rs
@@ -262,9 +262,16 @@ impl SimulationState {
     }
 
     /// Get agents sorted by balance (descending).
+    ///
+    /// The ordering is a *total* order: ties on balance are broken by
+    /// ascending `AgentId`. Without the tie-break, the input order for equal
+    /// balances came from `HashMap` iteration (randomly seeded per process),
+    /// so a downstream consumer that sums fee burns in iteration order could
+    /// produce process-dependent results (see #353). The tie-break makes the
+    /// output byte-reproducible across processes regardless of insertion order.
     pub fn agents_by_wealth(&self) -> Vec<(AgentId, u64)> {
         let mut agents: Vec<_> = self.agent_balances.iter().map(|(&k, &v)| (k, v)).collect();
-        agents.sort_by(|a, b| b.1.cmp(&a.1));
+        agents.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
         agents
     }
 }
@@ -332,6 +339,77 @@ mod tests {
         assert_eq!(
             state.total_fees_collected, expected,
             "cumulative fees must accumulate exactly past u64::MAX"
+        );
+    }
+
+    /// Regression for #353: `agents_by_wealth()` must be a *total* order so its
+    /// output is identical regardless of `HashMap` insertion/iteration order.
+    ///
+    /// Previously the sort was stable on balance only, so tied balances kept
+    /// their `HashMap` iteration order — randomly seeded per process — which let
+    /// a downstream fee/cluster consumer sum in a process-dependent order and
+    /// drift the result (S3 `fees_recycled` differed by ~3 nanoBTH across runs).
+    ///
+    /// This test inserts the *same* agents in two opposite orders and asserts the
+    /// output is byte-identical, then checks the explicit tie-break (ascending
+    /// `AgentId` within an equal balance). It does not need a subprocess: any
+    /// dependence on insertion order is exposed directly.
+    #[test]
+    fn agents_by_wealth_is_total_ordered_under_tied_balances() {
+        // Several agents share balances to force the tie-break path:
+        //   balance 100: agents 5, 1, 3
+        //   balance  50: agents 4, 2
+        //   balance 200: agent 6 (unique, must sort first)
+        let pairs = [
+            (AgentId(6), 200u64),
+            (AgentId(5), 100u64),
+            (AgentId(1), 100u64),
+            (AgentId(3), 100u64),
+            (AgentId(4), 50u64),
+            (AgentId(2), 50u64),
+        ];
+
+        // Insert ascending by id.
+        let mut ascending = SimulationState::default();
+        let mut ids: Vec<_> = pairs.iter().map(|p| p.0).collect();
+        ids.sort();
+        for id in &ids {
+            let balance = pairs.iter().find(|p| p.0 == *id).unwrap().1;
+            ascending.update_agent_balance(*id, balance);
+        }
+
+        // Insert descending by id (deliberately the reverse order).
+        let mut descending = SimulationState::default();
+        for id in ids.iter().rev() {
+            let balance = pairs.iter().find(|p| p.0 == *id).unwrap().1;
+            descending.update_agent_balance(*id, balance);
+        }
+
+        let from_ascending = ascending.agents_by_wealth();
+        let from_descending = descending.agents_by_wealth();
+
+        // Independence from insertion order is what guards against cross-process
+        // HashMap-seed drift: the same agents inserted in opposite orders must
+        // yield byte-identical output.
+        assert_eq!(
+            from_ascending, from_descending,
+            "agents_by_wealth() must be independent of insertion order"
+        );
+
+        // The default constructor starts with an empty agent set, so the output
+        // is exactly these six agents in the expected total order: descending
+        // balance, then ascending AgentId on ties.
+        let expected_order = vec![
+            (AgentId(6), 200u64),
+            (AgentId(1), 100u64),
+            (AgentId(3), 100u64),
+            (AgentId(5), 100u64),
+            (AgentId(2), 50u64),
+            (AgentId(4), 50u64),
+        ];
+        assert_eq!(
+            from_ascending, expected_order,
+            "ties must break by ascending AgentId under descending balance"
         );
     }
 }

--- a/cluster-tax/src/simulation/state.rs
+++ b/cluster-tax/src/simulation/state.rs
@@ -346,14 +346,15 @@ mod tests {
     /// output is identical regardless of `HashMap` insertion/iteration order.
     ///
     /// Previously the sort was stable on balance only, so tied balances kept
-    /// their `HashMap` iteration order — randomly seeded per process — which let
-    /// a downstream fee/cluster consumer sum in a process-dependent order and
-    /// drift the result (S3 `fees_recycled` differed by ~3 nanoBTH across runs).
+    /// their `HashMap` iteration order — randomly seeded per process — which
+    /// let a downstream fee/cluster consumer sum in a process-dependent
+    /// order and drift the result (S3 `fees_recycled` differed by ~3
+    /// nanoBTH across runs).
     ///
-    /// This test inserts the *same* agents in two opposite orders and asserts the
-    /// output is byte-identical, then checks the explicit tie-break (ascending
-    /// `AgentId` within an equal balance). It does not need a subprocess: any
-    /// dependence on insertion order is exposed directly.
+    /// This test inserts the *same* agents in two opposite orders and asserts
+    /// the output is byte-identical, then checks the explicit tie-break
+    /// (ascending `AgentId` within an equal balance). It does not need a
+    /// subprocess: any dependence on insertion order is exposed directly.
     #[test]
     fn agents_by_wealth_is_total_ordered_under_tied_balances() {
         // Several agents share balances to force the tie-break path:


### PR DESCRIPTION
## Summary

`SimulationState::agents_by_wealth()` sorted agents only on balance using a stable sort, so agents with **tied balances** kept their `HashMap` iteration order. `HashMap` is randomly seeded per process, so a downstream fee/cluster consumer summed in a process-dependent order whenever balances tied. This produced a ~3-nanoBTH drift in the emission sweep's S3 `fees_recycled` raw integer across separate process runs (run A `637863491645` vs run B `637863491648`), as reported in #353. Every rounded/decision-relevant metric was already stable; this only closes the determinism gap.

## Changes

- `cluster-tax/src/simulation/agent.rs`: derive `PartialOrd, Ord` on `AgentId` so it has a total order.
- `cluster-tax/src/simulation/state.rs`: change the sort to `b.1.cmp(&a.1).then(a.0.cmp(&b.0))` — descending balance with an ascending-`AgentId` tie-break, making the output a total order that is byte-reproducible regardless of `HashMap` insertion/iteration order.
- Add a targeted unit test `agents_by_wealth_is_total_ordered_under_tied_balances` that inserts the same tied-balance agents in two opposite orders and asserts the output is byte-identical and in the expected total order. This directly exercises the tie-break path without needing a subprocess — unlike the existing `sweep_is_reproducible`, which compares two `run_sweep()` calls within one process (fixed HashMap seed) and so gave false confidence about cross-process reproducibility.

The fix only determinizes the ordering of tied balances; it does not change any non-tied result, so calibration and all existing emission-sweep metrics are unchanged.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `agents_by_wealth()` is total-ordered (tie-break by AgentId) | done | Sort changed to `.then(a.0.cmp(&b.0))`; `AgentId` now derives `Ord`/`PartialOrd` |
| Test asserts deterministic ordering under tied balances / varying insertion order | done | New unit test inserts identical agents ascending vs descending and asserts byte-identical, fully-ordered output |
| `cargo build -p bth-cluster-tax --features cli` green | done | Builds with only pre-existing warnings |
| `cargo test -p bth-cluster-tax --features cli` green | done | lib suite (399 tests incl. emission_sweep + new test + sweep_is_reproducible) passed |
| Calibration unchanged (non-tied results unaffected) | done | All existing emission_sweep/monetary/state tests pass unchanged |

## Test Plan

- `cargo build -p bth-cluster-tax --features cli` — green (pre-existing warnings only).
- `cargo test -p bth-cluster-tax --features cli` — new `agents_by_wealth_is_total_ordered_under_tied_balances` passes; existing `sweep_is_reproducible`, `emission_sweep::*`, and `state::*` tests pass.
- Ran `cluster-tax-sim emission-sweep --quick` twice in **separate processes** into different output dirs: the resulting `emission_sweep.csv` files are byte-identical (matching MD5 `60a36fc9f5690cf2c512cf9e6b8c07f4`), confirming the cross-process drift is resolved.

Note: the `bth-cluster-tax` `serde` feature has pre-existing compile errors on clean main — unrelated and out of scope; built/tested with `--features cli`.

Closes #353