### PR TITLE
fix(consensus): deterministic + peer-cached transfer-tx path; chain no longer halts on a transfer (#449)

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -675,10 +675,28 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             debug!("Received transaction {} from network", hex::encode(&tx.hash()[0..8]));
                             let tx_hash = tx.hash();
                             let tx_fee = tx.fee;
+                            // Serialize before move so we can seed the consensus
+                            // cache once the mempool accepts the tx (issue #449).
+                            let tx_bytes = bincode::serialize(&tx)
+                                .expect("Failed to serialize transaction");
                             // Add to mempool for inclusion in next block
                             if let Err(e) = node.submit_transaction(tx) {
                                 debug!("Failed to add network transaction to mempool: {}", e);
                             } else {
+                                // Seed the consensus tx cache so the SCP
+                                // validity_fn lookup succeeds when a peer
+                                // nominates the value for this transfer tx.
+                                // Without this, peers fail validity ("Transaction
+                                // not in cache") and SCP silently drops the
+                                // nominate/ballot messages, so quorum can never
+                                // form on a set containing the transfer and the
+                                // chain halts (issue #449). This mirrors the
+                                // minting path's register_minting_tx (#409). The
+                                // mempool acceptance above is the validity gate:
+                                // it performs full structural + UTXO + signature
+                                // checks, so we only cache validated bytes.
+                                consensus.register_transfer_tx(tx_hash, tx_bytes);
+
                                 // Broadcast transaction and mempool update to WebSocket clients
                                 ws_broadcaster.new_transaction(&tx_hash, tx_fee, None);
                                 if let Ok(mempool) = node.shared_mempool().read() {
@@ -1557,6 +1575,7 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                 // and submit them to consensus
                 for tx in node.get_pending_transactions(10) {
                     let tx_hash = tx.hash();
+                    let tx_fee = tx.fee;
                     let tx_bytes = bincode::serialize(&tx)
                         .expect("Failed to serialize transaction");
 
@@ -1565,8 +1584,11 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                         debug!("Failed to broadcast transaction: {}", e);
                     }
 
-                    // Submit to consensus for ordering
-                    consensus.submit_transaction(tx_hash, tx_bytes);
+                    // Submit to consensus for ordering. The fee is threaded
+                    // through as the deterministic consensus-value priority
+                    // (issue #449) so the same tx maps to the same value on
+                    // every node and SCP nomination converges.
+                    consensus.submit_transaction(tx_hash, tx_fee, tx_bytes);
                 }
             }
 

--- a/botho/src/consensus/block_builder.rs
+++ b/botho/src/consensus/block_builder.rs
@@ -414,7 +414,7 @@ mod tests {
 
     #[test]
     fn test_build_from_externalized_no_minting_tx() {
-        let values = vec![ConsensusValue::from_transaction([1u8; 32])];
+        let values = vec![ConsensusValue::from_transaction([1u8; 32], 0)];
 
         let result = BlockBuilder::build_from_externalized(&values, |_| None, |_| None);
 

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -291,16 +291,33 @@ impl ConsensusService {
             // Only keep the best minting tx (one coinbase per block)
             minting_txs.truncate(1);
 
-            // Sort regular txs by priority (fee), then hash for determinism
+            // Sort regular txs by priority (fee), then hash for determinism.
+            // This is the SELECTION ordering (higher-fee txs are preferred); the
+            // resulting block tx order is decided later by the block builder.
             regular_txs.sort_by(|a, b| {
                 b.priority
                     .cmp(&a.priority)
                     .then_with(|| a.tx_hash.cmp(&b.tx_hash))
             });
 
-            // Combine: best minting tx first, then regular txs
+            // Combine the selected coinbase with the regular txs.
             let mut combined = minting_txs;
             combined.extend(regular_txs);
+
+            // BALLOT INVARIANT (issue #449): SCP wraps this output directly into
+            // a `Ballot` and `Msg::validate()` REQUIRES the ballot's values to be
+            // STRICTLY ascending per `ConsensusValue::Ord` (see
+            // `Ballot::is_values_sorted`). The fee/priority selection ordering
+            // above is NOT the `Ord` ordering (a coinbase's random PoW-derived
+            // tx_hash can sort before or after a transfer), so a block containing
+            // BOTH a coinbase and a transfer would violate the invariant and
+            // panic SCP's outgoing-message validation — exactly what halted any
+            // multi-value block. Re-sort by the canonical `Ord` and dedup so the
+            // ballot is always valid. (Minting-only blocks have a single value
+            // and were never affected, which is why this latent bug only
+            // surfaced once transfer txs reached the slot.)
+            combined.sort();
+            combined.dedup();
             Ok(combined)
         });
 
@@ -583,9 +600,13 @@ impl ConsensusService {
         self.scp_node.current_slot_index()
     }
 
-    /// Submit a transaction for consensus
-    pub fn submit_transaction(&mut self, tx_hash: [u8; 32], tx_data: Vec<u8>) {
-        let value = ConsensusValue::from_transaction(tx_hash);
+    /// Submit a transaction for consensus.
+    ///
+    /// `fee` is threaded through as the deterministic consensus-value priority
+    /// (issue #449): it must be identical on every node for the same tx so the
+    /// value identity converges in SCP nomination.
+    pub fn submit_transaction(&mut self, tx_hash: [u8; 32], fee: u64, tx_data: Vec<u8>) {
+        let value = ConsensusValue::from_transaction(tx_hash, fee);
 
         // Add to shared cache for validation callback
         if let Ok(mut state) = self.shared_state.write() {
@@ -635,6 +656,29 @@ impl ConsensusService {
             state.tx_cache.entry(tx_hash).or_insert(TxCacheEntry {
                 data: tx_data,
                 is_minting_tx: true,
+            });
+        }
+    }
+
+    /// Register a transfer (regular) transaction received from a peer into the
+    /// validation cache, without adding it to our own pending/proposed set.
+    ///
+    /// This is the transfer-tx parallel of [`Self::register_minting_tx`] (issue
+    /// #449). SCP messages only carry a value's `tx_hash`; the validity_fn does
+    /// a HARD `tx_cache` lookup before any structural check. When a peer
+    /// nominates a value for a transfer tx, every node in the quorum must have
+    /// the raw tx bytes cached or the SCP slot rejects the peer's message
+    /// ("Transaction not in cache") and nomination never reaches quorum — which
+    /// halted the chain the instant a transfer entered the mempool. Seeding the
+    /// cache on receipt lets the local SCP node accept the peer's
+    /// nominate/ballot votes so balloting can begin. The caller gates this
+    /// on intrinsic (tip-agnostic) structural validity, mirroring the
+    /// minting path.
+    pub fn register_transfer_tx(&mut self, tx_hash: [u8; 32], tx_data: Vec<u8>) {
+        if let Ok(mut state) = self.shared_state.write() {
+            state.tx_cache.entry(tx_hash).or_insert(TxCacheEntry {
+                data: tx_data,
+                is_minting_tx: false,
             });
         }
     }
@@ -1585,7 +1629,7 @@ mod tests {
         let mut svc = solo_service();
 
         // Drive a solo round: submit a tx and externalize it directly.
-        svc.submit_transaction([7u8; 32], vec![1, 2, 3]);
+        svc.submit_transaction([7u8; 32], 0, vec![1, 2, 3]);
         svc.propose_pending_values();
         assert!(
             svc.externalized.is_some(),
@@ -1622,7 +1666,7 @@ mod tests {
             solo.should_propose_this_round(),
             "min_peers==0 node must always be eligible to mint solo"
         );
-        solo.submit_transaction([7u8; 32], vec![1, 2, 3]);
+        solo.submit_transaction([7u8; 32], 0, vec![1, 2, 3]);
         solo.propose_pending_values();
         assert!(
             solo.externalized.is_some(),
@@ -1637,7 +1681,7 @@ mod tests {
             !gated.should_propose_this_round(),
             "node expecting peers must not mint while solo (pre-quorum)"
         );
-        gated.submit_transaction([8u8; 32], vec![4, 5, 6]);
+        gated.submit_transaction([8u8; 32], 0, vec![4, 5, 6]);
         gated.propose_pending_values();
         assert!(
             gated.externalized.is_none(),
@@ -1852,7 +1896,7 @@ mod tests {
                 },
             );
         }
-        let value = ConsensusValue::from_transaction(tx_hash);
+        let value = ConsensusValue::from_transaction(tx_hash, tx.fee);
 
         // Feed an inbound peer message directly into the SCP node so its
         // `current_slot` accumulates peer-driven nominate/ballot state.
@@ -2131,6 +2175,172 @@ mod tests {
             chosen == a_tx.hash() || chosen == b_tx.hash(),
             "externalized minting tx must be one of the two proposed coinbases"
         );
+    }
+
+    /// Issue #449 regression (THE load-bearing test): two real
+    /// `ConsensusService` instances in a 2-of-2 quorum must converge on and
+    /// externalize a block CONTAINING a regular TRANSFER tx, with both
+    /// nodes agreeing.
+    ///
+    /// This exercises the production transfer path end-to-end:
+    ///   - node A `submit_transaction(hash, fee, bytes)` (local-submit path)
+    ///   - node B `register_transfer_tx(hash, bytes)` (peer-gossip path)
+    /// plus each node proposing the SAME coinbase (a block needs a minting tx).
+    ///
+    /// PRE-FIX this FAILS for two compounding reasons:
+    ///   (A) `from_transaction` used `SystemTime::now()` → A and B built
+    ///       NON-EQUAL `ConsensusValue`s for the same tx, so nomination could
+    ///       never converge on a shared set; and
+    ///   (B) there was no `register_transfer_tx`, so B's validity_fn lookup
+    ///       ("Transaction not in cache") rejected A's nominate carrying the
+    ///       transfer value and SCP silently dropped it.
+    /// POST-FIX the value identity is deterministic (priority = fee) and the
+    /// peer cache is seeded, so the transfer value survives federated voting
+    /// and both nodes externalize an identical set containing it.
+    #[test]
+    fn two_nodes_externalize_block_containing_transfer_tx() {
+        let cfg = ConsensusConfig::fixed_timing(0);
+        let qs = recommended_quorum(&[1, 2]);
+
+        let mut a = ConsensusService::new(node(1), qs.clone(), cfg.clone(), genesis_chain_state());
+        let mut b = ConsensusService::new(node(2), qs, cfg, genesis_chain_state());
+
+        assert!(
+            !a.is_solo_mode() && !b.is_solo_mode(),
+            "must be a 2-node quorum"
+        );
+
+        // A block needs a coinbase; both nodes propose the SAME minting tx so the
+        // combiner has an unambiguous coinbase and the test isolates the transfer
+        // path.
+        let prev = [0u8; 32];
+        let coinbase = intrinsic_valid_minting_tx(1, prev, 1);
+        submit_and_register(&mut a, &mut b, &coinbase);
+        submit_and_register(&mut b, &mut a, &coinbase);
+
+        // A real, structurally valid transfer tx enters consensus via the
+        // production path:
+        //   - it originates at node A (a wallet send / faucet payout) and A submits it
+        //     locally (`submit_transaction`);
+        //   - node B receives it via gossip and seeds its consensus cache
+        //     (`register_transfer_tx`, the #449 fix) so B's SCP validity_fn can
+        //     validate A's nominate referencing the transfer value;
+        //   - B then pulls it from its own mempool and submits it too (every mining
+        //     node includes mempool txs), so a 2-of-2 quorum nominates it.
+        // The value identity must be IDENTICAL across nodes for nomination to
+        // converge — that is the deterministic-priority half of the fix.
+        let transfer = valid_transfer_tx();
+        let transfer_hash = [0xABu8; 32]; // stable hash placeholder for the value
+        let transfer_bytes = bincode::serialize(&transfer).expect("serialize transfer");
+        a.submit_transaction(transfer_hash, transfer.fee, transfer_bytes.clone());
+        b.register_transfer_tx(transfer_hash, transfer_bytes.clone());
+        b.submit_transaction(transfer_hash, transfer.fee, transfer_bytes);
+
+        // Sanity: both nodes built the SAME consensus value for the transfer
+        // (deterministic identity). Pre-fix (SystemTime::now()) this could differ.
+        let a_val = ConsensusValue::from_transaction(transfer_hash, transfer.fee);
+        let b_val = ConsensusValue::from_transaction(transfer_hash, transfer.fee);
+        assert_eq!(
+            a_val, b_val,
+            "transfer value identity must be deterministic"
+        );
+
+        let (a_ext, b_ext) = run_two_services(&mut a, &mut b, 4000);
+
+        let a_vals = a_ext.expect("node A never externalized (consensus stalled on transfer)");
+        let b_vals = b_ext.expect("node B never externalized (consensus stalled on transfer)");
+
+        assert_eq!(
+            a_vals, b_vals,
+            "the two nodes externalized DIFFERENT value sets (no agreement)"
+        );
+
+        // The externalized block must CONTAIN the transfer tx, as EXACTLY ONE
+        // transfer value. Pre-fix (non-deterministic priority) A and B build
+        // DIFFERENT ConsensusValues for the same tx_hash, so either nomination
+        // never converges (no externalize at all) or two distinct values for the
+        // same tx leak into the set — both caught here.
+        let transfers: Vec<_> = a_vals.iter().filter(|v| !v.is_minting_tx).collect();
+        assert_eq!(
+            transfers.len(),
+            1,
+            "externalized set must contain EXACTLY ONE transfer value; got {:?}",
+            a_vals
+        );
+        assert_eq!(
+            transfers[0].tx_hash, transfer_hash,
+            "the externalized transfer value must reference the submitted tx"
+        );
+        assert_eq!(
+            transfers[0].priority, transfer.fee,
+            "transfer value priority must be the deterministic fee (issue #449)"
+        );
+
+        // And exactly one coinbase.
+        let minting: Vec<_> = a_vals.iter().filter(|v| v.is_minting_tx).collect();
+        assert_eq!(minting.len(), 1, "exactly one coinbase per block");
+        assert_eq!(minting[0].tx_hash, coinbase.hash());
+    }
+
+    /// Issue #449 Defect B: a peer's SCP nominate carrying a TRANSFER value is
+    /// only accepted into the local SCP slot if the transfer tx is in our
+    /// consensus cache. The SCP validity_fn does a HARD cache lookup first
+    /// ("Transaction not in cache"); if it fails, `scp_node.handle_message`
+    /// rejects the peer's message and the slot never picks up the peer's
+    /// nominate/ballot state — quorum can't form. `register_transfer_tx` (the
+    /// peer-gossip seed) is what makes that lookup succeed.
+    ///
+    /// This isolates the cache-registration half of the fix: WITHOUT register,
+    /// the peer message is rejected and the slot stays idle; WITH register, the
+    /// peer message is accepted and the slot becomes peer-populated.
+    #[test]
+    fn register_transfer_tx_enables_peer_nominate_acceptance() {
+        let slot_qs = recommended_quorum(&[1, 2]);
+        let tx = valid_transfer_tx();
+        let tx_bytes = bincode::serialize(&tx).expect("tx serializes");
+        let tx_hash = [0x5Au8; 32];
+        let value = ConsensusValue::from_transaction(tx_hash, tx.fee);
+
+        // (a) WITHOUT registering the transfer tx, the peer's nominate carrying
+        // the transfer value is rejected by the validity_fn ("not in cache"),
+        // so the SCP slot stays idle.
+        {
+            let mut svc = peered_service(&[1, 2]);
+            let slot = svc.scp_node.current_slot_index();
+            let peer_msg = peer_nominate_prepare(node(2), slot_qs.clone(), slot, value);
+            // The message is dropped at the validity gate; the slot must not pick
+            // up any peer nominate state.
+            let _ = svc.scp_node.handle_message(&peer_msg);
+            let m = svc.scp_node.get_current_slot_metrics();
+            assert_eq!(
+                (m.num_voted_nominated, m.num_accepted_nominated),
+                (0, 0),
+                "without register_transfer_tx the peer's transfer nominate must be \
+                 rejected (validity: not in cache) and leave the slot idle"
+            );
+        }
+
+        // (b) WITH register_transfer_tx seeding the cache, the same peer nominate
+        // is accepted and the slot becomes peer-populated.
+        {
+            let mut svc = peered_service(&[1, 2]);
+            let slot = svc.scp_node.current_slot_index();
+            svc.register_transfer_tx(tx_hash, tx_bytes);
+            let peer_msg = peer_nominate_prepare(node(2), slot_qs, slot, value);
+            svc.scp_node
+                .handle_message(&peer_msg)
+                .expect("peer message must be accepted once the tx is in the cache");
+            let m = svc.scp_node.get_current_slot_metrics();
+            let active = m.num_voted_nominated > 0
+                || m.num_accepted_nominated > 0
+                || m.bN > 0
+                || m.phase != ScpPhase::NominatePrepare;
+            assert!(
+                active,
+                "with register_transfer_tx the peer's transfer nominate must be \
+                 accepted and make the slot peer-populated"
+            );
+        }
     }
 
     /// Finding 3: a node that catches up via block-sync must fast-forward its

--- a/botho/src/consensus/value.rs
+++ b/botho/src/consensus/value.rs
@@ -29,18 +29,26 @@ pub struct ConsensusValue {
 }
 
 impl ConsensusValue {
-    /// Create a new consensus value for a regular transaction
-    pub fn from_transaction(tx_hash: [u8; 32]) -> Self {
-        // Regular transactions have timestamp-based priority
-        let priority = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-
+    /// Create a new consensus value for a regular (transfer) transaction.
+    ///
+    /// SAFETY (issue #449): `priority` MUST be a pure, deterministic function
+    /// of the transaction so the same tx maps to the SAME `ConsensusValue`
+    /// on every node. `ConsensusValue` derives `Eq/Ord/Hash` over ALL
+    /// fields (incl. `priority`) and SCP nomination agrees on exact value
+    /// identity. The old implementation used `SystemTime::now()`, so the
+    /// same transfer tx became a DIFFERENT value on each node (and each
+    /// tick) and nomination could never converge — the multi-node chain
+    /// halted the instant a transfer entered the mempool. We use the
+    /// transaction `fee` as the priority: it is identical on all nodes for
+    /// the same tx and matches the combine_fn's documented "sort
+    /// regular txs by priority (fee)" ordering (higher-fee txs order first
+    /// within a block). This mirrors the minting path, which uses a
+    /// deterministic PoW hash as its priority (issue #419).
+    pub fn from_transaction(tx_hash: [u8; 32], fee: u64) -> Self {
         Self {
             tx_hash,
             is_minting_tx: false,
-            priority,
+            priority: fee,
         }
     }
 
@@ -96,8 +104,9 @@ mod tests {
 
     #[test]
     fn test_consensus_value_ordering() {
-        let v1 = ConsensusValue::from_transaction([1u8; 32]);
-        let v2 = ConsensusValue::from_transaction([2u8; 32]);
+        // Same fee/priority so ordering falls back to tx_hash.
+        let v1 = ConsensusValue::from_transaction([1u8; 32], 0);
+        let v2 = ConsensusValue::from_transaction([2u8; 32], 0);
 
         // Should be ordered by tx_hash
         assert!(v1 < v2);
@@ -106,7 +115,7 @@ mod tests {
     #[test]
     fn test_minting_vs_regular() {
         let minting = ConsensusValue::from_minting_tx([1u8; 32], 1000);
-        let regular = ConsensusValue::from_transaction([1u8; 32]);
+        let regular = ConsensusValue::from_transaction([1u8; 32], 1000);
 
         assert!(minting.is_minting_tx);
         assert!(!regular.is_minting_tx);
@@ -123,5 +132,29 @@ mod tests {
         let h1 = v.hash();
         let h2 = v.hash();
         assert_eq!(h1, h2);
+    }
+
+    /// Issue #449: the same transfer tx must map to the SAME `ConsensusValue`
+    /// regardless of when/where it is constructed. Previously `priority` came
+    /// from `SystemTime::now()`, so two constructions (or two nodes) produced
+    /// non-equal values and SCP nomination could never converge.
+    #[test]
+    fn test_from_transaction_deterministic() {
+        let tx_hash = [9u8; 32];
+        let fee = 4242;
+
+        let a = ConsensusValue::from_transaction(tx_hash, fee);
+        let b = ConsensusValue::from_transaction(tx_hash, fee);
+
+        // Identical value identity (Eq/Ord/Hash all over priority too).
+        assert_eq!(a, b);
+        assert_eq!(a.priority, fee);
+        assert_eq!(a.hash(), b.hash());
+
+        // A different fee yields a different value (priority participates in
+        // identity), so two distinct submissions of the SAME tx_hash with
+        // different fees do not silently collide.
+        let c = ConsensusValue::from_transaction(tx_hash, fee + 1);
+        assert_ne!(a, c);
     }
 }


### PR DESCRIPTION
Closes #449

## Problem
The multi-node chain HALTED the instant a regular (non-coinbase) transfer tx entered the mempool. Coinbase-only slots externalized fine; any pending transfer froze SCP nomination (reproduced live: frozen at h32, mempoolSize=1). This blocked ALL payments (faucet payouts, sends) — the testnet could mine but not transact. This is the transfer-tx parallel of the minting-convergence work (#409/#419), which the transfer path never received.

## Root cause — two compounding defects (both localized)

**Defect A — non-deterministic value identity.** `ConsensusValue::from_transaction` set `priority = SystemTime::now().as_secs()`. `ConsensusValue` derives `Eq/Ord/Hash` over ALL fields incl. `priority`, and SCP nomination agrees on exact value identity, so the same tx became a DIFFERENT value on each node (and each tick) and nomination could never converge. (Minting was immune: priority = deterministic PoW hash.)

**Defect B — no peer cache registration.** The SCP validity_fn does a HARD `tx_cache` lookup before structural checks. The `NewTransaction` peer handler routed received txs to the mempool ONLY, never seeding the consensus `tx_cache` (contrast `NewMintingTx` -> `register_minting_tx`). So peers failed validity ("Transaction not in cache") on any nominate carrying the transfer value and SCP silently dropped it.

## Fix (mirrors the minting path)
1. **`value.rs`** — `from_transaction(tx_hash, fee)` now uses the tx **`fee`** as a deterministic priority (identical on all nodes for the same tx; matches the combine_fn's documented "sort regular txs by fee" ordering). No more `SystemTime::now()`.
2. **`service.rs`** — added `register_transfer_tx(tx_hash, tx_bytes)` (mirrors `register_minting_tx`), and threaded `fee` through `submit_transaction(tx_hash, fee, tx_data)` (local submit already seeds the cache).
3. **`run.rs`** — the `NewTransaction` peer handler now calls `consensus.register_transfer_tx(...)` after the mempool accepts the tx (mempool acceptance is the structural/UTXO/signature validity gate), so every node seeds its cache. Local submit path threads `tx.fee`.
4. **`service.rs` combine_fn (latent bug surfaced by the first multi-value block)** — the combiner returned `[coinbase, ...regular]` in fee-selection order, but SCP wraps the output directly into a `Ballot` whose values MUST be strictly ascending per `ConsensusValue::Ord` (`Ballot::is_values_sorted`). A block containing BOTH a coinbase and a transfer therefore panicked SCP's outgoing-message validation non-deterministically (depending on the coinbase's PoW-derived hash). The combined output is now `sort()` + `dedup()` by `Ord`. Minting-only blocks (single value) were never affected, which is why this only surfaced with transfers. Block tx ordering is decided downstream by the block builder, so this is a pure ballot-invariant normalization (validity unchanged).

## Tests (fail pre-fix, pass post-fix — verified by temporarily reverting each defect)
- `value::tests::test_from_transaction_deterministic` — same `(tx_hash, fee)` -> same value.
- `service::tests::two_nodes_externalize_block_containing_transfer_tx` — **the load-bearing one**: two real `ConsensusService` instances each get a transfer tx via the production path (`submit_transaction` + peer `register_transfer_tx`) and externalize a block CONTAINING the transfer, both agreeing (exactly one transfer value + one coinbase). Pre-fix this panics in nomination ("ballot values not sorted" / value churn) and never externalizes the transfer.
- `service::tests::register_transfer_tx_enables_peer_nominate_acceptance` — isolates Defect B: a peer's transfer nominate is rejected ("not in cache") without `register_transfer_tx` and accepted with it.

## Results
- `cargo test -p botho` — lib **995 passed**, 0 failed (the new externalize test verified stable across repeated runs).
- `cargo test -p bth-consensus-scp` — **100 passed**, 0 failed.
- `cargo build --release -p botho` / `cargo fmt` clean.
- Pre-existing, UNRELATED doctest failures in `network/privacy/{capacity,selection}.rs` (`RelayCapacity::measure` doesn't exist) are present on clean `origin/main` (829ba5e) and untouched here.

## Live verification (post-merge)
Consensus-relevant: needs a fresh-genesis redeploy to fully take effect on the live testnet. The faucet->balance->send->recipient flow should be confirmed after merge + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)