### PR TITLE
feat(rpc): add getBlockByHash and wire explorer hash lookups

### DIFF
--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -546,6 +546,7 @@ async fn handle_rpc_method(request: &JsonRpcRequest, state: &RpcState) -> JsonRp
         "getChainInfo" => handle_chain_info(id, state).await,
         "getSupplyInfo" => handle_supply_info(id, state).await,
         "getBlockByHeight" => handle_get_block(id, &request.params, state).await,
+        "getBlockByHash" => handle_get_block_by_hash(id, &request.params, state).await,
         "getMempoolInfo" => handle_mempool_info(id, state).await,
         "estimateFee" | "tx_estimateFee" => handle_estimate_fee(id, &request.params, state).await,
         "fee_getRate" => handle_get_fee_rate(id, state).await,
@@ -835,6 +836,62 @@ async fn handle_get_block(id: Value, params: &Value, state: &RpcState) -> JsonRp
                 "mintingReward": block.minting_tx.reward,
             }),
         ),
+        Err(e) => JsonRpcResponse::error(id, -32000, &format!("Block not found: {}", e)),
+    }
+}
+
+/// Get a block by its hash.
+///
+/// Mirrors [`handle_get_block`] but resolves the block from its 32-byte hash
+/// instead of its height. This backs the explorer's block-by-hash search and
+/// `/explorer/block/:hash` deep links (issue #330).
+///
+/// The lookup is delegated to [`Ledger::get_block_by_hash`], scanning the full
+/// chain (from tip to genesis) so any historical block can be resolved, not
+/// just recent ones. An unknown hash returns a "Block not found" error so the
+/// adapter can map it to a not-found state.
+async fn handle_get_block_by_hash(id: Value, params: &Value, state: &RpcState) -> JsonRpcResponse {
+    // Parse hash parameter (accept either `hash` or `block_hash`).
+    let hash_hex = match params
+        .get("hash")
+        .or_else(|| params.get("block_hash"))
+        .and_then(|v| v.as_str())
+    {
+        Some(hex) => hex,
+        None => return JsonRpcResponse::error(id, -32602, "Missing hash parameter"),
+    };
+
+    let block_hash: [u8; 32] = match hex::decode(hash_hex) {
+        Ok(bytes) if bytes.len() == 32 => {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&bytes);
+            arr
+        }
+        _ => {
+            return JsonRpcResponse::error(id, -32602, "Invalid hash: expected 32-byte hex string")
+        }
+    };
+
+    let ledger = read_lock!(state.ledger, id.clone());
+
+    // Scan the entire chain (tip down to genesis) for a matching hash.
+    let chain_height = ledger.get_chain_state().map(|s| s.height).unwrap_or(0);
+
+    match ledger.get_block_by_hash(&block_hash, chain_height) {
+        Ok(Some(block)) => JsonRpcResponse::success(
+            id,
+            json!({
+                "height": block.height(),
+                "hash": hex::encode(block.hash()),
+                "prevHash": hex::encode(block.header.prev_block_hash),
+                "timestamp": block.header.timestamp,
+                "difficulty": block.header.difficulty,
+                "nonce": block.header.nonce,
+                "txCount": block.transactions.len(),
+                "mintingReward": block.minting_tx.reward,
+            }),
+        ),
+        Ok(None) => JsonRpcResponse::error(id, -32000, "Block not found"),
         Err(e) => JsonRpcResponse::error(id, -32000, &format!("Block not found: {}", e)),
     }
 }

--- a/botho/tests/rpc_integration.rs
+++ b/botho/tests/rpc_integration.rs
@@ -231,6 +231,92 @@ async fn test_get_block_invalid_height() {
         .contains("not found"));
 }
 
+#[tokio::test]
+#[serial]
+async fn test_get_block_by_hash_known() {
+    let (_temp_dir, addr, _handle) = spawn_test_rpc_server().await;
+    let client = Client::new();
+
+    // The genesis block always exists in a freshly opened ledger. Its hash is
+    // reported as the tip hash via getChainInfo. Use that to exercise the
+    // known-hash path of getBlockByHash.
+    let chain_info = rpc_call(&client, addr, "getChainInfo", json!({})).await;
+    assert!(chain_info["error"].is_null());
+    let tip_hash = chain_info["result"]["tipHash"]
+        .as_str()
+        .expect("tipHash should be a hex string")
+        .to_string();
+
+    let response = rpc_call(&client, addr, "getBlockByHash", json!({ "hash": tip_hash })).await;
+
+    assert!(
+        response["error"].is_null(),
+        "Unexpected error: {:?}",
+        response["error"]
+    );
+    let result = &response["result"];
+    assert!(result["height"].is_number());
+    assert!(result["hash"].is_string());
+    assert!(result["prevHash"].is_string());
+    assert!(result["timestamp"].is_number());
+    // The returned block's hash must match the requested hash.
+    assert_eq!(result["hash"].as_str().unwrap(), tip_hash);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_block_by_hash_unknown() {
+    let (_temp_dir, addr, _handle) = spawn_test_rpc_server().await;
+    let client = Client::new();
+
+    // A 32-byte all-zeros hash will not match any real block.
+    let unknown_hash = "0".repeat(64);
+    let response = rpc_call(
+        &client,
+        addr,
+        "getBlockByHash",
+        json!({ "hash": unknown_hash }),
+    )
+    .await;
+
+    assert!(response["error"].is_object());
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("not found"));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_block_by_hash_invalid_hash() {
+    let (_temp_dir, addr, _handle) = spawn_test_rpc_server().await;
+    let client = Client::new();
+
+    // Too-short hash should be rejected as invalid params.
+    let response = rpc_call(&client, addr, "getBlockByHash", json!({ "hash": "abcd" })).await;
+
+    assert!(response["error"].is_object());
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("Invalid hash"));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_block_by_hash_missing_param() {
+    let (_temp_dir, addr, _handle) = spawn_test_rpc_server().await;
+    let client = Client::new();
+
+    let response = rpc_call(&client, addr, "getBlockByHash", json!({})).await;
+
+    assert!(response["error"].is_object());
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("Missing hash"));
+}
+
 // ============================================================================
 // Mempool Tests
 // ============================================================================

--- a/web/e2e/tests/explorer/hash-lookup.spec.ts
+++ b/web/e2e/tests/explorer/hash-lookup.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test'
+import { URLS, TIMEOUTS } from '../../fixtures/test-data'
+
+/**
+ * Explorer hash-lookup coverage (issue #330).
+ *
+ * These specs verify that the explorer can resolve lookups BY HASH, which
+ * previously failed:
+ *   - block-by-hash deep links (/explorer/block/:hash) and hash search, backed
+ *     by the new `getBlockByHash` RPC method, and
+ *   - tx-detail-from-RPC (/explorer/tx/:hash and tx-hash search), backed by the
+ *     `getTransaction` RPC wiring in RemoteNodeAdapter.
+ *
+ * The suite proxies `/rpc` to the live seed node, whose chain tip moves over
+ * time. Rather than hardcode a (quickly-stale) block/tx hash, these tests
+ * derive a real, currently-valid block hash from the recent-blocks list at
+ * runtime, then verify it round-trips through both the in-app search and a
+ * cold deep-link reload. Specs skip cleanly when the explorer is not connected
+ * (e.g. seed node unreachable from CI) so they never produce false negatives.
+ */
+
+async function waitForExplorerReady(page: import('@playwright/test').Page): Promise<boolean> {
+  return await expect(page.getByPlaceholder(/Search by block height or hash/i))
+    .toBeVisible({ timeout: TIMEOUTS.WALLET_SYNC })
+    .then(() => true)
+    .catch(() => false)
+}
+
+/**
+ * Open the first recent block, read its full hash from the detail view's
+ * "Hash" row, then return to the list. Returns null when no blocks are
+ * available (disconnected). The block detail renders the full hash in a
+ * copyable/monospace field, which we read via the DetailRow labelled "Hash".
+ */
+async function discoverBlockHash(page: import('@playwright/test').Page): Promise<string | null> {
+  const hasBlocks = await page.getByText('Recent Blocks').isVisible()
+  if (!hasBlocks) return null
+
+  await page.locator('[class*="cursor-pointer"]').first().click()
+  await expect(page.getByRole('heading', { name: /Block #\d+/i })).toBeVisible({
+    timeout: TIMEOUTS.NETWORK_REQUEST,
+  })
+
+  // Read the 64-hex block hash rendered in the detail view.
+  const hashText = await page
+    .locator('text=/[0-9a-f]{64}/i')
+    .first()
+    .textContent({ timeout: TIMEOUTS.NETWORK_REQUEST })
+    .catch(() => null)
+
+  const match = hashText?.match(/[0-9a-f]{64}/i)
+  return match ? match[0] : null
+}
+
+test.describe('Explorer - Block by hash', () => {
+  test('search resolves a valid block hash to its block detail', async ({ page }) => {
+    await page.goto(URLS.EXPLORER, { timeout: TIMEOUTS.PAGE_LOAD })
+    await page.waitForLoadState('networkidle')
+
+    const ready = await waitForExplorerReady(page)
+    if (!ready) {
+      test.skip(true, 'Explorer did not connect to a node')
+      return
+    }
+
+    const blockHash = await discoverBlockHash(page)
+    if (!blockHash) {
+      test.skip(true, 'No recent blocks available to derive a hash')
+      return
+    }
+
+    // Return to the list, then search by the discovered hash.
+    await page.getByRole('button', { name: /Back to blocks/i }).click()
+    await expect(page.getByText('Recent Blocks')).toBeVisible()
+
+    const searchInput = page.getByPlaceholder(/Search by block height or hash/i)
+    await searchInput.fill(blockHash)
+    await page.getByRole('button', { name: 'Search' }).click()
+
+    // The hash should resolve via getBlockByHash to a block detail view.
+    await expect(page.getByRole('heading', { name: /Block #\d+/i })).toBeVisible({
+      timeout: TIMEOUTS.NETWORK_REQUEST,
+    })
+    expect(page.url()).toContain('/explorer/block/')
+  })
+
+  test('block-by-hash deep link resolves on cold load', async ({ page }) => {
+    // First discover a valid hash from a connected session.
+    await page.goto(URLS.EXPLORER, { timeout: TIMEOUTS.PAGE_LOAD })
+    await page.waitForLoadState('networkidle')
+
+    const ready = await waitForExplorerReady(page)
+    if (!ready) {
+      test.skip(true, 'Explorer did not connect to a node')
+      return
+    }
+
+    const blockHash = await discoverBlockHash(page)
+    if (!blockHash) {
+      test.skip(true, 'No recent blocks available to derive a hash')
+      return
+    }
+
+    // Cold-load the deep link directly (simulating a reload / shared link).
+    await page.goto(`${URLS.EXPLORER}/block/${blockHash}`, { timeout: TIMEOUTS.PAGE_LOAD })
+    await page.waitForLoadState('networkidle')
+
+    // The deep link must re-fetch the block via getBlockByHash and render it,
+    // rather than showing "Block or transaction not found".
+    await expect(page.getByRole('heading', { name: /Block #\d+/i })).toBeVisible({
+      timeout: TIMEOUTS.WALLET_SYNC,
+    })
+    await expect(page.getByText(/not found/i)).toHaveCount(0)
+  })
+
+  test('searching an unknown hash shows a not-found message', async ({ page }) => {
+    await page.goto(URLS.EXPLORER, { timeout: TIMEOUTS.PAGE_LOAD })
+    await page.waitForLoadState('networkidle')
+
+    const ready = await waitForExplorerReady(page)
+    if (!ready) {
+      test.skip(true, 'Explorer did not connect to a node')
+      return
+    }
+
+    // A non-zero 64-hex value that is not a real block or tx. (All-zeros is
+    // special-cased as height 0 by the search precedence logic, so use a
+    // value that is unambiguously a hash.)
+    const unknownHash = 'f'.repeat(64)
+    const searchInput = page.getByPlaceholder(/Search by block height or hash/i)
+    await searchInput.fill(unknownHash)
+    await page.getByRole('button', { name: 'Search' }).click()
+
+    await expect(page.getByText(/not found/i)).toBeVisible({
+      timeout: TIMEOUTS.NETWORK_REQUEST,
+    })
+  })
+})
+
+test.describe('Explorer - Transaction by hash', () => {
+  test('tx deep link resolves to a detail view or a not-found message (never hangs)', async ({
+    page,
+  }) => {
+    await page.goto(URLS.EXPLORER, { timeout: TIMEOUTS.PAGE_LOAD })
+    await page.waitForLoadState('networkidle')
+
+    const ready = await waitForExplorerReady(page)
+    if (!ready) {
+      test.skip(true, 'Explorer did not connect to a node')
+      return
+    }
+
+    // The seed testnet has very few transactions and tx hashes rotate, so we
+    // cannot rely on a fixed known-funded tx hash. Instead we assert that a tx
+    // deep link RESOLVES to a deterministic terminal state (either a rendered
+    // transaction detail, or a "not found" message) rather than getting stuck
+    // on the connecting/loading state. This exercises the getTransaction RPC
+    // path end-to-end regardless of whether the specific hash still exists.
+    const someTxHash = '3ca3c24209844d8f6d9bf38bd1571976a691423e329f4ca0cbbf3d044da3012e'
+    await page.goto(`${URLS.EXPLORER}/tx/${someTxHash}`, { timeout: TIMEOUTS.PAGE_LOAD })
+    await page.waitForLoadState('networkidle')
+
+    // Either the tx hash is rendered in a detail view, or a not-found message
+    // is shown. Both are acceptable terminal states; a stuck spinner is not.
+    const detail = page.getByText(someTxHash, { exact: false })
+    const notFound = page.getByText(/not found/i)
+    await expect(detail.or(notFound).first()).toBeVisible({
+      timeout: TIMEOUTS.WALLET_SYNC,
+    })
+  })
+})

--- a/web/packages/adapters/src/remote.ts
+++ b/web/packages/adapters/src/remote.ts
@@ -212,8 +212,27 @@ export class RemoteNodeAdapter implements NodeAdapter {
           difficulty: BigInt(result.difficulty || 0),
         }
       } else {
-        // Hash lookup not directly supported, would need additional RPC method
-        return null
+        // Resolve by hash via the node's getBlockByHash RPC (issue #330).
+        const result = await this.call<{
+          height: number
+          hash: string
+          prevHash: string
+          timestamp: number
+          difficulty: number
+          txCount: number
+          mintingReward: number
+        }>('getBlockByHash', { hash: heightOrHash })
+
+        return {
+          hash: result.hash,
+          height: result.height,
+          timestamp: result.timestamp,
+          previousHash: result.prevHash,
+          transactionCount: result.txCount,
+          size: 0, // Not provided
+          reward: BigInt(result.mintingReward || 0),
+          difficulty: BigInt(result.difficulty || 0),
+        }
       }
     } catch {
       return null
@@ -298,10 +317,45 @@ export class RemoteNodeAdapter implements NodeAdapter {
     )
   }
 
-  async getTransaction(_txHash: TxHash): Promise<Transaction | null> {
-    // Not directly supported by current RPC
-    // Would need to scan blocks or add a dedicated method
-    return null
+  async getTransaction(txHash: TxHash): Promise<Transaction | null> {
+    try {
+      // The node's getTransaction RPC returns a "Transaction not found" error
+      // for unknown hashes, which rpcCall surfaces as a throw -> null here.
+      const result = await this.call<{
+        txHash: string
+        status: 'confirmed' | 'pending' | 'unknown'
+        blockHeight: number | null
+        confirmations: number
+        inMempool: boolean
+        type?: string
+        fee?: number
+      }>('getTransaction', { tx_hash: txHash })
+
+      // Map RPC signature type to the explorer CryptoType.
+      let cryptoType: CryptoType = 'clsag'
+      if (result.type === 'mldsa') {
+        cryptoType = 'mldsa'
+      } else if (result.type === 'hybrid') {
+        cryptoType = 'hybrid'
+      }
+
+      const status: Transaction['status'] = result.status === 'confirmed' ? 'confirmed' : 'pending'
+
+      return {
+        id: result.txHash,
+        type: 'receive' as const,
+        amount: BigInt(0), // Private (ring signatures) - amount not visible
+        fee: BigInt(result.fee || 0),
+        privacyLevel: 'private' as const,
+        cryptoType,
+        status,
+        timestamp: Date.now(), // RPC does not expose tx timestamp; block timestamp would require an extra lookup
+        blockHeight: result.blockHeight ?? undefined,
+        confirmations: result.confirmations || 0,
+      }
+    } catch {
+      return null
+    }
   }
 
   // =========================================================================


### PR DESCRIPTION
## Summary

Resolves the explorer's by-hash lookup gap: block-by-hash and tx-by-hash now
resolve via real RPC reads instead of returning `null`. Adds a new
`getBlockByHash` node RPC method, wires the explorer's `RemoteNodeAdapter` to
both `getBlockByHash` and the existing `getTransaction` RPC, and adds Rust
integration tests plus Playwright e2e specs.

## Block-by-hash approach

The ledger store already exposes `Ledger::get_block_by_hash(hash, lookback)`
(originally for compact-block reconstruction), which checks the tip then scans
recent blocks. Rather than add a new index, the new `handle_get_block_by_hash`
RPC handler calls this accessor with `lookback = chain_height`, so it scans the
**entire chain** (tip down to genesis) and can resolve any historical block,
not just recent ones. The handler mirrors `handle_get_block_by_height`'s
response shape exactly (`height`, `hash`, `prevHash`, `timestamp`,
`difficulty`, `nonce`, `txCount`, `mintingReward`). Unknown hashes return a
"Block not found" error so the adapter maps them to a not-found state.

`getTransaction` / `tx_get` already existed on the node (returns "Transaction
not found" for unknown hashes) — no node change was needed there; the adapter
now maps its response (`status`, `blockHeight`, `confirmations`, `type`, `fee`)
to the explorer `Transaction` type.

## Changes

Rust (node):
- `botho/src/rpc/mod.rs`: add `getBlockByHash` route + `handle_get_block_by_hash`
  handler (accepts `hash`/`block_hash`, validates 32-byte hex, scans full chain).
- `botho/tests/rpc_integration.rs`: add 4 tests — known hash (genesis via
  `getChainInfo` tipHash), unknown hash, invalid hash, missing param.

TypeScript (web explorer adapter):
- `web/packages/adapters/src/remote.ts`: `getBlock(hash)` now calls
  `getBlockByHash`; `getTransaction(txHash)` now calls the `getTransaction` RPC
  and maps to the `Transaction` type (both previously hardcoded `null`).

e2e:
- `web/e2e/tests/explorer/hash-lookup.spec.ts`: specs for block-by-hash search,
  block-by-hash cold deep-link reload, unknown-hash not-found, and tx deep link
  resolving to a terminal state. Hashes are derived at runtime from the recent
  blocks list (the seed chain tip moves) and specs skip cleanly when the
  explorer is not connected.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `getBlockByHash` RPC added | Verified | New route + handler in `rpc/mod.rs` |
| `getBlockByHash` tested (known + unknown) | Verified | `cargo test -p botho --test rpc_integration` — 36 passed (4 new) |
| `getTransaction` RPC confirmed | Verified | Existing handler returns "Transaction not found"; adapter maps its shape |
| Adapter wires both hash lookups w/ type mapping | Verified | `getBlock(hash)` + `getTransaction(txHash)` in `remote.ts` |
| TS typecheck + build green | Verified | `pnpm -r typecheck` and `pnpm build` both pass |
| e2e specs added | Verified (added), NOT executed locally | See e2e note below |

## Test Plan

Verified locally:
- `cargo build` — clean (pre-existing warnings only).
- `cargo test -p botho --test rpc_integration` — 36 passed, 0 failed.
- `cargo +nightly-2025-12-03 fmt --all -- --check` — clean.
- `pnpm -r typecheck` — all 6 packages pass.
- `pnpm build` — web-wallet + desktop build successfully.

NOT executed locally (needs CI):
- Playwright e2e (`hash-lookup.spec.ts`). The specs are discovered and parse
  cleanly (`playwright test --list` lists all 4), but the chromium
  `chrome-headless-shell` binary could not be downloaded in this sandbox
  (`npx playwright install` is network-blocked), so the browser could not
  launch. These specs must be run in CI. Note: the seed testnet has only ~3
  txs and a moving chain tip, so the tx spec asserts the deep link reaches a
  terminal state (detail or not-found) rather than depending on a fixed funded
  tx hash.

Closes #330