### PR TITLE
fix(consensus): recalibrate RandomX genesis difficulty for ~5s blocks (#444)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,0 +1,6 @@
+# Loom-managed worktree marker
+# Created by .loom/scripts/worktree.sh
+# Issue: 444
+# Branch: feature/issue-444
+# Removing this file makes Loom treat the worktree as user-owned and refuse
+# to clean it up automatically.

--- a/botho/src/block.rs
+++ b/botho/src/block.rs
@@ -1158,6 +1158,59 @@ pub mod difficulty {
             // emission
         }
 
+        /// Documents the EmissionController's adjustment *direction* and its
+        /// limits as a block-time controller (#444).
+        ///
+        /// IMPORTANT: this controller is an *emission-rate* loop, not a
+        /// block-time loop. It compares actual emission-per-tx to a target
+        /// (`current_reward / EXPECTED_TX_PER_BLOCK`) and moves difficulty so
+        /// that emission converges, NOT so that block time converges to 5 s.
+        /// Block time is therefore governed primarily by `INITIAL_DIFFICULTY`.
+        ///
+        /// This test pins the direction of the emission loop: when actual
+        /// emission-per-tx is ABOVE target (emitting too fast), difficulty is
+        /// made HARDER, i.e. the numeric value DECREASES (recall higher
+        /// numeric difficulty = easier/faster here). When emission is BELOW
+        /// target, difficulty increases (easier).
+        #[test]
+        fn test_emission_controller_adjustment_direction() {
+            // Use a mid-range start so movement in either direction is visible
+            // without hitting the MIN/MAX_DIFFICULTY clamps.
+            let start_difficulty = INITIAL_DIFFICULTY / 2;
+
+            // target_emission_per_tx = current_reward / EXPECTED_TX_PER_BLOCK
+            // (EXPECTED_TX_PER_BLOCK = 20). actual = epoch_emission / epoch_tx.
+
+            // Over-emitting: 1 tx absorbing the full block reward gives
+            // actual = reward, target = reward / 20, so actual >> target.
+            // A full epoch is reached by recording ADJUSTMENT_TX_COUNT blocks
+            // of 1 tx each.
+            let mut fast = EmissionController::new(start_difficulty);
+            for _ in 0..ADJUSTMENT_TX_COUNT {
+                fast.record_block(1, INITIAL_REWARD, 0);
+            }
+            assert!(
+                fast.difficulty < start_difficulty,
+                "over-emitting must lower the numeric difficulty (harder/slower \
+                 emission), got {} from {}",
+                fast.difficulty,
+                start_difficulty
+            );
+
+            // Under-emitting: a single block carrying a whole epoch's worth of
+            // tx but a tiny total emission. current_reward = 100 keeps target
+            // nonzero (100 / 20 = 5), while actual = 100 / 1000 = 0 < target.
+            let mut slow = EmissionController::new(start_difficulty);
+            slow.record_block(ADJUSTMENT_TX_COUNT, 100, 0);
+            assert!(
+                slow.difficulty > start_difficulty,
+                "under-emitting must raise the numeric difficulty (easier), got \
+                 {} from {}",
+                slow.difficulty,
+                start_difficulty
+            );
+        }
+
         #[test]
         fn test_fee_burn_tracking() {
             let mut ctrl = EmissionController::new(1000);

--- a/botho/src/node/minter.rs
+++ b/botho/src/node/minter.rs
@@ -21,29 +21,52 @@ use crate::{
 
 /// Genesis / initial minting difficulty target for **RandomX**.
 ///
-/// The PoW check is `pow_value(hash) < difficulty`, so a single hash succeeds
-/// with probability `difficulty / 2^64` and the expected number of hashes per
-/// block is `2^64 / difficulty`. To hold the 5 s target block time at network
-/// hashrate `H` (hashes/sec): `difficulty = 2^64 / (H * 5)`.
-///
-/// RandomX runs at ~415 H/s on a 2-vCPU t4g.medium (the minimum *mining* tier,
-/// see #441), orders of magnitude below SHA-256. Sizing genesis for a single
-/// such node (the conservative floor — a fresh chain must not stall) gives:
+/// The PoW check is `pow_value(hash) < difficulty` (see [`pow::pow_value`] and
+/// [`mine`]), so a single hash succeeds with probability `difficulty / 2^64`
+/// and the expected number of hashes per block is `2^64 / difficulty`. Higher
+/// numeric `difficulty` = EASIER (more hashes pass) = FEWER hashes/block =
+/// FASTER blocks. To hold a target block time `T` (s) at network hashrate `H`
+/// (hashes/sec):
 ///
 /// ```text
-/// difficulty = 2^64 / (415 * 5) ≈ 8.89e15
+/// difficulty = 2^64 / (H * T)
 /// ```
 ///
-/// We use a clean `9_000_000_000_000_000` (≈ 0x1F_F973_CAFA_8000), i.e. ~2049
-/// expected hashes/block → ≈ 4.9 s at 415 H/s for one node, ≈ 2.5 s for two
-/// nodes. The `EmissionController` then adapts difficulty downward (toward
-/// `MIN_DIFFICULTY`) as hashrate grows. Higher numeric `difficulty` = EASIER
-/// here (more hashes pass), so this is also the controller's ceiling
-/// (`MAX_DIFFICULTY`).
+/// ## Calibration (see #444)
 ///
-/// NOTE: this is consensus-breaking vs the old SHA-256 value
-/// (`0x00FF_FFFF_FFFF_FFFF`, ~256 hashes/block) and requires a fresh genesis.
-pub const INITIAL_DIFFICULTY: u64 = 9_000_000_000_000_000;
+/// The earlier value `9_000_000_000_000_000` (9e15) was sized for an *idle*
+/// 2-thread benchmark of ~415 H/s (`2^64 / 9e15 ≈ 2049` hashes/block → ~4.9 s
+/// at 415 H/s). On the live testnet that proved far too optimistic: a single
+/// mining thread *in-process on the full node* (contending with consensus, RPC
+/// and networking on a burstable 2-vCPU t4g.medium, see #441) sustains only
+/// **~68 H/s**, so 9e15 yielded `2049 / 68 ≈ 30 s` blocks during the
+/// genesis/bootstrap window — far above the 5 s target.
+///
+/// Recalibrating for the realistic in-process single-thread hashrate
+/// (`H ≈ 68 H/s`, `T = 5 s`):
+///
+/// ```text
+/// target hashes/block = H * T      = 68 * 5     = 340
+/// difficulty          = 2^64 / 340             ≈ 5.42e16
+/// ```
+///
+/// We use a clean `54_000_000_000_000_000` (5.4e16, ≈ `0x00BF_D8B6_C1DF_0000`),
+/// i.e. `2^64 / 5.4e16 ≈ 341.6` expected hashes/block → `341.6 / 68 ≈ 5.0 s`.
+/// This is ~6x the old value, which is correct: 9e15 gave ~30 s and we want
+/// ~5 s (6x faster ⇒ 6x fewer hashes/block ⇒ 6x larger difficulty, since
+/// higher difficulty = easier here).
+///
+/// Note this only sets the *genesis* starting point. The live
+/// [`crate::block::EmissionController`] adjusts difficulty from an
+/// emission-rate (not block-time) error signal, so it does not pull block time
+/// back toward the 5 s target on its own; getting the genesis constant right is
+/// therefore the primary lever for early block time. See #444 for the
+/// convergence analysis.
+///
+/// NOTE: this is a consensus-relevant constant and requires a fresh genesis to
+/// take effect (the old SHA-256 value was `0x00FF_FFFF_FFFF_FFFF`, ~256
+/// hashes/block; #443 moved to RandomX).
+pub const INITIAL_DIFFICULTY: u64 = 54_000_000_000_000_000;
 
 /// Minting statistics
 #[derive(Debug, Clone)]
@@ -396,6 +419,61 @@ fn mint_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Documents and locks the genesis difficulty calibration (#444).
+    ///
+    /// The PoW check is `pow_value(hash) < difficulty`, so expected hashes per
+    /// block = `2^64 / difficulty`. We can't time real 5 s blocks in a unit
+    /// test (RandomX is slow), but we can assert the arithmetic that the
+    /// constant is derived from:
+    ///
+    ///   block_time ≈ (2^64 / INITIAL_DIFFICULTY) / hashrate
+    ///
+    /// at the measured in-process single-thread hashrate of ~68 H/s lands at
+    /// ~5 s, not the ~30 s seen with the previous 9e15 value.
+    #[test]
+    fn test_initial_difficulty_calibration() {
+        // Measured in-process single-thread hashrate on the live minter (#444).
+        const MEASURED_HASHRATE: f64 = 68.0;
+        const TARGET_BLOCK_TIME_SECS: f64 = 5.0;
+
+        // Pin the calibrated value so a future edit can't silently regress it.
+        assert_eq!(INITIAL_DIFFICULTY, 54_000_000_000_000_000);
+
+        // Expected hashes per block = 2^64 / difficulty.
+        let two_pow_64 = 2.0_f64.powi(64);
+        let hashes_per_block = two_pow_64 / INITIAL_DIFFICULTY as f64;
+
+        // ~341.6 hashes/block at the new constant.
+        assert!(
+            (hashes_per_block - 341.6).abs() < 1.0,
+            "expected ~341.6 hashes/block, got {hashes_per_block}"
+        );
+
+        // At ~68 H/s that is ~5 s/block (the target), within 0.5 s.
+        let block_time = hashes_per_block / MEASURED_HASHRATE;
+        assert!(
+            (block_time - TARGET_BLOCK_TIME_SECS).abs() < 0.5,
+            "expected ~5 s/block at {MEASURED_HASHRATE} H/s, got {block_time} s"
+        );
+
+        // Direction sanity check against the comparison operator: a LARGER
+        // difficulty constant means MORE hashes pass (`hash < difficulty`),
+        // hence FEWER hashes/block, hence FASTER blocks. The previous 9e15
+        // value therefore produced MORE hashes/block and SLOWER blocks.
+        let old_difficulty = 9_000_000_000_000_000_u64;
+        let old_hashes_per_block = two_pow_64 / old_difficulty as f64;
+        assert!(
+            old_hashes_per_block > hashes_per_block,
+            "larger difficulty must mean fewer hashes/block (faster blocks)"
+        );
+        // And it reproduces the observed ~30 s data point at 68 H/s.
+        let old_block_time = old_hashes_per_block / MEASURED_HASHRATE;
+        assert!(
+            (old_block_time - 30.0).abs() < 2.0,
+            "old 9e15 should reproduce the observed ~30 s/block, got {old_block_time} s"
+        );
+    }
 
     /// The minter's fast-mode RandomX hash MUST equal the light-mode verify
     /// hash for the same preimage + seed — otherwise mined blocks would fail


### PR DESCRIPTION
Closes #444

## What
Recalibrates `INITIAL_DIFFICULTY` (`botho/src/node/minter.rs`) from `9_000_000_000_000_000` (9e15) to `54_000_000_000_000_000` (5.4e16) so a fresh-genesis RandomX chain targets ~5s blocks instead of the observed ~30s.

## Why
9e15 was sized for an *idle* 2-thread benchmark (~415 H/s). On the live testnet, a single mining thread *in-process on the full node* (contending with consensus/RPC/networking on a burstable 2-vCPU t4g.medium) sustains only **~68 H/s**. At 9e15 that is `2^64/9e15 ≈ 2049` hashes/block → `2049/68 ≈ 30s` blocks during the bootstrap window.

## Calibration
The PoW check is `pow_value(hash) < difficulty`, so expected hashes/block = `2^64 / difficulty` and `difficulty = 2^64 / (H * T)`.

```
target hashes/block = H * T  = 68 * 5  = 340
difficulty          = 2^64 / 340       ≈ 5.42e16  → use 5.4e16
2^64 / 5.4e16 ≈ 341.6 hashes/block → 341.6 / 68 ≈ 5.0s
```

## Direction verification (against the code)
Higher numeric `difficulty` = EASIER (more hashes pass `hash < difficulty`) = FEWER hashes/block = FASTER blocks. So to go from ~30s to ~5s (6x faster) we INCREASE difficulty ~6x: `9e15 → 5.4e16`. This reproduces the observed `9e15 → 30s` data point at 68 H/s and is asserted in the test.

## DifficultyController convergence finding
The live difficulty controller is `EmissionController` in `botho/src/block.rs` (the cluster-tax `DifficultyController` in `monetary.rs` is NOT wired into the node). `EmissionController::adjust_difficulty` is an **emission-rate** loop: it compares actual emission-per-tx to a target (`current_reward / EXPECTED_TX_PER_BLOCK`) and moves difficulty to converge *emission*, not *block time*. It has no block-time feedback, so it does NOT self-correct block time toward 5s if real hashrate differs from the assumption. Therefore `INITIAL_DIFFICULTY` is the primary (effectively steady-state) lever for early block time, which is why this change is the right fix. Also note `MAX_DIFFICULTY = INITIAL_DIFFICULTY`, so the genesis value is also the controller ceiling.

## Tests added
- `node::minter::tests::test_initial_difficulty_calibration` — pins the constant; asserts hashes/block (~341.6), target block time (~5s at 68 H/s), the direction (larger difficulty → fewer hashes/block → faster), and that 9e15 reproduces ~30s.
- `block::difficulty::tests::test_emission_controller_adjustment_direction` — documents the emission-rate loop and pins its adjustment direction (over-emitting → harder/lower numeric difficulty; under-emitting → easier/higher).

## Verification
- `cargo test -p botho` → 992 passed, 0 failed.
- `cargo test -p bth-consensus-scp` → 100 passed, 0 failed.
- `cargo fmt --check -p botho` clean; `cargo build --release -p botho` clean.
- Pre-existing (not introduced here): `cargo clippy -p botho --tests` reports `print_stdout` errors in `botho/src/network/transport/fingerprint.rs` (untouched by this PR).

## Deploy note
This is a **consensus-relevant constant** and requires a **fresh-genesis testnet redeploy** to take effect on the live chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)