### PR TITLE
feat(web-wallet): wire send() to client-side build+sign; fix SLIP-10 key parity

### DIFF
--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -1018,6 +1018,32 @@ async fn handle_get_outputs(id: Value, params: &Value, state: &RpcState) -> Json
     for height in start_height..=end_height {
         if let Ok(block) = ledger.get_block(height) {
             let mut outputs = Vec::new();
+
+            // Coinbase (minting reward) output. This is a real stealth TxOutput
+            // stored in the UTXO set (see LedgerStore: `block.minting_tx
+            // .to_tx_output()`), but it is NOT part of `block.transactions`, so
+            // it must be emitted explicitly. Without it, thin wallets scanning a
+            // freshly-mined chain see no outputs at all — they cannot find their
+            // own (coinbase) UTXOs to spend, nor build a decoy ring. The
+            // `outputIndex` is encoded as u32::MAX to distinguish coinbase from
+            // regular transaction outputs.
+            let coinbase = block.minting_tx.to_tx_output();
+            let coinbase_tags: Vec<[u64; 2]> = coinbase
+                .cluster_tags
+                .entries
+                .iter()
+                .map(|e| [e.cluster_id.0, e.weight as u64])
+                .collect();
+            outputs.push(json!({
+                "txHash": hex::encode(block.minting_tx.hash()),
+                "outputIndex": u32::MAX,
+                "targetKey": hex::encode(coinbase.target_key),
+                "publicKey": hex::encode(coinbase.public_key),
+                "amountCommitment": hex::encode(coinbase.amount.to_le_bytes()),
+                "clusterTags": coinbase_tags,
+                "coinbase": true,
+            }));
+
             for tx in &block.transactions {
                 for (idx, output) in tx.outputs.iter().enumerate() {
                     // Serialize cluster tags as array of [cluster_id, weight] pairs

--- a/web/packages/adapters/src/remote.ts
+++ b/web/packages/adapters/src/remote.ts
@@ -49,6 +49,20 @@ function resolveUrl(endpoint: string): URL | null {
   }
 }
 
+/**
+ * Decode a little-endian hex string (the node's `amountCommitment`, which is
+ * `u64::to_le_bytes` hex-encoded) into a bigint amount.
+ */
+function leHexToBigInt(hex: string): bigint {
+  let result = 0n
+  // Each byte is two hex chars; iterate from the most-significant byte (end of
+  // the string for little-endian) down to the least.
+  for (let i = hex.length - 2; i >= 0; i -= 2) {
+    result = (result << 8n) | BigInt(parseInt(hex.slice(i, i + 2), 16))
+  }
+  return result
+}
+
 /** JSON-RPC 2.0 request */
 interface JsonRpcRequest {
   jsonrpc: '2.0'
@@ -314,6 +328,43 @@ export class RemoteNodeAdapter implements NodeAdapter {
         blockHeight: block.height,
         confirmations: 0,
       }))
+    )
+  }
+
+  /**
+   * Fetch raw chain outputs for a height range as
+   * `{ targetKey, publicKey, amount }`.
+   *
+   * Unlike {@link getTransactionHistory} (which maps to the explorer's
+   * `Transaction` shape and drops amounts), this returns the data the
+   * client-side transaction builder needs: the stealth keys plus the
+   * transparent amount recovered from the output's commitment (the node sends
+   * the amount as little-endian bytes in `amountCommitment`).
+   */
+  async getRawOutputs(
+    startHeight: number,
+    endHeight: number,
+  ): Promise<Array<{ targetKey: string; publicKey: string; amount: bigint }>> {
+    const result = await this.call<Array<{
+      height: number
+      outputs: Array<{
+        txHash: string
+        outputIndex: number
+        targetKey: string
+        publicKey: string
+        amountCommitment: string
+      }>
+    }>>('chain_getOutputs', {
+      start_height: startHeight,
+      end_height: endHeight,
+    })
+
+    return result.flatMap((block) =>
+      block.outputs.map((output) => ({
+        targetKey: output.targetKey,
+        publicKey: output.publicKey,
+        amount: leHexToBigInt(output.amountCommitment),
+      })),
     )
   }
 

--- a/web/packages/core/src/wallet/address.ts
+++ b/web/packages/core/src/wallet/address.ts
@@ -10,8 +10,8 @@
  */
 
 import { mnemonicToSeedSync } from '@scure/bip39'
-import { HDKey } from '@scure/bip32'
 import { hkdf } from '@noble/hashes/hkdf.js'
+import { hmac } from '@noble/hashes/hmac.js'
 import { sha512 } from '@noble/hashes/sha2.js'
 import { base58 } from '@scure/base'
 import { ristretto255 } from '@noble/curves/ed25519'
@@ -31,24 +31,70 @@ const TESTNET_PREFIX = 'tbotho://1/'
 const MAINNET_PREFIX = 'botho://1/'
 
 /**
- * Derive SLIP-10 Ed25519 key from BIP39 seed
+ * SLIP-0010 master key for the Ed25519 curve.
  *
- * Uses path m/44'/866'/account' for Botho
+ * `I = HMAC-SHA512("ed25519 seed", seed)`; left 32 bytes are the key, right 32
+ * bytes the chain code. (See SLIP-0010 §"Master key generation".)
+ */
+function slip10Ed25519Master(seed: Uint8Array): { key: Uint8Array; chainCode: Uint8Array } {
+  const I = hmac(sha512, encoder.encode('ed25519 seed'), seed)
+  return { key: I.slice(0, 32), chainCode: I.slice(32, 64) }
+}
+
+/** Serialize a 32-bit unsigned integer as 4 big-endian bytes. */
+function ser32(index: number): Uint8Array {
+  const out = new Uint8Array(4)
+  out[0] = (index >>> 24) & 0xff
+  out[1] = (index >>> 16) & 0xff
+  out[2] = (index >>> 8) & 0xff
+  out[3] = index & 0xff
+  return out
+}
+
+/**
+ * SLIP-0010 Ed25519 hardened child derivation.
+ *
+ * Ed25519 only supports hardened derivation: the high bit of the index is
+ * always set, and the data hashed is `0x00 || key || ser32(index')`.
+ * (See SLIP-0010 §"Private parent key -> private child key".)
+ */
+function slip10Ed25519Child(
+  parent: { key: Uint8Array; chainCode: Uint8Array },
+  index: number,
+): { key: Uint8Array; chainCode: Uint8Array } {
+  // Force hardened (>>> 0 keeps it an unsigned 32-bit value).
+  const hardened = (index | 0x80000000) >>> 0
+  const data = new Uint8Array(1 + 32 + 4)
+  data[0] = 0x00
+  data.set(parent.key, 1)
+  data.set(ser32(hardened), 33)
+  const I = hmac(sha512, parent.chainCode, data)
+  return { key: I.slice(0, 32), chainCode: I.slice(32, 64) }
+}
+
+/**
+ * Derive the SLIP-0010 Ed25519 private key from a BIP39 seed at the Botho
+ * wallet path `m/44'/866'/account'`.
+ *
+ * This MUST byte-match the Rust node's derivation
+ * (`slip10_ed25519::derive_ed25519_private_key` in `core/src/slip10/mod.rs`),
+ * otherwise the keys this wallet signs with will differ from the node's view of
+ * the account and any transaction it builds will be rejected. The parity is
+ * pinned by `derivation-parity.test.ts` against the same vectors the Rust unit
+ * tests assert.
+ *
+ * NOTE: an earlier implementation used `@scure/bip32`'s `HDKey`, which performs
+ * BIP-32 *secp256k1* derivation, not SLIP-0010 *Ed25519* derivation, and so
+ * produced keys incompatible with the node. This hand-rolled SLIP-0010 Ed25519
+ * path (HMAC-SHA512 with the "ed25519 seed" key, hardened-only children)
+ * matches the spec and the node.
  */
 function deriveSlip10Key(seed: Uint8Array, accountIndex: number = 0): Uint8Array {
-  // SLIP-10 uses Ed25519 derivation from BIP32
-  // We use @scure/bip32 which supports Ed25519 via HDKey
-  const masterKey = HDKey.fromMasterSeed(seed)
-
-  // Derive using hardened path: m/44'/866'/account'
-  const path = `m/${BIP44_PURPOSE}'/${BOTHO_COIN_TYPE}'/${accountIndex}'`
-  const derived = masterKey.derive(path)
-
-  if (!derived.privateKey) {
-    throw new Error('Failed to derive private key')
+  let node = slip10Ed25519Master(seed)
+  for (const component of [BIP44_PURPOSE, BOTHO_COIN_TYPE, accountIndex]) {
+    node = slip10Ed25519Child(node, component)
   }
-
-  return derived.privateKey
+  return node.key
 }
 
 /**

--- a/web/packages/core/src/wallet/derivation-parity.test.ts
+++ b/web/packages/core/src/wallet/derivation-parity.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Key-derivation parity test: TypeScript vs Rust.
+ *
+ * The browser wallet signs transactions with keys derived from the mnemonic in
+ * TypeScript (`deriveKeypairs`). For a node to accept a wallet-built tx, those
+ * keys MUST be byte-identical to the keys the Rust node derives from the same
+ * mnemonic (`Mnemonic::derive_slip10_key(0)` -> `Account::from(&slip10_key)` in
+ * `core/src/slip10/mod.rs`).
+ *
+ * The Rust derivation is:
+ *   1. BIP39 seed (empty passphrase)
+ *   2. SLIP-0010 Ed25519 derivation at m/44'/866'/account'
+ *   3. HKDF-SHA512(salt = "botho-ristretto255-{view,spend}", ikm = slip10 key)
+ *      -> 64-byte OKM
+ *   4. Scalar::from_bytes_mod_order_wide(OKM) -> the private scalar
+ *
+ * The authoritative expected OKM bytes are the `view_hex`/`spend_hex` fields of
+ * `core/tests/slip10_mnemonic.json` (the same vectors the Rust unit test
+ * `mnemonic_into_account_key` asserts against). We reduce them mod the curve
+ * order here exactly as `from_bytes_mod_order_wide` does, and require the TS
+ * `deriveKeypairs` private scalars to match. If this passes, JS-derived keys
+ * are guaranteed identical to the node's, so a wallet-signed tx will not be
+ * rejected for a key mismatch.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { deriveKeypairs } from './address'
+
+// Ed25519 / Ristretto255 group order L = 2^252 + 27742317777372353535851937790883648493.
+const CURVE_ORDER = BigInt(
+  '7237005577332262213973186563042994240857116359379907606001950938285454250989',
+)
+
+/** Parse a hex string into bytes. */
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}
+
+/** Little-endian bytes -> BigInt (matches curve25519-dalek scalar layout). */
+function bytesToBigIntLE(bytes: Uint8Array): bigint {
+  let result = 0n
+  for (let i = bytes.length - 1; i >= 0; i--) {
+    result = (result << 8n) | BigInt(bytes[i])
+  }
+  return result
+}
+
+/** BigInt -> 32 little-endian bytes. */
+function bigIntToBytesLE(n: bigint): Uint8Array {
+  const bytes = new Uint8Array(32)
+  let temp = n
+  for (let i = 0; i < 32; i++) {
+    bytes[i] = Number(temp & 0xffn)
+    temp >>= 8n
+  }
+  return bytes
+}
+
+/**
+ * Reduce a 64-byte wide value mod L, exactly as
+ * `curve25519_dalek::Scalar::from_bytes_mod_order_wide`. The Rust JSON vectors
+ * store the raw 64-byte HKDF OKM, so reducing here yields the canonical 32-byte
+ * private scalar the node holds.
+ */
+function reduceWide(wideHex: string): Uint8Array {
+  const wide = hexToBytes(wideHex)
+  expect(wide.length).toBe(64)
+  return bigIntToBytesLE(bytesToBigIntLE(wide) % CURVE_ORDER)
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+// Vectors copied verbatim from core/tests/slip10_mnemonic.json (account_index 0).
+// These are the same vectors the Rust `mnemonic_into_account_key` test asserts.
+const RUST_VECTORS: ReadonlyArray<{
+  phrase: string
+  viewWideHex: string
+  spendWideHex: string
+}> = [
+  {
+    phrase:
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    viewWideHex:
+      'b731055a24cf3afe6e18f86161dfd4d2ae05ce9f8263f0525a33ad12d56d78afea6d68ad279efbbf8ea55a08fa62949ea05d414d94a11961f5531c4cd2a88988',
+    spendWideHex:
+      '44beb5967db5e179c36aa91105c385cfa8cf1611d7d951a821874ae8b6641f57ef311486819ca887b0fe296a948d65c9d86fac01491597dc7a2ed60ca72a1e2e',
+  },
+  {
+    phrase:
+      'legal winner thank year wave sausage worth useful legal winner thank yellow',
+    viewWideHex:
+      '06b808e57f7e8b1dbc9e3907b5daa88d683c2089c153d6c6a2697b8efc69ad4f5d898dc8c29cd4e2f18bf9694f8c12921a1017ad52e837a8c274f87af75f5f7a',
+    spendWideHex:
+      '40c318c9d849e22d29cf3793e01b2ffbe9f397952038452a10f37c9c157d57da801f5f0a05f90c68b7761c9188d5625f9af4f33ec4dc18afacac6a24c071dec9',
+  },
+  {
+    phrase:
+      'letter advice cage absurd amount doctor acoustic avoid letter advice cage above',
+    viewWideHex:
+      '9523526422933f967f11f27347b662f2345ad3c38612321c64717f30aa0f0493ac94eb97385b871506e07c3b4a1346ac573b59f6c88d8a4a7307b28604d79133',
+    spendWideHex:
+      '695325a1b3563e19ba94f6e666d9a4d90e106c7914c6dafc51cd40a665ecf2308afc57ef4353d285c34f02e4d8097ef010765e3a949d47b8812bb1981a285ed2',
+  },
+]
+
+describe('SLIP-10 key derivation parity (TS <-> Rust)', () => {
+  for (const vec of RUST_VECTORS) {
+    it(`matches Rust spend/view scalars for "${vec.phrase.split(' ').slice(0, 3).join(' ')} ..."`, () => {
+      const kp = deriveKeypairs(vec.phrase, 0)
+
+      const expectedView = reduceWide(vec.viewWideHex)
+      const expectedSpend = reduceWide(vec.spendWideHex)
+
+      expect(toHex(kp.viewPrivate)).toBe(toHex(expectedView))
+      expect(toHex(kp.spendPrivate)).toBe(toHex(expectedSpend))
+    })
+  }
+})

--- a/web/packages/wasm-signer/package.json
+++ b/web/packages/wasm-signer/package.json
@@ -18,6 +18,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "@botho/core": "workspace:*",
     "@types/node": "^22.10.0",
     "typescript": "~5.9.3",
     "vitest": "^4.0.16"

--- a/web/packages/wasm-signer/src/core.rs
+++ b/web/packages/wasm-signer/src/core.rs
@@ -263,6 +263,83 @@ pub fn build_and_sign_with_rng<R: RngCore + CryptoRng>(
     Ok(tx)
 }
 
+/// A chain output the wallet wants to test for ownership / use as a decoy.
+///
+/// These are exactly the fields the node returns from `chain_getOutputs`
+/// (`targetKey`, `publicKey`, and the transparent `amount` recovered from
+/// `amountCommitment`).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainOutput {
+    /// Hex-encoded 32-byte one-time target key of the output.
+    pub target_key: String,
+    /// Hex-encoded 32-byte ephemeral public key of the output.
+    pub public_key: String,
+    /// Amount in picocredits (recovered from the transparent commitment).
+    pub amount: u64,
+}
+
+/// A scan request: the account's private keys plus candidate chain outputs.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanRequest {
+    /// Hex-encoded 32-byte account spend private key. **Stays client-side.**
+    pub spend_private_key: String,
+    /// Hex-encoded 32-byte account view private key. **Stays client-side.**
+    pub view_private_key: String,
+    /// Candidate outputs (e.g. every output the node returned for a height
+    /// range) to test for ownership.
+    pub outputs: Vec<ChainOutput>,
+}
+
+/// An owned output the scan identified, ready to be turned into a spend input.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OwnedOutput {
+    /// Hex-encoded 32-byte one-time target key of the owned output.
+    pub target_key: String,
+    /// Hex-encoded 32-byte ephemeral public key of the owned output.
+    pub public_key: String,
+    /// Amount in picocredits of the owned output.
+    pub amount: u64,
+    /// Subaddress index that received this output (0 = default, 1 = change).
+    pub subaddress_index: u64,
+}
+
+/// Identify which of `outputs` belong to the account, using the
+/// **node-identical** stealth-address ownership check
+/// ([`TxOutput::belongs_to`]).
+///
+/// This runs the same Rust the node runs in `scan_utxos_for_account`, so a
+/// thin client never has to re-implement the subaddress math in JavaScript (a
+/// notorious source of cross-implementation drift). The view/spend keys are
+/// used only to recover the stealth relationship and never leave the client.
+pub fn scan_owned_outputs_inner(req: &ScanRequest) -> Result<Vec<OwnedOutput>, String> {
+    let spend_private = parse_private("spendPrivateKey", &req.spend_private_key)?;
+    let view_private = parse_private("viewPrivateKey", &req.view_private_key)?;
+    let account = AccountKey::new(&spend_private, &view_private);
+
+    let mut owned = Vec::new();
+    for out in &req.outputs {
+        let tx_out = TxOutput {
+            amount: out.amount,
+            target_key: parse_hex_32("output.target_key", &out.target_key)?,
+            public_key: parse_hex_32("output.public_key", &out.public_key)?,
+            e_memo: None,
+            cluster_tags: Default::default(),
+        };
+        if let Some(subaddress_index) = tx_out.belongs_to(&account) {
+            owned.push(OwnedOutput {
+                target_key: out.target_key.clone(),
+                public_key: out.public_key.clone(),
+                amount: out.amount,
+                subaddress_index,
+            });
+        }
+    }
+    Ok(owned)
+}
+
 /// Build, CLSAG-sign, and bincode-serialize a transaction, returning hex.
 ///
 /// The returned hex is the exact `tx_hex` payload accepted by the node's
@@ -461,6 +538,41 @@ mod tests {
         );
         let err = build_and_sign_with_rng(&req, &mut rng).unwrap_err();
         assert!(err.contains("below minimum"), "got: {err}");
+    }
+
+    #[test]
+    fn scan_identifies_owned_outputs_only() {
+        let mut rng = StdRng::from_seed([29u8; 32]);
+        let me = AccountKey::random(&mut rng);
+        let stranger = AccountKey::random(&mut rng);
+
+        // Two outputs to me (default subaddress) and one to a stranger.
+        let mine_a = TxOutput::new(1_000, &me.default_subaddress());
+        let mine_b = TxOutput::new(2_000, &me.change_subaddress());
+        let theirs = TxOutput::new(3_000, &stranger.default_subaddress());
+
+        let to_chain = |o: &TxOutput| ChainOutput {
+            target_key: hex::encode(o.target_key),
+            public_key: hex::encode(o.public_key),
+            amount: o.amount,
+        };
+
+        let req = ScanRequest {
+            spend_private_key: hex::encode(me.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(me.view_private_key().to_bytes()),
+            outputs: vec![to_chain(&mine_a), to_chain(&theirs), to_chain(&mine_b)],
+        };
+
+        let owned = scan_owned_outputs_inner(&req).expect("scan should succeed");
+        // Exactly the two outputs paid to me, with correct subaddress indices.
+        assert_eq!(owned.len(), 2);
+        let by_amount: std::collections::BTreeMap<u64, u64> = owned
+            .iter()
+            .map(|o| (o.amount, o.subaddress_index))
+            .collect();
+        assert_eq!(by_amount.get(&1_000), Some(&0)); // default subaddress
+        assert_eq!(by_amount.get(&2_000), Some(&1)); // change subaddress
+        assert!(!by_amount.contains_key(&3_000)); // stranger's output excluded
     }
 
     #[test]

--- a/web/packages/wasm-signer/src/index.ts
+++ b/web/packages/wasm-signer/src/index.ts
@@ -78,6 +78,38 @@ export interface SignRequest {
   createdAtHeight: bigint | number
 }
 
+/** A chain output (as returned by `chain_getOutputs`) to test for ownership. */
+export interface ChainOutput {
+  /** Hex-encoded 32-byte one-time target key of the output. */
+  targetKey: string
+  /** Hex-encoded 32-byte ephemeral public key of the output. */
+  publicKey: string
+  /** Amount in picocredits (recovered from the transparent commitment). */
+  amount: bigint | number
+}
+
+/** A request to scan candidate outputs for ones owned by the account. */
+export interface ScanRequest {
+  /** Hex-encoded 32-byte account spend private key. Stays client-side. */
+  spendPrivateKey: string
+  /** Hex-encoded 32-byte account view private key. Stays client-side. */
+  viewPrivateKey: string
+  /** Candidate outputs to test for ownership. */
+  outputs: ChainOutput[]
+}
+
+/** An output the scan determined belongs to the account. */
+export interface OwnedOutput {
+  /** Hex-encoded 32-byte one-time target key of the owned output. */
+  targetKey: string
+  /** Hex-encoded 32-byte ephemeral public key of the owned output. */
+  publicKey: string
+  /** Amount in picocredits of the owned output. */
+  amount: bigint
+  /** Subaddress index that received this output (0 = default, 1 = change). */
+  subaddressIndex: bigint
+}
+
 /** The wasm module's exported surface. */
 export interface WasmSigner {
   /**
@@ -86,6 +118,12 @@ export interface WasmSigner {
    * Throws on any failure (bad keys, insufficient decoys, balance mismatch).
    */
   buildAndSign(request: SignRequest): string
+  /**
+   * Identify which of `request.outputs` belong to the account, using the
+   * node-identical stealth-address ownership check. Returns the owned outputs
+   * with their recovered subaddress index. The keys never leave the client.
+   */
+  scanOwnedOutputs(request: ScanRequest): OwnedOutput[]
   /** The CLSAG ring size the network requires (decoys + 1 real input). */
   ringSize(): number
   /** The minimum transaction fee in picocredits. */
@@ -106,6 +144,7 @@ export async function loadSigner(): Promise<WasmSigner> {
     let mod: {
       default: (init?: unknown) => Promise<unknown>
       buildAndSign: (request: unknown) => string
+      scanOwnedOutputs: (request: unknown) => unknown
       ringSize: () => number
       minFee: () => bigint
     }
@@ -126,6 +165,8 @@ export async function loadSigner(): Promise<WasmSigner> {
     await mod.default()
     return {
       buildAndSign: (request: SignRequest) => mod.buildAndSign(request),
+      scanOwnedOutputs: (request: ScanRequest) =>
+        mod.scanOwnedOutputs(request) as OwnedOutput[],
       ringSize: () => mod.ringSize(),
       minFee: () => mod.minFee(),
     }
@@ -137,3 +178,11 @@ export async function loadSigner(): Promise<WasmSigner> {
 export function resetSigner(): void {
   cached = null
 }
+
+export {
+  buildSendTransaction,
+  type BuildSendParams,
+  type BuildSendResult,
+  type SendRpc,
+  type SignerKeys,
+} from './send'

--- a/web/packages/wasm-signer/src/lib.rs
+++ b/web/packages/wasm-signer/src/lib.rs
@@ -35,7 +35,7 @@ pub mod core;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use crate::core::{build_and_sign_inner, SignRequest};
+    use crate::core::{build_and_sign_inner, scan_owned_outputs_inner, ScanRequest, SignRequest};
     use wasm_bindgen::prelude::*;
 
     /// Build and CLSAG-sign a Botho transaction entirely client-side.
@@ -52,6 +52,23 @@ mod wasm {
         let req: SignRequest = serde_wasm_bindgen::from_value(request)
             .map_err(|e| JsError::new(&format!("invalid request: {e}")))?;
         build_and_sign_inner(&req).map_err(|e| JsError::new(&e))
+    }
+
+    /// Identify which of the supplied chain outputs belong to the account.
+    ///
+    /// `request` is a JS object matching [`ScanRequest`]: the spend/view
+    /// private keys (hex) and the candidate outputs (as returned by
+    /// `chain_getOutputs`, with the transparent amount). Returns the owned
+    /// outputs (with recovered subaddress index), serialized as a JS value.
+    /// Uses the node-identical `belongs_to` check so ownership detection
+    /// cannot drift from the node.
+    #[wasm_bindgen(js_name = scanOwnedOutputs)]
+    pub fn scan_owned_outputs(request: JsValue) -> Result<JsValue, JsError> {
+        let req: ScanRequest = serde_wasm_bindgen::from_value(request)
+            .map_err(|e| JsError::new(&format!("invalid scan request: {e}")))?;
+        let owned = scan_owned_outputs_inner(&req).map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&owned)
+            .map_err(|e| JsError::new(&format!("failed to serialize owned outputs: {e}")))
     }
 
     /// The CLSAG ring size the network requires (decoys + 1 real input).

--- a/web/packages/wasm-signer/src/send.ts
+++ b/web/packages/wasm-signer/src/send.ts
@@ -1,0 +1,199 @@
+/**
+ * High-level "build a send" orchestrator.
+ *
+ * Composes the low-level wasm primitives ({@link loadSigner}'s
+ * `scanOwnedOutputs` / `buildAndSign`) plus the wallet's key derivation and the
+ * node RPC into a single call the wallet UI can use:
+ *
+ *   derive keys -> scan chain for owned outputs -> select inputs ->
+ *   gather decoys -> build + CLSAG-sign -> hex tx ready for `tx_submit`.
+ *
+ * All cryptography (ownership detection, one-time-key recovery, ring signature)
+ * runs inside the wasm module compiled from the same Rust the node runs, so the
+ * resulting transaction round-trips through the node's verifier. The spend/view
+ * private keys are passed straight into wasm and never sent to the node.
+ */
+
+import {
+  loadSigner,
+  type ChainOutput,
+  type OwnedOutput,
+  type RecipientAddress,
+  type SignRequest,
+  type SpendInput,
+} from './index'
+
+/** The account private keys the caller derived from the mnemonic. */
+export interface SignerKeys {
+  /** Hex-encoded 32-byte account spend private key. */
+  spendPrivateKey: string
+  /** Hex-encoded 32-byte account view private key. */
+  viewPrivateKey: string
+}
+
+/**
+ * The slice of node RPC the send path needs. Implemented by the wallet's
+ * `RemoteNodeAdapter`; abstracted here so this package does not depend on the
+ * adapters package.
+ */
+export interface SendRpc {
+  /** Current chain height (stamped on the tx for replay protection). */
+  getChainHeight(): Promise<number>
+  /**
+   * Fetch every output on the chain in `[startHeight, endHeight]` as raw
+   * `{ targetKey, publicKey, amount }`. The amount is the transparent value
+   * recovered from the output's commitment.
+   */
+  getOutputs(startHeight: number, endHeight: number): Promise<ChainOutput[]>
+}
+
+/** Inputs to {@link buildSendTransaction}. */
+export interface BuildSendParams {
+  /** Account keys derived from the wallet mnemonic. */
+  keys: SignerKeys
+  /** Recipient address keys (decoded from a `tbotho://` address). */
+  recipient: RecipientAddress
+  /** Amount to send, in picocredits. */
+  amount: bigint
+  /** Fee, in picocredits. Must be >= the network minimum. */
+  fee: bigint
+  /** Node RPC accessor. */
+  rpc: SendRpc
+}
+
+/** Result of a successful build: the signed tx plus the inputs that were used. */
+export interface BuildSendResult {
+  /** Hex-encoded bincode tx, ready for `tx_submit`. */
+  txHex: string
+  /** The owned outputs selected as inputs. */
+  inputs: OwnedOutput[]
+  /** Total picocredits of the selected inputs. */
+  inputTotal: bigint
+}
+
+function toBigInt(v: bigint | number): bigint {
+  return typeof v === 'bigint' ? v : BigInt(v)
+}
+
+/**
+ * Greedily select the fewest owned outputs whose total covers `target`,
+ * largest-first. Returns null if the wallet cannot cover the target.
+ */
+function selectInputs(owned: OwnedOutput[], target: bigint): OwnedOutput[] | null {
+  const sorted = [...owned].sort((a, b) => {
+    const d = toBigInt(b.amount) - toBigInt(a.amount)
+    return d > 0n ? 1 : d < 0n ? -1 : 0
+  })
+  const chosen: OwnedOutput[] = []
+  let total = 0n
+  for (const o of sorted) {
+    chosen.push(o)
+    total += toBigInt(o.amount)
+    if (total >= target) return chosen
+  }
+  return null
+}
+
+/**
+ * Build and CLSAG-sign a send transaction. Throws a descriptive error if the
+ * wallet has insufficient funds, the chain lacks enough decoys for the ring, or
+ * the signer rejects the request.
+ */
+export async function buildSendTransaction(
+  params: BuildSendParams,
+): Promise<BuildSendResult> {
+  const { keys, recipient, amount, fee, rpc } = params
+
+  if (amount <= 0n) throw new Error('Amount must be greater than 0')
+
+  const signer = await loadSigner()
+  const ringSize = signer.ringSize()
+  const decoysPerInput = ringSize - 1
+
+  const height = await rpc.getChainHeight()
+  // Scan the whole chain so we both (a) find every owned output and (b) have a
+  // large pool of real on-chain outputs to draw ring decoys from.
+  const candidates = await rpc.getOutputs(0, height)
+  if (candidates.length === 0) {
+    throw new Error('Node returned no outputs to scan')
+  }
+
+  // 1. Identify owned outputs via the node-identical wasm ownership check.
+  const owned = signer.scanOwnedOutputs({
+    spendPrivateKey: keys.spendPrivateKey,
+    viewPrivateKey: keys.viewPrivateKey,
+    outputs: candidates,
+  })
+  if (owned.length === 0) {
+    throw new Error('No spendable outputs found for this wallet')
+  }
+
+  // 2. Select inputs covering amount + fee.
+  const target = amount + fee
+  const inputs = selectInputs(owned, target)
+  if (!inputs) {
+    const have = owned.reduce((s, o) => s + toBigInt(o.amount), 0n)
+    throw new Error(
+      `Insufficient funds: need ${target} picocredits (amount + fee), have ${have}`,
+    )
+  }
+  const inputTotal = inputs.reduce((s, o) => s + toBigInt(o.amount), 0n)
+
+  // 3. Gather decoys. A decoy ring member only needs to be a valid on-chain
+  // output that is NOT one of the real inputs being spent — the node's own
+  // decoy selector likewise excludes only the real inputs (see
+  // `decoy_selection.rs` `select_decoys`, which filters by `exclude_keys` =
+  // the real inputs). In particular decoys MAY be the wallet's own other
+  // outputs; requiring foreign-only decoys would make a solo-mined / low-
+  // traffic chain unspendable. We still drop the all-zero genesis placeholder.
+  const inputKeys = new Set(inputs.map((o) => o.targetKey))
+  const isZeroKey = (k: string) => /^0+$/.test(k)
+  const decoyPool = candidates.filter(
+    (c) => !inputKeys.has(c.targetKey) && !isZeroKey(c.targetKey),
+  )
+  if (decoyPool.length < decoysPerInput) {
+    throw new Error(
+      `Not enough decoys on chain for a ring of ${ringSize}: ` +
+        `need ${decoysPerInput} per input, found ${decoyPool.length}. ` +
+        'Mine more blocks / wait for more on-chain outputs.',
+    )
+  }
+
+  const spendInputs: SpendInput[] = inputs.map((input, i) => {
+    // Rotate a window over the decoy pool so each input gets distinct decoys
+    // when the pool is large; if the pool is exactly the minimum, reuse it
+    // (rings still differ because the real member differs).
+    const decoys: ChainOutput[] = []
+    for (let j = 0; j < decoysPerInput; j++) {
+      decoys.push(decoyPool[(i * decoysPerInput + j) % decoyPool.length])
+    }
+    return {
+      target_key: input.targetKey,
+      public_key: input.publicKey,
+      amount: toBigInt(input.amount),
+      subaddress_index: toBigInt(input.subaddressIndex),
+      decoys: decoys.map((d) => ({
+        target_key: d.targetKey,
+        public_key: d.publicKey,
+        amount: toBigInt(d.amount),
+      })),
+    }
+  })
+
+  const request: SignRequest = {
+    spendPrivateKey: keys.spendPrivateKey,
+    viewPrivateKey: keys.viewPrivateKey,
+    inputs: spendInputs,
+    recipient,
+    amount,
+    fee,
+    createdAtHeight: height,
+  }
+
+  // 4. Build + CLSAG-sign inside wasm. The signer self-verifies the produced tx
+  // against the node's verifier before returning, so a returned hex is a tx the
+  // node should accept (subject to mempool policy like double-spend checks).
+  const txHex = signer.buildAndSign(request)
+
+  return { txHex, inputs, inputTotal }
+}

--- a/web/packages/wasm-signer/test/send-live-node.test.ts
+++ b/web/packages/wasm-signer/test/send-live-node.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Live-node end-to-end test for the client-side send path.
+ *
+ * This is GATED on `BOTHO_LIVE_RPC` + `BOTHO_LIVE_MNEMONIC` so it never runs in
+ * CI (no node available there). When those env vars are set it drives the SAME
+ * primitives the browser wallet uses — `deriveKeypairs` (@botho/core) and the
+ * wasm `buildAndSign`/`scanOwnedOutputs` (@botho/wasm-signer) — against a REAL
+ * botho node's JSON-RPC, submits the signed tx, and asserts the node accepts it
+ * (`tx_submit` returns a txHash). This is the make-or-break proof of key parity
+ * + the whole build/sign/submit path end to end.
+ *
+ * It mirrors `buildSendTransaction`'s orchestration but loads the wasm via the
+ * Node init path (raw bytes) instead of the browser `fetch` path, because under
+ * vitest/node the browser `loadSigner()` cannot `fetch` the wasm URL.
+ *
+ * Run against a local mining node (see PR description for setup):
+ *   BOTHO_LIVE_RPC=http://127.0.0.1:17199/rpc \
+ *   BOTHO_LIVE_MNEMONIC="abandon ... art" \
+ *   pnpm vitest run packages/web-wallet/src/contexts/send-live-node.test.ts
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+import { deriveKeypairs, parseAddress, deriveAddress } from '@botho/core'
+
+// Read env without depending on @types/node in this package.
+const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {}
+const RPC = env.BOTHO_LIVE_RPC
+const MNEMONIC = env.BOTHO_LIVE_MNEMONIC
+
+const here = dirname(fileURLToPath(import.meta.url))
+// packages/web-wallet/src/contexts -> packages/wasm-signer/pkg
+// packages/wasm-signer/test -> packages/wasm-signer/pkg
+const pkgDir = join(here, '..', 'pkg')
+const wasmGlue = join(pkgDir, 'bth_wasm_signer.js')
+const wasmBin = join(pkgDir, 'bth_wasm_signer_bg.wasm')
+
+const toHex = (b: Uint8Array) =>
+  Array.from(b).map((x) => x.toString(16).padStart(2, '0')).join('')
+
+function leHexToBigInt(hex: string): bigint {
+  let result = 0n
+  for (let i = hex.length - 2; i >= 0; i -= 2) {
+    result = (result << 8n) | BigInt(parseInt(hex.slice(i, i + 2), 16))
+  }
+  return result
+}
+
+let rpcId = 1
+async function rpc<T>(method: string, params: Record<string, unknown>): Promise<T> {
+  const res = await fetch(RPC!, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', method, params, id: rpcId++ }),
+  })
+  const json = (await res.json()) as { result?: T; error?: { message: string } }
+  if (json.error) throw new Error(`${method}: ${json.error.message}`)
+  return json.result as T
+}
+
+interface WasmMod {
+  default: (init: { module_or_path: BufferSource }) => Promise<unknown>
+  buildAndSign: (request: unknown) => string
+  scanOwnedOutputs: (request: unknown) => Array<{
+    targetKey: string
+    publicKey: string
+    amount: bigint
+    subaddressIndex: bigint
+  }>
+  ringSize: () => number
+  minFee: () => bigint
+}
+
+async function loadWasmNode(): Promise<WasmMod> {
+  const mod = (await import(/* @vite-ignore */ wasmGlue)) as unknown as WasmMod
+  await mod.default({ module_or_path: readFileSync(wasmBin) })
+  return mod
+}
+
+const wasmBuilt = existsSync(wasmGlue) && existsSync(wasmBin)
+const maybe = RPC && MNEMONIC && wasmBuilt ? describe : describe.skip
+
+maybe('live node: client-built tx is accepted', () => {
+  it('derives node-identical keys, builds+signs, and the node accepts it', async () => {
+    const mnemonic = MNEMONIC!
+    const wasm = await loadWasmNode()
+    const ringSize = wasm.ringSize()
+    const fee = wasm.minFee()
+
+    const kp = deriveKeypairs(mnemonic, 0)
+    const keys = {
+      spendPrivateKey: toHex(kp.spendPrivate),
+      viewPrivateKey: toHex(kp.viewPrivate),
+    }
+
+    // NOTE: `wallet_getAddress` returns the node's *default subaddress* keys,
+    // which are intentionally NOT the account root public keys deriveKeypairs
+    // returns (subaddress derivation hashes the account keys). So we do not
+    // compare them directly. The true proof of key parity is that the scan
+    // below (which uses belongs_to against the account keys) finds the node's
+    // own coinbase outputs, and that the node accepts the resulting signature.
+
+    // 2. Fetch chain outputs.
+    const status = await rpc<{ chainHeight: number }>('node_getStatus', {})
+    const height = status.chainHeight
+    const blocks = await rpc<
+      Array<{ outputs: Array<{ targetKey: string; publicKey: string; amountCommitment: string }> }>
+    >('chain_getOutputs', { start_height: 0, end_height: height })
+    const candidates = blocks.flatMap((b) =>
+      b.outputs.map((o) => ({
+        targetKey: o.targetKey,
+        publicKey: o.publicKey,
+        amount: leHexToBigInt(o.amountCommitment),
+      })),
+    )
+
+    // 3. Scan owned outputs via the node-identical wasm check.
+    const owned = wasm.scanOwnedOutputs({ ...keys, outputs: candidates })
+    expect(owned.length).toBeGreaterThan(0)
+
+    // 4. Select inputs + decoys (mirrors buildSendTransaction).
+    const amount = 1_000_000_000n
+    const target = amount + fee
+    const sorted = [...owned].sort((a, b) => (BigInt(b.amount) > BigInt(a.amount) ? 1 : -1))
+    const inputs: typeof owned = []
+    let total = 0n
+    for (const o of sorted) {
+      inputs.push(o)
+      total += BigInt(o.amount)
+      if (total >= target) break
+    }
+    expect(total).toBeGreaterThanOrEqual(target)
+
+    // Decoys exclude only the real inputs + the all-zero genesis placeholder
+    // (decoys may be the wallet's own other outputs; see send.ts rationale).
+    const inputKeys = new Set(inputs.map((o) => o.targetKey))
+    const decoyPool = candidates.filter(
+      (c) => !inputKeys.has(c.targetKey) && !/^0+$/.test(c.targetKey),
+    )
+    expect(decoyPool.length).toBeGreaterThanOrEqual(ringSize - 1)
+
+    const spendInputs = inputs.map((input, i) => {
+      const decoys = []
+      for (let j = 0; j < ringSize - 1; j++) {
+        decoys.push(decoyPool[(i * (ringSize - 1) + j) % decoyPool.length])
+      }
+      return {
+        target_key: input.targetKey,
+        public_key: input.publicKey,
+        amount: BigInt(input.amount),
+        subaddress_index: BigInt(input.subaddressIndex),
+        decoys: decoys.map((d) => ({
+          target_key: d.targetKey,
+          public_key: d.publicKey,
+          amount: BigInt(d.amount),
+        })),
+      }
+    })
+
+    // 5. Build + CLSAG-sign in wasm (recipient = our own address).
+    const recipientKeys = parseAddress(deriveAddress(mnemonic, 'testnet'))
+    const txHex = wasm.buildAndSign({
+      spendPrivateKey: keys.spendPrivateKey,
+      viewPrivateKey: keys.viewPrivateKey,
+      inputs: spendInputs,
+      recipient: {
+        spend_public_key: toHex(recipientKeys.spendPublic),
+        view_public_key: toHex(recipientKeys.viewPublic),
+      },
+      amount,
+      fee,
+      createdAtHeight: height,
+    })
+    expect(txHex.length).toBeGreaterThan(0)
+
+    // 6. Submit to the real node and require acceptance.
+    const result = await rpc<{ txHash: string }>('tx_submit', { tx_hex: txHex })
+    expect(result.txHash).toBeTruthy()
+    // eslint-disable-next-line no-console
+    console.log('NODE ACCEPTED wallet-built tx, txHash =', result.txHash)
+  }, 60_000)
+})

--- a/web/packages/wasm-signer/test/sign.test.ts
+++ b/web/packages/wasm-signer/test/sign.test.ts
@@ -23,6 +23,7 @@ async function loadSignerNode(): Promise<WasmSigner> {
   const mod = (await import(/* @vite-ignore */ wasmGlue)) as {
     default: (init: { module_or_path: BufferSource }) => Promise<unknown>
     buildAndSign: (request: unknown) => string
+    scanOwnedOutputs: (request: unknown) => unknown
     ringSize: () => number
     minFee: () => bigint
   }
@@ -30,6 +31,7 @@ async function loadSignerNode(): Promise<WasmSigner> {
   await mod.default({ module_or_path: bytes })
   return {
     buildAndSign: (request: SignRequest) => mod.buildAndSign(request),
+    scanOwnedOutputs: (request) => mod.scanOwnedOutputs(request) as ReturnType<WasmSigner['scanOwnedOutputs']>,
     ringSize: () => mod.ringSize(),
     minFee: () => mod.minFee(),
   }
@@ -102,5 +104,20 @@ maybe('wasm signer (requires build:wasm)', () => {
       createdAtHeight: 1000,
     }
     expect(() => signer.buildAndSign(request)).toThrow(/below minimum/)
+  })
+
+  it('scanOwnedOutputs returns empty for outputs not owned by the account', async () => {
+    const signer = await loadSignerNode()
+    // The Ristretto basepoint compressed encoding is a valid public key; reuse
+    // it as both target/public so parsing succeeds. The account keys below do
+    // not own this output, so the node-identical ownership check returns none.
+    const basepoint =
+      'e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76'
+    const owned = signer.scanOwnedOutputs({
+      spendPrivateKey: '01'.repeat(32),
+      viewPrivateKey: '02'.repeat(32),
+      outputs: [{ targetKey: basepoint, publicKey: basepoint, amount: 1000 }],
+    })
+    expect(owned).toEqual([])
   })
 })

--- a/web/packages/web-wallet/package.json
+++ b/web/packages/web-wallet/package.json
@@ -14,6 +14,7 @@
     "@botho/core": "workspace:*",
     "@botho/features": "workspace:*",
     "@botho/ui": "workspace:*",
+    "@botho/wasm-signer": "workspace:*",
     "lucide-react": "^0.562.0",
     "motion": "^12.23.26",
     "react": "^19.2.3",

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -8,8 +8,9 @@ import {
   type ReactNode,
 } from 'react'
 import { RemoteNodeAdapter, type WsConnectionStatus } from '@botho/adapters'
-import { AddressBook, saveWallet, loadWallet, getWalletInfo, deriveAddress, isValidMnemonic, clearWallet } from '@botho/core'
+import { AddressBook, saveWallet, loadWallet, getWalletInfo, deriveAddress, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet } from '@botho/core'
 import type { Balance, Contact, NodeInfo, Transaction } from '@botho/core'
+import { buildSendTransaction } from '@botho/wasm-signer'
 import { type NetworkConfig, loadSelectedNetwork, NETWORKS, DEFAULT_NETWORK_ID, createCustomNetwork } from '../config/networks'
 
 interface WalletState {
@@ -59,6 +60,22 @@ interface WalletContextValue extends WalletState {
   updateContact: (id: string, updates: Partial<Pick<Contact, 'name' | 'address' | 'notes'>>) => Promise<Contact>
   deleteContact: (id: string) => Promise<void>
   getContactName: (address: string) => string
+}
+
+/** Encode bytes as a lowercase hex string. */
+function toHex(bytes: Uint8Array): string {
+  let out = ''
+  for (const b of bytes) out += b.toString(16).padStart(2, '0')
+  return out
+}
+
+/** Decode a hex string into bytes. */
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
 }
 
 const WalletContext = createContext<WalletContextValue | null>(null)
@@ -375,11 +392,74 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     }))
   }, [])
 
-  const send = useCallback(async (to: string, amount: bigint, memo?: string): Promise<string> => {
-    // TODO: Implement actual transaction signing and submission
-    console.log('Sending', { to, amount, memo })
-    throw new Error('Transaction signing not yet implemented')
-  }, [])
+  const send = useCallback(async (to: string, amount: bigint, _memo?: string): Promise<string> => {
+    const adapter = adapterRef.current
+    if (!adapter.isConnected()) {
+      throw new Error('Not connected to a node')
+    }
+
+    const mnemonic = mnemonicRef.current
+    if (!mnemonic) {
+      throw new Error('Wallet is locked. Unlock it before sending.')
+    }
+
+    // 1. Derive the account spend/view private keys from the mnemonic. These
+    //    are byte-identical to the keys the node derives (verified by
+    //    derivation-parity.test.ts), so a tx signed with them is accepted.
+    const kp = deriveKeypairs(mnemonic, 0)
+
+    // 2. Decode the recipient address into its raw spend/view public keys.
+    const recipientKeys = parseAddress(to)
+
+    // 3. Determine a fee. estimateFee returns the node's recommended/minimum
+    //    fee in picocredits; fall back to a sane minimum if unavailable.
+    let fee: bigint
+    try {
+      fee = await adapter.estimateFee(0)
+    } catch {
+      fee = 0n
+    }
+    if (fee <= 0n) {
+      // Mirror the signer's MIN_TX_FEE (100_000_000 picocredits) so the build
+      // doesn't fail the minimum-fee check.
+      fee = 100_000_000n
+    }
+
+    // 4. Build + CLSAG-sign entirely client-side (wasm). The keys never leave
+    //    the browser; only the signed bytes are submitted.
+    const { txHex } = await buildSendTransaction({
+      keys: {
+        spendPrivateKey: toHex(kp.spendPrivate),
+        viewPrivateKey: toHex(kp.viewPrivate),
+      },
+      recipient: {
+        spend_public_key: toHex(recipientKeys.spendPublic),
+        view_public_key: toHex(recipientKeys.viewPublic),
+      },
+      amount,
+      fee,
+      rpc: {
+        getChainHeight: () => adapter.getBlockHeight(),
+        getOutputs: (start, end) => adapter.getRawOutputs(start, end),
+      },
+    })
+
+    // 5. Submit the signed tx to the node.
+    const result = await adapter.submitTransaction(hexToBytes(txHex))
+    if (!result.success || !result.txHash) {
+      throw new Error(result.error || 'Transaction submission failed')
+    }
+
+    // Refresh balance/history opportunistically; ignore failures.
+    if (state.address) {
+      adapter
+        .getBalance([state.address])
+        .then((balance) => setState((s) => ({ ...s, balance })))
+        .catch(() => {})
+    }
+
+    return result.txHash
+  }, [state.address])
 
   const refreshBalance = useCallback(async () => {
     const adapter = adapterRef.current

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
 
   packages/wasm-signer:
     devDependencies:
+      '@botho/core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.21
@@ -235,6 +238,9 @@ importers:
       '@botho/ui':
         specifier: workspace:*
         version: link:../ui
+      '@botho/wasm-signer':
+        specifier: workspace:*
+        version: link:../wasm-signer
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)


### PR DESCRIPTION
## Summary

Wires the browser wallet's `send()` (previously `throw "not implemented"`) to derive keys, scan owned outputs, build, CLSAG-sign, and submit a transaction **entirely client-side** via the wasm signer. **A real botho node accepted AND mined a wallet-built, client-signed transaction** during local verification.

This builds on the merged foundation (#379, `web/packages/wasm-signer`).

## Real verification (did a local node accept a wallet-built tx?) — YES

Drove the wired path against a local mining node (`botho run --testnet --mint`, throwaway wallet, ~25 blocks):

- `tx_submit` returned `txHash = 1c7e2528...1a86`
- Tx entered the mempool (`inMempool: true`), then was **mined into block 26**, `status: "confirmed"`, `confirmations: 1`, `type: "clsag"`, 2 outputs, fee 100000000.

The gated live-node test (`web/packages/wasm-signer/test/send-live-node.test.ts`, run with `BOTHO_LIVE_RPC`/`BOTHO_LIVE_MNEMONIC`) printed `NODE ACCEPTED wallet-built tx`. It is skipped in CI (no node available).

## The make-or-break: SLIP-10 key-derivation parity (found + fixed)

The TS derivation in `core/src/wallet/address.ts` used `@scure/bip32`'s `HDKey`, which performs **BIP-32 secp256k1** derivation — NOT **SLIP-0010 Ed25519** as the node uses (`core/src/slip10/mod.rs` `slip10_ed25519::derive_ed25519_private_key`). The HKDF-SHA512 step was correct, but the slip10 key fed into it was wrong, so the derived spend/view keys did **not** match the node. A tx signed with them would have been rejected.

Fixed with a spec-correct SLIP-0010 Ed25519 path (HMAC-SHA512 `"ed25519 seed"` master, hardened-only children). Pinned by `derivation-parity.test.ts`, which asserts the TS-derived private scalars equal the authoritative Rust vectors in `core/tests/slip10_mnemonic.json` (the same vectors the Rust `mnemonic_into_account_key` test uses).

## Changes

- **core**: replace incorrect `@scure/bip32` SLIP-10 with spec-correct SLIP-0010 Ed25519 derivation; add `derivation-parity.test.ts` (TS scalars == Rust vectors).
- **wasm-signer**: add node-identical `scanOwnedOutputs` (uses `TxOutput::belongs_to`, native-tested) + a `buildSendTransaction` orchestrator (scan -> select inputs -> gather decoys -> build+sign). Decoys exclude only the real inputs (matching the node's `select_decoys`), so a low-traffic chain stays spendable.
- **adapters**: `getRawOutputs()` returning `{ targetKey, publicKey, amount }` (decodes the transparent `amountCommitment`).
- **web-wallet**: `send()` derives keys, builds+CLSAG-signs via wasm, submits via `tx_submit`; real fee via `estimateFee` with a `MIN_TX_FEE` fallback.
- **rpc (node)**: `chain_getOutputs` now also emits the coinbase (minting-reward) output. That output is a real UTXO (`block.minting_tx.to_tx_output()`) but lives **outside** `block.transactions`, so previously a thin wallet on a freshly-mined chain saw zero outputs — no spendable UTXOs and no ring decoys. This was the blocker to a node-accepted send.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `send()` builds+signs+submits a tx a node **accepts** (txHash + mined) | ✅ | Local node accepted `1c7e2528...`, mined in block 26, `confirmed` |
| Client-side signing — keys never leave the browser | ✅ | Keys derived in TS, passed only into wasm; only signed bytes submitted |
| Key parity with the node (the hard part) | ✅ | `derivation-parity.test.ts` (TS scalars == Rust SLIP-10 vectors) + node accepted the signature |
| `pnpm -C web typecheck` + vitest green | ✅ | All packages typecheck; 82 vitest pass (live test skipped without env) |
| `cargo build` green; `cargo +nightly-2025-12-03 fmt --all -- --check` clean | ✅ | Both verified |
| wasm build reproducible/documented | ✅ | `pnpm --filter @botho/wasm-signer build:wasm` (wasm-pack); native `cargo test -p bth-wasm-signer` covers the core |

## Test Plan

- `cargo test -p bth-wasm-signer` (8 pass, incl. new `scan_identifies_owned_outputs_only`).
- `pnpm -C web typecheck` + `pnpm -C web vitest run` (82 pass, 1 skipped live test).
- Local mining node: built+signed+submitted a tx; node accepted (txHash) and mined it (block 26).

Closes #371