### PR TITLE
fix(consensus): make multi-node SCP externalize on a shared tip (#414)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 401
-# Branch: feature/issue-401
+# Issue: 414
+# Branch: feature/issue-414
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -1606,26 +1606,65 @@ fn rebuild_scp_quorum_set(
     QuorumSet::new(threshold, members)
 }
 
-/// Convert a libp2p PeerId to an SCP NodeID
+/// Convert a libp2p PeerId to an SCP NodeID.
+///
+/// SCP identifies, hashes and orders nodes solely by their Ed25519 *public
+/// key* (see `bth_common::NodeID`'s `Eq`/`Hash`/`Ord` impls, which ignore the
+/// `responder_id`). The quorum set is therefore considered invalid — and every
+/// outgoing SCP message is rejected by `Msg::validate` — if two distinct peers
+/// map to the same public key. So the mapping from `PeerId` to public key MUST
+/// be both *deterministic* (every node derives the same key for a given peer)
+/// and *injective* (distinct peers get distinct, valid keys).
+///
+/// The previous implementation copied the first 32 bytes of
+/// `peer_id.to_bytes()` straight into the key. For libp2p Ed25519 peers,
+/// `to_bytes()` is an identity multihash whose first six bytes (`00 24 08 01 12
+/// 20`) are a fixed prefix shared by *every* Ed25519 peer, and the trailing key
+/// bytes are truncated. In practice this collapsed multiple peers onto the same
+/// (often invalid) public key, producing an "Invalid quorum set" rejection that
+/// silently prevented any block from being externalized in multi-node consensus
+/// (issue #414).
+///
+/// We now hash the *full* PeerId bytes with a domain separator to obtain a
+/// well-distributed 32-byte seed, then derive a real Ed25519 keypair from it.
+/// Any 32-byte seed is a valid Ed25519 private key (the scalar is clamped
+/// internally), so the resulting public key is always a valid curve point, and
+/// distinct PeerIds yield distinct keys with overwhelming probability.
+///
+/// NOTE: this remains a deterministic *stand-in* for the peer's real signing
+/// key — it is not the key the peer actually signs SCP messages with. It exists
+/// only so every node builds an identical, valid quorum set from the same set
+/// of connected PeerIds. Exchanging and verifying real per-peer signing keys is
+/// tracked separately; this fix is limited to making the quorum-set membership
+/// well-formed so SCP can externalize.
 fn peer_id_to_node_id(peer_id: &libp2p::PeerId) -> NodeID {
-    // Use the PeerId's string representation as the responder ID
-    // This provides a deterministic mapping from PeerId to NodeID
+    use sha2::{Digest, Sha256};
+
+    // Use the PeerId's string representation as the responder ID. This is purely
+    // informational for SCP (NodeID equality ignores it) but keeps logs
+    // readable.
     let peer_str = peer_id.to_string();
     let responder_id =
         ResponderId::from_str(&format!("{}:8443", &peer_str[..12.min(peer_str.len())]))
             .unwrap_or_else(|_| ResponderId::from_str("peer:8443").unwrap());
 
-    // Derive a deterministic Ed25519 public key from the PeerId bytes
-    // This is a placeholder - in production, peers should exchange actual keys
-    let peer_bytes = peer_id.to_bytes();
-    let mut key_bytes = [0u8; 32];
-    let copy_len = peer_bytes.len().min(32);
-    key_bytes[..copy_len].copy_from_slice(&peer_bytes[..copy_len]);
+    // Derive a deterministic, unique, valid Ed25519 public key from the *full*
+    // PeerId bytes. Hashing avoids the fixed-multihash-prefix collision and the
+    // truncation of the old implementation.
+    let mut hasher = Sha256::new();
+    hasher.update(b"botho-scp-node-id-v1");
+    hasher.update(peer_id.to_bytes());
+    let seed = hasher.finalize();
+
+    // Any 32-byte value is a valid Ed25519 private key; deriving the public key
+    // cannot fail for a 32-byte input, but fall back defensively just in case.
+    let public_key = bth_crypto_keys::Ed25519Private::try_from(&seed[..])
+        .map(|private| Ed25519Public::from(&private))
+        .unwrap_or_default();
 
     NodeID {
         responder_id,
-        public_key: Ed25519Public::try_from(&key_bytes[..])
-            .unwrap_or_else(|_| Ed25519Public::default()),
+        public_key,
     }
 }
 
@@ -1799,5 +1838,90 @@ mod tests {
         let mid = LOW + (HIGH - LOW) / 2;
         assert!(!should_pause_for_balance(mid, HIGH, 0));
         assert!(!should_resume_from_balance_pause(mid, LOW, 0));
+    }
+
+    // ---- Issue #414: PeerId -> NodeID mapping must be deterministic + injective
+    // ----
+
+    /// Build a real libp2p Ed25519 PeerId from a 32-byte secret seed.
+    fn ed25519_peer_id(seed: [u8; 32]) -> libp2p::PeerId {
+        let secret = libp2p::identity::ed25519::SecretKey::try_from_bytes(seed.to_vec())
+            .expect("valid ed25519 secret");
+        let keypair =
+            libp2p::identity::Keypair::from(libp2p::identity::ed25519::Keypair::from(secret));
+        keypair.public().to_peer_id()
+    }
+
+    #[test]
+    fn peer_id_to_node_id_is_deterministic() {
+        // Regression test for issue #414: the mapping must be deterministic so
+        // every node derives the SAME quorum-set membership for a given peer.
+        let pid = ed25519_peer_id([7u8; 32]);
+        let a = peer_id_to_node_id(&pid);
+        let b = peer_id_to_node_id(&pid);
+        assert_eq!(a, b, "same PeerId must map to the same NodeID");
+        assert_eq!(a.public_key, b.public_key);
+    }
+
+    #[test]
+    fn peer_id_to_node_id_is_injective_for_distinct_peers() {
+        // Regression test for issue #414: distinct peers MUST map to distinct
+        // public keys. NodeID equality is by public key only, so a collision
+        // here makes the quorum set invalid (`Msg::validate` rejects every
+        // outgoing SCP message) and multi-node consensus can never externalize.
+        //
+        // The previous implementation copied the first 32 bytes of
+        // `peer_id.to_bytes()`, whose leading bytes are a fixed multihash prefix
+        // shared by all Ed25519 peers, so distinct peers collided.
+        let n = 16;
+        let mut keys = std::collections::HashSet::new();
+        let mut node_ids = std::collections::HashSet::new();
+        for i in 0..n {
+            let mut seed = [0u8; 32];
+            seed[0] = i as u8 + 1;
+            seed[31] = 0xAB;
+            let pid = ed25519_peer_id(seed);
+            let node_id = peer_id_to_node_id(&pid);
+            // Distinct public keys.
+            assert!(
+                keys.insert(node_id.public_key.clone()),
+                "duplicate public key derived for distinct PeerId {pid}"
+            );
+            // Distinct NodeIDs (which compare by public key).
+            assert!(node_ids.insert(node_id));
+        }
+        assert_eq!(keys.len(), n);
+    }
+
+    #[test]
+    fn two_peers_yield_a_valid_quorum_set() {
+        // Regression test for issue #414: a 2-of-2 quorum built from two distinct
+        // peers must be VALID. The bug produced two members with identical
+        // public keys, so `QuorumSet::is_valid()` returned false (duplicate
+        // member) and the externalize message was never broadcast, leaving both
+        // minters stuck at height 0.
+        use bth_consensus_scp_types::QuorumSetMember;
+
+        let local = peer_id_to_node_id(&ed25519_peer_id([1u8; 32]));
+        let peer = peer_id_to_node_id(&ed25519_peer_id([2u8; 32]));
+
+        assert_ne!(
+            local.public_key, peer.public_key,
+            "two distinct peers must not share a public key"
+        );
+
+        let qs = QuorumSet::new(
+            2,
+            vec![QuorumSetMember::Node(local), QuorumSetMember::Node(peer)],
+        );
+        assert!(
+            qs.is_valid(),
+            "2-of-2 quorum from distinct peers must be valid: {qs:?}"
+        );
+        assert_eq!(
+            qs.nodes().len(),
+            2,
+            "quorum must contain two distinct nodes"
+        );
     }
 }

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -164,6 +164,12 @@ pub struct ConsensusService {
     /// Current slot's externalized values (if any)
     externalized: Option<Vec<ConsensusValue>>,
 
+    /// Highest SCP slot index already surfaced as a `SlotExternalized` event.
+    /// Used in the multi-node path so an externalized slot is only emitted once
+    /// (the SCP node auto-advances on externalize, so the just-externalized
+    /// slot stays readable for several ticks).
+    last_externalized_slot: Option<SlotIndex>,
+
     /// A quorum set reconfiguration that arrived mid-round and was deferred to
     /// the next slot boundary to avoid stranding an in-flight slot.
     pending_quorum_set: Option<QuorumSet>,
@@ -282,6 +288,7 @@ impl ConsensusService {
             events: VecDeque::new(),
             last_slot_attempt: Instant::now(),
             externalized: None,
+            last_externalized_slot: None,
             pending_quorum_set: None,
         }
     }
@@ -713,27 +720,81 @@ impl ConsensusService {
         )
     )]
     fn check_externalized(&mut self) {
-        let slot = self.scp_node.current_slot_index();
+        // In solo mode the slot is externalized directly in
+        // `propose_pending_values` (which sets `self.externalized`), so there is
+        // nothing for the SCP-driven path to detect here.
+        if self.is_solo_mode() {
+            Span::current().record("externalized", false);
+            return;
+        }
 
-        if let Some(values) = self.scp_node.get_externalized_values(slot) {
-            if self.externalized.is_none() {
-                Span::current().record("externalized", true);
-                Span::current().record("value_count", values.len());
-                info!(slot, count = values.len(), "Slot externalized!");
+        // Once an externalize is pending application (block build + advance_slot),
+        // don't look for another.
+        if self.externalized.is_some() {
+            Span::current().record("externalized", false);
+            return;
+        }
 
-                // Remove externalized values from pending
-                for v in &values {
-                    self.pending_values.remove(v);
-                    self.proposed_values.remove(v);
-                }
+        // When the SCP node externalizes a slot it AUTOMATICALLY advances its
+        // current slot to `N + 1` and files the just-externalized slot `N` in
+        // its `externalized_slots` store (see node_impl::handle_messages ->
+        // externalize). So the slot we must read the externalized values from is
+        // the one immediately BELOW the current slot index, not the current one.
+        //
+        // Issue #414: the previous code queried `current_slot_index()` (i.e. the
+        // freshly-started slot `N + 1`), which never has externalized values, so
+        // `Slot externalized!` never fired and the chain stayed at height 0 even
+        // though SCP was reaching the Externalize phase and advancing slots.
+        let current = self.scp_node.current_slot_index();
+        let Some(highest_externalized) = current.checked_sub(1) else {
+            Span::current().record("externalized", false);
+            return;
+        };
 
-                self.externalized = Some(values.clone());
+        // Surface externalized slots strictly in order, one per call, so we never
+        // skip a slot if the SCP node advanced several slots between ticks. The
+        // next slot to surface is the one immediately after the last we emitted.
+        let externalized_slot = match self.last_externalized_slot {
+            Some(last) => last + 1,
+            None => highest_externalized,
+        };
+        if externalized_slot > highest_externalized {
+            Span::current().record("externalized", false);
+            return;
+        }
 
-                self.events.push_back(ConsensusEvent::SlotExternalized {
-                    slot_index: slot,
-                    values,
-                });
+        if let Some(values) = self.scp_node.get_externalized_values(externalized_slot) {
+            Span::current().record("externalized", true);
+            Span::current().record("value_count", values.len());
+            info!(
+                slot = externalized_slot,
+                count = values.len(),
+                "Slot externalized!"
+            );
+            self.last_externalized_slot = Some(externalized_slot);
+
+            // Remove externalized values from pending
+            for v in &values {
+                self.pending_values.remove(v);
+                self.proposed_values.remove(v);
             }
+
+            // Drop ALL pending minting txs: a minting tx is bound to a specific
+            // block height / prev-block-hash, so every minting tx proposed for
+            // the slot we just externalized is now stale (it builds on the old
+            // tip). Leaving them queued makes the node keep re-proposing minting
+            // txs with the wrong prev_block_hash, which never validate against
+            // the advanced chain and pile up in `pending_values` forever,
+            // stalling the next slot. This mirrors the solo-mode path, which
+            // already prunes stale minting txs after externalizing.
+            self.pending_values.retain(|v| !v.is_minting_tx);
+
+            self.externalized = Some(values.clone());
+
+            self.events.push_back(ConsensusEvent::SlotExternalized {
+                slot_index: externalized_slot,
+                values,
+            });
         } else {
             Span::current().record("externalized", false);
         }

--- a/consensus/scp/tests/test_mesh_networks.rs
+++ b/consensus/scp/tests/test_mesh_networks.rs
@@ -3,7 +3,13 @@
 mod mock_network;
 
 use bth_common::logger::{test_with_logger, Logger};
+use bth_consensus_scp::{msg::Msg, slot::CombineFn, test_utils, Node, QuorumSet, ScpNode};
 use serial_test::serial;
+use std::{
+    collections::BTreeSet,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 /// Performs a consensus test for a mesh network of (n) nodes.
 fn mesh_test_helper(
@@ -63,4 +69,186 @@ fn mesh_5k3(logger: Logger) {
 #[serial]
 fn mesh_5k4(logger: Logger) {
     mesh_test_helper(5, 4, logger);
+}
+
+/// A combine function that mimics Botho's `ConsensusValue` combiner for
+/// minting: it sorts the candidate set deterministically and keeps exactly ONE
+/// winner. Because it is deterministic and order-independent, all honest nodes
+/// that combine the *same* confirmed-nominated set `Z` produce the *same*
+/// output.
+fn pick_one_winner_combine_fn() -> CombineFn<String, test_utils::TransactionValidationError> {
+    Arc::new(
+        |values: &[String]| -> Result<Vec<String>, test_utils::TransactionValidationError> {
+            let mut v: Vec<String> = values.to_vec();
+            v.sort();
+            v.dedup();
+            v.truncate(1);
+            Ok(v)
+        },
+    )
+}
+
+/// Drive two SCP nodes that nominate DISTINCT values until both externalize, or
+/// the deadline elapses. Returns the externalized block (slot 0) for each node,
+/// or `None` for a node that never externalized.
+///
+/// This is a deterministic, single-threaded message pump: it repeatedly lets
+/// each node propose its own value, hand-delivers any emitted message to the
+/// peer, and processes timeouts, advancing a virtual clock so SCP round/ballot
+/// timers fire.
+fn run_two_node_distinct_values(
+    value_a: &str,
+    value_b: &str,
+    logger: Logger,
+) -> (Option<Vec<String>>, Option<Vec<String>>) {
+    let node_a_id = test_utils::test_node_id(1);
+    let node_b_id = test_utils::test_node_id(2);
+
+    // A 2-of-2 quorum: each node trusts both members.
+    let quorum_set = QuorumSet::new_with_node_ids(2, vec![node_a_id.clone(), node_b_id.clone()]);
+
+    let validity_fn = Arc::new(test_utils::trivial_validity_fn::<String>);
+    let combine_fn = pick_one_winner_combine_fn();
+
+    let mut node_a = Node::new(
+        node_a_id.clone(),
+        quorum_set.clone(),
+        validity_fn.clone(),
+        combine_fn.clone(),
+        0,
+        logger.clone(),
+    );
+    let mut node_b = Node::new(
+        node_b_id.clone(),
+        quorum_set,
+        validity_fn,
+        combine_fn,
+        0,
+        logger.clone(),
+    );
+
+    // Use a short timebase so round/ballot timers fire quickly in the virtual
+    // clock. SCP advances even without timeouts when nomination converges; the
+    // timers are a backstop.
+    node_a.scp_timebase = Duration::from_millis(50);
+    node_b.scp_timebase = Duration::from_millis(50);
+
+    let mut a_out: Vec<Msg<String>> = Vec::new();
+    let mut b_out: Vec<Msg<String>> = Vec::new();
+
+    let value_a_set: BTreeSet<String> = BTreeSet::from([value_a.to_string()]);
+    let value_b_set: BTreeSet<String> = BTreeSet::from([value_b.to_string()]);
+
+    let start = Instant::now();
+    let deadline = start + Duration::from_secs(20);
+
+    loop {
+        // Each node re-proposes its own (distinct) value every tick, just like a
+        // minter re-proposing its coinbase each slot tick.
+        if let Some(msg) = node_a
+            .propose_values(value_a_set.clone())
+            .expect("node_a propose_values failed")
+        {
+            a_out.push(msg);
+        }
+        if let Some(msg) = node_b
+            .propose_values(value_b_set.clone())
+            .expect("node_b propose_values failed")
+        {
+            b_out.push(msg);
+        }
+
+        // Deliver A's messages to B and vice-versa. Take the queues so we can
+        // push replies into the peer's queue without an aliasing borrow.
+        for msg in std::mem::take(&mut a_out) {
+            if let Some(reply) = node_b
+                .handle_message(&msg)
+                .expect("node_b handle_message failed")
+            {
+                b_out.push(reply);
+            }
+        }
+        for msg in std::mem::take(&mut b_out) {
+            if let Some(reply) = node_a
+                .handle_message(&msg)
+                .expect("node_a handle_message failed")
+            {
+                a_out.push(reply);
+            }
+        }
+
+        // Process timeouts on both nodes (this fires round/ballot timers).
+        for msg in node_a.process_timeouts() {
+            a_out.push(msg);
+        }
+        for msg in node_b.process_timeouts() {
+            b_out.push(msg);
+        }
+
+        let a_ext = node_a.get_externalized_values(0);
+        let b_ext = node_b.get_externalized_values(0);
+        if a_ext.is_some() && b_ext.is_some() {
+            return (a_ext, b_ext);
+        }
+
+        if Instant::now() > deadline {
+            return (
+                node_a.get_externalized_values(0),
+                node_b.get_externalized_values(0),
+            );
+        }
+
+        // Advance the virtual clock by sleeping a little. The nodes' SCP timers
+        // use wall-clock `Instant`, so a real (short) sleep lets them fire.
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}
+
+#[test_with_logger]
+#[serial]
+/// Two nodes nominating DISTINCT values (each its own coinbase-style value)
+/// with a deterministic "pick one winner" combiner must converge and
+/// externalize the SAME block on a SHARED tip (i.e. agree — no fork). This
+/// guards the SCP-level convergence property that multi-node consensus relies
+/// on: even when the two minters propose different single values, the protocol
+/// must agree on one shared block.
+fn two_node_distinct_values_converge(logger: Logger) {
+    let value_a = "aaa_node_a_value";
+    let value_b = "bbb_node_b_value";
+
+    let (a_ext, b_ext) = run_two_node_distinct_values(value_a, value_b, logger);
+
+    let a_block = a_ext.expect("node A never externalized slot 0 (stuck in NominatePrepare)");
+    let b_block = b_ext.expect("node B never externalized slot 0 (stuck in NominatePrepare)");
+
+    // Both nodes must externalize the SAME block (shared tip, not a fork). This
+    // is the load-bearing SCP safety/agreement assertion.
+    assert_eq!(
+        a_block, b_block,
+        "nodes externalized different blocks (fork!): A={a_block:?} B={b_block:?}"
+    );
+
+    // The combiner keeps exactly one winner, and it must be one of the two
+    // nominated values.
+    assert_eq!(a_block.len(), 1, "expected exactly one combined value");
+    assert!(
+        a_block[0] == value_a || a_block[0] == value_b,
+        "externalized value {:?} is neither nominated value",
+        a_block[0]
+    );
+}
+
+#[test_with_logger]
+#[serial]
+/// Edge case: both nodes nominate the IDENTICAL value. They must still converge
+/// and externalize that value (no regression for the already-agreeing case).
+fn two_node_identical_values_converge(logger: Logger) {
+    let value = "shared_value";
+    let (a_ext, b_ext) = run_two_node_distinct_values(value, value, logger);
+
+    let a_block = a_ext.expect("node A never externalized slot 0");
+    let b_block = b_ext.expect("node B never externalized slot 0");
+
+    assert_eq!(a_block, b_block);
+    assert_eq!(a_block, vec![value.to_string()]);
 }


### PR DESCRIPTION
## Summary

Two real `botho run` minters on loopback exchanged SCP messages and left solo mode but **never externalized a block** — both stuck at height 0 with the slot spinning in `NominatePrepare`. This is the headline blocker for real multi-node consensus.

Empirical investigation (two real minters with `RUST_LOG=...=debug`) showed the defect was **NOT in the SCP nomination/ballot state machine** (the curator's leading hypothesis). The SCP slot logic converges correctly — the deterministic combiner and federated voting are sound, and all 100 existing SCP tests pass. The blocker was **three bugs in the botho node layer**:

### 1. `peer_id_to_node_id()` produced colliding public keys (`botho/src/commands/run.rs`)
`NodeID` `Eq`/`Hash`/`Ord` compare **only the Ed25519 public key**. The old mapping copied the first 32 bytes of `peer_id.to_bytes()`, whose leading bytes are a fixed multihash prefix shared by every Ed25519 peer, so distinct peers collapsed onto the **same (often invalid) public key**. The quorum set then had duplicate members → `QuorumSet::is_valid()` was false → `Msg::validate` rejected **every** outgoing SCP message with `Invalid quorum set`. No SCP messages were ever broadcast, so nothing externalized.

**Fix:** hash the full PeerId with a domain separator into a 32-byte seed and derive a real Ed25519 keypair — always a valid curve point, deterministic, and injective across peers.

### 2. `check_externalized()` off-by-one (`botho/src/consensus/service.rs`)
On externalize the SCP `Node` auto-advances `current_slot` to `N+1` and files slot `N` in `externalized_slots`. The code queried `get_externalized_values(current_slot_index())` = slot `N+1`, which never has values, so `Slot externalized!` never fired and the chain stayed at height 0 even though SCP reached the Externalize phase and advanced slots.

**Fix:** read the just-externalized slot (`current-1`), surface slots strictly in order one-per-call (`last_externalized_slot` guard) so none are skipped, gated to the non-solo path.

### 3. Stale minting txs never pruned in the multi-node path (`botho/src/consensus/service.rs`)
A minting tx is bound to a specific height/prev-block-hash. After externalize, queued minting txs build on the old tip and never validate, piling up in `pending_values` and stalling the next slot. The multi-node externalize path now prunes pending minting txs, mirroring the solo path.

## End-to-end verification (the headline)

Two real minters (`recommended`, `min_peers=1`, `BOTHO_SLOT_DURATION_SECS=1`, loopback) now externalize in **non-solo mode** and reach a **shared chain at increasing heights**:

```
node A: Slot externalized! slot=1 / slot=2 / slot=3 / slot=4   (solo_mode=false)
node B: Slot externalized! slot=1 / slot=2 / slot=3 / slot=4   (solo_mode=false)
A: height 4 tip 1ada00535fe1f89a3a0a6c3e7e1911d55cb4f729181b7a883879b21f54e38a30
B: height 4 tip 1ada00535fe1f89a3a0a6c3e7e1911d55cb4f729181b7a883879b21f54e38a30
```

Identical tip hashes at increasing heights = a shared chain, not a fork. Before the fix: both nodes pinned at `chainHeight: 0` for the full run with repeated `Invalid quorum set` rejections.

## Tests
- `consensus/scp/tests/test_mesh_networks.rs`: two nodes nominating DISTINCT values with a deterministic pick-one combiner must agree on one shared block (no fork); identical-value edge case. Guards the SCP agreement property.
- `botho` `commands::run::tests`: `peer_id_to_node_id` determinism + injectivity, and a 2-of-2 quorum from distinct peers is valid. These **FAIL on the old mapping** (key collision / invalid quorum) and **PASS after the fix** — verified by temporarily restoring the old impl.

## Safety / determinism
- No SCP state-machine change: `B` is never silently mutated mid-ballot; `consensus/scp/src/slot.rs` is untouched.
- `cargo test -p bth-consensus-scp` green: all 100 unit tests + cyclic/mesh/metamesh/value-cache integration tests pass.
- `cargo test -p botho --lib`: 960 pass.
- Determinism preserved: key derivation and the combiner remain deterministic and order-independent.

## Out of scope / follow-up
Producing each new height's coinbase is gated by PoW mining throughput (a fresh block takes time to mine at the genesis difficulty), which is independent of this consensus fix. The pre-existing `clippy::print_stdout` errors in `botho/src/network/transport/fingerprint.rs` are unrelated and untouched.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)