### PR TITLE
fix(web-wallet): open wallet at root + real client-side tx history (no 0-BTH spam) (#459)

### DIFF
--- a/web/packages/adapters/src/remote.ts
+++ b/web/packages/adapters/src/remote.ts
@@ -297,38 +297,18 @@ export class RemoteNodeAdapter implements NodeAdapter {
     }
   }
 
-  async getTransactionHistory(_addresses: Address[], options?: TxHistoryOptions): Promise<Transaction[]> {
-    // Fetch outputs for the height range and filter client-side
-    const result = await this.call<Array<{
-      height: number
-      outputs: Array<{
-        txHash: string
-        outputIndex: number
-        targetKey: string
-        publicKey: string
-        amountCommitment: string
-      }>
-    }>>('chain_getOutputs', {
-      start_height: options?.startHeight || 0,
-      end_height: options?.endHeight || (options?.startHeight || 0) + 100,
-    })
-
-    // For now, return empty - client should process outputs locally
-    // Full implementation would scan outputs for matching addresses
-    return result.flatMap((block) =>
-      block.outputs.map((output) => ({
-        id: output.txHash,
-        type: 'receive' as const,
-        amount: BigInt(0), // Would need to decrypt
-        fee: BigInt(0),
-        privacyLevel: 'private' as const, // Ring signatures for privacy
-        cryptoType: 'clsag' as CryptoType, // Default to classical, actual type from RPC
-        status: 'confirmed' as const,
-        timestamp: Date.now(),
-        blockHeight: block.height,
-        confirmations: 0,
-      }))
-    )
+  /**
+   * @deprecated The adapter has no wallet keys, so it cannot tell which on-chain
+   * outputs the user owns or decode their amounts — its previous implementation
+   * mapped EVERY chain output to a `{ type: 'receive', amount: 0n }` entry,
+   * producing dozens of bogus "received 0 BTH" rows (#459). Transaction history
+   * is now built CLIENT-SIDE from the wallet's OWNED outputs in the wallet
+   * context (see `buildOwnedHistory`, which scans via the wasm signer exactly
+   * like balance does). This method is retained only so the `NodeAdapter`
+   * interface stays satisfied; it now returns an empty list rather than spam.
+   */
+  async getTransactionHistory(_addresses: Address[], _options?: TxHistoryOptions): Promise<Transaction[]> {
+    return []
   }
 
   /**
@@ -361,6 +341,51 @@ export class RemoteNodeAdapter implements NodeAdapter {
 
     return result.flatMap((block) =>
       block.outputs.map((output) => ({
+        targetKey: output.targetKey,
+        publicKey: output.publicKey,
+        amount: leHexToBigInt(output.amountCommitment),
+      })),
+    )
+  }
+
+  /**
+   * Like {@link getRawOutputs}, but preserves each output's block height (and
+   * its source transaction hash). The thin wallet uses this to build its
+   * transaction history CLIENT-SIDE: scan these for owned outputs (wasm), then
+   * stamp each owned receive with the block height it landed in (#459). Kept
+   * separate from {@link getRawOutputs} so the hot send/balance path stays a
+   * flat `{ targetKey, publicKey, amount }[]`.
+   */
+  async getRawOutputsWithMeta(
+    startHeight: number,
+    endHeight: number,
+  ): Promise<
+    Array<{
+      txHash: string
+      height: number
+      targetKey: string
+      publicKey: string
+      amount: bigint
+    }>
+  > {
+    const result = await this.call<Array<{
+      height: number
+      outputs: Array<{
+        txHash: string
+        outputIndex: number
+        targetKey: string
+        publicKey: string
+        amountCommitment: string
+      }>
+    }>>('chain_getOutputs', {
+      start_height: startHeight,
+      end_height: endHeight,
+    })
+
+    return result.flatMap((block) =>
+      block.outputs.map((output) => ({
+        txHash: output.txHash,
+        height: block.height,
         targetKey: output.targetKey,
         publicKey: output.publicKey,
         amount: leHexToBigInt(output.amountCommitment),

--- a/web/packages/wasm-signer/src/index.ts
+++ b/web/packages/wasm-signer/src/index.ts
@@ -237,10 +237,14 @@ export function setSigner(signer: WasmSigner): void {
 
 export {
   buildSendTransaction,
+  buildOwnedHistory,
   spendableBalance,
   spendableOwnedOutputs,
   type BuildSendParams,
   type BuildSendResult,
+  type ChainOutputWithMeta,
+  type HistoryEntry,
+  type HistoryRpc,
   type KeyImageSpentStatus,
   type SendRpc,
   type SignerKeys,

--- a/web/packages/wasm-signer/src/send.ts
+++ b/web/packages/wasm-signer/src/send.ts
@@ -135,6 +135,141 @@ export async function spendableBalance(
   return spendable.reduce((s, o) => s + toBigInt(o.amount), 0n)
 }
 
+/**
+ * A chain output annotated with the block it landed in and its source tx hash.
+ * This is what the node returns via `chain_getOutputs` (height per block, txHash
+ * per output) and is the raw material for client-side transaction history.
+ */
+export interface ChainOutputWithMeta extends ChainOutput {
+  /** Hex-encoded hash of the transaction that created this output. */
+  txHash: string
+  /** Block height the output was confirmed at. */
+  height: number
+}
+
+/** A single client-side transaction-history entry. */
+export interface HistoryEntry {
+  /** Source transaction hash (the output's creating tx). */
+  txHash: string
+  /** `receive` for an owned output; `spend` for an owned output later spent. */
+  type: 'receive' | 'spend'
+  /** Decoded amount of the owned output, in picocredits. */
+  amount: bigint
+  /** Block height the output landed in (its receive height). */
+  blockHeight: number
+  /** True if the output's key image is spent on-chain or pending. */
+  spent: boolean
+  /** Height the output was spent at, if known (on-chain spends only). */
+  spentHeight: number | null
+}
+
+/**
+ * The slice of node RPC the history path needs: every chain output in a height
+ * range WITH its block height + tx hash, plus the key-image spent check.
+ * Implemented by the wallet's `RemoteNodeAdapter`.
+ */
+export interface HistoryRpc {
+  getChainHeight(): Promise<number>
+  getOutputsWithMeta(
+    startHeight: number,
+    endHeight: number,
+  ): Promise<ChainOutputWithMeta[]>
+  areKeyImagesSpent(keyImages: string[]): Promise<KeyImageSpentStatus[]>
+}
+
+/**
+ * Build the wallet's transaction history CLIENT-SIDE from its OWNED outputs.
+ *
+ * This is the keys-aware counterpart to the node adapter's old
+ * `getTransactionHistory` stub, which mapped EVERY chain output to a bogus
+ * "received 0 BTH" entry because the adapter has no wallet keys (#459). Here we
+ * reuse the exact balance scan path:
+ *
+ *   fetch outputs (with block height) -> `scanOwnedOutputs` (wasm) keeps only
+ *   the user's outputs with their real decoded amounts -> derive key images and
+ *   ask `chain_areKeyImagesSpent` which are spent.
+ *
+ * Each owned output becomes ONE `receive` entry with its true amount and block
+ * height. Owned outputs whose key image is spent are additionally surfaced as a
+ * `spend` entry (we can prove the user spent the output even though the ring
+ * hides which tx consumed it), and the receive entry is flagged `spent`. No
+ * non-owned outputs are ever returned, so there is no 0-BTH spam.
+ *
+ * Returned newest-first (highest block height first).
+ */
+export async function buildOwnedHistory(
+  keys: SignerKeys,
+  rpc: HistoryRpc,
+): Promise<HistoryEntry[]> {
+  const signer = await loadSigner()
+  const height = await rpc.getChainHeight()
+  const candidates = await rpc.getOutputsWithMeta(0, height)
+  if (candidates.length === 0) return []
+
+  // Identify owned outputs (node-identical ownership check in wasm). The scan
+  // input drops the meta, so map owned outputs back to their height/txHash by
+  // their unique one-time target key.
+  const metaByTargetKey = new Map<string, ChainOutputWithMeta>()
+  for (const c of candidates) metaByTargetKey.set(c.targetKey, c)
+
+  const owned = signer.scanOwnedOutputs({
+    spendPrivateKey: keys.spendPrivateKey,
+    viewPrivateKey: keys.viewPrivateKey,
+    outputs: candidates.map((c) => ({
+      targetKey: c.targetKey,
+      publicKey: c.publicKey,
+      amount: c.amount,
+    })),
+  })
+  if (owned.length === 0) return []
+
+  // Derive key images for the owned outputs and ask the node which are spent.
+  const withImages = signer.computeOwnedOutputKeyImages({
+    spendPrivateKey: keys.spendPrivateKey,
+    viewPrivateKey: keys.viewPrivateKey,
+    outputs: owned,
+  })
+  const statuses = await rpc.areKeyImagesSpent(withImages.map((o) => o.keyImage))
+  const statusByKeyImage = new Map<string, KeyImageSpentStatus>()
+  for (const s of statuses) statusByKeyImage.set(s.keyImage, s)
+
+  const entries: HistoryEntry[] = []
+  for (const o of withImages) {
+    const meta = metaByTargetKey.get(o.targetKey)
+    const blockHeight = meta?.height ?? 0
+    const txHash = meta?.txHash ?? o.targetKey
+    const status = statusByKeyImage.get(o.keyImage)
+    const spent = !!status && (status.spent || status.pending)
+    const spentHeight = status?.spentHeight ?? null
+
+    // The receive of this owned output (always shown, with its real amount).
+    entries.push({
+      txHash,
+      type: 'receive',
+      amount: toBigInt(o.amount),
+      blockHeight,
+      spent,
+      spentHeight,
+    })
+
+    // If we've spent it, also record a spend entry so history shows the outflow.
+    if (spent) {
+      entries.push({
+        txHash,
+        type: 'spend',
+        amount: toBigInt(o.amount),
+        blockHeight: spentHeight ?? blockHeight,
+        spent: true,
+        spentHeight,
+      })
+    }
+  }
+
+  // Newest first.
+  entries.sort((a, b) => b.blockHeight - a.blockHeight)
+  return entries
+}
+
 /** Inputs to {@link buildSendTransaction}. */
 export interface BuildSendParams {
   /** Account keys derived from the wallet mnemonic. */

--- a/web/packages/wasm-signer/test/history.test.ts
+++ b/web/packages/wasm-signer/test/history.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  buildOwnedHistory,
+  resetSigner,
+  setSigner,
+  type ChainOutputWithMeta,
+  type HistoryRpc,
+  type KeyImageSpentStatus,
+  type WasmSigner,
+} from '../src/index'
+
+/**
+ * Unit tests for the client-side transaction-history builder (#459).
+ *
+ * The bug being fixed: the node adapter's old `getTransactionHistory` had no
+ * wallet keys, so it mapped EVERY on-chain output to a `{ receive, amount: 0 }`
+ * entry — ~100+ bogus "received 0 BTH" rows. `buildOwnedHistory` instead reuses
+ * the wasm OWNERSHIP scan (the same primitive balance uses) so only the user's
+ * outputs appear, with their REAL decoded amounts.
+ *
+ * These tests inject a fully-controlled fake `WasmSigner` via `setSigner` (the
+ * documented test seam), so we can assert the filtering / amount / spent / sort
+ * logic deterministically without real crypto or a live node. A `targetKey`
+ * starting with "owned" is treated as belonging to the wallet; everything else
+ * (decoys / other users' outputs) is foreign and must NOT appear in history.
+ */
+
+/** A fake signer: "owns" any output whose targetKey starts with "owned". */
+function fakeSigner(): WasmSigner {
+  return {
+    buildAndSign: () => {
+      throw new Error('not used')
+    },
+    ringSize: () => 20,
+    minFee: () => 100_000_000n,
+    scanOwnedOutputs: ({ outputs }) =>
+      outputs
+        .filter((o) => o.targetKey.startsWith('owned'))
+        .map((o) => ({
+          targetKey: o.targetKey,
+          publicKey: o.publicKey,
+          amount: typeof o.amount === 'bigint' ? o.amount : BigInt(o.amount),
+          subaddressIndex: 0n,
+        })),
+    // Key image is deterministically derived from the target key for the test.
+    computeOwnedOutputKeyImages: ({ outputs }) =>
+      outputs.map((o) => ({
+        targetKey: o.targetKey,
+        publicKey: o.publicKey,
+        amount: o.amount,
+        subaddressIndex: o.subaddressIndex,
+        keyImage: `ki-${o.targetKey}`,
+      })),
+  }
+}
+
+const KEYS = { spendPrivateKey: '00'.repeat(32), viewPrivateKey: '11'.repeat(32) }
+
+function rpcWith(
+  outputs: ChainOutputWithMeta[],
+  spent: Record<string, Partial<KeyImageSpentStatus>> = {},
+): HistoryRpc {
+  return {
+    getChainHeight: async () => 1000,
+    getOutputsWithMeta: async () => outputs,
+    areKeyImagesSpent: async (keyImages) =>
+      keyImages.map((keyImage) => ({
+        keyImage,
+        spent: spent[keyImage]?.spent ?? false,
+        spentHeight: spent[keyImage]?.spentHeight ?? null,
+        pending: spent[keyImage]?.pending ?? false,
+      })),
+  }
+}
+
+afterEach(() => resetSigner())
+
+describe('buildOwnedHistory (#459)', () => {
+  it('returns ONLY owned outputs with their real amounts — no 0-BTH spam', async () => {
+    setSigner(fakeSigner())
+
+    // 1 owned output among 100 foreign ones (the bug produced 101 zero-receives).
+    const foreign: ChainOutputWithMeta[] = Array.from({ length: 100 }, (_, i) => ({
+      txHash: `tx-foreign-${i}`,
+      height: i + 1,
+      targetKey: `foreign-${i}`,
+      publicKey: `pk-foreign-${i}`,
+      amount: 5_000_000_000n,
+    }))
+    const owned: ChainOutputWithMeta = {
+      txHash: 'tx-owned',
+      height: 42,
+      targetKey: 'owned-1',
+      publicKey: 'pk-owned-1',
+      amount: 10_000_000_000_000n, // 10 BTH (picocredits)
+    }
+
+    const history = await buildOwnedHistory(KEYS, rpcWith([...foreign, owned]))
+
+    // Exactly one entry, the owned receive — none of the 100 foreign outputs.
+    expect(history).toHaveLength(1)
+    expect(history[0]).toMatchObject({
+      txHash: 'tx-owned',
+      type: 'receive',
+      amount: 10_000_000_000_000n,
+      blockHeight: 42,
+      spent: false,
+    })
+    // No entry has amount 0 (the old spam).
+    expect(history.every((e) => e.amount > 0n)).toBe(true)
+  })
+
+  it('emits a spend entry (and flags the receive) for a spent owned output', async () => {
+    setSigner(fakeSigner())
+
+    const owned: ChainOutputWithMeta = {
+      txHash: 'tx-owned',
+      height: 10,
+      targetKey: 'owned-1',
+      publicKey: 'pk-owned-1',
+      amount: 7_000_000_000_000n,
+    }
+    const history = await buildOwnedHistory(
+      KEYS,
+      rpcWith([owned], { 'ki-owned-1': { spent: true, spentHeight: 55 } }),
+    )
+
+    const receive = history.find((e) => e.type === 'receive')
+    const spend = history.find((e) => e.type === 'spend')
+    expect(receive).toMatchObject({ amount: 7_000_000_000_000n, spent: true })
+    expect(spend).toMatchObject({ amount: 7_000_000_000_000n, blockHeight: 55 })
+  })
+
+  it('returns newest-first', async () => {
+    setSigner(fakeSigner())
+
+    const outputs: ChainOutputWithMeta[] = [
+      { txHash: 't1', height: 5, targetKey: 'owned-a', publicKey: 'p', amount: 1n },
+      { txHash: 't2', height: 90, targetKey: 'owned-b', publicKey: 'p', amount: 2n },
+      { txHash: 't3', height: 30, targetKey: 'owned-c', publicKey: 'p', amount: 3n },
+    ]
+    const history = await buildOwnedHistory(KEYS, rpcWith(outputs))
+    expect(history.map((e) => e.blockHeight)).toEqual([90, 30, 5])
+  })
+
+  it('returns empty when the wallet owns nothing (no spam)', async () => {
+    setSigner(fakeSigner())
+    const outputs: ChainOutputWithMeta[] = Array.from({ length: 50 }, (_, i) => ({
+      txHash: `t-${i}`,
+      height: i,
+      targetKey: `foreign-${i}`,
+      publicKey: 'p',
+      amount: 9_999n,
+    }))
+    expect(await buildOwnedHistory(KEYS, rpcWith(outputs))).toEqual([])
+  })
+})

--- a/web/packages/web-wallet/src/App.tsx
+++ b/web/packages/web-wallet/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { NetworkProvider } from './contexts/network'
 import { WalletProvider } from './contexts/wallet'
 import { LandingPage } from './pages/landing'
@@ -6,13 +6,41 @@ import { WalletPage } from './pages/wallet'
 import { DocsPage } from './pages/docs'
 import { ExplorerPage } from './pages/explorer'
 
+/**
+ * Decide what `/` should render.
+ *
+ * The same SPA bundle is deployed to two hostnames: the marketing site
+ * (botho.io) and the wallet subdomain (wallet.botho.io). On the wallet
+ * subdomain users expect the wallet, not the marketing homepage (#459), so we
+ * redirect `/` -> `/wallet` there. Everywhere else (botho.io, localhost, the
+ * Playwright preview) `/` keeps rendering the landing page, which also keeps the
+ * existing e2e smoke tests (`a[href="/"]` -> landing) green.
+ *
+ * The landing page is always reachable at `/` on the marketing host and at
+ * `/home` / `/about` on any host, and is linked from the wallet header.
+ */
+function isWalletHost(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.location.hostname.startsWith('wallet.')
+}
+
+function RootRoute() {
+  if (isWalletHost()) {
+    return <Navigate to="/wallet" replace />
+  }
+  return <LandingPage />
+}
+
 function App() {
   return (
     <NetworkProvider>
       <WalletProvider>
         <BrowserRouter>
           <Routes>
-            <Route path="/" element={<LandingPage />} />
+            <Route path="/" element={<RootRoute />} />
+            {/* Landing is always reachable directly, regardless of host. */}
+            <Route path="/home" element={<LandingPage />} />
+            <Route path="/about" element={<LandingPage />} />
             <Route path="/wallet" element={<WalletPage />} />
             <Route path="/explorer" element={<ExplorerPage />} />
             <Route path="/explorer/tx/:hash" element={<ExplorerPage />} />

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -10,7 +10,7 @@ import {
 import { RemoteNodeAdapter, type WsConnectionStatus } from '@botho/adapters'
 import { AddressBook, saveWallet, loadWallet, getWalletInfo, deriveAddress, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet } from '@botho/core'
 import type { Balance, Contact, NodeInfo, Transaction } from '@botho/core'
-import { buildSendTransaction, spendableBalance } from '@botho/wasm-signer'
+import { buildSendTransaction, spendableBalance, buildOwnedHistory } from '@botho/wasm-signer'
 import { type NetworkConfig, loadSelectedNetwork, loadSelectedIngress, NETWORKS, DEFAULT_NETWORK_ID, DEFAULT_INGRESS_ID, createCustomNetwork, networkForIngress, getIngressNode } from '../config/networks'
 
 interface WalletState {
@@ -117,6 +117,55 @@ async function fetchBalance(
     // artifact failed to load), fall back to the node RPC balance rather than
     // surfacing no balance at all.
     return adapter.getBalance([address])
+  }
+}
+
+/**
+ * Build the wallet's transaction history CLIENT-SIDE from its OWNED outputs
+ * (#459), mirroring how {@link fetchBalance} computes balance.
+ *
+ * The node has no way to tell which on-chain outputs belong to a thin wallet, so
+ * the old adapter `getTransactionHistory` mapped EVERY chain output to a bogus
+ * "received 0 BTH" entry (~100+ rows of spam). Instead we reuse the wasm scan
+ * path: fetch outputs (with block height) and let the wasm signer keep only the
+ * ones this wallet owns, with their REAL decoded amounts, then map each owned
+ * output to a `receive` (and a `spend` if its key image is spent). Requires the
+ * mnemonic (unlocked wallet); when locked we return an empty history rather than
+ * the old spam.
+ */
+async function fetchHistory(
+  adapter: RemoteNodeAdapter,
+  mnemonic: string | null,
+): Promise<Transaction[]> {
+  if (!mnemonic) return []
+  try {
+    const kp = deriveKeypairs(mnemonic, 0)
+    const entries = await buildOwnedHistory(
+      {
+        spendPrivateKey: toHex(kp.spendPrivate),
+        viewPrivateKey: toHex(kp.viewPrivate),
+      },
+      {
+        getChainHeight: () => adapter.getBlockHeight(),
+        getOutputsWithMeta: (start, end) => adapter.getRawOutputsWithMeta(start, end),
+        areKeyImagesSpent: (keyImages) => adapter.areKeyImagesSpent(keyImages),
+      },
+    )
+    return entries.map((e) => ({
+      id: e.txHash,
+      type: e.type === 'spend' ? ('send' as const) : ('receive' as const),
+      amount: e.amount,
+      fee: 0n,
+      privacyLevel: 'private' as const,
+      cryptoType: 'clsag' as const,
+      status: 'confirmed' as const,
+      timestamp: Date.now(),
+      blockHeight: e.blockHeight,
+      confirmations: 0,
+    }))
+  } catch {
+    // wasm artifact missing or scan failed: show no history rather than spam.
+    return []
   }
 }
 
@@ -245,7 +294,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       try {
         const [balance, transactions] = await Promise.all([
           fetchBalance(adapter, state.address!, mnemonicRef.current),
-          adapter.getTransactionHistory([state.address!], { limit: 50 }),
+          fetchHistory(adapter, mnemonicRef.current),
         ])
         setState(s => ({ ...s, balance, transactions }))
       } catch {
@@ -267,7 +316,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       try {
         const [balance, transactions] = await Promise.all([
           fetchBalance(adapter, state.address!, mnemonicRef.current),
-          adapter.getTransactionHistory([state.address!], { limit: 50 }),
+          fetchHistory(adapter, mnemonicRef.current),
         ])
         setState(s => ({ ...s, balance, transactions }))
       } catch {
@@ -311,7 +360,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
           }
           const [balance, transactions] = await Promise.all([
             fetchBalance(adapter, walletInfo.address, mnemonicRef.current),
-            adapter.getTransactionHistory([walletInfo.address], { limit: 50 }),
+            fetchHistory(adapter, mnemonicRef.current),
           ])
           setState(s => ({ ...s, balance, transactions }))
         }
@@ -390,7 +439,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const adapter = adapterRef.current
     if (adapter.isConnected()) {
       const balance = await fetchBalance(adapter, address, mnemonicRef.current)
-      const transactions = await adapter.getTransactionHistory([address], { limit: 50 })
+      const transactions = await fetchHistory(adapter, mnemonicRef.current)
       setState(s => ({ ...s, balance, transactions }))
     }
   }, [])
@@ -411,7 +460,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     if (adapter.isConnected() && stored.address) {
       const [balance, transactions] = await Promise.all([
         fetchBalance(adapter, stored.address, mnemonicRef.current),
-        adapter.getTransactionHistory([stored.address], { limit: 50 }),
+        fetchHistory(adapter, mnemonicRef.current),
       ])
       setState(s => ({ ...s, balance, transactions }))
     }
@@ -526,7 +575,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   const refreshTransactions = useCallback(async () => {
     const adapter = adapterRef.current
     if (!state.address || !adapter.isConnected()) return
-    const transactions = await adapter.getTransactionHistory([state.address], { limit: 50 })
+    const transactions = await fetchHistory(adapter, mnemonicRef.current)
     setState(s => ({ ...s, transactions }))
   }, [state.address])
 

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -464,11 +464,20 @@ export function WalletPage() {
     return <WalletDashboard />
   }
 
+  // The marketing landing page lives at `/`, but on the wallet subdomain
+  // (wallet.botho.io) `/` redirects back to the wallet (#459). Point the header
+  // "back" link at `/home` there so the landing stays reachable from the wallet;
+  // on every other host keep `/` so existing nav/e2e behavior is unchanged.
+  const homeHref =
+    typeof window !== 'undefined' && window.location.hostname.startsWith('wallet.')
+      ? '/home'
+      : '/'
+
   return (
     <div className="min-h-screen">
       <header className="border-b border-steel bg-abyss/50 backdrop-blur-md sticky top-0 z-40">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between">
-          <Link to="/" className="flex items-center gap-2 sm:gap-3">
+          <Link to={homeHref} className="flex items-center gap-2 sm:gap-3">
             <ArrowLeft size={18} className="text-ghost" />
             <Logo size="sm" showText={false} />
             <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">Botho Wallet</span>


### PR DESCRIPTION
Closes #459

## Summary
Fixes two bugs found on the live wallet at wallet.botho.io.

### Bug 1 — root opens the wallet (not the marketing homepage)
`web/packages/web-wallet/src/App.tsx`: `/` now redirects to `/wallet` **only** when the app is served from a `wallet.*` hostname (i.e. wallet.botho.io). On every other host — botho.io, localhost, the Playwright preview — `/` keeps rendering the landing page. This satisfies the "wallet subdomain opens the wallet" requirement while keeping the existing smoke e2e (`a[href="/"]` → landing) green. The landing is always reachable at `/home` and `/about`, and the wallet header's back link points to `/home` on the wallet subdomain so the landing stays one click away.

### Bug 2 — real client-side transaction history (the main fix)
The adapter's `getTransactionHistory` was an unfinished stub: it pulled every chain output over a height range and mapped each to `{ type: 'receive', amount: 0n }` with **no owned-output filtering** (the adapter has no wallet keys), producing ~102 "received 0 BTH" rows.

History is now built **client-side from the user's OWNED outputs**, reusing the exact balance scan path:

- **`adapters/remote.ts`** — new `getRawOutputsWithMeta(start, end)` returns outputs with block height + tx hash, decoding the amount from the LE `amountCommitment` (same decode `getRawOutputs`/balance already use). The old `getTransactionHistory` is kept to satisfy the `NodeAdapter` interface but now returns `[]` (no more spam, ever).
- **`wasm-signer/send.ts`** — new `buildOwnedHistory(keys, rpc)`: fetch outputs → `scanOwnedOutputs` (the same wasm ownership primitive balance uses) keeps only the user's outputs with their **real decoded amounts** → `computeOwnedOutputKeyImages` + `chain_areKeyImagesSpent` flag spent ones. Each owned output = one `receive` (real amount + block height); spent owned outputs also emit a `spend` entry. Non-owned outputs are never returned.
- **`web-wallet/contexts/wallet.tsx`** — new `fetchHistory` derives keys from the mnemonic (non-custodial; keys stay in the browser) and maps entries to the `Transaction` shape, replacing every `adapter.getTransactionHistory` call. A locked wallet shows empty history rather than spam.

A freshly-faucet'd wallet now shows a single ~+10 BTH receive instead of 100+ zeros.

## Tests
- `pnpm --filter @botho/web-wallet typecheck` — green (also wasm-signer + adapters typecheck green).
- `pnpm --filter @botho/web-wallet build` — green (after `build:wasm`).
- New hermetic unit tests `packages/wasm-signer/test/history.test.ts` (4 tests, pass): only owned outputs returned, real amounts, no 0-BTH entries, spend entries for spent outputs, newest-first, empty when nothing owned.
- Existing hermetic `sign.test.ts` — pass.
- Playwright smoke e2e (local mock, system Chrome) — all routing tests pass, incl. "navigate back to landing from wallet". The one failing test ("Explorer › displays recent blocks") is a pre-existing flake (passes on retry / in isolation; references #334) unrelated to this change and untouched by it.
- Playwright `web-wallet` e2e (create + import, local mock) — 17/17 pass; wallet create/import/unlock flows intact.

## Verification notes
- The history-from-owned-outputs logic reuses the same `scanOwnedOutputs` + `chain_areKeyImagesSpent` + commitment-decode path that `spendableBalance` already uses, so receives are exactly the outputs counted in the balance.
- Did not run the live-testnet check end-to-end in this environment (live-node tests require a running node), but the logic is unit-tested and mirrors the proven balance path.

## Post-merge
After merge, redeploy to Cloudflare Pages with `--branch=main` (maintainer will handle the redeploy).

## Files touched
- `web/packages/web-wallet/src/App.tsx`
- `web/packages/web-wallet/src/pages/wallet.tsx`
- `web/packages/web-wallet/src/contexts/wallet.tsx`
- `web/packages/adapters/src/remote.ts`
- `web/packages/wasm-signer/src/send.ts`
- `web/packages/wasm-signer/src/index.ts`
- `web/packages/wasm-signer/test/history.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)