### PR TITLE
feat(network): persist libp2p node key for stable peer IDs across restarts (#439)

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -243,7 +243,21 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     let rate_limit_peers = GossipConfig::default().max_connections.max(1) as u32;
     let rate_limit_config =
         PeerRateLimitConfig::for_slot_duration(effective_slot_secs, rate_limit_peers);
-    let mut discovery = NetworkDiscovery::with_rate_limit_config(
+
+    // Load (or, on first run, generate + persist) the node's identity keypair so
+    // its peer ID is STABLE across restarts (issue #439). An unstable peer ID
+    // breaks DNS-seed discovery (TXT records pin peer IDs) and resets peer
+    // reputation/ban state on every boot. The key lives at <data_dir>/node_key
+    // by default, or at the configured `network.node_key_path` override.
+    let node_key_path = config
+        .network
+        .node_key_path
+        .clone()
+        .unwrap_or_else(|| crate::config::node_key_path_from_config(config_path));
+    let node_keypair = crate::network::load_or_create_keypair(&node_key_path)?;
+
+    let mut discovery = NetworkDiscovery::with_keypair(
+        node_keypair,
         config.network.gossip_port(network_type),
         bootstrap_peers,
         rate_limit_config,

--- a/botho/src/config.rs
+++ b/botho/src/config.rs
@@ -79,6 +79,13 @@ pub struct NetworkConfig {
     #[serde(default)]
     pub dns_seeds: DnsSeedConfig,
 
+    /// Optional override for the persistent libp2p node identity key path
+    /// (issue #439). If unset, the key lives at `<data_dir>/node_key` alongside
+    /// the ledger and config. The key is generated on first run and loaded
+    /// thereafter so the node's peer ID is stable across restarts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_key_path: Option<PathBuf>,
+
     /// Quorum configuration
     #[serde(default)]
     pub quorum: QuorumConfig,
@@ -580,6 +587,8 @@ impl Default for NetworkConfig {
             cors_origins: default_cors_origins(),
             bootstrap_peers: Vec::new(), // Uses DNS discovery or network-specific defaults
             dns_seeds: DnsSeedConfig::default(),
+            node_key_path: None, // Defaults to <data_dir>/node_key
+
             quorum: QuorumConfig::default(),
             api_keys: Vec::new(),
             max_connections_per_ip: default_max_connections_per_ip(),
@@ -693,6 +702,16 @@ pub fn ledger_db_path(network: Network) -> PathBuf {
 /// Get the ledger database path from config file path
 pub fn ledger_db_path_from_config(config_path: &Path) -> PathBuf {
     config_path.parent().unwrap_or(config_path).join("ledger")
+}
+
+/// Get the persistent libp2p node-key path from the config file path (issue
+/// #439).
+///
+/// Defaults to `<data_dir>/node_key` (the data dir is the directory containing
+/// `config.toml`, the same dir that holds `ledger/`). This is the file that
+/// stores the node's identity keypair so its peer ID is stable across restarts.
+pub fn node_key_path_from_config(config_path: &Path) -> PathBuf {
+    config_path.parent().unwrap_or(config_path).join("node_key")
 }
 
 /// Get the wallet database path for a network

--- a/botho/src/network/discovery.rs
+++ b/botho/src/network/discovery.rs
@@ -331,6 +331,13 @@ pub struct BothoBehaviour {
 
 /// Network discovery and gossip service
 pub struct NetworkDiscovery {
+    /// Persistent libp2p identity keypair (issue #439).
+    ///
+    /// This is the single, canonical identity for the node: it is used both to
+    /// derive `local_peer_id` and to build the swarm in [`start`], so the
+    /// logged peer ID always matches the swarm's actual peer ID. Persisting it
+    /// to disk keeps the peer ID stable across restarts.
+    keypair: identity::Keypair,
     /// Local peer ID
     local_peer_id: PeerId,
     /// Gossip port
@@ -353,23 +360,51 @@ pub struct NetworkDiscovery {
 }
 
 impl NetworkDiscovery {
-    /// Create a new network discovery service
+    /// Create a new network discovery service.
+    ///
+    /// Generates an ephemeral identity keypair. Production startup should
+    /// prefer [`with_keypair`](Self::with_keypair) with a persisted key so
+    /// the peer ID is stable across restarts (issue #439).
     pub fn new(port: u16, bootstrap_peers: Vec<String>) -> Self {
         Self::with_rate_limit_config(port, bootstrap_peers, PeerRateLimitConfig::default())
     }
 
     /// Create a new network discovery service with custom rate limit
-    /// configuration
+    /// configuration.
+    ///
+    /// Generates an ephemeral identity keypair. Production startup should
+    /// prefer [`with_keypair`](Self::with_keypair) with a persisted key so
+    /// the peer ID is stable across restarts (issue #439).
     pub fn with_rate_limit_config(
+        port: u16,
+        bootstrap_peers: Vec<String>,
+        rate_limit_config: PeerRateLimitConfig,
+    ) -> Self {
+        Self::with_keypair(
+            identity::Keypair::generate_ed25519(),
+            port,
+            bootstrap_peers,
+            rate_limit_config,
+        )
+    }
+
+    /// Create a new network discovery service from an explicit identity
+    /// keypair (issue #439).
+    ///
+    /// The supplied keypair is the node's single canonical identity: it is used
+    /// both for the logged/queried `local_peer_id` and to build the swarm in
+    /// [`start`](Self::start). Passing a keypair loaded from disk keeps the
+    /// peer ID stable across restarts (the prerequisite for durable DNS-seed
+    /// discovery), and ensures a startup logs exactly ONE peer ID.
+    pub fn with_keypair(
+        keypair: identity::Keypair,
         port: u16,
         bootstrap_peers: Vec<String>,
         rate_limit_config: PeerRateLimitConfig,
     ) -> Self {
         let (event_tx, event_rx) = mpsc::channel(100);
 
-        // Generate a random keypair for this node
-        let local_key = identity::Keypair::generate_ed25519();
-        let local_peer_id = PeerId::from(local_key.public());
+        let local_peer_id = PeerId::from(keypair.public());
 
         info!("Local peer ID: {}", local_peer_id);
         info!(
@@ -385,6 +420,7 @@ impl NetworkDiscovery {
         );
 
         Self {
+            keypair,
             local_peer_id,
             port,
             bootstrap_peers,
@@ -489,8 +525,12 @@ impl NetworkDiscovery {
 
     /// Start the network service (runs in background)
     pub async fn start(&mut self) -> anyhow::Result<Swarm<BothoBehaviour>> {
-        // Create swarm
-        let mut swarm = libp2p::SwarmBuilder::with_new_identity()
+        // Build the swarm from the node's canonical identity keypair (issue
+        // #439). Using `with_existing_identity` (rather than the previous
+        // `with_new_identity`, which minted a SECOND, throwaway keypair) means
+        // the swarm's peer ID matches `self.local_peer_id` and is stable across
+        // restarts when the keypair was loaded from disk.
+        let mut swarm = libp2p::SwarmBuilder::with_existing_identity(self.keypair.clone())
             .with_tokio()
             .with_tcp(
                 tcp::Config::default(),
@@ -589,6 +629,10 @@ impl NetworkDiscovery {
             }
         }
 
+        // The swarm now derives from the same canonical keypair, so its peer ID
+        // already equals `self.local_peer_id`; this assignment is a no-op kept
+        // for clarity. Guard against any future drift in debug builds.
+        debug_assert_eq!(self.local_peer_id, *swarm.local_peer_id());
         self.local_peer_id = *swarm.local_peer_id();
         info!("Network started on port {}", self.port);
 

--- a/botho/src/network/mod.rs
+++ b/botho/src/network/mod.rs
@@ -12,6 +12,7 @@ mod compact_block;
 mod connection_limiter;
 mod discovery;
 mod dns_seeds;
+mod node_key;
 mod pex;
 pub mod privacy;
 mod quorum;
@@ -34,6 +35,7 @@ pub use discovery::{
 // Re-export rate limit configuration from bth-gossip for network setup
 pub use bth_gossip::{GossipMessageType, MessageTypeLimits, PeerRateLimitConfig};
 pub use dns_seeds::{DnsSeedDiscovery, DnsSeedError};
+pub use node_key::load_or_create_keypair;
 pub use pex::{
     PeerSource, PexEntry, PexFilter, PexManager, PexMessage, PexRateLimiter, PexSourceTracker,
     MAX_PEERS_PER_SUBNET, MAX_PEER_AGE_SECS, MAX_PEX_MESSAGE_SIZE, MAX_PEX_PEERS, MAX_PEX_PER_HOUR,

--- a/botho/src/network/node_key.rs
+++ b/botho/src/network/node_key.rs
@@ -1,0 +1,237 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Persistent libp2p node identity key (issue #439).
+//!
+//! botho previously generated a fresh libp2p [`Keypair`] on every process
+//! start, so the node's peer ID changed on every restart. That broke DNS-seed
+//! discovery (the `seeds.testnet.botho.io` TXT records pin peer IDs, which went
+//! stale on any restart) and reset peer-level reputation/ban state.
+//!
+//! This module persists the keypair to disk and loads it on startup, so the
+//! peer ID is **stable across restarts**. The key lives next to the ledger and
+//! config in the per-network data directory (default
+//! `~/.botho/<network>/node_key`) and is written with `0600` permissions.
+//!
+//! ## Serialization
+//!
+//! The key is stored using libp2p's protobuf keypair encoding
+//! ([`Keypair::to_protobuf_encoding`] / [`Keypair::from_protobuf_encoding`]).
+//! This is self-describing (it records the key type), round-trips losslessly,
+//! and is forward-compatible with non-ed25519 key types should we ever adopt
+//! one. The bytes are written raw (no base64/hex wrapper) to keep the format
+//! minimal.
+//!
+//! ## Security
+//!
+//! - The file is created with mode `0600` (owner read/write only) on Unix.
+//! - The private key is **never logged**; only the derived peer ID is logged.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use libp2p::{identity::Keypair, PeerId};
+use tracing::info;
+
+/// Load the node identity keypair from `path`, generating and persisting a new
+/// one on first run.
+///
+/// Behaviour:
+/// - If `path` exists, the keypair is read and decoded from it.
+/// - If `path` does not exist, a fresh ed25519 keypair is generated, written to
+///   `path` (creating parent directories as needed, mode `0600`), and returned.
+///
+/// This makes the node's peer ID stable across restarts: the same file yields
+/// the same keypair (and therefore the same [`PeerId`]), while distinct data
+/// directories yield distinct keys.
+///
+/// The private key material is never logged; the returned [`PeerId`] is logged
+/// at INFO so operators can confirm a stable identity across restarts.
+pub fn load_or_create_keypair(path: &Path) -> Result<Keypair> {
+    if path.exists() {
+        let keypair = read_keypair(path)
+            .with_context(|| format!("loading node key from {}", path.display()))?;
+        info!(
+            "Loaded persistent node identity from {} (peer ID: {})",
+            path.display(),
+            PeerId::from(keypair.public())
+        );
+        Ok(keypair)
+    } else {
+        let keypair = Keypair::generate_ed25519();
+        write_keypair(path, &keypair)
+            .with_context(|| format!("persisting new node key to {}", path.display()))?;
+        info!(
+            "Generated new persistent node identity at {} (peer ID: {})",
+            path.display(),
+            PeerId::from(keypair.public())
+        );
+        Ok(keypair)
+    }
+}
+
+/// Decode a keypair from the protobuf bytes stored at `path`.
+fn read_keypair(path: &Path) -> Result<Keypair> {
+    let bytes = std::fs::read(path).context("reading key file")?;
+    let keypair = Keypair::from_protobuf_encoding(&bytes)
+        .context("decoding key file (corrupt or unsupported node_key format)")?;
+    Ok(keypair)
+}
+
+/// Encode `keypair` to protobuf bytes and write them to `path` with `0600`
+/// permissions, creating parent directories as needed.
+fn write_keypair(path: &Path, keypair: &Keypair) -> Result<()> {
+    let bytes = keypair
+        .to_protobuf_encoding()
+        .context("encoding keypair for persistence")?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating key directory {}", parent.display()))?;
+    }
+
+    write_private_file(path, &bytes).context("writing key file")?;
+    Ok(())
+}
+
+/// Write `bytes` to `path` with owner-only (`0600`) permissions on Unix.
+///
+/// On non-Unix platforms the file is written without explicit permission bits
+/// (filesystem ACLs apply); the protobuf format is identical across platforms.
+#[cfg(unix)]
+fn write_private_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::{io::Write, os::unix::fs::OpenOptionsExt};
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_private_file(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    std::fs::write(path, bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use libp2p::PeerId;
+
+    /// Helper: a unique temp path that does not yet exist.
+    fn temp_key_path(name: &str) -> std::path::PathBuf {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "botho_node_key_test_{}_{}_{}",
+            name,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        dir
+    }
+
+    #[test]
+    fn generates_on_first_call_and_persists_file() {
+        // Issue #439 acceptance #2: first run with no key file generates +
+        // persists one.
+        let dir = temp_key_path("generate");
+        let path = dir.join("node_key");
+        assert!(!path.exists(), "precondition: key file must not exist");
+
+        let keypair = load_or_create_keypair(&path).expect("first load creates key");
+        assert!(path.exists(), "key file must be persisted after first call");
+
+        // Sanity: the persisted bytes round-trip back to the same peer ID.
+        let reloaded = read_keypair(&path).expect("reload persisted key");
+        assert_eq!(
+            PeerId::from(keypair.public()),
+            PeerId::from(reloaded.public()),
+            "persisted key must decode to the same peer ID"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn same_file_yields_same_peer_id_across_calls() {
+        // Issue #439 acceptance #1: a node's peer ID is identical across
+        // restarts when the same node_key file is used.
+        let dir = temp_key_path("stable");
+        let path = dir.join("node_key");
+
+        let first = load_or_create_keypair(&path).expect("first load");
+        // Simulate a process restart: a brand-new load from the same path.
+        let second = load_or_create_keypair(&path).expect("second load");
+
+        assert_eq!(
+            PeerId::from(first.public()),
+            PeerId::from(second.public()),
+            "same key file must yield the same peer ID across restarts"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn distinct_files_yield_distinct_peer_ids() {
+        // Issue #439 acceptance #3 + HARD CONSTRAINT: distinct nodes (distinct
+        // data dirs) must get distinct keys / peer IDs. A shared key would make
+        // every node the same peer and break the quorum.
+        let dir_a = temp_key_path("node_a");
+        let dir_b = temp_key_path("node_b");
+        let path_a = dir_a.join("node_key");
+        let path_b = dir_b.join("node_key");
+
+        let a = load_or_create_keypair(&path_a).expect("node a key");
+        let b = load_or_create_keypair(&path_b).expect("node b key");
+
+        assert_ne!(
+            PeerId::from(a.public()),
+            PeerId::from(b.public()),
+            "distinct data dirs must produce distinct peer IDs"
+        );
+
+        std::fs::remove_dir_all(&dir_a).ok();
+        std::fs::remove_dir_all(&dir_b).ok();
+    }
+
+    #[test]
+    fn protobuf_serialization_round_trips() {
+        // Issue #439 acceptance #4: round-trip the serialization.
+        let original = Keypair::generate_ed25519();
+        let encoded = original.to_protobuf_encoding().expect("encode");
+        let decoded = Keypair::from_protobuf_encoding(&encoded).expect("decode");
+        assert_eq!(
+            PeerId::from(original.public()),
+            PeerId::from(decoded.public()),
+            "protobuf encoding must round-trip to the same peer ID"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persisted_key_has_0600_permissions() {
+        // Issue #439 acceptance #2 + HARD CONSTRAINT: key file perms 0600.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = temp_key_path("perms");
+        let path = dir.join("node_key");
+        load_or_create_keypair(&path).expect("create key");
+
+        let mode = std::fs::metadata(&path)
+            .expect("stat key file")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "node_key must be owner-read/write only");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}


### PR DESCRIPTION
Closes #439

## Problem
botho generated a fresh libp2p `Keypair` on every process start, so the node's peer ID changed on every restart. This broke DNS-seed discovery (the `seeds.testnet.botho.io` TXT records pin peer IDs, which went stale on any restart) and reset peer reputation/ban state each boot. Confirmed live: a DNS-only node dialed stale pinned IDs -> peer-ID mismatch -> 0 peers.

## The "multiple peer IDs per startup" finding
`NetworkDiscovery` created **two** distinct ephemeral keypairs per startup:
1. In the constructor (`identity::Keypair::generate_ed25519()`), used only to derive the logged `local_peer_id`.
2. A **second** one via `SwarmBuilder::with_new_identity()` for the actual swarm.

`start()` then overwrote `local_peer_id` with the swarm's id. So a single startup logged a peer ID (from keypair #1) that did not even match the swarm's real identity (keypair #2) — the "multiple distinct 12D3Koo… per startup" observation in the issue. This is now consolidated to ONE canonical keypair.

## Fix
- **`botho/src/network/node_key.rs`** (new): `load_or_create_keypair(path)` — reads the key if present, else generates an ed25519 key and persists it. Stored at `<data_dir>/node_key` (next to `ledger/` + `config.toml`), `0600` perms, parent dirs created as needed. The private key is never logged (only the derived peer ID).
  - **Serialization**: libp2p protobuf keypair encoding (`Keypair::to_protobuf_encoding` / `from_protobuf_encoding`) — self-describing (records key type), lossless round-trip. libp2p 0.56.
- **`discovery.rs`**: new `NetworkDiscovery::with_keypair(keypair, …)`; `start()` now uses `SwarmBuilder::with_existing_identity(self.keypair.clone())`. The logged `local_peer_id` and the swarm's peer ID are now the same key and stable across restarts. Existing `new`/`with_rate_limit_config` constructors keep generating ephemeral keys (preserves test behavior).
- **`run.rs`**: load-or-create the key on startup; path defaults to `<data_dir>/node_key`, overridable via `network.node_key_path`.
- **`config.rs`**: optional `node_key_path: Option<PathBuf>` field + `node_key_path_from_config()` helper.

## Hard constraints honored
- Each node still gets a UNIQUE key (generate-on-first-run per data dir; no hardcoded/shared key).
- No-key node generates + persists one; existing-key node loads it.
- Network-identity only — consensus stack untouched.
- Key file `0600`; private key never logged.

## Tests (`node_key.rs`)
- `generates_on_first_call_and_persists_file`
- `same_file_yields_same_peer_id_across_calls` (restart -> identical peer ID)
- `distinct_files_yield_distinct_peer_ids`
- `protobuf_serialization_round_trips`
- `persisted_key_has_0600_permissions`

## Results
- `cargo test -p botho`: all pass (one stress test initially failed due to a disk-full ENOSPC in the env; passes after freeing space — unrelated to this change, it touches no networking).
- `cargo test -p bth-consensus-scp`: 100 passed.
- build / fmt clean; clippy clean on new code (the 8 pre-existing `println!` clippy errors in `fingerprint.rs` tests exist on `main`).
- No web files touched.

## Deployment note
After merge, deploy this and restart the seed nodes to give them STABLE peer IDs. Then refresh the `seeds.testnet.botho.io` TXT records ONCE with the new stable IDs, after which DNS-seed discovery becomes durable across restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)