### PR TITLE
fix(consensus): gate minting on quorum participation (fix solo-latch fork)

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -477,9 +477,24 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
         chain_state,
     );
 
+    // Participation gate (issue #428): tell the consensus service how many
+    // connected peers this node expects before it may produce a block, and the
+    // current live count. `min_peers_to_wait` is the configured expectation
+    // (Explicit mode: at least one trusted peer; Recommended mode: the
+    // configured `min_peers`). When it is 0 the node is a genuine single-node
+    // network and mints solo (no gate). When it is >= 1 the consensus service
+    // withholds minting/propose until at least that many peers are connected,
+    // so the node never externalizes a divergent solo block during the
+    // pre-quorum startup window. The live count is refreshed on every
+    // PeerDiscovered / PeerDisconnected event below.
+    consensus.set_min_peers(min_peers_to_wait);
+    consensus.set_connected_peers(discovery.peer_count());
+
     info!(
-        "Consensus service initialized at slot {}",
-        consensus.current_slot()
+        "Consensus service initialized at slot {} (participation gate min_peers={}, connected={})",
+        consensus.current_slot(),
+        min_peers_to_wait,
+        discovery.peer_count()
     );
 
     // Chain-sync state machine: drives initial block download (IBD) / catch-up.
@@ -695,6 +710,11 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             // Broadcast peer event to WebSocket clients
                             ws_broadcaster.peer_connected(new_peer_count, &peer_id.to_string());
 
+                            // Refresh the participation gate's live peer count
+                            // (issue #428) so the consensus service can resume
+                            // proposing once enough peers are connected.
+                            consensus.set_connected_peers(new_peer_count);
+
                             // Reconfigure the consensus quorum to include the
                             // newly connected peer. This is what lifts a node
                             // out of latched solo mode without a restart.
@@ -747,6 +767,13 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
 
                             // Broadcast peer event to WebSocket clients
                             ws_broadcaster.peer_disconnected(new_peer_count, &peer_id.to_string());
+
+                            // Refresh the participation gate's live peer count
+                            // (issue #428). If this drops below the configured
+                            // expectation the consensus service pauses proposing
+                            // rather than falling back to solo minting — a
+                            // quorum that loses a member halts, it does not fork.
+                            consensus.set_connected_peers(new_peer_count);
 
                             // Shrink the consensus quorum to drop the departed
                             // peer so we don't deadlock waiting on a member that

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -173,6 +173,22 @@ pub struct ConsensusService {
     /// A quorum set reconfiguration that arrived mid-round and was deferred to
     /// the next slot boundary to avoid stranding an in-flight slot.
     pending_quorum_set: Option<QuorumSet>,
+
+    /// Participation gate (issue #428): the number of connected peers the
+    /// operator declared they expect before this node may produce blocks
+    /// (the configured `min_peers`). `0` means the node is a genuine
+    /// single-node dev/genesis network and mints solo forever — no gate.
+    /// `>= 1` means the node expects peers and MUST NOT mint/propose a block
+    /// while it has fewer than this many connected peers, so it never produces
+    /// a divergent solo block during the pre-quorum startup window (or after a
+    /// quorum member disconnects). See [`Self::should_propose_this_round`].
+    min_peers: usize,
+
+    /// Live count of currently connected peers, kept up to date by the node
+    /// run loop on PeerDiscovered/PeerDisconnected (see
+    /// [`Self::set_connected_peers`]). Compared against `min_peers` by the
+    /// participation gate.
+    connected_peers: usize,
 }
 
 impl ConsensusService {
@@ -307,7 +323,61 @@ impl ConsensusService {
             externalized: None,
             last_externalized_slot: None,
             pending_quorum_set: None,
+            // Default to 0 = no participation gate (genuine solo / dev / tests).
+            // The node run loop calls `set_min_peers` to enable the gate when
+            // the operator declared an expectation of peers.
+            min_peers: 0,
+            connected_peers: 0,
         }
+    }
+
+    /// Declare how many connected peers this node expects before it may produce
+    /// blocks (issue #428). Wired from the node's quorum config `min_peers`.
+    ///
+    /// `0` (the default) disables the participation gate: the node is a genuine
+    /// single-node dev/genesis network and mints solo. `>= 1` enables the gate:
+    /// the node will withhold minting/proposing while it has fewer than this
+    /// many connected peers (see [`Self::should_propose_this_round`]).
+    pub fn set_min_peers(&mut self, min_peers: usize) {
+        self.min_peers = min_peers;
+    }
+
+    /// Update the live connected-peer count used by the participation gate
+    /// (issue #428). Called by the node run loop on PeerDiscovered /
+    /// PeerDisconnected and once at startup.
+    pub fn set_connected_peers(&mut self, connected_peers: usize) {
+        self.connected_peers = connected_peers;
+    }
+
+    /// Participation gate (issue #428): may this node propose/externalize a
+    /// block in the current round?
+    ///
+    /// A node that declared it expects peers (`min_peers >= 1`) must NOT mint
+    /// or externalize a block while it has fewer than `min_peers` connected
+    /// peers. During the pre-quorum startup window such a node transiently
+    /// holds a solo (1-of-1) quorum set; if it externalized a block there it
+    /// would produce a divergent solo chain and fork once peers connect (the
+    /// solo-latch race from #424/#427). Gating the proposer here makes that
+    /// window produce *no* block at all.
+    ///
+    /// A node with `min_peers == 0` is a genuine single-node network and always
+    /// returns `true` — no regression for dev/genesis solo minting.
+    ///
+    /// This is purely a node-layer liveness/proposer gate: it does not touch
+    /// SCP protocol semantics, validity, or the no-fork guarantee (#420).
+    /// Peering/discovery is independent of minting, so the node still discovers
+    /// peers and forms the quorum while gated (it waits for *connections*, not
+    /// for *blocks*) — no deadlock.
+    fn should_propose_this_round(&self) -> bool {
+        if self.min_peers == 0 {
+            // Genuine single-node network: always mint solo.
+            return true;
+        }
+        // Expects peers: only propose once enough are connected to form the
+        // configured quorum. If peers later drop below the expectation the
+        // node pauses (block) rather than falling back to solo minting — a
+        // quorum that loses a member halts (SCP safety-over-liveness).
+        self.connected_peers >= self.min_peers
     }
 
     /// Update the chain state (call when chain tip changes)
@@ -629,6 +699,23 @@ impl ConsensusService {
     )]
     fn propose_pending_values(&mut self) {
         if self.pending_values.is_empty() {
+            return;
+        }
+
+        // Participation gate (issue #428): a node that expects peers
+        // (`min_peers >= 1`) must not propose/externalize a block while it has
+        // fewer than `min_peers` connected peers. This withholds any block
+        // during the pre-quorum startup window (when the node transiently holds
+        // a solo 1-of-1 quorum) so it never produces a divergent solo chain and
+        // forks once peers connect. Values stay queued in `pending_values` and
+        // are proposed normally once the quorum forms. `min_peers == 0` keeps
+        // genuine single-node minting unaffected.
+        if !self.should_propose_this_round() {
+            debug!(
+                min_peers = self.min_peers,
+                connected_peers = self.connected_peers,
+                "Withholding propose: not enough connected peers for quorum (issue #428)"
+            );
             return;
         }
 
@@ -1169,6 +1256,62 @@ mod tests {
         assert!(!svc.is_solo_mode());
         assert_eq!(svc.quorum_set(), &two);
         assert_eq!(svc.scp_node.quorum_set(), two);
+    }
+
+    /// Issue #428 regression: the participation gate must withhold any
+    /// propose/externalize while a node that expects peers (`min_peers >= 1`)
+    /// has fewer than `min_peers` connected peers, and resume once enough are
+    /// connected. A node with `min_peers == 0` must always propose (genuine
+    /// solo, no regression).
+    #[test]
+    fn participation_gate_blocks_solo_block_until_peers_connected() {
+        // Default (min_peers == 0): genuine solo node always proposes.
+        let mut solo = solo_service();
+        assert!(
+            solo.should_propose_this_round(),
+            "min_peers==0 node must always be eligible to mint solo"
+        );
+        solo.submit_transaction([7u8; 32], vec![1, 2, 3]);
+        solo.propose_pending_values();
+        assert!(
+            solo.externalized.is_some(),
+            "min_peers==0 node must externalize solo (no regression)"
+        );
+
+        // A node that expects 1 peer but has 0 connected must NOT propose.
+        let mut gated = solo_service();
+        gated.set_min_peers(1);
+        gated.set_connected_peers(0);
+        assert!(
+            !gated.should_propose_this_round(),
+            "node expecting peers must not mint while solo (pre-quorum)"
+        );
+        gated.submit_transaction([8u8; 32], vec![4, 5, 6]);
+        gated.propose_pending_values();
+        assert!(
+            gated.externalized.is_none(),
+            "gated node must NOT produce a pre-quorum solo block (issue #428)"
+        );
+        // The value stays queued so it is proposed once the quorum forms.
+        assert!(
+            !gated.pending_values.is_empty(),
+            "withheld values must remain pending, not be dropped"
+        );
+
+        // Once a peer connects (connected >= min_peers) the gate opens.
+        gated.set_connected_peers(1);
+        assert!(
+            gated.should_propose_this_round(),
+            "node must become eligible once connected peers >= min_peers"
+        );
+
+        // If peers later drop below the expectation, minting pauses again
+        // (halt, don't fork to solo).
+        gated.set_connected_peers(0);
+        assert!(
+            !gated.should_propose_this_round(),
+            "losing a quorum member must pause minting, not fall back to solo"
+        );
     }
 
     /// A multi-node service whose quorum is the given node ids (node 1 is us).

--- a/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
+++ b/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
@@ -144,6 +144,27 @@ const RUN_LOCAL_NODE = env.BOTHO_E2E_NODE === '1'
 //   with block height (a deeper protocol change tracked separately), so this
 //   end-to-end soak stays gated until then. Re-enable (drop `&& false`) once the
 //   SCP-slot/height drift is fixed.
+// #428 status (participation/proposer gate — block minting while connected
+// peers < min_peers): the gate removes the pre-quorum solo-latch fork, and
+// this soak now gets MUCH further than before. Verified end-to-end over real
+// loopback `botho run` processes (BOTHO_E2E_NODE=1, release binary):
+//   - A+B (2-of-2) reliably reach the shared target height N=ringSize+4 with
+//     IDENTICAL tip hashes (real SCP agreement, no divergent solo chain), and
+//   - C joins, connects (peerCount=2), and catches up 0 -> >=N onto A's exact
+//     chain (the #423 sync), so all three sit on ONE tip at height N.
+// i.e. acceptance #5's "A+B phase reaches target reliably" + the catch-up are
+// MET. What remains: the FINAL step — the 3-node network advancing PAST N with
+// C's freshly-mined block accepted by all three — stalls. That is the
+// pre-existing SCP-slot/height DRIFT (#421), re-opened by the #422 revert and
+// independent of the proposer gate: once the established A+B minters' SCP slot
+// drifts ahead of the ledger height, the freshly-synced joiner C and the
+// drifted minters discard each other's messages, so the 3-of-3 step jams.
+//
+// Per #428's STOP guardrail we do NOT force this green: the soak stays gated on
+// the full 3-node end state until #421 (SCP-slot/height drift) is re-fixed in a
+// way that does not regress two-minter liveness. Re-enable (drop `&& false`)
+// then. The proposer gate's own acceptance (no pre-quorum solo block; staggered
+// 2-node no fork; A+B target + C catch-up) is proven separately (#428).
 const enabled = wasmBuilt && RUN_LOCAL_NODE && false
 const maybe = enabled ? describe : describe.skip
 


### PR DESCRIPTION
## Summary

Implements **#427 direction #2** (the solo-latch startup race) and **unblocks #396**: blocks minting/propose in any round where a node that *expects* peers does not yet have enough connected participants to form its configured quorum, so it never produces a divergent pre-quorum solo block.

Closes #428

## The gate (where + condition)

Added a participation gate to `ConsensusService` (`botho/src/consensus/service.rs`):
- Two fields: `min_peers` (the operator's declared expectation) and a live `connected_peers` count, with setters `set_min_peers` / `set_connected_peers`.
- `should_propose_this_round()`: returns `false` when `min_peers >= 1 && connected_peers < min_peers`; `true` when `min_peers == 0` (genuine solo) or once `connected_peers >= min_peers`.
- `propose_pending_values()` consults the gate up front and withholds **both** the solo direct-externalize path **and** the normal SCP propose while under-quorum. Withheld values stay queued (`pending_values`) and are proposed once the quorum forms.

Wired from the node run loop (`botho/src/commands/run.rs`):
- `consensus.set_min_peers(min_peers_to_wait)` + initial `set_connected_peers(...)` at startup.
- `consensus.set_connected_peers(new_peer_count)` refreshed on every `PeerDiscovered` / `PeerDisconnected` event.

Discovery/peering is independent of minting, so the node still forms its quorum while gated — **no deadlock** (it waits for *connections*, not *blocks*). This is a node-layer liveness/proposer gate only; it does **not** change SCP protocol semantics, validity, or the #420 no-fork guarantee.

Behavior:
- `min_peers >= 1` + connected < min_peers → **no block** (pre-quorum window silent).
- `min_peers == 0` → mints solo (no regression for dev/genesis).
- peers drop below `min_peers` → minting **pauses** (halt), does not fall back to solo (no fork).

## Regression test

`participation_gate_blocks_solo_block_until_peers_connected` in `service.rs` exercises the real gate: a `min_peers==0` node externalizes solo; a `min_peers>=1` node with 0 connected peers does **not** externalize and keeps its value pending; the gate opens once `connected >= min_peers` and re-closes if peers drop.

## Empirical verification (real loopback `botho run`, release binary)

**Staggered 2-node (the deterministic fork repro):**
- A (`min_peers=1`) launched alone: stayed at **height 0 for the full 15s** while alone (`peers=0`), logs show `participation gate min_peers=1, connected=0` and `Quorum not satisfied`. No pre-quorum solo block.
- B launched + peered: both converged on the **identical tip hash** (`597e452e…2919`) at heights 50/51. The previously-deterministic fork is **gone**.

**Simultaneous 2-node (no regression):** converged on identical tip (`8be2f0cd…7010`) at height 17.

**#396 soak (`BOTHO_E2E_NODE=1`, 2x):**
- A+B (2-of-2) reliably reach shared target **N=24 with identical tips**; C joins (`peerCount=2`) and **catches up 0→24 onto A's exact chain**. All three sit on one tip at N.
- The FINAL step (network advancing **past N** with C's freshly-mined block accepted by all three) stalls on the pre-existing **#421 SCP-slot/height drift** (re-opened by the #422 revert), which is independent of the proposer gate.
- Per #428's STOP guardrail the soak is **re-gated with an accurate comment** rather than forced green; it stays gated on the full 3-node end state until #421 is re-fixed without regressing two-minter liveness.

## Tests / build

- `cargo test -p botho` — green (the 2 failing `network/privacy` *doctests* are pre-existing on the base commit, unrelated).
- `cargo test -p bth-consensus-scp` — 100 passed; `no_fork_with_tip_agnostic_validity` (+ `fork_with_tip_dependent_validity`) #420 tests pass.
- Build + `cargo fmt` clean; clippy warnings are all pre-existing unused-import noise.
- `pnpm -C web typecheck` — green.

## Files touched
- `botho/src/consensus/service.rs` — participation gate + regression test
- `botho/src/commands/run.rs` — wire `min_peers` + live connected count into the gate
- `web/packages/wasm-signer/test/mine-after-join-live-node.test.ts` — #396 soak status comment + re-gate note

🤖 Generated with [Claude Code](https://claude.com/claude-code)