### PR TITLE
fix(network): stop SyncCodec from half-closing the sync substream during negotiation

### DIFF
--- a/botho/src/network/sync.rs
+++ b/botho/src/network/sync.rs
@@ -262,7 +262,20 @@ impl Codec for SyncCodec {
             let bytes = bincode::serialize(&req)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
             io.write_all(&bytes).await?;
-            io.close().await
+            // NOTE: do NOT call `io.close()` here. Under libp2p 0.56's
+            // request-response handler, the *handler* (not the codec) is
+            // responsible for half-closing the substream after the codec
+            // returns (it calls `stream.close()` right after
+            // `write_request`/`write_response`). Closing inside the codec
+            // races with libp2p's optimistic multistream-select negotiation:
+            // tearing the substream down before the remote confirms the
+            // protocol surfaces as "Stream closed. Confirmation from remote
+            // for optimistic protocol negotiation still pending." On loopback
+            // this cascades into the whole connection being dropped and
+            // redialed (issue #411). The peer's read side still observes EOF
+            // because the handler half-closes the write direction once we
+            // return.
+            Ok(())
         })
     }
 
@@ -283,7 +296,12 @@ impl Codec for SyncCodec {
             let bytes = bincode::serialize(&resp)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
             io.write_all(&bytes).await?;
-            io.close().await
+            // See the note in `write_request`: the libp2p request-response
+            // handler half-closes the substream after this returns, so the
+            // codec must not call `io.close()` itself (it races with
+            // optimistic protocol negotiation and destabilizes the
+            // connection — issue #411).
+            Ok(())
         })
     }
 }
@@ -1372,6 +1390,126 @@ mod tests {
         // No connected peers: nothing to request.
         let action = manager.tick(&[]);
         assert!(action.is_none());
+    }
+
+    // ========================================================================
+    // SyncCodec framing tests (#411)
+    //
+    // Regression coverage for the transport-stability bug: the codec must not
+    // call `io.close()` itself. The libp2p request-response handler owns
+    // closing the substream (it half-closes the write direction *after* the
+    // codec returns). Calling `close()` inside the codec raced with libp2p
+    // 0.56 optimistic protocol negotiation and tore down whole connections on
+    // loopback. These tests verify the round-trip still works under the
+    // handler's "write, then handler closes, peer reads to EOF" contract.
+    // ========================================================================
+
+    /// Drives the codec exactly as the libp2p request-response handler does:
+    /// the writer serializes via the codec, the handler then half-closes the
+    /// write side, and the reader consumes until EOF. We model the closed
+    /// write side with a `Cursor` over the produced bytes (which yields EOF
+    /// once exhausted), proving the codec frames correctly without ever
+    /// calling `io.close()` itself.
+    async fn roundtrip_request(req: SyncRequest) -> SyncRequest {
+        use futures::io::Cursor;
+
+        let protocol = StreamProtocol::new(SYNC_PROTOCOL);
+        let mut codec = SyncCodec;
+
+        // Writer side: codec writes bytes into the buffer. The handler — not
+        // the codec — is responsible for closing afterwards, so we explicitly
+        // do NOT close here; we just take the written bytes.
+        let mut write_buf = Cursor::new(Vec::new());
+        codec
+            .write_request(&protocol, &mut write_buf, req)
+            .await
+            .expect("write_request should succeed without closing the stream");
+        let bytes = write_buf.into_inner();
+
+        // Reader side: a Cursor yields EOF once the bytes are exhausted,
+        // exactly like a peer's half-closed substream.
+        let mut read_buf = Cursor::new(bytes);
+        codec
+            .read_request(&protocol, &mut read_buf)
+            .await
+            .expect("read_request should decode the framed message")
+    }
+
+    async fn roundtrip_response(resp: SyncResponse) -> SyncResponse {
+        use futures::io::Cursor;
+
+        let protocol = StreamProtocol::new(SYNC_PROTOCOL);
+        let mut codec = SyncCodec;
+
+        let mut write_buf = Cursor::new(Vec::new());
+        codec
+            .write_response(&protocol, &mut write_buf, resp)
+            .await
+            .expect("write_response should succeed without closing the stream");
+        let bytes = write_buf.into_inner();
+
+        let mut read_buf = Cursor::new(bytes);
+        codec
+            .read_response(&protocol, &mut read_buf)
+            .await
+            .expect("read_response should decode the framed message")
+    }
+
+    #[tokio::test]
+    async fn test_codec_request_roundtrip_get_status() {
+        let decoded = roundtrip_request(SyncRequest::GetStatus).await;
+        assert!(matches!(decoded, SyncRequest::GetStatus));
+    }
+
+    #[tokio::test]
+    async fn test_codec_request_roundtrip_get_blocks() {
+        let decoded = roundtrip_request(SyncRequest::GetBlocks {
+            start_height: 42,
+            count: 100,
+        })
+        .await;
+        match decoded {
+            SyncRequest::GetBlocks {
+                start_height,
+                count,
+            } => {
+                assert_eq!(start_height, 42);
+                assert_eq!(count, 100);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_codec_response_roundtrip_status() {
+        let decoded = roundtrip_response(SyncResponse::Status {
+            height: 1234,
+            tip_hash: [7u8; 32],
+        })
+        .await;
+        match decoded {
+            SyncResponse::Status { height, tip_hash } => {
+                assert_eq!(height, 1234);
+                assert_eq!(tip_hash, [7u8; 32]);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_codec_response_roundtrip_blocks_empty() {
+        let decoded = roundtrip_response(SyncResponse::Blocks {
+            blocks: vec![],
+            has_more: true,
+        })
+        .await;
+        match decoded {
+            SyncResponse::Blocks { blocks, has_more } => {
+                assert!(blocks.is_empty());
+                assert!(has_more);
+            }
+            _ => panic!("wrong variant"),
+        }
     }
 
     #[test]

--- a/botho/tests/network_integration.rs
+++ b/botho/tests/network_integration.rs
@@ -848,3 +848,172 @@ fn test_sync_messages_size_limits() {
         "GetBlocks should fit in request size limit"
     );
 }
+
+// ============================================================================
+// Transport-stability regression (#411)
+//
+// Two local libp2p nodes must establish AND MAINTAIN a stable connection while
+// the sync request-response protocol is exercised. The original bug was that
+// `SyncCodec::write_{request,response}` called `io.close()` as a framing
+// terminator; under libp2p's request-response handler (which itself closes the
+// substream after the codec returns) this double-closed the substream and
+// raced with optimistic multistream-select negotiation, surfacing as
+// "Stream closed. Confirmation from remote for optimistic protocol negotiation
+// still pending." and cascading into the whole connection being dropped and
+// redialed.
+//
+// This test drives MANY sequential sync round-trips over a SINGLE connection
+// (each round-trip opens, writes, and closes a fresh `/botho/sync/1.0.0`
+// substream — the exact path that misbehaved) and asserts that:
+//   1. every round-trip completes (the codec frames correctly without closing
+//      the stream itself), and
+//   2. the underlying connection is NEVER torn down throughout (no
+//      `ConnectionClosed`), i.e. the peer link stays stable.
+// ============================================================================
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_sync_connection_stays_stable_across_many_requests() {
+    use tokio::sync::{mpsc, oneshot};
+
+    let (mut swarm1, peer1, addr1) = create_test_swarm().await;
+    let (mut swarm2, _peer2, _addr2) = create_test_swarm().await;
+
+    // Connect node 2 -> node 1.
+    swarm2.dial(addr1.clone()).unwrap();
+
+    // Wait for both ends to report the connection established.
+    let (tx1, rx1) = oneshot::channel();
+    let (tx2, rx2) = oneshot::channel();
+    let c1 = tokio::spawn(async move {
+        while let Some(event) = swarm1.next().await {
+            if let SwarmEvent::ConnectionEstablished { .. } = event {
+                tx1.send(swarm1).ok();
+                return;
+            }
+        }
+    });
+    let c2 = tokio::spawn(async move {
+        while let Some(event) = swarm2.next().await {
+            if let SwarmEvent::ConnectionEstablished { .. } = event {
+                tx2.send(swarm2).ok();
+                return;
+            }
+        }
+    });
+    let (mut swarm1, mut swarm2) = timeout(Duration::from_secs(10), async {
+        let s1 = rx1.await.unwrap();
+        let s2 = rx2.await.unwrap();
+        (s1, s2)
+    })
+    .await
+    .expect("two local nodes should establish a connection");
+    c1.abort();
+    c2.abort();
+
+    // Number of sequential sync round-trips to drive over the one connection.
+    const ROUNDS: usize = 25;
+
+    // Server side (node 1): answer every status request, and fail the test
+    // immediately if the connection is ever closed.
+    let server_task = tokio::spawn(async move {
+        loop {
+            match swarm1.next().await {
+                Some(SwarmEvent::Behaviour(TestBehaviourEvent::Sync(
+                    request_response::Event::Message {
+                        message: request_response::Message::Request { channel, .. },
+                        ..
+                    },
+                ))) => {
+                    let response = SyncResponse::Status {
+                        height: 7,
+                        tip_hash: [9u8; 32],
+                    };
+                    swarm1
+                        .behaviour_mut()
+                        .sync
+                        .send_response(channel, response)
+                        .ok();
+                }
+                Some(SwarmEvent::ConnectionClosed { cause, .. }) => {
+                    panic!("server connection closed mid-test (cause={cause:?})");
+                }
+                Some(_) => {}
+                None => return,
+            }
+        }
+    });
+
+    // Client side (node 2): issue ROUNDS sequential requests, awaiting each
+    // response before sending the next. Report each completed round and bail
+    // out if the connection closes.
+    let (round_tx, mut round_rx) = mpsc::unbounded_channel::<()>();
+    let client_task = tokio::spawn(async move {
+        let mut sent = 0usize;
+        let mut completed = 0usize;
+        // Kick off the first request.
+        swarm2
+            .behaviour_mut()
+            .sync
+            .send_request(&peer1, SyncRequest::GetStatus);
+        sent += 1;
+
+        loop {
+            match swarm2.next().await {
+                Some(SwarmEvent::Behaviour(TestBehaviourEvent::Sync(
+                    request_response::Event::Message {
+                        message: request_response::Message::Response { .. },
+                        ..
+                    },
+                ))) => {
+                    completed += 1;
+                    round_tx.send(()).ok();
+                    if completed >= ROUNDS {
+                        return;
+                    }
+                    if sent < ROUNDS {
+                        swarm2
+                            .behaviour_mut()
+                            .sync
+                            .send_request(&peer1, SyncRequest::GetStatus);
+                        sent += 1;
+                    }
+                }
+                Some(SwarmEvent::ConnectionClosed { cause, .. }) => {
+                    panic!("client connection closed mid-test (cause={cause:?})");
+                }
+                Some(SwarmEvent::Behaviour(TestBehaviourEvent::Sync(
+                    request_response::Event::OutboundFailure { error, .. },
+                ))) => {
+                    panic!("sync outbound failure mid-test: {error:?}");
+                }
+                Some(_) => {}
+                None => return,
+            }
+        }
+    });
+
+    // Drive the round counter: all ROUNDS round-trips must complete within a
+    // bounded time without the connection dropping.
+    let mut completed = 0usize;
+    let outcome = timeout(Duration::from_secs(30), async {
+        while completed < ROUNDS {
+            if round_rx.recv().await.is_none() {
+                break;
+            }
+            completed += 1;
+        }
+    })
+    .await;
+
+    server_task.abort();
+    client_task.abort();
+
+    assert!(
+        outcome.is_ok(),
+        "expected {ROUNDS} sync round-trips to complete on a stable connection, \
+         only completed {completed} before timeout"
+    );
+    assert_eq!(
+        completed, ROUNDS,
+        "all sync round-trips should complete over a single stable connection"
+    );
+}


### PR DESCRIPTION
## Summary

Two local `botho run` nodes were reported to repeatedly drop and redial their libp2p connection with `multistream-select: "Stream closed. Confirmation from remote for optimistic protocol negotiation still pending."`, never forming a stable peer link (issue #411).

Root cause (Curator's Lead 1, confirmed against libp2p source): the hand-rolled `SyncCodec` (`botho/src/network/sync.rs`) used `io.write_all(&bytes); io.close()` as its message-framing terminator in both `write_request` and `write_response`, with the read side looping until EOF.

Under libp2p 0.56's request-response protocol the **handler**, not the codec, owns closing the substream — `libp2p-request-response`'s handler calls `stream.close().await?` immediately *after* `write_request`/`write_response` return (handler.rs:153 for responses, handler.rs:191 for requests). Closing inside the codec therefore double-closes the substream and races with libp2p's optimistic multistream-select negotiation: tearing the substream down before the remote confirms the protocol produces exactly the reported error, and on fast loopback this can cascade into the whole connection being dropped + redialed. libp2p's own reference `cbor`/`json` codecs deliberately do NOT call `close()` for this reason — they only `write_all` and return.

## Fix

Remove the `io.close()` calls from `SyncCodec::write_request` and `SyncCodec::write_response`. The peer's read side still observes EOF because the handler half-closes the write direction once the codec returns. This is the smallest viable change:

- **Wire format unchanged**: still bincode; `SyncRequest`/`SyncResponse` types untouched, so #376 catch-up sync round-trips identically. No persisted/cross-version compatibility concern (and pre-mainnet regardless).
- **Behaviour type unchanged**: stays `request_response::Behaviour<SyncCodec>`, so no ripple into `discovery.rs` signatures.
- Lead 2 (explicit upgrade timeout) and Lead 3 (identify ordering) were not needed — the codec was the contract violation.

## Changes

- `botho/src/network/sync.rs`: drop `io.close()` from both codec write methods (with an explanatory comment); add codec round-trip unit tests that model the handler's "write, handler closes, peer reads to EOF" contract for `GetStatus`/`GetBlocks`/`Status`/`Blocks`.
- `botho/tests/network_integration.rs`: add `test_sync_connection_stays_stable_across_many_requests` — a real two-swarm libp2p test that drives 25 sequential sync round-trips over one connection and asserts the connection is never closed (`ConnectionClosed`/`OutboundFailure` fail the test).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Two local nodes establish AND maintain a stable connection (no redial loop) | ✅ | Two `botho run` nodes on 127.0.0.1 (A solo minter, B follower bootstrapping to A): `peerCount` held steadily at 1 on both for the full 35s poll; 0 "optimistic protocol negotiation still pending" occurrences; sync substream negotiated + confirmed cleanly in logs |
| `peerCount` stays >= 1 steadily (>= 30s) | ✅ | 35/35 one-second polls reported `B.peerCount=1` (and `A.peerCount=1`) |
| Root cause documented with reasoning | ✅ | Lead 1 (codec `close()`-as-framing) confirmed against libp2p handler source; see Summary + commit body |
| #376 catch-up sync still works | ✅ | `cargo test -p botho --test chain_sync_catchup_integration` — 5/5 pass (incl. `test_fresh_node_syncs_existing_chain_to_tip`) |
| No regression to network/sync tests | ✅ | `network_integration` 18/18, `network::sync` lib 49/49, both `test_sync_request_response` and `test_sync_blocks_request` still pass |
| Harness assertion that two nodes stay connected for a bounded duration | ✅ | New `test_sync_connection_stays_stable_across_many_requests` |

## Reproduction note (transparency)

On macOS loopback the reported failure is timing-sensitive: the *baseline* (origin/main) binary did NOT reproduce the redial loop in my two-node run, and both codec variants pass the in-process swarm tests (fast localhost yamux lands the close after negotiation completes). The fix is nonetheless an unambiguous correction of the libp2p request-response codec contract (matches libp2p's own `cbor` codec and the handler's documented close behaviour), removes a redundant double-close, and is low-risk. The reported race is most likely to bite under the slower/heavier timing of CI or a loaded host; this change closes that race at its source. Single-node solo minting is unaffected (codec only fires on sync request/response traffic).

## Test Plan

- `cargo test -p botho --lib network::sync` — 49/49
- `cargo test -p botho --test network_integration` — 18/18
- `cargo test -p botho --test chain_sync_catchup_integration` — 5/5
- `cargo build --release --bin botho` + two-node localhost run: stable `peerCount=1` for 35s, 0 negotiation-close errors.
- `cargo clippy -p botho --tests` / `cargo fmt` clean (only pre-existing warnings).

Closes #411