### PR TITLE
ci(workspace): add Linux cargo build --workspace signal for #361

### DIFF
--- a/.github/workflows/workspace-build.yml
+++ b/.github/workflows/workspace-build.yml
@@ -1,0 +1,56 @@
+name: Workspace Build
+
+# Linux-only `cargo build --workspace` check. The full workspace includes the
+# Tauri desktop crate, whose Linux-gated GUI subtree triggers a k256
+# feature-unification break that only manifests on Linux (#361). This job
+# exists to give that bug — and any future Linux-only feature-unification
+# regression — a red/green signal so it can be fixed and stay fixed.
+
+on:
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - 'crypto/**'
+      - 'web/packages/desktop/**'
+      - '.github/workflows/workspace-build.yml'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  workspace-build:
+    name: cargo build --workspace (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-12-03
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: workspace-build-linux
+
+      # The Tauri desktop crate pulls glib-sys/gtk-sys via pkg-config; without
+      # these dev packages the build fails before reaching the Rust compile
+      # step that surfaces the k256 issue we're actually trying to gate on.
+      # Package set matches Tauri v2 Linux prerequisites for ubuntu-latest
+      # (webkit2gtk 4.1).
+      - name: Install GTK/glib system deps (Tauri desktop crate)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libglib2.0-dev \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libsoup-3.0-dev \
+            librsvg2-dev \
+            libayatana-appindicator3-dev
+
+      - name: Build workspace
+        run: cargo build --workspace


### PR DESCRIPTION
## Summary

- Adds a minimal `ubuntu-latest` workflow (`.github/workflows/workspace-build.yml`) that runs `cargo build --workspace` with Tauri's GTK/glib system deps pre-installed.
- Purpose: give the latent Linux-only k256 feature-unification break (#361) a red/green CI signal so a fix can be iterated against.
- Expected first run: **red** (reproduces #361). That's the intended signal — once green, also guards against future Linux-only feature-unification regressions.

## Why this is needed

#361 is `loom:blocked` because the bug:
- Only manifests on Linux (GTK/webkit subtree is Linux-gated)
- Only manifests under `--workspace` (Tauri desktop crate pulls `k256` with `precomputed-tables` but without `std`/`critical-section`, breaking no_std unification)
- Cannot be reproduced on macOS, where most of the team works

No existing CI job exercises that path:
- `benchmarks.yml` was scoped to `-p` crates in #358 to dodge this
- `release.yml` / `scripts/build-release.sh` explicitly avoid `--workspace`

So a builder has no signal to develop a fix against. This workflow is the missing gate.

## Implementation notes

- Apt package set lifted from the intermediate state of #358 (verified to satisfy Tauri's pkg-config needs on ubuntu-latest / webkit2gtk 4.1).
- Toolchain pinned to `nightly-2025-12-03` to match `rust-toolchain.toml` — feature-unification bugs are compiler-sensitive, so matching local dev is important.
- Path-filtered to `Cargo.toml`/`Cargo.lock`/`crypto/**`/`web/packages/desktop/**` plus the workflow file itself, so it doesn't run on unrelated PRs.

## Test plan

- [ ] CI run on this PR is red with the k256 `precomputed-tables` error described in #361 (confirms repro).
- [ ] After merging: drop `loom:blocked` from #361, add `loom:issue`, sweep picks up the fix against this CI signal.
- [ ] Once #361 lands: this workflow goes green and stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)