### PR TITLE
feat(consensus): add quorum.fault_model (crash 2f+1 default / bft 3f+1) (#432)

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -1701,8 +1701,10 @@ fn build_scp_quorum_set(quorum: &QuorumBuilder, local_peer_id: &libp2p::PeerId) 
 /// node plus every connected peer; the threshold follows the configured quorum
 /// policy:
 ///
-/// - `Recommended`: BFT threshold `n - floor((n-1)/3)` over `n = peers + 1`
-///   (matches [`QuorumConfig::effective_threshold`]).
+/// - `Recommended`: the fault-model-aware threshold over `n = peers + 1`
+///   (matches [`QuorumConfig::effective_threshold`]) — crash 2f+1 simple
+///   majority `floor(n/2)+1` by default, or BFT 3f+1 `n - floor((n-1)/3)` when
+///   `quorum.fault_model = bft`.
 /// - `Explicit`: the configured threshold, clamped to the member count so we
 ///   never demand more confirmations than there are members.
 ///

--- a/botho/src/config.rs
+++ b/botho/src/config.rs
@@ -286,14 +286,56 @@ impl Default for QuorumMode {
     }
 }
 
+/// Fault model posture for `Recommended` quorum mode.
+///
+/// Selects how the auto-calculated quorum threshold is derived from the live
+/// member count `n`:
+///
+/// - [`FaultModel::Crash`] (DEFAULT): crash-fault tolerance via a 2f+1 simple
+///   majority — `threshold = floor(n/2) + 1`. This gives genuine fault
+///   tolerance for small homogeneous clusters (e.g. 2-of-3 at n=3) so a single
+///   crashed or lagging node cannot stall liveness. This is the
+///   trusted-operator testnet posture and matches Stellar Core's
+///   homogeneous-cluster default.
+/// - [`FaultModel::Bft`]: Byzantine-fault tolerance via a 3f+1 quorum —
+///   `threshold = n - floor((n-1)/3)`. Tolerates up to f Byzantine (arbitrarily
+///   malicious) members but requires n >= 4 for any genuine BFT (n<=3 collapses
+///   to unanimity).
+///
+/// Note: under either model botho currently auto-trusts every connected peer in
+/// `Recommended` mode, so n<=3 has no real Byzantine robustness regardless;
+/// `Crash` therefore loses nothing real at small n and gains liveness +
+/// crash-fault tolerance. #420 no-fork safety is preserved because any two
+/// 2f+1 majority subsets always intersect.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum FaultModel {
+    /// Crash-fault tolerance: 2f+1 simple majority (`floor(n/2) + 1`).
+    Crash,
+    /// Byzantine-fault tolerance: 3f+1 quorum (`n - floor((n-1)/3)`).
+    Bft,
+}
+
+impl Default for FaultModel {
+    fn default() -> Self {
+        Self::Crash
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QuorumConfig {
     /// Quorum mode: explicit (user lists peers) or recommended (auto-discover)
     #[serde(default)]
     pub mode: QuorumMode,
 
+    /// Fault model posture for `Recommended` mode: `crash` (2f+1 simple
+    /// majority, the default) or `bft` (3f+1 Byzantine quorum). Ignored in
+    /// `Explicit` mode, where the operator sets an exact threshold.
+    #[serde(default)]
+    pub fault_model: FaultModel,
+
     /// For explicit mode: number of peers required to agree (e.g., 2 in a
-    /// 2-of-3) For recommended mode: this is auto-calculated as ceil(2n/3)
+    /// 2-of-3) For recommended mode: this is auto-calculated from `fault_model`
     #[serde(default = "default_threshold")]
     pub threshold: u32,
 
@@ -310,6 +352,7 @@ impl Default for QuorumConfig {
     fn default() -> Self {
         Self {
             mode: QuorumMode::Recommended,
+            fault_model: FaultModel::default(),
             threshold: 2,
             members: Vec::new(),
             min_peers: 1,
@@ -318,17 +361,34 @@ impl Default for QuorumConfig {
 }
 
 impl QuorumConfig {
-    /// Calculate the effective threshold for a given number of connected peers
-    /// Uses BFT formula: threshold = n - floor((n-1)/3) ≈ ceil(2n/3)
+    /// Calculate the effective threshold for a given number of connected peers.
+    ///
+    /// In `Recommended` mode the threshold is derived from the configured
+    /// [`FaultModel`] over `n = connected_count + 1` (peers plus self):
+    ///
+    /// - `Crash` (default): `floor(n/2) + 1` (2f+1 simple majority). n=1->1,
+    ///   n=2->2, n=3->2, n=4->3, n=5->3, n=6->4.
+    /// - `Bft`: `n - floor((n-1)/3)` (3f+1 quorum). n=1->1, n=2->2, n=3->3,
+    ///   n=4->3, n=5->4, n=6->5.
+    ///
+    /// In `Explicit` mode the operator-configured `threshold` is returned
+    /// as-is.
     pub fn effective_threshold(&self, connected_count: usize) -> usize {
         match self.mode {
             QuorumMode::Explicit => self.threshold as usize,
             QuorumMode::Recommended => {
                 // n = total nodes including self
                 let n = connected_count + 1;
-                // BFT threshold: n - f where f = floor((n-1)/3)
-                let f = n.saturating_sub(1) / 3;
-                n - f
+                match self.fault_model {
+                    // Crash-fault: 2f+1 simple majority.
+                    FaultModel::Crash => n / 2 + 1,
+                    // Byzantine-fault: 3f+1 quorum, threshold = n - f
+                    // where f = floor((n-1)/3).
+                    FaultModel::Bft => {
+                        let f = n.saturating_sub(1) / 3;
+                        n - f
+                    }
+                }
             }
         }
     }
@@ -750,6 +810,7 @@ mod tests {
     fn test_quorum_explicit_mode() {
         let quorum = QuorumConfig {
             mode: QuorumMode::Explicit,
+            fault_model: FaultModel::default(),
             threshold: 2,
             members: vec!["peer1".to_string(), "peer2".to_string()],
             min_peers: 1,
@@ -774,8 +835,10 @@ mod tests {
 
     #[test]
     fn test_quorum_recommended_mode() {
+        // Default fault model is crash (2f+1 simple majority).
         let quorum = QuorumConfig {
             mode: QuorumMode::Recommended,
+            fault_model: FaultModel::Crash,
             threshold: 2,    // ignored in recommended mode
             members: vec![], // ignored in recommended mode
             min_peers: 1,
@@ -789,41 +852,56 @@ mod tests {
         let (can_mine, size, thresh) = quorum.can_reach_quorum(&["peer1".to_string()]);
         assert!(can_mine);
         assert_eq!(size, 2);
-        assert_eq!(thresh, 2); // 2-of-2
+        assert_eq!(thresh, 2); // 2-of-2 (can't tolerate a fault at n=2)
 
-        // Two peers - can mine (3 nodes, threshold=3)
-        // BFT with n=3: f=(3-1)/3=0, threshold=3-0=3
+        // Two peers - can mine (3 nodes, threshold=2 under crash 2f+1).
+        // Crash with n=3: floor(3/2)+1 = 2 -> 2-of-3 (tolerates 1 crash/lag).
         let (can_mine, size, thresh) =
             quorum.can_reach_quorum(&["peer1".to_string(), "peer2".to_string()]);
         assert!(can_mine);
         assert_eq!(size, 3);
-        assert_eq!(thresh, 3); // 3-of-3 (can't tolerate any faults with 3
-                               // nodes)
+        assert_eq!(thresh, 2); // 2-of-3 under crash fault model
     }
 
     #[test]
-    fn test_quorum_effective_threshold() {
+    fn test_quorum_effective_threshold_crash() {
+        // Crash fault model (DEFAULT): 2f+1 simple majority = floor(n/2) + 1.
         let quorum = QuorumConfig::default();
+        assert_eq!(quorum.fault_model, FaultModel::Crash);
 
-        // BFT thresholds: threshold = n - floor((n-1)/3)
-        // n=2: f=0, threshold=2
-        // n=3: f=0, threshold=3
-        // n=4: f=1, threshold=3
-        // n=5: f=1, threshold=4
-        // n=6: f=1, threshold=5
-        // n=7: f=2, threshold=5
-        assert_eq!(quorum.effective_threshold(1), 2); // 2 nodes: 2-of-2
-        assert_eq!(quorum.effective_threshold(2), 3); // 3 nodes: 3-of-3
-        assert_eq!(quorum.effective_threshold(3), 3); // 4 nodes: 3-of-4
-        assert_eq!(quorum.effective_threshold(4), 4); // 5 nodes: 4-of-5
-        assert_eq!(quorum.effective_threshold(5), 5); // 6 nodes: 5-of-6
-        assert_eq!(quorum.effective_threshold(6), 5); // 7 nodes: 5-of-7
+        // connected_count = n - 1 (peers; n includes self).
+        assert_eq!(quorum.effective_threshold(0), 1); // n=1: 1-of-1
+        assert_eq!(quorum.effective_threshold(1), 2); // n=2: 2-of-2
+        assert_eq!(quorum.effective_threshold(2), 2); // n=3: 2-of-3
+        assert_eq!(quorum.effective_threshold(3), 3); // n=4: 3-of-4
+        assert_eq!(quorum.effective_threshold(4), 3); // n=5: 3-of-5
+        assert_eq!(quorum.effective_threshold(5), 4); // n=6: 4-of-6
+    }
+
+    #[test]
+    fn test_quorum_effective_threshold_bft() {
+        // BFT fault model: 3f+1 quorum = n - floor((n-1)/3).
+        let quorum = QuorumConfig {
+            mode: QuorumMode::Recommended,
+            fault_model: FaultModel::Bft,
+            threshold: 2,
+            members: vec![],
+            min_peers: 1,
+        };
+
+        assert_eq!(quorum.effective_threshold(0), 1); // n=1: 1-of-1
+        assert_eq!(quorum.effective_threshold(1), 2); // n=2: 2-of-2
+        assert_eq!(quorum.effective_threshold(2), 3); // n=3: 3-of-3
+        assert_eq!(quorum.effective_threshold(3), 3); // n=4: 3-of-4
+        assert_eq!(quorum.effective_threshold(4), 4); // n=5: 4-of-5
+        assert_eq!(quorum.effective_threshold(5), 5); // n=6: 5-of-6
     }
 
     #[test]
     fn test_quorum_min_peers() {
         let quorum = QuorumConfig {
             mode: QuorumMode::Recommended,
+            fault_model: FaultModel::Crash,
             threshold: 2,
             members: vec![],
             min_peers: 2, // Require at least 2 peers
@@ -833,12 +911,47 @@ mod tests {
         let (can_mine, _, _) = quorum.can_reach_quorum(&["peer1".to_string()]);
         assert!(!can_mine);
 
-        // Two peers - enough (3 nodes, threshold=3 with BFT)
+        // Two peers - enough (3 nodes, threshold=2 under crash 2f+1).
         let (can_mine, size, thresh) =
             quorum.can_reach_quorum(&["peer1".to_string(), "peer2".to_string()]);
         assert!(can_mine);
         assert_eq!(size, 3);
-        assert_eq!(thresh, 3); // BFT: 3-of-3 for n=3
+        assert_eq!(thresh, 2); // crash: 2-of-3 for n=3
+    }
+
+    #[test]
+    fn test_fault_model_parses_crash_and_bft() {
+        // crash
+        let q: QuorumConfig =
+            toml::from_str("mode = \"recommended\"\nfault_model = \"crash\"\n").unwrap();
+        assert_eq!(q.fault_model, FaultModel::Crash);
+        assert_eq!(q.effective_threshold(2), 2); // n=3 -> 2-of-3
+
+        // bft
+        let q: QuorumConfig =
+            toml::from_str("mode = \"recommended\"\nfault_model = \"bft\"\n").unwrap();
+        assert_eq!(q.fault_model, FaultModel::Bft);
+        assert_eq!(q.effective_threshold(2), 3); // n=3 -> 3-of-3
+    }
+
+    #[test]
+    fn test_fault_model_defaults_to_crash_when_absent() {
+        // Omitting fault_model defaults to crash.
+        let q: QuorumConfig = toml::from_str("mode = \"recommended\"\n").unwrap();
+        assert_eq!(q.fault_model, FaultModel::Crash);
+    }
+
+    #[test]
+    fn test_fault_model_invalid_value_errors_clearly() {
+        let err =
+            toml::from_str::<QuorumConfig>("mode = \"recommended\"\nfault_model = \"paxos\"\n")
+                .unwrap_err();
+        let msg = err.to_string();
+        // serde reports the unknown variant and the allowed set.
+        assert!(
+            msg.contains("crash") && msg.contains("bft"),
+            "error should name valid fault models, got: {msg}"
+        );
     }
 
     #[test]

--- a/docs/minting.md
+++ b/docs/minting.md
@@ -29,6 +29,19 @@ Unlike Bitcoin where the first valid block to propagate "wins," Botho separates 
 
 **Solo minting is impossible by design.** Minting requires a satisfiable quorum with at least one other peer.
 
+In recommended mode the quorum threshold follows the configured **fault model**:
+
+- `crash` (default): a 2f+1 simple majority (`floor(n/2)+1`) — high-availability
+  / liveness for trusted homogeneous clusters. A single crashed or lagging node
+  (including a peer that is still catching up) cannot stall consensus. At n=3
+  the quorum is 2-of-3.
+- `bft`: a 3f+1 Byzantine quorum (`n - floor((n-1)/3)`) for an adversarial
+  posture. Genuine Byzantine tolerance needs **at least 4 nodes**; at n<=3 it
+  degenerates to unanimity.
+
+See [Configuration → network.quorum](operations/configuration.md#networkquorum)
+for the full threshold tables.
+
 ### Minting State Machine
 
 ```

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -26,10 +26,11 @@ cors_origins = ["http://localhost", "http://127.0.0.1", "https://botho.io"]
 
 # Quorum configuration for consensus
 [network.quorum]
-mode = "recommended"  # or "explicit"
-min_peers = 1         # For recommended mode: minimum peers before minting
-threshold = 2         # For explicit mode: required agreement count
-members = []          # For explicit mode: list of trusted peer IDs
+mode = "recommended"   # or "explicit"
+fault_model = "crash"  # (recommended mode) "crash" (default) or "bft"
+min_peers = 1          # For recommended mode: minimum peers before minting
+threshold = 2          # For explicit mode: required agreement count
+members = []           # For explicit mode: list of trusted peer IDs
 
 [minting]
 enabled = false
@@ -66,30 +67,65 @@ Controls how the node participates in SCP consensus.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `mode` | string | "recommended" | Either "recommended" or "explicit" |
+| `fault_model` | string | "crash" | (Recommended mode) "crash" (2f+1) or "bft" (3f+1) |
 | `min_peers` | integer | 1 | (Recommended mode) Minimum peers before minting |
 | `threshold` | integer | 2 | (Explicit mode) Required agreement count |
 | `members` | array | [] | (Explicit mode) List of trusted peer IDs |
 
 #### Recommended Mode
 
-Automatically trusts discovered peers and calculates a BFT-safe threshold:
+Automatically trusts discovered peers and calculates a quorum threshold from
+the configured **fault model** over `n` (peers + self).
 
 ```toml
 [network.quorum]
 mode = "recommended"
+fault_model = "crash"   # default; use "bft" for a Byzantine posture
 min_peers = 1
 ```
 
-The threshold is calculated as `n - f` where `f = (n - 1) / 3` (failures tolerated).
+##### Fault model: `crash` (default)
 
-| Nodes | Threshold | Fault Tolerance |
-|-------|-----------|-----------------|
-| 2     | 2-of-2    | 0               |
-| 3     | 2-of-3    | 1               |
-| 4     | 3-of-4    | 1               |
-| 5     | 4-of-5    | 1               |
-| 6     | 4-of-6    | 2               |
-| 7     | 5-of-7    | 2               |
+Crash-fault tolerance via a **2f+1 simple majority**: `threshold = floor(n/2) + 1`.
+This is the recommended posture for trusted homogeneous clusters (the testnet
+default). It gives genuine high-availability / liveness — a single crashed or
+lagging node cannot stall consensus — and matches Stellar Core's homogeneous
+default. Crash-fault safety (no fork) is preserved because any two majority
+subsets always intersect, and block-apply tip checks are unchanged.
+
+| Nodes | Threshold | Crash faults tolerated |
+|-------|-----------|------------------------|
+| 1     | 1-of-1    | 0                      |
+| 2     | 2-of-2    | 0                      |
+| 3     | 2-of-3    | 1                      |
+| 4     | 3-of-4    | 1                      |
+| 5     | 3-of-5    | 2                      |
+| 6     | 4-of-6    | 2                      |
+
+##### Fault model: `bft`
+
+Byzantine-fault tolerance via a **3f+1 quorum**: `threshold = n - floor((n-1)/3)`.
+Tolerates up to `f` arbitrarily malicious (Byzantine) members. Note that
+**genuine BFT requires at least 4 nodes**; at `n <= 3` this collapses to
+unanimity (n-of-n) and tolerates zero faults.
+
+```toml
+[network.quorum]
+mode = "recommended"
+fault_model = "bft"
+```
+
+| Nodes | Threshold | Byzantine faults tolerated |
+|-------|-----------|----------------------------|
+| 1     | 1-of-1    | 0                          |
+| 2     | 2-of-2    | 0                          |
+| 3     | 3-of-3    | 0                          |
+| 4     | 3-of-4    | 1                          |
+| 5     | 4-of-5    | 1                          |
+| 6     | 5-of-6    | 1                          |
+
+An invalid `fault_model` value (anything other than `crash` or `bft`) is
+rejected at config load with a clear error.
 
 #### Explicit Mode
 

--- a/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
+++ b/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
@@ -32,20 +32,22 @@
  *
  * Quorum config used (and why)
  * ----------------------------
- * All three nodes use `recommended` mode with `min_peers = 1`. The node's
- * consensus quorum set tracks LIVE membership (`rebuild_scp_quorum_set` in
- * `botho/src/commands/run.rs`), and the BFT threshold is
- * `n - floor((n-1)/3)` over `n = connected_peers + 1`
- * (`QuorumConfig::effective_threshold`):
+ * All three nodes use `recommended` mode with `min_peers = 1` and the DEFAULT
+ * `fault_model = crash` (#432). The node's consensus quorum set tracks LIVE
+ * membership (`rebuild_scp_quorum_set` in `botho/src/commands/run.rs`), and the
+ * crash-fault threshold is the 2f+1 simple majority `floor(n/2) + 1` over
+ * `n = connected_peers + 1` (`QuorumConfig::effective_threshold`):
  *   - while A + B are the only members:  n = 2 -> threshold 2 (2-of-2),
- *   - once C has joined and is counted:  n = 3 -> threshold 3 (3-of-3).
+ *   - once C has joined and is counted:  n = 3 -> threshold 2 (2-of-3).
  * `recommended` is used (rather than an `explicit` static peer list) precisely
  * because the joiner's peer id is not known ahead of time; recommended
  * auto-trusts connected peers, and the #404 dynamic reconfigure folds C into
  * the quorum the moment it connects, so C's proposed block is accepted by the
- * whole set. (A 3-node recommended quorum is unanimous — 3-of-3 — which is the
- * documented tradeoff; once C finishes catch-up all three participate every
- * slot, so the chain keeps advancing and C's blocks are accepted.)
+ * whole set. The crash fault model (#432) is the key fix that unblocks this
+ * soak: at n=3 the quorum is 2-of-3 (NOT the old 3-of-3 unanimous set), so A+B
+ * can keep externalizing while C is still catching up — a behind/lagging node
+ * no longer acts like a fault that stalls the whole network — and once C is
+ * synced its freshly-mined blocks are accepted by the 2-of-3 majority.
  *
  * Distinguishing "mined by the joiner": the coinbase of each block pays the
  * minter's own stealth address, and each node has a DISTINCT BIP39 mnemonic, so
@@ -179,24 +181,40 @@ const RUN_LOCAL_NODE = env.BOTHO_E2E_NODE === '1'
 //     slot 1 forever; with this PR all three nodes align on the same slot index.
 //     i.e. the #421 drift convergence symptom is closed.
 //
-// What STILL blocks the FINAL "C mines a block accepted past N" end-state, and
-// is OUT OF SCOPE for #421's drift fix: the 3-node quorum at n=3 is a 3-of-3
-// UNANIMOUS (n-of-n) set, and the 2->3 quorum reconfiguration at C's join is
-// DEFERRED on the busy established minters (round in flight) — so at the join-
-// boundary slot the nodes operate under MISMATCHED memberships (C on 3-of-3, the
-// established minters still on 2-of-2 until the deferred reconfig applies, which
-// itself needs that slot to externalize first → deadlock). This n-of-n /
-// join-boundary reconfiguration coordination problem is the SCP cluster-health
-// concern tracked by #427, NOT the SCP-slot/height drift of #421. Baseline
-// (3fb656a, pre-#421-fix) stalls at the SAME height N with C never even
-// participating, so this PR strictly improves convergence (C now aligns) without
-// regressing two-minter liveness (verified: 2-minter simultaneous + staggered
-// loopback both reach height ~25-28 with no wedge; T5 guards it in-process).
+// #432 status (quorum.fault_model = crash 2f+1): the n=3 JOIN-BOUNDARY blocker
+// is FIXED. The FINAL "C mines a block accepted past N" end-state previously
+// stalled because the n=3 recommended quorum was a 3-of-3 UNANIMOUS (n-of-n)
+// set: a joiner C still catching up acted like a fault (the SCP cluster-health
+// concern from #427). #432 defaults `quorum.fault_model = crash`, so the n=3
+// recommended threshold is the 2f+1 simple majority `floor(3/2)+1 = 2` (2-of-3)
+// instead of 3-of-3. With 2-of-3, this CAPSTONE PROVABLY PASSES over real
+// loopback `botho run` processes (BOTHO_E2E_NODE=1, release binary): verified
+// end-to-end across multiple full runs —
+//   - A+B (2-of-2) reach the shared target N=ringSize+4 with IDENTICAL tips,
+//   - C joins, connects, catches up 0 -> N onto A's EXACT chain (#423),
+//   - the 3-node net ADVANCES PAST N to a single converged tip (e.g. height 27
+//     with all of A/B/C on IDENTICAL hashes), and
+//   - C MINES an accepted block and EARNS an on-chain coinbase
+//     (confirmed balance 50000000000000) — proving a freshly-joined node's
+//     block is accepted by the 2-of-3 majority.
+// #420 no-fork safety is preserved (any two 2-of-3 subsets intersect; block-apply
+// tip checks unchanged); the n=2 threshold is unchanged (crash n=2 is still
+// 2-of-2).
 //
-// Per #421's STOP guardrail we do NOT force this green and do NOT reintroduce any
-// #422-style proposal filter / backward slot rewind to brute-force it. The soak
-// stays gated on the full 3-node end-state until #427 (n-of-n threshold + join-
-// boundary reconfig coordination) lands. Re-enable (drop `&& false`) then.
+// WHY THIS SOAK STAYS GATED (per #432's STOP guardrail — NOT a fault_model bug):
+// the run is INTERMITTENT due to a SEPARATE, PRE-EXISTING two-minter (n=2)
+// liveness/safety defect that is independent of fault_model and of node C. In a
+// fraction of runs the two established minters A and B BOTH fall into SCP
+// solo-mode ("Advanced to next slot (solo mode)" / "Solo mode: directly
+// externalizing values") despite each reporting "Quorum satisfied: 2-of-2", and
+// mine DIVERGENT solo chains that never reconcile (verified: an A/B-only run with
+// no C at all forks — they disagree as low as height 20 and run to different tips
+// at 111/115). Because n=2 crash == n=2 bft (both 2-of-2), #432 neither causes
+// nor fixes this; it is an `is_solo_mode` vs dynamic quorum-rebuild coordination
+// bug at the 1-of-1 -> 2-of-2 transition. Per the STOP guardrail we do NOT force
+// this green by masking that fork. Re-enable (drop `&& false`) once the n=2
+// solo-mode fork is fixed (tracked in the #432 follow-up). The fault_model change
+// itself is complete and unit-tested, and the 2-of-3 capstone is proven above.
 const enabled = wasmBuilt && RUN_LOCAL_NODE && false
 const maybe = enabled ? describe : describe.skip
 
@@ -375,9 +393,21 @@ maybe(
       expect(heightN).toBeGreaterThan(ringSize)
 
       // A + B agree on the chain at N (real SCP agreement, not divergent forks).
+      // heightN is the LIVE tip the instant both crossed N, so the block at that
+      // exact height may still be settling for a moment (the latest slot can be
+      // momentarily in flight before SCP externalizes one value). Poll for
+      // agreement within a bounded window: a genuine persistent fork never
+      // converges and still fails, but a transient tip race resolves quickly.
       {
-        const ha = await blockHashAt(rpcA, heightN)
-        const hb = await blockHashAt(rpcB, heightN)
+        const deadline = Date.now() + 60_000
+        let ha: string | null = null
+        let hb: string | null = null
+        while (Date.now() < deadline) {
+          ha = await blockHashAt(rpcA, heightN)
+          hb = await blockHashAt(rpcB, heightN)
+          if (ha && hb && ha === hb) break
+          await sleep(1000)
+        }
         expect(ha, 'A should have block N').not.toBeNull()
         expect(hb, "B's block N must match A's (A+B agree via SCP)").toBe(ha)
       }


### PR DESCRIPTION
Closes #432

Implements the maintainer-approved #427 Finding-1 decision and the n=3
join-boundary half of #396: default small homogeneous clusters to
**crash-fault tolerance (2f+1 simple majority)** so a lagging/crashed node no
longer acts like a fault that stalls liveness, while keeping a 3f+1 Byzantine
posture available as `bft`.

## What changed

**Config (`botho/src/config.rs`)**
- New `FaultModel` enum (`crash` = DEFAULT | `bft`), added as
  `quorum.fault_model` next to `quorum.mode`. Serde `rename_all = "lowercase"`;
  an invalid value errors clearly at config load.
- `QuorumConfig::effective_threshold` (Recommended mode) now branches on the
  fault model:

  | n | crash `floor(n/2)+1` | bft `n-floor((n-1)/3)` |
  |---|----------------------|------------------------|
  | 1 | 1 | 1 |
  | 2 | 2 | 2 |
  | 3 | **2 (2-of-3)** | 3 |
  | 4 | 3 | 3 |
  | 5 | 3 | 4 |
  | 6 | 4 | 5 |

  Explicit mode is unchanged (operator-set exact threshold).

**Threshold reuse (`botho/src/commands/run.rs`)**
- `rebuild_scp_quorum_set` already delegates to `effective_threshold`, so it is
  fault-model-aware with no duplicated formula. Docstring updated.

**Tests (`config.rs`)**
- Unit tables for BOTH models, n=1..6
  (`test_quorum_effective_threshold_crash` / `_bft`).
- `fault_model` parse tests: crash, bft, default-when-absent, invalid-errors.
- Updated `can_reach_quorum` recommended-mode tests for the new 2-of-3 default.

**Docs**
- `docs/operations/configuration.md`: full crash/bft posture + threshold tables;
  notes crash = HA/liveness for trusted clusters (default), bft = Byzantine and
  needs >=4 nodes for genuine BFT.
- `docs/minting.md`: fault-model summary + cross-link.

## Hard constraints honored
- **#420 no-fork preserved**: any two 2f+1 majority subsets intersect; block-apply
  tip checks are untouched. #420 `no_fork_with_tip_agnostic_validity` /
  `fork_with_tip_dependent_validity` both pass.
- **n=2 unchanged**: crash n=2 == bft n=2 == 2-of-2, so 2-minter behavior is not
  altered by this change.
- #429 participation gate / #430 drift fix untouched.

## #396 capstone — proven, but soak stays gated (STOP guardrail)
With `fault_model=crash` the n=3 quorum is **2-of-3**, which FIXES the
join-boundary blocker. Verified end-to-end over real loopback `botho run`
processes (`BOTHO_E2E_NODE=1`, release binary) across multiple full runs:
- A+B (2-of-2) reach the shared target N=ringSize+4 with IDENTICAL tips,
- C joins, connects, catches up 0 -> N onto A's EXACT chain (#423),
- the 3-node net ADVANCES PAST N to a single converged tip
  (e.g. **height 27, all of A/B/C on identical hashes** vs N=24), and
- **C mines an accepted block and earns an on-chain coinbase**
  (confirmed balance `50000000000000`).

Per #432's STOP guardrail the soak is **not** forced green: it is re-gated
(`&& false`) because of a SEPARATE, pre-existing **two-minter (n=2) solo-mode
fork** — A and B intermittently BOTH run SCP solo mode despite reporting
`Quorum satisfied: 2-of-2` and mine divergent solo chains. This reproduces in a
plain A+B-only run (no C) and is independent of fault_model (n=2 is 2-of-2 under
both models). Filed as **#433** with logs and repro. The step-1 A/B agreement
check is hardened with a bounded settle window for when #433 is fixed and the
soak is re-enabled.

## Test/build results
- `cargo test -p botho --lib config::tests` — 43 passed.
- `cargo test -p botho --lib --tests` — all green (pre-existing `network::privacy`
  doctest failures exist on `main` unchanged, unrelated to this PR).
- `cargo test -p bth-consensus-scp` — 100 passed; `test_tip_dependent_validity_fork`
  (the #420 fork tests) — 2 passed.
- `cargo build --release --bin botho` — clean; `cargo fmt --check` clean;
  `cargo clippy -p botho --lib` — no errors.
- `pnpm -C web typecheck` — green.

## Files touched
- `botho/src/config.rs`
- `botho/src/commands/run.rs`
- `docs/operations/configuration.md`
- `docs/minting.md`
- `web/packages/wasm-signer/test/mine-after-join-live-node.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)