### PR TITLE
fix(consensus): make QuorumSetMember externally tagged so SCP msgs decode over the wire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,6 +1124,7 @@ dependencies = [
 name = "bth-consensus-scp"
 version = "7.1.0"
 dependencies = [
+ "bincode",
  "bth-common",
  "bth-consensus-scp-types",
  "bth-crypto-digestible",

--- a/consensus/scp/Cargo.toml
+++ b/consensus/scp/Cargo.toml
@@ -32,6 +32,7 @@ bth-consensus-scp-types = { workspace = true, features = ["test_utils"] }
 bth-util-logger-macros = { workspace = true }
 bth-util-test-helper = { workspace = true }
 
+bincode = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true }
 maplit = { workspace = true }

--- a/consensus/scp/play/src/main.rs
+++ b/consensus/scp/play/src/main.rs
@@ -30,8 +30,8 @@ pub struct Config {
     /// Quorum set.
     ///
     /// The quorum set is represented in JSON. For example:
-    /// {"threshold":1,"members":[{"type":"Node","args":"node2.test.botho.
-    /// com:8443"},{"type":"Node","args":"node3.test.botho.com:4843"}]}
+    /// {"threshold":1,"members":[{"Node":"node2.test.botho.
+    /// com:8443"},{"Node":"node3.test.botho.com:4843"}]}
     #[clap(long, value_parser = parse_quorum_set_from_json, env = "MC_QUORUM_SET")]
     pub quorum_set: Option<QuorumSet>,
 

--- a/consensus/scp/src/msg.rs
+++ b/consensus/scp/src/msg.rs
@@ -680,8 +680,155 @@ impl<V: Value, ID: GenericNodeId> fmt::Display for Msg<V, ID> {
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod msg_tests {
     use super::*;
-    use crate::test_utils::test_node_id;
+    use crate::{test_utils::test_node_id, QuorumSetMember};
     use rand::seq::SliceRandom;
+    use serde::{Deserialize, Serialize};
+
+    /// A realistic consensus value that mirrors the shape of the node's
+    /// `ConsensusValue` (a 32-byte tx hash, a minting flag, and a priority).
+    /// Defined locally so the codec regression test exercises the same
+    /// serialized layout the node sends over the wire without depending on the
+    /// `botho` crate (which depends on this one).
+    #[derive(
+        Clone, Copy, Debug, Deserialize, Digestible, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
+    )]
+    struct TestConsensusValue {
+        tx_hash: [u8; 32],
+        is_minting_tx: bool,
+        priority: u64,
+    }
+
+    impl TestConsensusValue {
+        fn new(seed: u8, minting: bool, priority: u64) -> Self {
+            Self {
+                tx_hash: [seed; 32],
+                is_minting_tx: minting,
+                priority,
+            }
+        }
+    }
+
+    /// Build a non-trivial quorum set that includes a nested `InnerSet` member.
+    ///
+    /// The nested `InnerSet` exercises the `QuorumSetMember` enum, which is the
+    /// type whose serde representation previously broke binary deserialization.
+    fn realistic_quorum_set() -> QuorumSet {
+        let inner = QuorumSet::new_with_node_ids(1, vec![test_node_id(3), test_node_id(4)]);
+        QuorumSet::new(
+            2,
+            vec![
+                QuorumSetMember::Node(test_node_id(1)),
+                QuorumSetMember::Node(test_node_id(2)),
+                QuorumSetMember::InnerSet(inner),
+            ],
+        )
+    }
+
+    /// One representative `Msg` for every SCP `Topic` variant, each carrying a
+    /// realistic consensus-value payload and a quorum set with a nested
+    /// `InnerSet`.
+    fn all_topic_messages() -> Vec<Msg<TestConsensusValue>> {
+        let v1 = TestConsensusValue::new(1, false, 100);
+        let v2 = TestConsensusValue::new(2, true, 200);
+        let qs = realistic_quorum_set();
+
+        let nominate = NominatePayload {
+            X: BTreeSet::from_iter([v1]),
+            Y: BTreeSet::from_iter([v2]),
+        };
+        let prepare = PreparePayload {
+            B: Ballot::new(10, &[v1, v2]),
+            P: Some(Ballot::new(7, &[v1, v2])),
+            PP: Some(Ballot::new(6, &[v2])),
+            CN: 1,
+            HN: 7,
+        };
+        let commit = CommitPayload {
+            B: Ballot::new(10, &[v1, v2]),
+            PN: 9,
+            CN: 7,
+            HN: 8,
+        };
+        let externalize = ExternalizePayload {
+            C: Ballot::new(10, &[v1, v2]),
+            HN: 12,
+        };
+
+        vec![
+            Msg::new(test_node_id(1), qs.clone(), 7, Nominate(nominate.clone())),
+            Msg::new(
+                test_node_id(1),
+                qs.clone(),
+                7,
+                NominatePrepare(nominate, prepare.clone()),
+            ),
+            Msg::new(test_node_id(1), qs.clone(), 7, Prepare(prepare)),
+            Msg::new(test_node_id(1), qs.clone(), 7, Commit(commit)),
+            Msg::new(test_node_id(1), qs, 7, Externalize(externalize)),
+        ]
+    }
+
+    /// Regression guard for the SCP wire codec (see issue #400).
+    ///
+    /// Every `Msg<V>` embeds a `QuorumSet`, whose `QuorumSetMember` enum must
+    /// use serde's default externally-tagged representation. An adjacently- or
+    /// internally-tagged representation forces deserialization through
+    /// `Deserializer::deserialize_identifier`, which non-self-describing binary
+    /// codecs (bincode, postcard) refuse to support — so every received SCP
+    /// message would fail to decode and peered minters stall at height 0.
+    ///
+    /// This test serializes and deserializes every `Topic` variant through
+    /// bincode (the wire codec used at `botho/src/consensus/service.rs`). It
+    /// FAILS on the pre-fix `#[serde(tag = "type", content = "args")]`
+    /// representation and PASSES once the tag attribute is removed.
+    #[test]
+    fn scp_msg_round_trips_through_wire_codec_all_variants() {
+        for msg in all_topic_messages() {
+            let bytes = bincode::serialize(&msg).expect("SCP Msg must serialize under bincode");
+            let decoded: Msg<TestConsensusValue> = bincode::deserialize(&bytes)
+                .unwrap_or_else(|e| panic!("SCP Msg failed to deserialize ({}): {}", msg, e));
+            assert_eq!(msg, decoded, "round-trip mismatch for {msg}");
+        }
+    }
+
+    /// The wire encoding must be byte-identical across nodes regardless of the
+    /// insertion order of values into the nominate sets — serialization must
+    /// not leak nondeterministic iteration order onto the wire.
+    #[test]
+    fn scp_msg_wire_encoding_is_deterministic() {
+        let qs = realistic_quorum_set();
+        let values: Vec<TestConsensusValue> = (0..8)
+            .map(|i| TestConsensusValue::new(i, i % 2 == 0, i as u64))
+            .collect();
+
+        let reference = bincode::serialize(&Msg::new(
+            test_node_id(1),
+            qs.clone(),
+            7,
+            Nominate(NominatePayload {
+                X: BTreeSet::from_iter(values.clone()),
+                Y: BTreeSet::from_iter(values.clone()),
+            }),
+        ))
+        .unwrap();
+
+        let mut rng = bth_util_test_helper::get_seeded_rng();
+        for _ in 0..50 {
+            let mut shuffled = values.clone();
+            shuffled.shuffle(&mut rng);
+            let bytes = bincode::serialize(&Msg::new(
+                test_node_id(1),
+                qs.clone(),
+                7,
+                Nominate(NominatePayload {
+                    X: BTreeSet::from_iter(shuffled.clone()),
+                    Y: BTreeSet::from_iter(shuffled.clone()),
+                }),
+            ))
+            .unwrap();
+            assert_eq!(reference, bytes, "SCP wire encoding must be deterministic");
+        }
+    }
 
     #[test]
     /// Prepare implies "vote_or_accept prepare" for B, P, and PP.

--- a/consensus/scp/types/src/quorum_set.rs
+++ b/consensus/scp/types/src/quorum_set.rs
@@ -16,10 +16,18 @@ use prost::{Message, Oneof};
 use serde::{Deserialize, Serialize};
 
 /// A member in a QuorumSet. Can be either a Node or another QuorumSet.
+///
+/// NOTE: This enum uses serde's default externally-tagged representation
+/// (e.g. `{"Node": <id>}`), NOT an adjacently-tagged one. An adjacently- or
+/// internally-tagged representation (`#[serde(tag = ..., content = ...)]`)
+/// forces deserialization through `Deserializer::deserialize_identifier`,
+/// which non-self-describing binary codecs (bincode, postcard) refuse to
+/// support. Because `QuorumSet` is embedded in every SCP `Msg` sent over the
+/// wire, a tagged representation here makes every received SCP message fail to
+/// deserialize. Keep this externally tagged so the SCP wire codec round-trips.
 #[derive(
     Clone, Deserialize, Digestible, Eq, Hash, Oneof, Ord, PartialEq, PartialOrd, Serialize,
 )]
-#[serde(tag = "type", content = "args")]
 pub enum QuorumSetMember<ID: GenericNodeId> {
     /// A single trusted entity with an identity.
     #[prost(message, tag = 1)]


### PR DESCRIPTION
## Summary

Real multi-node SCP could not exchange ballot messages: every received SCP message failed to deserialize with `Bincode does not support Deserializer::deserialize_identifier`, so peered minters stalled at height 0.

**Root cause:** `QuorumSetMember` (in `bth-consensus-scp-types`) carried `#[serde(tag = "type", content = "args")]` — an *adjacently-tagged* serde representation. Adjacently/internally-tagged enums deserialize by reading the tag *field name* first, which routes through `Deserializer::deserialize_identifier`. Non-self-describing binary codecs refuse to implement that method (bincode errors; postcard explicitly says "a feature that PostCard will never implement"). Since `QuorumSet` is embedded in every SCP `Msg`, the whole message failed to decode even though it serialized fine.

**Fix chosen (issue option 1 — minimal repr change):** remove the tag attribute so the enum uses serde's default externally-tagged, index-based representation. I verified empirically that this round-trips under both bincode and postcard, whereas the tagged form fails under *both*. Option 2 (switching the wire codec off bincode) would NOT have fixed it — the workspace's alternative codec (postcard, via `bth-util-serial`) hits the same `deserialize_identifier` wall. So the repr change is the actual fix, and it keeps the existing bincode wire codec with no new dependency.

## Changes

- `consensus/scp/types/src/quorum_set.rs`: remove `#[serde(tag = "type", content = "args")]` from `QuorumSetMember`; document why it must stay externally tagged.
- `consensus/scp/src/msg.rs`: add `scp_msg_round_trips_through_wire_codec_all_variants` (round-trips every `Topic` variant of `Msg<V>` through bincode with a realistic consensus-value payload and a quorum set containing a nested `InnerSet`) and `scp_msg_wire_encoding_is_deterministic` (wire bytes independent of value insertion order).
- `consensus/scp/Cargo.toml` + `Cargo.lock`: add `bincode` as a dev-dependency for the regression test.
- `consensus/scp/play/src/main.rs`: update the JSON doc example to the new externally-tagged shape (`{"Node": ...}`).

Block/transaction serialization is untouched: the `#[prost(...)]` protobuf tags (used for Digestible block hashing) are unchanged; only the serde representation of one enum changed. The encoding remains deterministic (`BTreeSet` ordering + index-based enum tags; verified by the determinism test).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. Unit test round-trips EVERY `Msg<V>` variant; FAILS on main, PASSES after fix | done | `scp_msg_round_trips_through_wire_codec_all_variants` covers Nominate, NominatePrepare, Prepare, Commit, Externalize. Confirmed it FAILS on the pre-fix repr with `Bincode does not support Deserializer::deserialize_identifier` and PASSES after removing the tag attribute. |
| 2. `deserialize_identifier` path gone; encode→decode symmetric at call site and crate | done | `botho/src/consensus/service.rs` bincode encode/decode now round-trips (52 botho consensus tests pass); crate-level round-trip test passes. |
| 3. No change to block/tx serialization; determinism preserved | done | Only serde repr of `QuorumSetMember` changed; prost tags untouched. `scp_msg_wire_encoding_is_deterministic` asserts byte-identical output across 50 shuffles. |

## Test Plan

- `cargo test -p bth-consensus-scp --lib msg_tests` — 31 passed (incl. 2 new).
- Temporarily re-added the tag attribute: round-trip test FAILED with the exact `deserialize_identifier` error; restored fix and it passes.
- `cargo test -p bth-consensus-scp-types --lib` — 5 passed.
- `cargo test -p botho --lib consensus` — 52 passed (incl. #401 dynamic-quorum tests).
- `cargo check -p botho -p bth-consensus-scp-play` — clean.
- `cargo clippy`/`cargo fmt` on touched crates — no new warnings.

Closes #400