### PR TITLE
fix(wallet): pack default-subaddress keys into the displayed address

### DIFF
--- a/web/packages/core/src/wallet/address.ts
+++ b/web/packages/core/src/wallet/address.ts
@@ -13,6 +13,7 @@ import { mnemonicToSeedSync } from '@scure/bip39'
 import { hkdf } from '@noble/hashes/hkdf.js'
 import { hmac } from '@noble/hashes/hmac.js'
 import { sha512 } from '@noble/hashes/sha2.js'
+import { blake2b } from '@noble/hashes/blake2.js'
 import { base58 } from '@scure/base'
 import { ristretto255 } from '@noble/curves/ed25519'
 
@@ -25,6 +26,16 @@ const BOTHO_COIN_TYPE = 866
 // Domain separators for key derivation (must match Rust implementation)
 const VIEW_DOMAIN = 'botho-ristretto255-view'
 const SPEND_DOMAIN = 'botho-ristretto255-spend'
+
+// Subaddress derivation domain tag (must match the node's
+// `SUBADDRESS_DOMAIN_TAG` in `core/src/consts.rs`).
+const SUBADDRESS_DOMAIN_TAG = 'bth_subaddress'
+
+// The default subaddress index. Outputs paid to a recipient are addressed to
+// their default subaddress (index 0); the node's `TxOutput::belongs_to`
+// (`transaction/clsag/src/lib.rs`) only recognizes outputs paid to the default
+// (0) or change subaddress, NOT the account-root keys.
+const DEFAULT_SUBADDRESS_INDEX = 0
 
 // Address prefixes
 const TESTNET_PREFIX = 'tbotho://1/'
@@ -179,6 +190,71 @@ function derivePublicKey(privateScalar: Uint8Array): Uint8Array {
 }
 
 /**
+ * Reduce a scalar (given as a BigInt) modulo the curve order L.
+ *
+ * Matches Rust scalar arithmetic, where every `Scalar` operation is implicitly
+ * reduced mod L.
+ */
+function modL(n: bigint): bigint {
+  const r = n % CURVE_ORDER
+  return r < 0n ? r + CURVE_ORDER : r
+}
+
+/**
+ * Derive the DEFAULT-SUBADDRESS (index 0) private keys from the account-root
+ * view/spend private scalars.
+ *
+ * This MUST byte-match the node's subaddress derivation in
+ * `core/src/subaddress.rs` (the `(&RootViewPrivate, &RootSpendPrivate)`
+ * implementation), which for index `n` computes:
+ *
+ *   a  = view_private (scalar)
+ *   b  = spend_private (scalar)
+ *   Hs = Scalar::from_hash(Blake2b512("bth_subaddress" || a.as_bytes() || n.as_bytes()))
+ *   subaddress_spend_private = Hs + b
+ *   subaddress_view_private  = a * (Hs + b)
+ *
+ * `Scalar::from_hash` reduces the 64-byte Blake2b512 output via
+ * `from_bytes_mod_order_wide` (little-endian), and `a.as_bytes()` /
+ * `n.as_bytes()` are the canonical 32-byte little-endian scalar encodings.
+ *
+ * The node addresses outputs to a recipient's default subaddress and scans for
+ * ownership against the default/change subaddress (`TxOutput::belongs_to`), so
+ * the address the wallet displays must pack THESE keys — not the account-root
+ * keys — or funds sent to the displayed address are undetectable by the
+ * recipient's scan.
+ */
+function deriveSubaddressPrivateScalars(
+  viewPrivate: Uint8Array,
+  spendPrivate: Uint8Array,
+  index: number = DEFAULT_SUBADDRESS_INDEX,
+): { viewSubPrivate: Uint8Array; spendSubPrivate: Uint8Array } {
+  const a = bytesToBigInt(viewPrivate)
+  const b = bytesToBigInt(spendPrivate)
+
+  // `n = Scalar::from(index)` -> canonical 32-byte little-endian encoding.
+  const nBytes = bigIntToBytes(BigInt(index))
+
+  // Hs = from_bytes_mod_order_wide(Blake2b512(tag || a.as_bytes() || n.as_bytes()))
+  const tag = encoder.encode(SUBADDRESS_DOMAIN_TAG)
+  const digestInput = new Uint8Array(tag.length + 32 + 32)
+  digestInput.set(tag, 0)
+  digestInput.set(viewPrivate, tag.length) // a.as_bytes() (32-byte LE)
+  digestInput.set(nBytes, tag.length + 32) // n.as_bytes() (32-byte LE)
+  const wide = blake2b(digestInput, { dkLen: 64 })
+  const Hs = bytesToBigInt(scalarFromWide(wide))
+
+  // subaddress spend private = Hs + b; view private = a * (Hs + b)
+  const spendSub = modL(Hs + b)
+  const viewSub = modL(a * spendSub)
+
+  return {
+    viewSubPrivate: bigIntToBytes(viewSub),
+    spendSubPrivate: bigIntToBytes(spendSub),
+  }
+}
+
+/**
  * Derive view and spend keypairs from a mnemonic
  */
 export interface BothoKeypairs {
@@ -216,6 +292,30 @@ export function deriveKeypairs(mnemonic: string, accountIndex: number = 0): Both
 }
 
 /**
+ * Derive the account's DEFAULT-SUBADDRESS (index 0) public keys from a mnemonic.
+ *
+ * These are the keys a recipient's address must advertise: the node addresses
+ * outputs to the default subaddress and scans for ownership against it
+ * (`TxOutput::belongs_to`). The account-root public keys (`deriveKeypairs`'
+ * `viewPublic`/`spendPublic`) are used for signing, NOT for receiving.
+ */
+export function deriveDefaultSubaddressPublicKeys(
+  mnemonic: string,
+  accountIndex: number = 0,
+): { viewPublic: Uint8Array; spendPublic: Uint8Array } {
+  const kp = deriveKeypairs(mnemonic, accountIndex)
+  const { viewSubPrivate, spendSubPrivate } = deriveSubaddressPrivateScalars(
+    kp.viewPrivate,
+    kp.spendPrivate,
+    DEFAULT_SUBADDRESS_INDEX,
+  )
+  return {
+    viewPublic: derivePublicKey(viewSubPrivate),
+    spendPublic: derivePublicKey(spendSubPrivate),
+  }
+}
+
+/**
  * Format a Botho address from view and spend public keys
  *
  * Classical address format: tbotho://1/<base58(view || spend)>
@@ -240,14 +340,20 @@ export function formatAddress(
 
 /**
  * Derive a complete Botho address from a mnemonic
+ *
+ * Packs the DEFAULT-SUBADDRESS (index 0) public keys, matching the node's
+ * `wallet_getAddress` (which returns default-subaddress keys) and the
+ * recipient scan `TxOutput::belongs_to` (default/change subaddress). Packing
+ * the account-root keys here instead would produce an address whose outputs
+ * the recipient's scan cannot detect.
  */
 export function deriveAddressFromMnemonic(
   mnemonic: string,
   network: 'mainnet' | 'testnet' = 'testnet',
   accountIndex: number = 0
 ): string {
-  const keypairs = deriveKeypairs(mnemonic, accountIndex)
-  return formatAddress(keypairs.viewPublic, keypairs.spendPublic, network)
+  const { viewPublic, spendPublic } = deriveDefaultSubaddressPublicKeys(mnemonic, accountIndex)
+  return formatAddress(viewPublic, spendPublic, network)
 }
 
 /**

--- a/web/packages/core/src/wallet/derivation-parity.test.ts
+++ b/web/packages/core/src/wallet/derivation-parity.test.ts
@@ -24,7 +24,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { deriveKeypairs } from './address'
+import { deriveKeypairs, deriveDefaultSubaddressPublicKeys } from './address'
 
 // Ed25519 / Ristretto255 group order L = 2^252 + 27742317777372353535851937790883648493.
 const CURVE_ORDER = BigInt(
@@ -121,6 +121,54 @@ describe('SLIP-10 key derivation parity (TS <-> Rust)', () => {
 
       expect(toHex(kp.viewPrivate)).toBe(toHex(expectedView))
       expect(toHex(kp.spendPrivate)).toBe(toHex(expectedSpend))
+    })
+  }
+})
+
+// Authoritative DEFAULT-SUBADDRESS (index 0) public keys, generated from the
+// Rust node's subaddress derivation (`core/src/subaddress.rs`, the
+// `(&RootViewPrivate, &RootSpendPrivate)` impl reached via
+// `Account::subaddress(0)`). The wallet displays an address built from THESE
+// keys, and the node's `TxOutput::belongs_to` scans for ownership against the
+// default-subaddress spend key — so the TS subaddress derivation must produce
+// these exact bytes or funds sent to the displayed address are undetectable by
+// the recipient (the bug fixed by #383).
+//
+// To regenerate: add a temporary test in `core/src/slip10/mod.rs` that prints
+// `hex::encode(account_key.subaddress(0).{view,spend}_public_key().to_bytes())`
+// for each phrase and run `cargo test -p bth-core --features bip39 ... --nocapture`.
+const DEFAULT_SUBADDRESS_PUBKEY_VECTORS: ReadonlyArray<{
+  phrase: string
+  viewPublicHex: string
+  spendPublicHex: string
+}> = [
+  {
+    phrase:
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    viewPublicHex: '60eeebc23d5d4fa3b90621292da88f39c6df05114bd405319cf9adc905905773',
+    spendPublicHex: '8e2cf7239559d62c6ca0c0718eac345da1fa9348aa741a94d6489025a05a917c',
+  },
+  {
+    phrase:
+      'legal winner thank year wave sausage worth useful legal winner thank yellow',
+    viewPublicHex: 'fe8b11112542a664c5ce2954596fafd21a0766f5b02b3e4cbea5ee6d56b0d845',
+    spendPublicHex: 'e22d1ee2eb8f99c3af59c615d11b7eb4560feff4be667e12172ce6e5ba119372',
+  },
+  {
+    phrase:
+      'letter advice cage absurd amount doctor acoustic avoid letter advice cage above',
+    viewPublicHex: '9085161414daed6c8f503092940a2d13778cd581c16bbb9bc84b0dccf6cb8d33',
+    spendPublicHex: 'eca8c52ed862f73c38d7322663819001a14da1dad96003e9f98849707fee8838',
+  },
+]
+
+describe('Default-subaddress public-key parity (TS <-> Rust)', () => {
+  for (const vec of DEFAULT_SUBADDRESS_PUBKEY_VECTORS) {
+    it(`matches Rust default-subaddress keys for "${vec.phrase.split(' ').slice(0, 3).join(' ')} ..."`, () => {
+      const { viewPublic, spendPublic } = deriveDefaultSubaddressPublicKeys(vec.phrase, 0)
+
+      expect(toHex(viewPublic)).toBe(vec.viewPublicHex)
+      expect(toHex(spendPublic)).toBe(vec.spendPublicHex)
     })
   }
 })

--- a/web/packages/wasm-signer/src/core.rs
+++ b/web/packages/wasm-signer/src/core.rs
@@ -575,6 +575,71 @@ mod tests {
         assert!(!by_amount.contains_key(&3_000)); // stranger's output excluded
     }
 
+    /// Regression test for #383: an output built TO a recipient's wallet
+    /// address (the keys the TS `deriveAddress`/`formatAddress` now packs) MUST
+    /// be detected by the recipient's own scan (`belongs_to`), and an output
+    /// built to the recipient's ACCOUNT-ROOT keys (what the buggy address
+    /// previously packed) must NOT be detected.
+    ///
+    /// The wallet address packs the recipient's DEFAULT-SUBADDRESS public keys
+    /// (proven byte-identical to the node's `Account::subaddress(0)` by
+    /// `derivation-parity.test.ts`). This test confirms the receiving end:
+    /// building a stealth output to the default-subaddress address and scanning
+    /// as the recipient detects it at subaddress index 0. The account-root case
+    /// returning `None` is the exact gap that left funds unspendable before the
+    /// fix.
+    #[test]
+    fn output_to_wallet_address_is_detected_by_recipient() {
+        use bth_account_keys::PublicAddress;
+        use bth_crypto_keys::RistrettoPublic;
+
+        let mut rng = StdRng::from_seed([31u8; 32]);
+        let recipient = AccountKey::random(&mut rng);
+
+        // The address the wallet displays now packs the DEFAULT-SUBADDRESS keys.
+        // (TS `deriveAddress` -> these exact bytes, see derivation-parity test.)
+        let wallet_address = recipient.default_subaddress();
+        let to_subaddress = TxOutput::new(7_000, &wallet_address);
+
+        // The buggy pre-#383 address packed the ACCOUNT-ROOT keys instead.
+        let root_spend_public = RistrettoPublic::from(recipient.spend_private_key());
+        let root_view_public = RistrettoPublic::from(recipient.view_private_key());
+        let account_root_address = PublicAddress::new(&root_spend_public, &root_view_public);
+        let to_account_root = TxOutput::new(7_000, &account_root_address);
+
+        let to_chain = |o: &TxOutput| ChainOutput {
+            target_key: hex::encode(o.target_key),
+            public_key: hex::encode(o.public_key),
+            amount: o.amount,
+        };
+
+        let req = ScanRequest {
+            spend_private_key: hex::encode(recipient.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(recipient.view_private_key().to_bytes()),
+            outputs: vec![to_chain(&to_subaddress), to_chain(&to_account_root)],
+        };
+
+        let owned = scan_owned_outputs_inner(&req).expect("scan should succeed");
+
+        // The output to the wallet (default-subaddress) address is detected at
+        // index 0; the account-root output is invisible to the scan.
+        assert_eq!(
+            owned.len(),
+            1,
+            "exactly the default-subaddress output must be detected"
+        );
+        assert_eq!(owned[0].amount, 7_000);
+        assert_eq!(owned[0].subaddress_index, 0);
+
+        // Sanity: building to the account-root keys really is undetectable,
+        // which is precisely the bug #383 fixes by changing the address
+        // encoding to the default subaddress.
+        assert!(
+            to_account_root.belongs_to(&recipient).is_none(),
+            "account-root output must NOT be detectable (the original bug)"
+        );
+    }
+
     #[test]
     fn shuffle_preserves_membership() {
         let mut rng = StdRng::from_seed([23u8; 32]);


### PR DESCRIPTION
## Summary

The TS wallet's `deriveAddress`/`formatAddress` packed the **account-root** view/spend public keys into the `tbotho://1/<base58>` address. But the node addresses outputs to (and scans ownership against) the recipient's **default subaddress (index 0)** via `TxOutput::belongs_to` (`transaction/clsag/src/lib.rs`). Consequently, funds sent to a `deriveAddress`-format address were undetectable by the recipient's scan and could not be spent.

This adopts the node's existing subaddress convention (the issue's option 1): the wallet now packs the **default-subaddress** public keys, matching the node's `wallet_getAddress` and `belongs_to`. Consensus `belongs_to` is left untouched.

## Changes

- `web/packages/core/src/wallet/address.ts`:
  - Implement the node's subaddress derivation (`core/src/subaddress.rs`): for index `n`, `Hs = from_bytes_mod_order_wide(Blake2b512("bth_subaddress" || a.as_bytes() || n.as_bytes()))`, `spend' = Hs + b`, `view' = a * (Hs + b)`, then `pub = priv * G`. Reuses the existing SLIP-10/HKDF root keys (from #382) and scalar helpers.
  - New exported `deriveDefaultSubaddressPublicKeys(mnemonic, accountIndex)`.
  - `deriveAddressFromMnemonic` now packs the default-subaddress public keys. `deriveKeypairs` still returns account-root keys for signing/scanning.
- `web/packages/core/src/wallet/derivation-parity.test.ts`: new parity block asserting the TS default-subaddress public keys equal authoritative Rust vectors generated from `Account::subaddress(0)`.
- `web/packages/wasm-signer/src/core.rs`: new test `output_to_wallet_address_is_detected_by_recipient` — builds a stealth output to the recipient's wallet (default-subaddress) address and asserts the recipient's `scanOwnedOutputs`/`belongs_to` detects it at index 0, and that the old account-root encoding is NOT detected.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `deriveAddress` packs default-subaddress keys matching the node | ✅ | `deriveAddressFromMnemonic` uses `deriveDefaultSubaddressPublicKeys`; parity test asserts byte-equality with Rust `Account::subaddress(0)` |
| Parity test: TS subaddress keys == node's default subaddress | ✅ | `Default-subaddress public-key parity (TS <-> Rust)` — 3 vectors pass |
| Recipient-detection test added + passing | ✅ | `output_to_wallet_address_is_detected_by_recipient` passes; detects index-0 output, rejects account-root |
| `cargo test -p bth-wasm-signer` passes | ✅ | 9 passed |
| `cargo build` green | ✅ | Finished, pre-existing warnings only |
| `cargo +nightly-2025-12-03 fmt --all -- --check` clean | ✅ | No output |
| `pnpm -C web typecheck` passes | ✅ | All 7 projects pass |
| vitest (parity + detection) passes | ✅ | 81 passed, 5 skipped (live-node) |
| Address-determinism tests still valid | ✅ | `wallet.test.ts` asserts format/determinism, not a hardcoded value — 62 pass |

## Test Plan

- `cargo test -p bth-wasm-signer` → 9 passed (incl. recipient-detection)
- `cargo test -p bth-core --features bip39` → 24 passed
- `cargo build` → green
- `cargo +nightly-2025-12-03 fmt --all -- --check` → clean
- `pnpm -C web typecheck` → green
- `npx vitest run` → 81 passed, 5 skipped

Note: this changes the address STRING `deriveAddress` produces (as #382 also did). Acceptable pre-mainnet; no test asserted a hardcoded address value.

Closes #383