### PR TITLE
test(e2e): mock /rpc for hermetic explorer specs

### DIFF
--- a/web/e2e/playwright.config.ts
+++ b/web/e2e/playwright.config.ts
@@ -16,6 +16,13 @@ const WEB_BASE_URL = process.env.E2E_WEB_BASE_URL ?? 'http://localhost:4173'
 const FAUCET_BASE_URL = process.env.E2E_FAUCET_BASE_URL ?? 'http://localhost:4174'
 const useLocalServers = !process.env.E2E_WEB_BASE_URL && !process.env.E2E_FAUCET_BASE_URL
 
+// Local JSON-RPC mock for the explorer/wallet. Pointing the vite-preview `/rpc`
+// proxy here (instead of the live seed node) makes the explorer specs hermetic:
+// the connect handshake (node_getStatus) and block reads resolve deterministically
+// from fixed fixtures, eliminating the "Connecting to network..." flake (#334).
+const RPC_MOCK_PORT = 4175
+const RPC_MOCK_URL = `http://localhost:${RPC_MOCK_PORT}`
+
 /**
  * Playwright E2E test configuration for Botho web services.
  *
@@ -64,14 +71,28 @@ export default defineConfig({
   webServer: useLocalServers
     ? [
         {
+          // Local JSON-RPC mock the wallet/explorer talk to via the same-origin
+          // /rpc proxy. Started before the preview server so the proxy target is
+          // up by the time the explorer connects. Returns fixed node_getStatus /
+          // getChainInfo / getBlockByHeight payloads so connect + block reads are
+          // deterministic (no live-node dependency).
+          command: 'node e2e/serve-rpc-mock.mjs',
+          cwd: path.resolve(__dirname, '..'),
+          url: RPC_MOCK_URL,
+          reuseExistingServer: !process.env.CI,
+          timeout: 30_000,
+        },
+        {
           // Build the web wallet with the RPC endpoint pointed at the
-          // same-origin /rpc proxy (configured in the wallet's vite preview
-          // config to forward to https://seed.botho.io), then serve
-          // landing/wallet/explorer as a SPA via vite preview on port 4173.
-          // This lets the explorer perform a real RPC read in e2e without
-          // depending on cross-origin CORS.
+          // same-origin /rpc proxy, then serve landing/wallet/explorer as a SPA
+          // via vite preview on port 4173. E2E_RPC_PROXY_TARGET points the
+          // preview's /rpc proxy at the local mock above (instead of the live
+          // seed node), so the explorer performs a real RPC read in e2e against
+          // deterministic fixtures without cross-origin CORS or live-node flake.
           command:
-            'VITE_RPC_ENDPOINT=/rpc pnpm --filter @botho/web-wallet build && pnpm --filter @botho/web-wallet preview --port 4173 --strictPort',
+            'VITE_RPC_ENDPOINT=/rpc pnpm --filter @botho/web-wallet build && E2E_RPC_PROXY_TARGET=' +
+            RPC_MOCK_URL +
+            ' pnpm --filter @botho/web-wallet preview --port 4173 --strictPort',
           cwd: path.resolve(__dirname, '..'),
           url: 'http://localhost:4173/',
           reuseExistingServer: !process.env.CI,

--- a/web/e2e/serve-rpc-mock.mjs
+++ b/web/e2e/serve-rpc-mock.mjs
@@ -1,0 +1,144 @@
+/**
+ * Minimal JSON-RPC mock for the seed node read RPC used by the explorer/wallet
+ * during e2e.
+ *
+ * The explorer connects to a node via the same-origin `/rpc` proxy, which in
+ * production forwards to https://seed.botho.io. Pointing that proxy at the live
+ * node makes the explorer specs depend on a shared public node being responsive
+ * — which flaked ~1/run, always stuck in the "Connecting to network..." phase
+ * (the connect-time `node_getStatus` call timing out). See issue #334.
+ *
+ * This server returns fixed, deterministic payloads for the JSON-RPC methods the
+ * explorer exercises on load and during search:
+ *   - node_getStatus   -> connect handshake + chain height
+ *   - getChainInfo     -> difficulty (network stats)
+ *   - getBlockByHeight -> recent-block list + block-detail + height search
+ *
+ * Wire it into the Playwright run by pointing the vite-preview `/rpc` proxy at
+ * this server (see playwright.config.ts + web-wallet/vite.config.ts, both honor
+ * the E2E_RPC_PROXY_TARGET env var).
+ *
+ * No external dependencies — uses only Node's built-in http module.
+ */
+import { createServer } from 'node:http'
+
+const PORT = Number(process.env.RPC_MOCK_PORT ?? 4175)
+
+// Deterministic chain shape served by the mock. CHAIN_HEIGHT is the tip; the
+// explorer's getRecentBlocks fetches the top `limit` heights ending at the tip,
+// and search-by-height fetches an arbitrary in-range height. Any height in
+// [0, CHAIN_HEIGHT] resolves to a synthetic-but-valid block so the recent-block
+// list, block-detail view, and height search are all deterministic.
+const CHAIN_HEIGHT = 1000
+const NETWORK = 'botho-testnet'
+const VERSION = '0.1.0-e2e-mock'
+const DIFFICULTY = 12345
+
+/** Pad a number into a 64-hex-char string so block/prev hashes look realistic. */
+function fakeHash(seed) {
+  const base = `e2e${seed}`
+  let hex = ''
+  for (let i = 0; i < base.length; i++) {
+    hex += base.charCodeAt(i).toString(16).padStart(2, '0')
+  }
+  return hex.padEnd(64, '0').slice(0, 64)
+}
+
+/** Build a deterministic block payload for a given height. */
+function blockAt(height) {
+  return {
+    height,
+    hash: fakeHash(`block-${height}`),
+    prevHash: height > 0 ? fakeHash(`block-${height - 1}`) : fakeHash('genesis'),
+    // Fixed base timestamp (2024-01-01T00:00:00Z) + 60s per block, in seconds.
+    timestamp: 1704067200 + height * 60,
+    difficulty: DIFFICULTY,
+    txCount: 0,
+    mintingReward: 5_000_000,
+  }
+}
+
+/** Dispatch a single JSON-RPC method to its fixed result. */
+function handleMethod(method, params) {
+  switch (method) {
+    case 'node_getStatus':
+      return {
+        result: {
+          version: VERSION,
+          network: NETWORK,
+          chainHeight: CHAIN_HEIGHT,
+          peerCount: 1,
+          mempoolSize: 0,
+        },
+      }
+    case 'getChainInfo':
+      return { result: { difficulty: DIFFICULTY } }
+    case 'getBlockByHeight': {
+      const height = Number(params?.height)
+      if (!Number.isFinite(height) || height < 0 || height > CHAIN_HEIGHT) {
+        // Out-of-range heights (e.g. the "non-existent block" search) return a
+        // JSON-RPC error, which the adapter maps to a null block -> "not found".
+        return { error: { code: -32001, message: 'Block not found' } }
+      }
+      return { result: blockAt(height) }
+    }
+    default:
+      return { error: { code: -32601, message: `Method not found: ${method}` } }
+  }
+}
+
+const server = createServer((req, res) => {
+  // CORS preflight / headers so the mock works whether reached directly or via
+  // the same-origin proxy.
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204)
+    res.end()
+    return
+  }
+
+  // Health check: Playwright's webServer readiness probe issues a GET to the
+  // server URL and only treats a < 400 status as "ready". Respond 200 to any
+  // non-POST request so the server is detected as up.
+  if (req.method !== 'POST') {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ status: 'ok', service: 'botho-e2e-rpc-mock' }))
+    return
+  }
+
+  let body = ''
+  req.on('data', (chunk) => {
+    body += chunk
+  })
+  req.on('end', () => {
+    let request
+    try {
+      request = JSON.parse(body)
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32700, message: 'Parse error' }, id: null }))
+      return
+    }
+
+    const { method, params, id } = request ?? {}
+    const outcome = handleMethod(method, params)
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ jsonrpc: '2.0', id: id ?? null, ...outcome }))
+  })
+})
+
+// The adapter opens a WebSocket to <origin>/rpc/ws for live updates. There is no
+// real-time channel in the mock; reject upgrades so the socket closes cleanly.
+// The adapter treats a failed/closed WS as "no real-time updates" and continues
+// polling, so this does not block connect.
+server.on('upgrade', (_req, socket) => {
+  socket.destroy()
+})
+
+server.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`RPC mock listening on http://localhost:${PORT} (chainHeight=${CHAIN_HEIGHT})`)
+})

--- a/web/e2e/tests/explorer/blocks.spec.ts
+++ b/web/e2e/tests/explorer/blocks.spec.ts
@@ -38,22 +38,18 @@ test.describe('Explorer - Block List', () => {
   test('displays recent blocks when connected', async ({ page }) => {
     await waitForExplorerReady(page)
 
-    // Check if blocks loaded
-    const hasBlocks = await page.getByText('Recent Blocks').isVisible()
-    if (hasBlocks) {
-      // Should show at least one block with height indicator
-      await expect(page.locator('text=/#\\d+/').first()).toBeVisible()
-    }
-    // If not connected yet, that's acceptable - skip the assertion
+    // The e2e RPC mock always serves a recent-block list, so this is deterministic.
+    await expect(page.getByText('Recent Blocks')).toBeVisible()
+    // Should show at least one block with height indicator
+    await expect(page.locator('text=/#\\d+/').first()).toBeVisible()
   })
 
   test('has load more button when blocks loaded', async ({ page }) => {
     await waitForExplorerReady(page)
 
-    const hasBlocks = await page.getByText('Recent Blocks').isVisible()
-    if (hasBlocks) {
-      await expect(page.getByRole('button', { name: 'Load More' })).toBeVisible()
-    }
+    // The e2e RPC mock always serves a recent-block list, so this is deterministic.
+    await expect(page.getByText('Recent Blocks')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Load More' })).toBeVisible()
   })
 })
 
@@ -63,11 +59,8 @@ test.describe('Explorer - Block Detail', () => {
     await page.waitForLoadState('networkidle')
     await waitForExplorerReady(page)
 
-    const hasBlocks = await page.getByText('Recent Blocks').isVisible()
-    if (!hasBlocks) {
-      test.skip()
-      return
-    }
+    // The e2e RPC mock always serves a recent-block list, so this is deterministic.
+    await expect(page.getByText('Recent Blocks')).toBeVisible()
 
     // Click on the first block
     await page.locator('[class*="cursor-pointer"]').first().click()
@@ -86,11 +79,8 @@ test.describe('Explorer - Block Detail', () => {
     await page.waitForLoadState('networkidle')
     await waitForExplorerReady(page)
 
-    const hasBlocks = await page.getByText('Recent Blocks').isVisible()
-    if (!hasBlocks) {
-      test.skip()
-      return
-    }
+    // The e2e RPC mock always serves a recent-block list, so this is deterministic.
+    await expect(page.getByText('Recent Blocks')).toBeVisible()
 
     // Click first block
     await page.locator('[class*="cursor-pointer"]').first().click()
@@ -111,11 +101,8 @@ test.describe('Explorer - Block Detail', () => {
     await page.waitForLoadState('networkidle')
     await waitForExplorerReady(page)
 
-    const hasBlocks = await page.getByText('Recent Blocks').isVisible()
-    if (!hasBlocks) {
-      test.skip()
-      return
-    }
+    // The e2e RPC mock always serves a recent-block list, so this is deterministic.
+    await expect(page.getByText('Recent Blocks')).toBeVisible()
 
     // Click a block
     await page.locator('[class*="cursor-pointer"]').first().click()

--- a/web/e2e/tests/explorer/search.spec.ts
+++ b/web/e2e/tests/explorer/search.spec.ts
@@ -19,11 +19,8 @@ test.describe('Explorer - Search', () => {
   test('can search by block height', async ({ page }) => {
     await waitForExplorerReady(page)
 
-    const hasBlocks = await page.getByText('Recent Blocks').isVisible()
-    if (!hasBlocks) {
-      test.skip()
-      return
-    }
+    // The e2e RPC mock always serves a recent-block list, so this is deterministic.
+    await expect(page.getByText('Recent Blocks')).toBeVisible()
 
     // Get first block's height
     const firstBlockHeight = await page.locator('text=/#\\d+/').first().textContent()
@@ -43,11 +40,8 @@ test.describe('Explorer - Search', () => {
   test('can search by pressing Enter', async ({ page }) => {
     await waitForExplorerReady(page)
 
-    const hasBlocks = await page.getByText('Recent Blocks').isVisible()
-    if (!hasBlocks) {
-      test.skip()
-      return
-    }
+    // The e2e RPC mock always serves a recent-block list, so this is deterministic.
+    await expect(page.getByText('Recent Blocks')).toBeVisible()
 
     // Get first block's height
     const firstBlockHeight = await page.locator('text=/#\\d+/').first().textContent()
@@ -95,11 +89,8 @@ test.describe('Explorer - Search', () => {
   test('URL updates when viewing block', async ({ page }) => {
     await waitForExplorerReady(page)
 
-    const hasBlocks = await page.getByText('Recent Blocks').isVisible()
-    if (!hasBlocks) {
-      test.skip()
-      return
-    }
+    // The e2e RPC mock always serves a recent-block list, so this is deterministic.
+    await expect(page.getByText('Recent Blocks')).toBeVisible()
 
     // Get first block's height
     const firstBlockHeight = await page.locator('text=/#\\d+/').first().textContent()

--- a/web/packages/web-wallet/vite.config.ts
+++ b/web/packages/web-wallet/vite.config.ts
@@ -4,6 +4,12 @@ import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import path from 'path'
 
+// Target for the same-origin `/rpc` proxy. Defaults to the live seed node for
+// local dev / preview, but the e2e suite overrides it (E2E_RPC_PROXY_TARGET) to
+// point at a local JSON-RPC mock so the explorer specs are hermetic and do not
+// depend on the shared public node being responsive. See web/e2e/serve-rpc-mock.mjs.
+const RPC_PROXY_TARGET = process.env.E2E_RPC_PROXY_TARGET || 'https://seed.botho.io'
+
 export default defineConfig({
   plugins: [
     react(),
@@ -78,7 +84,7 @@ export default defineConfig({
       // e2e (build with VITE_RPC_ENDPOINT=/rpc) so the app reaches a real node
       // without depending on cross-origin CORS.
       '/rpc': {
-        target: 'https://seed.botho.io',
+        target: RPC_PROXY_TARGET,
         changeOrigin: true,
       },
     },
@@ -88,7 +94,7 @@ export default defineConfig({
   preview: {
     proxy: {
       '/rpc': {
-        target: 'https://seed.botho.io',
+        target: RPC_PROXY_TARGET,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

The Playwright explorer specs (`web/e2e/tests/explorer/*`) connected to the live public seed RPC (`https://seed.botho.io/rpc`) through the vite-preview `/rpc` proxy. The connect-time `node_getStatus` call could time out on the shared public node, surfacing as a rotating ~1/run failure stuck at `waitForExplorerReady` / "Connecting to network...". This makes the explorer e2e **hermetic** by mocking `/rpc` with a small local server, so the suite no longer depends on the live node.

## Changes

- **`web/e2e/serve-rpc-mock.mjs`** (new): dependency-free JSON-RPC mock (mirrors the `serve-faucet.mjs` pattern). Returns deterministic payloads for the methods the explorer calls on load + in the specs:
  - `node_getStatus` -> connect handshake + chain height (`chainHeight: 1000`, `peerCount: 1`)
  - `getChainInfo` -> difficulty (network stats)
  - `getBlockByHeight` -> any in-range height resolves to a synthetic-but-valid block (recent-block list, block detail, height search); out-of-range heights return a JSON-RPC error so the "non-existent block" search shows "not found".
  - Responds 200 to GET so Playwright's `webServer` readiness probe detects it; rejects WS upgrades (adapter falls back to polling).
- **`web/packages/web-wallet/vite.config.ts`**: the dev + preview `/rpc` proxy target now reads `E2E_RPC_PROXY_TARGET` (defaults to `https://seed.botho.io` for normal dev/preview).
- **`web/e2e/playwright.config.ts`**: start the mock as a `webServer` (port 4175) and set `E2E_RPC_PROXY_TARGET=http://localhost:4175` on the preview command so the preview `/rpc` proxy forwards to the mock instead of the live node.
- **`web/e2e/tests/explorer/{blocks,search}.spec.ts`**: replaced the conditional `if (!hasBlocks) test.skip()` branches with deterministic `expect('Recent Blocks').toBeVisible()` assertions, since the mock always serves a recent-block list. No tests remain skipped on data availability.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Explorer e2e hermetic (mock `/rpc`, no live-node dependency) | ✅ | Mock returns fixed JSON-RPC; preview `/rpc` proxy retargeted to it via env var |
| Mock returns valid JSON-RPC for connect + search methods | ✅ | `curl`'d `node_getStatus`, `getChainInfo`, `getBlockByHeight` (in-range + out-of-range) directly and **through the preview proxy** (`POST localhost:4173/rpc`) — all returned correct payloads |
| Previously-skipped specs un-skipped where mock supports them | ✅ | All `test.skip()`-on-missing-data branches removed; 12 explorer tests listed, none data-gated |
| Playwright config well-formed | ✅ | `playwright test --project=explorer --list` lists all 12 tests; e2e run got past `webServer` startup (build + `vite preview` started, all 3 servers up) to browser launch |

## Test Plan / honest execution status

What I verified locally in this environment:
- Mock server returns valid JSON-RPC for every method, both directly (`curl localhost:4175`) and **end-to-end through the vite-preview proxy** (`curl -X POST localhost:4173/rpc`) — confirming the proxy now reaches the mock, not `seed.botho.io`.
- `pnpm --filter @botho/web-wallet build` and `vite preview` start cleanly with the new env wiring; Playwright started all three webServers (mock, preview, faucet) and proceeded to browser launch.
- `pnpm --filter @botho/web-wallet typecheck` passes; `playwright ... --list` enumerates the 12 explorer tests.

**The full Playwright browser run could NOT be executed here**: the Chromium / `chrome-headless-shell` download from the Playwright CDN is blocked in this sandbox (every test failed with `browserType.launch: Executable doesn't exist`, an environment issue, not a code defect). I did not fake a "0 failed" result. **The end-to-end browser run (explorer suite, ideally 3-5x to confirm zero connect-flake) needs CI**, where the bundled browsers install normally. The connect path is now fully deterministic against the local mock, so the "Connecting to network..." flake should be eliminated.

Closes #334