### PR TITLE
feat(consensus): reconfigure SCP quorum set dynamically on peer churn

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,0 +1,6 @@
+# Loom-managed worktree marker
+# Created by .loom/scripts/worktree.sh
+# Issue: 401
+# Branch: feature/issue-401
+# Removing this file makes Loom treat the worktree as user-owned and refuse
+# to clean it up automatically.

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -415,8 +415,11 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
         .get_chain_state()
         .map_err(|e| anyhow::anyhow!("Failed to get chain state: {}", e))?;
 
-    // Create consensus service using local peer ID for node identity
-    let local_peer_id = discovery.local_peer_id();
+    // Create consensus service using local peer ID for node identity.
+    // Own the PeerId (rather than borrowing from `discovery`) so we can still
+    // call `&mut discovery` methods later while rebuilding the quorum set on
+    // peer connect/disconnect.
+    let local_peer_id = *discovery.local_peer_id();
     let node_id = peer_id_to_node_id(&local_peer_id);
 
     // Build SCP quorum set from connected peers (or just ourselves for solo mining)
@@ -622,6 +625,18 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             // Broadcast peer event to WebSocket clients
                             ws_broadcaster.peer_connected(new_peer_count, &peer_id.to_string());
 
+                            // Reconfigure the consensus quorum to include the
+                            // newly connected peer. This is what lifts a node
+                            // out of latched solo mode without a restart.
+                            let new_qs = rebuild_scp_quorum_set(&config, &discovery, &local_peer_id);
+                            if consensus.reconfigure_quorum(new_qs) {
+                                info!(
+                                    threshold = consensus.quorum_set().threshold,
+                                    members = consensus.quorum_set().members.len(),
+                                    "Consensus quorum reconfigured after peer connect"
+                                );
+                            }
+
                             // Re-evaluate minting eligibility
                             if mint && !minting_enabled {
                                 let connected = get_connected_peer_ids(&discovery);
@@ -662,6 +677,21 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
 
                             // Broadcast peer event to WebSocket clients
                             ws_broadcaster.peer_disconnected(new_peer_count, &peer_id.to_string());
+
+                            // Shrink the consensus quorum to drop the departed
+                            // peer so we don't deadlock waiting on a member that
+                            // is gone. rebuild_scp_quorum_set always yields a
+                            // non-empty set (local node is always a member) and
+                            // recomputes a satisfiable threshold, so churn can
+                            // never produce an empty or unreachable quorum.
+                            let new_qs = rebuild_scp_quorum_set(&config, &discovery, &local_peer_id);
+                            if consensus.reconfigure_quorum(new_qs) {
+                                info!(
+                                    threshold = consensus.quorum_set().threshold,
+                                    members = consensus.quorum_set().members.len(),
+                                    "Consensus quorum reconfigured after peer disconnect"
+                                );
+                            }
 
                             // Re-evaluate minting eligibility
                             if minting_enabled {
@@ -1440,6 +1470,47 @@ fn build_scp_quorum_set(quorum: &QuorumBuilder, local_peer_id: &libp2p::PeerId) 
         1
     } else {
         quorum.threshold()
+    };
+
+    QuorumSet::new(threshold, members)
+}
+
+/// Rebuild the SCP quorum set from the *current* set of connected peers.
+///
+/// Called whenever peers connect or disconnect so the consensus quorum tracks
+/// live membership instead of being frozen at startup. Members are the local
+/// node plus every connected peer; the threshold follows the configured quorum
+/// policy:
+///
+/// - `Recommended`: BFT threshold `n - floor((n-1)/3)` over `n = peers + 1`
+///   (matches [`QuorumConfig::effective_threshold`]).
+/// - `Explicit`: the configured threshold, clamped to the member count so we
+///   never demand more confirmations than there are members.
+///
+/// A lone node (no peers) yields a 1-of-1 solo quorum.
+fn rebuild_scp_quorum_set(
+    config: &Config,
+    discovery: &NetworkDiscovery,
+    local_peer_id: &libp2p::PeerId,
+) -> QuorumSet {
+    use bth_consensus_scp_types::QuorumSetMember;
+
+    // Local node is always a member.
+    let mut members: Vec<QuorumSetMember<NodeID>> =
+        vec![QuorumSetMember::Node(peer_id_to_node_id(local_peer_id))];
+
+    for peer in discovery.peer_table() {
+        members.push(QuorumSetMember::Node(peer_id_to_node_id(&peer.peer_id)));
+    }
+
+    let n = members.len();
+    let threshold = match config.network.quorum.mode {
+        QuorumMode::Recommended => config.network.quorum.effective_threshold(n - 1) as u32,
+        QuorumMode::Explicit => {
+            // Clamp to member count; a threshold larger than n can never be met
+            // and would deadlock consensus.
+            (config.network.quorum.threshold).min(n as u32).max(1)
+        }
     };
 
     QuorumSet::new(threshold, members)

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -162,6 +162,10 @@ pub struct ConsensusService {
 
     /// Current slot's externalized values (if any)
     externalized: Option<Vec<ConsensusValue>>,
+
+    /// A quorum set reconfiguration that arrived mid-round and was deferred to
+    /// the next slot boundary to avoid stranding an in-flight slot.
+    pending_quorum_set: Option<QuorumSet>,
 }
 
 impl ConsensusService {
@@ -277,6 +281,7 @@ impl ConsensusService {
             events: VecDeque::new(),
             last_slot_attempt: Instant::now(),
             externalized: None,
+            pending_quorum_set: None,
         }
     }
 
@@ -284,6 +289,87 @@ impl ConsensusService {
     pub fn update_chain_state(&mut self, chain_state: ChainState) {
         if let Ok(mut state) = self.shared_state.write() {
             state.chain_state = chain_state;
+        }
+    }
+
+    /// Get the current quorum set (for status/RPC/test assertions).
+    pub fn quorum_set(&self) -> &QuorumSet {
+        &self.quorum_set
+    }
+
+    /// Reconfigure the consensus quorum set as peers connect or disconnect.
+    ///
+    /// This recomputes membership/threshold and toggles solo mode off (or back
+    /// on) without requiring a restart. To avoid corrupting an active consensus
+    /// round, the change is only applied to the SCP node at a slot boundary:
+    ///
+    /// - If the current slot has not yet proposed/externalized anything, the
+    ///   new quorum set takes effect immediately (the current slot is rebuilt
+    ///   at the same index).
+    /// - Otherwise the change is stashed and applied on the next
+    ///   [`advance_slot`](Self::advance_slot), so an in-flight slot is never
+    ///   stranded mid-round.
+    ///
+    /// Churn that does not change the effective membership/threshold (e.g. a
+    /// transient disconnect that immediately reconnects the same peer set) is a
+    /// no-op: the new set is compared against both the active set and any
+    /// already-pending set before anything is touched.
+    ///
+    /// Returns `true` if the quorum set changed (applied or deferred).
+    pub fn reconfigure_quorum(&mut self, new_quorum_set: QuorumSet) -> bool {
+        // Never allow an empty quorum set; that would be unsafe and is almost
+        // certainly a wiring bug. Keep the current configuration instead.
+        if new_quorum_set.members.is_empty() {
+            warn!("Ignoring quorum reconfiguration with empty member set");
+            return false;
+        }
+
+        // Compare against whatever the node will eventually run with: a pending
+        // set (not yet applied) takes precedence over the currently active one.
+        let effective = self.pending_quorum_set.as_ref().unwrap_or(&self.quorum_set);
+        if effective == &new_quorum_set {
+            // No effective change — debounce churn / flapping.
+            return false;
+        }
+
+        // Determine whether the current slot is at a safe boundary to swap the
+        // quorum set without stranding an in-flight round. A slot is safe if we
+        // have not proposed anything into it and it has not externalized.
+        let at_slot_boundary = self.proposed_values.is_empty() && self.externalized.is_none();
+
+        if at_slot_boundary {
+            self.apply_quorum_set(new_quorum_set);
+        } else {
+            info!(
+                slot = self.scp_node.current_slot_index(),
+                threshold = new_quorum_set.threshold,
+                members = new_quorum_set.members.len(),
+                "Quorum reconfiguration deferred to next slot boundary (round in flight)"
+            );
+            self.pending_quorum_set = Some(new_quorum_set);
+        }
+
+        true
+    }
+
+    /// Apply a new quorum set to both the service and the SCP node, rebuilding
+    /// the current slot at its existing index.
+    fn apply_quorum_set(&mut self, new_quorum_set: QuorumSet) {
+        let was_solo = self.is_solo_mode();
+        info!(
+            slot = self.scp_node.current_slot_index(),
+            threshold = new_quorum_set.threshold,
+            members = new_quorum_set.members.len(),
+            was_solo,
+            "Applying quorum set reconfiguration"
+        );
+        self.quorum_set = new_quorum_set.clone();
+        self.scp_node.set_quorum_set(new_quorum_set);
+
+        if was_solo && !self.is_solo_mode() {
+            info!("Exited solo mode: peers present, switching to SCP consensus path");
+        } else if !was_solo && self.is_solo_mode() {
+            info!("Entered solo mode: no peers, using direct-externalize path");
         }
     }
 
@@ -671,14 +757,27 @@ impl ConsensusService {
         self.proposed_values.clear();
 
         // For solo mode, we need to explicitly advance the SCP slot
-        // since we bypassed the normal SCP externalization path
+        // since we bypassed the normal SCP externalization path. Capture
+        // solo-ness BEFORE applying any pending quorum reconfiguration, since
+        // gaining a peer flips us out of solo mode.
         if self.is_solo_mode() {
             let next_slot = self.scp_node.current_slot_index() + 1;
             self.scp_node.reset_slot_index(next_slot);
             info!(slot = next_slot, "Advanced to next slot (solo mode)");
         }
         // In multi-node mode, SCP node automatically advances after
-        // externalization
+        // externalization.
+
+        // Now that the slot has advanced and no values are proposed for the new
+        // slot, it is safe to apply any quorum reconfiguration that arrived
+        // mid-round.
+        if let Some(pending) = self.pending_quorum_set.take() {
+            // Re-check it still differs from the active set (a later churn
+            // event may have already converged it).
+            if self.quorum_set != pending {
+                self.apply_quorum_set(pending);
+            }
+        }
     }
 
     /// Get pending transaction count
@@ -694,5 +793,154 @@ impl fmt::Debug for ConsensusService {
             .field("slot", &self.scp_node.current_slot_index())
             .field("pending", &self.pending_values.len())
             .finish()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use bth_consensus_scp::{QuorumSetMember, ScpNode};
+    use bth_consensus_scp_types::test_utils::test_node_id;
+
+    /// A NodeID for each numeric id; node 1 is "us".
+    fn node(n: u32) -> NodeID {
+        test_node_id(n)
+    }
+
+    /// Build a quorum set whose members are the given node ids, using the
+    /// recommended BFT threshold n - floor((n-1)/3).
+    fn recommended_quorum(ids: &[u32]) -> QuorumSet {
+        let n = ids.len();
+        let f = n.saturating_sub(1) / 3;
+        let threshold = (n - f) as u32;
+        let members: Vec<QuorumSetMember<NodeID>> = ids
+            .iter()
+            .map(|i| QuorumSetMember::Node(node(*i)))
+            .collect();
+        QuorumSet::new(threshold, members)
+    }
+
+    /// A solo (1-of-1) service whose only member is node 1.
+    fn solo_service() -> ConsensusService {
+        ConsensusService::new(
+            node(1),
+            QuorumSet::new(1, vec![QuorumSetMember::Node(node(1))]),
+            ConsensusConfig::fixed_timing(1),
+            ChainState::default(),
+        )
+    }
+
+    #[test]
+    fn boots_in_solo_mode() {
+        let svc = solo_service();
+        assert!(svc.is_solo_mode(), "1-of-1 quorum must be solo mode");
+        assert_eq!(svc.quorum_set().members.len(), 1);
+        assert_eq!(svc.quorum_set().threshold, 1);
+    }
+
+    /// Acceptance criterion 1: a node that boots solo and later gains a peer
+    /// transitions out of solo mode and includes the peer in its quorum set,
+    /// without a restart.
+    #[test]
+    fn solo_to_peered_transition_lifts_solo_mode() {
+        let mut svc = solo_service();
+        assert!(svc.is_solo_mode());
+
+        // A peer (node 2) connects: 2-of-2 recommended quorum.
+        let new_qs = recommended_quorum(&[1, 2]);
+        let changed = svc.reconfigure_quorum(new_qs.clone());
+
+        assert!(changed, "gaining a peer must change the quorum set");
+        assert!(
+            !svc.is_solo_mode(),
+            "node must leave solo mode once a peer is present"
+        );
+        assert_eq!(svc.quorum_set().members.len(), 2);
+        assert_eq!(svc.quorum_set(), &new_qs);
+        // The SCP node itself must also have the new quorum set.
+        assert_eq!(svc.scp_node.quorum_set(), new_qs);
+    }
+
+    #[test]
+    fn reconfigure_with_same_membership_is_a_noop() {
+        let mut svc = solo_service();
+        // Reconfiguring to the identical 1-of-1 set is a no-op (churn debounce).
+        let same = QuorumSet::new(1, vec![QuorumSetMember::Node(node(1))]);
+        assert!(!svc.reconfigure_quorum(same));
+
+        // Add a peer, then re-send the same 2-node set: still a no-op.
+        let two = recommended_quorum(&[1, 2]);
+        assert!(svc.reconfigure_quorum(two.clone()));
+        assert!(!svc.reconfigure_quorum(two));
+    }
+
+    #[test]
+    fn empty_quorum_set_is_rejected() {
+        let mut svc = solo_service();
+        let empty = QuorumSet::new(1, vec![]);
+        assert!(!svc.reconfigure_quorum(empty));
+        // Quorum is unchanged and still solo.
+        assert!(svc.is_solo_mode());
+    }
+
+    /// Acceptance criterion 2: PeerDisconnected shrinks the quorum sensibly and
+    /// does not panic on churn back to solo.
+    #[test]
+    fn peer_disconnect_shrinks_quorum_without_panic() {
+        let mut svc = solo_service();
+
+        // Grow to three nodes, then churn members down repeatedly.
+        assert!(svc.reconfigure_quorum(recommended_quorum(&[1, 2, 3])));
+        assert!(!svc.is_solo_mode());
+        assert_eq!(svc.quorum_set().members.len(), 3);
+
+        // Node 3 leaves -> 2-of-2.
+        assert!(svc.reconfigure_quorum(recommended_quorum(&[1, 2])));
+        assert!(!svc.is_solo_mode());
+        assert_eq!(svc.quorum_set().members.len(), 2);
+
+        // Node 2 leaves -> back to solo. Must not deadlock or panic.
+        assert!(svc.reconfigure_quorum(QuorumSet::new(1, vec![QuorumSetMember::Node(node(1))])));
+        assert!(svc.is_solo_mode());
+        assert_eq!(svc.quorum_set().members.len(), 1);
+
+        // Rapid flapping: connect, disconnect, connect again — no panic.
+        for _ in 0..5 {
+            svc.reconfigure_quorum(recommended_quorum(&[1, 2]));
+            svc.reconfigure_quorum(QuorumSet::new(1, vec![QuorumSetMember::Node(node(1))]));
+        }
+    }
+
+    /// A reconfiguration that arrives while a slot is in flight must be
+    /// deferred to the next slot boundary so the active round is not
+    /// stranded.
+    #[test]
+    fn reconfigure_mid_round_is_deferred_until_advance_slot() {
+        let mut svc = solo_service();
+
+        // Drive a solo round: submit a tx and externalize it directly.
+        svc.submit_transaction([7u8; 32], vec![1, 2, 3]);
+        svc.propose_pending_values();
+        assert!(
+            svc.externalized.is_some(),
+            "solo mode should have externalized the value"
+        );
+
+        // A peer connects mid-round. The change is recorded but deferred.
+        let two = recommended_quorum(&[1, 2]);
+        assert!(svc.reconfigure_quorum(two.clone()));
+        assert!(
+            svc.is_solo_mode(),
+            "active round must keep the old (solo) quorum until the slot boundary"
+        );
+        assert!(svc.pending_quorum_set.is_some());
+
+        // Advancing the slot applies the deferred quorum set.
+        svc.advance_slot();
+        assert!(svc.pending_quorum_set.is_none());
+        assert!(!svc.is_solo_mode());
+        assert_eq!(svc.quorum_set(), &two);
+        assert_eq!(svc.scp_node.quorum_set(), two);
     }
 }

--- a/consensus/scp/src/node/node_impl.rs
+++ b/consensus/scp/src/node/node_impl.rs
@@ -154,6 +154,35 @@ impl<V: Value, ValidationError: Clone + Display + 'static> ScpNode<V> for Node<V
         self.Q.clone()
     }
 
+    /// Replace this node's quorum set, rebuilding the current slot at its
+    /// existing index with the new membership/threshold. Any in-progress slot
+    /// state and stored externalized slots are abandoned, so callers must only
+    /// invoke this at a slot boundary.
+    fn set_quorum_set(&mut self, quorum_set: QuorumSet) {
+        let slot_index = self.current_slot.get_index();
+
+        log::info!(
+            self.logger,
+            "Reconfiguring quorum set at slot {}: threshold={}, members={}",
+            slot_index,
+            quorum_set.threshold,
+            quorum_set.members.len()
+        );
+
+        self.Q = quorum_set.clone();
+
+        self.current_slot = Box::new(Slot::new(
+            self.ID.clone(),
+            quorum_set,
+            slot_index,
+            self.validity_fn.clone(),
+            self.combine_fn.clone(),
+            self.logger.clone(),
+        ));
+
+        self.externalized_slots.clear();
+    }
+
     /// Propose values for this node to nominate.
     fn propose_values(&mut self, values: BTreeSet<V>) -> Result<Option<Msg<V>>, String> {
         if values.is_empty() {

--- a/consensus/scp/src/node/node_trait.rs
+++ b/consensus/scp/src/node/node_trait.rs
@@ -14,6 +14,15 @@ pub trait ScpNode<V: Value>: Send {
     /// Get local node quorum set.
     fn quorum_set(&self) -> QuorumSet;
 
+    /// Replace this node's quorum set, rebuilding the current slot so the new
+    /// membership/threshold takes effect immediately.
+    ///
+    /// This abandons any in-progress state for the current slot and any stored
+    /// externalized slots, so callers must only invoke it at a slot boundary
+    /// (e.g. before the current slot has nominated/proposed any values). The
+    /// current slot index is preserved.
+    fn set_quorum_set(&mut self, quorum_set: QuorumSet);
+
     /// Propose values for this node to nominate.
     fn propose_values(&mut self, values: BTreeSet<V>) -> Result<Option<Msg<V>>, String>;
 

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -233,6 +233,10 @@ impl<V: Value, N: ScpNode<V>> ScpNode<V> for LoggingScpNode<V, N> {
         self.node.quorum_set()
     }
 
+    fn set_quorum_set(&mut self, quorum_set: QuorumSet) {
+        self.node.set_quorum_set(quorum_set)
+    }
+
     fn propose_values(&mut self, values: BTreeSet<V>) -> Result<Option<Msg<V>>, String> {
         let slot_index = self.node.current_slot_index();
         self.write(LoggedMsg::Nominate(slot_index, values.clone()))?;


### PR DESCRIPTION
## Summary

The consensus `QuorumSet` was built **once** at startup (`build_scp_quorum_set`, `run.rs:296`/`:1419`) and never updated when peers connected later. `NetworkEvent::PeerDiscovered` updated peer counts and minting eligibility but never touched the consensus quorum, so `solo_mode` (`service.rs:467`) latched at boot: a node that started without a connected peer stayed permanently 1-of-1, and two late-peering minters forked.

This PR makes the consensus quorum track live membership: it is rebuilt whenever peers connect or disconnect, so a node that boots solo and later gains a peer leaves solo mode and includes the peer in its quorum set without a restart. Scope is limited to the latched-solo quorum-reconfiguration wiring; it does not depend on or include sibling #400.

## Changes

- **`ScpNode::set_quorum_set`** (`node_trait.rs`, `node_impl.rs`): new trait method that replaces the node's quorum set and rebuilds the current slot at its existing index. Documented as slot-boundary-only (abandons in-progress slot state). Forwarded by `LoggingScpNode` (`scp_log.rs`).
- **`ConsensusService::reconfigure_quorum`** (`service.rs`): recomputes membership/threshold and toggles solo mode. Guards:
  - **No-op debounce**: compares the incoming set against the active *and* any already-deferred set (`QuorumSet` `PartialEq` is order-independent); transient churn that doesn't change membership is ignored.
  - **Empty-set rejection**: never installs an empty quorum.
  - **Slot-boundary safety**: applies immediately only when nothing has been proposed/externalized in the current slot; otherwise stashes the change and applies it on the next `advance_slot`, so an in-flight round is never stranded.
  - Added `quorum_set()` getter for status/test assertions.
- **`run.rs`**: new `rebuild_scp_quorum_set` builds the SCP set from the current peer table (local node + connected peers) using the recommended BFT threshold `n - floor((n-1)/3)` (matches `QuorumConfig::effective_threshold`), clamping explicit thresholds to the member count so churn can't demand an unreachable quorum. Wired into both `PeerDiscovered` and `PeerDisconnected`. `local_peer_id` is now owned so `&discovery` can be re-borrowed in the handlers.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Node that boots solo + gains a peer leaves solo mode and includes peer in quorum, no restart | ✅ | Unit test `solo_to_peered_transition_lifts_solo_mode` asserts `!is_solo_mode()`, 2 members, and that the SCP node's own quorum set updated; `PeerDiscovered` wiring calls `reconfigure_quorum` |
| Full two-node convergence (needs #400) — not depended on here; solo→peered transition tested without #400 | ✅ | Transition test uses `ConsensusService` directly, no SCP wire/deserialize path, no dependency on #400 |
| `PeerDisconnected` shrinks quorum sensibly; no panic on churn | ✅ | Unit test `peer_disconnect_shrinks_quorum_without_panic` grows to 3, shrinks 3→2→solo, then flaps connect/disconnect 5×; `rebuild_scp_quorum_set` always yields a non-empty set + satisfiable threshold |
| Threshold policy uses `recommended` and transitions don't strand an in-flight slot | ✅ | `rebuild_scp_quorum_set` uses `effective_threshold`; `reconfigure_mid_round_is_deferred_until_advance_slot` asserts a mid-round change defers and applies on `advance_slot` |
| Churn/flapping guard | ✅ | `reconfigure_with_same_membership_is_a_noop` + `empty_quorum_set_is_rejected` |

## Test Plan

- `cargo test -p botho --lib consensus::service` — 6 new tests pass.
- `cargo test -p bth-consensus-scp` — 98 existing SCP tests pass (no regressions).
- `cargo clippy -p botho -p bth-consensus-scp` — no new warnings/errors.
- `cargo build -p botho` — succeeds.

Closes #401