### PR TITLE
test(web): #396 mine-after-join reproduction harness (test-only; blocked on #417 multi-node fork)

### DIFF
--- a/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
+++ b/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
@@ -85,7 +85,43 @@ const wasmBin = join(pkgDir, 'bth_wasm_signer_bg.wasm')
 const wasmBuilt = existsSync(wasmGlue) && existsSync(wasmBin)
 
 const RUN_LOCAL_NODE = env.BOTHO_E2E_NODE === '1'
-const enabled = wasmBuilt && RUN_LOCAL_NODE
+
+// BLOCKED ON #397 (multi-node SCP agreement). Empirical investigation for #396
+// (see PR / issue comment) found that the full mine-after-join scenario cannot
+// pass reliably today because the multi-node consensus path is BOTH non-live
+// AND unsafe:
+//   1. Stale-minting-tx jam: in a multi-minter network each node's PoW thread
+//      races to mint the next block; when a peer's block externalizes first,
+//      the local minting tx is bound to a now-stale tip and is rejected by
+//      every validator. In a unanimous quorum the slot then never externalizes
+//      and the chain stalls within a few blocks (reproduced: a 2-node net jams
+//      at height ~1-4).
+//   2. Joiner SCP-slot desync: a node that catches up via the #376 block-sync
+//      path advances its ledger but NOT its SCP `current_slot_index`, so it
+//      stays stranded on its genesis slot while peers run a far-higher slot and
+//      it discards their messages as "future slots" — it can never join the
+//      live round (reproduced: 3-node net deadlocks the moment the joiner is
+//      required for the quorum).
+//   3. SAFETY FORK: most seriously, two minters in a 2-of-2 ("recommended")
+//      quorum were observed externalizing DIFFERENT blocks at the same heights
+//      (e.g. divergent hashes at heights 22/23/24) and never reconciling — a
+//      consensus safety violation that a correct unanimous quorum must never
+//      exhibit. This is the #397 multi-node agreement bug surfacing as an
+//      actual fork, and it is the hard blocker for this test.
+//
+// A liveness-only workaround (stale-tx pruning + jam-recovery that restarts a
+// stuck SCP slot, plus fast-forwarding a joiner's SCP slot to the synced chain
+// height) makes the network advance further and lets a joiner participate, but
+// it does NOT fix the fork — and restarting an in-progress SCP slot can itself
+// discard committed ballot state. Shipping it would let a forking chain run
+// further rather than fix the fork, so it was deliberately NOT merged (Botho's
+// "no hard forks" policy: a consensus change must be provably safe).
+//
+// This file is kept as the executable reproduction harness for the target
+// capability. Re-enable (drop `&& false`) once #397 lands genuine multi-node
+// agreement (a unanimous quorum that cannot fork) so a joiner's mined block is
+// accepted by all nodes on a single shared chain.
+const enabled = wasmBuilt && RUN_LOCAL_NODE && false
 const maybe = enabled ? describe : describe.skip
 
 interface WasmMod extends WasmSigner {

--- a/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
+++ b/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
@@ -86,7 +86,7 @@ const wasmBuilt = existsSync(wasmGlue) && existsSync(wasmBin)
 
 const RUN_LOCAL_NODE = env.BOTHO_E2E_NODE === '1'
 
-// BLOCKED ON #397 (multi-node SCP agreement). Empirical investigation for #396
+// BLOCKED ON #417 (multi-node SCP agreement). Empirical investigation for #396
 // (see PR / issue comment) found that the full mine-after-join scenario cannot
 // pass reliably today because the multi-node consensus path is BOTH non-live
 // AND unsafe:
@@ -106,7 +106,7 @@ const RUN_LOCAL_NODE = env.BOTHO_E2E_NODE === '1'
 //      quorum were observed externalizing DIFFERENT blocks at the same heights
 //      (e.g. divergent hashes at heights 22/23/24) and never reconciling — a
 //      consensus safety violation that a correct unanimous quorum must never
-//      exhibit. This is the #397 multi-node agreement bug surfacing as an
+//      exhibit. This is the #417 multi-node agreement bug surfacing as an
 //      actual fork, and it is the hard blocker for this test.
 //
 // A liveness-only workaround (stale-tx pruning + jam-recovery that restarts a
@@ -118,7 +118,7 @@ const RUN_LOCAL_NODE = env.BOTHO_E2E_NODE === '1'
 // "no hard forks" policy: a consensus change must be provably safe).
 //
 // This file is kept as the executable reproduction harness for the target
-// capability. Re-enable (drop `&& false`) once #397 lands genuine multi-node
+// capability. Re-enable (drop `&& false`) once #417 lands genuine multi-node
 // agreement (a unanimous quorum that cannot fork) so a joiner's mined block is
 // accepted by all nodes on a single shared chain.
 const enabled = wasmBuilt && RUN_LOCAL_NODE && false

--- a/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
+++ b/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Node-backed "fresh node JOINS a running local chain, PARTICIPATES in
+ * consensus, and MINES an accepted block" test (issue #396, flavor A —
+ * hermetic local), exercised against REAL `botho run` processes peering over
+ * real libp2p loopback.
+ *
+ * This is the full "run your own node and participate" demonstration, end to
+ * end and over real processes (no `TestNetwork` sim, no live betanet):
+ *
+ *   1. Two real minters (A + B) peer over loopback and form a quorum, mining a
+ *      shared chain to a height N > ring size (real history + decoy outputs).
+ *      They converge via real SCP (the #406 wire-decode fix lets their SCP
+ *      ballots actually deserialize; the #404/#408 dynamic quorum reconfigure
+ *      keeps their quorum set tracking live membership).
+ *   2. A 3rd FRESH node C (empty ledger, minting enabled) bootstraps to the
+ *      running pair, CONNECTS (peerCount >= 1), and CATCHES UP 0 -> N via the
+ *      real #376 catch-up sync — converging on the SAME block hashes as A/B.
+ *   3. Once synced, C PARTICIPATES: the quorum reconfigures to include C, and C
+ *      MINES a block the established nodes ACCEPT — the network tip advances and
+ *      ALL THREE nodes converge on the SAME extended tip (identical hashes).
+ *   4. C EARNED COINS: its own wallet balance (coinbase paid to C's address)
+ *      becomes non-zero and on-chain — proving a freshly-joined node's coinbase
+ *      reward is accepted by consensus.
+ *
+ * Why this is distinct from the other node-backed tests:
+ *   - `e2e_consensus_integration` starts all nodes at genesis together; no node
+ *     ever JOINS an already-running chain mid-flight.
+ *   - `join-consensus-live-node.test.ts` (#398) proves only the JOIN + CATCH-UP
+ *     half (one solo minter + one passive follower); the follower never mines.
+ *   - the in-process `TestNetwork` sim uses DashMap message-passing — no real
+ *     libp2p bootstrap, no #376 sync, no run-loop consensus.
+ *
+ * Quorum config used (and why)
+ * ----------------------------
+ * All three nodes use `recommended` mode with `min_peers = 1`. The node's
+ * consensus quorum set tracks LIVE membership (`rebuild_scp_quorum_set` in
+ * `botho/src/commands/run.rs`), and the BFT threshold is
+ * `n - floor((n-1)/3)` over `n = connected_peers + 1`
+ * (`QuorumConfig::effective_threshold`):
+ *   - while A + B are the only members:  n = 2 -> threshold 2 (2-of-2),
+ *   - once C has joined and is counted:  n = 3 -> threshold 3 (3-of-3).
+ * `recommended` is used (rather than an `explicit` static peer list) precisely
+ * because the joiner's peer id is not known ahead of time; recommended
+ * auto-trusts connected peers, and the #404 dynamic reconfigure folds C into
+ * the quorum the moment it connects, so C's proposed block is accepted by the
+ * whole set. (A 3-node recommended quorum is unanimous — 3-of-3 — which is the
+ * documented tradeoff; once C finishes catch-up all three participate every
+ * slot, so the chain keeps advancing and C's blocks are accepted.)
+ *
+ * Distinguishing "mined by the joiner": the coinbase of each block pays the
+ * minter's own stealth address, and each node has a DISTINCT BIP39 mnemonic, so
+ * C's `wallet_getBalance` is non-zero ONLY if a block whose coinbase pays C was
+ * accepted on-chain. We additionally require the network tip to advance beyond
+ * N (so new blocks were produced after C joined) with all nodes converged.
+ *
+ * Bounded by timeouts; tears down all node processes + temp dirs.
+ *
+ * Gating + how to run: identical to the other node-backed tests — set
+ * `BOTHO_E2E_NODE=1` and run via the node-backed runner. Requires
+ * `cargo build --release --bin botho` (or BOTHO_BIN=/path) and a built wasm
+ * artifact (`pnpm --filter @botho/wasm-signer build:wasm`).
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { type WasmSigner } from '../src/index'
+import {
+  startMultiNodeNetwork,
+  nodeHeight,
+  nodePeerCount,
+  type MultiNodeNetwork,
+  type RunningNode,
+} from './multi-node-harness'
+
+const env =
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {}
+
+const here = dirname(fileURLToPath(import.meta.url))
+const pkgDir = join(here, '..', 'pkg')
+const wasmGlue = join(pkgDir, 'bth_wasm_signer.js')
+const wasmBin = join(pkgDir, 'bth_wasm_signer_bg.wasm')
+const wasmBuilt = existsSync(wasmGlue) && existsSync(wasmBin)
+
+const RUN_LOCAL_NODE = env.BOTHO_E2E_NODE === '1'
+const enabled = wasmBuilt && RUN_LOCAL_NODE
+const maybe = enabled ? describe : describe.skip
+
+interface WasmMod extends WasmSigner {
+  default: (init: { module_or_path: BufferSource }) => Promise<unknown>
+}
+
+async function loadWasmNode(): Promise<WasmSigner> {
+  const mod = (await import(/* @vite-ignore */ wasmGlue)) as unknown as WasmMod
+  await mod.default({ module_or_path: readFileSync(wasmBin) })
+  return {
+    buildAndSign: (request) => mod.buildAndSign(request),
+    scanOwnedOutputs: (request) => mod.scanOwnedOutputs(request),
+    computeOwnedOutputKeyImages: (request) => mod.computeOwnedOutputKeyImages(request),
+    ringSize: () => mod.ringSize(),
+    minFee: () => mod.minFee(),
+  }
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+function makeRpc(url: string) {
+  let id = 1
+  return async function rpc<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    for (let attempt = 0; ; attempt++) {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', method, params, id: id++ }),
+      })
+      const json = (await res.json()) as { result?: T; error?: { message: string } }
+      if (json.error) {
+        if (json.error.message.includes('Rate limit') && attempt < 40) {
+          await sleep(2000)
+          continue
+        }
+        throw new Error(`${method}: ${json.error.message}`)
+      }
+      return json.result as T
+    }
+  }
+}
+
+/** Fetch a block's hash at `height` from a node, or null if it lacks it yet. */
+async function blockHashAt(
+  rpc: ReturnType<typeof makeRpc>,
+  height: number,
+): Promise<string | null> {
+  try {
+    const b = await rpc<{ hash: string; height: number }>('getBlockByHeight', { height })
+    return b?.hash ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Read a node's tip (height + hash) via node_getStatus. */
+async function nodeTip(rpc: ReturnType<typeof makeRpc>): Promise<{ height: number; hash: string }> {
+  const s = await rpc<{ chainHeight: number; tipHash: string }>('node_getStatus', {})
+  return { height: s.chainHeight, hash: s.tipHash }
+}
+
+/** Read a node's own wallet confirmed balance (coinbase paid to its address). */
+async function nodeBalance(rpc: ReturnType<typeof makeRpc>): Promise<bigint> {
+  const b = await rpc<{ confirmed: number | string }>('wallet_getBalance', {})
+  return BigInt(b.confirmed)
+}
+
+function tail(node: RunningNode, n = 30): string {
+  return node.readLog().split('\n').slice(-n).join('\n')
+}
+
+// Distinct valid BIP39 test vectors. Throwaway testnet keys, no value. Each
+// node's coinbase pays its own address, so a distinct mnemonic per node makes
+// "who mined this block" attributable via that node's wallet balance.
+const MNEMONIC_A =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon ' +
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon ' +
+  'abandon abandon abandon abandon abandon art'
+const MNEMONIC_B = 'legal winner thank year wave sausage worth useful legal winner thank yellow'
+const MNEMONIC_C =
+  'letter advice cage absurd amount doctor acoustic avoid letter advice cage above'
+
+maybe(
+  'node-backed: a fresh node joins a running local chain, participates in consensus, and mines an accepted block (#396)',
+  () => {
+    let network: MultiNodeNetwork | null = null
+    let ringSize: number
+
+    // Ports: keep clear of the other node-backed tests (17599/17798/17820...).
+    const PORTS = {
+      A: { gossip: 17840, rpc: 17841 },
+      B: { gossip: 17842, rpc: 17843 },
+      C: { gossip: 17844, rpc: 17845 },
+    }
+
+    beforeAll(async () => {
+      const signer = await loadWasmNode()
+      ringSize = signer.ringSize()
+    }, 60_000)
+
+    afterAll(async () => {
+      if (network) await network.stop()
+    })
+
+    it('A+B mine to N; fresh C joins, catches up 0 -> N, then mines a block the whole network accepts + earns coinbase', async () => {
+      // --------------------------------------------------------------------
+      // Step 1: start A + B — two real minters in a `recommended` quorum
+      // (min_peers = 1). They peer over loopback, form a 2-of-2 quorum, and
+      // mine a SHARED chain to N > ringSize (real history + a decoy ring).
+      // --------------------------------------------------------------------
+      network = await startMultiNodeNetwork(
+        [
+          {
+            name: 'A',
+            mnemonic: MNEMONIC_A,
+            gossipPort: PORTS.A.gossip,
+            rpcPort: PORTS.A.rpc,
+            bootstrapGossipPorts: [PORTS.B.gossip],
+            mint: true,
+            minPeers: 1,
+          },
+          {
+            name: 'B',
+            mnemonic: MNEMONIC_B,
+            gossipPort: PORTS.B.gossip,
+            rpcPort: PORTS.B.rpc,
+            bootstrapGossipPorts: [PORTS.A.gossip],
+            mint: true,
+            minPeers: 1,
+          },
+        ],
+        // Fast lottery eligibility keeps the run bounded (same test-only env
+        // overrides as the other node-backed tests).
+        { lottery: { minUtxoAge: 1, minUtxoValue: 1 } },
+      )
+
+      const nodeA = network.get('A')
+      const nodeB = network.get('B')
+      const rpcA = makeRpc(nodeA.rpcUrl)
+      const rpcB = makeRpc(nodeB.rpcUrl)
+
+      // A + B must peer before they can reach their 2-of-2 quorum and mine.
+      {
+        const deadline = Date.now() + 60_000
+        let peered = false
+        while (Date.now() < deadline) {
+          if ((await nodePeerCount(nodeA.rpcUrl)) >= 1 && (await nodePeerCount(nodeB.rpcUrl)) >= 1) {
+            peered = true
+            break
+          }
+          await sleep(1000)
+        }
+        expect(
+          peered,
+          `A and B never peered.\nA log:\n${tail(nodeA)}\n\nB log:\n${tail(nodeB)}`,
+        ).toBe(true)
+      }
+
+      const N = ringSize + 4
+      {
+        const deadline = Date.now() + 240_000
+        let h = 0
+        while (Date.now() < deadline) {
+          h = Math.min(await nodeHeight(nodeA.rpcUrl), await nodeHeight(nodeB.rpcUrl))
+          if (h >= N) break
+          await sleep(1000)
+        }
+        expect(
+          h,
+          `A+B only mined a shared height of ${h}/${N}.\n` +
+            `A log:\n${tail(nodeA, 25)}\n\nB log:\n${tail(nodeB, 25)}`,
+        ).toBeGreaterThanOrEqual(N)
+      }
+      const heightN = Math.min(await nodeHeight(nodeA.rpcUrl), await nodeHeight(nodeB.rpcUrl))
+      expect(heightN).toBeGreaterThan(ringSize)
+
+      // A + B agree on the chain at N (real SCP agreement, not divergent forks).
+      {
+        const ha = await blockHashAt(rpcA, heightN)
+        const hb = await blockHashAt(rpcB, heightN)
+        expect(ha, 'A should have block N').not.toBeNull()
+        expect(hb, "B's block N must match A's (A+B agree via SCP)").toBe(ha)
+      }
+      // eslint-disable-next-line no-console
+      console.log(`[#396] A+B (2-of-2) reached a shared height N=${heightN} (ringSize=${ringSize})`)
+
+      // --------------------------------------------------------------------
+      // Step 2: start C — a FRESH minter (empty ledger) — bootstrapping to A
+      // and B. Assert it connects (peerCount >= 1).
+      // --------------------------------------------------------------------
+      const cNetwork = await startMultiNodeNetwork(
+        [
+          {
+            name: 'C',
+            mnemonic: MNEMONIC_C,
+            gossipPort: PORTS.C.gossip,
+            rpcPort: PORTS.C.rpc,
+            bootstrapGossipPorts: [PORTS.A.gossip, PORTS.B.gossip],
+            mint: true,
+            minPeers: 1,
+          },
+        ],
+        { lottery: { minUtxoAge: 1, minUtxoValue: 1 } },
+      )
+      // Fold C into the same network object so teardown kills all three.
+      const nodeC = cNetwork.get('C')
+      network.nodes.push(nodeC)
+      const origStop = network.stop
+      const cStop = cNetwork.stop
+      network.stop = async () => {
+        await cStop()
+        await origStop()
+      }
+      const rpcC = makeRpc(nodeC.rpcUrl)
+
+      // C starts near genesis (its own empty ledger).
+      const cStart = await nodeHeight(nodeC.rpcUrl)
+      expect(cStart, 'C should start near genesis').toBeLessThan(heightN)
+
+      {
+        const deadline = Date.now() + 60_000
+        let connected = false
+        while (Date.now() < deadline) {
+          if ((await nodePeerCount(nodeC.rpcUrl)) >= 1) {
+            connected = true
+            break
+          }
+          await sleep(1000)
+        }
+        expect(connected, `C did not connect to the running pair.\nC log:\n${tail(nodeC)}`).toBe(
+          true,
+        )
+      }
+      // eslint-disable-next-line no-console
+      console.log(`[#396] C connected (peerCount=${await nodePeerCount(nodeC.rpcUrl)})`)
+
+      // --------------------------------------------------------------------
+      // Step 3: C catches up from 0 to at least N via the real #376 sync.
+      // --------------------------------------------------------------------
+      {
+        const deadline = Date.now() + 240_000
+        let hc = 0
+        while (Date.now() < deadline) {
+          hc = await nodeHeight(nodeC.rpcUrl)
+          if (hc >= heightN) break
+          await sleep(1000)
+        }
+        expect(
+          hc,
+          `C only caught up to ${hc}/${heightN} (stuck — the pre-#376 failure).\n` +
+            `C log:\n${tail(nodeC, 40)}`,
+        ).toBeGreaterThanOrEqual(heightN)
+      }
+      // C converged on the SAME chain as A at several heights (not a private fork).
+      {
+        const checkHeights = Array.from(
+          new Set([1, Math.floor(heightN / 2), heightN]),
+        ).filter((h) => h >= 1 && h <= heightN)
+        for (const h of checkHeights) {
+          const hashA = await blockHashAt(rpcA, h)
+          let hashC: string | null = null
+          const deadline = Date.now() + 30_000
+          while (Date.now() < deadline) {
+            hashC = await blockHashAt(rpcC, h)
+            if (hashC) break
+            await sleep(1000)
+          }
+          expect(hashC, `C's block ${h} hash must match A's (same chain, real sync)`).toBe(hashA)
+        }
+      }
+      // eslint-disable-next-line no-console
+      console.log(`[#396] C caught up 0 -> >=${heightN} via the real sync, on A's exact chain`)
+
+      // --------------------------------------------------------------------
+      // Step 4: C PARTICIPATES + MINES an accepted block. Now that C is part
+      // of the live quorum, require:
+      //   (a) the network tip advances beyond N (new blocks produced after C
+      //       joined), and ALL THREE nodes converge on the SAME extended tip
+      //       (identical hash) — i.e. C's blocks are accepted by A + B, not a
+      //       private fork; and
+      //   (b) C's own wallet balance becomes non-zero — its coinbase reward is
+      //       on-chain and owned by it (distinct mnemonic per node, so balance
+      //       is attributable to C having minted an accepted block).
+      // --------------------------------------------------------------------
+      const targetTip = heightN + 3
+      {
+        const deadline = Date.now() + 300_000
+        let converged = false
+        while (Date.now() < deadline) {
+          const [ta, tb, tc] = await Promise.all([
+            nodeTip(rpcA),
+            nodeTip(rpcB),
+            nodeTip(rpcC),
+          ])
+          if (
+            ta.height >= targetTip &&
+            ta.hash === tb.hash &&
+            tb.hash === tc.hash &&
+            ta.height === tb.height &&
+            tb.height === tc.height
+          ) {
+            converged = true
+            break
+          }
+          await sleep(1000)
+        }
+        const [ta, tb, tc] = await Promise.all([nodeTip(rpcA), nodeTip(rpcB), nodeTip(rpcC)])
+        expect(
+          converged,
+          `Network did not advance past N=${heightN} with all three converged on one tip.\n` +
+            `A=${ta.height}/${ta.hash.slice(0, 12)} ` +
+            `B=${tb.height}/${tb.hash.slice(0, 12)} ` +
+            `C=${tc.height}/${tc.hash.slice(0, 12)}\n` +
+            `C log:\n${tail(nodeC, 40)}`,
+        ).toBe(true)
+      }
+      const finalTip = await nodeTip(rpcA)
+      // eslint-disable-next-line no-console
+      console.log(
+        `[#396] network advanced to a single converged tip at height ${finalTip.height} ` +
+          `(all of A/B/C agree on ${finalTip.hash.slice(0, 16)}...)`,
+      )
+
+      // (b) C earned coins: its coinbase reward is on-chain and owned by it.
+      {
+        const deadline = Date.now() + 240_000
+        let bal = 0n
+        while (Date.now() < deadline) {
+          bal = await nodeBalance(rpcC)
+          if (bal > 0n) break
+          await sleep(2000)
+        }
+        expect(
+          bal,
+          `C never received a coinbase reward — it did not mine an accepted block.\n` +
+            `C log:\n${tail(nodeC, 40)}`,
+        ).toBeGreaterThan(0n)
+        // eslint-disable-next-line no-console
+        console.log(`[#396] C earned an on-chain coinbase reward: confirmed balance = ${bal}`)
+      }
+
+      // Sanity: A and B are still at the converged tip (the chain is live and shared).
+      const tA = await nodeTip(rpcA)
+      const tB = await nodeTip(rpcB)
+      expect(tA.hash).toBe(tB.hash)
+      expect(tA.height).toBeGreaterThanOrEqual(targetTip)
+    }, 900_000)
+  },
+)

--- a/web/packages/wasm-signer/test/run-node-backed.mjs
+++ b/web/packages/wasm-signer/test/run-node-backed.mjs
@@ -67,9 +67,9 @@ const result = spawnSync(
     'packages/wasm-signer/test/exchange-live-node.test.ts',
     'packages/wasm-signer/test/lottery-live-node.test.ts',
     'packages/wasm-signer/test/join-consensus-live-node.test.ts',
-    // mine-after-join is BLOCKED ON #397 (multi-node SCP agreement / fork) and
+    // mine-after-join is BLOCKED ON #417 (multi-node SCP agreement / fork) and
     // is `describe.skip` for now; kept listed so it re-activates automatically
-    // once #397 lands genuine, fork-free multi-node agreement.
+    // once #417 lands genuine, fork-free multi-node agreement.
     'packages/wasm-signer/test/mine-after-join-live-node.test.ts',
   ],
   {

--- a/web/packages/wasm-signer/test/run-node-backed.mjs
+++ b/web/packages/wasm-signer/test/run-node-backed.mjs
@@ -67,6 +67,9 @@ const result = spawnSync(
     'packages/wasm-signer/test/exchange-live-node.test.ts',
     'packages/wasm-signer/test/lottery-live-node.test.ts',
     'packages/wasm-signer/test/join-consensus-live-node.test.ts',
+    // mine-after-join is BLOCKED ON #397 (multi-node SCP agreement / fork) and
+    // is `describe.skip` for now; kept listed so it re-activates automatically
+    // once #397 lands genuine, fork-free multi-node agreement.
     'packages/wasm-signer/test/mine-after-join-live-node.test.ts',
   ],
   {

--- a/web/packages/wasm-signer/test/run-node-backed.mjs
+++ b/web/packages/wasm-signer/test/run-node-backed.mjs
@@ -6,10 +6,14 @@
  * runs the gated `send-live-node.test.ts` (single send, #372),
  * `exchange-live-node.test.ts` (two-user bidirectional exchange, #390),
  * `lottery-live-node.test.ts` (three-user exchange until a lottery payout, #394)
- * and `join-consensus-live-node.test.ts` (a fresh node joins a running local
- * chain over real libp2p and catches up 0 -> N onto the same chain, #396) with
- * BOTHO_E2E_NODE=1 so each test spins up its own throwaway node(s), asserts the
- * ledger/sync invariants, and tears the node(s) down.
+ * `join-consensus-live-node.test.ts` (a fresh node joins a running local
+ * chain over real libp2p and catches up 0 -> N onto the same chain, #396) and
+ * `mine-after-join-live-node.test.ts` (the full #396 flavor-A demonstration:
+ * a fresh node joins a running multi-minter chain, catches up 0 -> N, then
+ * PARTICIPATES in consensus and MINES a block the whole network accepts,
+ * earning an on-chain coinbase) with BOTHO_E2E_NODE=1 so each test spins up
+ * its own throwaway node(s), asserts the ledger/sync invariants, and tears the
+ * node(s) down.
  *
  *   node packages/wasm-signer/test/run-node-backed.mjs
  *
@@ -63,6 +67,7 @@ const result = spawnSync(
     'packages/wasm-signer/test/exchange-live-node.test.ts',
     'packages/wasm-signer/test/lottery-live-node.test.ts',
     'packages/wasm-signer/test/join-consensus-live-node.test.ts',
+    'packages/wasm-signer/test/mine-after-join-live-node.test.ts',
   ],
   {
     cwd: webDir,


### PR DESCRIPTION
## What this PR is

The committed flavor-A reproduction harness for #396 — a real-`botho`-process,
hermetic local test where two minters reach a shared height N, a fresh node
joins, catches up 0->N, then participates in consensus and mines an accepted
block — **plus a gate marking it blocked on a newly-filed multi-node consensus
bug (#417)**.

This PR is **test-only**. It contains NO consensus-layer change. A consensus
workaround was prototyped during validation and deliberately NOT shipped (see
below).

Refs #396 (the test deliverable lands; the underlying capability it asserts
remains blocked on #417, which the test is gated on, so #396 stays open).

## Why it does not enable the assertions yet

I validated the scenario empirically with real release-binary processes and
found the multi-minter consensus path is BOTH non-live AND unsafe. Full detail
and evidence are in **#417**; in brief:

1. **CRITICAL safety fork:** two minters in a 2-of-2 (`recommended`) quorum were
   observed externalizing **different blocks at the same heights** (divergent
   hashes at 22/23/24) and never reconciling — a fork a unanimous quorum must
   never exhibit. Intermittent (some runs reach height 28+; others fork by ~22).
2. **Stale-minting-tx jam:** a minting tx bound to a tip that lost the height
   race is rejected by every validator; in a unanimous quorum the slot then
   never externalizes and the chain stalls within a few blocks.
3. **Joiner SCP-slot desync:** a node that catches up via #376 block-sync
   advances its ledger but not its SCP `current_slot_index`, so it discards its
   peers' messages as "future slots" and can never join the live round.

## Consensus change considered and NOT included (by design)

A prior session had prototyped a liveness workaround (stale-tx pruning + a
jam-recovery that restarts a stuck SCP slot in place + a joiner SCP-slot
fast-forward). I evaluated it rigorously:

- It is genuinely NEEDED for 2-node liveness (without it a 2-node net jams at
  height ~1-4; with it, it advances), and the fast-forward did let a joiner
  participate and earn an on-chain coinbase in some runs.
- BUT it does not fix the fork (the fork reproduced with no jam-reset involved),
  and the jam-recovery restarts an in-progress SCP slot at the SAME index, which
  can discard committed ballot state — itself a fork risk. The SCP node even
  asserts `slot_index > current` for the existing reset primitive, underscoring
  that resetting a live slot is not a safe operation.

Per Botho's no-hard-forks policy (a consensus change must be provably safe), I
**reverted the consensus change** rather than ship a green-but-unsafe PR that
would let a forking chain merely run further. **Reviewers: there is no consensus
code in this PR** — please confirm `git diff` touches only the two web test
files, and scrutinize the #417 writeup for the fork.

## Recommendation

Keep #396 blocked on #417. The test is retained as the executable reproduction
harness (`describe.skip` via `&& false`); drop the guard once #417 lands genuine,
fork-free multi-node agreement.

## Validation
- `cargo test -p bth-consensus-scp`: 100 unit + 21 integration green (no change).
- `cargo test -p botho --lib`: 960 green (no change).
- `cargo build` clean; `pnpm -C web typecheck` green.
- The #396 test now reports **skipped** (exit 0) under `BOTHO_E2E_NODE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
