### PR TITLE
docs: reconcile README + docs/ monetary numbers with shipped ~1yr/611M schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Fees are not simply burned. Each block, collected fees are split **80% into a cl
 Bitcoin's security budget will eventually depend entirely on transaction fees. Botho ensures permanent security through **perpetual tail emission**:
 
 - Initial reward: 50 BTH per block
-- ~2-year halving schedule (5 halvings over 10 years)
-- Perpetual tail emission: ~1.59 BTH per block targeting 2% annual inflation
+- ~1-year halving schedule (5 halvings over ~5 years)
+- Perpetual tail emission targeting 2% net annual inflation; the per-block tail reward is supply-dependent (~1.9 BTH/block at the ~611M Phase-1 supply, growing as supply grows)
 
 This guarantees minters are always incentivized to secure the network, without relying on ever-increasing transaction volume.
 
@@ -113,8 +113,8 @@ Unlike Bitcoin's probabilistic finality (wait 6 blocks = 60 minutes to be "sure"
 | Dynamic block time | 5-40 seconds (adapts to network load) |
 | Monetary baseline | 5 seconds (for emission calculations) |
 | Difficulty adjustment | Every 1,440 blocks (~8 hours) |
-| Phase 1 supply | ~100 million BTH (10 years of halvings) |
-| Tail emission | ~1.59 BTH/block (2% net annual inflation) |
+| Phase 1 supply | ~611 million BTH (~5 years of halvings) |
+| Tail emission | Supply-dependent, ~1.9 BTH/block at the ~611M tail-onset supply (2% net annual inflation) |
 | Native unit | BTH (9 decimal places) |
 
 Block timing adapts to network activity: busy networks produce faster blocks (5s), idle networks produce slower blocks (40s). This creates natural inflation dampening—less activity means less emission.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -175,18 +175,18 @@ Botho uses SHA-256, which is ASIC-friendly. However, while the network is small,
 
 Botho has no hard cap. Instead:
 
-- **Phase 1 (years 0-10)**: ~100 million BTH via halvings
-- **Phase 2 (year 10+)**: ~2% annual tail emission
+- **Phase 1 (years 0-5)**: ~611 million BTH via 5 halvings (~1 year each)
+- **Phase 2 (year 5+)**: ~2% annual net tail emission (supply-dependent per-block reward, ~1.9 BTH/block at the ~611M tail-onset supply)
 
 This ensures permanent mining incentives while maintaining predictable monetary policy.
 
-### Why are fees burned instead of paid to miners?
+### What happens to transaction fees?
 
-Burning fees creates deflationary pressure that offsets tail emission, keeping net inflation around 2%. It also:
+Fees are not paid to miners. Each block, collected fees are split **80% into a cluster-tilted redistribution lottery** (paid back out to randomly selected, mostly small/well-circulated holders) and **20% burned**. Only the burned 20% is deflationary and partially offsets tail emission, keeping net inflation around 2%. This split also:
 
-- Simplifies economics (no complex fee distribution)
+- Recycles wealth-concentration charges back into the economy rather than destroying them
 - Prevents fee-based miner centralization
-- Creates predictable monetary policy: `net_supply = minted - burned`
+- Keeps monetary policy predictable: only the burned portion reduces supply (`net_supply = minted - burned`)
 
 ### What are "cluster fees" and why do they exist?
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -271,7 +271,7 @@ Get circulating supply information. Useful for exchanges and block explorers to 
 | `totalFeesBurned` | integer | Cumulative transaction fees burned, in nanoBTH |
 | `circulatingSupply` | integer | Net supply (totalMined - totalFeesBurned), in nanoBTH |
 
-**Note:** All values are in nanoBTH (1 BTH = 1,000,000,000 nanoBTH). Transaction fees are burned (removed from circulation), which is why circulating supply = totalMined - totalFeesBurned.
+**Note:** All values are in nanoBTH (1 BTH = 1,000,000,000 nanoBTH). Collected transaction fees are split 80% into the cluster-tilted redistribution lottery and 20% burned; only the burned 20% (`totalFeesBurned`) is removed from circulation, which is why circulating supply = totalMined - totalFeesBurned.
 
 **Example:**
 ```bash

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -262,7 +262,7 @@ This 5s assumption represents the **minimum block time under high load**. All em
 target_block_time_secs: 5,    // Assumed for monetary calculations
 min_block_time_secs: 3,       // Absolute floor (consensus needs time)
 max_block_time_secs: 60,      // Absolute ceiling
-halving_interval: 12_614_400, // ~2 years at 5s blocks
+halving_interval: 6_307_200,  // ~1 year at 5s blocks
 ```
 
 ### 2. Dynamic Block Timing (5-40s actual)
@@ -310,9 +310,9 @@ This design creates a **self-regulating inflation dampener**:
 
 | Actual Block Time | Effective Inflation | Halving Period |
 |-------------------|---------------------|----------------|
-| 5s (high load) | 2.0%/year (full) | ~2 years |
-| 20s (normal) | 0.5%/year | ~8 years |
-| 40s (idle) | 0.25%/year | ~16 years |
+| 5s (high load) | 2.0%/year (full) | ~1 year |
+| 20s (normal) | 0.5%/year | ~4 years |
+| 40s (idle) | 0.25%/year | ~8 years |
 
 **Benefits**:
 - Busy network (high utility) → Full emission rewards participants

--- a/docs/concepts/comparison.md
+++ b/docs/concepts/comparison.md
@@ -72,7 +72,7 @@ Botho's SCP hybrid provides final consensus in seconds. There are no reorgs and 
 
 Monero fees go to miners, creating a typical fee market.
 
-Botho fees are burned, creating deflationary pressure that offsets tail emission. This simplifies monetary policy and prevents fee-based miner centralization.
+Botho fees go neither entirely to miners nor are entirely burned: each block, 80% of collected fees fund the cluster-tilted redistribution lottery and 20% are burned. The burned 20% creates deflationary pressure that partially offsets tail emission, while the 80% recycles wealth-concentration charges back to small/well-circulated holders. This prevents fee-based miner centralization.
 
 **Wealth Distribution**
 

--- a/docs/concepts/monetary-policy.md
+++ b/docs/concepts/monetary-policy.md
@@ -22,8 +22,8 @@ This separation allows precise monetary targeting without affecting transaction 
 > **Block-Based Monetary Schedule**: The halving schedule is tied to **block height**,
 > using a 5-second block assumption for monetary calculations.
 >
-> - Halving occurs every 12,614,400 blocks (~2 years at 5s blocks)
-> - 5 halvings total before tail emission (~10 years at 5s blocks)
+> - Halving occurs every 6,307,200 blocks (~1 year at 5s blocks)
+> - 5 halvings total before tail emission (~5 years at 5s blocks)
 > - See `monetary.rs::mainnet_policy()` for the authoritative implementation
 >
 > **Adaptive Inflation**: Since actual block times vary (5-40s based on network load),
@@ -31,9 +31,9 @@ This separation allows precise monetary targeting without affecting transaction 
 >
 > | Block Time | Effective Inflation | Halving Period |
 > |------------|--------------------:|---------------:|
-> | 5s (high load) | 2.0%/year | 2 years |
-> | 20s (normal) | 0.5%/year | 8 years |
-> | 40s (idle) | 0.25%/year | 16 years |
+> | 5s (high load) | 2.0%/year | 1 year |
+> | 20s (normal) | 0.5%/year | 4 years |
+> | 40s (idle) | 0.25%/year | 8 years |
 >
 > This creates a natural inflation dampener: busy network = full inflation,
 > idle network = reduced inflation.
@@ -554,12 +554,12 @@ pub struct MonetaryEpoch {
 | Epoch | Height | ~Year | Min Fee | Block Reward | Notes |
 |-------|--------|-------|---------|--------------|-------|
 | 0 | 0 | 0 | 400 µBTH | 50 BTH | Genesis |
-| 1 | 3,153,600 | 2 | 200 µBTH | 25 BTH | First halving |
-| 2 | 6,307,200 | 4 | 100 µBTH | 12.5 BTH | Second halving |
-| 3 | 9,460,800 | 6 | 50 µBTH | 6.25 BTH | Third halving |
-| 4 | 12,614,400 | 8 | 25 µBTH | 3.125 BTH | Fourth halving |
-| 5 | 15,768,000 | 10 | 12.5 µBTH | ~1.59 BTH | Tail emission begins |
-| 6 | 31,536,000 | 20 | 10 µBTH | ~1.59 BTH | Maturity (possible inflation reduction) |
+| 1 | 6,307,200 | 1 | 200 µBTH | 25 BTH | First halving |
+| 2 | 12,614,400 | 2 | 100 µBTH | 12.5 BTH | Second halving |
+| 3 | 18,921,600 | 3 | 50 µBTH | 6.25 BTH | Third halving |
+| 4 | 25,228,800 | 4 | 25 µBTH | 3.125 BTH | Fourth halving |
+| 5 | 31,536,000 | 5 | 12.5 µBTH | ~1.9 BTH (supply-dependent) | Tail emission begins |
+| 6 | 63,072,000 | 10 | 10 µBTH | supply-dependent | Maturity (possible inflation reduction) |
 
 ### Epoch 0: Genesis
 
@@ -592,7 +592,7 @@ MonetaryEpoch {
 
 ```rust
 MonetaryEpoch {
-    activation_height: 15_768_000,                 // ~10 years
+    activation_height: 31_536_000,                 // ~5 years (5 × 6,307,200)
 
     // Fees (halved 5 times from genesis)
     min_fee: 12_500,                               // 12.5 µBTH
@@ -603,7 +603,7 @@ MonetaryEpoch {
 
     // Emission (tail begins)
     target_net_inflation_bps: 200,                 // 2% - now actively targeted
-    tail_emission_override: 1_590_000_000,         // ~1.59 BTH per block
+    tail_emission_override: 0,                     // 0 = supply-dependent tail (recomputed each block to target 2% net)
 
     // Difficulty (monetary-focused for Phase 2)
     timing_weight_bps: 3000,                       // 30%
@@ -1042,8 +1042,8 @@ As the network matures, the community may decide to reduce the inflation target:
 
 | Year | Possible Target | Rationale |
 |------|-----------------|-----------|
-| 0-10 | N/A (halvings) | Distribution phase |
-| 10-20 | 2.0% | Initial tail emission |
+| 0-5 | N/A (halvings) | Distribution phase |
+| 5-20 | 2.0% | Initial tail emission |
 | 20-30 | 1.5% | Reduced as network stabilizes |
 | 30+ | 1.0% | Long-term maintenance |
 

--- a/docs/concepts/tokenomics.md
+++ b/docs/concepts/tokenomics.md
@@ -10,7 +10,7 @@ Botho (BTH) uses a two-phase emission model designed for long-term sustainabilit
 | Internal precision | picocredits (10⁻¹² BTH) |
 | Display unit | nanoBTH (10⁻⁹ BTH) |
 | Pre-mine | None (100% mined) |
-| Phase 1 supply | ~100 million BTH |
+| Phase 1 supply | ~611 million BTH (~5 years of halvings) |
 | Block time | 5-40 seconds (dynamic based on load); 5s baseline for monetary calculations |
 | Consensus | SCP (Stellar Consensus Protocol) |
 
@@ -50,21 +50,21 @@ User interfaces and fee calculations use nanoBTH for manageable numbers:
 
 ## Emission Schedule
 
-### Phase 1: Halving Period (Years 0-10)
+### Phase 1: Halving Period (Years 0-5)
 
-Block rewards halve every ~2 years, distributing approximately 100 million BTH over 10 years.
+Block rewards halve every ~1 year, distributing approximately 611 million BTH over ~5 years.
 
 | Period | Years | Block Reward | Cumulative Supply |
 |--------|-------|--------------|-------------------|
-| Halving 0 | 0-2 | 50 BTH | ~52.6M BTH |
-| Halving 1 | 2-4 | 25 BTH | ~78.9M BTH |
-| Halving 2 | 4-6 | 12.5 BTH | ~92.0M BTH |
-| Halving 3 | 6-8 | 6.25 BTH | ~98.6M BTH |
-| Halving 4 | 8-10 | 3.125 BTH | ~100M BTH |
+| Halving 0 | 0-1 | 50 BTH | ~315.4M BTH |
+| Halving 1 | 1-2 | 25 BTH | ~473.0M BTH |
+| Halving 2 | 2-3 | 12.5 BTH | ~551.9M BTH |
+| Halving 3 | 3-4 | 6.25 BTH | ~591.3M BTH |
+| Halving 4 | 4-5 | 3.125 BTH | ~611.0M BTH |
 
-**Halving interval**: 12,614,400 blocks (~2 years at the 5-second monetary baseline; proportionally longer at slower actual block times)
+**Halving interval**: 6,307,200 blocks (~1 year at the 5-second monetary baseline; proportionally longer at slower actual block times)
 
-### Phase 2: Tail Emission (Year 10+)
+### Phase 2: Tail Emission (Year 5+)
 
 After Phase 1, Botho transitions to perpetual tail emission targeting **2% annual net inflation**.
 
@@ -84,14 +84,14 @@ tail_reward = (target_net_inflation + expected_fee_burns) / blocks_per_year
 
 Here `fees_burned` is only the **20% burn share** of fees that is actually destroyed (audit cycle 6, M4). The 80% lottery-redistributed share and the emission share routed into the lottery pool both remain in circulating supply, so they do **not** count toward `fees_burned`.
 
-At 100M BTH supply:
-- Target net emission: 2% × 100M = 2M BTH/year
-- Expected fee burns (20% share only): ~0.5% × 100M = 0.5M BTH/year
-- Gross emission needed: 2.5M BTH/year
-- Blocks per year: 1,576,800
-- **Tail reward: ~1.59 BTH/block**
+At the ~611M BTH tail-onset supply:
+- Target net emission: 2% × 611M = ~12.2M BTH/year
+- Expected fee burns (20% share only): ~0.5% × 611M = ~3.1M BTH/year
+- Gross emission needed: ~15.3M BTH/year
+- Blocks per year (5s baseline): 6,307,200
+- **Tail reward: supply-dependent, ~2.4 BTH/block gross (~1.9 BTH/block net) at this supply**
 
-(The exact tail-reward figure depends on the assumed block time; cross-source numeric reconciliation is tracked separately in issue #321.)
+The tail reward is **not a fixed constant**: it is recomputed from circulating supply each block to target 2% net annual inflation, so it grows as supply grows. (The exact tail-reward figure also depends on the assumed block time; cross-source numeric reconciliation is tracked separately in issue #321.)
 
 ### Emission Routing into the Lottery Pool
 
@@ -308,19 +308,20 @@ This ensures:
 | Year | Approximate Supply | Annual Inflation |
 |------|-------------------|------------------|
 | 0 | 0 | N/A |
-| 2 | ~52.6M BTH | High (initial distribution) |
-| 5 | ~85M BTH | ~15% |
-| 10 | ~100M BTH | ~3% |
-| 20 | ~122M BTH | 2% |
-| 50 | ~180M BTH | 2% |
-| 100 | ~295M BTH | 2% |
+| 1 | ~315.4M BTH | High (initial distribution) |
+| 2 | ~473.0M BTH | High (initial distribution) |
+| 5 | ~611M BTH (tail onset) | ~2% from here |
+| 10 | ~674M BTH | 2% |
+| 20 | ~822M BTH | 2% |
+| 50 | ~1.49B BTH | 2% |
+| 100 | ~4.0B BTH | 2% |
 
 ### Overflow Safety
 
-- Phase 1 completion: 100M BTH = 10¹⁷ nanoBTH
+- Phase 1 completion (~year 5): ~611M BTH = ~6.11 × 10¹⁷ nanoBTH
 - Maximum representable (u64): ~1.84 × 10¹⁹ nanoBTH
-- Growth capacity: ~184× current supply
-- At 2% annual inflation: **~260 years before overflow**
+- Growth capacity: ~30× tail-onset supply
+- At 2% annual inflation: **~170 years before overflow** (internal accounting uses picocredits in u128, so this u64 nanoBTH headroom is a display-tier bound, not a hard limit)
 
 ## Economic Design Philosophy
 

--- a/docs/design/archive/wealth-conditional-privacy.md
+++ b/docs/design/archive/wealth-conditional-privacy.md
@@ -84,7 +84,7 @@ pub struct PrivacyPolicy {
 }
 ```
 
-**Coverage Analysis** (at 100M BTH supply):
+**Coverage Analysis** (at a 100M BTH simulation-calibration scale — not the ~611M BTH mainnet Phase-1 supply):
 
 | Source Wealth | % of Supply | Privacy Level | Affected Users |
 |---------------|-------------|---------------|----------------|

--- a/docs/design/asymmetric-fees-simulation.md
+++ b/docs/design/asymmetric-fees-simulation.md
@@ -570,7 +570,7 @@ PARAMETER_SPACE = {
 ```python
 FIXED_PARAMS = {
     "num_agents": 1000,
-    "initial_supply": 100_000_000_000_000,               # 100M BTH in picocredits
+    "initial_supply": 100_000_000_000_000,               # simulation calibration scale, not the ~611M BTH mainnet Phase-1 supply
     "initial_gini": 0.85,
     "simulation_rounds": 1000,
     "rounds_per_day": 4320,                              # ~20 sec blocks

--- a/docs/design/cluster-tilted-redistribution.md
+++ b/docs/design/cluster-tilted-redistribution.md
@@ -79,7 +79,9 @@ velocities; idle wealth must be touched.
 
 ## Evidence
 
-Agent-based simulation, 100M BTH economy, initial Gini 0.77, each scenario
+Agent-based simulation, 100M BTH economy (this is the **simulation calibration
+scale**, not a supply claim — mainnet Phase-1 supply is ~611M BTH; see
+[minting.md](../minting.md)), initial Gini 0.77, each scenario
 run honest AND gamed (strategic whale splits 5M BTH into 1,000 UTXOs and
 churns weekly to defeat eligibility decay). Five-year horizon, conservative
 parameters (2.5%/yr emission, 2%/yr max demurrage, 6:1 tilt). Full matrix in

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -20,7 +20,7 @@ A public identifier for receiving funds. In Botho, addresses are derived from yo
 A collection of transactions bundled together and added to the blockchain. Each block references the previous block, forming a chain.
 
 ### Block Reward
-The amount of BTH created when a new block is mined. Botho starts at 50 BTH per block, halving every ~2 years until reaching tail emission.
+The amount of BTH created when a new block is mined. Botho starts at 50 BTH per block, halving every ~1 year until reaching tail emission.
 
 ### BTH
 The native currency unit of Botho. BTH uses a two-tier precision system:
@@ -82,7 +82,7 @@ The creation of new coins through mining. See [Tokenomics](tokenomics.md#emissio
 ## F
 
 ### Fee Burn
-When transaction fees are destroyed rather than paid to miners. Botho burns all fees, creating deflationary pressure.
+When transaction fees are destroyed rather than paid to miners. Botho burns 20% of collected fees (the other 80% funds the cluster-tilted redistribution lottery); only this 20% burn share creates deflationary pressure.
 
 ### Finality
 The point at which a transaction cannot be reversed. Botho provides immediate finality via SCP consensus.
@@ -105,7 +105,7 @@ A pub/sub protocol used by libp2p for peer-to-peer message propagation. Botho us
 ## H
 
 ### Halving
-A scheduled reduction in block rewards, typically by 50%. Botho halves every ~2 years for 10 years, then transitions to tail emission.
+A scheduled reduction in block rewards, typically by 50%. Botho halves every ~1 year for ~5 years (5 halvings), then transitions to tail emission.
 
 ### Hash
 A fixed-size output produced by a hash function. Used for block identification, proof-of-work, and data integrity.

--- a/docs/minting.md
+++ b/docs/minting.md
@@ -77,34 +77,43 @@ For dedicated minting machines, leave at 0. For machines doing other work, set t
 
 Minting rewards follow a two-phase model: halvings followed by perpetual tail emission.
 
-### Phase 1: Halving Period (~10 years at 5s blocks)
+### Phase 1: Halving Period (~5 years at 5s blocks)
 
 | Parameter | Value |
 |-----------|-------|
 | Initial reward | 50 BTH |
-| Halving interval | 12,614,400 blocks (~2 years at 5s blocks) |
+| Halving interval | 6,307,200 blocks (~1 year at 5s blocks) |
 | Number of halvings | 5 |
-| Phase 1 supply | ~100 million BTH |
+| Phase 1 supply | ~611 million BTH |
+
+Each halving epoch is 6,307,200 blocks; the cumulative supply is the running sum
+of `reward × 6,307,200` per epoch (e.g. 50 × 6,307,200 = 315.36M BTH in epoch 0):
 
 | Period | Years (at 5s) | Block Reward | Cumulative Supply |
 |--------|---------------|--------------|-------------------|
-| Halving 0 | 0-2 | 50 BTH | ~52.6M BTH |
-| Halving 1 | 2-4 | 25 BTH | ~78.9M BTH |
-| Halving 2 | 4-6 | 12.5 BTH | ~92.0M BTH |
-| Halving 3 | 6-8 | 6.25 BTH | ~98.6M BTH |
-| Halving 4 | 8-10 | 3.125 BTH | ~100M BTH |
+| Halving 0 | 0-1 | 50 BTH | ~315.4M BTH |
+| Halving 1 | 1-2 | 25 BTH | ~473.0M BTH |
+| Halving 2 | 2-3 | 12.5 BTH | ~551.9M BTH |
+| Halving 3 | 3-4 | 6.25 BTH | ~591.3M BTH |
+| Halving 4 | 4-5 | 3.125 BTH | ~611.0M BTH |
 
-**Note**: Actual halving periods depend on dynamic block timing. If average block time is 20s (typical for moderate load), halvings will occur ~4x slower (every ~8 years instead of ~2 years).
+**Note**: Actual halving periods depend on dynamic block timing. If average block time is 20s (typical for moderate load), halvings will occur ~4x slower (every ~4 years instead of ~1 year).
 
-### Phase 2: Tail Emission (Year 10+)
+### Phase 2: Tail Emission (Year 5+)
 
 After Phase 1, Botho transitions to perpetual tail emission targeting **2% annual net inflation**.
 
 | Parameter | Value |
 |-----------|-------|
 | Target net inflation | 2% annually |
-| Tail reward | ~0.40 BTH per block (at 5s blocks) |
+| Tail reward | Supply-dependent: ~1.9 BTH per block at the ~611M tail-onset supply, growing with supply (at 5s blocks) |
 | Fee burn offset | ~0.5% expected |
+
+The tail reward is **not a fixed constant** — it is recomputed from circulating
+supply each block to target 2% net annual inflation. The gross per-block reward
+is `supply × (2% + 0.5% expected burns) / 6,307,200`; at the ~611M tail-onset
+supply this is ~2.4 BTH/block gross (~1.9 BTH/block net), and it scales upward as
+supply grows.
 
 **Why tail emission?**
 - Ensures minters always have incentive to secure the network
@@ -174,17 +183,23 @@ This ensures the network can adapt block rate to hit inflation targets even when
 
 ## Transaction Fees
 
-Transaction fees in Botho are **burned** (removed from circulation), creating deflationary pressure that offsets tail emission.
+Transaction fees in Botho are **split 80% / 20%**: each block, 80% of collected
+fees fund the cluster-tilted redistribution lottery (paid back out to randomly
+selected, mostly small/well-circulated holders) and 20% are **burned** (removed
+from circulation). Only the burned 20% is deflationary; it partially offsets tail
+emission. See [Cluster-Tilted Redistribution](design/cluster-tilted-redistribution.md).
 
 | Parameter | Value |
 |-----------|-------|
 | Minimum fee | 400 µBTH (0.0004 BTH) |
-| Fee destination | Burned |
+| Fee destination | 80% redistribution lottery, 20% burned |
 | Priority | Higher fees = faster confirmation |
 
-Minters earn block rewards only—fees are not collected by minters but instead removed from the total supply.
+Minters earn block rewards only—fees are not collected by minters but instead routed to the redistribution lottery (80%) and burned (20%).
 
 ### Net Supply Formula
+
+Only the burned portion (20% of fees) reduces total supply:
 
 ```
 net_supply = total_mined - total_fees_burned
@@ -276,9 +291,10 @@ A peer required for your quorum went offline.
 | Block time (monetary baseline) | 5 seconds |
 | Block time (actual range) | 3-40 seconds (dynamic) |
 | Initial reward | 50 BTH |
-| Halving interval | ~2 years (at 5s blocks) |
+| Halving interval | 6,307,200 blocks (~1 year at 5s blocks) |
 | Number of halvings | 5 |
-| Tail emission | ~0.40 BTH/block |
+| Phase 1 supply | ~611 million BTH (~5 years) |
+| Tail emission | Supply-dependent (~1.9 BTH/block at ~611M tail-onset supply) |
 | Tail inflation target | 2% net |
 | Difficulty adjustment | Every 17,280 blocks (~24h at 5s) |
 | Gossip port | 7100 |

--- a/docs/specification/protocol-v0.1.0.md
+++ b/docs/specification/protocol-v0.1.0.md
@@ -767,6 +767,12 @@ Total Phase 1 supply: **100,000,000 BTH**
 
 Emission follows a halving schedule over approximately 10 years.
 
+> **Superseded**: The canonical mainnet emission schedule (issue #351, shipped in
+> `botho/src/monetary.rs`) sets the halving interval to 6,307,200 blocks (~1 year),
+> 5 halvings, for a ~611M BTH Phase-1 supply over ~5 years. See
+> [protocol-v0.2.0.md](protocol-v0.2.0.md) §8.2 and [minting.md](../minting.md).
+> The figures in this v0.1.0 document are retained for historical reference only.
+
 #### 8.2.2 Block Reward
 
 Block rewards decrease according to:

--- a/docs/specification/protocol-v0.2.0.md
+++ b/docs/specification/protocol-v0.2.0.md
@@ -739,9 +739,9 @@ The **picocredit** is the atomic unit used in all protocol calculations.
 
 #### 8.2.1 Phase 1 Distribution
 
-Total Phase 1 supply: **100,000,000 BTH**
+Total Phase 1 supply: **~611,010,000 BTH**
 
-Emission follows a halving schedule over approximately 10 years.
+Emission follows a halving schedule (50 BTH initial reward, halving every 6,307,200 blocks, 5 halvings) over approximately 5 years at the 5-second monetary baseline.
 
 #### 8.2.2 Block Reward
 


### PR DESCRIPTION
## Summary

Reconciles the README and `docs/` monetary parameters with the canonical emission schedule shipped in `botho/src/monetary.rs` (#351, on `origin/main` via #362): ~1-year halvings, 5 over ~5 years, ~611M BTH Phase-1 supply, supply-dependent tail reward targeting 2% net annual inflation, and the 80% redistribution-lottery / 20% burn fee model. Markdown only — no code changed and `whitepaper/` untouched (whitepaper LaTeX reconciliation stays in #321).

## Canonical source-of-truth values (from `mainnet_policy()`)

`halving_interval = BLOCKS_PER_YEAR = 6,307,200` (~1yr at 5s), `halving_count = 5` -> time-to-tail = 5.00yr, derived Phase-1 supply `R0 * H * (2 - 2^-(K-1))` = 50 * 6,307,200 * 1.9375 = **611,010,000 BTH**, `tail_inflation_bps = 200`. Tail reward is recomputed each block from supply (`block.rs::calculate_tail_reward_u128`): gross = `supply * (2% + 0.5% expected burns) / 6,307,200` -> ~2.4 BTH/block gross (~1.9 BTH/block net) at the ~611M tail-onset supply, growing with supply.

## Changes (every file changed)

- **README.md** — halving "~2yr/10yr" -> "~1yr/~5yr"; tail "~1.59 BTH/block" -> supply-dependent (~1.9 BTH/block net); Phase-1 supply "~100M" -> "~611M".
- **docs/minting.md** — recomputed the halving cumulative-supply table to land at ~611.0M; halving interval -> 6,307,200; Phase 2 header -> "Year 5+"; tail reward -> supply-dependent with derivation; rewrote the **all-fees-burned** section to 80/20 lottery+burn; updated Quick Reference table.
- **docs/concepts/tokenomics.md** — Phase-1 supply, halving table (lands at ~611M), tail-reward example (~611M anchor, supply-dependent), long-term supply projection table, and u64 overflow-headroom figures.
- **docs/concepts/monetary-policy.md** — block-based-halving callout + adaptive-inflation table (1yr/4yr/8yr), Planned Epoch Schedule heights/years/tail reward, Epoch 5 example (`activation_height` 31,536,000, `tail_emission_override` 0 = supply-dependent), inflation-reduction-roadmap years.
- **docs/concepts/architecture.md** — `mainnet_policy()` code excerpt `halving_interval` -> 6,307,200; inflation-dampener table periods.
- **docs/concepts/comparison.md** — all-fees-burned -> 80/20 split.
- **docs/glossary.md** — Block Reward / Halving / Fee Burn entries -> ~1yr halvings, 80/20 split.
- **docs/FAQ.md** — Phase-1 "years 0-10/~100M" -> "years 0-5/~611M"; rewrote the burn Q/A to 80/20.
- **docs/api.md** — note clarifying only the 20% burn share reduces circulating supply.
- **docs/design/cluster-tilted-redistribution.md** — annotated the 100M sim-calibration scale vs ~611M mainnet supply.
- **docs/design/asymmetric-fees-simulation.md**, **docs/design/archive/wealth-conditional-privacy.md** — annotated 100M sim-calibration scale.
- **docs/specification/protocol-v0.2.0.md** — Phase-1 supply ~611M / ~5yr.
- **docs/specification/protocol-v0.1.0.md** — added a "superseded" note pointing to the canonical schedule (frozen versioned spec retained for history).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Halving interval/period, count, time-to-tail, Phase-1 supply, tail-inflation, tail-reward in README + docs/ match `monetary.rs` | done | Derived from `mainnet_policy()`/`calculate_tail_reward_u128`; halving tables sum to ~611.0M (matches the 611,010,000 BTH in `monetary.rs` schedule-lock test) |
| No all-fees-burned language; 80/20 consistently described | done | Rewrote minting.md, FAQ.md, api.md, comparison.md, glossary.md; grep for "fees are burned"/"burns all fees" returns only 80/20-correct text |
| Repo-wide grep (excl whitepaper/) for stale tokens returns only intentional/annotated hits | done | Remaining `1.59`/`12,614,400`/`100M`/`10 year` hits are either annotated sim-calibration notes, the superseded-v0.1.0 note, or correct halving-*height* values (e.g. 12,614,400 = 2nd-halving height) |
| Markdown only; no code; whitepaper/ untouched | done | `git diff --name-only` = 14 `.md` files; no `whitepaper/` paths |

## Test Plan

- `git diff --name-only` confirms all 14 changed files are markdown; none under `whitepaper/`.
- Verified halving cumulative-supply arithmetic: 50/25/12.5/6.25/3.125 BTH x 6,307,200 sums to 611,010,000 BTH.
- No Rust touched, so rustfmt CI gate is N/A.

Closes #363