### PR TITLE
feat(web-wallet): 3-node SCP ingress picker + Cloudflare Pages PWA deploy config

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 451
-# Branch: feature/issue-451
+# Issue: 456
+# Branch: feature/issue-456
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/web/packages/web-wallet/package.json
+++ b/web/packages/web-wallet/package.json
@@ -6,8 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:wasm": "pnpm --filter @botho/wasm-signer build:wasm",
+    "build:all": "pnpm build:wasm && pnpm build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "deploy": "pnpm build && wrangler pages deploy dist --project-name=botho-wallet",
+    "deploy:all": "pnpm build:all && wrangler pages deploy dist --project-name=botho-wallet"
   },
   "dependencies": {
     "@botho/adapters": "workspace:*",
@@ -31,6 +35,7 @@
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
     "vite": "^7.2.4",
-    "vite-plugin-pwa": "^1.2.0"
+    "vite-plugin-pwa": "^1.2.0",
+    "wrangler": "^4.59.1"
   }
 }

--- a/web/packages/web-wallet/src/components/NetworkSelector.tsx
+++ b/web/packages/web-wallet/src/components/NetworkSelector.tsx
@@ -36,11 +36,16 @@ export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
     setCustomEndpoint,
     isValidating,
     validationError,
+    startHealthPolling,
   } = useNetwork()
   const [isOpen, setIsOpen] = useState(false)
   const [showCustomInput, setShowCustomInput] = useState(false)
   const [customEndpoint, setCustomEndpointInput] = useState('')
   const dropdownRef = useRef<HTMLDivElement>(null)
+
+  // Poll node health while the selector is mounted (wallet/explorer pages).
+  // The landing page does not render the selector, so it makes no node calls.
+  useEffect(() => startHealthPolling(), [startHealthPolling])
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/web/packages/web-wallet/src/components/NetworkSelector.tsx
+++ b/web/packages/web-wallet/src/components/NetworkSelector.tsx
@@ -1,15 +1,42 @@
 import { useState, useRef, useEffect } from 'react'
 import { Button, Input } from '@botho/ui'
-import { ChevronDown, Globe, Check, Loader2, AlertCircle, X } from 'lucide-react'
+import { ChevronDown, Server, Check, Loader2, AlertCircle, X } from 'lucide-react'
 import { useNetwork } from '../contexts/network'
+import type { NodeHealth } from '../config/networks'
 
 interface NetworkSelectorProps {
   /** Additional CSS classes */
   className?: string
 }
 
+/** Small colored dot + label describing a node's health. */
+function HealthDot({ health }: { health: NodeHealth | undefined }) {
+  const status = health?.status ?? 'checking'
+  const color =
+    status === 'online' ? 'bg-success' : status === 'offline' ? 'bg-danger' : 'bg-ghost'
+  return <div className={`w-2 h-2 rounded-full shrink-0 ${color}`} />
+}
+
+/** One-line health summary text for a node. */
+function healthLabel(health: NodeHealth | undefined): string {
+  if (!health || health.status === 'checking') return 'Checking…'
+  if (health.status === 'offline') return 'Unreachable'
+  const h = health.chainHeight != null ? `height ${health.chainHeight}` : 'online'
+  const sync = health.synced ? 'synced' : `${Math.round(health.syncProgress ?? 0)}%`
+  return `${h} · ${sync}`
+}
+
 export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
-  const { network, availableNetworks, switchNetwork, setCustomEndpoint, isValidating, validationError } = useNetwork()
+  const {
+    network,
+    ingressId,
+    ingressNodes,
+    nodeHealth,
+    selectIngress,
+    setCustomEndpoint,
+    isValidating,
+    validationError,
+  } = useNetwork()
   const [isOpen, setIsOpen] = useState(false)
   const [showCustomInput, setShowCustomInput] = useState(false)
   const [customEndpoint, setCustomEndpointInput] = useState('')
@@ -28,14 +55,10 @@ export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  const handleNetworkSelect = (networkId: string) => {
-    if (networkId === 'custom') {
-      setShowCustomInput(true)
-    } else {
-      switchNetwork(networkId)
-      setIsOpen(false)
-      setShowCustomInput(false)
-    }
+  const handleSelect = (nodeId: string) => {
+    selectIngress(nodeId)
+    setIsOpen(false)
+    setShowCustomInput(false)
   }
 
   const handleCustomSubmit = async () => {
@@ -58,6 +81,10 @@ export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
     }
   }
 
+  // Label shown on the trigger button: the selected ingress node's name.
+  const selectedNode = ingressNodes.find((n) => n.id === ingressId)
+  const triggerLabel = selectedNode?.name ?? (ingressId === 'custom' ? 'Custom RPC' : 'Node')
+
   return (
     <div className={`relative ${className}`} ref={dropdownRef}>
       <Button
@@ -66,8 +93,8 @@ export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
         onClick={() => setIsOpen(!isOpen)}
         className="gap-2"
       >
-        <Globe size={14} />
-        <span className="hidden sm:inline">{network.name}</span>
+        <Server size={14} />
+        <span className="hidden sm:inline max-w-[10rem] truncate">{triggerLabel}</span>
         {network.isTestnet && (
           <span className="px-1.5 py-0.5 text-xs rounded bg-warning/20 text-warning">
             Testnet
@@ -77,44 +104,57 @@ export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
       </Button>
 
       {isOpen && (
-        <div className="absolute right-0 mt-2 w-64 rounded-lg bg-abyss border border-steel shadow-lg z-50 overflow-hidden">
+        <div className="absolute right-0 mt-2 w-72 rounded-lg bg-abyss border border-steel shadow-lg z-50 overflow-hidden">
           <div className="p-2 border-b border-steel">
-            <span className="text-xs text-ghost uppercase tracking-wide px-2">Select Network</span>
+            <span className="text-xs text-ghost uppercase tracking-wide px-2">
+              Trusted RPC ingress
+            </span>
           </div>
 
           <div className="py-1">
-            {availableNetworks.map((net) => (
-              <button
-                key={net.id}
-                onClick={() => handleNetworkSelect(net.id)}
-                className={`w-full px-3 py-2 flex items-center gap-3 hover:bg-steel/50 transition-colors ${
-                  network.id === net.id ? 'bg-steel/30' : ''
-                }`}
-              >
-                <div className={`w-2 h-2 rounded-full ${net.isTestnet ? 'bg-warning' : 'bg-success'}`} />
-                <div className="flex-1 text-left">
-                  <div className="text-sm text-light">{net.name}</div>
-                  <div className="text-xs text-ghost truncate">{net.rpcEndpoint}</div>
-                </div>
-                {network.id === net.id && <Check size={16} className="text-pulse" />}
-              </button>
-            ))}
+            {ingressNodes.map((node) => {
+              const health = nodeHealth[node.id]
+              const selected = ingressId === node.id
+              return (
+                <button
+                  key={node.id}
+                  onClick={() => handleSelect(node.id)}
+                  className={`w-full px-3 py-2 flex items-center gap-3 hover:bg-steel/50 transition-colors ${
+                    selected ? 'bg-steel/30' : ''
+                  }`}
+                >
+                  <HealthDot health={health} />
+                  <div className="flex-1 text-left min-w-0">
+                    <div className="text-sm text-light flex items-center gap-2">
+                      {node.name}
+                      {node.servesFaucet && (
+                        <span className="px-1 py-0.5 text-[10px] rounded bg-pulse/15 text-pulse">
+                          faucet
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-ghost truncate">{healthLabel(health)}</div>
+                  </div>
+                  {selected && <Check size={16} className="text-pulse shrink-0" />}
+                </button>
+              )
+            })}
 
             {/* Custom endpoint option */}
             <button
-              onClick={() => handleNetworkSelect('custom')}
+              onClick={() => setShowCustomInput((v) => !v)}
               className={`w-full px-3 py-2 flex items-center gap-3 hover:bg-steel/50 transition-colors ${
-                network.id === 'custom' ? 'bg-steel/30' : ''
+                ingressId === 'custom' ? 'bg-steel/30' : ''
               }`}
             >
-              <div className="w-2 h-2 rounded-full bg-ghost" />
-              <div className="flex-1 text-left">
+              <div className="w-2 h-2 rounded-full bg-ghost shrink-0" />
+              <div className="flex-1 text-left min-w-0">
                 <div className="text-sm text-light">Custom RPC</div>
-                {network.id === 'custom' && (
+                {ingressId === 'custom' && (
                   <div className="text-xs text-ghost truncate">{network.rpcEndpoint}</div>
                 )}
               </div>
-              {network.id === 'custom' && <Check size={16} className="text-pulse" />}
+              {ingressId === 'custom' && <Check size={16} className="text-pulse shrink-0" />}
             </button>
           </div>
 
@@ -124,7 +164,7 @@ export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
               <div className="flex gap-2">
                 <Input
                   type="url"
-                  placeholder="https://node.example.com"
+                  placeholder="https://node.example.com/rpc"
                   value={customEndpoint}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCustomEndpointInput(e.target.value)}
                   onKeyDown={handleKeyDown}
@@ -157,6 +197,12 @@ export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
               )}
             </div>
           )}
+
+          <div className="px-3 py-2 border-t border-steel">
+            <p className="text-[11px] text-ghost leading-snug">
+              Keys never leave your device. Faucet requests always use the faucet node.
+            </p>
+          </div>
         </div>
       )}
     </div>

--- a/web/packages/web-wallet/src/config/networks.ts
+++ b/web/packages/web-wallet/src/config/networks.ts
@@ -1,6 +1,12 @@
 /**
  * Network configuration for the Botho Web Wallet
- * Supports testnet, mainnet, and custom RPC endpoints
+ *
+ * The wallet talks to a single "ingress" node — the SCP node the user trusts to
+ * relay their RPC. The live testnet exposes three such nodes; the user picks
+ * WHICH one is their ingress (persisted in localStorage). All read/write RPC is
+ * routed to the selected ingress. Faucet RPC (`faucet_request` /
+ * `faucet_getStatus`) only lives on the faucet node, so it is pinned there
+ * regardless of which ingress is selected.
  */
 
 export interface NetworkConfig {
@@ -11,6 +17,22 @@ export interface NetworkConfig {
   explorerUrl?: string
   networkId: string
   isTestnet: boolean
+}
+
+/**
+ * One of the live SCP nodes the user can choose as their RPC ingress.
+ */
+export interface IngressNode {
+  /** Stable id, persisted in localStorage. */
+  id: string
+  /** Human-readable label shown in the picker. */
+  name: string
+  /** Short role description (validator / faucet node). */
+  role: string
+  /** Absolute JSON-RPC endpoint (https://host/rpc). */
+  rpcEndpoint: string
+  /** Whether this node also serves the faucet RPC. */
+  servesFaucet: boolean
 }
 
 /**
@@ -28,21 +50,79 @@ function getEnvFaucetEndpoint(): string | undefined {
 }
 
 /**
- * Predefined network configurations
+ * The live testnet SCP nodes the user can select as their trusted ingress.
+ *
+ * Each is a real validator/faucet node with CORS enabled for browser access.
+ * `seed2` is a second validator — kept in the list so the picker always offers
+ * three SCP ingress options; its health check surfaces reachability so users
+ * can see when it is down (e.g. no public DNS/TLS) before selecting it.
  */
-export const NETWORKS: Record<string, NetworkConfig> = {
-  testnet: {
-    id: 'testnet',
+export const INGRESS_NODES: IngressNode[] = [
+  {
+    id: 'seed',
+    name: 'Seed (validator)',
+    role: 'Primary SCP validator',
+    rpcEndpoint: 'https://seed.botho.io/rpc',
+    servesFaucet: false,
+  },
+  {
+    id: 'seed2',
+    name: 'Seed 2 (validator)',
+    role: 'Secondary SCP validator',
+    rpcEndpoint: 'https://seed2.botho.io/rpc',
+    servesFaucet: false,
+  },
+  {
+    id: 'faucet',
+    name: 'Faucet node',
+    role: 'SCP validator + faucet',
+    rpcEndpoint: 'https://faucet.botho.io/rpc',
+    servesFaucet: true,
+  },
+]
+
+/** The endpoint that serves faucet RPC, pinned regardless of ingress choice. */
+export const FAUCET_ENDPOINT =
+  getEnvFaucetEndpoint() ||
+  INGRESS_NODES.find((n) => n.servesFaucet)?.rpcEndpoint ||
+  'https://faucet.botho.io/rpc'
+
+/** Default ingress node id when none is persisted. */
+export const DEFAULT_INGRESS_ID = 'seed'
+
+/** Find an ingress node by id. */
+export function getIngressNode(id: string): IngressNode | undefined {
+  return INGRESS_NODES.find((n) => n.id === id)
+}
+
+/**
+ * Build the effective NetworkConfig for a given ingress node.
+ *
+ * The selected ingress supplies the read/write RPC endpoint; the faucet endpoint
+ * is always pinned to the faucet node. When `VITE_RPC_ENDPOINT` is set (e2e /
+ * same-origin-proxy builds) it overrides the ingress endpoint so the hermetic
+ * test harness keeps working.
+ */
+export function networkForIngress(ingress: IngressNode): NetworkConfig {
+  return {
+    id: `testnet:${ingress.id}`,
     name: 'Testnet',
-    // Read RPC is served by the seed node at https://seed.botho.io/rpc
-    // (CORS-enabled via infra/seed/seed-nginx.conf). The faucet endpoint is a
-    // separate deployment used only for faucet_request / faucet_getStatus.
-    rpcEndpoint: getEnvRpcEndpoint() || 'https://seed.botho.io/rpc',
-    faucetEndpoint: getEnvFaucetEndpoint() || 'https://faucet.botho.io/rpc',
+    rpcEndpoint: getEnvRpcEndpoint() || ingress.rpcEndpoint,
+    faucetEndpoint: FAUCET_ENDPOINT,
     explorerUrl: 'https://botho.io/explorer',
     networkId: 'botho-testnet',
     isTestnet: true,
-  },
+  }
+}
+
+/**
+ * Predefined network configurations.
+ *
+ * Kept for backwards compatibility (the explorer / wallet read `NETWORKS` and
+ * `DEFAULT_NETWORK_ID`). `testnet` resolves to the default ingress node.
+ */
+export const NETWORKS: Record<string, NetworkConfig> = {
+  testnet: networkForIngress(getIngressNode(DEFAULT_INGRESS_ID) || INGRESS_NODES[0]),
 }
 
 /**
@@ -72,15 +152,29 @@ export function createCustomNetwork(rpcEndpoint: string, name?: string): Network
     id: 'custom',
     name: name || 'Custom',
     rpcEndpoint,
+    faucetEndpoint: FAUCET_ENDPOINT,
     networkId: 'botho-custom',
     isTestnet: false,
   }
 }
 
+/** Health snapshot for an ingress node, from `node_getStatus`. */
+export interface NodeHealth {
+  /** 'online' if node_getStatus succeeded, 'offline' on error/timeout. */
+  status: 'online' | 'offline' | 'checking'
+  /** Current chain height (when online). */
+  chainHeight?: number
+  /** Whether the node reports itself synced. */
+  synced?: boolean
+  /** Sync progress percentage (0-100). */
+  syncProgress?: number
+}
+
 /**
- * Validate that an RPC endpoint is reachable
+ * Query a node's health via `node_getStatus`. Never throws — returns an
+ * 'offline' snapshot on any network/timeout/RPC error.
  */
-export async function validateRpcEndpoint(endpoint: string): Promise<boolean> {
+export async function fetchNodeHealth(endpoint: string): Promise<NodeHealth> {
   try {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 5000)
@@ -98,20 +192,67 @@ export async function validateRpcEndpoint(endpoint: string): Promise<boolean> {
     })
 
     clearTimeout(timeoutId)
-    return response.ok
+    if (!response.ok) return { status: 'offline' }
+
+    const json = (await response.json()) as {
+      result?: { chainHeight?: number; synced?: boolean; syncProgress?: number }
+      error?: unknown
+    }
+    if (json.error || !json.result) return { status: 'offline' }
+
+    return {
+      status: 'online',
+      chainHeight: json.result.chainHeight,
+      synced: json.result.synced,
+      syncProgress: json.result.syncProgress,
+    }
   } catch {
-    return false
+    return { status: 'offline' }
   }
 }
 
 /**
- * Storage key for persisted network selection
+ * Validate that an RPC endpoint is reachable
  */
+export async function validateRpcEndpoint(endpoint: string): Promise<boolean> {
+  const health = await fetchNodeHealth(endpoint)
+  return health.status === 'online'
+}
+
+/**
+ * Storage key for persisted ingress / network selection
+ */
+const INGRESS_STORAGE_KEY = 'botho_selected_ingress'
 const NETWORK_STORAGE_KEY = 'botho_selected_network'
 const CUSTOM_ENDPOINT_KEY = 'botho_custom_endpoint'
 
 /**
- * Save selected network to localStorage
+ * Save selected ingress node to localStorage.
+ */
+export function saveSelectedIngress(ingressId: string): void {
+  try {
+    localStorage.setItem(INGRESS_STORAGE_KEY, ingressId)
+    // Keep the legacy network key consistent so older reads stay valid.
+    localStorage.setItem(NETWORK_STORAGE_KEY, DEFAULT_NETWORK_ID)
+    localStorage.removeItem(CUSTOM_ENDPOINT_KEY)
+  } catch {
+    // localStorage may not be available
+  }
+}
+
+/**
+ * Load the selected ingress node id from localStorage.
+ */
+export function loadSelectedIngress(): string {
+  try {
+    return localStorage.getItem(INGRESS_STORAGE_KEY) || DEFAULT_INGRESS_ID
+  } catch {
+    return DEFAULT_INGRESS_ID
+  }
+}
+
+/**
+ * Save selected network to localStorage (legacy custom-endpoint path).
  */
 export function saveSelectedNetwork(networkId: string, customEndpoint?: string): void {
   try {
@@ -127,7 +268,7 @@ export function saveSelectedNetwork(networkId: string, customEndpoint?: string):
 }
 
 /**
- * Load selected network from localStorage
+ * Load selected network from localStorage (legacy custom-endpoint path).
  */
 export function loadSelectedNetwork(): { networkId: string; customEndpoint?: string } {
   try {

--- a/web/packages/web-wallet/src/contexts/network.tsx
+++ b/web/packages/web-wallet/src/contexts/network.tsx
@@ -54,6 +54,12 @@ interface NetworkContextValue extends NetworkState {
   ingressNodes: IngressNode[]
   /** Re-run the health checks for every ingress node. */
   refreshHealth: () => void
+  /**
+   * Begin polling node health. Returns an unsubscribe fn; polling stops once
+   * the last subscriber unsubscribes. Call from components that show health
+   * (the NetworkSelector) so the landing page makes no node calls.
+   */
+  startHealthPolling: () => () => void
 }
 
 const NetworkContext = createContext<NetworkContextValue | null>(null)
@@ -104,7 +110,15 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
   }, [state.network])
 
   // Poll each ingress node's health via node_getStatus.
+  //
+  // Polling is started on demand (see `startHealthPolling`) rather than on
+  // mount: the landing page does not render the node picker and must not reach
+  // out to the SCP nodes (an unreachable node would otherwise emit a console
+  // network error on every page). The NetworkSelector starts polling while it
+  // is mounted (wallet/explorer pages) and stops on unmount.
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const pollSubscribers = useRef(0)
+
   const runHealthChecks = useCallback(() => {
     for (const node of INGRESS_NODES) {
       fetchNodeHealth(node.rpcEndpoint).then((health) => {
@@ -116,11 +130,18 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
-  useEffect(() => {
-    runHealthChecks()
-    pollTimerRef.current = setInterval(runHealthChecks, HEALTH_POLL_INTERVAL)
+  const startHealthPolling = useCallback((): (() => void) => {
+    pollSubscribers.current += 1
+    if (pollSubscribers.current === 1) {
+      runHealthChecks()
+      pollTimerRef.current = setInterval(runHealthChecks, HEALTH_POLL_INTERVAL)
+    }
     return () => {
-      if (pollTimerRef.current) clearInterval(pollTimerRef.current)
+      pollSubscribers.current = Math.max(0, pollSubscribers.current - 1)
+      if (pollSubscribers.current === 0 && pollTimerRef.current) {
+        clearInterval(pollTimerRef.current)
+        pollTimerRef.current = null
+      }
     }
   }, [runHealthChecks])
 
@@ -201,6 +222,7 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
         availableNetworks: Object.values(NETWORKS),
         ingressNodes: INGRESS_NODES,
         refreshHealth: runHealthChecks,
+        startHealthPolling,
       }}
     >
       {children}

--- a/web/packages/web-wallet/src/contexts/network.tsx
+++ b/web/packages/web-wallet/src/contexts/network.tsx
@@ -4,61 +4,94 @@ import {
   useState,
   useCallback,
   useEffect,
+  useRef,
   type ReactNode,
 } from 'react'
 import {
   type NetworkConfig,
+  type IngressNode,
+  type NodeHealth,
   NETWORKS,
+  INGRESS_NODES,
   DEFAULT_NETWORK_ID,
+  DEFAULT_INGRESS_ID,
   createCustomNetwork,
+  networkForIngress,
+  getIngressNode,
   saveSelectedNetwork,
+  saveSelectedIngress,
+  loadSelectedIngress,
   loadSelectedNetwork,
   validateRpcEndpoint,
+  fetchNodeHealth,
 } from '../config/networks'
 
 interface NetworkState {
-  /** Currently selected network */
+  /** Currently selected network (derived from the selected ingress node). */
   network: NetworkConfig
+  /** Id of the selected ingress node (or 'custom'). */
+  ingressId: string
   /** Whether we're validating a custom endpoint */
   isValidating: boolean
   /** Validation error message */
   validationError: string | null
   /** Whether the network has a faucet available */
   hasFaucet: boolean
+  /** Per-ingress-node health snapshots, keyed by ingress id. */
+  nodeHealth: Record<string, NodeHealth>
 }
 
 interface NetworkContextValue extends NetworkState {
-  /** Switch to a different network */
+  /** Pick which SCP node is the trusted RPC ingress. */
+  selectIngress: (ingressId: string) => void
+  /** Switch to a different network (legacy; maps testnet -> default ingress). */
   switchNetwork: (networkId: string) => void
   /** Set a custom RPC endpoint */
   setCustomEndpoint: (endpoint: string) => Promise<boolean>
   /** Get all available networks */
   availableNetworks: NetworkConfig[]
+  /** The selectable ingress nodes. */
+  ingressNodes: IngressNode[]
+  /** Re-run the health checks for every ingress node. */
+  refreshHealth: () => void
 }
 
 const NetworkContext = createContext<NetworkContextValue | null>(null)
 
-/**
- * Get initial network configuration
- */
-function getInitialNetwork(): NetworkConfig {
-  const { networkId, customEndpoint } = loadSelectedNetwork()
+/** Health is re-polled on this cadence (ms). */
+const HEALTH_POLL_INTERVAL = 20_000
 
+/**
+ * Get initial network configuration from the persisted ingress selection
+ * (falling back to the legacy custom-endpoint path).
+ */
+function getInitialNetwork(): { network: NetworkConfig; ingressId: string } {
+  const { networkId, customEndpoint } = loadSelectedNetwork()
   if (networkId === 'custom' && customEndpoint) {
-    return createCustomNetwork(customEndpoint)
+    return { network: createCustomNetwork(customEndpoint), ingressId: 'custom' }
   }
 
-  return NETWORKS[networkId] || NETWORKS[DEFAULT_NETWORK_ID]
+  const ingressId = loadSelectedIngress()
+  const ingress = getIngressNode(ingressId)
+  if (ingress) {
+    return { network: networkForIngress(ingress), ingressId: ingress.id }
+  }
+
+  return { network: NETWORKS[DEFAULT_NETWORK_ID], ingressId: DEFAULT_INGRESS_ID }
 }
 
 export function NetworkProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<NetworkState>(() => {
-    const network = getInitialNetwork()
+    const { network, ingressId } = getInitialNetwork()
+    const nodeHealth: Record<string, NodeHealth> = {}
+    for (const n of INGRESS_NODES) nodeHealth[n.id] = { status: 'checking' }
     return {
       network,
+      ingressId,
       isValidating: false,
       validationError: null,
       hasFaucet: !!network.faucetEndpoint,
+      nodeHealth,
     }
   })
 
@@ -70,21 +103,50 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
     }))
   }, [state.network])
 
-  const switchNetwork = useCallback((networkId: string) => {
-    const network = NETWORKS[networkId]
-    if (!network) {
-      console.error(`Unknown network: ${networkId}`)
+  // Poll each ingress node's health via node_getStatus.
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const runHealthChecks = useCallback(() => {
+    for (const node of INGRESS_NODES) {
+      fetchNodeHealth(node.rpcEndpoint).then((health) => {
+        setState((s) => ({
+          ...s,
+          nodeHealth: { ...s.nodeHealth, [node.id]: health },
+        }))
+      })
+    }
+  }, [])
+
+  useEffect(() => {
+    runHealthChecks()
+    pollTimerRef.current = setInterval(runHealthChecks, HEALTH_POLL_INTERVAL)
+    return () => {
+      if (pollTimerRef.current) clearInterval(pollTimerRef.current)
+    }
+  }, [runHealthChecks])
+
+  const selectIngress = useCallback((ingressId: string) => {
+    const ingress = getIngressNode(ingressId)
+    if (!ingress) {
+      console.error(`Unknown ingress node: ${ingressId}`)
       return
     }
-
-    saveSelectedNetwork(networkId)
-    setState({
+    saveSelectedIngress(ingressId)
+    const network = networkForIngress(ingress)
+    setState((s) => ({
+      ...s,
       network,
+      ingressId,
       isValidating: false,
       validationError: null,
       hasFaucet: !!network.faucetEndpoint,
-    })
+    }))
   }, [])
+
+  const switchNetwork = useCallback((networkId: string) => {
+    // Legacy entry point: any non-custom network maps to the default ingress.
+    if (networkId === 'custom') return
+    selectIngress(DEFAULT_INGRESS_ID)
+  }, [selectIngress])
 
   const setCustomEndpoint = useCallback(async (endpoint: string): Promise<boolean> => {
     setState(s => ({
@@ -109,12 +171,14 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
       const network = createCustomNetwork(endpoint)
       saveSelectedNetwork('custom', endpoint)
 
-      setState({
+      setState(s => ({
+        ...s,
         network,
+        ingressId: 'custom',
         isValidating: false,
         validationError: null,
-        hasFaucet: false,
-      })
+        hasFaucet: !!network.faucetEndpoint,
+      }))
 
       return true
     } catch (err) {
@@ -131,9 +195,12 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
     <NetworkContext.Provider
       value={{
         ...state,
+        selectIngress,
         switchNetwork,
         setCustomEndpoint,
         availableNetworks: Object.values(NETWORKS),
+        ingressNodes: INGRESS_NODES,
+        refreshHealth: runHealthChecks,
       }}
     >
       {children}

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -11,7 +11,7 @@ import { RemoteNodeAdapter, type WsConnectionStatus } from '@botho/adapters'
 import { AddressBook, saveWallet, loadWallet, getWalletInfo, deriveAddress, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet } from '@botho/core'
 import type { Balance, Contact, NodeInfo, Transaction } from '@botho/core'
 import { buildSendTransaction, spendableBalance } from '@botho/wasm-signer'
-import { type NetworkConfig, loadSelectedNetwork, NETWORKS, DEFAULT_NETWORK_ID, createCustomNetwork } from '../config/networks'
+import { type NetworkConfig, loadSelectedNetwork, loadSelectedIngress, NETWORKS, DEFAULT_NETWORK_ID, DEFAULT_INGRESS_ID, createCustomNetwork, networkForIngress, getIngressNode } from '../config/networks'
 
 interface WalletState {
   // Connection
@@ -147,7 +147,13 @@ function getInitialNetwork(): NetworkConfig {
     return createCustomNetwork(customEndpoint)
   }
 
-  return NETWORKS[networkId] || NETWORKS[DEFAULT_NETWORK_ID]
+  // Route the adapter to the user's selected SCP ingress node on first load.
+  const ingress = getIngressNode(loadSelectedIngress())
+  if (ingress) {
+    return networkForIngress(ingress)
+  }
+
+  return NETWORKS[networkId] || NETWORKS[DEFAULT_NETWORK_ID] || NETWORKS[DEFAULT_INGRESS_ID]
 }
 
 export function WalletProvider({ children }: { children: ReactNode }) {

--- a/web/packages/web-wallet/wrangler.toml
+++ b/web/packages/web-wallet/wrangler.toml
@@ -1,0 +1,12 @@
+# Cloudflare Pages configuration for the Botho web wallet (mobile PWA).
+#
+# Deploy with:
+#   pnpm --filter @botho/web-wallet deploy
+# which runs `wrangler pages deploy dist --project-name=botho-wallet`.
+#
+# Requires CLOUDFLARE_API_TOKEN with the "Cloudflare Pages: Edit" permission.
+name = "botho-wallet"
+compatibility_date = "2024-01-01"
+
+# Pages serves the built SPA from dist/ (Vite build output).
+pages_build_output_dir = "dist"

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       vite-plugin-pwa:
         specifier: ^1.2.0
         version: 1.2.0(vite@7.3.0(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
+      wrangler:
+        specifier: ^4.59.1
+        version: 4.103.0
 
 packages:
 
@@ -825,6 +828,53 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260617.1':
+    resolution: {integrity: sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260617.1':
+    resolution: {integrity: sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260617.1':
+    resolution: {integrity: sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260617.1':
+    resolution: {integrity: sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260617.1':
+    resolution: {integrity: sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
     engines: {node: '>=18'}
@@ -857,8 +907,17 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -869,8 +928,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm@0.27.2':
     resolution: {integrity: sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -881,8 +952,20 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -893,8 +976,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -905,8 +1000,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -917,8 +1024,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -929,8 +1048,20 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -941,8 +1072,20 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -953,8 +1096,20 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.2':
     resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -965,8 +1120,20 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.2':
     resolution: {integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -977,8 +1144,20 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.27.2':
     resolution: {integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -989,8 +1168,20 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1001,14 +1192,32 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.2':
     resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1036,6 +1245,159 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
@@ -1068,6 +1430,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
@@ -1084,6 +1449,15 @@ packages:
     resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1552,6 +1926,13 @@ packages:
   '@scure/bip39@2.0.1':
     resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.17':
+    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1994,6 +2375,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -2224,6 +2608,9 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
     engines: {node: '>= 0.4'}
@@ -2253,6 +2640,11 @@ packages:
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2657,6 +3049,10 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -2920,6 +3316,11 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  miniflare@4.20260617.1:
+    resolution: {integrity: sha512-Go3/gzStm99QHptsSgU+q1S+xDfLoRgwjJNY80kaTVi0ENhTyqKq+sc4xZiWBSbM7uUcJwmzm8+QFKtcYLJ9nw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
@@ -3001,6 +3402,9 @@ packages:
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3208,6 +3612,10 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3324,6 +3732,10 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3436,6 +3848,13 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -3686,6 +4105,21 @@ packages:
   workbox-window@7.4.0:
     resolution: {integrity: sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==}
 
+  workerd@1.20260617.1:
+    resolution: {integrity: sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.103.0:
+    resolution: {integrity: sha512-3Lv1P5t2xcSEkSTKtG+Lz+3JFryuU7YPLkaCUj7gNe+CJsjZJLtUwqsh1x595QBxkIbCE0GAvDx2DCJUU4+oqw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260617.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -3706,6 +4140,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -3715,6 +4161,12 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -4429,6 +4881,33 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260617.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260617.1
+
+  '@cloudflare/workerd-darwin-64@1.20260617.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260617.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260617.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260617.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260617.1':
+    optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -4451,82 +4930,165 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
     optional: true
 
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
     optional: true
 
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
   '@esbuild/linux-x64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@exodus/bytes@1.7.0': {}
@@ -4547,6 +5109,102 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -4587,6 +5245,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -4598,6 +5261,18 @@ snapshots:
   '@playwright/test@1.57.0':
     dependencies:
       playwright: 1.57.0
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -4984,6 +5659,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 2.0.1
       '@scure/base': 2.0.0
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.17': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5421,6 +6100,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  blake3-wasm@2.1.5: {}
+
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -5635,6 +6316,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  error-stack-parser-es@1.0.5: {}
+
   es-abstract@1.24.1:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -5743,6 +6426,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.2
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -6164,6 +6876,8 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonpointer@5.0.1: {}
+
+  kleur@4.1.5: {}
 
   leven@3.1.0: {}
 
@@ -6608,6 +7322,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  miniflare@4.20260617.1:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.28.0
+      workerd: 1.20260617.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.1.1:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
@@ -6683,6 +7409,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.4
       minipass: 7.1.2
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -6951,6 +7679,37 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.3
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -7097,6 +7856,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -7215,6 +7976,12 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@7.28.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -7539,6 +8306,30 @@ snapshots:
       '@types/trusted-types': 2.0.7
       workbox-core: 7.4.0
 
+  workerd@1.20260617.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260617.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260617.1
+      '@cloudflare/workerd-linux-64': 1.20260617.1
+      '@cloudflare/workerd-linux-arm64': 1.20260617.1
+      '@cloudflare/workerd-windows-64': 1.20260617.1
+
+  wrangler@4.103.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260617.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 4.20260617.1
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260617.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -7553,11 +8344,26 @@ snapshots:
 
   ws@8.18.3: {}
 
+  ws@8.21.0: {}
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.17
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zustand@4.5.7(@types/react@19.2.7)(react@19.2.3):
     dependencies:


### PR DESCRIPTION
## Summary
Ships `web/packages/web-wallet` as a deployable mobile PWA modeled on
`../once-around/apps/web`. Adds a 3-node SCP ingress picker (the user chooses
which live testnet validator/faucet node relays their RPC), adds Cloudflare
Pages deploy config + scripts, and verifies the build, PWA assets, and the
faucet path against the live testnet. Reuses `@botho/wasm-signer` — keys never
leave the browser.

## Changes
- **3-node ingress picker** (`src/config/networks.ts`): model `INGRESS_NODES`
  (seed / seed2 / faucet), pin `FAUCET_ENDPOINT` to the faucet node regardless
  of ingress choice, add `fetchNodeHealth` (via `node_getStatus`) and ingress
  persistence in localStorage. Legacy custom-RPC + `NETWORKS` exports kept.
- **`src/contexts/network.tsx`**: `selectIngress` + on-demand per-node health
  polling (subscribed by the selector while mounted; the landing page makes no
  node calls).
- **`src/components/NetworkSelector.tsx`**: renders the 3 ingress nodes with
  live health dots (height/sync), a faucet badge, and keeps the Custom RPC
  option.
- **`src/contexts/wallet.tsx`**: routes the initial RPC adapter to the persisted
  ingress node.
- **Cloudflare Pages**: `wrangler.toml` (`pages_build_output_dir = "dist"`) +
  `deploy` / `deploy:all` / `build:wasm` scripts in package.json mirroring
  once-around (`wrangler pages deploy dist --project-name=botho-wallet`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Pick 1 of 3 SCP nodes; persists; routes RPC; node health shown | Done | `selectIngress` persists to localStorage; wallet adapter inits from selection; selector shows per-node `node_getStatus` health |
| Faucet pinned to faucet node | Done | `FAUCET_ENDPOINT` is fixed to the faucet node; FaucetButton uses `network.faucetEndpoint` which is always the faucet RPC |
| `build` (incl. wasm) + `typecheck` green | Done | `build:wasm` regenerated pkg; `tsc --noEmit` clean; `vite build` emits dist + PWA |
| Playwright e2e reported per-spec vs live testnet | Partial | See Test Plan; faucet live RPC verified; explorer block-by-hash fails on the mock (pre-existing, no `getBlockByHash` in mock) |
| Cloudflare Pages deploy (live URL) | Blocked | Token lacks Pages permission — exact fix below |
| PWA installable (manifest + SW + icons) | Done | `dist/manifest.webmanifest` (192/512 + maskable), `dist/sw.js`, `registerSW.js`, icons all emitted |

## Cloudflare Pages deploy: blocked on token permission
The `CLOUDFLARE_API_TOKEN` in repo-root `.env` is valid + active but is
Zone(DNS)-scoped only. Both the Cloudflare API and `wrangler pages` return
`Authentication error [code: 10000]` for Pages operations.

**Exact fix:** add an **Account > Cloudflare Pages > Edit** permission to the
token (Personal Account `251e6e8626d921603fdc3f0d75576bc6`), or mint a new
token with that scope. Then:
`pnpm --filter @botho/web-wallet deploy` deploys to `botho-wallet.pages.dev`.

## Test Plan
- `pnpm --filter @botho/wasm-signer build:wasm` — pkg regenerated.
- `pnpm --filter @botho/web-wallet typecheck` — clean.
- `pnpm --filter @botho/web-wallet build` — dist + PWA (manifest/sw/icons + wasm pkg).
- Playwright (system Chrome): smoke + web-wallet = all wallet/create/import + landing/nav pass; explorer block-list/height-search pass in isolation. Pre-existing: explorer block-by-hash (mock has no `getBlockByHash`) and an explorer-render timing flake under the shared mock.
- Live testnet: `node_getStatus` on seed + faucet nodes returns height 201 / synced; `faucet_getStatus` returns enabled + 10 BTH drip; `faucet_request` validates addresses against the live faucet. seed2.botho.io currently has no public DNS and the IP `34.220.36.204:443` refuses connections — the picker surfaces it as Unreachable.

Closes #456