### PR TITLE
feat(infra): centralize bootstrap seeds + harden testnet-reset scripts

### DIFF
--- a/botho/src/config.rs
+++ b/botho/src/config.rs
@@ -177,18 +177,12 @@ impl Default for DnsSeedConfig {
 }
 
 /// Default bootstrap peers for network discovery, by network.
+///
+/// Delegates to [`crate::network::seeds::fallback_seeds`] (the single source of
+/// truth) so the config defaults and the DNS-discovery fallback list never
+/// drift apart. The regional (multi-seed) scaffolding is opt-in there.
 fn default_bootstrap_peers(network: Network) -> Vec<String> {
-    match network {
-        Network::Mainnet => vec![
-            // Mainnet seed node
-            "/dns4/seed.botho.io/tcp/7100/p2p/12D3KooWBrjTYjNrEwi9MM3AKFenmymyWVXtXbQiSx7eDnDwv9qQ"
-                .to_string(),
-        ],
-        Network::Testnet => vec![
-            // Testnet seed node (no peer ID - resolved dynamically)
-            "/dns4/seed.botho.io/tcp/17100".to_string(),
-        ],
-    }
+    crate::network::fallback_seeds(network)
 }
 
 impl NetworkConfig {

--- a/botho/src/network/dns_seeds.rs
+++ b/botho/src/network/dns_seeds.rs
@@ -235,16 +235,12 @@ impl DnsSeedDiscovery {
         Ok(multiaddr)
     }
 
-    /// Get hardcoded fallback seeds
+    /// Get hardcoded fallback seeds.
+    ///
+    /// Delegates to [`crate::network::seeds`] (the single source of truth) so
+    /// the DNS-fallback list and the config-default list never drift apart.
     fn hardcoded_seeds(&self) -> Vec<String> {
-        match self.network {
-            Network::Mainnet => vec![
-                "/dns4/seed.botho.io/tcp/7100/p2p/12D3KooWBrjTYjNrEwi9MM3AKFenmymyWVXtXbQiSx7eDnDwv9qQ".to_string(),
-            ],
-            Network::Testnet => vec![
-                "/dns4/seed.botho.io/tcp/17100".to_string(),
-            ],
-        }
+        crate::network::seeds::fallback_seeds(self.network)
     }
 
     /// Invalidate the cache to force a fresh DNS lookup

--- a/botho/src/network/mod.rs
+++ b/botho/src/network/mod.rs
@@ -16,6 +16,7 @@ mod pex;
 pub mod privacy;
 mod quorum;
 mod reputation;
+mod seeds;
 mod sync;
 pub mod transport;
 
@@ -40,6 +41,7 @@ pub use pex::{
 };
 pub use quorum::{QuorumBuilder, QuorumValidation};
 pub use reputation::{PeerReputation, ReputationManager};
+pub use seeds::{fallback_seeds, include_regional_seeds};
 pub use sync::{
     create_sync_behaviour, ChainSyncManager, SyncAction, SyncCodec, SyncRateLimiter, SyncRequest,
     SyncResponse, SyncState, BLOCKS_PER_REQUEST, MAX_REQUESTS_PER_MINUTE, MAX_REQUEST_SIZE,

--- a/botho/src/network/seeds.rs
+++ b/botho/src/network/seeds.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Canonical hardcoded bootstrap-seed list (single source of truth).
+//!
+//! This module is the one place that defines the *hardcoded fallback* seed
+//! multiaddrs for each network. Both [`crate::config::NetworkConfig`] and
+//! [`crate::network::DnsSeedDiscovery`] delegate here so the two layers never
+//! drift apart.
+//!
+//! ## Bootstrap order (see PLAN.md "Network Bootstrap Strategy")
+//!
+//! 1. Explicitly configured `bootstrap_peers` in `config.toml` (if non-empty).
+//! 2. DNS TXT-record discovery (`seeds.botho.io` / `seeds.testnet.botho.io`).
+//! 3. The hardcoded fallback list defined here.
+//!
+//! ## Multi-seed / regional scaffolding
+//!
+//! PLAN.md calls for >= 3 geographically diverse seeds + DNS failover. The
+//! regional hostnames below (`us`, `eu`, `ap`) are *scaffolding*: they are
+//! emitted only when [`include_regional_seeds`] is true, which currently
+//! requires the `BOTHO_REGIONAL_SEEDS=1` environment variable. They stay OFF
+//! by default because the regional DNS records are not yet provisioned —
+//! dialing unresolvable hostnames just wastes connection attempts.
+//!
+//! Operator activation (NOT done by this code):
+//!   1. Launch the regional seed hosts and point DNS at them.
+//!   2. Either set `BOTHO_REGIONAL_SEEDS=1`, or (preferred) publish the seeds
+//!      as `seeds.testnet.botho.io` TXT records so DNS discovery picks them up
+//!      with zero client changes.
+
+use bth_transaction_types::constants::Network;
+
+/// Primary live testnet seed (gossip on the testnet port; peer ID resolved
+/// dynamically so a host re-key does not require a client release).
+const TESTNET_PRIMARY_SEED: &str = "/dns4/seed.botho.io/tcp/17100";
+
+/// Primary live mainnet seed (with pinned peer ID).
+const MAINNET_PRIMARY_SEED: &str =
+    "/dns4/seed.botho.io/tcp/7100/p2p/12D3KooWBrjTYjNrEwi9MM3AKFenmymyWVXtXbQiSx7eDnDwv9qQ";
+
+/// Regional testnet seeds (>= 3 regions per PLAN.md). NOT yet live — gated
+/// behind [`include_regional_seeds`]. Peer IDs are resolved dynamically.
+const TESTNET_REGIONAL_SEEDS: &[&str] = &[
+    "/dns4/us.seed.botho.io/tcp/17100",
+    "/dns4/eu.seed.botho.io/tcp/17100",
+    "/dns4/ap.seed.botho.io/tcp/17100",
+];
+
+/// Regional mainnet seeds (>= 3 regions per PLAN.md). NOT yet live — gated
+/// behind [`include_regional_seeds`].
+const MAINNET_REGIONAL_SEEDS: &[&str] = &[
+    "/dns4/us.seed.botho.io/tcp/7100",
+    "/dns4/eu.seed.botho.io/tcp/7100",
+    "/dns4/ap.seed.botho.io/tcp/7100",
+];
+
+/// Whether to include the (not-yet-live) regional seed scaffolding.
+///
+/// Returns true only when `BOTHO_REGIONAL_SEEDS` is set to a truthy value
+/// (`1`, `true`, `yes`). Keeping this opt-in avoids dialing unresolvable
+/// hostnames before the regional infra exists.
+pub fn include_regional_seeds() -> bool {
+    match std::env::var("BOTHO_REGIONAL_SEEDS") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            v == "1" || v == "true" || v == "yes"
+        }
+        Err(_) => false,
+    }
+}
+
+/// Hardcoded fallback bootstrap seeds for a network.
+///
+/// Always includes the primary live seed. Includes the regional scaffolding
+/// only when [`include_regional_seeds`] is true.
+pub fn fallback_seeds(network: Network) -> Vec<String> {
+    let (primary, regional): (&str, &[&str]) = match network {
+        Network::Mainnet => (MAINNET_PRIMARY_SEED, MAINNET_REGIONAL_SEEDS),
+        Network::Testnet => (TESTNET_PRIMARY_SEED, TESTNET_REGIONAL_SEEDS),
+    };
+
+    let mut seeds = vec![primary.to_string()];
+    if include_regional_seeds() {
+        seeds.extend(regional.iter().map(|s| s.to_string()));
+    }
+    seeds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primary_seed_always_present() {
+        // Regardless of env, the primary live seed is always first.
+        let testnet = fallback_seeds(Network::Testnet);
+        assert!(!testnet.is_empty());
+        assert!(testnet[0].contains("seed.botho.io"));
+        assert!(testnet[0].contains("17100"));
+
+        let mainnet = fallback_seeds(Network::Mainnet);
+        assert!(mainnet[0].contains("seed.botho.io"));
+        assert!(mainnet[0].contains("7100"));
+    }
+
+    #[test]
+    fn regional_seeds_cover_three_regions() {
+        // The scaffolding must define >= 3 regions for both networks
+        // (PLAN.md "min 3 geographic regions").
+        assert!(TESTNET_REGIONAL_SEEDS.len() >= 3);
+        assert!(MAINNET_REGIONAL_SEEDS.len() >= 3);
+
+        let regions = ["us.", "eu.", "ap."];
+        for r in regions {
+            assert!(
+                TESTNET_REGIONAL_SEEDS.iter().any(|s| s.contains(r)),
+                "missing testnet region {r}"
+            );
+            assert!(
+                MAINNET_REGIONAL_SEEDS.iter().any(|s| s.contains(r)),
+                "missing mainnet region {r}"
+            );
+        }
+    }
+
+    #[test]
+    fn regional_seeds_off_by_default() {
+        // This test does not set BOTHO_REGIONAL_SEEDS. In a clean environment
+        // only the primary seed is returned. (We avoid mutating the process
+        // env here to stay robust against parallel test execution.)
+        if std::env::var("BOTHO_REGIONAL_SEEDS").is_err() {
+            assert_eq!(fallback_seeds(Network::Testnet).len(), 1);
+            assert_eq!(fallback_seeds(Network::Mainnet).len(), 1);
+        }
+    }
+}

--- a/infra/seed/README.md
+++ b/infra/seed/README.md
@@ -15,8 +15,11 @@ Primary bootstrap node for the Botho network, with web-based status page.
 ```
 infra/seed/
 ├── README.md                 # This file
+├── TESTNET_RESET.md          # Reset + multi-seed bootstrap runbook (operator)
 ├── botho-seed.service        # Systemd service file
-├── reset-to-testnet.sh       # Reset script for testnet
+├── reset-chain.sh            # Wipe chain data over SSH (--dry-run / --help)
+├── reset-to-testnet.sh       # Local on-host reset to testnet (--dry-run / --help)
+├── deploy-botho.sh           # Build + deploy node binary to host
 ├── deploy-web.sh             # Deploy web files to server
 ├── seed-nginx.conf           # Nginx configuration
 └── web/
@@ -26,6 +29,21 @@ infra/seed/
     └── js/
         └── status.js         # Status fetching logic
 ```
+
+## Testnet Reset & Multi-Seed Bootstrap
+
+For the coordinated reset onto current `main` (protocol 2.0.0), the
+genesis/network-parameter reconciliation table, single-seed vs multi-seed
+quorum config, the regional-seed scaffolding, and the operator deploy steps,
+see **[`TESTNET_RESET.md`](./TESTNET_RESET.md)**.
+
+### Single-seed vs multi-seed
+
+A lone seed cannot form the default `recommended` quorum (needs >= 2 nodes), so
+minting stalls. For single-seed bring-up, run with `--mint --mint-threads 1`
+and set `[network.quorum]` to `mode = "explicit"`, `threshold = 1`,
+`members = []`. Switch back to `--relay` + `recommended` once a second node
+joins. The exact `ExecStart` variants are documented in `botho-seed.service`.
 
 ## Node Setup
 

--- a/infra/seed/TESTNET_RESET.md
+++ b/infra/seed/TESTNET_RESET.md
@@ -1,0 +1,148 @@
+# Testnet Reset & Multi-Seed Bootstrap (operator runbook)
+
+This document covers the **coordinated testnet reset** onto current `main`
+(protocol `2.0.0`) and the **multi-seed bootstrap** plan. It pairs with the
+automatable-prep PR for issue #323.
+
+> **Scope split.** The *code/config* prep (scripts, genesis reconciliation,
+> multi-seed config scaffolding, release-build path) is in the repo. The
+> *deploy/reset/DNS/faucet* steps below require AWS/DNS credentials and are
+> performed by a human operator. Nothing in CI touches live infra.
+
+## 1. Genesis / network-parameter reconciliation (verified)
+
+Current `main` values that any reset must match:
+
+| Parameter | Value | Source |
+|-----------|-------|--------|
+| Protocol version | `2.0.0` | `botho/src/network/discovery.rs` (`PROTOCOL_VERSION`, `MIN_SUPPORTED_PROTOCOL_VERSION`) |
+| Testnet genesis magic | `BOTHO_TESTNET_GENESIS_V1` (32-byte, in `prev_block_hash`) | `botho/src/block.rs` (`TESTNET_GENESIS_MAGIC`) |
+| Mainnet genesis magic | `BOTHO_MAINNET_GENESIS_V1` | `botho/src/block.rs` (`MAINNET_GENESIS_MAGIC`) |
+| Testnet network magic | `BTHT` (`0x42 0x54 0x48 0x54`) | `transaction/types/src/constants.rs` (`Network::magic_bytes`) |
+| Testnet gossip / RPC ports | `17100` / `17101` | `transaction/types/src/constants.rs` |
+| RPC `network` string | `botho-testnet` | `botho/src/rpc/mod.rs` (`format!("botho-{}", network.name())`) |
+| Data dir | `~/.botho/testnet/` (`ledger/`, `wallet/`, `config.toml`) | `botho/src/config.rs` (`data_dir`) |
+
+These are consistent across `block.rs`, the network constants, and the RPC
+layer — **no genesis/param drift to fix on `main`** as of this PR. A fresh
+genesis is produced automatically the first time a node starts with an empty
+`~/.botho/testnet/ledger` (the reset scripts clear it).
+
+## 2. Reset scripts
+
+Both scripts support `--help` and `--dry-run` (the dry run prints every
+command without contacting any host — safe to run anywhere, no credentials).
+
+### `reset-chain.sh` — wipe chain data over SSH
+Runs from a workstation, connects to the seed host over SSH, stops the
+service, deletes `~/.botho/<network>/{ledger,wallet}` (preserving
+`config.toml`), and restarts.
+
+```bash
+./reset-chain.sh --dry-run                 # preview, no SSH
+./reset-chain.sh ubuntu@seed.botho.io      # interactive confirm
+./reset-chain.sh --force ubuntu@seed.botho.io
+./reset-chain.sh --network testnet --service botho-seed ubuntu@seed.botho.io
+```
+
+Fixed in this PR: it previously deleted stale `blocks/`, `state/`,
+`peers.json` paths that the current node never writes, and targeted the wrong
+service name. It now deletes the real artifacts (`ledger/`, `wallet/`) and
+defaults to the `botho-seed` unit.
+
+### `reset-to-testnet.sh` — run locally on the host
+Runs **on** the seed host. Removes any stale `~/.botho/mainnet`, (re)installs
+the `botho-seed` systemd unit, starts it, and verifies `network == botho-testnet`
+via RPC on `localhost:17101`.
+
+```bash
+./reset-to-testnet.sh --dry-run
+./reset-to-testnet.sh
+```
+
+## 3. Single-seed vs multi-seed quorum
+
+A lone seed cannot satisfy the default `recommended` quorum (needs >= 2 nodes),
+so minting stalls at *"have 1, need 2"*.
+
+- **Single-seed bring-up (mint from a self-quorum):** run the node with
+  `--mint --mint-threads 1` and set in `~/.botho/testnet/config.toml`:
+
+  ```toml
+  [network.quorum]
+  mode = "explicit"
+  threshold = 1
+  members = []
+  ```
+
+- **Multi-seed (>= 2 nodes):** use the committed `botho-seed.service` as-is
+  (`run --relay`, no minting on seeds) and quorum `mode = "recommended"`.
+  Run minting on a dedicated validator/faucet node.
+
+See the header comments in `botho-seed.service` for the exact `ExecStart`
+variants.
+
+## 4. Multi-seed bootstrap config (scaffolding)
+
+PLAN.md "Network Bootstrap Strategy" calls for >= 3 geographically diverse
+seeds plus DNS-seed discovery and a hardcoded fallback.
+
+What already exists in code:
+
+- **DNS-seed discovery** — `botho/src/network/dns_seeds.rs`
+  (`seeds.botho.io` / `seeds.testnet.botho.io` TXT records, TTL caching, DNS
+  failure falls back to hardcoded seeds).
+- **PEX** — `botho/src/network/pex.rs` (decentralized peer exchange).
+- **Bootstrap order** — explicit `config.bootstrap_peers` -> DNS -> hardcoded
+  fallback (`NetworkConfig::bootstrap_peers_async`).
+
+Added in this PR:
+
+- **`botho/src/network/seeds.rs`** — single source of truth for hardcoded
+  fallback seeds. `config.rs` and `dns_seeds.rs` now both delegate here, so the
+  two lists can no longer drift. It defines regional seed scaffolding for three
+  regions (`us`, `eu`, `ap`) for both networks, **gated off by default** behind
+  `BOTHO_REGIONAL_SEEDS=1` because the regional DNS records are not yet live.
+
+### Activating regional seeds (operator, when infra exists)
+
+Preferred path (zero client release): publish the new seeds as
+`seeds.testnet.botho.io` TXT records (`PEER_ID@host:port`); DNS discovery picks
+them up automatically.
+
+Fallback path: launch `us.seed.botho.io`, `eu.seed.botho.io`,
+`ap.seed.botho.io` and start nodes with `BOTHO_REGIONAL_SEEDS=1` so the
+hardcoded fallback includes them.
+
+## 5. Reproducible release build (verified path, not cut here)
+
+- Workflow: `.github/workflows/release.yml` — triggers on `v*` tags, and
+  supports `workflow_dispatch` with a `dry_run` input that builds without
+  publishing a release.
+- Script: `scripts/build-release.sh` — builds `botho`, `botho-wallet`,
+  `botho-exchange-scanner` with pinned `SOURCE_DATE_EPOCH`, isolated
+  `CARGO_HOME`, `LC_ALL=C.UTF-8`, `TZ=UTC`, `CARGO_INCREMENTAL=0` for
+  reproducibility, then emits SHA256 checksums + `build-info.txt`.
+- Deploy hosts are **linux-aarch64** (ARM64 Ubuntu); the release matrix builds
+  that target natively (`ubuntu-24.04-arm`).
+
+The v0.1.0 tag is stale (predates cycle-6 / I4). **Cutting a fresh tag is an
+operator action** (see below). To validate the build path without publishing,
+run `workflow_dispatch` with `dry_run=true`, or locally:
+`./scripts/build-release.sh`.
+
+## Operator steps remaining (NOT in this PR — require AWS/DNS/credentials)
+
+1. **Build/publish a current release binary** — either push a fresh `v0.2.x`
+   tag (triggers `release.yml`) or build `linux-aarch64` and copy to the host.
+2. **Deploy the binary** to `seed.botho.io` (`infra/seed/deploy-botho.sh`,
+   needs SSH key).
+3. **Reset the chain** to fresh genesis on protocol 2.0.0
+   (`reset-chain.sh` / `reset-to-testnet.sh` against the live host).
+4. **Bring up >= 1 additional regional seed** to retire `peerCount: 0`, switch
+   quorum back to `recommended`, and either publish DNS TXT seeds or set
+   `BOTHO_REGIONAL_SEEDS=1`.
+5. **Restore the faucet service** (`infra/faucet/`) and confirm reachability.
+6. **CloudWatch monitoring + Route53 DNS failover** (PLAN.md "Seed Node" /
+   "Disaster Recovery").
+7. **Point web wallet + ledger browser** at the new RPC; verify end-to-end.

--- a/infra/seed/botho-seed.service
+++ b/infra/seed/botho-seed.service
@@ -10,7 +10,28 @@ User=ubuntu
 Group=ubuntu
 WorkingDirectory=/home/ubuntu
 
-# Run as testnet relay node (no minting on seed node)
+# Run as testnet relay node (no minting on seed node).
+#
+# This is the correct unit for a MULTI-SEED network (>= 2 seeds): seeds relay
+# and gossip, while minting happens on a separate validator/faucet node, and
+# the [network.quorum] mode stays "recommended" (auto BFT threshold).
+#
+# SINGLE-SEED bootstrap exception: a lone seed cannot form a "recommended"
+# quorum (it needs >= 2 nodes -> minting stalls at "have 1, need 2"). To mint
+# from a single self-quorum seed during initial bring-up, instead use:
+#
+#   ExecStart=/usr/local/bin/botho --testnet run --mint --mint-threads 1
+#
+# and set the following in ~/.botho/testnet/config.toml so the lone node forms
+# its own quorum:
+#
+#   [network.quorum]
+#   mode = "explicit"
+#   threshold = 1
+#   members = []
+#
+# Switch BACK to --relay (and quorum mode "recommended") once a second seed /
+# validator joins. See infra/seed/README.md "Single-seed vs multi-seed".
 ExecStart=/usr/local/bin/botho --testnet run --relay
 
 # Restart on failure

--- a/infra/seed/reset-chain.sh
+++ b/infra/seed/reset-chain.sh
@@ -2,18 +2,34 @@
 #
 # Reset Blockchain Data on Seed Node
 #
-# This script stops the Botho service, clears all blockchain data,
-# and restarts the service. Use with caution - this is destructive!
+# This script stops the Botho service, clears all blockchain data (ledger +
+# wallet), preserves config.toml, and restarts the service. Use with caution -
+# this is destructive!
 #
 # Usage:
 #   ./reset-chain.sh [user@host]
 #
 # Options:
-#   --force    Skip confirmation prompt
+#   --force            Skip confirmation prompt
+#   --dry-run          Print the remote commands that would run, do NOT execute
+#   --network NAME     Network data dir to reset (default: testnet)
+#   --service NAME     systemd service to control (default: botho-seed)
+#   --help, -h         Show this help and exit
 #
 # Example:
 #   ./reset-chain.sh ubuntu@seed.botho.io
-#   ./reset-chain.sh --force  # Skip confirmation
+#   ./reset-chain.sh --force                 # Skip confirmation
+#   ./reset-chain.sh --dry-run               # Show what would happen (no SSH)
+#
+# Data layout (must match botho/src/config.rs::data_dir / Network::dir_name):
+#   ~/.botho/<network>/            base data dir (network = "testnet"|"mainnet")
+#   ~/.botho/<network>/ledger/     chain database (deleted on reset)
+#   ~/.botho/<network>/wallet/     minting/relay wallet (deleted on reset)
+#   ~/.botho/<network>/config.toml node config (preserved on reset)
+#
+# NOTE: This is an OPERATOR script that connects to a live host over SSH.
+# It is intentionally never invoked by CI. --dry-run requires no credentials
+# and is safe to run anywhere for validation.
 
 set -euo pipefail
 
@@ -29,72 +45,135 @@ log_step() { echo -e "${BLUE}[STEP]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
+usage() {
+    # Print the leading comment block (lines 2..N up to the first blank-after-header)
+    sed -n '2,33p' "$0" | sed 's/^#\s\{0,1\}//'
+}
+
 # Configuration
 DEFAULT_HOST="ubuntu@seed.botho.io"
 SSH_KEY="${SSH_KEY:-$HOME/.ssh/botho-nodes.pem}"
-SERVICE_NAME="botho"
-DATA_DIR=".botho/testnet"
+SERVICE_NAME="botho-seed"
+NETWORK="testnet"
 FORCE=false
+DRY_RUN=false
 
 # Parse arguments
 HOST="$DEFAULT_HOST"
-for arg in "$@"; do
-    case $arg in
+host_set=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
         --force)
             FORCE=true
             ;;
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        --network)
+            NETWORK="$2"
+            shift
+            ;;
+        --service)
+            SERVICE_NAME="$2"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            log_error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
         *)
-            HOST="$arg"
+            HOST="$1"
+            host_set=true
             ;;
     esac
+    shift
 done
 
-# Validate SSH key exists
-if [[ ! -f "$SSH_KEY" ]]; then
-    log_error "SSH key not found: $SSH_KEY"
-    log_info "Set SSH_KEY environment variable or ensure key exists at default location"
-    exit 1
+DATA_DIR=".botho/$NETWORK"
+
+# run_remote: execute (or, in dry-run mode, just print) a command on $HOST.
+run_remote() {
+    local cmd="$1"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    ssh $SSH_OPTS_DISPLAY $HOST \"$cmd\""
+    else
+        # SC2086: word-split SSH_OPTS intentionally. SC2029: $cmd is a fixed,
+        # script-controlled string (no untrusted input), so client-side
+        # expansion is fine.
+        # shellcheck disable=SC2086,SC2029
+        ssh $SSH_OPTS "$HOST" "$cmd"
+    fi
+}
+
+SSH_OPTS_DISPLAY="-i $SSH_KEY -o StrictHostKeyChecking=accept-new"
+SSH_OPTS="$SSH_OPTS_DISPLAY"
+
+# Validate SSH key exists (skip in dry-run so it works without credentials)
+if [[ "$DRY_RUN" != "true" ]]; then
+    if [[ ! -f "$SSH_KEY" ]]; then
+        log_error "SSH key not found: $SSH_KEY"
+        log_info "Set SSH_KEY environment variable or ensure key exists at default location"
+        exit 1
+    fi
 fi
 
-SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new"
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_warn "DRY RUN: no SSH connection will be made; commands are printed only."
+fi
 
 # Confirmation
-if [[ "$FORCE" != "true" ]]; then
+if [[ "$FORCE" != "true" && "$DRY_RUN" != "true" ]]; then
     log_warn "This will DELETE ALL blockchain data on $HOST"
-    log_warn "Data directory: ~/$DATA_DIR"
+    log_warn "Data directory: ~/$DATA_DIR (ledger + wallet)"
     echo ""
-    read -p "Are you sure? Type 'yes' to confirm: " confirm
+    read -r -p "Are you sure? Type 'yes' to confirm: " confirm
     if [[ "$confirm" != "yes" ]]; then
         log_info "Aborted."
         exit 0
     fi
 fi
 
-log_info "Resetting blockchain data on $HOST"
+log_info "Resetting $NETWORK chain data on $HOST (service: $SERVICE_NAME)"
 
 # Step 1: Stop service
-log_step "Stopping Botho service..."
-ssh $SSH_OPTS "$HOST" "sudo systemctl stop $SERVICE_NAME || true"
+log_step "Stopping Botho service ($SERVICE_NAME)..."
+run_remote "sudo systemctl stop $SERVICE_NAME || true"
 
 # Step 2: Backup config (just in case)
 log_step "Backing up configuration..."
-ssh $SSH_OPTS "$HOST" "cp ~/$DATA_DIR/config.toml /tmp/botho-config-backup.toml 2>/dev/null || true"
+run_remote "cp ~/$DATA_DIR/config.toml /tmp/botho-config-backup.toml 2>/dev/null || true"
 
 # Step 3: Clear blockchain data
-log_step "Clearing blockchain data..."
-ssh $SSH_OPTS "$HOST" "rm -rf ~/$DATA_DIR/ledger ~/$DATA_DIR/blocks ~/$DATA_DIR/state ~/$DATA_DIR/peers.json"
+# The node writes its chain DB to ~/.botho/<network>/ledger and its wallet to
+# ~/.botho/<network>/wallet (see botho/src/config.rs). config.toml is preserved.
+log_step "Clearing blockchain data (ledger + wallet)..."
+run_remote "rm -rf ~/$DATA_DIR/ledger ~/$DATA_DIR/wallet"
 
 # Step 4: Restore config if needed
 log_step "Ensuring configuration exists..."
-ssh $SSH_OPTS "$HOST" "mkdir -p ~/$DATA_DIR && cp /tmp/botho-config-backup.toml ~/$DATA_DIR/config.toml 2>/dev/null || true"
+run_remote "mkdir -p ~/$DATA_DIR && cp /tmp/botho-config-backup.toml ~/$DATA_DIR/config.toml 2>/dev/null || true"
 
 # Step 5: Restart service
-log_step "Starting Botho service..."
-ssh $SSH_OPTS "$HOST" "sudo systemctl daemon-reload && sudo systemctl start $SERVICE_NAME"
+log_step "Starting Botho service ($SERVICE_NAME)..."
+run_remote "sudo systemctl daemon-reload && sudo systemctl start $SERVICE_NAME"
 
 # Step 6: Verify
-sleep 3
+if [[ "$DRY_RUN" != "true" ]]; then
+    sleep 3
+fi
 log_step "Verifying service..."
-ssh $SSH_OPTS "$HOST" "sudo systemctl status $SERVICE_NAME --no-pager"
+run_remote "sudo systemctl status $SERVICE_NAME --no-pager"
 
-log_info "Reset complete! The node will sync from genesis."
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "Dry run complete. No changes were made."
+else
+    log_info "Reset complete! The node will mint/sync from a fresh genesis."
+fi
+
+# Avoid 'unused variable' lint when host not explicitly provided
+: "${host_set}"

--- a/infra/seed/reset-to-testnet.sh
+++ b/infra/seed/reset-to-testnet.sh
@@ -9,9 +9,14 @@
 # 4. Starts the node on testnet
 #
 # Usage:
-#   ./reset-to-testnet.sh
+#   ./reset-to-testnet.sh [--dry-run]
 #
-# Run this on seed.botho.io as ubuntu user with sudo access.
+# Options:
+#   --dry-run    Print the steps without stopping/removing/restarting anything
+#   --help, -h   Show this help and exit
+#
+# Run this ON seed.botho.io as the ubuntu user with sudo access. (Unlike
+# reset-chain.sh, this script runs locally on the host, not over SSH.)
 
 set -euo pipefail
 
@@ -24,6 +29,26 @@ NC='\033[0m'
 log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+usage() { sed -n '2,18p' "$0" | sed 's/^#\s\{0,1\}//'; }
+
+DRY_RUN=false
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help) usage; exit 0 ;;
+        *) log_error "Unknown option: $arg"; usage; exit 1 ;;
+    esac
+done
+
+# run: execute a command, or just print it in dry-run mode.
+run() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    $*"
+    else
+        "$@"
+    fi
+}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DATA_DIR="$HOME/.botho"
@@ -38,23 +63,27 @@ echo ""
 log_warn "This will DELETE all mainnet data and restart as testnet."
 log_warn "Data directory: $DATA_DIR"
 echo ""
-read -p "Are you sure you want to proceed? (yes/no): " confirm
-if [[ "$confirm" != "yes" ]]; then
-    log_info "Aborted."
-    exit 0
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_warn "DRY RUN: no services stopped, no data removed, nothing restarted."
+else
+    read -r -p "Are you sure you want to proceed? (yes/no): " confirm
+    if [[ "$confirm" != "yes" ]]; then
+        log_info "Aborted."
+        exit 0
+    fi
 fi
 
 # Step 1: Stop services
 log_info "Stopping botho services..."
-sudo systemctl stop botho-seed 2>/dev/null || true
-sudo systemctl stop botho 2>/dev/null || true
-sudo systemctl stop botho-faucet 2>/dev/null || true
+run sudo systemctl stop botho-seed
+run sudo systemctl stop botho
+run sudo systemctl stop botho-faucet
 
 # Wait for processes to stop
-sleep 2
+[[ "$DRY_RUN" == "true" ]] || sleep 2
 
 # Check if any botho process is still running
-if pgrep -x botho > /dev/null; then
+if [[ "$DRY_RUN" != "true" ]] && pgrep -x botho > /dev/null; then
     log_warn "Botho process still running, killing..."
     sudo pkill -9 botho || true
     sleep 1
@@ -62,7 +91,9 @@ fi
 
 # Step 2: Remove mainnet data
 log_info "Removing mainnet data..."
-if [[ -d "$DATA_DIR/mainnet" ]]; then
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "    rm -rf $DATA_DIR/mainnet  # (if present)"
+elif [[ -d "$DATA_DIR/mainnet" ]]; then
     rm -rf "$DATA_DIR/mainnet"
     log_info "Removed $DATA_DIR/mainnet"
 else
@@ -71,13 +102,19 @@ fi
 
 # Step 3: Install systemd service
 log_info "Installing botho-seed systemd service..."
-sudo cp "$SCRIPT_DIR/botho-seed.service" /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable botho-seed
+run sudo cp "$SCRIPT_DIR/botho-seed.service" /etc/systemd/system/
+run sudo systemctl daemon-reload
+run sudo systemctl enable botho-seed
 
 # Step 4: Start the service
 log_info "Starting botho-seed service..."
-sudo systemctl start botho-seed
+run sudo systemctl start botho-seed
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo ""
+    log_info "Dry run complete. No changes were made."
+    exit 0
+fi
 
 # Step 5: Verify
 sleep 3


### PR DESCRIPTION
## Summary

Implements the **automatable-prep half** of the testnet redeploy/reset epic
(#323). This is the code/config + documentation portion only. The
deploy/reset/DNS/faucet steps require AWS/DNS credentials and remain with the
human operator (see below). **Nothing here touches live infrastructure** — the
only execution was local builds, unit tests, and script `--dry-run`.

This PR intentionally does **not** auto-close #323 (it only partially addresses
the epic); the operator steps stay tracked.

## Changes

- **`botho/src/network/seeds.rs` (new):** single source of truth for hardcoded
  fallback bootstrap seeds. `config.rs::default_bootstrap_peers` and
  `dns_seeds.rs::hardcoded_seeds` now both delegate here, removing a previously
  duplicated/drift-prone seed list. Adds regional (`us`/`eu`/`ap`) seed
  scaffolding for >=3 regions on both networks, **gated off by default** behind
  `BOTHO_REGIONAL_SEEDS=1` since the regional DNS records are not yet live.
- **`infra/seed/reset-chain.sh`:** now deletes the real data artifacts the node
  actually writes (`ledger/`, `wallet/`) instead of stale `blocks/`, `state/`,
  `peers.json`; defaults to the correct `botho-seed` systemd unit; adds
  `--dry-run`, `--help`, `--network`, `--service`.
- **`infra/seed/reset-to-testnet.sh`:** adds `--dry-run` / `--help`, uses
  `read -r`.
- **`infra/seed/botho-seed.service`:** documents the single-seed (mint +
  explicit threshold-1 quorum) vs multi-seed (relay + recommended quorum)
  `ExecStart` variants.
- **`infra/seed/TESTNET_RESET.md` (new) + `README.md`:** genesis/network-param
  reconciliation table, multi-seed bootstrap plan, reproducible release-build
  path, and the operator deploy runbook.

## Prep items addressed (from #323)

| # | Item | Status |
|---|------|--------|
| 1 | Verify/refresh reset + genesis tooling against current `main` | Done — fixed `reset-chain.sh` data-path/service drift; added dry-run/help to both scripts |
| 2 | Confirm `botho-testnet` genesis magic / network params match `block.rs` | Verified consistent (protocol 2.0.0, `TESTNET_GENESIS_MAGIC`, `BTHT`, ports 17100/17101, RPC `botho-testnet`); reconciliation table in `TESTNET_RESET.md`. No code change needed |
| 3 | Multi-seed bootstrap config + DNS-seed discovery scaffolding | DNS discovery + PEX already existed; added `seeds.rs` single-source-of-truth + opt-in regional (>=3 region) scaffolding + docs |
| 4 | Reproducible release-build tooling from `main` HEAD | Verified path: `release.yml` (`workflow_dispatch` `dry_run`) + `scripts/build-release.sh` build a current `linux-aarch64` binary. Documented. Tag NOT cut (operator action) |

## Acceptance Criteria Verification

The epic's acceptance criteria are operator/runtime gated (live seed, peerCount,
faucet, web wallet) and cannot be satisfied by a code PR. This PR satisfies the
**automatable-prep checklist** instead:

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Reset/genesis tooling works against current `main` | OK | `reset-chain.sh --dry-run` / `reset-to-testnet.sh --dry-run` print correct steps; data paths match `config.rs` |
| Genesis magic / network params reconciled | OK | Table cross-referenced to `block.rs`, `constants.rs`, `rpc/mod.rs`; all consistent |
| Multi-seed config + DNS scaffolding | OK | `seeds.rs` with 3-region scaffolding; unit tests assert >=3 regions and off-by-default; `cargo test` green |
| Release-build path from HEAD | OK | `build-release.sh` + `release.yml` reviewed; documented dry-run path |

## Operator steps remaining (NOT in this PR — require AWS/DNS/credentials)

1. Build/publish a current release binary — push a fresh `v0.2.x` tag (triggers
   `release.yml`) or build `linux-aarch64` and copy to the host.
2. Deploy the binary to `seed.botho.io` (`infra/seed/deploy-botho.sh`, needs SSH key).
3. Reset the live chain to fresh genesis on protocol 2.0.0 (`reset-chain.sh` /
   `reset-to-testnet.sh` against the live host).
4. Bring up >=1 additional regional seed; switch quorum back to `recommended`;
   publish `seeds.testnet.botho.io` TXT records (or set `BOTHO_REGIONAL_SEEDS=1`).
5. Restore the faucet service (`infra/faucet/`) and confirm reachability.
6. CloudWatch monitoring + Route53 DNS failover.
7. Point web wallet + ledger browser at the new RPC; verify end-to-end.

## Test Plan (local only — no live infra touched)

- `cargo build -p botho` — clean (pre-existing warnings only).
- `cargo test -p botho --lib config:: network::seeds:: network::dns_seeds::` —
  56 passed, 0 failed (includes new tests: primary seed always present,
  regional seeds cover 3 regions, off-by-default).
- `cargo clippy -p botho --lib` — no errors.
- `shellcheck infra/seed/reset-chain.sh` — clean; `reset-to-testnet.sh` — clean.
- `reset-chain.sh --help` / `--dry-run`, `reset-to-testnet.sh --help` /
  `--dry-run` — print expected commands, make no SSH connection, mutate nothing.
- No AWS/DNS/SSH/cloud commands were run; no live chain was connected to or reset.

Part of #323
Refs #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)