### PR TITLE
feat(wallet): spent-filter thin-wallet balance via chain_areKeyImagesSpent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,6 +1648,7 @@ dependencies = [
  "bincode",
  "bth-account-keys",
  "bth-crypto-keys",
+ "bth-crypto-ring-signature",
  "bth-transaction-clsag",
  "getrandom 0.2.16",
  "hex",

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -1200,6 +1200,26 @@ impl Ledger {
             .map_err(|e| LedgerError::Database(format!("Failed to put key image: {}", e)))
     }
 
+    /// Test-only helper: record a key image as spent at the given height in a
+    /// self-contained write transaction. Lets tests in sibling modules (e.g.
+    /// the RPC layer's `chain_areKeyImagesSpent` test) seed the double-spend
+    /// set without reaching into the private LMDB environment.
+    #[cfg(test)]
+    pub fn record_key_image_for_test(
+        &self,
+        key_image: &[u8; 32],
+        height: u64,
+    ) -> Result<(), LedgerError> {
+        let mut wtxn = self
+            .env
+            .write_txn()
+            .map_err(|e| LedgerError::Database(format!("Failed to start write txn: {}", e)))?;
+        self.record_key_image(&mut wtxn, key_image, height)?;
+        wtxn.commit()
+            .map_err(|e| LedgerError::Database(format!("Failed to commit: {}", e)))?;
+        Ok(())
+    }
+
     /// Get a random sample of UTXOs for use as decoys in ring signatures.
     pub fn get_decoy_outputs(
         &self,

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -580,6 +580,7 @@ async fn handle_rpc_method(request: &JsonRpcRequest, state: &RpcState) -> JsonRp
 
         // Wallet methods (for thin wallet sync)
         "chain_getOutputs" => handle_get_outputs(id, &request.params, state).await,
+        "chain_areKeyImagesSpent" => handle_are_key_images_spent(id, &request.params, state).await,
         "wallet_getBalance" => handle_wallet_balance(id, state).await,
         "wallet_getAddress" => handle_wallet_address(id, state).await,
 
@@ -1099,6 +1100,113 @@ async fn handle_get_outputs(id: Value, params: &Value, state: &RpcState) -> Json
     }
 
     JsonRpcResponse::success(id, json!(blocks))
+}
+
+/// Report which of the supplied key images have been spent.
+///
+/// This is a read-only query that lets thin (web) wallets learn whether their
+/// owned outputs have already been spent, so they can exclude spent outputs
+/// from both their displayed balance and their spendable-output selection.
+/// The thin wallet computes each owned output's key image client-side (it holds
+/// the spend key) and asks the node which are spent — mirroring the
+/// double-spend check the node already performs for its own configured wallet
+/// in `handle_wallet_balance`.
+///
+/// Params: `{ "keyImages": ["<hex>", ...] }` (hex-encoded 32-byte key images).
+/// Also accepts the snake_case alias `key_images` for convenience.
+///
+/// Result: a list with one entry per input key image, preserving order:
+/// `[{ "keyImage": "<hex>", "spent": bool, "spentHeight": <u64|null>,
+/// "pending": bool }]`.
+/// - `spent` is true if the key image is recorded on-chain (double-spend set).
+/// - `spentHeight` is the block height at which it was spent (null if unspent).
+/// - `pending` is true if the key image is currently pending in the mempool (an
+///   in-flight spend not yet mined). Wallets should treat either `spent ||
+///   pending` as "not spendable".
+///
+/// Invalid hex or wrong-length entries are reported with `spent: false`,
+/// `pending: false`, and an `error` field rather than failing the whole call.
+async fn handle_are_key_images_spent(
+    id: Value,
+    params: &Value,
+    state: &RpcState,
+) -> JsonRpcResponse {
+    let key_images = params
+        .get("keyImages")
+        .or_else(|| params.get("key_images"))
+        .and_then(|v| v.as_array());
+
+    let key_images = match key_images {
+        Some(arr) => arr,
+        None => {
+            return JsonRpcResponse::error(
+                id,
+                -32602,
+                "Missing keyImages parameter (expected an array of hex strings)",
+            )
+        }
+    };
+
+    let ledger = read_lock!(state.ledger, id.clone());
+    let mempool = read_lock!(state.mempool, id);
+
+    let mut results = Vec::with_capacity(key_images.len());
+
+    for entry in key_images {
+        let ki_hex = match entry.as_str() {
+            Some(s) => s,
+            None => {
+                results.push(json!({
+                    "keyImage": entry,
+                    "spent": false,
+                    "spentHeight": Value::Null,
+                    "pending": false,
+                    "error": "key image must be a hex string",
+                }));
+                continue;
+            }
+        };
+
+        let bytes = match hex::decode(ki_hex) {
+            Ok(b) => b,
+            Err(_) => {
+                results.push(json!({
+                    "keyImage": ki_hex,
+                    "spent": false,
+                    "spentHeight": Value::Null,
+                    "pending": false,
+                    "error": "invalid hex encoding",
+                }));
+                continue;
+            }
+        };
+
+        let key_image_bytes: [u8; 32] = match bytes.try_into() {
+            Ok(arr) => arr,
+            Err(_) => {
+                results.push(json!({
+                    "keyImage": ki_hex,
+                    "spent": false,
+                    "spentHeight": Value::Null,
+                    "pending": false,
+                    "error": "key image must be 32 bytes",
+                }));
+                continue;
+            }
+        };
+
+        let spent_height = ledger.is_key_image_spent(&key_image_bytes).unwrap_or(None);
+        let pending = mempool.is_key_image_pending(&key_image_bytes);
+
+        results.push(json!({
+            "keyImage": ki_hex,
+            "spent": spent_height.is_some(),
+            "spentHeight": spent_height,
+            "pending": pending,
+        }));
+    }
+
+    JsonRpcResponse::success(id, json!(results))
 }
 
 async fn handle_wallet_balance(id: Value, state: &RpcState) -> JsonRpcResponse {
@@ -2780,6 +2888,92 @@ async fn handle_faucet_status(id: Value, state: &RpcState) -> JsonRpcResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #392: thin wallets cannot learn which of their owned outputs are spent
+    /// because `chain_getOutputs` reports ownership only.
+    /// `chain_areKeyImagesSpent` exposes the node's on-chain double-spend
+    /// set so the wallet can exclude spent outputs from its balance and
+    /// spendable selection. This verifies a spent key image is reported
+    /// `spent: true` (with height) and an unspent one `spent: false`.
+    #[tokio::test]
+    async fn test_are_key_images_spent_reports_spent_and_unspent() {
+        use crate::{ledger::Ledger, mempool::Mempool};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        // Record one key image as spent on-chain at height 7.
+        let spent_ki: [u8; 32] = [0x11; 32];
+        let unspent_ki: [u8; 32] = [0x22; 32];
+        ledger.record_key_image_for_test(&spent_ki, 7).unwrap();
+
+        let state = RpcState::new(
+            ledger,
+            Mempool::new(),
+            Network::Testnet,
+            None,
+            None,
+            vec![],
+            Arc::new(WsBroadcaster::new(16)),
+        );
+
+        let params = json!({
+            "keyImages": [hex::encode(spent_ki), hex::encode(unspent_ki)],
+        });
+
+        let resp = handle_are_key_images_spent(json!(1), &params, &state).await;
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+        let result = resp.result.unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+
+        // First key image: spent on-chain at height 7.
+        assert_eq!(arr[0]["spent"], json!(true));
+        assert_eq!(arr[0]["spentHeight"], json!(7));
+        assert_eq!(arr[0]["pending"], json!(false));
+        assert_eq!(arr[0]["keyImage"], json!(hex::encode(spent_ki)));
+
+        // Second key image: never spent.
+        assert_eq!(arr[1]["spent"], json!(false));
+        assert_eq!(arr[1]["spentHeight"], Value::Null);
+        assert_eq!(arr[1]["pending"], json!(false));
+        assert_eq!(arr[1]["keyImage"], json!(hex::encode(unspent_ki)));
+    }
+
+    /// #392: malformed key-image entries must be reported per-entry rather than
+    /// failing the whole batch, and a missing `keyImages` param is a -32602.
+    #[tokio::test]
+    async fn test_are_key_images_spent_handles_bad_input() {
+        use crate::{ledger::Ledger, mempool::Mempool};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        let state = RpcState::new(
+            ledger,
+            Mempool::new(),
+            Network::Testnet,
+            None,
+            None,
+            vec![],
+            Arc::new(WsBroadcaster::new(16)),
+        );
+
+        // Missing param -> invalid params error.
+        let resp = handle_are_key_images_spent(json!(1), &json!({}), &state).await;
+        assert!(resp.error.is_some());
+        assert_eq!(resp.error.unwrap().code, -32602);
+
+        // Bad hex and wrong length are reported per-entry, not fatal.
+        let params = json!({ "keyImages": ["zz", "abcd"] });
+        let resp = handle_are_key_images_spent(json!(1), &params, &state).await;
+        let arr = resp.result.unwrap();
+        let arr = arr.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["spent"], json!(false));
+        assert!(arr[0]["error"].is_string());
+        assert_eq!(arr[1]["spent"], json!(false));
+        assert!(arr[1]["error"].is_string());
+    }
 
     #[test]
     fn test_cors_wildcard_allows_any_origin() {

--- a/web/packages/adapters/src/remote.ts
+++ b/web/packages/adapters/src/remote.ts
@@ -368,6 +368,34 @@ export class RemoteNodeAdapter implements NodeAdapter {
     )
   }
 
+  /**
+   * Query the node's `chain_areKeyImagesSpent` RPC: for each supplied
+   * hex-encoded key image, report whether it is spent on-chain or pending in
+   * the mempool. The thin wallet uses this (with key images derived client-side
+   * by the wasm signer) to exclude already-spent owned outputs from its balance
+   * and from spendable-input selection — the node's `wallet_getBalance` only
+   * spent-filters the node's OWN wallet, not arbitrary thin-wallet keys (#392).
+   */
+  async areKeyImagesSpent(
+    keyImages: string[],
+  ): Promise<
+    Array<{
+      keyImage: string
+      spent: boolean
+      spentHeight: number | null
+      pending: boolean
+    }>
+  > {
+    return this.call<
+      Array<{
+        keyImage: string
+        spent: boolean
+        spentHeight: number | null
+        pending: boolean
+      }>
+    >('chain_areKeyImagesSpent', { keyImages })
+  }
+
   async getTransaction(txHash: TxHash): Promise<Transaction | null> {
     try {
       // The node's getTransaction RPC returns a "Transaction not found" error

--- a/web/packages/wasm-signer/Cargo.toml
+++ b/web/packages/wasm-signer/Cargo.toml
@@ -21,6 +21,10 @@ path = "src/lib.rs"
 bth-transaction-clsag = { path = "../../../transaction/clsag" }
 bth-account-keys = { path = "../../../account-keys" }
 bth-crypto-keys = { path = "../../../crypto/keys" }
+# Key-image derivation, identical to the node's double-spend check. Used to
+# compute owned-output key images so the wallet can query spent status via the
+# node's `chain_areKeyImagesSpent` RPC and exclude spent outputs.
+bth-crypto-ring-signature = { path = "../../../crypto/ring-signature" }
 
 serde = { version = "1", features = ["derive"] }
 bincode = "1"

--- a/web/packages/wasm-signer/src/core.rs
+++ b/web/packages/wasm-signer/src/core.rs
@@ -340,6 +340,83 @@ pub fn scan_owned_outputs_inner(req: &ScanRequest) -> Result<Vec<OwnedOutput>, S
     Ok(owned)
 }
 
+/// Request to compute key images for a set of owned outputs.
+///
+/// The wallet supplies its private keys plus the outputs it owns (as returned
+/// by [`scan_owned_outputs_inner`]). The signer recovers each output's one-time
+/// private key and derives its key image — exactly the value the node records
+/// in its double-spend set when the output is spent.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyImageRequest {
+    /// Hex-encoded 32-byte account spend private key. **Stays client-side.**
+    pub spend_private_key: String,
+    /// Hex-encoded 32-byte account view private key. **Stays client-side.**
+    pub view_private_key: String,
+    /// The wallet's owned outputs to derive key images for.
+    pub outputs: Vec<OwnedOutput>,
+}
+
+/// An owned output paired with its derived key image.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OwnedOutputKeyImage {
+    /// Hex-encoded 32-byte one-time target key of the owned output.
+    pub target_key: String,
+    /// Hex-encoded 32-byte ephemeral public key of the owned output.
+    pub public_key: String,
+    /// Amount in picocredits of the owned output.
+    pub amount: u64,
+    /// Subaddress index that received this output (0 = default, 1 = change).
+    pub subaddress_index: u64,
+    /// Hex-encoded 32-byte key image. Querying the node's
+    /// `chain_areKeyImagesSpent` RPC with this value reveals whether the output
+    /// has already been spent on-chain (or is pending in the mempool).
+    pub key_image: String,
+}
+
+/// Derive the key image for each owned output.
+///
+/// Uses the **node-identical** derivation: recover the one-time private key via
+/// [`TxOutput::recover_spend_key`] (same as the node's
+/// `recover_spend_key`), then `KeyImage::from(&onetime_private)` —
+/// byte-for-byte what the node records in its double-spend set and checks in
+/// `wallet_getBalance` / `handle_are_key_images_spent`. This lets a thin wallet
+/// learn which of its owned outputs are spent without re-implementing the
+/// derivation in JS.
+pub fn compute_owned_output_key_images_inner(
+    req: &KeyImageRequest,
+) -> Result<Vec<OwnedOutputKeyImage>, String> {
+    use bth_crypto_ring_signature::KeyImage;
+
+    let spend_private = parse_private("spendPrivateKey", &req.spend_private_key)?;
+    let view_private = parse_private("viewPrivateKey", &req.view_private_key)?;
+    let account = AccountKey::new(&spend_private, &view_private);
+
+    let mut result = Vec::with_capacity(req.outputs.len());
+    for out in &req.outputs {
+        let tx_out = TxOutput {
+            amount: out.amount,
+            target_key: parse_hex_32("output.target_key", &out.target_key)?,
+            public_key: parse_hex_32("output.public_key", &out.public_key)?,
+            e_memo: None,
+            cluster_tags: Default::default(),
+        };
+        let onetime_private = tx_out
+            .recover_spend_key(&account, out.subaddress_index)
+            .ok_or("failed to recover one-time private key for owned output")?;
+        let key_image = KeyImage::from(&onetime_private);
+        result.push(OwnedOutputKeyImage {
+            target_key: out.target_key.clone(),
+            public_key: out.public_key.clone(),
+            amount: out.amount,
+            subaddress_index: out.subaddress_index,
+            key_image: hex::encode(key_image.as_bytes()),
+        });
+    }
+    Ok(result)
+}
+
 /// Build, CLSAG-sign, and bincode-serialize a transaction, returning hex.
 ///
 /// The returned hex is the exact `tx_hex` payload accepted by the node's
@@ -480,6 +557,102 @@ mod tests {
             .expect("deserialized tx must still verify");
         assert_eq!(decoded.fee, tx.fee);
         assert_eq!(decoded.outputs.len(), tx.outputs.len());
+    }
+
+    /// #392: the key image the wallet computes for an owned output must equal
+    /// the key image embedded in a CLSAG signature spending that same output.
+    /// If they match, the wallet can reliably query the node's
+    /// `chain_areKeyImagesSpent` and exclude spent outputs from its balance.
+    #[test]
+    fn computed_key_image_matches_signed_input() {
+        let mut rng = StdRng::from_seed([13u8; 32]);
+        let sender = AccountKey::random(&mut rng);
+
+        // The wallet's own output (default subaddress, index 0).
+        let owned_amount = 10_000_000_000u64;
+        let owned = TxOutput::new(owned_amount, &sender.default_subaddress());
+
+        // Compute the key image via the wallet path.
+        let ki_req = KeyImageRequest {
+            spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            outputs: vec![OwnedOutput {
+                target_key: hex::encode(owned.target_key),
+                public_key: hex::encode(owned.public_key),
+                amount: owned_amount,
+                subaddress_index: 0,
+            }],
+        };
+        let computed = compute_owned_output_key_images_inner(&ki_req).unwrap();
+        assert_eq!(computed.len(), 1);
+
+        // Build + sign a tx spending the same output, then read the key image
+        // the CLSAG signature actually used.
+        let decoys = make_decoys(DEFAULT_RING_SIZE - 1, owned_amount, &mut rng);
+        let recipient_account = AccountKey::random(&mut rng);
+        let req = SignRequest {
+            spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            inputs: vec![SpendInput {
+                target_key: hex::encode(owned.target_key),
+                public_key: hex::encode(owned.public_key),
+                amount: owned_amount,
+                subaddress_index: 0,
+                decoys,
+            }],
+            recipient: recipient_of(&recipient_account),
+            amount: 5_000_000_000,
+            fee: MIN_TX_FEE,
+            created_at_height: 1000,
+        };
+        let tx = build_and_sign_with_rng(&req, &mut rng).unwrap();
+        let signed_ki = hex::encode(tx.inputs.clsag()[0].key_image());
+
+        assert_eq!(
+            computed[0].key_image, signed_ki,
+            "wallet-computed key image must match the CLSAG signature's key image"
+        );
+    }
+
+    /// #392: ownership scan + key-image derivation must agree on which outputs
+    /// are the wallet's. An output paid to a different account yields no owned
+    /// outputs, hence no key images.
+    #[test]
+    fn key_images_only_for_owned_outputs() {
+        let mut rng = StdRng::from_seed([17u8; 32]);
+        let me = AccountKey::random(&mut rng);
+        let other = AccountKey::random(&mut rng);
+
+        let mine = TxOutput::new(1_000_000_000, &me.default_subaddress());
+        let theirs = TxOutput::new(2_000_000_000, &other.default_subaddress());
+
+        let scan = ScanRequest {
+            spend_private_key: hex::encode(me.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(me.view_private_key().to_bytes()),
+            outputs: vec![
+                ChainOutput {
+                    target_key: hex::encode(mine.target_key),
+                    public_key: hex::encode(mine.public_key),
+                    amount: 1_000_000_000,
+                },
+                ChainOutput {
+                    target_key: hex::encode(theirs.target_key),
+                    public_key: hex::encode(theirs.public_key),
+                    amount: 2_000_000_000,
+                },
+            ],
+        };
+        let owned = scan_owned_outputs_inner(&scan).unwrap();
+        assert_eq!(owned.len(), 1, "only my output should be owned");
+
+        let ki_req = KeyImageRequest {
+            spend_private_key: scan.spend_private_key.clone(),
+            view_private_key: scan.view_private_key.clone(),
+            outputs: owned,
+        };
+        let kis = compute_owned_output_key_images_inner(&ki_req).unwrap();
+        assert_eq!(kis.len(), 1);
+        assert_eq!(kis[0].amount, 1_000_000_000);
     }
 
     #[test]

--- a/web/packages/wasm-signer/src/index.ts
+++ b/web/packages/wasm-signer/src/index.ts
@@ -110,6 +110,37 @@ export interface OwnedOutput {
   subaddressIndex: bigint
 }
 
+/**
+ * A request to compute key images for owned outputs. The wallet supplies the
+ * outputs returned by `scanOwnedOutputs`.
+ */
+export interface KeyImageRequest {
+  /** Hex-encoded 32-byte account spend private key. Stays client-side. */
+  spendPrivateKey: string
+  /** Hex-encoded 32-byte account view private key. Stays client-side. */
+  viewPrivateKey: string
+  /** The wallet's owned outputs to derive key images for. */
+  outputs: OwnedOutput[]
+}
+
+/** An owned output annotated with its derived key image. */
+export interface OwnedOutputKeyImage {
+  /** Hex-encoded 32-byte one-time target key of the owned output. */
+  targetKey: string
+  /** Hex-encoded 32-byte ephemeral public key of the owned output. */
+  publicKey: string
+  /** Amount in picocredits of the owned output. */
+  amount: bigint
+  /** Subaddress index that received this output (0 = default, 1 = change). */
+  subaddressIndex: bigint
+  /**
+   * Hex-encoded 32-byte key image. Querying the node's
+   * `chain_areKeyImagesSpent` RPC with this value reveals whether the output
+   * has already been spent.
+   */
+  keyImage: string
+}
+
 /** The wasm module's exported surface. */
 export interface WasmSigner {
   /**
@@ -124,6 +155,13 @@ export interface WasmSigner {
    * with their recovered subaddress index. The keys never leave the client.
    */
   scanOwnedOutputs(request: ScanRequest): OwnedOutput[]
+  /**
+   * Compute the key image for each owned output, using the node-identical
+   * derivation. Pass the resulting key images to `chain_areKeyImagesSpent` to
+   * learn which owned outputs are already spent so they can be excluded from
+   * balance and spendable selection. The keys never leave the client.
+   */
+  computeOwnedOutputKeyImages(request: KeyImageRequest): OwnedOutputKeyImage[]
   /** The CLSAG ring size the network requires (decoys + 1 real input). */
   ringSize(): number
   /** The minimum transaction fee in picocredits. */
@@ -145,6 +183,7 @@ export async function loadSigner(): Promise<WasmSigner> {
       default: (init?: unknown) => Promise<unknown>
       buildAndSign: (request: unknown) => string
       scanOwnedOutputs: (request: unknown) => unknown
+      computeOwnedOutputKeyImages: (request: unknown) => unknown
       ringSize: () => number
       minFee: () => bigint
     }
@@ -167,6 +206,8 @@ export async function loadSigner(): Promise<WasmSigner> {
       buildAndSign: (request: SignRequest) => mod.buildAndSign(request),
       scanOwnedOutputs: (request: ScanRequest) =>
         mod.scanOwnedOutputs(request) as OwnedOutput[],
+      computeOwnedOutputKeyImages: (request: KeyImageRequest) =>
+        mod.computeOwnedOutputKeyImages(request) as OwnedOutputKeyImage[],
       ringSize: () => mod.ringSize(),
       minFee: () => mod.minFee(),
     }
@@ -196,8 +237,11 @@ export function setSigner(signer: WasmSigner): void {
 
 export {
   buildSendTransaction,
+  spendableBalance,
+  spendableOwnedOutputs,
   type BuildSendParams,
   type BuildSendResult,
+  type KeyImageSpentStatus,
   type SendRpc,
   type SignerKeys,
 } from './send'

--- a/web/packages/wasm-signer/src/lib.rs
+++ b/web/packages/wasm-signer/src/lib.rs
@@ -35,7 +35,10 @@ pub mod core;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use crate::core::{build_and_sign_inner, scan_owned_outputs_inner, ScanRequest, SignRequest};
+    use crate::core::{
+        build_and_sign_inner, compute_owned_output_key_images_inner, scan_owned_outputs_inner,
+        KeyImageRequest, ScanRequest, SignRequest,
+    };
     use wasm_bindgen::prelude::*;
 
     /// Build and CLSAG-sign a Botho transaction entirely client-side.
@@ -69,6 +72,24 @@ mod wasm {
         let owned = scan_owned_outputs_inner(&req).map_err(|e| JsError::new(&e))?;
         serde_wasm_bindgen::to_value(&owned)
             .map_err(|e| JsError::new(&format!("failed to serialize owned outputs: {e}")))
+    }
+
+    /// Compute the key image for each of the wallet's owned outputs.
+    ///
+    /// `request` is a JS object matching [`KeyImageRequest`]: the spend/view
+    /// private keys (hex) and the owned outputs (as returned by
+    /// `scanOwnedOutputs`). Returns each output annotated with its hex-encoded
+    /// key image. The wallet passes these key images to the node's
+    /// `chain_areKeyImagesSpent` RPC to learn which owned outputs are already
+    /// spent, so it can exclude them from its balance and spendable selection.
+    /// Uses the node-identical derivation, so spent-status cannot drift.
+    #[wasm_bindgen(js_name = computeOwnedOutputKeyImages)]
+    pub fn compute_owned_output_key_images(request: JsValue) -> Result<JsValue, JsError> {
+        let req: KeyImageRequest = serde_wasm_bindgen::from_value(request)
+            .map_err(|e| JsError::new(&format!("invalid key image request: {e}")))?;
+        let result = compute_owned_output_key_images_inner(&req).map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&result)
+            .map_err(|e| JsError::new(&format!("failed to serialize key images: {e}")))
     }
 
     /// The CLSAG ring size the network requires (decoys + 1 real input).

--- a/web/packages/wasm-signer/src/send.ts
+++ b/web/packages/wasm-signer/src/send.ts
@@ -21,6 +21,7 @@ import {
   type RecipientAddress,
   type SignRequest,
   type SpendInput,
+  type WasmSigner,
 } from './index'
 
 /** The account private keys the caller derived from the mnemonic. */
@@ -45,6 +46,93 @@ export interface SendRpc {
    * recovered from the output's commitment.
    */
   getOutputs(startHeight: number, endHeight: number): Promise<ChainOutput[]>
+  /**
+   * Query the node's `chain_areKeyImagesSpent` RPC: given a list of hex-encoded
+   * key images, return for each whether it is spent on-chain or pending in the
+   * mempool. The wallet uses this to exclude already-spent owned outputs from
+   * its balance and from spendable-input selection (so it never tries to
+   * double-spend its own output). Order is preserved to match the input list.
+   */
+  areKeyImagesSpent(keyImages: string[]): Promise<KeyImageSpentStatus[]>
+}
+
+/** The spent/pending status of a single key image, as returned by the node. */
+export interface KeyImageSpentStatus {
+  /** The queried key image (hex). */
+  keyImage: string
+  /** True if the key image is recorded in the on-chain double-spend set. */
+  spent: boolean
+  /** Block height the key image was spent at, or null if unspent. */
+  spentHeight: number | null
+  /** True if the key image is currently pending in the mempool. */
+  pending: boolean
+}
+
+/**
+ * Filter a wallet's owned outputs down to the ones that are actually spendable:
+ * those whose key image is neither spent on-chain nor pending in the mempool.
+ *
+ * This is the core of the thin-wallet spent-awareness fix (#392): without it,
+ * the wallet counts already-spent outputs in its balance (overstating it) and
+ * could select a spent output as a transaction input (a guaranteed
+ * double-spend rejection). It mirrors the node's own `wallet_getBalance`
+ * filtering, but works for arbitrary thin-wallet keys.
+ */
+export async function spendableOwnedOutputs(
+  signer: WasmSigner,
+  keys: SignerKeys,
+  owned: OwnedOutput[],
+  rpc: SendRpc,
+): Promise<OwnedOutput[]> {
+  if (owned.length === 0) return []
+
+  // Derive each owned output's key image (node-identical derivation inside
+  // wasm), then ask the node which are spent/pending.
+  const withImages = signer.computeOwnedOutputKeyImages({
+    spendPrivateKey: keys.spendPrivateKey,
+    viewPrivateKey: keys.viewPrivateKey,
+    outputs: owned,
+  })
+  const statuses = await rpc.areKeyImagesSpent(withImages.map((o) => o.keyImage))
+
+  // Map key image -> spendable. Treat anything we couldn't get a clear answer
+  // for as spent (conservative: never overstate balance / never select it).
+  const spendableByKeyImage = new Map<string, boolean>()
+  for (const s of statuses) {
+    spendableByKeyImage.set(s.keyImage, !s.spent && !s.pending)
+  }
+
+  return withImages
+    .filter((o) => spendableByKeyImage.get(o.keyImage) === true)
+    .map((o) => ({
+      targetKey: o.targetKey,
+      publicKey: o.publicKey,
+      amount: o.amount,
+      subaddressIndex: o.subaddressIndex,
+    }))
+}
+
+/**
+ * Compute the wallet's spendable balance: the sum of owned outputs that are
+ * neither spent on-chain nor pending. This is the figure the UI should display
+ * — it excludes outputs the wallet has already spent (#392).
+ */
+export async function spendableBalance(
+  keys: SignerKeys,
+  rpc: SendRpc,
+): Promise<bigint> {
+  const signer = await loadSigner()
+  const height = await rpc.getChainHeight()
+  const candidates = await rpc.getOutputs(0, height)
+  if (candidates.length === 0) return 0n
+
+  const owned = signer.scanOwnedOutputs({
+    spendPrivateKey: keys.spendPrivateKey,
+    viewPrivateKey: keys.viewPrivateKey,
+    outputs: candidates,
+  })
+  const spendable = await spendableOwnedOutputs(signer, keys, owned, rpc)
+  return spendable.reduce((s, o) => s + toBigInt(o.amount), 0n)
 }
 
 /** Inputs to {@link buildSendTransaction}. */
@@ -128,11 +216,19 @@ export async function buildSendTransaction(
     throw new Error('No spendable outputs found for this wallet')
   }
 
+  // 1b. Exclude outputs the wallet has already spent (on-chain or pending).
+  // Selecting a spent output as an input is a guaranteed double-spend
+  // rejection, so we filter to spendable outputs before input selection (#392).
+  const spendable = await spendableOwnedOutputs(signer, keys, owned, rpc)
+  if (spendable.length === 0) {
+    throw new Error('No spendable outputs found for this wallet (all spent)')
+  }
+
   // 2. Select inputs covering amount + fee.
   const target = amount + fee
-  const inputs = selectInputs(owned, target)
+  const inputs = selectInputs(spendable, target)
   if (!inputs) {
-    const have = owned.reduce((s, o) => s + toBigInt(o.amount), 0n)
+    const have = spendable.reduce((s, o) => s + toBigInt(o.amount), 0n)
     throw new Error(
       `Insufficient funds: need ${target} picocredits (amount + fee), have ${have}`,
     )

--- a/web/packages/wasm-signer/test/exchange-live-node.test.ts
+++ b/web/packages/wasm-signer/test/exchange-live-node.test.ts
@@ -53,9 +53,11 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { deriveKeypairs, deriveAddress, parseAddress } from '@botho/core'
 import {
   buildSendTransaction,
+  spendableBalance,
   setSigner,
   resetSigner,
   type ChainOutput,
+  type KeyImageSpentStatus,
   type SendRpc,
   type WasmSigner,
 } from '../src/index'
@@ -103,6 +105,7 @@ async function loadWasmNode(): Promise<WasmSigner> {
   return {
     buildAndSign: (request) => mod.buildAndSign(request),
     scanOwnedOutputs: (request) => mod.scanOwnedOutputs(request),
+    computeOwnedOutputKeyImages: (request) => mod.computeOwnedOutputKeyImages(request),
     ringSize: () => mod.ringSize(),
     minFee: () => mod.minFee(),
   }
@@ -195,6 +198,8 @@ maybe('node-backed: two-user bidirectional payment exchange (#390)', () => {
           })),
         ),
       ),
+    areKeyImagesSpent: (keyImages) =>
+      rpc<KeyImageSpentStatus[]>('chain_areKeyImagesSpent', { keyImages }),
   })
 
   /**
@@ -397,23 +402,26 @@ maybe('node-backed: two-user bidirectional payment exchange (#390)', () => {
 
     // Assert: B's SPENDABLE balance after the round-trip == sendAmount -
     // returnAmount - fee (B received `sendAmount`, then spent `returnAmount` +
-    // `fee`, the remainder returns to B as change). B consumed the output it
-    // received from A (`bReceived`) as the B->A input, so we exclude that
-    // now-spent output from B's spendable set (scanOwnedOutputs still reports
-    // it as owned — see `ownedBalance`). What remains is exactly B's change.
-    const bSpent = new Set(ba.inputs.map((i) => i.targetKey))
-    expect(bSpent.has(bReceived!.targetKey)).toBe(true)
-    const bBalAfterBA = await ownedBalance(keysB, bSpent)
+    // `fee`, the remainder returns to B as change).
+    //
+    // #392: this is now computed by the WALLET's real spent-filtered balance
+    // (`spendableBalance`), which derives B's owned-output key images in wasm
+    // and queries the node's `chain_areKeyImagesSpent` RPC to exclude the
+    // already-spent output. There is NO manual exclusion of `bReceived` here —
+    // the wallet/RPC must do the filtering itself. (Previously the test had to
+    // pass the known-spent target key to `ownedBalance` because the thin-wallet
+    // path had no spent awareness; that workaround is gone, proving the fix.)
+    const bBalAfterBA = await spendableBalance(keysB, sendRpc())
     expect(bBalAfterBA).toBe(sendAmount - returnAmount - fee)
     // eslint-disable-next-line no-console
     console.log(
-      '[#390] B balance: received',
+      '[#390] B wallet-computed spendable balance: received',
       sendAmount,
       '-> after re-spend',
       bBalAfterBA,
       '(== sendAmount - returnAmount - fee =',
       sendAmount - returnAmount - fee,
-      ')',
+      ', no manual exclusion)',
     )
   }, 300_000)
 })

--- a/web/packages/wasm-signer/test/send-live-node.test.ts
+++ b/web/packages/wasm-signer/test/send-live-node.test.ts
@@ -44,6 +44,7 @@ import {
   setSigner,
   resetSigner,
   type ChainOutput,
+  type KeyImageSpentStatus,
   type SendRpc,
   type WasmSigner,
 } from '../src/index'
@@ -97,6 +98,7 @@ async function loadWasmNode(): Promise<WasmSigner> {
   return {
     buildAndSign: (request) => mod.buildAndSign(request),
     scanOwnedOutputs: (request) => mod.scanOwnedOutputs(request),
+    computeOwnedOutputKeyImages: (request) => mod.computeOwnedOutputKeyImages(request),
     ringSize: () => mod.ringSize(),
     minFee: () => mod.minFee(),
   }
@@ -233,6 +235,8 @@ maybe('node-backed: web-wallet -> tx -> ledger', () => {
             })),
           ),
         ),
+      areKeyImagesSpent: (keyImages) =>
+        rpc<KeyImageSpentStatus[]>('chain_areKeyImagesSpent', { keyImages }),
     }
 
     const { txHex, inputTotal } = await buildSendTransaction({

--- a/web/packages/wasm-signer/test/sign.test.ts
+++ b/web/packages/wasm-signer/test/sign.test.ts
@@ -24,6 +24,7 @@ async function loadSignerNode(): Promise<WasmSigner> {
     default: (init: { module_or_path: BufferSource }) => Promise<unknown>
     buildAndSign: (request: unknown) => string
     scanOwnedOutputs: (request: unknown) => unknown
+    computeOwnedOutputKeyImages: (request: unknown) => unknown
     ringSize: () => number
     minFee: () => bigint
   }
@@ -32,6 +33,10 @@ async function loadSignerNode(): Promise<WasmSigner> {
   return {
     buildAndSign: (request: SignRequest) => mod.buildAndSign(request),
     scanOwnedOutputs: (request) => mod.scanOwnedOutputs(request) as ReturnType<WasmSigner['scanOwnedOutputs']>,
+    computeOwnedOutputKeyImages: (request) =>
+      mod.computeOwnedOutputKeyImages(request) as ReturnType<
+        WasmSigner['computeOwnedOutputKeyImages']
+      >,
     ringSize: () => mod.ringSize(),
     minFee: () => mod.minFee(),
   }

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -10,7 +10,7 @@ import {
 import { RemoteNodeAdapter, type WsConnectionStatus } from '@botho/adapters'
 import { AddressBook, saveWallet, loadWallet, getWalletInfo, deriveAddress, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet } from '@botho/core'
 import type { Balance, Contact, NodeInfo, Transaction } from '@botho/core'
-import { buildSendTransaction } from '@botho/wasm-signer'
+import { buildSendTransaction, spendableBalance } from '@botho/wasm-signer'
 import { type NetworkConfig, loadSelectedNetwork, NETWORKS, DEFAULT_NETWORK_ID, createCustomNetwork } from '../config/networks'
 
 interface WalletState {
@@ -76,6 +76,48 @@ function hexToBytes(hex: string): Uint8Array {
     out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
   }
   return out
+}
+
+/**
+ * Compute the wallet's balance, spent-filtered for the thin-wallet path (#392).
+ *
+ * The node's `wallet_getBalance` (used by `adapter.getBalance`) only
+ * spent-filters the node's OWN configured wallet — for an arbitrary thin-wallet
+ * key it would either error or report ownership-only sums that count
+ * already-spent outputs, overstating the balance after a send. When the wallet
+ * is unlocked (mnemonic available), we instead compute the true SPENDABLE
+ * balance entirely client-side: derive owned-output key images in wasm and ask
+ * the node's `chain_areKeyImagesSpent` RPC which are spent. If the wallet is
+ * locked (no mnemonic), fall back to the node RPC balance.
+ */
+async function fetchBalance(
+  adapter: RemoteNodeAdapter,
+  address: string,
+  mnemonic: string | null,
+): Promise<Balance> {
+  if (!mnemonic) {
+    return adapter.getBalance([address])
+  }
+  try {
+    const kp = deriveKeypairs(mnemonic, 0)
+    const available = await spendableBalance(
+      {
+        spendPrivateKey: toHex(kp.spendPrivate),
+        viewPrivateKey: toHex(kp.viewPrivate),
+      },
+      {
+        getChainHeight: () => adapter.getBlockHeight(),
+        getOutputs: (start, end) => adapter.getRawOutputs(start, end),
+        areKeyImagesSpent: (keyImages) => adapter.areKeyImagesSpent(keyImages),
+      },
+    )
+    return { available, pending: 0n, total: available }
+  } catch {
+    // If the client-side spendable computation is unavailable (e.g. the wasm
+    // artifact failed to load), fall back to the node RPC balance rather than
+    // surfacing no balance at all.
+    return adapter.getBalance([address])
+  }
 }
 
 const WalletContext = createContext<WalletContextValue | null>(null)
@@ -196,7 +238,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       // Refresh balance and transactions when new block arrives
       try {
         const [balance, transactions] = await Promise.all([
-          adapter.getBalance([state.address!]),
+          fetchBalance(adapter, state.address!, mnemonicRef.current),
           adapter.getTransactionHistory([state.address!], { limit: 50 }),
         ])
         setState(s => ({ ...s, balance, transactions }))
@@ -218,7 +260,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const pollInterval = setInterval(async () => {
       try {
         const [balance, transactions] = await Promise.all([
-          adapter.getBalance([state.address!]),
+          fetchBalance(adapter, state.address!, mnemonicRef.current),
           adapter.getTransactionHistory([state.address!], { limit: 50 }),
         ])
         setState(s => ({ ...s, balance, transactions }))
@@ -254,10 +296,15 @@ export function WalletProvider({ children }: { children: ReactNode }) {
           address: walletInfo.address,
         }))
 
-        // If not encrypted, load balance immediately
+        // If not encrypted, load balance immediately. Load the (unencrypted)
+        // mnemonic into memory first so the balance is spent-filtered (#392).
         if (!walletInfo.isEncrypted && walletInfo.address) {
+          if (!mnemonicRef.current) {
+            const stored = await loadWallet()
+            if (stored) mnemonicRef.current = stored.mnemonic
+          }
           const [balance, transactions] = await Promise.all([
-            adapter.getBalance([walletInfo.address]),
+            fetchBalance(adapter, walletInfo.address, mnemonicRef.current),
             adapter.getTransactionHistory([walletInfo.address], { limit: 50 }),
           ])
           setState(s => ({ ...s, balance, transactions }))
@@ -336,7 +383,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     // Fetch balance
     const adapter = adapterRef.current
     if (adapter.isConnected()) {
-      const balance = await adapter.getBalance([address])
+      const balance = await fetchBalance(adapter, address, mnemonicRef.current)
       const transactions = await adapter.getTransactionHistory([address], { limit: 50 })
       setState(s => ({ ...s, balance, transactions }))
     }
@@ -357,7 +404,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const adapter = adapterRef.current
     if (adapter.isConnected() && stored.address) {
       const [balance, transactions] = await Promise.all([
-        adapter.getBalance([stored.address]),
+        fetchBalance(adapter, stored.address, mnemonicRef.current),
         adapter.getTransactionHistory([stored.address], { limit: 50 }),
       ])
       setState(s => ({ ...s, balance, transactions }))
@@ -443,6 +490,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       rpc: {
         getChainHeight: () => adapter.getBlockHeight(),
         getOutputs: (start, end) => adapter.getRawOutputs(start, end),
+        areKeyImagesSpent: (keyImages) => adapter.areKeyImagesSpent(keyImages),
       },
     })
 
@@ -454,8 +502,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 
     // Refresh balance/history opportunistically; ignore failures.
     if (state.address) {
-      adapter
-        .getBalance([state.address])
+      fetchBalance(adapter, state.address, mnemonicRef.current)
         .then((balance) => setState((s) => ({ ...s, balance })))
         .catch(() => {})
     }
@@ -466,7 +513,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const refreshBalance = useCallback(async () => {
     const adapter = adapterRef.current
     if (!state.address || !adapter.isConnected()) return
-    const balance = await adapter.getBalance([state.address])
+    const balance = await fetchBalance(adapter, state.address, mnemonicRef.current)
     setState(s => ({ ...s, balance }))
   }, [state.address])
 


### PR DESCRIPTION
## Summary

The thin (web) wallet computed its balance from `chain_getOutputs` + `scanOwnedOutputs` (ownership only), with no spent/key-image filtering. After a user sent funds, the displayed balance still counted the already-spent output and was overstated. The node's spent-filtered `wallet_getBalance` only covers the node's OWN configured wallet, not arbitrary thin-wallet keys.

This gives the thin wallet spent-awareness end-to-end: a new read-only node RPC, client-side key-image derivation in wasm, spent-filtered balance + spendable-input selection, and the web wallet wired to display the spendable balance.

## Changes

- **Node RPC** (`botho/src/rpc/mod.rs`): new `chain_areKeyImagesSpent` taking `{ keyImages: ["<hex>", ...] }` and returning, per image, `{ keyImage, spent, spentHeight, pending }`. Checks the ledger double-spend set (`is_key_image_spent`) and the mempool (`is_key_image_pending`). Read-only; no consensus/validation changes. (Chose the key-image-check RPC over a `spent` flag on `chain_getOutputs` — it keeps spent-status out of the output feed and lets the wallet ask only about its own outputs.)
- **Ledger** (`botho/src/ledger/store.rs`): `#[cfg(test)]` helper `record_key_image_for_test` so sibling-module tests can seed the spent set without touching the private LMDB env.
- **wasm signer** (`web/packages/wasm-signer/src/core.rs` + `lib.rs`): `computeOwnedOutputKeyImages` derives each owned output's key image with the node-identical `KeyImage::from(&onetime_private)` (added `bth-crypto-ring-signature` dep). A native test asserts the computed key image equals the one embedded in a CLSAG signature spending that output.
- **send orchestration** (`web/packages/wasm-signer/src/send.ts`): `SendRpc` gains `areKeyImagesSpent`; new `spendableOwnedOutputs` / `spendableBalance` exclude spent+pending outputs; `buildSendTransaction` filters to spendable outputs before input selection so the wallet never selects an already-spent output.
- **adapter** (`web/packages/adapters/src/remote.ts`): `RemoteNodeAdapter.areKeyImagesSpent` wraps the new RPC.
- **web wallet** (`web/packages/web-wallet/src/contexts/wallet.tsx`): balance display now uses the spent-filtered `spendableBalance` (with a fallback to the node RPC balance if wasm is unavailable).
- **#390 test** (`exchange-live-node.test.ts`): the post-send assertion now uses the wallet's real `spendableBalance` and **drops the manual `bSpent` exclusion** — the wallet/RPC does the filtering.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| After a send, computed balance reflects SPENDABLE balance (excludes spent) | ✅ | #390 e2e: B's wallet-computed spendable balance == 2.9e9 == sendAmount − returnAmount − fee |
| #390 test asserts spendable balance WITHOUT manual exclusion | ✅ | `bSpent` removed; uses `spendableBalance(keysB, sendRpc())` |
| Spendable-output selection excludes spent outputs | ✅ | `buildSendTransaction` filters via `spendableOwnedOutputs` before `selectInputs` |
| Node RPC reports spent/unspent correctly | ✅ | `test_are_key_images_spent_reports_spent_and_unspent` (+ bad-input test) |
| cargo/web build + tests green | ✅ | see Test Plan |

## Test Plan

- `cargo test -p botho --lib rpc::tests::test_are_key_images` — 2 passed
- `cargo test -p bth-wasm-signer` — 11 passed (incl. key-image parity + owned-only)
- `cargo build -p botho` — green; `cargo +nightly-2025-12-03 fmt --all -- --check` — clean
- `pnpm typecheck` — all packages pass; `pnpm test:run` — 81 passed / 6 skipped
- `BOTHO_E2E_NODE=1 node packages/wasm-signer/test/run-node-backed.mjs` — both #372 and #390 pass. Log: `[#390] B wallet-computed spendable balance: received 5000000000n -> after re-spend 2900000000n (== sendAmount - returnAmount - fee = 2900000000n , no manual exclusion)`

Closes #392