### PR TITLE
feat(monetary): set canonical mainnet emission to ~1yr halvings (611M BTH, 5yr to tail)

### DIFF
--- a/botho/src/monetary.rs
+++ b/botho/src/monetary.rs
@@ -7,8 +7,8 @@
 //!
 //! ## Two-Phase Model
 //!
-//! - **Phase 1 (Halving)**: Bitcoin-like halving schedule for ~10 years.
-//!   Difficulty adjusts to maintain target block time.
+//! - **Phase 1 (Halving)**: Bitcoin-like halving schedule for ~5 years (~1-year
+//!   halvings x 5). Difficulty adjusts to maintain target block time.
 //!
 //! - **Phase 2 (Tail Emission)**: Fixed tail reward with inflation-targeting.
 //!   Difficulty adjusts to hit 2% net inflation (gross emission - fee burns).
@@ -214,9 +214,22 @@ fn current_unix_time() -> u64 {
 ///
 /// | Actual Block Time | Effective Inflation | Halving Period |
 /// |-------------------|--------------------:|---------------:|
-/// | 5s (high load)    | 2.0%/year           | 2 years        |
-/// | 20s (normal)      | 0.5%/year           | 8 years        |
-/// | 40s (idle)        | 0.25%/year          | 16 years       |
+/// | 5s (high load)    | 2.0%/year           | 1 year         |
+/// | 20s (normal)      | 0.5%/year           | 4 years        |
+/// | 40s (idle)        | 0.25%/year          | 8 years        |
+///
+/// # Canonical Emission Schedule (decided 2026-06-15, issue #351)
+///
+/// Chosen from the #350 emission sweep on monetary-policy grounds:
+///
+/// - `initial_reward` = 50 BTH
+/// - `halving_interval` = `BLOCKS_PER_YEAR` (~1 year at 5s blocks)
+/// - `halving_count` = 5  →  time-to-tail = `H * K / BLOCKS_PER_YEAR` = 5.00
+///   years
+/// - `tail_inflation_bps` = 200 (2% perpetual net inflation)
+///
+/// Derived Phase-1 supply = `R0 * H * (2 - 2^-(K-1))`
+/// = 50 * 6,307,200 * 1.9375 = **611,010,000 BTH** (~611M).
 pub fn mainnet_policy() -> MonetaryPolicy {
     // Constants based on 5-second blocks (minimum block time)
     const SECS_PER_YEAR: u64 = 365 * 24 * 60 * 60;
@@ -224,10 +237,10 @@ pub fn mainnet_policy() -> MonetaryPolicy {
     const BLOCKS_PER_YEAR: u64 = SECS_PER_YEAR / ASSUMED_BLOCK_TIME; // 6,307,200
 
     MonetaryPolicy {
-        // Phase 1: ~10 years of halvings (at 5s blocks under full load)
+        // Phase 1: ~5 years of halvings (at 5s blocks under full load)
         initial_reward: 50_000_000_000_000, // 50 BTH in picocredits
-        halving_interval: BLOCKS_PER_YEAR * 2, // 12,614,400 blocks (~2 years at 5s)
-        halving_count: 5,                   // 5 halvings over ~10 years
+        halving_interval: BLOCKS_PER_YEAR,  // 6,307,200 blocks (~1 year at 5s)
+        halving_count: 5,                   // 5 halvings over ~5 years
 
         // Phase 2: 2% target net inflation (at 5s blocks)
         tail_inflation_bps: 200,
@@ -328,9 +341,56 @@ mod tests {
 
         assert_eq!(policy.halving_count, 5);
         assert_eq!(policy.tail_inflation_bps, 200);
-        // Block time is now 5s (assumed minimum under high load)
+        assert_eq!(policy.initial_reward, 50_000_000_000_000); // 50 BTH
+                                                               // Block time is now 5s (assumed minimum under high load)
         assert_eq!(policy.target_block_time_secs, 5);
-        // 2 years worth of 5s blocks
-        assert_eq!(policy.halving_interval, 12_614_400);
+        // Canonical schedule (#351): 1 year worth of 5s blocks (BLOCKS_PER_YEAR).
+        assert_eq!(policy.halving_interval, 6_307_200);
+    }
+
+    /// Locks the canonical emission schedule chosen in #351 so the decision is
+    /// regression-proof: derived Phase-1 supply ~611M BTH and time-to-tail = 5
+    /// years, computed directly from the policy parameters.
+    #[test]
+    fn test_mainnet_emission_schedule_locked() {
+        const BLOCKS_PER_YEAR: u64 = 6_307_200;
+        const PICO_PER_BTH: u128 = 1_000_000_000_000;
+
+        let policy = mainnet_policy();
+
+        // Time-to-tail = H * K / BLOCKS_PER_YEAR.
+        let h = policy.halving_interval;
+        let k = policy.halving_count as u64;
+        let years_to_tail = (h * k) as f64 / BLOCKS_PER_YEAR as f64;
+        assert!(
+            (years_to_tail - 5.0).abs() < 1e-9,
+            "time-to-tail expected 5.00 years, got {years_to_tail}",
+        );
+
+        // Derived Phase-1 supply by summing the halving schedule:
+        //   sum_{i=0}^{K-1} (R0 >> i) * H  (in picocredits).
+        let r0 = policy.initial_reward as u128;
+        let h128 = h as u128;
+        let mut supply_pico: u128 = 0;
+        for i in 0..policy.halving_count {
+            supply_pico += (r0 >> i) * h128;
+        }
+
+        // Closed form: R0 * H * (2 - 2^-(K-1)).
+        // = 50 * 6,307,200 * 1.9375 BTH = 611,010,000 BTH.
+        let supply_bth = supply_pico / PICO_PER_BTH;
+        assert_eq!(
+            supply_bth, 611_010_000,
+            "Phase-1 supply expected 611,010,000 BTH, got {supply_bth}",
+        );
+
+        // u128 supply accounting (#333): ~611M BTH = 6.11e20 picocredits, which
+        // exceeds u64::MAX (~1.84e19). Confirm the chosen scale still requires
+        // u128 and is represented without truncation.
+        assert!(
+            supply_pico > u64::MAX as u128,
+            "611M BTH in picocredits ({supply_pico}) must exceed u64::MAX",
+        );
+        assert_eq!(supply_pico, 611_010_000 * PICO_PER_BTH);
     }
 }

--- a/cluster-tax/src/monetary.rs
+++ b/cluster-tax/src/monetary.rs
@@ -125,11 +125,20 @@ impl Default for MonetaryPolicy {
     /// Library defaults for monetary policy.
     ///
     /// **NOTE**: This is a generic library default assuming 60-second blocks.
-    /// Botho mainnet uses different parameters via
-    /// `botho/src/monetary.rs::mainnet_policy()`:
+    /// It is intentionally NOT the canonical mainnet schedule and is not used
+    /// for any mainnet/consensus decision. Botho mainnet uses different
+    /// parameters via `botho/src/monetary.rs::mainnet_policy()`:
     /// - 5-second assumed block time (not 60s)
     /// - Dynamic timing adjusts actual blocks 3-40s based on network load
+    /// - Canonical schedule (#351): ~1-year halvings (`BLOCKS_PER_YEAR` at 5s),
+    ///   5 halvings → ~5 years to tail, 2% tail, derived ~611M BTH supply
     /// - See `docs/architecture.md#block-timing-architecture` for details
+    ///
+    /// The emission sweep (#350, `simulation::emission_sweep`) sets each
+    /// candidate `MonetaryPolicy` explicitly per-schedule, so it does not rely
+    /// on this default. Calibrated Gini/lottery/demurrage tests likewise build
+    /// their own policies. This default therefore stays at the generic 60s/1min
+    /// units and is left unchanged by the #351 schedule decision.
     fn default() -> Self {
         Self {
             // Phase 1: ~10 years of halvings


### PR DESCRIPTION
## Summary

Sets Botho's canonical mainnet emission schedule to the values chosen from the #350 sweep: 5-year decay to tail, 2% perpetual tail, R0=50 BTH, K=5 halvings. The net effect is a single-constant change in `mainnet_policy()` plus test and doc alignment.

The change rides the planned testnet reset (#323): it is a consensus-breaking emission-parameter change with no migration. It unblocks the whitepaper (#321).

## Changes

- `botho/src/monetary.rs` — `mainnet_policy().halving_interval`: `BLOCKS_PER_YEAR * 2` (12,614,400, ~2yr) -> `BLOCKS_PER_YEAR` (6,307,200, ~1yr). `initial_reward` (50 BTH), `halving_count` (5), `tail_inflation_bps` (200) unchanged. Updated the adjacent doc comments and the inflation/halving-period table to reflect ~1-year halvings, ~5 years to tail, and ~611M derived supply. `fast_test()`/testnet policy untouched.
- Updated the constant-assertion test (`test_mainnet_policy`) to expect `halving_interval == 6_307_200`; kept the other field assertions and added `initial_reward`.
- Added `test_mainnet_emission_schedule_locked`: derives and asserts Phase-1 supply == 611,010,000 BTH (summing the halving schedule), time-to-tail == 5.00 years, and that the picocredit total (6.11e20) exceeds `u64::MAX` (u128 accounting, #333).
- `cluster-tax/src/monetary.rs` — documented why `MonetaryPolicy::default()` (generic 60s/1min library baseline, nanoBTH units) intentionally diverges from the canonical mainnet schedule and is left unchanged; noted the #350 `emission_sweep` sets policies explicitly per-schedule and is therefore unaffected.

## Derived numbers

- time-to-tail = `H*K/BLOCKS_PER_YEAR` = 6,307,200 * 5 / 6,307,200 = **5.00 years**
- Phase-1 supply = `R0*H*(2 - 2^-(K-1))` = 50 * 6,307,200 * 1.9375 = **611,010,000 BTH**

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `mainnet_policy().halving_interval == 6_307_200`; other fields unchanged; docs updated | done | Edit + `test_mainnet_policy` |
| Schedule-lock test asserts ~611M supply + 5yr to tail; constant test updated | done | `test_mainnet_emission_schedule_locked` |
| u128 supply accounting holds at ~611M (6.11e20 > u64::MAX) | done | assertion in new test |
| Sim baseline aligned or divergence documented; #350 sweep not broken | done | doc comment in cluster-tax; emission_sweep tests pass |
| `cargo test -p botho` green | done | 938 lib tests pass (2 pre-existing network/privacy doctest failures unrelated, on base commit) |
| `cargo test -p bth-cluster-tax --features cli` green | done | 399 lib + 5 bin tests pass, 0 failures |
| `cargo build --release` green | done | finished, warnings only |
| rustfmt-clean under pinned nightly (#354) | done | `cargo +nightly-2025-12-03 fmt --all -- --check` exits 0 |

## Test Plan

- `cargo test -p botho --lib` — 938 pass (incl. new schedule-lock test)
- `cargo test -p bth-cluster-tax --features cli` — 399 + 5 pass; emission_sweep S1/S3/S5 tests still pass
- `cargo build --release` — green
- `cargo +nightly-2025-12-03 fmt --all -- --check` — exit 0

Note: two pre-existing doctest failures in `botho/src/network/privacy/{capacity,selection}.rs` exist on the base commit and are unrelated to this change (out of scope).

Closes #351