### PR TITLE
fix(faucet): reset daily counter in stats() to avoid midnight over-report

### DIFF
--- a/botho/src/rpc/faucet.rs
+++ b/botho/src/rpc/faucet.rs
@@ -392,6 +392,12 @@ impl FaucetState {
 
     /// Get current stats for monitoring
     pub fn stats(&self) -> FaucetStats {
+        // Normalize the in-memory daily counter to the current UTC day before
+        // reading it. Without this, after crossing a UTC-midnight boundary with
+        // no new dispense, `daily_dispensed` still holds yesterday's total and
+        // the status endpoint over-reports until the first dispense self-corrects.
+        self.maybe_reset_daily_counter();
+
         FaucetStats {
             enabled: self.config.enabled,
             amount_per_request: self.config.amount,
@@ -607,5 +613,42 @@ mod tests {
         assert_eq!(stats.daily_dispensed, 10_000_000_000_000);
         assert_eq!(stats.tracked_ips, 1);
         assert_eq!(stats.tracked_addresses, 1);
+    }
+
+    #[test]
+    fn test_stats_resets_daily_dispensed_across_utc_midnight() {
+        let state = FaucetState::new(test_config());
+
+        // Simulate state left over from a prior UTC day: a nonzero in-memory
+        // counter whose `day_start` is anchored to yesterday.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let yesterday_day_start = (now - (now % 86400)) - 86400;
+        state
+            .day_start
+            .store(yesterday_day_start, Ordering::Relaxed);
+        state
+            .daily_dispensed
+            .store(10_000_000_000_000, Ordering::Relaxed);
+
+        // stats() must normalize to the current UTC day and report 0, rather
+        // than over-reporting yesterday's total.
+        let stats = state.stats();
+        assert_eq!(stats.daily_dispensed, 0);
+    }
+
+    #[test]
+    fn test_stats_reflects_same_day_dispense() {
+        let state = FaucetState::new(test_config());
+        let ip: IpAddr = "192.168.1.1".parse().unwrap();
+
+        // A dispense earlier today should still be reflected by stats() (the
+        // reset only fires when the stored day_start is in a prior UTC day).
+        state.record_request(ip, "view:abc\nspend:def", 10_000_000_000_000);
+
+        let stats = state.stats();
+        assert_eq!(stats.daily_dispensed, 10_000_000_000_000);
     }
 }


### PR DESCRIPTION
## Summary
`faucet_getStatus` reports `dailyDispensed` as `max(blockchain-confirmed, in-memory counter)`. The in-memory `daily_dispensed` counter was only reset on the dispense path (via `check_rate_limit` -> `maybe_reset_daily_counter`), never in `stats()`. So after crossing a UTC-midnight boundary with no new dispense, the in-memory counter still held yesterday's total and the status endpoint over-reported `dailyDispensed` until the first dispense of the new day self-corrected. Cosmetic (status endpoint only; never affected rate-limiting or real accounting).

## Changes
- Call `maybe_reset_daily_counter()` at the start of `FaucetState::stats()` so the in-memory counter is normalized to the current UTC day before it is read/reported. Reuses the existing reset logic exactly (same atomic `compare_exchange` day-boundary computation the dispense path uses) — no second/divergent notion of "current day".
- No borrow/lock change needed: both `stats()` and `maybe_reset_daily_counter()` take `&self` and the counters are `AtomicU64`, so the access pattern mirrors the dispense path.
- Added `test_stats_resets_daily_dispensed_across_utc_midnight`: anchors `day_start` to a prior UTC day with a nonzero `daily_dispensed`, calls `stats()`, asserts reported `daily_dispensed == 0`.
- Added `test_stats_reflects_same_day_dispense`: confirms a dispense earlier today is still reflected (reset only fires across a day boundary).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `stats()` resets in-memory counter to current UTC day before reporting | done | Reset call added at start of `stats()`; new midnight test asserts 0 |
| Reuses existing reset logic (no divergent day computation) | done | Calls existing `maybe_reset_daily_counter()` unchanged |
| Same-day behavior unchanged | done | `test_stats_reflects_same_day_dispense` passes |
| `cargo test -p botho` faucet tests green | done | 9/9 faucet tests pass incl. 2 new |
| `cargo build` green | done | dev build finished successfully |
| rustfmt-clean under pinned nightly | done | `cargo +nightly-2025-12-03 fmt --all -- --check` exits 0 |

## Test Plan
- `cargo test -p botho faucet` -> 9 passed (incl. `test_stats_resets_daily_dispensed_across_utc_midnight`, `test_stats_reflects_same_day_dispense`).
- `cargo build` -> green.
- `cargo +nightly-2025-12-03 fmt --all -- --check` -> exit 0.

Closes #327