### PR TITLE
fix(gossip): enable DNS resolver in libp2p transport for /dns4 bootstrap

### DIFF
--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -28,6 +28,7 @@ libp2p = { workspace = true, features = [
     "request-response",
     "noise",
     "tcp",
+    "dns",
     "yamux",
     "macros",
     "ed25519",

--- a/gossip/src/service.rs
+++ b/gossip/src/service.rs
@@ -220,6 +220,39 @@ impl GossipService {
     }
 }
 
+/// Build the libp2p swarm for the gossip service.
+///
+/// The base TCP transport is wrapped with a DNS resolver (`with_dns`) so that
+/// `/dns4/` and `/dns6/` multiaddrs resolve and dial. The default testnet
+/// bootstrap peer is `/dns4/seed.botho.io/tcp/17100`; without DNS support the
+/// transport rejects such hostname multiaddrs with `MultiaddrNotSupported`,
+/// leaving a default-configured node unable to bootstrap.
+fn build_swarm(config: &GossipConfig) -> GossipResult<Swarm<GossipBehaviour>> {
+    let swarm = SwarmBuilder::with_new_identity()
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )
+        .map_err(|e| GossipError::Libp2pError(e.to_string()))?
+        // Wrap the base TCP transport with a DNS resolver so that `/dns4/` and
+        // `/dns6/` multiaddrs (e.g. the default testnet bootstrap peer
+        // `/dns4/seed.botho.io/tcp/17100`) resolve and dial. Without this the
+        // transport rejects hostname multiaddrs with `MultiaddrNotSupported`.
+        .with_dns()
+        .map_err(|e| GossipError::Libp2pError(e.to_string()))?
+        .with_behaviour(|key| {
+            let local_peer_id = PeerId::from(key.public());
+            GossipBehaviour::new(local_peer_id, config).expect("Failed to create behaviour")
+        })
+        .map_err(|e| GossipError::Libp2pError(e.to_string()))?
+        .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(60)))
+        .build();
+
+    Ok(swarm)
+}
+
 /// Run the libp2p swarm.
 async fn run_swarm(
     config: GossipConfig,
@@ -229,21 +262,7 @@ async fn run_swarm(
     initial_announcement: NodeAnnouncement,
 ) -> GossipResult<()> {
     // Create the swarm
-    let mut swarm = SwarmBuilder::with_new_identity()
-        .with_tokio()
-        .with_tcp(
-            tcp::Config::default(),
-            noise::Config::new,
-            yamux::Config::default,
-        )
-        .map_err(|e| GossipError::Libp2pError(e.to_string()))?
-        .with_behaviour(|key| {
-            let local_peer_id = PeerId::from(key.public());
-            GossipBehaviour::new(local_peer_id, &config).expect("Failed to create behaviour")
-        })
-        .map_err(|e| GossipError::Libp2pError(e.to_string()))?
-        .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(60)))
-        .build();
+    let mut swarm = build_swarm(&config)?;
 
     // Subscribe to gossip topics
     swarm.behaviour_mut().subscribe_announcements()?;
@@ -691,6 +710,49 @@ mod tests {
             "1.0.0".to_string(),
             GossipConfig::default(),
         )
+    }
+
+    #[tokio::test]
+    async fn test_swarm_dials_dns4_multiaddr() {
+        // Regression test for the default testnet bootstrap peer being
+        // undialable: the transport must accept `/dns4/` multiaddrs rather than
+        // rejecting them with `MultiaddrNotSupported`.
+        let mut swarm = build_swarm(&GossipConfig::default()).expect("swarm should build with DNS");
+
+        // The shipped default testnet bootstrap address.
+        let addr = libp2p::Multiaddr::from_str("/dns4/seed.botho.io/tcp/17100")
+            .expect("valid dns4 multiaddr");
+
+        match swarm.dial(addr) {
+            Ok(()) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    !msg.contains("MultiaddrNotSupported") && !msg.contains("not supported"),
+                    "transport rejected /dns4/ multiaddr: {msg}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_swarm_dials_dns6_multiaddr() {
+        // DNS resolution should cover both /dns4/ and /dns6/.
+        let mut swarm = build_swarm(&GossipConfig::default()).expect("swarm should build with DNS");
+
+        let addr = libp2p::Multiaddr::from_str("/dns6/seed.botho.io/tcp/17100")
+            .expect("valid dns6 multiaddr");
+
+        match swarm.dial(addr) {
+            Ok(()) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    !msg.contains("MultiaddrNotSupported") && !msg.contains("not supported"),
+                    "transport rejected /dns6/ multiaddr: {msg}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The gossip libp2p transport was built with bare TCP and **no DNS resolver**, so `/dns4/` and `/dns6/` multiaddrs were rejected with `MultiaddrNotSupported`. The shipped default testnet bootstrap peer is `/dns4/seed.botho.io/tcp/17100` (`botho/src/config.rs:189`), so a node using the shipped defaults could not dial the seed and `peerCount` stayed 0. This was found by the #373 betanet-join smoke test, which worked around it by resolving the host to an `/ip4/` literal.

## Root Cause

In `gossip/src/service.rs`, `run_swarm` built the swarm via `SwarmBuilder...with_tcp(...).with_behaviour(...)`. The `with_dns()` builder phase (which wraps the base transport in `libp2p_dns::tokio::Transport::system(...)`) was never called, and the `dns` feature was absent from the libp2p dependency. With no DNS resolver in the transport stack, hostname multiaddrs cannot be resolved or dialed.

## Fix (chosen: enable DNS in the transport)

Per the issue's preferred option, DNS support is enabled in the transport itself rather than pre-resolving hostnames to IP literals (which would lose DNS re-resolution and risk staleness if the seed's EIP changes). The default `/dns4/seed.botho.io/tcp/17100` bootstrap entry is kept and now works out-of-the-box.

## Changes

- `gossip/Cargo.toml`: add the `dns` feature to the `libp2p` dependency (pulls in `libp2p-dns`; no new entries in `Cargo.lock` — the dep tree already contained it transitively).
- `gossip/src/service.rs`:
  - Add `.with_dns()` after `.with_tcp(...)` so the transport resolves and dials `/dns4/` and `/dns6/` multiaddrs.
  - Extract swarm construction into a `build_swarm(config)` helper so it is unit-testable.
  - Add regression tests `test_swarm_dials_dns4_multiaddr` and `test_swarm_dials_dns6_multiaddr` asserting a dns4/dns6 dial does not fail with `MultiaddrNotSupported`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `/dns4/` multiaddr accepted/dialable (no `MultiaddrNotSupported`) | done | New `test_swarm_dials_dns4_multiaddr` passes; `swarm.dial("/dns4/seed.botho.io/tcp/17100")` no longer rejected |
| `/dns6/` also supported | done | New `test_swarm_dials_dns6_multiaddr` passes |
| Default testnet bootstrap works out-of-the-box (no IP substitution) | done | Default `/dns4/seed.botho.io/tcp/17100` is now dialable by the DNS-wrapped transport |
| Existing network/gossip tests still pass | done | `cargo test -p bth-gossip` 63 passed |
| Build green | done | `cargo build -p bth-gossip` succeeds |
| rustfmt-clean (pinned nightly) | done | `cargo +nightly-2025-12-03 fmt --all -- --check` clean |

## Test Plan

- `cargo build -p bth-gossip` — green.
- `cargo test -p bth-gossip` — 63 passed (incl. 2 new DNS tests).
- `cargo test -p botho` — passes; one unrelated test (`byzantine_integration::test_random_message_drops`, a random-seed message-drop simulation) flaked once and passed on re-run — not related to this transport change.
- `cargo +nightly-2025-12-03 fmt --all -- --check` — clean.

Note: real-dial verification against the live seed was not run from the node binary; the unit-level dial test confirms the transport now accepts `/dns4/`/`/dns6/` instead of returning `MultiaddrNotSupported`.

Closes #375