### PR TITLE
fix(gossip): slot-rate-aware rate limits + violation decay so SCP/minting messages aren't dropped (#413)

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result};
 use bth_common::{NodeID, ResponderId};
 use bth_consensus_scp::QuorumSet;
 use bth_crypto_keys::Ed25519Public;
+use bth_gossip::{GossipConfig, PeerRateLimitConfig};
 use futures::StreamExt;
 use std::{
     net::SocketAddr,
@@ -222,9 +223,31 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // for a node whose only peers are bootstrap nodes (issue #409).
     let reconnect_bootstrap_peers = bootstrap_peers.clone();
 
-    // Start network discovery
-    let mut discovery =
-        NetworkDiscovery::new(config.network.gossip_port(network_type), bootstrap_peers);
+    // Start network discovery.
+    //
+    // Size the gossipsub per-peer rate limiter from the *effective* slot
+    // cadence and the peer ceiling so honest multi-node SCP/minting traffic is
+    // never silently dropped (issue #413). The fastest cadence the node may run
+    // at determines the highest honest message rate: under dynamic timing the
+    // slot duration can drop to `MIN_BLOCK_TIME_SECS`, and under the
+    // `BOTHO_SLOT_DURATION_SECS` test override it is whatever was configured.
+    // We use the smaller of the two as the rate-limit basis (a smaller slot ->
+    // higher rate -> higher cap), and the gossip layer's connection ceiling as
+    // the peer bound (each connected peer may broadcast SCP/minting traffic).
+    let consensus_cfg = consensus_config_from_env();
+    let effective_slot_secs = if consensus_cfg.dynamic_timing {
+        ConsensusConfig::MIN_BLOCK_TIME_SECS
+    } else {
+        consensus_cfg.slot_duration.as_secs().max(1)
+    };
+    let rate_limit_peers = GossipConfig::default().max_connections.max(1) as u32;
+    let rate_limit_config =
+        PeerRateLimitConfig::for_slot_duration(effective_slot_secs, rate_limit_peers);
+    let mut discovery = NetworkDiscovery::with_rate_limit_config(
+        config.network.gossip_port(network_type),
+        bootstrap_peers,
+        rate_limit_config,
+    );
 
     let mut swarm = discovery.start().await?;
 

--- a/gossip/src/config.rs
+++ b/gossip/src/config.rs
@@ -143,28 +143,139 @@ pub struct MessageTypeLimits {
 
 impl Default for MessageTypeLimits {
     fn default() -> Self {
+        // These caps must comfortably exceed the message rate that honest
+        // multi-node SCP consensus produces, while remaining far below a
+        // genuine flood. A single SCP slot is not one message: nomination
+        // rounds plus the ballot protocol (PREPARE / CONFIRM / EXTERNALIZE),
+        // each potentially rebroadcast on timeout, plus a per-slot minting tx.
+        // A conservative bound is ~10-30 consensus messages per slot per peer
+        // during active rounds. At the *default* slot duration (20s) that is
+        // tiny, but the same binary is run with `BOTHO_SLOT_DURATION_SECS=1`
+        // in tests, where it is ~600-1800 consensus msgs/min/peer. The old
+        // fixed caps (50/min consensus, 100/min tx) silently dropped honest
+        // SCP/minting traffic, kept nodes in solo mode, and caused forks
+        // (issue #413). We size the defaults for the fast-slot, multi-peer
+        // case and rely on `for_slot_duration` to scale further when the
+        // effective slot duration / quorum size is known.
+        Self::for_slot_duration(DEFAULT_SLOT_DURATION_SECS, DEFAULT_QUORUM_PEERS)
+    }
+}
+
+/// Default slot duration (seconds) assumed when sizing rate limits without an
+/// explicit value. Matches `ConsensusConfig::default().slot_duration`.
+const DEFAULT_SLOT_DURATION_SECS: u64 = 20;
+
+/// Default quorum size assumed when sizing rate limits without an explicit
+/// value. Small testnets run 2-of-2; we leave generous headroom.
+const DEFAULT_QUORUM_PEERS: u32 = 8;
+
+/// Estimated number of consensus (SCP) messages a single peer broadcasts per
+/// slot during active nomination + ballot rounds (with rebroadcast headroom).
+const CONSENSUS_MSGS_PER_SLOT: u32 = 30;
+
+/// Estimated number of transaction (incl. minting tx) messages a single peer
+/// broadcasts per slot.
+const TX_MSGS_PER_SLOT: u32 = 8;
+
+/// Multiplicative safety headroom applied to derived rate limits so transient
+/// bursts (e.g. several rebroadcasts colliding) never trip honest traffic.
+const RATE_LIMIT_HEADROOM: u32 = 4;
+
+impl MessageTypeLimits {
+    /// Derive per-type per-minute caps from the effective slot duration and the
+    /// quorum size. The consensus/transaction caps scale with `peers` and with
+    /// `60 / slot_secs`, so a faster slot or a larger quorum raises the ceiling
+    /// instead of silently dropping honest consensus traffic.
+    ///
+    /// The result is still a *flood ceiling*: a genuinely abusive peer sending
+    /// orders of magnitude more than the honest cadence is still caught.
+    pub fn for_slot_duration(slot_secs: u64, peers: u32) -> Self {
+        let slot_secs = slot_secs.max(1);
+        // Slots per minute at this cadence: a 1s slot yields 60, a 20s slot
+        // yields 3. Floored at 1 so very long slots still get a sane cap.
+        let slots_per_min = (60 / slot_secs).max(1) as u32;
+        let peers = peers.max(1);
+
+        // consensus_per_minute = msgs_per_slot * slots_per_min * peers * headroom
+        let consensus_per_minute = CONSENSUS_MSGS_PER_SLOT
+            .saturating_mul(slots_per_min)
+            .saturating_mul(peers)
+            .saturating_mul(RATE_LIMIT_HEADROOM);
+        let transactions_per_minute = TX_MSGS_PER_SLOT
+            .saturating_mul(slots_per_min)
+            .saturating_mul(peers)
+            .saturating_mul(RATE_LIMIT_HEADROOM);
+
         Self {
-            // From audit requirements:
-            // - Transaction announcements: 100/min
-            // - Block announcements: 10/min
-            // - Consensus messages: 50/min
-            transactions_per_minute: 100,
-            blocks_per_minute: 10,
-            consensus_per_minute: 50,
-            announcements_per_minute: 20,
+            transactions_per_minute,
+            blocks_per_minute: 60,
+            consensus_per_minute,
+            announcements_per_minute: 60,
         }
     }
 }
 
 impl Default for PeerRateLimitConfig {
     fn default() -> Self {
+        Self::for_slot_duration(DEFAULT_SLOT_DURATION_SECS, DEFAULT_QUORUM_PEERS)
+    }
+}
+
+impl PeerRateLimitConfig {
+    /// Build a rate-limit config sized for the given effective slot duration
+    /// and quorum size.
+    ///
+    /// Both the per-type caps *and* the global gates
+    /// (`max_messages_per_second`, `burst_limit`) are derived together. The
+    /// original bug (issue #413) was that the global gates (10 msg/s, 50
+    /// msg/5s) trip *before* the per-type caps, so raising only the
+    /// per-type caps still dropped honest SCP/minting traffic. Here the
+    /// global gates are scaled from the same slot-rate model with extra
+    /// headroom so they sit above the honest aggregate rate while
+    /// still tripping for a true flood.
+    pub fn for_slot_duration(slot_secs: u64, peers: u32) -> Self {
+        let limits = MessageTypeLimits::for_slot_duration(slot_secs, peers);
+
+        let peers = peers.max(1);
+
+        // Aggregate honest rate across all types, per minute, then convert to a
+        // per-second global ceiling with generous headroom.
+        let aggregate_per_min = limits
+            .consensus_per_minute
+            .saturating_add(limits.transactions_per_minute)
+            .saturating_add(limits.blocks_per_minute)
+            .saturating_add(limits.announcements_per_minute);
+
+        // A full slot's worth of consensus+tx messages from all peers can
+        // legitimately cluster inside a single second (e.g. an active ballot
+        // round with rebroadcasts), even at long slot durations. The global
+        // per-second gate must sit above that instantaneous cluster, not just
+        // above the time-averaged aggregate, otherwise it trips before the
+        // per-type caps (the core #413 failure). Take the larger of:
+        //   - the per-slot instantaneous cluster across peers, with headroom
+        //   - the time-averaged aggregate per second, with headroom
+        let per_slot_cluster = CONSENSUS_MSGS_PER_SLOT
+            .saturating_add(TX_MSGS_PER_SLOT)
+            .saturating_mul(peers)
+            .saturating_mul(RATE_LIMIT_HEADROOM);
+        let averaged_per_second = ((aggregate_per_min / 60) + 1).saturating_mul(2);
+        let max_messages_per_second = per_slot_cluster.max(averaged_per_second).max(50);
+        // Burst limit over a 5s window: 5s of the per-second ceiling, with
+        // headroom for rebroadcast collisions.
+        let burst_limit = max_messages_per_second.saturating_mul(5).max(250);
+
         Self {
-            max_messages_per_second: 10,
-            burst_limit: 50,
+            max_messages_per_second,
+            burst_limit,
             burst_window_ms: 5000, // 5 second window
-            disconnect_threshold: 3,
+            // Raised from 3: a busy honest peer can momentarily exceed a cap
+            // during a rebroadcast storm. Combined with violation decay (see
+            // `PeerRateState::decay_violations`) this avoids permanently
+            // blacklisting an honest peer after a transient burst, while a
+            // sustained abuser still accrues violations faster than they decay.
+            disconnect_threshold: 10,
             enabled: true,
-            message_limits: MessageTypeLimits::default(),
+            message_limits: limits,
         }
     }
 }

--- a/gossip/src/rate_limit.rs
+++ b/gossip/src/rate_limit.rs
@@ -54,7 +54,32 @@ impl GossipMessageType {
             GossipMessageType::Other => config.max_messages_per_second * 60, // Use global limit
         }
     }
+
+    /// Whether exceeding the rate limit for this message type may flag the peer
+    /// for disconnection.
+    ///
+    /// Consensus (SCP) and Transaction (minting-tx) traffic is
+    /// consensus-critical: dropping it stalls the protocol and forks the
+    /// chain (issue #413). Honest minters can briefly exceed a cap during a
+    /// rebroadcast storm, so we never *disconnect* a peer on the basis of
+    /// this traffic — at most the excess is rate-limited (counted, with the
+    /// individual over-cap message dropped). The generous slot-rate-aware
+    /// caps mean honest traffic is not even rate-limited under normal load;
+    /// the cap exists purely as a memory/processing bound, and a genuine
+    /// flood is still throttled (just not auto-banned on these topics).
+    pub fn is_disconnect_eligible(&self) -> bool {
+        !matches!(
+            self,
+            GossipMessageType::Consensus | GossipMessageType::Transaction
+        )
+    }
 }
+
+/// After this much continuous good behavior (no new violation), a peer's
+/// accumulated violation count decays by one. This gives a transient burst a
+/// path back to good standing instead of permanently blacklisting an honest
+/// peer, while a sustained abuser accrues violations faster than they decay.
+const VIOLATION_DECAY_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Tracks rate limiting state for a single peer.
 #[derive(Debug, Clone)]
@@ -102,6 +127,36 @@ impl PeerRateState {
         self.violations = 0;
     }
 
+    /// Decay accumulated violations after a period of good behavior.
+    ///
+    /// If the peer has not violated a limit for at least one
+    /// `VIOLATION_DECAY_INTERVAL`, decrement the violation count by the number
+    /// of whole intervals elapsed (advancing `last_warning` accordingly). This
+    /// is the *live* cooldown path that issue #413 found missing: without it a
+    /// peer that briefly burst over a cap stayed `>= disconnect_threshold`
+    /// permanently and every subsequent message was dropped/flagged forever.
+    fn decay_violations(&mut self, now: Instant) {
+        if self.violations == 0 {
+            return;
+        }
+        let Some(last) = self.last_warning else {
+            return;
+        };
+        let elapsed = now.saturating_duration_since(last);
+        let intervals = (elapsed.as_secs() / VIOLATION_DECAY_INTERVAL.as_secs()) as u32;
+        if intervals == 0 {
+            return;
+        }
+        self.violations = self.violations.saturating_sub(intervals);
+        if self.violations == 0 {
+            self.last_warning = None;
+        } else {
+            // Advance the clock by the consumed intervals so leftover time
+            // counts toward the next decay step.
+            self.last_warning = Some(last + VIOLATION_DECAY_INTERVAL * intervals);
+        }
+    }
+
     /// Record a message and check if it exceeds rate limits.
     /// Returns true if the message should be allowed, false if rate limited.
     pub fn record_message(&mut self, config: &PeerRateLimitConfig) -> bool {
@@ -118,6 +173,10 @@ impl PeerRateState {
         let now = Instant::now();
         let one_minute = Duration::from_secs(60);
         let burst_window = Duration::from_millis(config.burst_window_ms);
+
+        // Live cooldown: let accumulated violations decay after good behavior so
+        // a transient burst does not permanently flag an honest peer (#413).
+        self.decay_violations(now);
 
         // Clean up old global messages
         self.global_message_times
@@ -244,14 +303,25 @@ impl PeerRateLimiter {
             // Record rate limit hit
             self.metrics.record_rate_limit_hit(msg_type);
 
-            if state.should_disconnect(self.config.disconnect_threshold) {
+            // Consensus (SCP) and Transaction (minting-tx) traffic is
+            // consensus-critical and must never push a peer onto the
+            // disconnect path on its own: an honest minter that briefly
+            // exceeds the (already generous, slot-rate-aware) cap during a
+            // rebroadcast storm would otherwise be permanently flagged,
+            // stalling consensus and forking the chain (#413). For these
+            // types we throttle the individual over-cap message but never
+            // return Disconnect, regardless of violation count.
+            if msg_type.is_disconnect_eligible()
+                && state.should_disconnect(self.config.disconnect_threshold)
+            {
                 self.flagged_peers.push(*peer);
                 self.metrics.record_peer_ban();
                 RateLimitResult::Disconnect
             } else {
+                let violations = state.violations();
                 RateLimitResult::RateLimited {
-                    violations: state.violations(),
-                    remaining: self.config.disconnect_threshold - state.violations(),
+                    violations,
+                    remaining: self.config.disconnect_threshold.saturating_sub(violations),
                     message_type: msg_type,
                 }
             }
@@ -722,20 +792,196 @@ mod tests {
 
     #[test]
     fn test_message_type_rate_limits() {
+        // Defaults are now slot-rate-aware (issue #413): consensus and
+        // transaction caps are generous (sized for fast slots x quorum) rather
+        // than the old fixed 50/100 that dropped honest SCP/minting traffic.
         let config = PeerRateLimitConfig::default();
 
-        // Verify default rate limits from audit requirements
-        assert_eq!(
-            GossipMessageType::Transaction.rate_limit(&config),
-            100 // 100/min for transactions
+        // Consensus and transaction caps must be well above the old fixed
+        // values so honest multi-node consensus is not throttled.
+        assert!(
+            GossipMessageType::Consensus.rate_limit(&config) > 50,
+            "consensus cap should exceed the old fixed 50/min"
         );
-        assert_eq!(
-            GossipMessageType::Block.rate_limit(&config),
-            10 // 10/min for blocks
+        assert!(
+            GossipMessageType::Transaction.rate_limit(&config) > 100,
+            "transaction cap should exceed the old fixed 100/min"
         );
+        // Blocks remain comparatively bounded.
+        assert!(GossipMessageType::Block.rate_limit(&config) >= 10);
+    }
+
+    /// Approximate the *instantaneous* per-second message rate a single honest
+    /// peer produces at a given slot duration: ~30 consensus msgs per slot,
+    /// emitted within that slot, so per-second ~= 30 / slot_secs (at least 30
+    /// for sub-second / 1s slots since a slot's messages cluster).
+    fn honest_consensus_per_second(slot_secs: u64) -> u32 {
+        (30 / slot_secs.max(1)).max(30) as u32
+    }
+
+    #[test]
+    fn test_honest_consensus_rate_allowed_at_fast_slots() {
+        // Issue #413 regression: at BOTHO_SLOT_DURATION_SECS=1 a minter emits
+        // ~30 consensus msgs per 1s slot, clustered within the slot. Across a
+        // small quorum that aggregate must clear BOTH the per-type cap AND the
+        // global per-second / burst gates. We model the worst realistic
+        // instantaneous burst: all peers' per-slot messages arriving in the
+        // same second.
+        let peers = 4u32;
+        let config = PeerRateLimitConfig::for_slot_duration(1, peers);
+        let mut limiter = PeerRateLimiter::new(config);
+        let peer = PeerId::random();
+
+        // Worst-case instantaneous burst this peer's slot may produce, scaled
+        // by quorum (rebroadcasts of peers' ballots can cluster). Stay within a
+        // single second so we exercise the global per-second gate.
+        let burst = honest_consensus_per_second(1).saturating_mul(peers);
+        for i in 0..burst {
+            let result = limiter.record_message_typed(&peer, GossipMessageType::Consensus);
+            assert!(
+                result.is_allowed(),
+                "honest consensus burst msg #{i}/{burst} should be Allowed at 1s slots, got {result:?}"
+            );
+        }
+        // No peer should be flagged for disconnection under honest load.
+        assert!(
+            limiter.take_flagged_peers().is_empty(),
+            "honest minter must not be flagged for disconnection"
+        );
+    }
+
+    #[test]
+    fn test_honest_consensus_rate_allowed_at_default_slots() {
+        let config = PeerRateLimitConfig::for_slot_duration(20, 2);
+        let per_second = config.max_messages_per_second;
+        let mut limiter = PeerRateLimiter::new(config);
+        let peer = PeerId::random();
+
+        // At 20s slots the honest instantaneous rate is far lower than the
+        // global per-second gate. A realistic single-slot burst (well under the
+        // per-second ceiling) must be Allowed.
+        let burst = (per_second / 2).max(15);
+        for i in 0..burst {
+            let result = limiter.record_message_typed(&peer, GossipMessageType::Consensus);
+            assert!(
+                result.is_allowed(),
+                "honest consensus msg #{i}/{burst} at 20s slots should be Allowed, got {result:?}"
+            );
+        }
+        assert!(limiter.take_flagged_peers().is_empty());
+    }
+
+    #[test]
+    fn test_consensus_never_auto_disconnects() {
+        // Even a genuinely excessive consensus rate must NOT push a peer onto
+        // the disconnect path: consensus/minting traffic is exempt from
+        // auto-ban (it is throttled but the peer is never disconnected on this
+        // basis). This prevents an honest-but-busy minter from being
+        // permanently dropped, which forked the chain (#413).
+        let config = PeerRateLimitConfig::for_slot_duration(1, 1);
+        let mut limiter = PeerRateLimiter::new(config);
+        let peer = PeerId::random();
+
+        let mut saw_rate_limited = false;
+        for _ in 0..200_000 {
+            match limiter.record_message_typed(&peer, GossipMessageType::Consensus) {
+                RateLimitResult::Disconnect => {
+                    panic!("consensus traffic must never trigger Disconnect");
+                }
+                RateLimitResult::RateLimited { .. } => saw_rate_limited = true,
+                RateLimitResult::Allowed => {}
+            }
+        }
+        assert!(
+            saw_rate_limited,
+            "a sustained flood should still be RateLimited (throttled), just not disconnected"
+        );
+        assert!(
+            limiter.take_flagged_peers().is_empty(),
+            "consensus traffic must never flag a peer for disconnection"
+        );
+    }
+
+    #[test]
+    fn test_flood_on_disconnect_eligible_type_still_disconnects() {
+        // Anti-flood is preserved for non-consensus types: a genuine flood on
+        // an auto-disconnect-eligible type (e.g. Block) still flags the peer.
+        let config = PeerRateLimitConfig::for_slot_duration(1, 1);
+        let threshold = config.disconnect_threshold;
+        let mut limiter = PeerRateLimiter::new(config);
+        let peer = PeerId::random();
+
+        let mut disconnected = false;
+        for _ in 0..200_000 {
+            if limiter
+                .record_message_typed(&peer, GossipMessageType::Block)
+                .should_disconnect()
+            {
+                disconnected = true;
+                break;
+            }
+        }
+        assert!(
+            disconnected,
+            "a sustained flood on a disconnect-eligible type must eventually disconnect \
+             (threshold={threshold})"
+        );
+        assert_eq!(limiter.take_flagged_peers().len(), 1);
+    }
+
+    #[test]
+    fn test_violation_decay_clears_transient_burst() {
+        // A transient burst should not permanently flag an honest peer: after a
+        // cooldown of good behavior, accumulated violations decay (#413).
+        let config = test_config();
+        let mut state = PeerRateState::new();
+
+        // Drive violations on a disconnect-eligible type.
+        for _ in 0..10 {
+            state.record_message_typed(&config, GossipMessageType::Block);
+        }
+        let peak = state.violations();
+        assert!(
+            peak >= 3,
+            "expected several violations from the burst, got {peak}"
+        );
+
+        // Simulate a long cooldown: rewind the last-violation timestamp past
+        // many decay intervals, and clear the recent message history so the
+        // next message is genuinely "good behavior".
+        state.global_message_times.clear();
+        state.message_times_by_type.clear();
+        state.last_warning = Some(Instant::now() - VIOLATION_DECAY_INTERVAL * (peak + 1));
+
+        // The next recorded message runs the decay path first; with a clean
+        // history it is itself Allowed, so violations should fully decay to 0.
+        let allowed = state.record_message_typed(&config, GossipMessageType::Block);
+        assert!(allowed, "the post-cooldown message should be Allowed");
         assert_eq!(
-            GossipMessageType::Consensus.rate_limit(&config),
-            50 // 50/min for consensus
+            state.violations(),
+            0,
+            "violations should fully decay after a long period of good behavior"
+        );
+    }
+
+    #[test]
+    fn test_slot_aware_global_gates_scale() {
+        // Issue #413: the GLOBAL per-second / burst gates trip before per-type
+        // caps. Faster slots must raise those gates too, not just per-type
+        // caps.
+        let fast = PeerRateLimitConfig::for_slot_duration(1, 8);
+        let slow = PeerRateLimitConfig::for_slot_duration(20, 8);
+        assert!(
+            fast.max_messages_per_second >= slow.max_messages_per_second,
+            "faster slots should not lower the global per-second gate"
+        );
+        assert!(
+            fast.max_messages_per_second > 10,
+            "global per-second gate must exceed the old fixed 10/s"
+        );
+        assert!(
+            fast.burst_limit > 50,
+            "global burst gate must exceed the old fixed 50/5s"
         );
     }
 }


### PR DESCRIPTION
Closes #413

## Problem

The gossipsub per-peer rate limiter silently dropped consensus (SCP) and minting (Transaction) messages and *permanently* flagged honest peers for disconnection. As a result, multi-node nodes never received peer SCP messages, never left solo mode, and forked (observed `flagged for disconnection: 98x` for a single peer, `Received SCP message from network: 0`).

Three coupled root causes (per the Curator's grounding), all addressed via the recommended **Option 3 / hybrid** — generous slot-rate-aware ceiling for anti-flood + exempt consensus/minting from auto-disconnect + violation decay, while keeping a real flood ceiling:

### 1. Fixed per-type caps were far below honest cadence
`MessageTypeLimits::for_slot_duration(slot_secs, peers)` and `PeerRateLimitConfig::for_slot_duration(...)` derive the consensus/transaction caps from `msgs_per_slot * slots_per_min * peers * headroom`. A faster slot or larger quorum raises the ceiling instead of dropping honest traffic. `run.rs` plumbs the **effective** slot duration (min block time under dynamic timing, or `BOTHO_SLOT_DURATION_SECS` when fixed) and the gossip connection ceiling into the limiter.

### 2. Global gates tripped before per-type caps
The global `max_messages_per_second` (was 10) and `burst_limit` (was 50/5s) gates are checked first, so raising only per-type caps would still drop messages. They are now derived from the same slot-rate model and sized above a **full slot's instantaneous message cluster across peers** (not just the time-averaged rate), with headroom. Honest bursts pass; a true flood still trips.

### 3. Violations were sticky (no live cooldown)
`reset_violations()` was never called on a live path, so once a peer hit `disconnect_threshold` it stayed flagged forever. Added `PeerRateState::decay_violations()` invoked on every recorded message (decays one violation per 30s of good behavior), and made `GossipMessageType::Consensus`/`Transaction` **never** push a peer to the disconnect path (`is_disconnect_eligible()`), so an honest-but-busy minter is throttled at most, never banned. Non-consensus types still disconnect a genuine abuser.

## Anti-flood preserved
A sustained abusive rate is still `RateLimited` for consensus/minting (over-cap messages dropped, peer not banned), and still escalates to `Disconnect` for disconnect-eligible types (e.g. Block). Covered by regression tests.

## Tests (`cargo test -p bth-gossip` green, 69 pass)
- `test_honest_consensus_rate_allowed_at_fast_slots` / `_at_default_slots` — honest rates pass per-type AND global gates.
- `test_consensus_never_auto_disconnects` — a flood on consensus is throttled but never disconnects/flags.
- `test_flood_on_disconnect_eligible_type_still_disconnects` — a flood on Block still flags + disconnects (anti-flood intact).
- `test_violation_decay_clears_transient_burst` — transient burst decays back to 0.
- `test_slot_aware_global_gates_scale` — faster slots raise the global gates above the old fixed 10/s, 50/5s.

## Empirical two-minter verification (release binary, loopback, `recommended`/`min_peers=1`, `BOTHO_SLOT_DURATION_SECS=1`)
- `flagged for disconnection`: **0** (was 98x). `Rate limited message from peer`: **0**.
- `Exited solo mode` fires on both; `consensus.propose_values{solo_mode=false}` is the active path.
- Inbound peer SCP messages now reach SCP: `consensus.handle_message{peer_id=1100... }: scp.handle_messages{phase=NominatePrepare}` fired **24x on A, 14x on B** (was 0 — the rate limiter no longer drops them).

The gossip rate limiter is no longer the blocker. A **downstream** SCP nomination/ballot convergence stall remains (the two nodes receive each other's SCP messages and exit solo mode but still don't externalize a shared block — they nominate distinct per-slot minting txs and never converge). Per the task instructions I did not force it; filed as **#414** with exact logs.

## Files
- `gossip/src/config.rs` — slot-rate-aware `MessageTypeLimits`/`PeerRateLimitConfig` constructors + global-gate derivation.
- `gossip/src/rate_limit.rs` — `is_disconnect_eligible()`, `decay_violations()` live cooldown, consensus/minting exempt from disconnect, regression tests.
- `botho/src/commands/run.rs` — plumb effective slot duration + peer ceiling into the limiter.

## Determinism / security notes
- No SCP wire format or protocol changes; only the gossip-layer admission control. SCP message bytes are unchanged.
- Anti-flood/DoS protection is **raised and refined, not removed**: the limiter still throttles consensus/minting traffic and still disconnects genuine abusers on non-consensus topics.
- Limits are derived deterministically from slot duration + a fixed peer ceiling (no wall-clock/env nondeterminism in the values themselves); violation decay uses monotonic `Instant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)