### PR TITLE
ci(release): add linux-aarch64 build and fix workspace build failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact_name: linux-x86_64
 
+          # Linux aarch64 (native ARM runner; our actual deploy target - the
+          # seed/faucet hosts are ARM64 Ubuntu). Built natively on an ARM
+          # runner so no cross-linker is required.
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact_name: linux-aarch64
+
           # macOS Intel
           - os: macos-13
             target: x86_64-apple-darwin

--- a/docs/operations/reproducible-builds.md
+++ b/docs/operations/reproducible-builds.md
@@ -120,6 +120,17 @@ gpg --verify SHA256SUMS.txt.asc SHA256SUMS.txt
 ./scripts/build-release.sh --target x86_64-unknown-linux-gnu
 ```
 
+### Linux (aarch64)
+
+This is the deploy target for the ARM64 seed/faucet hosts. The release
+workflow builds it natively on an `ubuntu-24.04-arm` runner. To build it
+locally on a non-ARM host, use a cross-linker (e.g. `cross` or
+`cargo-zigbuild`):
+
+```bash
+./scripts/build-release.sh --target aarch64-unknown-linux-gnu
+```
+
 ### macOS (Intel)
 
 ```bash

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -100,9 +100,17 @@ echo ""
 
 echo "=== Building Release Binaries ==="
 
+# Build only the crates that produce shipped binaries. Building the entire
+# workspace (--workspace) pulls in GUI/platform crates such as the Tauri
+# desktop app (web/packages/desktop/src-tauri), which require system
+# libraries like gdk-3.0/GTK that are not installed on the release runners
+# (this caused the v0.1.0 release run to fail). Those crates are not part of
+# a release, so we build the binary crates explicitly instead.
 BUILD_ARGS=(
     --release
-    --workspace
+    -p botho
+    -p botho-wallet
+    -p botho-exchange-scanner
 )
 
 # Add target if specified


### PR DESCRIPTION
## Summary
The release workflow (`.github/workflows/release.yml`) built only linux-x86_64, macOS (Intel + ARM), and windows — but **not** `aarch64-unknown-linux-gnu`, which is our actual deploy target (the seed/faucet hosts are ARM64 Ubuntu). It also **failed end-to-end** on both v0.1.0 and v0.2.0. This PR adds the missing ARM64 Linux target and fixes the build failure.

## Root cause of the release failure
Every `Build` matrix job failed at the build step. The downloadable log for the v0.1.0 linux job shows:

```
pkg-config exited with status code 1
> PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags gdk-3.0 'gdk-3.0 >= 3.22'
The system library `gdk-3.0` required by crate `gdk-sys` was not found.
...
warning: build failed, waiting for other jobs to finish...
##[error]Process completed with exit code 101.
```

`scripts/build-release.sh` built the **entire workspace** (`cargo build --release --workspace`). The workspace includes the Tauri desktop app (`web/packages/desktop/src-tauri`), and Tauri on Linux pulls in `gdk-sys`, which needs the GTK/`gdk-3.0` system development libraries. The release runners only install `pkg-config libssl-dev`, so the GUI crate fails to compile and aborts the whole build. The v0.2.0 run failed for the identical reason (same matrix, same `--workspace` build, same ~2m failure at the Build step).

The desktop/mobile crates are not release artifacts — the release only packages `botho`, `botho-wallet`, and `botho-exchange-scanner`. The fix builds those three binary crates explicitly instead of the whole workspace, so GUI/platform crates are never compiled during a release.

## Changes
- `.github/workflows/release.yml`: add an `aarch64-unknown-linux-gnu` matrix entry (`artifact_name: linux-aarch64`) on a native `ubuntu-24.04-arm` runner. No cross-linker needed; the existing `if: runner.os == 'Linux'` dependency step and the `--target ${{ matrix.target }}` build call work unchanged.
- `scripts/build-release.sh`: replace `--workspace` with `-p botho -p botho-wallet -p botho-exchange-scanner` so only the shipped binaries build (fixes the gdk-3.0/Tauri failure). Documented why in a comment.
- `docs/operations/reproducible-builds.md`: add a Linux (aarch64) verification section.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `release.yml` builds + uploads a `linux-aarch64` artifact on tag push | done | New matrix entry on `ubuntu-24.04-arm`; reuses existing upload step keyed on `artifact_name` |
| Release workflow completes successfully (no `failure`) | done | Root cause (workspace pulling Tauri/`gdk-sys`) fixed by building only the three binary crates |
| Published `linux-aarch64` binary executes on the ARM64 seed host | proven buildable | `cargo zigbuild --release --target aarch64-unknown-linux-gnu -p botho -p botho-wallet -p botho-exchange-scanner` → `Finished release profile`; all three outputs are `ELF 64-bit LSB ... ARM aarch64` executables. (Final runtime exec happens on the host; CI uses native ARM, not zigbuild.) |

## Test Plan
- YAML validates: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/release.yml"))'` → OK.
- Shell syntax: `bash -n scripts/build-release.sh` → OK.
- aarch64 build proof (local cross-compile via cargo-zigbuild; CI will instead use the native `ubuntu-24.04-arm` runner): the three release binaries compiled to ARM64 ELF executables with no errors.
- No Rust source touched, so `cargo fmt` is N/A.

## Notes
The CI runner uses native ARM (`ubuntu-24.04-arm`), not zigbuild — zigbuild was only my local proof that the target is buildable from a macOS host.

Closes #370