### PR TITLE
test(web): real-process test that a fresh node joins a running local chain and catches up

### DIFF
--- a/web/packages/wasm-signer/test/join-consensus-live-node.test.ts
+++ b/web/packages/wasm-signer/test/join-consensus-live-node.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Node-backed "fresh node JOINS a running local chain and catches up" test
+ * (issue #396), exercised against REAL `botho run` processes peering over real
+ * libp2p loopback.
+ *
+ * This is the hermetic, real-process demonstration of the first half of the
+ * "run your own node and participate" capability: a fresh node, starting with
+ * an empty ledger, bootstraps to an already-running chain over real libp2p (no
+ * live network), CONNECTS, and CATCHES UP from 0 to the network tip N via the
+ * real #376 catch-up sync — converging on the SAME blocks (identical hashes) as
+ * the running node. It is distinct from:
+ *   - `e2e_consensus_integration` (all nodes start at genesis together; no node
+ *     ever JOINS mid-chain),
+ *   - the in-process `TestNetwork` sim (DashMap message-passing; no real
+ *     bootstrap/sync/run-loop), and
+ *   - `scripts/join-betanet.sh` (joins the LIVE betanet over the internet; not
+ *     hermetic, not a CI gate).
+ *
+ * Topology
+ * --------
+ * Two real nodes on 127.0.0.1, each with its own throwaway data dir + config +
+ * BIP39 mnemonic and distinct gossip/rpc ports:
+ *   - A: a solo minter (explicit 1-of-1 quorum, like the single-node harness),
+ *     started first, mining the chain to a height N > ring size (real history +
+ *     decoy outputs).
+ *   - B: a fresh FOLLOWER (minting disabled), started after A reaches N,
+ *     bootstrapping to A. It must connect and catch up 0 -> N over the real
+ *     sync, ending on the exact same block hashes as A.
+ *
+ * Why a follower (and not a third minter that mines an accepted block)
+ * --------------------------------------------------------------------
+ * The original #396 goal also asked for the joiner to MINT a block the network
+ * accepts. While building this test against real processes I found that Botho
+ * has **no working multi-node block agreement today** (filed as #397):
+ *   1. Real multi-node SCP cannot exchange messages — every received SCP ballot
+ *      fails to deserialize ("Bincode does not support
+ *      Deserializer::deserialize_identifier"), so a real multi-member quorum
+ *      stalls at height 0 and produces no blocks.
+ *   2. In "solo mode" (the path that actually mints), the consensus quorum set
+ *      is frozen at startup and never updated when peers connect, so two peered
+ *      minters each mine a DIVERGENT chain and reject each other's blocks
+ *      ("Previous block hash mismatch").
+ * Consequently a joined node can sync as a follower (proven here) but cannot
+ * currently have a mined block accepted into a shared chain by established
+ * peers. The "joiner mines an accepted block + earns coinbase" half of #396 is
+ * therefore tracked in #397 (fix multi-node consensus), and this test pins the
+ * capability that DOES work end-to-end over real processes: join + catch-up.
+ *
+ * Bounded by timeouts; tears down all node processes + temp dirs.
+ *
+ * Gating + how to run: identical to the other node-backed tests — set
+ * `BOTHO_E2E_NODE=1` and run via the node-backed runner. Requires
+ * `cargo build --release -p botho` (or BOTHO_BIN=/path) and a built wasm
+ * artifact (`pnpm --filter @botho/wasm-signer build:wasm`).
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { type WasmSigner } from '../src/index'
+import {
+  startMultiNodeNetwork,
+  nodeHeight,
+  nodePeerCount,
+  type MultiNodeNetwork,
+} from './multi-node-harness'
+
+const env =
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {}
+
+const here = dirname(fileURLToPath(import.meta.url))
+const pkgDir = join(here, '..', 'pkg')
+const wasmGlue = join(pkgDir, 'bth_wasm_signer.js')
+const wasmBin = join(pkgDir, 'bth_wasm_signer_bg.wasm')
+const wasmBuilt = existsSync(wasmGlue) && existsSync(wasmBin)
+
+// This test ALWAYS needs to spawn its own local network, so it is gated solely
+// on BOTHO_E2E_NODE. (The wasm artifact is used only to read the ring size that
+// sizes N, keeping it consistent with the other node-backed tests.)
+const RUN_LOCAL_NODE = env.BOTHO_E2E_NODE === '1'
+const enabled = wasmBuilt && RUN_LOCAL_NODE
+const maybe = enabled ? describe : describe.skip
+
+interface WasmMod extends WasmSigner {
+  default: (init: { module_or_path: BufferSource }) => Promise<unknown>
+}
+
+async function loadWasmNode(): Promise<WasmSigner> {
+  const mod = (await import(/* @vite-ignore */ wasmGlue)) as unknown as WasmMod
+  await mod.default({ module_or_path: readFileSync(wasmBin) })
+  return {
+    buildAndSign: (request) => mod.buildAndSign(request),
+    scanOwnedOutputs: (request) => mod.scanOwnedOutputs(request),
+    computeOwnedOutputKeyImages: (request) => mod.computeOwnedOutputKeyImages(request),
+    ringSize: () => mod.ringSize(),
+    minFee: () => mod.minFee(),
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+function makeRpc(url: string) {
+  let id = 1
+  return async function rpc<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', method, params, id: id++ }),
+      })
+      const json = (await res.json()) as { result?: T; error?: { message: string } }
+      if (json.error) {
+        if (json.error.message.includes('Rate limit') && attempt < 40) {
+          await sleep(2000)
+          continue
+        }
+        throw new Error(`${method}: ${json.error.message}`)
+      }
+      return json.result as T
+    }
+  }
+}
+
+/** Fetch a block's hash at `height` from a node, or null if it lacks it yet. */
+async function blockHashAt(
+  rpc: ReturnType<typeof makeRpc>,
+  height: number,
+): Promise<string | null> {
+  try {
+    const b = await rpc<{ hash: string; height: number }>('getBlockByHeight', { height })
+    return b?.hash ?? null
+  } catch {
+    return null
+  }
+}
+
+// Distinct valid BIP39 test vectors. Throwaway testnet keys, no value.
+const MNEMONIC_A =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon ' +
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon ' +
+  'abandon abandon abandon abandon abandon art'
+const MNEMONIC_B = 'legal winner thank year wave sausage worth useful legal winner thank yellow'
+
+maybe('node-backed: a fresh node joins a running local chain and catches up (#396)', () => {
+  let network: MultiNodeNetwork | null = null
+  let ringSize: number
+
+  // Ports: keep clear of the other node-backed tests (17599/17798/...).
+  const PORTS = {
+    A: { gossip: 17820, rpc: 17821 },
+    B: { gossip: 17822, rpc: 17823 },
+  }
+
+  beforeAll(async () => {
+    const signer = await loadWasmNode()
+    ringSize = signer.ringSize()
+  }, 60_000)
+
+  afterAll(async () => {
+    if (network) await network.stop()
+  })
+
+  it('A mines to N > ringSize; a fresh follower B joins, connects, and syncs 0 -> N onto the same chain', async () => {
+    // ----------------------------------------------------------------------
+    // Step 1: start A — a solo minter (explicit 1-of-1 quorum, exactly like the
+    // single-node harness) — and mine to N > ringSize so there is real history
+    // and a decoy ring. B is NOT started yet.
+    // ----------------------------------------------------------------------
+    network = await startMultiNodeNetwork(
+      [
+        {
+          name: 'A',
+          mnemonic: MNEMONIC_A,
+          gossipPort: PORTS.A.gossip,
+          rpcPort: PORTS.A.rpc,
+          bootstrapGossipPorts: [],
+          mint: true,
+          // Solo minter: explicit 1-of-1 quorum (the harness emits this when
+          // minPeers === 0 — see multi-node-harness.ts), so A mines on its own
+          // and B can later follow it.
+          minPeers: 0,
+        },
+      ],
+      {
+        // Match the other node-backed tests' fast lottery eligibility so the
+        // run stays bounded; A is a solo proposer+validator, so the draw is
+        // consensus-deterministic.
+        lottery: { minUtxoAge: 1, minUtxoValue: 1 },
+      },
+    )
+
+    const nodeA = network.get('A')
+    const rpcA = makeRpc(nodeA.rpcUrl)
+
+    const N = ringSize + 4
+    {
+      const deadline = Date.now() + 180_000
+      let h = 0
+      while (Date.now() < deadline) {
+        h = await nodeHeight(nodeA.rpcUrl)
+        if (h >= N) break
+        await sleep(1000)
+      }
+      expect(
+        h,
+        `A only mined ${h}/${N} blocks.\nA log:\n${nodeA
+          .readLog()
+          .split('\n')
+          .slice(-25)
+          .join('\n')}`,
+      ).toBeGreaterThanOrEqual(N)
+    }
+    const heightN = await nodeHeight(nodeA.rpcUrl)
+    expect(heightN).toBeGreaterThan(ringSize)
+    // eslint-disable-next-line no-console
+    console.log(`[#396] A (solo minter) reached height N=${heightN} (ringSize=${ringSize})`)
+
+    // ----------------------------------------------------------------------
+    // Step 2: start B — a FRESH FOLLOWER (empty ledger, minting disabled) —
+    // bootstrapping to A. Assert it connects (peerCount >= 1).
+    // ----------------------------------------------------------------------
+    const bNetwork = await startMultiNodeNetwork(
+      [
+        {
+          name: 'B',
+          mnemonic: MNEMONIC_B,
+          gossipPort: PORTS.B.gossip,
+          rpcPort: PORTS.B.rpc,
+          bootstrapGossipPorts: [PORTS.A.gossip],
+          mint: false,
+          minPeers: 1,
+        },
+      ],
+      { lottery: { minUtxoAge: 1, minUtxoValue: 1 } },
+    )
+    // Fold B into the same network object so teardown kills both.
+    const nodeB = bNetwork.get('B')
+    network.nodes.push(nodeB)
+    const origStop = network.stop
+    const bStop = bNetwork.stop
+    network.stop = async () => {
+      await bStop()
+      await origStop()
+    }
+    const rpcB = makeRpc(nodeB.rpcUrl)
+
+    // B starts near genesis (it has its own empty ledger).
+    const bStart = await nodeHeight(nodeB.rpcUrl)
+    expect(bStart, 'B should start near genesis').toBeLessThan(heightN)
+
+    {
+      const deadline = Date.now() + 60_000
+      let connected = false
+      while (Date.now() < deadline) {
+        if ((await nodePeerCount(nodeB.rpcUrl)) >= 1) {
+          connected = true
+          break
+        }
+        await sleep(1000)
+      }
+      expect(
+        connected,
+        `B did not connect to the running node A.\nB log:\n${nodeB
+          .readLog()
+          .split('\n')
+          .slice(-30)
+          .join('\n')}`,
+      ).toBe(true)
+    }
+    // eslint-disable-next-line no-console
+    console.log(`[#396] B connected to A (peerCount=${await nodePeerCount(nodeB.rpcUrl)})`)
+
+    // ----------------------------------------------------------------------
+    // Step 3: B must catch up from 0 toward N via the real #376 catch-up sync.
+    // A keeps mining (its tip moves), so require B to reach at least the height
+    // A had when B joined — proving B backfilled history rather than getting
+    // stuck at genesis (the pre-#376 failure mode).
+    // ----------------------------------------------------------------------
+    {
+      const deadline = Date.now() + 180_000
+      let hb = 0
+      while (Date.now() < deadline) {
+        hb = await nodeHeight(nodeB.rpcUrl)
+        if (hb >= heightN) break
+        await sleep(1000)
+      }
+      expect(
+        hb,
+        `B only caught up to ${hb}/${heightN} (stuck — the pre-#376 failure).\n` +
+          `B log:\n${nodeB.readLog().split('\n').slice(-40).join('\n')}`,
+      ).toBeGreaterThanOrEqual(heightN)
+    }
+    const bHeight = await nodeHeight(nodeB.rpcUrl)
+    // eslint-disable-next-line no-console
+    console.log(`[#396] B caught up 0 -> ${bHeight} (joined at N=${heightN}) via the real sync`)
+
+    // ----------------------------------------------------------------------
+    // Step 4: B converged on the SAME chain as A — not a private fork. Compare
+    // block hashes at several heights spanning the caught-up range; every one
+    // must match A's. This proves B applied A's actual blocks (real sync), not
+    // that it merely reached a similar height.
+    // ----------------------------------------------------------------------
+    const checkHeights = Array.from(
+      new Set([1, Math.floor(heightN / 2), heightN - 1, heightN]),
+    ).filter((h) => h >= 1 && h <= heightN)
+
+    for (const h of checkHeights) {
+      const hashA = await blockHashAt(rpcA, h)
+      // B may still be a block or two behind A's *current* tip, but it must
+      // have the block at height <= heightN; poll briefly for it.
+      let hashB: string | null = null
+      const deadline = Date.now() + 30_000
+      while (Date.now() < deadline) {
+        hashB = await blockHashAt(rpcB, h)
+        if (hashB) break
+        await sleep(1000)
+      }
+      expect(hashA, `A should have block ${h}`).not.toBeNull()
+      expect(hashB, `B should have synced block ${h}`).not.toBeNull()
+      expect(hashB, `B's block ${h} hash must match A's (same chain, real sync)`).toBe(hashA)
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      `[#396] B converged on A's chain: identical block hashes at heights [${checkHeights.join(
+        ', ',
+      )}]`,
+    )
+
+    // Sanity: the running node never paused on its own (the chain is live).
+    expect(await nodeHeight(nodeA.rpcUrl)).toBeGreaterThanOrEqual(heightN)
+  }, 600_000)
+})

--- a/web/packages/wasm-signer/test/multi-node-harness.ts
+++ b/web/packages/wasm-signer/test/multi-node-harness.ts
@@ -1,0 +1,335 @@
+/**
+ * Multi-node local-network harness for the #396 "fresh node joins a running
+ * local chain and catches up" test.
+ *
+ * Where {@link node-harness.ts} spins up ONE solo-minting node, this harness
+ * spawns SEVERAL real `botho run` processes that peer with each other over real
+ * libp2p loopback transports. It is used to exercise the REAL bootstrap + #376
+ * catch-up paths that the in-process `TestNetwork` sim (DashMap message-passing)
+ * and the solo harness do not:
+ *
+ *   - real libp2p bootstrap (a fresh node dialing an already-running peer),
+ *   - the #376 catch-up sync (a fresh follower backfilling 0 -> N and
+ *     converging on the running node's exact chain).
+ *
+ * (Multi-node block *agreement* — two minters reaching one chain — does not
+ * work today; see #397. So #396's test uses one solo minter + one follower
+ * joiner, which is the capability that works end-to-end over real processes.)
+ *
+ * Each node:
+ *   - has its own throwaway data dir + config (own BIP39 mnemonic),
+ *   - binds distinct gossip/rpc ports on 127.0.0.1,
+ *   - bootstraps to other nodes via `/ip4/127.0.0.1/tcp/<gossipPort>`
+ *     multiaddrs (the transport dials a bare ip4/tcp multiaddr without a peer
+ *     id, exactly as `scripts/join-betanet.sh` does).
+ *
+ * Quorum is selected per node by `minPeers`: `0` -> a solo minter (explicit
+ * 1-of-1, like the single-node harness); `>= 1` -> a `recommended` quorum
+ * requiring that many connected peers (used by followers).
+ *
+ * Block timing is fast (`BOTHO_SLOT_DURATION_SECS=1`) and lottery eligibility
+ * is tunable (same test-only env overrides as the solo harness), so the test
+ * runs within a bounded time.
+ *
+ * Only used under Node/vitest (shells out to the node binary); imported lazily
+ * by the gated test and relies on `node:*` builtins.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+export interface NodeSpec {
+  /** Human-readable label, e.g. "A", "B", "joiner". */
+  name: string
+  /** Valid 24/12-word BIP39 mnemonic. Distinct per node so coinbase is attributable. */
+  mnemonic: string
+  /** Gossip (libp2p) port. */
+  gossipPort: number
+  /** JSON-RPC port. */
+  rpcPort: number
+  /** Gossip ports of peers to bootstrap to (loopback). */
+  bootstrapGossipPorts: number[]
+  /** Enable minting on this node. */
+  mint: boolean
+  /**
+   * Quorum selector:
+   *   - `0`  -> a SOLO minter (explicit 1-of-1 quorum, no peers required).
+   *   - `>=1` -> a `recommended` quorum requiring this many connected peers
+   *     before the node considers itself in-network (used by followers).
+   */
+  minPeers: number
+}
+
+export interface RunningNode {
+  spec: NodeSpec
+  /** Base JSON-RPC URL, e.g. http://127.0.0.1:17811/rpc. */
+  rpcUrl: string
+  /** The node's child process. */
+  child: ChildProcess
+  /** Path to the node's log file (stdout+stderr). */
+  logPath: string
+  /** Read the node's accumulated log (best-effort). */
+  readLog(): string
+}
+
+export interface MultiNodeNetwork {
+  nodes: RunningNode[]
+  /** Look a running node up by its spec name. */
+  get(name: string): RunningNode
+  /** Kill all node processes and remove all temp dirs. */
+  stop(): Promise<void>
+}
+
+export interface MultiNodeOptions {
+  /** Path to the botho binary (default: BOTHO_BIN env or repo target/release). */
+  binPath?: string
+  /** Test-only lottery eligibility overrides forwarded to every node. */
+  lottery?: {
+    minUtxoAge?: number
+    minUtxoValue?: bigint | number
+  }
+  /** Slot duration in seconds (default 1). */
+  slotDurationSecs?: number
+}
+
+function env(): Record<string, string | undefined> {
+  return (
+    (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {}
+  )
+}
+
+function resolveBinPath(explicit?: string): string {
+  const e = env()
+  if (explicit) return explicit
+  if (e.BOTHO_BIN) return e.BOTHO_BIN
+  const cwd = e.PWD ?? process.cwd()
+  const candidates = [
+    join(cwd, '..', 'target', 'release', 'botho'),
+    join(cwd, 'target', 'release', 'botho'),
+    join(cwd, '..', '..', 'target', 'release', 'botho'),
+  ]
+  for (const c of candidates) if (existsSync(c)) return c
+  return candidates[0]
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function rpcCall<T>(
+  url: string,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', method, params, id: 1 }),
+  })
+  const json = (await res.json()) as { result?: T; error?: { message: string } }
+  if (json.error) throw new Error(`${method}: ${json.error.message}`)
+  return json.result as T
+}
+
+/** Read a node's mined chain height (0 if RPC is not up yet). */
+export async function nodeHeight(rpcUrl: string): Promise<number> {
+  try {
+    const s = await rpcCall<{ chainHeight: number }>(rpcUrl, 'node_getStatus', {})
+    return s.chainHeight
+  } catch {
+    return 0
+  }
+}
+
+/** Read a node's connected peer count (0 if RPC is not up yet). */
+export async function nodePeerCount(rpcUrl: string): Promise<number> {
+  try {
+    const s = await rpcCall<{ peerCount: number }>(rpcUrl, 'node_getStatus', {})
+    return s.peerCount
+  } catch {
+    return 0
+  }
+}
+
+/**
+ * Spawn a multi-node local botho network from the supplied specs. Each node
+ * gets its own temp data dir + config; all nodes share the same binary, slot
+ * duration and lottery overrides. Returns once every node's RPC is responding
+ * (NOT once they have peered/synced — callers poll for those conditions).
+ */
+export async function startMultiNodeNetwork(
+  specs: NodeSpec[],
+  opts: MultiNodeOptions = {},
+): Promise<MultiNodeNetwork> {
+  const binPath = resolveBinPath(opts.binPath)
+  if (!existsSync(binPath)) {
+    throw new Error(
+      `botho binary not found at ${binPath}. Build it with ` +
+        '`cargo build --release -p botho` or set BOTHO_BIN.',
+    )
+  }
+
+  const slot = opts.slotDurationSecs ?? 1
+  const lotteryEnv: Record<string, string> = {}
+  if (opts.lottery?.minUtxoAge !== undefined) {
+    lotteryEnv.BOTHO_LOTTERY_MIN_UTXO_AGE = String(opts.lottery.minUtxoAge)
+  }
+  if (opts.lottery?.minUtxoValue !== undefined) {
+    lotteryEnv.BOTHO_LOTTERY_MIN_UTXO_VALUE = String(opts.lottery.minUtxoValue)
+  }
+
+  const running: RunningNode[] = []
+  const dataDirs: string[] = []
+
+  const stop = async () => {
+    for (const n of running) {
+      if (!n.child.killed) n.child.kill('SIGTERM')
+    }
+    await sleep(500)
+    for (const n of running) {
+      if (!n.child.killed) n.child.kill('SIGKILL')
+    }
+    for (const d of dataDirs) {
+      try {
+        rmSync(d, { recursive: true, force: true })
+      } catch {
+        /* best effort */
+      }
+    }
+  }
+
+  try {
+    for (const spec of specs) {
+      const dataDir = mkdtempSync(join(tmpdir(), `botho-e2e-${spec.name}-`))
+      dataDirs.push(dataDir)
+      const configPath = join(dataDir, 'config.toml')
+      const logPath = join(dataDir, 'node.log')
+
+      const bootstrap = spec.bootstrapGossipPorts
+        .map((p) => `"/ip4/127.0.0.1/tcp/${p}"`)
+        .join(', ')
+
+      // Quorum config:
+      //   minPeers === 0 -> a SOLO minter: explicit 1-of-1 quorum (no peers
+      //     required), identical to the single-node harness, so the node mines
+      //     on its own from genesis.
+      //   minPeers >= 1  -> recommended quorum: auto-trust connected peers and
+      //     require at least `minPeers` connected before minting. A follower
+      //     uses this to require a peer before it considers itself in-network.
+      const quorumLines =
+        spec.minPeers === 0
+          ? ['[network.quorum]', 'mode = "explicit"', 'threshold = 1', 'members = []', 'min_peers = 0']
+          : ['[network.quorum]', 'mode = "recommended"', `min_peers = ${spec.minPeers}`]
+
+      writeFileSync(
+        configPath,
+        [
+          'network_type = "testnet"',
+          '',
+          '[wallet]',
+          `mnemonic = "${spec.mnemonic}"`,
+          '',
+          '[network]',
+          `gossip_port = ${spec.gossipPort}`,
+          `rpc_port = ${spec.rpcPort}`,
+          'metrics_port = 0',
+          'cors_origins = ["*"]',
+          `bootstrap_peers = [${bootstrap}]`,
+          '',
+          '[network.dns_seeds]',
+          'enabled = false',
+          '',
+          ...quorumLines,
+          '',
+          '[minting]',
+          `enabled = ${spec.mint}`,
+          'threads = 1',
+          '',
+          '[faucet]',
+          '',
+        ].join('\n'),
+      )
+
+      const args = ['--testnet', '--config', configPath, 'run']
+      if (spec.mint) args.push('--mint', '--mint-threads', '1')
+
+      // Append each node's output to its own log file via a shell so we can
+      // surface diagnostics on failure (mirrors join-betanet.sh's NODE_LOG).
+      const child = spawn(binPath, args, {
+        env: {
+          ...env(),
+          BOTHO_HOME: dataDir,
+          BOTHO_SLOT_DURATION_SECS: String(slot),
+          RUST_LOG: env().RUST_LOG ?? 'info',
+          ...lotteryEnv,
+        } as NodeJS.ProcessEnv,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      const fsChunks: Buffer[] = []
+      child.stdout?.on('data', (d: Buffer) => fsChunks.push(d))
+      child.stderr?.on('data', (d: Buffer) => fsChunks.push(d))
+      child.on('exit', () => {
+        try {
+          writeFileSync(logPath, Buffer.concat(fsChunks))
+        } catch {
+          /* best effort */
+        }
+      })
+
+      running.push({
+        spec,
+        rpcUrl: `http://127.0.0.1:${spec.rpcPort}/rpc`,
+        child,
+        logPath,
+        readLog: () => {
+          try {
+            // Prefer in-memory buffer; fall back to the flushed file.
+            if (fsChunks.length) return Buffer.concat(fsChunks).toString('utf8')
+            if (existsSync(logPath)) return readFileSync(logPath, 'utf8')
+          } catch {
+            /* best effort */
+          }
+          return ''
+        },
+      })
+    }
+
+    // Wait for every node's RPC to come up.
+    const deadline = Date.now() + 90_000
+    for (const n of running) {
+      let up = false
+      while (Date.now() < deadline) {
+        try {
+          await rpcCall(n.rpcUrl, 'node_getStatus', {})
+          up = true
+          break
+        } catch {
+          if (n.child.exitCode !== null) {
+            throw new Error(
+              `node ${n.spec.name} exited (code ${n.child.exitCode}) before RPC came up:\n` +
+                n.readLog().split('\n').slice(-30).join('\n'),
+            )
+          }
+          await sleep(1000)
+        }
+      }
+      if (!up) {
+        throw new Error(`node ${n.spec.name} RPC did not come up within timeout`)
+      }
+    }
+
+    const network: MultiNodeNetwork = {
+      nodes: running,
+      get(name: string) {
+        const n = running.find((r) => r.spec.name === name)
+        if (!n) throw new Error(`no node named ${name}`)
+        return n
+      },
+      stop,
+    }
+    return network
+  } catch (err) {
+    await stop()
+    throw err
+  }
+}

--- a/web/packages/wasm-signer/test/run-node-backed.mjs
+++ b/web/packages/wasm-signer/test/run-node-backed.mjs
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 /**
- * Convenience runner for the node-backed #372 + #390 + #394 tests.
+ * Convenience runner for the node-backed #372 + #390 + #394 + #396 tests.
  *
  * Ensures the prerequisites exist (release botho binary + wasm artifact), then
  * runs the gated `send-live-node.test.ts` (single send, #372),
- * `exchange-live-node.test.ts` (two-user bidirectional exchange, #390) and
+ * `exchange-live-node.test.ts` (two-user bidirectional exchange, #390),
  * `lottery-live-node.test.ts` (three-user exchange until a lottery payout, #394)
- * with BOTHO_E2E_NODE=1 so each test spins up its own throwaway solo-minting
- * node, asserts the ledger invariants, and tears the node down.
+ * and `join-consensus-live-node.test.ts` (a fresh node joins a running local
+ * chain over real libp2p and catches up 0 -> N onto the same chain, #396) with
+ * BOTHO_E2E_NODE=1 so each test spins up its own throwaway node(s), asserts the
+ * ledger/sync invariants, and tears the node(s) down.
  *
  *   node packages/wasm-signer/test/run-node-backed.mjs
  *
@@ -60,6 +62,7 @@ const result = spawnSync(
     'packages/wasm-signer/test/send-live-node.test.ts',
     'packages/wasm-signer/test/exchange-live-node.test.ts',
     'packages/wasm-signer/test/lottery-live-node.test.ts',
+    'packages/wasm-signer/test/join-consensus-live-node.test.ts',
   ],
   {
     cwd: webDir,


### PR DESCRIPTION
## Summary
Real-process node-backed test proving the **join + catch-up** capability: a fresh node bootstraps to a running local chain over real libp2p loopback, connects, and syncs 0→N onto the network's exact block hashes (via the #376 sync).

**Part of #396** (does NOT fully close it). The "participate in consensus + mine an accepted block" half of #396 is **blocked by #397** — multi-node SCP block agreement is broken (SCP ballot deserialize fails; solo-mode peers fork). Documented in #397.

## Verified (real local run, BOTHO_E2E_NODE=1)
- A (solo minter) reached N=24 (ringSize 20); B connected (peerCount=1); B caught up 0→26; B converged on A's exact block hashes at heights [1,12,23,24]. ~68s.

## Findings (→ #397)
1. Multi-node SCP stalls at height 0 — `Bincode does not support Deserializer::deserialize_identifier` (consensus/service.rs:415).
2. Solo-mode peers fork — QuorumSet frozen at startup, never updated on PeerDiscovered (run.rs:296/1419/608) → divergent chains.

Part of #396; blocked-remainder tracked in #397.