### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,73 @@ bumps (`0.X.Y`) are backwards-compatible.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-15
+
+### Summary
+
+Consensus-breaking release (requires a coordinated network reset — see #323).
+Hardens supply integrity, sets the canonical emission schedule, and reconciles
+all economic documentation with the shipped code. Follows an extended fuzzing
+and audit pass that surfaced and closed a critical inflation vector.
+
+### Changed (consensus-breaking — requires network reset)
+
+- **Emission schedule set to ~1-year halvings.** `mainnet_policy()` halving
+  interval is now `BLOCKS_PER_YEAR` (6,307,200 blocks, ~1 year at 5s), 5
+  halvings → ~611M BTH Phase-1 supply, reaching the perpetual 2% net tail in
+  ~5 years. Chosen from an agent-based emission-schedule sweep (#350/#352).
+  (#362)
+- **Supply accounting widened to `u128`.** `ChainState.total_mined` /
+  `total_fees_burned`, the `EmissionController` mirrors, and the cumulative
+  lottery-pool carryover are now `u128`; on-disk metadata grows 8→16 bytes.
+  Per-amount fields (`TxOutput.amount`, reward, fee) remain `u64`, so the
+  block/tx wire format is unchanged. RPC supply fields now emit as JSON
+  strings (exceed JS 2^53). (#342, #346)
+- **Per-input CLSAG balance verification** for multi-input transactions
+  (audit I4). (#317)
+- **Lottery payout UTXOs are minted** and burn accounting corrected (M4). (#323-era)
+
+### Fixed
+
+- **Critical: inflation via output-sum overflow.** `total_output()` summed
+  output amounts with an unchecked `u64` that wrapped under
+  `overflow-checks=false`, defeating the balance check; overflowing
+  transactions are now rejected. Found by fuzzing. (#340)
+- Cluster-tax simulation supply accumulators widened to `u128` to avoid
+  overflow at full-supply scale. (#344)
+- `agents_by_wealth()` made a total order (AgentId tie-break) to remove
+  cross-process nondeterminism in simulations. (#360)
+- Faucet `getStatus` no longer over-reports `dailyDispensed` across the UTC
+  midnight boundary. (#366)
+- Web wallet + explorer wired to a reachable seed RPC; connection and search
+  bugs fixed. (#322)
+- `totalMined` RPC field asserted as a parseable decimal string. (#348)
+
+### Added
+
+- **`getBlockByHash` RPC** and explorer block-by-hash / tx-by-hash lookups. (#367)
+- **Emission-schedule sweep** simulation subcommand + comparison report under
+  `experiments/results/`. (#352)
+- **Fuzzing suite revived** against the current API with a PR build guard, plus
+  4 consensus-critical fuzz targets (add_block, multi-input balance, lottery,
+  cluster-tax math). (#338, #339)
+- **Repo-wide rustfmt baseline + CI fmt check** on the pinned nightly. (#355)
+- GTK/glib system deps for the workspace benchmark CI job. (#358)
+
+### Documentation
+
+- Whitepaper reconciled with the shipped ~1yr/611M/2%-tail schedule and 5s
+  block timing; PDF rebuilt and deployed copy regenerated. (#321)
+- README + `docs/` monetary parameters reconciled with shipped code; fee
+  economics corrected to the 80/20 lottery+burn model. (#324, #364)
+
+### Testing
+
+- Privacy-metrics tests serialized to remove process-global-state races. (#359)
+- Sybil-resistance lottery simulation made deterministic (seeded RNG). (#349)
+- Explorer e2e made hermetic via a mocked `/rpc` endpoint. (#334)
+- 5-node consensus and tx-lifecycle e2e tests re-enabled for the lottery era.
+
 ## [0.1.0] - 2026-06-12
 
 ### Summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "botho"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "botho-desktop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "botho-wallet",
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "botho-exchange-scanner"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "botho-metrics-daemon"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "botho-mobile"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bip39",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "botho-wallet"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "bth-bridge-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "hex",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "bth-bridge-service"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bth-bridge-core",
  "chrono",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "bth-cluster-tax"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bth-transaction-types",
  "clap",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "bth-crypto-pq"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "bth-crypto-secp256k1"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hex",
  "hmac",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "bth-discover"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bth-common",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "bth-gossip"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags 2.10.0",
  "bth-common",

--- a/botho-exchange-scanner/Cargo.toml
+++ b/botho-exchange-scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-exchange-scanner"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Exchange deposit scanner for Botho cryptocurrency"
 license = "Apache-2.0"

--- a/botho-wallet/Cargo.toml
+++ b/botho-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-wallet"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Standalone thin wallet client for Botho cryptocurrency"
 license = "Apache-2.0"

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A privacy-preserving mined cryptocurrency"
 license = "GPL-3.0"

--- a/bridge/core/Cargo.toml
+++ b/bridge/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-bridge-core"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Botho"]
 edition = "2021"
 description = "Core types and logic for BTH bridge"

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-bridge-service"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Botho"]
 edition = "2021"
 description = "BTH bridge service for Ethereum and Solana"

--- a/cluster-tax/Cargo.toml
+++ b/cluster-tax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-cluster-tax"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = { workspace = true }

--- a/contracts/ethereum/package.json
+++ b/contracts/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wbth-ethereum",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Wrapped BTH ERC-20 token for Ethereum",
   "scripts": {
     "compile": "hardhat compile",

--- a/crypto/pq/Cargo.toml
+++ b/crypto/pq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-crypto-pq"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/secp256k1/Cargo.toml
+++ b/crypto/secp256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-crypto-secp256k1"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Botho"]
 edition = "2021"
 description = "Secp256k1 key support for Ethereum compatibility"

--- a/discover/Cargo.toml
+++ b/discover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-discover"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-gossip"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/infra/faucet/metrics-daemon/Cargo.toml
+++ b/infra/faucet/metrics-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-metrics-daemon"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Historical metrics collection daemon for Botho faucet"
 license = "MIT"

--- a/mobile/app/package.json
+++ b/mobile/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botho-mobile",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Botho Mobile Wallet",
   "main": "expo-router/entry",
   "scripts": {

--- a/mobile/rust-bridge/Cargo.toml
+++ b/mobile/rust-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-mobile"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Mobile FFI bindings for Botho wallet"
 license = "Apache-2.0"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botho-web",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @botho/web-wallet dev",

--- a/web/packages/desktop/src-tauri/Cargo.toml
+++ b/web/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-desktop"
-version = "0.1.0"
+version = "0.2.0"
 description = "Botho Desktop Wallet"
 authors = ["Botho"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Version bump **0.1.0 → 0.2.0**. This is a **consensus-breaking** release (MINOR bump in the 0.x line = coordinated network reset required — see #323).

Bumps all workspace `Cargo.toml`/`package.json` files + `Cargo.lock` via `scripts/version.sh`, and promotes the `[Unreleased]` CHANGELOG section to `[0.2.0]`.

## Highlights (full detail in CHANGELOG.md)

- **Supply integrity**: closed a critical inflation vector (output-sum overflow, #340); widened cumulative supply accounting to `u128` (#342, #346). Per-amount fields stay `u64` → wire format unchanged.
- **Emission schedule set**: ~1-year halvings, ~611M BTH Phase-1 supply, 2% perpetual tail, ~5yr to tail — chosen from an agent-based sweep (#350/#352/#362).
- **Docs reconciled**: README, `docs/`, and the whitepaper now all match the shipped schedule + 80/20 fee model (#321, #324, #364).
- **CI/test hardening**: revived fuzzing suite + consensus fuzz targets, rustfmt baseline + gate, benchmark CI fix, e2e hermeticity, flaky-test fixes.
- **Explorer**: block-by-hash / tx-by-hash lookups (#367).

## Test plan

- [x] `scripts/version.sh check` — all 16 version files in sync at 0.2.0
- [x] `cargo build -p botho` green
- [x] `cargo +nightly-2025-12-03 fmt --all -- --check` clean (the fmt CI gate)
- [ ] CI green on this PR
- [ ] After merge: tag `v0.2.0` on the merge commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)