### PR TITLE
fix(network): drive chain-sync state machine for IBD / catch-up (#376)

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -27,8 +27,8 @@ use crate::{
         TransactionValidator,
     },
     network::{
-        BlockTxn, CompactBlock, GetBlockTxn, NetworkDiscovery, NetworkEvent, QuorumBuilder,
-        ReconstructionResult,
+        BlockTxn, ChainSyncManager, CompactBlock, GetBlockTxn, NetworkDiscovery, NetworkEvent,
+        QuorumBuilder, ReconstructionResult, SyncAction, SyncRequest, SyncResponse,
     },
     node::{MintedMintingTx, Node, SharedLedger},
     rpc::{
@@ -49,6 +49,15 @@ fn get_connected_peer_ids(discovery: &NetworkDiscovery) -> Vec<String> {
         .iter()
         .map(|p| p.peer_id.to_string())
         .collect()
+}
+
+/// Helper to get connected peers as libp2p `PeerId`s.
+///
+/// Used to drive the chain-sync state machine, which needs the typed peer
+/// identifiers (not their string form) to address sync request/response
+/// messages.
+fn get_connected_peers(discovery: &NetworkDiscovery) -> Vec<libp2p::PeerId> {
+    discovery.peer_table().iter().map(|p| p.peer_id).collect()
 }
 
 /// Check if minting should be enabled based on quorum config and connected
@@ -347,6 +356,11 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // Build SCP quorum set from connected peers (or just ourselves for solo mining)
     let scp_quorum_set = build_scp_quorum_set(&quorum, &local_peer_id);
 
+    // Capture the starting height before chain_state is moved into the
+    // consensus service; the sync state machine needs it to know how far
+    // behind the network we are at startup.
+    let local_height = chain_state.height;
+
     // Update initial metrics before chain_state is moved
     metrics_updater.set_block_height(chain_state.height);
     metrics_updater.set_difficulty(chain_state.difficulty);
@@ -368,6 +382,15 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
         "Consensus service initialized at slot {}",
         consensus.current_slot()
     );
+
+    // Chain-sync state machine: drives initial block download (IBD) / catch-up.
+    //
+    // A node joining an existing chain only learns about the current tip via
+    // gossip; that tip is rejected by the ledger because the intermediate
+    // blocks are missing ("Expected height 1, got N"). The sync manager closes
+    // this gap by polling peers for their chain status and, when we are behind,
+    // requesting the missing block range and applying it sequentially.
+    let mut sync_manager = ChainSyncManager::new(local_height);
 
     // Track minting state - can change as peers connect/disconnect
     let mut minting_enabled = false;
@@ -422,6 +445,11 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // Run the combined event loop
     let mut status_interval = tokio::time::interval(Duration::from_secs(10));
     let mut consensus_tick = tokio::time::interval(Duration::from_millis(500));
+    // Drive the chain-sync (IBD / catch-up) state machine. A short interval
+    // keeps a freshly joined node requesting peer status and missing block
+    // ranges promptly so it can reach the network tip without waiting on
+    // gossip alone.
+    let mut sync_tick = tokio::time::interval(Duration::from_secs(2));
     let mut minting_check_interval = tokio::time::interval(Duration::from_millis(100));
     let mut faucet_balance_interval = tokio::time::interval(Duration::from_secs(10));
 
@@ -551,6 +579,9 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                         }
                         NetworkEvent::PeerDisconnected(peer_id) => {
                             warn!("Peer disconnected: {}", peer_id);
+                            // Drop any sync state tied to this peer so we
+                            // re-discover and re-select a sync source.
+                            sync_manager.on_peer_disconnected(&peer_id);
                             let new_peer_count = discovery.peer_count();
 
                             // Update RPC peer count and metrics
@@ -585,7 +616,6 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             }
                         }
                         NetworkEvent::SyncRequest { peer, request_id: _, request, channel } => {
-                            use crate::network::{SyncRequest, SyncResponse};
                             debug!("Sync request from {:?}: {:?}", peer, request);
                             // Handle the sync request
                             let shared_ledger = node.shared_ledger();
@@ -619,45 +649,65 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                                 warn!("Failed to send sync response: {:?}", e);
                             }
                         }
-                        NetworkEvent::SyncResponse { peer: _, request_id: _, response } => {
-                            use crate::network::SyncResponse;
+                        NetworkEvent::SyncResponse { peer, request_id: _, response } => {
                             match response {
-                                SyncResponse::Blocks { blocks, has_more: _ } => {
-                                    debug!("Received {} blocks from sync", blocks.len());
-                                    for block in &blocks {
-                                        if let Err(e) = node.add_block_from_network(block) {
-                                            warn!("Failed to add synced block: {}", e);
-                                            break;
+                                SyncResponse::Blocks { blocks, has_more } => {
+                                    debug!("Received {} blocks from sync (has_more={})", blocks.len(), has_more);
+                                    // Hand the batch to the sync state machine so it can
+                                    // advance its download cursor and decide what to fetch
+                                    // next. Blocks are applied sequentially via the ledger,
+                                    // which is what lets a fresh node catch up to a chain
+                                    // that is already at height N.
+                                    if let Some(SyncAction::AddBlocks(blocks)) =
+                                        sync_manager.on_blocks(&peer, blocks, has_more)
+                                    {
+                                        let mut applied_any = false;
+                                        for block in &blocks {
+                                            if let Err(e) = node.add_block_from_network(block) {
+                                                warn!("Failed to add synced block {}: {}", block.height(), e);
+                                                sync_manager.on_failure(Some(&peer), e.to_string());
+                                                break;
+                                            }
+                                            applied_any = true;
+                                            // Record for dynamic timing
+                                            consensus.record_block(block.header.timestamp, block.transactions.len());
                                         }
-                                        // Record for dynamic timing
-                                        consensus.record_block(block.header.timestamp, block.transactions.len());
-                                    }
-                                    // Update dynamic fee after syncing all blocks (use last block's tx count)
-                                    if let Some(last_block) = blocks.last() {
-                                        let slot_duration = consensus.current_slot_duration();
-                                        let at_min_time = ConsensusConfig::is_at_min_block_time(
-                                            &ConsensusConfig::default(),
-                                            slot_duration,
-                                        );
-                                        let max_txs = ConsensusConfig::default().max_txs_per_slot;
-                                        node.update_dynamic_fee_after_block(
-                                            last_block.transactions.len(),
-                                            max_txs,
-                                            at_min_time,
-                                        );
-                                    }
-                                    // Update consensus chain state
-                                    if let Ok(ledger) = node.shared_ledger().read() {
-                                        if let Ok(state) = ledger.get_chain_state() {
-                                            consensus.update_chain_state(state);
+
+                                        if applied_any {
+                                            // Update dynamic fee after syncing (use last block's tx count)
+                                            if let Some(last_block) = blocks.last() {
+                                                let slot_duration = consensus.current_slot_duration();
+                                                let at_min_time = ConsensusConfig::is_at_min_block_time(
+                                                    &ConsensusConfig::default(),
+                                                    slot_duration,
+                                                );
+                                                let max_txs = ConsensusConfig::default().max_txs_per_slot;
+                                                node.update_dynamic_fee_after_block(
+                                                    last_block.transactions.len(),
+                                                    max_txs,
+                                                    at_min_time,
+                                                );
+                                            }
+                                            // Update consensus chain state and inform the
+                                            // sync manager of our new height so it can tell
+                                            // whether we have caught up to the target.
+                                            if let Ok(ledger) = node.shared_ledger().read() {
+                                                if let Ok(state) = ledger.get_chain_state() {
+                                                    metrics_updater.set_block_height(state.height);
+                                                    sync_manager.on_blocks_added(state.height);
+                                                    consensus.update_chain_state(state);
+                                                }
+                                            }
                                         }
                                     }
                                 }
                                 SyncResponse::Status { height, tip_hash } => {
-                                    debug!("Peer at height {} with tip {}", height, hex::encode(&tip_hash[0..8]));
+                                    debug!("Peer {:?} at height {} with tip {}", peer, height, hex::encode(&tip_hash[0..8]));
+                                    sync_manager.on_status(peer, height, tip_hash);
                                 }
                                 SyncResponse::Error(e) => {
-                                    warn!("Sync error from peer: {}", e);
+                                    warn!("Sync error from peer {:?}: {}", peer, e);
+                                    sync_manager.on_failure(Some(&peer), e);
                                 }
                             }
                         }
@@ -1027,6 +1077,52 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                     if minting_enabled { "active" } else { "inactive" },
                     quorum_status
                 );
+            }
+
+            // Chain sync (IBD / catch-up) tick. Drives the sync state machine,
+            // emitting status/block requests as needed so a node behind the
+            // network tip backfills the missing blocks from a peer.
+            _ = sync_tick.tick() => {
+                // Keep the sync manager's view of our local height current so
+                // it can detect when we have fallen behind (e.g. after gossip
+                // delivered blocks, or a peer advanced past us).
+                if let Ok(ledger) = node.shared_ledger().read() {
+                    if let Ok(state) = ledger.get_chain_state() {
+                        sync_manager.set_local_height(state.height);
+                    }
+                }
+
+                let connected = get_connected_peers(&discovery);
+                if let Some(action) = sync_manager.tick(&connected) {
+                    match action {
+                        SyncAction::RequestStatus(peer) => {
+                            debug!("Sync: requesting status from {:?}", peer);
+                            sync_manager.on_request_sent(peer);
+                            NetworkDiscovery::send_sync_request(&mut swarm, peer, SyncRequest::GetStatus);
+                        }
+                        SyncAction::RequestBlocks { peer, start_height, count } => {
+                            debug!(
+                                "Sync: requesting blocks [{}..{}] from {:?}",
+                                start_height,
+                                start_height + count as u64 - 1,
+                                peer
+                            );
+                            sync_manager.on_request_sent(peer);
+                            NetworkDiscovery::send_sync_request(
+                                &mut swarm,
+                                peer,
+                                SyncRequest::GetBlocks { start_height, count },
+                            );
+                        }
+                        SyncAction::Synced => {
+                            debug!("Sync: caught up with network tip");
+                        }
+                        SyncAction::AddBlocks(_) | SyncAction::Wait(_) => {
+                            // AddBlocks is produced only by on_blocks() (handled
+                            // in the SyncResponse arm); Wait is advisory.
+                        }
+                    }
+                }
             }
 
             // Check for minted minting transactions

--- a/botho/src/network/sync.rs
+++ b/botho/src/network/sync.rs
@@ -48,6 +48,14 @@ pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// Blocks behind threshold before re-syncing
 pub const SYNC_BEHIND_THRESHOLD: u64 = 10;
 
+/// How often a synced node re-polls peers for their chain status.
+///
+/// While `Synced`, the manager has no other way to learn that a peer has
+/// advanced (status is request/response, not gossiped). Periodically
+/// re-requesting status lets a long-running node detect that the chain grew
+/// and re-enter catch-up, instead of relying solely on gossiped tip blocks.
+pub const STATUS_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+
 // ============================================================================
 // Protocol Messages
 // ============================================================================
@@ -341,6 +349,8 @@ pub struct ChainSyncManager {
     retry_backoff: Duration,
     /// Peer reputation tracking for sync selection
     reputation: ReputationManager,
+    /// Last time we re-polled peers for status while synced
+    last_status_refresh: Instant,
 }
 
 impl ChainSyncManager {
@@ -354,6 +364,7 @@ impl ChainSyncManager {
             rate_limiter: SyncRateLimiter::default(),
             retry_backoff: Duration::from_secs(5),
             reputation: ReputationManager::new(),
+            last_status_refresh: Instant::now(),
         }
     }
 
@@ -401,8 +412,11 @@ impl ChainSyncManager {
             },
         );
 
-        // If in discovery and we have at least one peer ahead, start downloading
-        if matches!(self.state, SyncState::Discovery) {
+        // If we're not already downloading and a peer is far enough ahead,
+        // (re)enter catch-up. This covers both the initial join (Discovery) and
+        // a synced node that just learned, via a status refresh, that a peer
+        // advanced past us.
+        if !matches!(self.state, SyncState::Downloading { .. }) {
             if let Some((best_peer, status)) = self.best_peer() {
                 if status.height > self.local_height + SYNC_BEHIND_THRESHOLD {
                     self.state = SyncState::Downloading {
@@ -410,8 +424,8 @@ impl ChainSyncManager {
                         target_height: status.height,
                     };
                     self.download_height = self.local_height;
-                } else {
-                    // We're close enough, consider synced
+                } else if matches!(self.state, SyncState::Discovery) {
+                    // We're close enough during initial discovery: synced.
                     self.state = SyncState::Synced;
                 }
             }
@@ -617,7 +631,7 @@ impl ChainSyncManager {
             }
 
             SyncState::Synced => {
-                // Check if we've fallen behind
+                // Check if we've fallen behind based on the statuses we have.
                 if let Some((best_peer, status)) = self.best_peer() {
                     if status.height > self.local_height + SYNC_BEHIND_THRESHOLD {
                         self.state = SyncState::Downloading {
@@ -625,6 +639,18 @@ impl ChainSyncManager {
                             target_height: status.height,
                         };
                         self.download_height = self.local_height;
+                        return None;
+                    }
+                }
+
+                // Periodically re-poll a peer for its status. Status is
+                // request/response (not gossiped), so without this a synced
+                // node would never learn that a peer advanced and would rely
+                // solely on gossiped tip blocks to stay current.
+                if self.last_status_refresh.elapsed() >= STATUS_REFRESH_INTERVAL {
+                    if let Some(peer) = connected_peers.first() {
+                        self.last_status_refresh = Instant::now();
+                        return Some(SyncAction::RequestStatus(*peer));
                     }
                 }
                 None
@@ -1284,5 +1310,110 @@ mod tests {
     #[test]
     fn test_request_timeout_constant() {
         assert_eq!(REQUEST_TIMEOUT, Duration::from_secs(30));
+    }
+
+    // ========================================================================
+    // Catch-up / IBD re-entry tests (#376)
+    // ========================================================================
+
+    #[test]
+    fn test_synced_node_reenters_download_on_fresh_status() {
+        // A node that already caught up should re-enter Downloading when a
+        // fresh status shows the peer has advanced well beyond us.
+        let mut manager = ChainSyncManager::new(100);
+        let peer = make_peer_id();
+
+        // Initial status: peer at our height -> Synced.
+        manager.on_status(peer, 100, [1u8; 32]);
+        assert!(manager.is_synced());
+
+        // Our height stays 100, peer jumps to 250 (a fresh status arrives).
+        manager.on_status(peer, 250, [2u8; 32]);
+
+        assert!(matches!(
+            manager.state(),
+            SyncState::Downloading {
+                target_height: 250,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_synced_node_refreshes_status_after_interval() {
+        let mut manager = ChainSyncManager::new(100);
+        let peer = make_peer_id();
+
+        // Reach Synced.
+        manager.on_status(peer, 100, [1u8; 32]);
+        assert!(manager.is_synced());
+
+        // Force the refresh timer into the past so the next tick re-polls.
+        manager.last_status_refresh =
+            Instant::now() - STATUS_REFRESH_INTERVAL - Duration::from_secs(1);
+
+        let action = manager.tick(&[peer]);
+        assert!(
+            matches!(action, Some(SyncAction::RequestStatus(p)) if p == peer),
+            "synced node should re-request status after the refresh interval"
+        );
+    }
+
+    #[test]
+    fn test_synced_node_no_refresh_without_peers() {
+        let mut manager = ChainSyncManager::new(100);
+        let peer = make_peer_id();
+        manager.on_status(peer, 100, [1u8; 32]);
+        assert!(manager.is_synced());
+
+        manager.last_status_refresh =
+            Instant::now() - STATUS_REFRESH_INTERVAL - Duration::from_secs(1);
+
+        // No connected peers: nothing to request.
+        let action = manager.tick(&[]);
+        assert!(action.is_none());
+    }
+
+    #[test]
+    fn test_full_catchup_cycle_from_genesis() {
+        // End-to-end of the state machine: genesis node discovers a peer at a
+        // high height, downloads the full range in batches, and ends Synced.
+        let mut manager = ChainSyncManager::new(0);
+        let peer = make_peer_id();
+        let target = 250u64;
+
+        // Discovery -> request status.
+        assert!(matches!(
+            manager.tick(&[peer]),
+            Some(SyncAction::RequestStatus(_))
+        ));
+        manager.on_status(peer, target, [9u8; 32]);
+        assert!(matches!(manager.state(), SyncState::Downloading { .. }));
+
+        // Drive batched downloads until synced.
+        let mut height = 0u64;
+        for _ in 0..100 {
+            if manager.is_synced() {
+                break;
+            }
+            match manager.tick(&[peer]) {
+                Some(SyncAction::RequestBlocks {
+                    start_height,
+                    count,
+                    ..
+                }) => {
+                    assert_eq!(start_height, height + 1);
+                    let end = (start_height + count as u64 - 1).min(target);
+                    let blocks_added = end - start_height + 1;
+                    height += blocks_added;
+                    manager.on_blocks_added(height);
+                }
+                Some(SyncAction::Synced) => break,
+                other => panic!("unexpected action while downloading: {:?}", other),
+            }
+        }
+
+        assert!(manager.is_synced());
+        assert_eq!(height, target);
     }
 }

--- a/botho/tests/chain_sync_catchup_integration.rs
+++ b/botho/tests/chain_sync_catchup_integration.rs
@@ -1,0 +1,447 @@
+// Copyright (c) 2024 Botho Foundation
+//
+//! Chain-sync (initial block download / catch-up) integration tests.
+//!
+//! Regression coverage for #376: a node joining an existing chain (peer tip at
+//! height N) could not sync the historical blocks. It only received the current
+//! tip via gossip and rejected it ("Expected height 1, got N"), staying at
+//! height 0 forever, because the `ChainSyncManager` state machine — although
+//! implemented — was never driven and no node ever requested the missing block
+//! range.
+//!
+//! These tests exercise the *production* `ChainSyncManager` against real
+//! LMDB-backed ledgers. They simulate the request/response loop that the node
+//! event loop now runs (see `commands/run.rs`): a fresh node detects it is
+//! behind a peer, requests the missing range, and applies the blocks
+//! sequentially via the ledger's `add_block` — the exact path where the
+//! "Expected height" error originated. Driving the real state machine + real
+//! ledger (rather than libp2p networking, which is non-deterministic in a unit
+//! test) gives a fast, deterministic proof that the catch-up path works.
+
+use std::time::SystemTime;
+
+use libp2p::PeerId;
+use serial_test::serial;
+use tempfile::TempDir;
+
+use botho::{
+    block::{Block, BlockHeader, BlockLotterySummary, MintingTx},
+    ledger::Ledger,
+    network::{ChainSyncManager, SyncAction, SyncRequest, SyncResponse},
+    transaction::{Transaction, PICOCREDITS_PER_CREDIT},
+};
+use botho_wallet::WalletKeys;
+use bth_account_keys::PublicAddress;
+use sha2::{Digest, Sha256};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const TEST_BLOCK_REWARD: u64 = 50 * PICOCREDITS_PER_CREDIT;
+const TRIVIAL_DIFFICULTY: u64 = 0x00FF_FFFF_FFFF_FFFF;
+
+/// Ring size floor: the existing all-at-genesis tests never push a node past a
+/// few blocks; #376 specifically requires syncing a chain "of height N > ring
+/// size", so we build well past this.
+const RING_SIZE: u64 = 20;
+
+// ============================================================================
+// Block-building helpers (mirror ledger_consistency_integration.rs)
+// ============================================================================
+
+fn create_test_wallet() -> WalletKeys {
+    let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+    WalletKeys::from_mnemonic(mnemonic).expect("Failed to create wallet from mnemonic")
+}
+
+fn create_mock_minting_tx(
+    height: u64,
+    reward: u64,
+    minter_address: &PublicAddress,
+    prev_block_hash: [u8; 32],
+) -> MintingTx {
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let mut minting_tx = MintingTx::new(
+        height,
+        reward,
+        minter_address,
+        prev_block_hash,
+        TRIVIAL_DIFFICULTY,
+        timestamp,
+    );
+
+    for nonce in 0..u64::MAX {
+        minting_tx.nonce = nonce;
+        if minting_tx.verify_pow() {
+            break;
+        }
+    }
+
+    minting_tx
+}
+
+/// Build (but do not apply) the next block on top of the ledger's tip.
+fn mine_block(
+    ledger: &Ledger,
+    minter_address: &PublicAddress,
+    transactions: Vec<Transaction>,
+) -> Block {
+    let state = ledger.get_chain_state().expect("Failed to get chain state");
+    let prev_block = ledger.get_tip().expect("Failed to get tip");
+    let prev_hash = prev_block.hash();
+    let height = state.height + 1;
+
+    let minting_tx = create_mock_minting_tx(height, TEST_BLOCK_REWARD, minter_address, prev_hash);
+
+    let tx_root = if transactions.is_empty() {
+        [0u8; 32]
+    } else {
+        let mut hasher = Sha256::new();
+        for tx in &transactions {
+            hasher.update(tx.hash());
+        }
+        hasher.finalize().into()
+    };
+
+    Block {
+        header: BlockHeader {
+            version: 1,
+            prev_block_hash: prev_hash,
+            tx_root,
+            timestamp: minting_tx.timestamp,
+            height: minting_tx.block_height,
+            difficulty: minting_tx.difficulty,
+            nonce: minting_tx.nonce,
+            minter_view_key: minting_tx.minter_view_key,
+            minter_spend_key: minting_tx.minter_spend_key,
+        },
+        minting_tx,
+        transactions,
+        lottery_outputs: Vec::new(),
+        lottery_summary: BlockLotterySummary::default(),
+    }
+}
+
+/// Build a chain in `ledger` up to `target_height` (empty blocks).
+fn build_chain_to_height(ledger: &Ledger, minter: &PublicAddress, target_height: u64) {
+    while ledger.get_chain_state().unwrap().height < target_height {
+        let block = mine_block(ledger, minter, vec![]);
+        ledger.add_block(&block).expect("Failed to add block");
+    }
+}
+
+/// Serve a `GetBlocks` request from a source ledger, exactly as the node event
+/// loop does in `commands/run.rs`.
+fn serve_get_blocks(source: &Ledger, start_height: u64, count: u32) -> SyncResponse {
+    let mut blocks = Vec::new();
+    let end_height = start_height.saturating_add(count as u64).saturating_sub(1);
+    for height in start_height..=end_height.min(start_height + 99) {
+        if let Ok(block) = source.get_block(height) {
+            blocks.push(block);
+        } else {
+            break;
+        }
+    }
+    let has_more = blocks.len() == count as usize;
+    SyncResponse::Blocks { blocks, has_more }
+}
+
+/// Run the chain-sync state machine for a fresh `node` ledger against a
+/// `source` ledger that is already at some height, mirroring the production
+/// request/response dispatch in `commands/run.rs`. Returns the number of sync
+/// iterations performed (for sanity assertions).
+///
+/// This is the in-process analogue of: node B connects to node A, discovers A
+/// is ahead, requests the missing block range, and applies it sequentially.
+fn run_catchup(
+    sync_manager: &mut ChainSyncManager,
+    node: &Ledger,
+    source: &Ledger,
+    peer: PeerId,
+) -> usize {
+    let source_state = source.get_chain_state().unwrap();
+    let connected = [peer];
+
+    let mut iterations = 0;
+    // Generous cap: each iteration makes forward progress (status, or a batch
+    // of up to 100 blocks). A runaway loop indicates a real bug, not a slow
+    // sync, so the cap doubles as a liveness assertion.
+    let max_iterations = 10_000;
+
+    loop {
+        iterations += 1;
+        assert!(
+            iterations < max_iterations,
+            "chain sync did not converge within {} iterations",
+            max_iterations
+        );
+
+        // Keep the manager's view of our height current, as the node does on
+        // every sync tick.
+        sync_manager.set_local_height(node.get_chain_state().unwrap().height);
+
+        let Some(action) = sync_manager.tick(&connected) else {
+            // No action this tick.
+            if node.get_chain_state().unwrap().height >= source_state.height {
+                break;
+            }
+            // We are still behind but the manager produced no action (e.g. it
+            // is Synced against a stale status because the peer advanced after
+            // our last poll). Feed it a fresh status, as the node does when a
+            // periodic status refresh or gossiped tip arrives, so it re-enters
+            // catch-up.
+            sync_manager.on_status(peer, source_state.height, source_state.tip_hash);
+            continue;
+        };
+
+        match action {
+            SyncAction::RequestStatus(p) => {
+                assert_eq!(p, peer);
+                sync_manager.on_request_sent(p);
+                // Source answers with its current status.
+                sync_manager.on_status(p, source_state.height, source_state.tip_hash);
+            }
+            SyncAction::RequestBlocks {
+                peer: p,
+                start_height,
+                count,
+            } => {
+                assert_eq!(p, peer);
+                sync_manager.on_request_sent(p);
+                // Source answers with the requested block range.
+                let SyncResponse::Blocks { blocks, has_more } =
+                    serve_get_blocks(source, start_height, count)
+                else {
+                    panic!("expected Blocks response");
+                };
+
+                if let Some(SyncAction::AddBlocks(blocks)) =
+                    sync_manager.on_blocks(&p, blocks, has_more)
+                {
+                    for block in &blocks {
+                        node.add_block(block).unwrap_or_else(|e| {
+                            panic!("failed to apply synced block {}: {}", block.height(), e)
+                        });
+                    }
+                    let new_height = node.get_chain_state().unwrap().height;
+                    sync_manager.on_blocks_added(new_height);
+                }
+            }
+            SyncAction::Synced => break,
+            SyncAction::Wait(_) | SyncAction::AddBlocks(_) => {}
+        }
+
+        if sync_manager.is_synced() && node.get_chain_state().unwrap().height >= source_state.height
+        {
+            break;
+        }
+    }
+
+    iterations
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// Core regression test for #376.
+///
+/// Node B starts with an empty ledger (genesis only, height 0) and joins a peer
+/// (node A) whose chain is already at height N (> ring size). B must sync all
+/// the way to A's tip via the chain-sync state machine. This is distinct from
+/// the existing `e2e_consensus_integration` tests, where every node starts at
+/// genesis and grows in lockstep — so no node ever has to *catch up*.
+#[test]
+#[serial]
+fn test_fresh_node_syncs_existing_chain_to_tip() {
+    let target_height = RING_SIZE + 75; // 95 — well past ring size, mirrors the betanet repro
+
+    // --- Source node A: build a chain to height N ---
+    let source_dir = TempDir::new().unwrap();
+    let source = Ledger::open(source_dir.path()).unwrap();
+    let minter = create_test_wallet().public_address();
+    build_chain_to_height(&source, &minter, target_height);
+
+    let source_state = source.get_chain_state().unwrap();
+    assert_eq!(source_state.height, target_height, "source built to target");
+
+    // --- Fresh node B: empty ledger at genesis ---
+    let node_dir = TempDir::new().unwrap();
+    let node = Ledger::open(node_dir.path()).unwrap();
+    assert_eq!(
+        node.get_chain_state().unwrap().height,
+        0,
+        "fresh node starts at genesis"
+    );
+
+    // Sanity: confirm the bug's symptom — gossiping the tip block alone to a
+    // fresh node is rejected, because the intermediate blocks are missing.
+    let tip_block = source.get_block(target_height).unwrap();
+    let rejected = node.add_block(&tip_block);
+    assert!(
+        rejected.is_err(),
+        "tip block should be rejected by a genesis node (the #376 symptom)"
+    );
+
+    // --- Drive the catch-up state machine ---
+    let mut sync_manager = ChainSyncManager::new(0);
+    let peer = PeerId::random();
+    let iterations = run_catchup(&mut sync_manager, &node, &source, peer);
+
+    // --- Verify B reached the tip and matches A exactly ---
+    let node_state = node.get_chain_state().unwrap();
+    assert_eq!(
+        node_state.height, target_height,
+        "fresh node should have synced to the source tip height"
+    );
+    assert_eq!(
+        node_state.tip_hash, source_state.tip_hash,
+        "fresh node tip hash must match the source chain tip"
+    );
+    assert!(
+        sync_manager.is_synced(),
+        "sync manager should report Synced after catching up"
+    );
+
+    // The sync should have completed in a reasonable number of round trips:
+    // 1 status + ceil(95/100) = 1 block batch, plus a couple of housekeeping
+    // ticks. This guards against a regression that re-requests the same range.
+    assert!(
+        iterations < 50,
+        "catch-up took an unexpected number of iterations: {}",
+        iterations
+    );
+
+    // Every historical block must be present and walkable.
+    for h in 1..=target_height {
+        let block = node
+            .get_block(h)
+            .unwrap_or_else(|e| panic!("synced node missing block {}: {}", h, e));
+        assert_eq!(block.height(), h);
+    }
+}
+
+/// A node that is only slightly behind (within the sync-behind threshold) does
+/// not trigger an initial block download; it is considered synced. This guards
+/// the boundary so we don't thrash on every small gossip lag.
+#[test]
+#[serial]
+fn test_node_close_to_tip_does_not_trigger_ibd() {
+    // Local height 100, peer at 105 — within SYNC_BEHIND_THRESHOLD (10).
+    let mut sync_manager = ChainSyncManager::new(100);
+    let peer = PeerId::random();
+    sync_manager.on_status(peer, 105, [7u8; 32]);
+
+    assert!(
+        sync_manager.is_synced(),
+        "a node within the sync-behind threshold should not start IBD"
+    );
+}
+
+/// A node that catches up, then sees the peer advance further, must re-enter
+/// download and sync the new blocks too. This models a node that joins, syncs
+/// to the (then-current) tip, and keeps up as the chain grows.
+#[test]
+#[serial]
+fn test_node_resyncs_when_peer_advances() {
+    let first_target = RING_SIZE + 40; // 60
+    let second_target = first_target + 60; // 120
+
+    let source_dir = TempDir::new().unwrap();
+    let source = Ledger::open(source_dir.path()).unwrap();
+    let minter = create_test_wallet().public_address();
+    build_chain_to_height(&source, &minter, first_target);
+
+    let node_dir = TempDir::new().unwrap();
+    let node = Ledger::open(node_dir.path()).unwrap();
+
+    let mut sync_manager = ChainSyncManager::new(0);
+    let peer = PeerId::random();
+
+    // First catch-up to the initial tip.
+    run_catchup(&mut sync_manager, &node, &source, peer);
+    assert_eq!(node.get_chain_state().unwrap().height, first_target);
+
+    // Peer advances; node must notice and resync.
+    build_chain_to_height(&source, &minter, second_target);
+    run_catchup(&mut sync_manager, &node, &source, peer);
+
+    let node_state = node.get_chain_state().unwrap();
+    let source_state = source.get_chain_state().unwrap();
+    assert_eq!(node_state.height, second_target);
+    assert_eq!(node_state.tip_hash, source_state.tip_hash);
+}
+
+/// The block-serving logic (mirrored from the node's `GetBlocks` handler)
+/// returns exactly the requested contiguous range and signals `has_more`
+/// correctly so the requester keeps paging until caught up.
+#[test]
+#[serial]
+fn test_get_blocks_serves_requested_range() {
+    let source_dir = TempDir::new().unwrap();
+    let source = Ledger::open(source_dir.path()).unwrap();
+    let minter = create_test_wallet().public_address();
+    build_chain_to_height(&source, &minter, 30);
+
+    // Request a full batch of 100 starting at 1: only 30 blocks exist, so
+    // fewer than `count` come back and `has_more` is false.
+    let resp = serve_get_blocks(&source, 1, 100);
+    let SyncResponse::Blocks { blocks, has_more } = resp else {
+        panic!("expected Blocks");
+    };
+    assert_eq!(blocks.len(), 30);
+    assert!(
+        !has_more,
+        "fewer blocks than requested means no more to page"
+    );
+    assert_eq!(blocks.first().unwrap().height(), 1);
+    assert_eq!(blocks.last().unwrap().height(), 30);
+
+    // Request a smaller window that is fully satisfied: has_more is true.
+    let resp = serve_get_blocks(&source, 5, 10);
+    let SyncResponse::Blocks { blocks, has_more } = resp else {
+        panic!("expected Blocks");
+    };
+    assert_eq!(blocks.len(), 10);
+    assert!(has_more, "a fully satisfied window signals more may follow");
+    assert_eq!(blocks.first().unwrap().height(), 5);
+    assert_eq!(blocks.last().unwrap().height(), 14);
+}
+
+/// `SyncRequest`/`SyncResponse` round-trip via bincode, the wire codec used by
+/// the sync protocol. A serialization regression would silently break IBD.
+#[test]
+fn test_sync_messages_roundtrip() {
+    let req = SyncRequest::GetBlocks {
+        start_height: 1,
+        count: 100,
+    };
+    let bytes = bincode::serialize(&req).unwrap();
+    let decoded: SyncRequest = bincode::deserialize(&bytes).unwrap();
+    assert!(matches!(
+        decoded,
+        SyncRequest::GetBlocks {
+            start_height: 1,
+            count: 100
+        }
+    ));
+
+    let resp = SyncResponse::Status {
+        height: 95,
+        tip_hash: [9u8; 32],
+    };
+    let bytes = bincode::serialize(&resp).unwrap();
+    let decoded: SyncResponse = bincode::deserialize(&bytes).unwrap();
+    assert!(matches!(
+        decoded,
+        SyncResponse::Status {
+            height: 95,
+            tip_hash
+        } if tip_hash == [9u8; 32]
+    ));
+}


### PR DESCRIPTION
Closes #376

## Root cause

The `ChainSyncManager` state machine (in `botho/src/network/sync.rs`) and the libp2p `GetStatus`/`GetBlocks` request/response protocol were **already fully implemented and unit-tested** — but the manager was **never instantiated or driven** in the node event loop (`botho/src/commands/run.rs`). Nothing ever sent a status or block-range request. A fresh node only received the current tip via gossip (`NewBlock`/`NewCompactBlock`) and rejected it with `Expected height 1, got N`, because the intermediate blocks were missing. There was no initial block download (IBD) / catch-up path actually running.

This was invisible to existing tests: `e2e_consensus_integration` starts every node at genesis and grows them in lockstep, so no node ever has to *catch up*.

## What this PR does (done)

**Wire `ChainSyncManager` into the node event loop** (`commands/run.rs`):
- Instantiate it at startup seeded with the local chain height.
- New `sync_tick` (every 2s): refresh the manager's local height, drive `tick()`, and dispatch its actions — sending `GetStatus` / `GetBlocks` to the selected peer.
- Feed `SyncResponse::Status` into `on_status`, apply `SyncResponse::Blocks` sequentially via `add_block_from_network` and report the new height via `on_blocks_added`, and surface `SyncResponse::Error` / peer disconnects back into the state machine.

**Keep a synced node current** (`network/sync.rs`): status is request/response (not gossiped), so a synced node previously had no way to learn a peer advanced. Added a periodic status re-poll (`STATUS_REFRESH_INTERVAL`, 30s) and made `on_status` re-enter `Downloading` from any non-downloading state when a peer is far enough ahead.

**Tests:**
- New `botho/tests/chain_sync_catchup_integration.rs` — drives the **production** `ChainSyncManager` against real LMDB ledgers:
  - `test_fresh_node_syncs_existing_chain_to_tip`: a genesis node (height 0) joins a peer already at height 95 (> ring size) and syncs to the exact tip; also asserts the bug's symptom (a genesis node rejects a lone gossiped tip block). **This is the required join-at-height-N proof.**
  - `test_node_resyncs_when_peer_advances`: catches up, peer grows, node resyncs.
  - `test_get_blocks_serves_requested_range` + message round-trip.
- New `network::sync` unit tests for synced-state refresh, re-entry, and a full batched download cycle.

## Verification

- `cargo build -p botho` — green.
- `cargo test -p botho --lib --tests` — green (944 lib tests + all integration suites, including the 5 new catch-up tests and 45 sync unit tests).
- `cargo +nightly-2025-12-03 fmt --all -- --check` — clean (#354 gate).
- Pre-existing failures unrelated to this PR: two **doctests** in `network/privacy/{capacity,selection}.rs` fail on `origin/main` already (untouched here).

## Remaining / honest scope notes

- The in-process integration test proves the catch-up logic + ledger apply path end to end. The **live betanet external-sync case (#373 smoke test)** is expected to be addressed by this wiring (a fresh external node will now issue status/block requests instead of only consuming gossip), but I could not run the external smoke test from here, so I have not independently confirmed a full betanet PASS. Recommend re-running the #373 smoke test against a node built from this branch to flip it from PARTIAL to PASS before closing the betanet acceptance item.
- Reorg/fork handling on the sync path is out of scope (the manager applies a single best-peer's contiguous range; competing forks are not reconciled here).
- The current page size is 100 blocks per `GetBlocks` (existing `BLOCKS_PER_REQUEST`); large chains will page through many requests but converge.