### PR TITLE
fix(consensus): make transfer-tx SCP validity tip-agnostic; height-staleness at build+apply (#451)

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 444
-# Branch: feature/issue-444
+# Issue: 451
+# Branch: feature/issue-451
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/botho/src/consensus/block_builder.rs
+++ b/botho/src/consensus/block_builder.rs
@@ -21,6 +21,29 @@ use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use tracing::{debug, info, warn};
 
+/// Maximum age (in blocks) of a transfer transaction relative to the height of
+/// the block that includes it.
+///
+/// A transfer tx whose `created_at_height + MAX_TX_AGE < block_height` is
+/// considered stale and is excluded at block-build (and rejected at block-apply
+/// as a deterministic backstop).
+///
+/// This staleness rule used to live in the SCP transfer-validity function
+/// (`validate_transfer_tx`) and was evaluated against each node's *local
+/// current tip*. Because two honest nodes can be at different tips while
+/// nominating the same value, that made transfer-tx validity tip-dependent — a
+/// value valid for one honest node could be silently dropped as
+/// `StaleTransaction` by another, the #417-class asymmetric-validity fork
+/// condition (issue #451).
+///
+/// The fix keeps block-height as the staleness metric (NOT wall-clock — no
+/// timezone/leap-second/clock-skew dependence) but evaluates it against the
+/// height of the block being built/applied. Every honest node assembles and
+/// applies block N at the same height N, so the check is deterministic and
+/// cannot fork. Defining it once here (used by both build and apply) guarantees
+/// the two paths agree exactly.
+pub const MAX_TX_AGE: u64 = 100;
+
 /// Result of building a block from externalized values
 #[derive(Debug)]
 pub struct BuiltBlock {
@@ -78,6 +101,12 @@ impl BlockBuilder {
             "Building block from externalized minting tx"
         );
 
+        // The block's own height. Staleness is evaluated against THIS height
+        // (deterministic across all honest nodes), never against any node's
+        // local current tip — that tip-dependence was the #417-class fork risk
+        // removed from the SCP validity gate in issue #451.
+        let block_height = minting_tx.block_height;
+
         // Collect transfer transactions with key image deduplication
         // This is a defense-in-depth measure to prevent double-spend attacks where
         // two transactions with the same key image somehow both made it to consensus
@@ -88,6 +117,25 @@ impl BlockBuilder {
         for value in &transfer_values {
             match get_transfer_tx(&value.tx_hash) {
                 Some(tx) => {
+                    // Height-based staleness filter (issue #451). Exclude any
+                    // transfer tx that is too old relative to THIS block's
+                    // height. Filtering here (rather than rejecting after
+                    // externalize) guarantees the built block always applies
+                    // cleanly: a block we build never contains a stale tx, so
+                    // the apply-time backstop never fires for our own blocks
+                    // (no externalize-then-reject halt — the #449/#421 failure
+                    // mode).
+                    if tx.created_at_height + MAX_TX_AGE < block_height {
+                        warn!(
+                            tx_hash = hex::encode(&value.tx_hash[0..8]),
+                            created_at_height = tx.created_at_height,
+                            block_height,
+                            "Skipping stale transfer tx in block (created_at_height + \
+                             MAX_TX_AGE < block_height)"
+                        );
+                        continue;
+                    }
+
                     // Check for duplicate key images (defense in depth)
                     let mut has_duplicate = false;
                     for input in tx.inputs.clsag() {
@@ -419,6 +467,72 @@ mod tests {
         let result = BlockBuilder::build_from_externalized(&values, |_| None, |_| None);
 
         assert!(matches!(result, Err(BlockBuildError::NoMintingTx)));
+    }
+
+    /// Issue #451 (Test B, build side): a block built at height H must EXCLUDE
+    /// any transfer tx whose `created_at_height + MAX_TX_AGE < H`. Filtering at
+    /// build time (against the block's own height, deterministic across nodes)
+    /// keeps staleness enforced without the tip-dependence that caused the
+    /// #417-class fork, and guarantees the built block always applies cleanly
+    /// (no externalize-then-reject halt).
+    #[test]
+    fn test_build_excludes_stale_transfer_tx() {
+        use crate::transaction::TxInputs;
+
+        let block_height = 200u64;
+
+        // Fresh tx: created_at_height + MAX_TX_AGE >= block_height (kept).
+        let fresh = Transaction {
+            inputs: TxInputs::new(vec![]),
+            outputs: vec![],
+            fee: 0,
+            created_at_height: block_height - MAX_TX_AGE, // exactly on the boundary, kept
+        };
+        // Stale tx: created_at_height + MAX_TX_AGE < block_height (filtered).
+        let stale = Transaction {
+            inputs: TxInputs::new(vec![]),
+            outputs: vec![],
+            fee: 0,
+            created_at_height: block_height - MAX_TX_AGE - 1,
+        };
+        let fresh_hash = fresh.hash();
+        let stale_hash = stale.hash();
+
+        let values = vec![
+            ConsensusValue::from_minting_tx([9u8; 32], 0),
+            ConsensusValue::from_transaction(fresh_hash, 0),
+            ConsensusValue::from_transaction(stale_hash, 0),
+        ];
+
+        let minting_tx = mock_minting_tx(block_height);
+        let get_minting = |_: &[u8; 32]| Some(minting_tx.clone());
+        let get_transfer = move |h: &[u8; 32]| {
+            if *h == fresh_hash {
+                Some(fresh.clone())
+            } else if *h == stale_hash {
+                Some(stale.clone())
+            } else {
+                None
+            }
+        };
+
+        let built = BlockBuilder::build_from_externalized(&values, get_minting, get_transfer)
+            .expect("build should succeed");
+
+        assert_eq!(
+            built.block.transactions.len(),
+            1,
+            "stale transfer tx must be filtered out at build"
+        );
+        assert_eq!(
+            built.block.transactions[0].created_at_height,
+            block_height - MAX_TX_AGE,
+            "only the fresh tx (on the boundary) should remain"
+        );
+        assert!(
+            !built.transfer_tx_hashes.contains(&stale_hash),
+            "stale tx hash must not be recorded in the built block"
+        );
     }
 
     // ========================================================================

--- a/botho/src/consensus/mod.rs
+++ b/botho/src/consensus/mod.rs
@@ -16,7 +16,7 @@ mod service;
 mod validation;
 mod value;
 
-pub use block_builder::{BlockBuildError, BlockBuilder, BuiltBlock};
+pub use block_builder::{BlockBuildError, BlockBuilder, BuiltBlock, MAX_TX_AGE};
 pub use lottery::{
     draw_lottery_winners, split_fees, utxo_to_candidate, validate_block_lottery,
     verify_lottery_result, BlockLotteryResult, LotteryFeeConfig, LotteryStats,

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -254,8 +254,12 @@ impl ConsensusService {
                 })?;
 
                 // Create a temporary validator for the (tip-agnostic) check.
-                // The chain_state is only used by the transfer-tx structural
-                // path; the minting-tx path is fully tip-agnostic.
+                // BOTH the minting-tx and transfer-tx intrinsic paths are now
+                // fully tip-agnostic (issue #451 removed the transfer staleness
+                // check that read the local tip), so `validate_from_bytes_intrinsic`
+                // never reads `chain_state`. The clone below is retained only
+                // because `TransactionValidator::new` requires a chain-state
+                // handle for its non-intrinsic (gossip/apply) methods.
                 let temp_state = Arc::new(RwLock::new(state.chain_state.clone()));
                 let temp_validator = TransactionValidator::new(temp_state);
 

--- a/botho/src/consensus/validation.rs
+++ b/botho/src/consensus/validation.rs
@@ -306,19 +306,41 @@ impl TransactionValidator {
         Ok(())
     }
 
-    /// Validate a transfer transaction (structure only for now)
+    /// Validate a transfer transaction's INTRINSIC (tip-agnostic) structure.
     ///
-    /// Full UTXO validation requires access to the UTXO set, which
-    /// will be integrated when we add the mempool.
+    /// SAFETY / no-fork invariant: this function is the SCP consensus validity
+    /// gate for transfer values (via
+    /// [`validate_from_bytes_intrinsic`](Self::validate_from_bytes_intrinsic)).
+    /// SCP's agreement (no-fork) theorem requires validity to be a *pure
+    /// function of the value*: a value valid for one honest node must be valid
+    /// for all honest nodes. SCP silently DROPS any peer message carrying a
+    /// value the local node cannot validate, so a tip-dependent check here can
+    /// partition the quorum (issue #451; the same #417/#419 condition the
+    /// minting `*_intrinsic` split fixed).
+    ///
+    /// Therefore the only checks here are ones every honest node agrees on
+    /// regardless of which tip it currently holds:
+    /// - inputs are non-empty,
+    /// - outputs are non-empty,
+    /// - no output has a zero amount.
+    ///
+    /// The former tip-relative staleness check (`created_at_height + MAX_TX_AGE
+    /// < state.height`, removed in #451) is NOT performed here, because
+    /// `state.height` is the local tip and two honest nodes straddling the
+    /// boundary would disagree on validity. Stale-tx handling now lives where
+    /// it cannot fork or halt the chain:
+    /// - the mempool evicts old txs by wall-clock (`mempool.rs`
+    ///   `MAX_TX_AGE_SECS`, ~1h), so stale txs are never proposed as values;
+    /// - full UTXO existence / double-spend / signature checks happen at
+    ///   mempool-admission and block-apply time, which have ledger access.
+    ///
+    /// This is a pure function of the transaction; it does NOT read
+    /// `chain_state`.
     pub fn validate_transfer_tx(&self, tx: &Transaction) -> Result<(), ValidationError> {
-        let state = self
-            .chain_state
-            .read()
-            .map_err(|_| ValidationError::ChainStateUnavailable)?;
+        debug!("Validating transfer transaction (intrinsic / tip-agnostic)");
 
-        debug!("Validating transfer transaction");
-
-        // 1. Check structure
+        // Structural well-formedness only. These are properties of the value
+        // itself, so all honest nodes agree on them regardless of tip.
         if tx.inputs.is_empty() {
             return Err(ValidationError::NoInputs);
         }
@@ -329,21 +351,15 @@ impl TransactionValidator {
             return Err(ValidationError::ZeroAmountOutput);
         }
 
-        // 2. Check transaction is not stale
-        // Allow transactions from recent blocks (within 100 blocks)
-        const MAX_TX_AGE: u64 = 100;
-        if tx.created_at_height + MAX_TX_AGE < state.height {
-            return Err(ValidationError::StaleTransaction);
-        }
-
-        // 3. UTXO existence and signature verification
-        // Note: Full UTXO and signature validation happens in mempool.add_tx()
-        // which has ledger access. The mempool verifies:
+        // UTXO existence, double-spend, and signature verification are NOT done
+        // here. They happen in mempool.add_tx() and at block-apply, which have
+        // ledger access and verify:
         // - UTXO existence in ledger
         // - Signature validity against UTXO target_key
         // - Input sum >= output sum + fee
+        // - No double-spend (key-image uniqueness)
 
-        debug!("Transfer transaction validated successfully");
+        debug!("Transfer transaction passed intrinsic validation");
         Ok(())
     }
 
@@ -482,9 +498,13 @@ impl TransactionValidator {
     /// [`validate_minting_tx_intrinsic`](Self::validate_minting_tx_intrinsic),
     /// dropping the tip-equality checks so that a peer's competing-but-valid
     /// minting value is never silently dropped by SCP (issue #419 / #417
-    /// Finding 1). For transfer txs the existing structural validation is
-    /// already effectively intrinsic enough for the consensus-value gate
-    /// (full UTXO/signature validation happens at mempool/apply time).
+    /// Finding 1). For transfer txs this delegates to
+    /// [`validate_transfer_tx`](Self::validate_transfer_tx), which is now also
+    /// fully tip-agnostic — its former `state.height` staleness check was
+    /// removed in issue #451 so a transfer value valid for one honest node is
+    /// valid for all (full UTXO/double-spend/signature validation happens at
+    /// mempool/apply time; stale txs are evicted by the mempool's wall-clock
+    /// age limit so they are never proposed as values).
     pub fn validate_from_bytes_intrinsic(
         &self,
         tx_bytes: &[u8],
@@ -543,8 +563,12 @@ mod tests {
     use bth_transaction_types::ClusterTagVector;
 
     fn mock_chain_state() -> Arc<RwLock<ChainState>> {
+        mock_chain_state_at(10)
+    }
+
+    fn mock_chain_state_at(height: u64) -> Arc<RwLock<ChainState>> {
         Arc::new(RwLock::new(ChainState {
-            height: 10,
+            height,
             tip_hash: [0u8; 32],
             tip_timestamp: 1000000,
             difficulty: 1000,
@@ -629,6 +653,75 @@ mod tests {
         let tx = Transaction::new_clsag(vec![], vec![test_output(1000, 1)], MIN_TX_FEE, 10);
         let result = validator.validate_transfer_tx(&tx);
         assert!(matches!(result, Err(ValidationError::NoInputs)));
+    }
+
+    /// Issue #451 regression: the SCP transfer-tx validity gate
+    /// (`validate_transfer_tx`) MUST be tip-agnostic.
+    ///
+    /// Two honest nodes at DIFFERENT heights straddling the old
+    /// `created_at_height + MAX_TX_AGE` (100-block) boundary must AGREE on
+    /// transfer-tx validity. With the old tip-dependent staleness check a tx
+    /// created at height 10 validated at local height 10 but was dropped as
+    /// `StaleTransaction` at local height 111 (10 + 100 + 1) — the #417-class
+    /// asymmetric-validity fork condition. After the fix, validity is a pure
+    /// function of the value and the result is identical regardless of tip.
+    #[test]
+    fn test_transfer_tx_validity_is_tip_agnostic() {
+        // A well-formed transfer tx created at height 10.
+        let tx = Transaction::new_clsag(
+            vec![test_clsag_input(1)],
+            vec![test_output(1000, 1)],
+            MIN_TX_FEE,
+            10, // created_at_height
+        );
+
+        // Node A: local tip at the creation height (well within the old window).
+        let validator_low = TransactionValidator::new(mock_chain_state_at(10));
+        let result_low = validator_low.validate_transfer_tx(&tx);
+
+        // Node B: local tip far past the old 100-block staleness boundary
+        // (10 + 100 + 1 = 111). Under the OLD check this returned
+        // StaleTransaction; both nodes must now agree.
+        let validator_high = TransactionValidator::new(mock_chain_state_at(111));
+        let result_high = validator_high.validate_transfer_tx(&tx);
+
+        assert!(
+            result_low.is_ok(),
+            "tx must be valid at the creation-height tip: {result_low:?}"
+        );
+        assert!(
+            result_high.is_ok(),
+            "tx must remain valid past the old staleness boundary (no asymmetric \
+             drop / no #417-class fork): {result_high:?}"
+        );
+        assert_eq!(
+            result_low.is_ok(),
+            result_high.is_ok(),
+            "transfer-tx validity must be identical regardless of local tip height"
+        );
+    }
+
+    /// The intrinsic SCP path must yield the same result regardless of tip,
+    /// even when invoked through `validate_from_bytes_intrinsic` (the exact
+    /// entry point SCP's validity_fn uses).
+    #[test]
+    fn test_transfer_tx_intrinsic_path_tip_agnostic() {
+        let tx = Transaction::new_clsag(
+            vec![test_clsag_input(2)],
+            vec![test_output(500, 2)],
+            MIN_TX_FEE,
+            5, // created_at_height
+        );
+        let bytes = bincode::serialize(&tx).expect("serialize tx");
+
+        let low = TransactionValidator::new(mock_chain_state_at(5));
+        let high = TransactionValidator::new(mock_chain_state_at(5 + 100 + 50));
+
+        let r_low = low.validate_from_bytes_intrinsic(&bytes, false);
+        let r_high = high.validate_from_bytes_intrinsic(&bytes, false);
+
+        assert!(r_low.is_ok(), "intrinsic validity at low tip: {r_low:?}");
+        assert!(r_high.is_ok(), "intrinsic validity at high tip: {r_high:?}");
     }
 
     #[test]

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info, warn};
 use super::{ChainState, LedgerError};
 use crate::{
     block::{calculate_block_reward, Block},
-    consensus::{validate_block_lottery, LotteryFeeConfig},
+    consensus::{validate_block_lottery, LotteryFeeConfig, MAX_TX_AGE},
     decoy_selection::{DecoySelectionError, GammaDecoySelector, OutputCandidate},
     transaction::{RingMember, Transaction as BothoTransaction, TxOutput, Utxo, UtxoId},
 };
@@ -22,6 +22,27 @@ use crate::{
 /// Matches the bound enforced on minting transactions in the SCP proposal
 /// path (`consensus::validation::MAX_FUTURE_TIMESTAMP_SECS`).
 const MAX_FUTURE_TIMESTAMP_SECS: u64 = 2 * 60 * 60;
+
+/// Deterministic height-based staleness backstop (issue #451).
+///
+/// Returns the index of the first transfer tx in `block` that is too old
+/// relative to the block's OWN height (`created_at_height + MAX_TX_AGE <
+/// block.height()`), or `None` if all transfer txs are fresh enough.
+///
+/// This mirrors the staleness rule that the SCP transfer-validity gate used to
+/// enforce against the local *current tip* (removed in #451 because tip-
+/// dependence is the #417-class fork condition). Evaluated against the block's
+/// own height — identical on every honest node applying block N — it is
+/// deterministic and cannot diverge across nodes. Honest block-builders filter
+/// these out at build time, so this is a defense-in-depth check that never
+/// fires for blocks we build (no externalize-then-reject halt).
+fn first_stale_transfer_tx(block: &Block) -> Option<usize> {
+    let block_height = block.height();
+    block
+        .transactions
+        .iter()
+        .position(|tx| tx.created_at_height + MAX_TX_AGE < block_height)
+}
 
 /// LMDB-backed ledger storage using heed
 pub struct Ledger {
@@ -502,6 +523,31 @@ impl Ledger {
             return Err(LedgerError::InvalidBlock(
                 "Block tx_root does not match transactions".to_string(),
             ));
+        }
+
+        // C5 (issue #451): Deterministic height-based staleness backstop.
+        //
+        // Reject any block that contains a transfer tx that is too old relative
+        // to the block's OWN height. This mirrors the staleness rule that the
+        // SCP transfer-validity gate used to enforce against the local *current
+        // tip* (`validate_transfer_tx`, removed in #451 because tip-dependence
+        // is the #417-class fork condition). Evaluated against `block.height()`
+        // — which is identical on every honest node applying block N — this
+        // check is deterministic and cannot diverge across nodes.
+        //
+        // Honest block-builders already filter these out at build time
+        // (`BlockBuilder::build_from_externalized`), so this is defense-in-depth
+        // against a malformed/adversarial block, not the primary gate (it never
+        // fires for blocks we build → no externalize-then-reject halt).
+        if let Some(tx_idx) = first_stale_transfer_tx(block) {
+            let tx = &block.transactions[tx_idx];
+            return Err(LedgerError::InvalidBlock(format!(
+                "Transaction {} is stale: created_at_height {} + MAX_TX_AGE {} < block height {}",
+                tx_idx,
+                tx.created_at_height,
+                MAX_TX_AGE,
+                block.height()
+            )));
         }
 
         // C3: Resolve every ring member against the UTXO set.
@@ -2253,6 +2299,71 @@ mod tests {
     use super::*;
     use bth_transaction_types::ClusterTagVector;
     use tempfile::tempdir;
+
+    /// Issue #451 (Test B, apply side): the deterministic backstop must flag a
+    /// block containing a transfer tx that is too old relative to the block's
+    /// OWN height, and must accept one that is exactly on the boundary. The
+    /// check is purely a function of (created_at_height, block.height()), so it
+    /// is identical on every node applying block N — no tip-dependence, no
+    /// fork.
+    #[test]
+    fn test_first_stale_transfer_tx_backstop() {
+        use crate::{
+            consensus::{BlockBuilder, MAX_TX_AGE},
+            transaction::{Transaction, TxInputs},
+        };
+
+        let block_height = 500u64;
+
+        let mk_tx = |created_at_height: u64| Transaction {
+            inputs: TxInputs::new(vec![]),
+            outputs: vec![],
+            fee: 0,
+            created_at_height,
+        };
+
+        // mock_minting_tx-equivalent: build_direct sets header.height from the
+        // minting tx's block_height.
+        let minting = crate::block::MintingTx {
+            block_height,
+            reward: 0,
+            minter_view_key: [1u8; 32],
+            minter_spend_key: [2u8; 32],
+            target_key: [3u8; 32],
+            public_key: [4u8; 32],
+            prev_block_hash: [0u8; 32],
+            difficulty: 1000,
+            nonce: 0,
+            timestamp: 1000,
+        };
+
+        // All fresh: boundary tx (created_at_height + MAX_TX_AGE == height) is
+        // NOT stale.
+        let fresh_block = BlockBuilder::build_direct(
+            minting.clone(),
+            vec![mk_tx(block_height - MAX_TX_AGE), mk_tx(block_height)],
+        );
+        assert_eq!(fresh_block.height(), block_height);
+        assert_eq!(
+            first_stale_transfer_tx(&fresh_block),
+            None,
+            "boundary/fresh transfer txs must not be flagged stale"
+        );
+
+        // Contains a stale tx (created_at_height + MAX_TX_AGE < height) at idx 1.
+        let stale_block = BlockBuilder::build_direct(
+            minting,
+            vec![
+                mk_tx(block_height - MAX_TX_AGE),
+                mk_tx(block_height - MAX_TX_AGE - 1),
+            ],
+        );
+        assert_eq!(
+            first_stale_transfer_tx(&stale_block),
+            Some(1),
+            "a transfer tx older than MAX_TX_AGE relative to block height must be flagged"
+        );
+    }
 
     #[test]
     fn test_ledger_open_and_genesis() {


### PR DESCRIPTION
Closes #451

## Problem
The SCP validity gate for **transfer** txs (`validate_transfer_tx`, reached via the validity_fn → `validate_from_bytes_intrinsic`) read each node's **local current tip** (`state.height`) to enforce a 100-block staleness window:

```rust
if tx.created_at_height + MAX_TX_AGE < state.height { return Err(StaleTransaction); }
```

Two honest nodes straddling `created_at_height + 100` disagree on validity → asymmetric validity → **#417-class fork** (reachable since #449/#450 route transfers through federated SCP voting). The bug is not the use of block height (correct, deterministic metric — kept) but evaluating it against the **local current tip during nomination**.

## Fix — keep height-based staleness, move it from tip-dependent nomination to deterministic build/apply

1. **`validate_transfer_tx` is now purely intrinsic** — structure only, **no `chain_state`/tip read**. Validity is a pure function of the tx ⇒ "valid for one honest node iff valid for all" (the no-fork invariant the minting `*_intrinsic` split established in #419/#417). Verified: the transfer SCP-validity path (`validity_fn` → `validate_from_bytes_intrinsic` → `validate_transfer_tx`) has no remaining tip/state-dependent read; the `tx_cache` lookup is content-addressed.

2. **Block-build filter** (`BlockBuilder::build_from_externalized`): drop any transfer tx where `created_at_height + MAX_TX_AGE < block_height`, using the **block's own height** (deterministic across nodes). So an externalized block never contains a too-old tx and always applies cleanly — **no externalize-then-reject halt** (#449/#421 failure mode).

3. **Block-apply backstop** (`LedgerStore::add_block` via `first_stale_transfer_tx`): reject a block containing a transfer tx older than `MAX_TX_AGE` relative to `block.height()`. Deterministic defense-in-depth (mirrors #420 moving minting tip-equality checks to apply-time). Never fires for blocks honest builders produce.

`MAX_TX_AGE = 100` is now a single shared const (`consensus::MAX_TX_AGE`), used by both build and apply so they agree exactly.

The mempool's wall-clock `MAX_TX_AGE_SECS` is left unchanged (mempool memory hygiene, not the consensus rule).

## Why correct (honors "block height > wall-clock")
- Block height stays the staleness metric (no clock-skew/timezone/leap-second dependence).
- Fork risk came from evaluating staleness against the **local current tip** during nomination; evaluating against the **block's own height** at build/apply is deterministic → no fork.
- Building with stale txs filtered → externalized block is always apply-valid → no halt.

## Tests
- `test_transfer_tx_validity_is_tip_agnostic` / `test_transfer_tx_intrinsic_path_tip_agnostic` (Test A): validity_fn returns the SAME result at tip 10 and tip 111 for a tx created at height 10. **Fail-pre** (old code rejected it as `StaleTransaction` once local tip passes `created_at_height+100`); **pass-post** (tip-independent).
- `test_build_excludes_stale_transfer_tx` (Test B, build): block built at H=200 excludes a tx with `created_at_height = H-101`, keeps the boundary tx (`H-100`).
- `test_first_stale_transfer_tx_backstop` (Test B, apply): backstop flags the stale tx, accepts the boundary tx.

## Results
- `cargo test -p botho --lib`: 999 passed, 0 failed.
- `cargo test -p bth-consensus-scp`: 100 passed, 0 failed.
- `cargo build --release -p botho`: clean. `cargo fmt`/clippy clean on touched files.
- Pre-existing failures: 2 `network/privacy` doctests fail on a clean `origin/main` too — unrelated to this change.

## Files touched
- `botho/src/consensus/validation.rs` — `validate_transfer_tx` made tip-agnostic (drop `state.height` read) + Test A.
- `botho/src/consensus/block_builder.rs` — shared `pub const MAX_TX_AGE`, build-time staleness filter + Test B (build).
- `botho/src/consensus/mod.rs` — export `MAX_TX_AGE`.
- `botho/src/consensus/service.rs` — validity_fn doc/SAFETY note (now fully tip-agnostic).
- `botho/src/ledger/store.rs` — `first_stale_transfer_tx` apply backstop + Test B (apply).

## Deployment
This is a consensus-validity change (the SCP transfer-validity gate and block accept rules change). A **testnet redeploy is recommended** so all nodes run the tip-agnostic gate consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)