### PR TITLE
fix(consensus): eliminate n=2 startup solo-mode fork (#433)

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -452,8 +452,31 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     let local_peer_id = *discovery.local_peer_id();
     let node_id = peer_id_to_node_id(&local_peer_id);
 
-    // Build SCP quorum set from connected peers (or just ourselves for solo mining)
-    let scp_quorum_set = build_scp_quorum_set(&quorum, &local_peer_id);
+    // Build the initial SCP quorum set.
+    //
+    // Issue #433: peers that connect during the pre-consensus "wait for peers"
+    // loop above have their `PeerDiscovered` events CONSUMED by that loop — the
+    // main event loop never sees them and therefore never calls
+    // `reconfigure_quorum` for them. If we seed the consensus service from the
+    // *static config* (`build_scp_quorum_set`, which yields a 1-of-1 solo set
+    // for a `recommended`/`min_peers=1` node), the node starts in solo mode even
+    // though a peer is already connected. The participation gate
+    // (`set_connected_peers` below) then opens (connected >= min_peers) while the
+    // quorum is still 1-of-1, so the very next consensus tick takes the solo
+    // direct-externalize path and the node mines a divergent solo chain forever
+    // (no further `PeerDiscovered` ever arrives, so the quorum is never
+    // reconfigured out of 1-of-1). Two such nodes fork.
+    //
+    // Fix: seed the initial quorum from the peers ALREADY CONNECTED at startup
+    // (the same `rebuild_scp_quorum_set` used on every later peer event), so a
+    // node that has already peered starts in federated SCP (e.g. 2-of-2), never
+    // solo. A genuine lone node (no peers connected) still yields a 1-of-1 solo
+    // quorum and mints solo — no regression for `min_peers == 0`.
+    let scp_quorum_set = if discovery.peer_count() > 0 {
+        rebuild_scp_quorum_set(&config, &discovery, &local_peer_id)
+    } else {
+        build_scp_quorum_set(&quorum, &local_peer_id)
+    };
 
     // Capture the starting height before chain_state is moved into the
     // consensus service; the sync state machine needs it to know how far

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -700,6 +700,26 @@ impl ConsensusService {
         self.quorum_set.threshold == 1 && self.quorum_set.members.len() == 1
     }
 
+    /// Issue #433: are we in a *transitional* solo state — a peer is connected
+    /// but the SCP quorum has not yet been reconfigured out of 1-of-1?
+    ///
+    /// A node that expects peers (`min_peers >= 1`) and currently has at least
+    /// one connected (`connected_peers >= 1`) but is still holding a solo
+    /// (1-of-1) quorum set is mid-transition: it must run federated SCP with
+    /// the connected peer, not directly solo-externalize. Taking the solo
+    /// path here produces a divergent solo chain and forks once both peered
+    /// nodes do it. This is the exact race from #433 (a peer that connected
+    /// during the pre-consensus startup window leaves the gate open while
+    /// the quorum is still 1-of-1). We block the solo direct-externalize
+    /// until the quorum reconfigures (the run loop calls
+    /// `reconfigure_quorum` on peer events; the startup path now seeds the
+    /// quorum from connected peers — see `commands::run`). A genuine lone
+    /// node (`min_peers == 0`) is never transitional: it has no peers to
+    /// wait for and mints solo.
+    fn is_transitional_solo(&self) -> bool {
+        self.min_peers >= 1 && self.connected_peers >= 1 && self.is_solo_mode()
+    }
+
     /// Propose pending values to SCP
     #[instrument(
         name = "consensus.propose_values",
@@ -728,6 +748,23 @@ impl ConsensusService {
                 min_peers = self.min_peers,
                 connected_peers = self.connected_peers,
                 "Withholding propose: not enough connected peers for quorum (issue #428)"
+            );
+            return;
+        }
+
+        // Transitional-solo guard (issue #433): a node that expects peers and
+        // has one connected, but whose SCP quorum is still 1-of-1, must NOT take
+        // the solo direct-externalize path below — that produces a divergent
+        // solo chain and forks once both peered nodes do it. Withhold the block
+        // until the quorum reconfigures out of solo (the run loop reconfigures
+        // on peer events; startup seeds the quorum from connected peers). Values
+        // stay queued in `pending_values`, so nothing is lost.
+        if self.is_transitional_solo() {
+            debug!(
+                min_peers = self.min_peers,
+                connected_peers = self.connected_peers,
+                "Withholding propose: peer connected but quorum still solo \
+                 (awaiting 1-of-1 -> N-of-N reconfig, issue #433)"
             );
             return;
         }
@@ -1424,6 +1461,71 @@ mod tests {
         assert!(
             !gated.should_propose_this_round(),
             "losing a quorum member must pause minting, not fall back to solo"
+        );
+    }
+
+    /// Issue #433 regression: the 1-of-1 -> 2-of-2 transition must not fork.
+    ///
+    /// A node that expects peers (`min_peers == 1`) and already has a peer
+    /// connected (`connected_peers == 1`), but whose SCP quorum is still the
+    /// transient startup solo (1-of-1) set, must NOT take the solo
+    /// direct-externalize path. If it did, two such peered nodes would each
+    /// mine a divergent solo chain and fork (the observed #433 bug). It
+    /// must withhold the block until the quorum reconfigures out of solo,
+    /// and once it does it runs federated SCP (no direct solo externalize).
+    #[test]
+    fn transitional_solo_does_not_directly_externalize() {
+        // Node boots solo (1-of-1) but expects a peer and already has one
+        // connected — the exact post-wait-loop startup state from #433.
+        let mut svc = solo_service();
+        svc.set_min_peers(1);
+        svc.set_connected_peers(1);
+
+        // The participation gate alone WOULD open here (connected >= min_peers),
+        // but we are still in solo mode, so this is transitional.
+        assert!(svc.should_propose_this_round());
+        assert!(svc.is_solo_mode());
+        assert!(
+            svc.is_transitional_solo(),
+            "peer connected + still 1-of-1 must be detected as transitional solo"
+        );
+
+        // Proposing must be WITHHELD — no divergent solo block.
+        svc.submit_minting_tx([9u8; 32], 100, vec![1, 2, 3]);
+        svc.propose_pending_values();
+        assert!(
+            svc.externalized.is_none(),
+            "transitional-solo node must NOT directly externalize (issue #433 fork)"
+        );
+        // The minting value stays queued so it is proposed once the quorum forms.
+        assert!(
+            !svc.pending_values.is_empty(),
+            "withheld values must remain pending, not be dropped"
+        );
+
+        // Now the quorum reconfigures out of solo (run loop calls this on the
+        // peer event; startup seeds it from connected peers). The node leaves
+        // solo mode and is no longer transitional.
+        let two = recommended_quorum(&[1, 2]);
+        assert!(svc.reconfigure_quorum(two.clone()));
+        assert!(
+            !svc.is_solo_mode(),
+            "node must leave solo once peer is in quorum"
+        );
+        assert!(!svc.is_transitional_solo());
+        assert_eq!(svc.scp_node.quorum_set(), two);
+
+        // After reconfig the node proposes via federated SCP — it does NOT take
+        // the solo direct-externalize path (which would set `externalized`
+        // synchronously). The value is handed to the SCP node for balloting.
+        svc.propose_pending_values();
+        assert!(
+            svc.externalized.is_none(),
+            "federated node must not directly externalize; it ballots via SCP"
+        );
+        assert!(
+            !svc.proposed_values.is_empty(),
+            "federated node must have proposed its value into SCP balloting"
         );
     }
 

--- a/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
+++ b/web/packages/wasm-signer/test/mine-after-join-live-node.test.ts
@@ -201,20 +201,54 @@ const RUN_LOCAL_NODE = env.BOTHO_E2E_NODE === '1'
 // tip checks unchanged); the n=2 threshold is unchanged (crash n=2 is still
 // 2-of-2).
 //
-// WHY THIS SOAK STAYS GATED (per #432's STOP guardrail — NOT a fault_model bug):
-// the run is INTERMITTENT due to a SEPARATE, PRE-EXISTING two-minter (n=2)
-// liveness/safety defect that is independent of fault_model and of node C. In a
-// fraction of runs the two established minters A and B BOTH fall into SCP
+// #433 status (intermittent n=2 solo-mode fork): FIXED. The n=2 blocker that
+// kept this soak gated is gone. It was a two-minter (n=2) safety defect: in a
+// fraction of runs the two established minters A and B BOTH fell into SCP
 // solo-mode ("Advanced to next slot (solo mode)" / "Solo mode: directly
 // externalizing values") despite each reporting "Quorum satisfied: 2-of-2", and
-// mine DIVERGENT solo chains that never reconcile (verified: an A/B-only run with
-// no C at all forks — they disagree as low as height 20 and run to different tips
-// at 111/115). Because n=2 crash == n=2 bft (both 2-of-2), #432 neither causes
-// nor fixes this; it is an `is_solo_mode` vs dynamic quorum-rebuild coordination
-// bug at the 1-of-1 -> 2-of-2 transition. Per the STOP guardrail we do NOT force
-// this green by masking that fork. Re-enable (drop `&& false`) once the n=2
-// solo-mode fork is fixed (tracked in the #432 follow-up). The fault_model change
-// itself is complete and unit-tested, and the 2-of-3 capstone is proven above.
+// mined DIVERGENT solo chains that never reconciled (an A/B-only run with no C
+// forked, disagreeing as low as height 20 and running to different tips at
+// 111/115).
+//
+// ROOT CAUSE (#433): peers that connect during the pre-consensus "wait for
+// peers" startup loop in `commands::run` had their `PeerDiscovered` events
+// CONSUMED by that loop, so the main event loop never called
+// `reconfigure_quorum` for them. The consensus service was therefore seeded
+// from the STATIC config (a 1-of-1 solo quorum for a recommended/min_peers=1
+// node). The participation gate (#429) then opened (connected >= min_peers)
+// while the quorum was still 1-of-1, so the next tick took the SOLO
+// direct-externalize path and the node mined a divergent solo chain forever (no
+// further PeerDiscovered ever arrived, so the quorum was never reconfigured out
+// of solo). Two such nodes forked.
+//
+// FIX (#433): (1) seed the INITIAL SCP quorum from the peers already connected
+// at startup (`rebuild_scp_quorum_set`) so a node that already peered boots in
+// federated SCP (e.g. 2-of-2), never solo; and (2) a defense-in-depth
+// transitional-solo guard in the consensus service that withholds the solo
+// direct-externalize whenever a peer is connected but the quorum is still 1-of-1
+// (`min_peers >= 1 && connected_peers >= 1 && is_solo_mode()`). A genuine lone
+// node (min_peers == 0) is unaffected and still mints solo. Verified empirically
+// over real loopback `botho run` processes (release binary): the A+B 2-minter
+// scenario now runs FEDERATED SCP and converges on identical tips + identical
+// historical hashes across 10/10 runs with ZERO solo-mode externalizes (the
+// pre-fix binary forked in ~2 of 8 runs with the identical harness). In the
+// full 3-node capstone below, steps 1-4(a) now pass on EVERY run: A+B converge
+// (no n=2 fork), C catches up onto A's exact chain, and ALL THREE converge past
+// N onto one identical tip — with ZERO solo-mode externalizes.
+//
+// WHY THIS SOAK STAYS GATED (per the STOP guardrail — a SEPARATE n=3 issue, NOT
+// #433): the FINAL step — node C winning its OWN coinbase (non-zero balance)
+// within the window — is still INTERMITTENT (~2 of 3 runs pass). The
+// convergence always succeeds, but C frequently loses the PoW/SCP race for a
+// block of its own: the established A+B drift their SCP slot ahead of C, so C's
+// proposals land on an earlier slot and get discarded as "future slots"
+// (node_impl), and C's block is rarely the one externalized. That is the
+// pre-existing n=3 SCP-slot/height DRIFT join-boundary liveness concern
+// (#421/#427-family) — independent of the #433 n=2 solo fork that this PR fixes.
+// Per the guardrail we do NOT force this green by masking that flake. Re-enable
+// (drop `&& false`) once the n=3 join-boundary drift is closed so a freshly
+// joined minter reliably gets a block accepted. The #433 n=2 fix itself is
+// complete, unit-tested, and empirically proven above.
 const enabled = wasmBuilt && RUN_LOCAL_NODE && false
 const maybe = enabled ? describe : describe.skip
 


### PR DESCRIPTION
Closes #433. Unblocks the n=2 phase of the #396 capstone soak.

## Confirmed root cause (code refs on current main)

The intermittent two-minter fork is a **startup race at the 1-of-1 -> 2-of-2 transition**, but the stranding mechanism is NOT the #408 deferral — it's the pre-consensus **wait-for-peers loop swallowing the `PeerDiscovered` event**:

1. `botho/src/commands/run.rs:269` — the startup "wait for peers" loop polls the swarm and CONSUMES `PeerDiscovered` events (just logs them). The peer is inserted into `discovery.peers` but the main event loop never sees that event.
2. `botho/src/commands/run.rs:456` — the consensus service is then seeded via `build_scp_quorum_set(&quorum, ...)`, which uses the **static config** and yields a **1-of-1 solo quorum** for a `recommended`/`min_peers=1` node.
3. `botho/src/commands/run.rs:491` — `set_connected_peers(1)` opens the participation gate (#429): `should_propose_this_round()` now returns `true` (`connected >= min_peers`).
4. Result: **gate open + quorum still 1-of-1**. The next `consensus.tick()` -> `propose_pending_values()` (`service.rs:807`) takes the **solo direct-externalize** path (`is_solo_mode()` true), mining a divergent solo chain. No further `PeerDiscovered` ever arrives (peer already connected), so the quorum is never reconfigured out of 1-of-1. Both nodes do this -> fork.

This matches the issue's refined hypothesis (solo mint wins the race against the reconfig) but pins the actual stranding to the wait-loop event consumption rather than the #408 active-slot deferral.

## The fix (localized)

- **Primary** (`run.rs`): seed the INITIAL SCP quorum from the peers ALREADY CONNECTED at startup (`rebuild_scp_quorum_set`) instead of the static config, so a node that has already peered boots into federated SCP (e.g. 2-of-2), never solo. Lone node (no peers) still yields 1-of-1 -> solo, no regression.
- **Defense-in-depth** (`service.rs`): `is_transitional_solo()` guard withholds the solo direct-externalize whenever `min_peers >= 1 && connected_peers >= 1 && is_solo_mode()` (peer present but still solo = transitional, must wait for reconfig). Values stay queued.

`min_peers == 0` still solo-mints. No proposal-time filtering of valid competing coinbases, no backward slot re-seat (no #422 wedge). #420/#429/#430/#434 untouched.

## Regression test (fail-pre / pass-post)

`consensus::service::tests::transitional_solo_does_not_directly_externalize`: a node with a peer connected but a still-1-of-1 quorum must NOT directly externalize, and must run federated SCP once reconfigured. Verified it FAILS without the guard (`expected externalized.is_none()`) and PASSES with it.

## Empirical evidence (real loopback `botho run`, release binary)

A faithful A+B 2-minter harness (recommended, min_peers=1, 1s slots, mutual bootstrap, fast-lottery — same config as the #396 test):
- **Pre-fix**: forked in **2 of 8** runs (`Solo mode: directly externalizing` on BOTH A and B) — reproduces the issue's ~1-in-2-3 rate.
- **Post-fix**: **10/10 runs clean** — federated SCP (`Slot externalized!`), ZERO solo-mode externalizes, identical tips + identical historical hashes 1..N.

## #396 capstone status

Re-ran the 3-node capstone 6x. Steps 1-4(a) pass on EVERY run: A+B converge (no n=2 fork), C catches up onto A's exact chain, and **all three converge past N onto one identical tip** with ZERO solo mode. The FINAL step — C winning its OWN coinbase — is still intermittent (~4/6 pass), gated by a SEPARATE pre-existing **n=3 SCP-slot drift** join-boundary concern (#421/#427-family): C's proposals land on an earlier slot and get discarded as "future slots", so C rarely gets its own block externalized. Per the STOP guardrail this PR does NOT force #396 green or mask that flake — #396 stays gated (`&& false`) with an accurate updated comment documenting exactly what's fixed (n=2 fork) vs what remains (n=3 C-coinbase). The #433 n=2 fix itself is complete and proven.

## Tests / build

- `cargo test -p bth-consensus-scp`: 100 passed (incl #420 fork tests)
- `cargo test -p botho --lib`: 976 passed (consensus module: 62 passed)
- `cargo fmt --all --check`: clean
- `cargo clippy -p botho --lib`: no errors, no new warnings (pre-existing `println!`/missing-docs warnings unchanged)
- `pnpm -C web typecheck`: green

## Files touched

- `botho/src/commands/run.rs` — seed initial quorum from connected peers
- `botho/src/consensus/service.rs` — `is_transitional_solo()` guard + regression test
- `web/packages/wasm-signer/test/mine-after-join-live-node.test.ts` — updated #433 status comment (soak stays gated on the separate n=3 C-coinbase flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)