### PR TITLE
fix(node): give each minter its own shutdown flag so resume mines again

### DIFF
--- a/botho/src/node/minter.rs
+++ b/botho/src/node/minter.rs
@@ -83,7 +83,17 @@ pub struct Minter {
 }
 
 impl Minter {
-    pub fn new(threads: usize, address: PublicAddress, shutdown: Arc<AtomicBool>) -> Self {
+    /// Create a new minter.
+    ///
+    /// Each minter owns its own `shutdown` flag (created here, initialized to
+    /// `false`). This is deliberate: a minter must NOT share the node-wide
+    /// shutdown flag, because [`Minter::stop`] sets the flag to `true`
+    /// permanently. If the flag were shared, a subsequent `start_minting`
+    /// would spawn threads that immediately observe `shutdown == true` and exit
+    /// before ever picking up work — producing a "zombie minter" that reports
+    /// active but never mines (see issue #388, the pause→resume cycle from
+    /// #386/#387).
+    pub fn new(threads: usize, address: PublicAddress) -> Self {
         let (tx_sender, tx_receiver) = channel();
 
         // Initialize with default work (will be updated before minting starts)
@@ -97,7 +107,7 @@ impl Minter {
         Self {
             threads,
             address,
-            shutdown,
+            shutdown: Arc::new(AtomicBool::new(false)),
             total_hashes: Arc::new(AtomicU64::new(0)),
             txs_found: Arc::new(AtomicU64::new(0)),
             start_time: Instant::now(),
@@ -346,5 +356,56 @@ mod tests {
         // Different nonce should produce different hash
         let hash3 = compute_pow_hash(nonce + 1, &prev_hash, &address);
         assert_ne!(hash, hash3);
+    }
+
+    /// Spin up a minter the way `Node::start_minting` does, run it until it
+    /// picks up work and produces at least one minting tx, then stop it.
+    /// Returns whether a minting tx was received within the timeout.
+    fn run_minter_once(address: &PublicAddress) -> bool {
+        let mut minter = Minter::new(1, address.clone());
+        let rx = minter.take_tx_receiver().expect("receiver available");
+
+        // Easy difficulty so PoW is found almost immediately.
+        minter.update_work(MintingWork {
+            prev_block_hash: [7u8; 32],
+            height: 1,
+            difficulty: INITIAL_DIFFICULTY,
+            total_minted: 0,
+        });
+        minter.start();
+
+        // A minting tx must arrive — this proves the thread picked up work and
+        // mined a block, not merely that the thread is alive.
+        let produced = rx.recv_timeout(std::time::Duration::from_secs(10)).is_ok();
+
+        minter.stop();
+        produced
+    }
+
+    /// Regression test for issue #388 (zombie minter).
+    ///
+    /// Previously, `Minter` shared the node-wide shutdown flag. `Minter::stop`
+    /// set that flag to `true` permanently, so the SECOND minter created after
+    /// a stop saw `shutdown == true` immediately and exited before picking up
+    /// any work — the node reported "minting active" but produced no blocks.
+    ///
+    /// This test reproduces the start → stop → start cycle and asserts that the
+    /// resumed minter ALSO produces a minting tx, exactly like a fresh startup.
+    #[test]
+    fn test_minter_resumes_work_after_stop_start_cycle() {
+        let address = PublicAddress::from_random(&mut OsRng);
+
+        // Fresh startup: produces work.
+        assert!(
+            run_minter_once(&address),
+            "initial minter should pick up work and produce a minting tx"
+        );
+
+        // Resume after a stop: must ALSO produce work (the regression).
+        assert!(
+            run_minter_once(&address),
+            "resumed minter (start after stop) should pick up work and \
+             produce a minting tx — a no-op here is the #388 zombie-minter bug"
+        );
     }
 }

--- a/botho/src/node/mod.rs
+++ b/botho/src/node/mod.rs
@@ -3,7 +3,7 @@ pub mod minter;
 use anyhow::Result;
 use std::{
     path::{Path, PathBuf},
-    sync::{atomic::AtomicBool, mpsc::Receiver, Arc, RwLock},
+    sync::{mpsc::Receiver, Arc, RwLock},
 };
 use tracing::{info, warn};
 
@@ -36,7 +36,6 @@ pub struct Node {
     wallet: Option<Wallet>,
     ledger: SharedLedger,
     mempool: SharedMempool,
-    shutdown: Arc<AtomicBool>,
     minter: Option<Minter>,
     /// Receiver for minted minting transactions (to be submitted to consensus)
     minting_tx_receiver: Option<Receiver<MintedMintingTx>>,
@@ -89,7 +88,6 @@ impl Node {
             wallet,
             ledger,
             mempool,
-            shutdown: Arc::new(AtomicBool::new(false)),
             minter: None,
             minting_tx_receiver: None,
             config_dir,
@@ -172,7 +170,11 @@ impl Node {
 
         info!("Starting minting with {} threads", threads);
 
-        let mut minter = Minter::new(threads, wallet.default_address(), self.shutdown.clone());
+        // Each minter owns its own shutdown flag (see `Minter::new`). We must
+        // NOT pass the node-wide `self.shutdown` here: `Minter::stop` sets the
+        // shutdown flag permanently, so reusing a shared flag would make every
+        // minter after the first stop a no-op (issue #388).
+        let mut minter = Minter::new(threads, wallet.default_address());
 
         // Take the minting tx receiver
         self.minting_tx_receiver = minter.take_tx_receiver();


### PR DESCRIPTION
## Summary
After minting is stopped then restarted (`stop_minting_public()` then `start_minting_public()` — e.g. the #386/#387 balance pause→resume cycle), the minting worker thread restarted but never picked up work: no `Thread picked up new work`, no blocks, pending txs never confirmed. Startup minting worked; only *resumed* minting was broken. This made the live betanet faucet a "zombie minter" (active, but height frozen).

## Root cause
`Minter` was constructed with a **clone of the node-wide shutdown flag** (`Minter::new(threads, addr, self.shutdown.clone())`). `Minter::stop()` does `self.shutdown.store(true, ...)` — and because that `Arc<AtomicBool>` was shared with the node, the flag stayed `true` forever after the first stop. On the next `start_minting()`, a fresh `Minter` was created with the *same* (now-`true`) flag, so every spawned mint thread immediately failed the `while !shutdown.load(...)` guard and exited before picking up any work. The work-generation/`update_work` path was fine; the threads were dead-on-arrival.

The node's `self.shutdown` field was not wired to the run-loop's shutdown signal (run.rs uses its own local flag) — it was only ever consumed by the minter — so it was safe to remove.

## The fix
- `Minter::new` no longer takes a shutdown argument; each `Minter` creates and **owns** its own `shutdown` flag (`Arc::new(AtomicBool::new(false))`). A stop→start cycle therefore gets a fresh `false` flag and fully restarts the pipeline, identical to a fresh startup.
- Removed the now-unused `Node.shutdown` field and its `AtomicBool` import.
- No change to PoW, validation, work-generation, or the #386/#387 pause/resume decision logic.

## Changes
- `botho/src/node/minter.rs`: `Minter::new(threads, address)` owns its shutdown flag (doc-commented); add regression test `test_minter_resumes_work_after_stop_start_cycle`.
- `botho/src/node/mod.rs`: drop `Node.shutdown` field; call `Minter::new(threads, wallet.default_address())`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| After stop then start, node resumes producing blocks — verified by a test that stops then restarts minting and asserts a block is produced | ✅ | `test_minter_resumes_work_after_stop_start_cycle`: starts a minter, asserts a minting tx arrives on the channel (proves work picked up + block mined, not just thread liveness), stops it, then starts a fresh minter and asserts a minting tx arrives **again** |
| Live faucet: dispense after a balance-pause resume gets mined | ✅ (mechanism) | Resumed minter now spawns threads with a `false` shutdown flag and mines; verified at the `Minter` lifecycle level the run-loop uses |
| No regression to startup minting or #386 thresholds | ✅ | Only the minter shutdown-flag ownership changed; pause/resume decision and work-generation untouched. Full `cargo test -p botho --lib` green (940 passed) |

## Test Plan
- `cargo test -p botho --lib` — 940 passed, 0 failed (includes the new regression test).
- `cargo build -p botho` — green.
- `cargo +nightly-2025-12-03 fmt --all -- --check` — clean.

Closes #388