### PR TITLE
feat(wallet): claimable payment links — send BTH via a shareable claim link (#460)

### DIFF
--- a/web/packages/core/src/storage/claim-links.test.ts
+++ b/web/packages/core/src/storage/claim-links.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  ClaimLinkStore,
+  LocalStorageClaimLinks,
+  CLAIM_LINK_EXPIRY_WINDOW_SECONDS,
+  type ClaimLinkRecord,
+} from './claim-links'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+  }
+})()
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+const SAMPLE = {
+  ephMnemonic:
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+  ephAddress: 'tbotho://1/sample',
+  amount: 5_000_000_000_000n,
+}
+
+describe('ClaimLinkStore', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+  })
+
+  it('adds and lists records', async () => {
+    const store = new ClaimLinkStore()
+    await store.load()
+    const rec = await store.add(SAMPLE)
+    expect(rec.status).toBe('outstanding')
+    expect(rec.id).toBeTruthy()
+    expect(store.getAll()).toHaveLength(1)
+    expect(store.getAll()[0].amount).toBe(SAMPLE.amount)
+  })
+
+  it('persists bigint amounts across reload (round-trip serialization)', async () => {
+    const store1 = new ClaimLinkStore()
+    await store1.load()
+    await store1.add(SAMPLE)
+
+    const store2 = new ClaimLinkStore()
+    await store2.load()
+    const all = store2.getAll()
+    expect(all).toHaveLength(1)
+    expect(all[0].amount).toBe(SAMPLE.amount)
+    expect(typeof all[0].amount).toBe('bigint')
+  })
+
+  it('updates status', async () => {
+    const store = new ClaimLinkStore()
+    await store.load()
+    const rec = await store.add(SAMPLE)
+    await store.setStatus(rec.id, 'claimed')
+    expect(store.getAll()[0].status).toBe('claimed')
+  })
+
+  it('deletes records', async () => {
+    const store = new ClaimLinkStore()
+    await store.load()
+    const rec = await store.add(SAMPLE)
+    await store.delete(rec.id)
+    expect(store.getAll()).toHaveLength(0)
+  })
+
+  it('sorts newest first', async () => {
+    const store = new ClaimLinkStore()
+    await store.load()
+    await store.add({ ...SAMPLE, createdAt: 100 })
+    await store.add({ ...SAMPLE, ephAddress: 'tbotho://1/newer', createdAt: 200 })
+    const all = store.getAll()
+    expect(all[0].createdAt).toBe(200)
+    expect(all[1].createdAt).toBe(100)
+  })
+
+  it('detects expiry against the UX window', async () => {
+    const store = new ClaimLinkStore()
+    const now = 1_000_000
+    const fresh: ClaimLinkRecord = {
+      id: 'a', ...SAMPLE, createdAt: now - 10, status: 'outstanding',
+    }
+    const old: ClaimLinkRecord = {
+      id: 'b', ...SAMPLE, createdAt: now - CLAIM_LINK_EXPIRY_WINDOW_SECONDS - 1, status: 'outstanding',
+    }
+    expect(store.isExpired(fresh, now)).toBe(false)
+    expect(store.isExpired(old, now)).toBe(true)
+  })
+
+  it('tolerates corrupt localStorage data', async () => {
+    localStorage.setItem('botho-claim-links', 'not json')
+    const storage = new LocalStorageClaimLinks()
+    expect(await storage.load()).toEqual([])
+  })
+})

--- a/web/packages/core/src/storage/claim-links.ts
+++ b/web/packages/core/src/storage/claim-links.ts
@@ -1,0 +1,155 @@
+/**
+ * Outstanding claim-link tracking (sender side, #460 phase 3).
+ *
+ * When a sender creates a bearer claim link, they fund an ephemeral wallet and
+ * hand out its secret. To support **refund** (reclaiming an unclaimed link),
+ * the sender must be able to re-derive that ephemeral secret later. The MVP
+ * stores the ephemeral mnemonic locally (mirrors `AddressBook`'s localStorage
+ * pattern). This is device-bound — a refund only works from the same browser
+ * that created the link. (A deterministic-from-sender-seed derivation would
+ * remove that limitation; deferred per the architect's open decision #1.)
+ *
+ * SECURITY: each record contains the ephemeral mnemonic, which is bearer-secret
+ * for the funds. It lives only in this browser's localStorage and is never sent
+ * to a server — same trust model as the wallet's own stored mnemonic.
+ *
+ * This module only persists/tracks records. Scanning the ephemeral wallet,
+ * detecting "claimed" (output spent), and sweeping a refund all reuse the
+ * existing wasm-signer send/scan path in the web-wallet — no node change.
+ */
+
+/** Lifecycle status of an outstanding claim link. */
+export type ClaimLinkStatus = 'outstanding' | 'claimed' | 'refunded'
+
+/** A locally-tracked outstanding (or resolved) claim link. */
+export interface ClaimLinkRecord {
+  /** Stable local id. */
+  id: string
+  /** The ephemeral 12-word mnemonic that owns the funded output (bearer secret). */
+  ephMnemonic: string
+  /** The ephemeral receiving address the funds were sent to. */
+  ephAddress: string
+  /** Net amount intended for the recipient, in picocredits (excludes sweep fee). */
+  amount: bigint
+  /** Unix seconds when the link was created. */
+  createdAt: number
+  /** The funding transaction hash, if known. */
+  fundingTxHash?: string
+  /** Current status. */
+  status: ClaimLinkStatus
+}
+
+/** JSON-serializable form (bigint -> decimal string) for localStorage. */
+interface SerializedClaimLinkRecord {
+  id: string
+  ephMnemonic: string
+  ephAddress: string
+  amount: string
+  createdAt: number
+  fundingTxHash?: string
+  status: ClaimLinkStatus
+}
+
+function serialize(r: ClaimLinkRecord): SerializedClaimLinkRecord {
+  return { ...r, amount: r.amount.toString() }
+}
+
+function deserialize(r: SerializedClaimLinkRecord): ClaimLinkRecord {
+  return { ...r, amount: BigInt(r.amount) }
+}
+
+/** Storage interface for claim-link persistence. */
+export interface ClaimLinkStorage {
+  load(): Promise<ClaimLinkRecord[]>
+  save(records: ClaimLinkRecord[]): Promise<void>
+}
+
+/** localStorage-based claim-link storage. */
+export class LocalStorageClaimLinks implements ClaimLinkStorage {
+  private readonly key: string
+
+  constructor(key = 'botho-claim-links') {
+    this.key = key
+  }
+
+  async load(): Promise<ClaimLinkRecord[]> {
+    const data = localStorage.getItem(this.key)
+    if (!data) return []
+    try {
+      const parsed = JSON.parse(data) as SerializedClaimLinkRecord[]
+      return parsed.map(deserialize)
+    } catch {
+      return []
+    }
+  }
+
+  async save(records: ClaimLinkRecord[]): Promise<void> {
+    localStorage.setItem(this.key, JSON.stringify(records.map(serialize)))
+  }
+}
+
+/** Default UX expiry-nudge window (7 days, seconds). Reclaim is always allowed. */
+export const CLAIM_LINK_EXPIRY_WINDOW_SECONDS = 7 * 24 * 60 * 60
+
+/** Manager for the sender's outstanding claim links. */
+export class ClaimLinkStore {
+  private records: Map<string, ClaimLinkRecord> = new Map()
+  private storage: ClaimLinkStorage
+
+  constructor(storage: ClaimLinkStorage = new LocalStorageClaimLinks()) {
+    this.storage = storage
+  }
+
+  async load(): Promise<void> {
+    const records = await this.storage.load()
+    this.records = new Map(records.map((r) => [r.id, r]))
+  }
+
+  private async persist(): Promise<void> {
+    await this.storage.save(Array.from(this.records.values()))
+  }
+
+  /** All records, newest first. */
+  getAll(): ClaimLinkRecord[] {
+    return Array.from(this.records.values()).sort((a, b) => b.createdAt - a.createdAt)
+  }
+
+  /** Add a freshly-created outstanding link. */
+  async add(
+    input: Omit<ClaimLinkRecord, 'id' | 'createdAt' | 'status'> &
+      Partial<Pick<ClaimLinkRecord, 'id' | 'createdAt' | 'status'>>,
+  ): Promise<ClaimLinkRecord> {
+    const record: ClaimLinkRecord = {
+      id: input.id ?? crypto.randomUUID(),
+      ephMnemonic: input.ephMnemonic,
+      ephAddress: input.ephAddress,
+      amount: input.amount,
+      createdAt: input.createdAt ?? Math.floor(Date.now() / 1000),
+      fundingTxHash: input.fundingTxHash,
+      status: input.status ?? 'outstanding',
+    }
+    this.records.set(record.id, record)
+    await this.persist()
+    return record
+  }
+
+  /** Update a record's status (e.g. mark claimed / refunded). */
+  async setStatus(id: string, status: ClaimLinkStatus): Promise<void> {
+    const r = this.records.get(id)
+    if (!r) return
+    r.status = status
+    await this.persist()
+  }
+
+  /** Remove a record. */
+  async delete(id: string): Promise<void> {
+    if (this.records.delete(id)) {
+      await this.persist()
+    }
+  }
+
+  /** True if the record is past the UX expiry-nudge window. */
+  isExpired(record: ClaimLinkRecord, nowSeconds = Math.floor(Date.now() / 1000)): boolean {
+    return nowSeconds - record.createdAt >= CLAIM_LINK_EXPIRY_WINDOW_SECONDS
+  }
+}

--- a/web/packages/core/src/storage/index.ts
+++ b/web/packages/core/src/storage/index.ts
@@ -1,1 +1,9 @@
 export { AddressBook, LocalStorageAddressBook, type AddressBookStorage } from './address-book'
+export {
+  ClaimLinkStore,
+  LocalStorageClaimLinks,
+  CLAIM_LINK_EXPIRY_WINDOW_SECONDS,
+  type ClaimLinkStorage,
+  type ClaimLinkRecord,
+  type ClaimLinkStatus,
+} from './claim-links'

--- a/web/packages/core/src/wallet/claim-link.test.ts
+++ b/web/packages/core/src/wallet/claim-link.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CLAIM_LINK_VERSION,
+  CLAIM_LINK_ENTROPY_BYTES,
+  createClaimLinkMnemonic,
+  encodeClaimLinkFragment,
+  buildClaimLink,
+  parseClaimLinkFragment,
+} from './claim-link'
+import { isValidMnemonic, deriveAddress, createMnemonic } from './index'
+
+describe('claim-link helpers', () => {
+  describe('createClaimLinkMnemonic', () => {
+    it('produces a valid 12-word BIP39 mnemonic', () => {
+      const m = createClaimLinkMnemonic()
+      expect(m.split(' ')).toHaveLength(12)
+      expect(isValidMnemonic(m)).toBe(true)
+    })
+
+    it('produces unique mnemonics', () => {
+      expect(createClaimLinkMnemonic()).not.toBe(createClaimLinkMnemonic())
+    })
+  })
+
+  describe('encode / parse round-trip', () => {
+    it('round-trips an ephemeral mnemonic through the fragment', () => {
+      const m = createClaimLinkMnemonic()
+      const fragment = encodeClaimLinkFragment(m)
+      const parsed = parseClaimLinkFragment(fragment)
+      expect(parsed.mnemonic).toBe(m)
+      expect(parsed.amountHint).toBeUndefined()
+    })
+
+    it('embeds and recovers an amount hint', () => {
+      const m = createClaimLinkMnemonic()
+      const hint = 5_000_000_000_000n
+      const fragment = encodeClaimLinkFragment(m, hint)
+      const parsed = parseClaimLinkFragment(fragment)
+      expect(parsed.mnemonic).toBe(m)
+      expect(parsed.amountHint).toBe(hint)
+    })
+
+    it('reconstructs the same ephemeral ADDRESS from a parsed link', () => {
+      const m = createClaimLinkMnemonic()
+      const expectedAddress = deriveAddress(m)
+      const parsed = parseClaimLinkFragment(encodeClaimLinkFragment(m))
+      expect(deriveAddress(parsed.mnemonic)).toBe(expectedAddress)
+    })
+
+    it('produces a versioned fragment with base58 entropy', () => {
+      const m = createClaimLinkMnemonic()
+      const fragment = encodeClaimLinkFragment(m)
+      const parts = fragment.split('.')
+      expect(parts[0]).toBe(CLAIM_LINK_VERSION)
+      // base58 of 16 bytes is ~22 chars and uses no 0/O/I/l
+      expect(parts[1]).toMatch(/^[A-HJ-NP-Za-km-z1-9]+$/)
+    })
+
+    it('keeps the fragment short (chat/QR friendly)', () => {
+      const fragment = encodeClaimLinkFragment(createClaimLinkMnemonic())
+      // v1. + ~22 base58 chars
+      expect(fragment.length).toBeLessThan(30)
+    })
+  })
+
+  describe('buildClaimLink', () => {
+    it('builds a /claim URL with the secret in the fragment', () => {
+      const m = createClaimLinkMnemonic()
+      const url = buildClaimLink('https://wallet.botho.io', m)
+      expect(url.startsWith('https://wallet.botho.io/claim#')).toBe(true)
+      const parsed = parseClaimLinkFragment(url)
+      expect(parsed.mnemonic).toBe(m)
+    })
+
+    it('normalizes a trailing slash on the origin', () => {
+      const m = createClaimLinkMnemonic()
+      const url = buildClaimLink('https://wallet.botho.io/', m)
+      expect(url).toContain('/claim#')
+      expect(url).not.toContain('//claim')
+    })
+  })
+
+  describe('parseClaimLinkFragment robustness', () => {
+    it('accepts a fragment with a leading #', () => {
+      const m = createClaimLinkMnemonic()
+      const frag = encodeClaimLinkFragment(m)
+      expect(parseClaimLinkFragment('#' + frag).mnemonic).toBe(m)
+    })
+
+    it('accepts a full URL', () => {
+      const m = createClaimLinkMnemonic()
+      const url = buildClaimLink('https://wallet.botho.io', m)
+      expect(parseClaimLinkFragment(url).mnemonic).toBe(m)
+    })
+
+    it('rejects an empty fragment', () => {
+      expect(() => parseClaimLinkFragment('')).toThrow()
+      expect(() => parseClaimLinkFragment('#')).toThrow()
+    })
+
+    it('rejects an unsupported version', () => {
+      expect(() => parseClaimLinkFragment('v9.abcdef')).toThrow(/version/i)
+    })
+
+    it('rejects a non-base58 secret', () => {
+      expect(() => parseClaimLinkFragment(`${CLAIM_LINK_VERSION}.0OIl`)).toThrow()
+    })
+
+    it('rejects a wrong-length secret', () => {
+      // base58 of a 4-byte payload — wrong length for a 16-byte secret
+      expect(() => parseClaimLinkFragment(`${CLAIM_LINK_VERSION}.2VfUX`)).toThrow(/length/i)
+    })
+
+    it('ignores a malformed amount hint rather than failing', () => {
+      const m = createClaimLinkMnemonic()
+      const frag = encodeClaimLinkFragment(m)
+      const parsed = parseClaimLinkFragment(`${frag}.notanumber`)
+      expect(parsed.mnemonic).toBe(m)
+      expect(parsed.amountHint).toBeUndefined()
+    })
+  })
+
+  describe('encodeClaimLinkFragment guards', () => {
+    it('rejects a 24-word mnemonic (needs 128-bit entropy)', () => {
+      const m24 = createMnemonic()
+      expect(() => encodeClaimLinkFragment(m24)).toThrow()
+    })
+
+    it('exposes the expected entropy size constant', () => {
+      expect(CLAIM_LINK_ENTROPY_BYTES).toBe(16)
+    })
+  })
+})

--- a/web/packages/core/src/wallet/claim-link.ts
+++ b/web/packages/core/src/wallet/claim-link.ts
@@ -1,0 +1,147 @@
+/**
+ * Claimable payment links — bearer claim-link helpers.
+ *
+ * A claim-link is a *bearer instrument backed by a throwaway (ephemeral)
+ * wallet*. The link secret IS an ephemeral BIP39 mnemonic; whoever holds it
+ * owns the funds. This is 100% client-side: these helpers only generate /
+ * encode / decode the ephemeral secret. Funding (a normal CLSAG send to the
+ * ephemeral address) and sweeping (a normal CLSAG send FROM the ephemeral keys)
+ * reuse the existing wasm-signer send path — no node/consensus/RPC change.
+ *
+ * Link format (issue #460, architect "Option A"):
+ *
+ *   https://wallet.botho.io/claim#v1.<base58(16-byte entropy)>[.<amount-hint-pc>]
+ *
+ * - `v1`           one-char-ish version tag so the format can evolve.
+ * - base58 entropy the 12-word (128-bit) mnemonic's raw 16-byte entropy,
+ *                  base58-encoded (~22 chars). Reconstructed to the mnemonic via
+ *                  `entropyToMnemonic`. Keeping the entropy (not the words) makes
+ *                  the link short and chat/QR friendly.
+ * - amount-hint-pc OPTIONAL, non-secret cosmetic hint (picocredits) so the claim
+ *                  page can show "X BTH" before the on-chain scan completes. The
+ *                  scan is always authoritative; the hint adds no privacy loss
+ *                  (the holder learns the amount from the scan anyway).
+ *
+ * Security / bearer model:
+ * - 128-bit entropy from `@scure/bip39`'s CSPRNG (same generator as real
+ *   wallets). Adequate for a transient bearer secret.
+ * - The secret lives ONLY in the URL fragment, which browsers never transmit to
+ *   a server. The claim page must strip it (`history.replaceState`) after
+ *   reading and never log it.
+ * - Anyone with the link can claim — treat it like cash.
+ */
+
+import { generateMnemonic, entropyToMnemonic, mnemonicToEntropy } from '@scure/bip39'
+import { wordlist } from '@scure/bip39/wordlists/english.js'
+import { base58 } from '@scure/base'
+
+/** Current claim-link fragment version tag. */
+export const CLAIM_LINK_VERSION = 'v1'
+
+/** Length, in bytes, of the entropy backing a 12-word (128-bit) mnemonic. */
+export const CLAIM_LINK_ENTROPY_BYTES = 16
+
+/**
+ * A parsed claim-link secret: the reconstructed ephemeral mnemonic plus the
+ * optional, non-authoritative amount hint (picocredits) carried in the link.
+ */
+export interface ClaimLinkSecret {
+  /** The ephemeral 12-word BIP39 mnemonic that owns the funded output(s). */
+  mnemonic: string
+  /**
+   * Optional cosmetic amount hint in picocredits, if the link carried one.
+   * NEVER trust this for the claimed value — always show the scanned amount.
+   */
+  amountHint?: bigint
+}
+
+/**
+ * Generate a fresh ephemeral 12-word mnemonic (128-bit entropy) to back a new
+ * claim link. Thin wrapper over the same CSPRNG used for real wallets.
+ */
+export function createClaimLinkMnemonic(): string {
+  return generateMnemonic(wordlist, 128)
+}
+
+/**
+ * Encode a claim-link fragment for a given ephemeral mnemonic.
+ *
+ * Returns the fragment WITHOUT the leading `#`, e.g.
+ * `v1.<base58 entropy>` or `v1.<base58 entropy>.<amountHint>`.
+ *
+ * @param mnemonic  the ephemeral 12-word mnemonic (must be 128-bit / 12 words)
+ * @param amountHint optional cosmetic picocredit hint to embed
+ */
+export function encodeClaimLinkFragment(mnemonic: string, amountHint?: bigint): string {
+  const entropy = mnemonicToEntropy(mnemonic, wordlist)
+  if (entropy.length !== CLAIM_LINK_ENTROPY_BYTES) {
+    throw new Error(
+      `Claim links require a 12-word (128-bit) mnemonic; got ${entropy.length}-byte entropy`,
+    )
+  }
+  const encoded = base58.encode(entropy)
+  let fragment = `${CLAIM_LINK_VERSION}.${encoded}`
+  if (amountHint !== undefined) {
+    if (amountHint < 0n) throw new Error('amountHint must be non-negative')
+    fragment += `.${amountHint.toString()}`
+  }
+  return fragment
+}
+
+/**
+ * Build the full shareable claim URL for an ephemeral mnemonic.
+ *
+ * @param origin      e.g. `https://wallet.botho.io` (no trailing slash needed)
+ * @param mnemonic    the ephemeral 12-word mnemonic
+ * @param amountHint  optional cosmetic picocredit hint
+ */
+export function buildClaimLink(origin: string, mnemonic: string, amountHint?: bigint): string {
+  const base = origin.replace(/\/$/, '')
+  return `${base}/claim#${encodeClaimLinkFragment(mnemonic, amountHint)}`
+}
+
+/**
+ * Parse a claim-link fragment back into its ephemeral mnemonic (+ optional
+ * amount hint). Accepts the fragment with or without a leading `#`, and accepts
+ * a full URL (the part after `#` is used). Throws on a malformed/unsupported
+ * fragment.
+ */
+export function parseClaimLinkFragment(fragment: string): ClaimLinkSecret {
+  let raw = fragment.trim()
+  // Allow passing a whole URL — take only the fragment portion.
+  const hashIdx = raw.indexOf('#')
+  if (hashIdx >= 0) raw = raw.slice(hashIdx + 1)
+  if (raw.startsWith('#')) raw = raw.slice(1)
+  if (!raw) throw new Error('Empty claim-link fragment')
+
+  const parts = raw.split('.')
+  if (parts[0] !== CLAIM_LINK_VERSION) {
+    throw new Error(`Unsupported claim-link version: ${parts[0] || '(none)'}`)
+  }
+  const encoded = parts[1]
+  if (!encoded) throw new Error('Claim-link fragment is missing its secret')
+
+  let entropy: Uint8Array
+  try {
+    entropy = base58.decode(encoded)
+  } catch {
+    throw new Error('Claim-link secret is not valid base58')
+  }
+  if (entropy.length !== CLAIM_LINK_ENTROPY_BYTES) {
+    throw new Error('Claim-link secret has the wrong length')
+  }
+
+  const mnemonic = entropyToMnemonic(entropy, wordlist)
+
+  let amountHint: bigint | undefined
+  if (parts[2] !== undefined && parts[2] !== '') {
+    try {
+      amountHint = BigInt(parts[2])
+    } catch {
+      // A malformed hint is cosmetic-only; ignore it rather than fail the claim.
+      amountHint = undefined
+    }
+  }
+
+  return { mnemonic, amountHint }
+}

--- a/web/packages/core/src/wallet/index.ts
+++ b/web/packages/core/src/wallet/index.ts
@@ -12,6 +12,17 @@ import {
   type ParsedAddress,
 } from './address'
 
+// Claim-link (bearer payment link) helpers
+export {
+  CLAIM_LINK_VERSION,
+  CLAIM_LINK_ENTROPY_BYTES,
+  createClaimLinkMnemonic,
+  encodeClaimLinkFragment,
+  buildClaimLink,
+  parseClaimLinkFragment,
+  type ClaimLinkSecret,
+} from './claim-link'
+
 // Re-export address utilities
 export {
   deriveAddressFromMnemonic,

--- a/web/packages/wasm-signer/test/claim-link-live-node.test.ts
+++ b/web/packages/wasm-signer/test/claim-link-live-node.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Node-backed end-to-end test for CLAIMABLE PAYMENT LINKS (#460).
+ *
+ * Exercises the full bearer claim-link cycle against a REAL botho node, driving
+ * the SAME code the browser wallet uses: `@botho/core` claim-link helpers
+ * (generate ephemeral mnemonic, build/parse the link) + `@botho/core` address
+ * derivation + the `@botho/wasm-signer` `buildSendTransaction` / `spendableBalance`
+ * send/scan path. NO node, consensus, RPC, or address-format change — a claim
+ * link is just a normal CLSAG send to (then from) an ephemeral wallet.
+ *
+ *   1. CREATE: the sender funds a fresh ephemeral wallet (amount + sweep-fee
+ *      reserve) with a normal CLSAG send -> the funding tx mines.
+ *   2. PARSE:  the link round-trips (entropy <-> mnemonic <-> ephemeral address).
+ *   3. SCAN:   the ephemeral wallet's spendable balance == funded amount.
+ *   4. CLAIM:  sweep the ephemeral output to a DISTINCT recipient, paying the
+ *      sweep fee from the funded output -> recipient receives ~amount.
+ *   5. DOUBLE-CLAIM: after the sweep, the ephemeral wallet is empty (key image
+ *      spent) -> a second scan reads back 0 ("already claimed").
+ *
+ * Gating: identical to send-live-node.test.ts. Run with a throwaway local node:
+ *   BOTHO_E2E_NODE=1 pnpm --filter @botho/wasm-signer test
+ * or against a running node (must be MINTING so txs confirm):
+ *   BOTHO_LIVE_RPC=http://127.0.0.1:17501/rpc \
+ *   BOTHO_LIVE_MNEMONIC="<funded sender phrase>" \
+ *   pnpm --filter @botho/wasm-signer test
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import {
+  deriveKeypairs,
+  deriveAddress,
+  parseAddress,
+  createClaimLinkMnemonic,
+  buildClaimLink,
+  parseClaimLinkFragment,
+} from '@botho/core'
+import {
+  buildSendTransaction,
+  spendableBalance,
+  setSigner,
+  resetSigner,
+  type KeyImageSpentStatus,
+  type SendRpc,
+  type WasmSigner,
+} from '../src/index'
+import { startNodeBackedHarness, type NodeHarness } from './node-harness'
+
+const env =
+  (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {}
+
+const here = dirname(fileURLToPath(import.meta.url))
+const pkgDir = join(here, '..', 'pkg')
+const wasmGlue = join(pkgDir, 'bth_wasm_signer.js')
+const wasmBin = join(pkgDir, 'bth_wasm_signer_bg.wasm')
+const wasmBuilt = existsSync(wasmGlue) && existsSync(wasmBin)
+
+const RUN_LOCAL_NODE = env.BOTHO_E2E_NODE === '1'
+const PRE_RUNNING_RPC = env.BOTHO_LIVE_RPC
+const PRE_RUNNING_MNEMONIC = env.BOTHO_LIVE_MNEMONIC
+const enabled = wasmBuilt && (RUN_LOCAL_NODE || (PRE_RUNNING_RPC && PRE_RUNNING_MNEMONIC))
+const maybe = enabled ? describe : describe.skip
+
+const MIN_TX_FEE = 100_000_000n
+const SWEEP_FEE_RESERVE = 2n * MIN_TX_FEE
+const LINK_NET = 1_000_000_000_000n // 1 BTH net to the recipient
+
+const toHex = (b: Uint8Array) =>
+  Array.from(b).map((x) => x.toString(16).padStart(2, '0')).join('')
+function leHexToBigInt(hex: string): bigint {
+  let r = 0n
+  for (let i = hex.length - 2; i >= 0; i -= 2) r = (r << 8n) | BigInt(parseInt(hex.slice(i, i + 2), 16))
+  return r
+}
+
+interface RawOutput {
+  targetKey: string
+  publicKey: string
+  amountCommitment: string
+}
+
+interface WasmMod extends WasmSigner {
+  default: (init: { module_or_path: BufferSource }) => Promise<unknown>
+}
+async function loadWasmNode(): Promise<WasmSigner> {
+  const mod = (await import(/* @vite-ignore */ wasmGlue)) as unknown as WasmMod
+  await mod.default({ module_or_path: readFileSync(wasmBin) })
+  return {
+    buildAndSign: (r) => mod.buildAndSign(r),
+    scanOwnedOutputs: (r) => mod.scanOwnedOutputs(r),
+    computeOwnedOutputKeyImages: (r) => mod.computeOwnedOutputKeyImages(r),
+    ringSize: () => mod.ringSize(),
+    minFee: () => mod.minFee(),
+  }
+}
+
+function makeRpc(url: string) {
+  let id = 1
+  return async function rpc<T>(method: string, params: Record<string, unknown>): Promise<T> {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method, params, id: id++ }),
+    })
+    const json = (await res.json()) as { result?: T; error?: { message: string } }
+    if (json.error) throw new Error(`${method}: ${json.error.message}`)
+    return json.result as T
+  }
+}
+
+const keysOf = (m: string) => {
+  const kp = deriveKeypairs(m, 0)
+  return { spendPrivateKey: toHex(kp.spendPrivate), viewPrivateKey: toHex(kp.viewPrivate) }
+}
+const recipientOf = (addr: string) => {
+  const k = parseAddress(addr)
+  return { spend_public_key: toHex(k.spendPublic), view_public_key: toHex(k.viewPublic) }
+}
+
+maybe('claim-link node-backed: create -> claim -> already-claimed (#460)', () => {
+  let harness: NodeHarness | null = null
+  let rpcUrl: string
+  let senderMnemonic: string
+  let signer: WasmSigner
+  let rpc: ReturnType<typeof makeRpc>
+  let sendRpc: SendRpc
+
+  beforeAll(async () => {
+    signer = await loadWasmNode()
+    setSigner(signer)
+    if (RUN_LOCAL_NODE) {
+      const minBlocks = signer.ringSize() + 5
+      harness = await startNodeBackedHarness({ minBlocks })
+      rpcUrl = harness.rpcUrl
+      senderMnemonic = harness.mnemonic
+    } else {
+      rpcUrl = PRE_RUNNING_RPC!
+      senderMnemonic = PRE_RUNNING_MNEMONIC!
+    }
+    rpc = makeRpc(rpcUrl)
+    sendRpc = {
+      getChainHeight: async () => (await rpc<{ chainHeight: number }>('node_getStatus', {})).chainHeight,
+      getOutputs: (start, end) =>
+        rpc<Array<{ outputs: RawOutput[] }>>('chain_getOutputs', {
+          start_height: start,
+          end_height: end,
+        }).then((blocks) =>
+          blocks.flatMap((b) =>
+            b.outputs.map((o) => ({
+              targetKey: o.targetKey,
+              publicKey: o.publicKey,
+              amount: leHexToBigInt(o.amountCommitment),
+            })),
+          ),
+        ),
+      areKeyImagesSpent: (keyImages) =>
+        rpc<KeyImageSpentStatus[]>('chain_areKeyImagesSpent', { keyImages }),
+    }
+  }, 300_000)
+
+  afterAll(async () => {
+    if (harness) await harness.stop()
+    resetSigner()
+  })
+
+  async function waitForMined(txHash: string): Promise<number> {
+    for (let i = 0; i < 180; i++) {
+      const status = await rpc<{ status: string; blockHeight: number | null }>('tx_get', {
+        tx_hash: txHash,
+      })
+      if (status.status === 'confirmed' && status.blockHeight != null) return status.blockHeight
+      await new Promise((r) => setTimeout(r, 1000))
+    }
+    throw new Error(`tx ${txHash} was not mined in time`)
+  }
+
+  async function sendTx(senderM: string, destAddr: string, amount: bigint, fee: bigint) {
+    const { txHex } = await buildSendTransaction({
+      keys: keysOf(senderM),
+      recipient: recipientOf(destAddr),
+      amount,
+      fee,
+      rpc: sendRpc,
+    })
+    const { txHash } = await rpc<{ txHash: string }>('tx_submit', { tx_hex: txHex })
+    return txHash
+  }
+
+  it('funds an ephemeral link, claims it to a fresh address, then reads back claimed', async () => {
+    // 1. CREATE — fund a fresh ephemeral wallet (net + sweep-fee reserve).
+    const ephMnemonic = createClaimLinkMnemonic()
+    const ephAddress = deriveAddress(ephMnemonic)
+    const url = buildClaimLink('https://wallet.botho.io', ephMnemonic, LINK_NET)
+
+    const fundTx = await sendTx(senderMnemonic, ephAddress, LINK_NET + SWEEP_FEE_RESERVE, MIN_TX_FEE)
+    expect(fundTx).toBeTruthy()
+    await waitForMined(fundTx)
+
+    // 2. PARSE — link round-trips back to the same ephemeral wallet.
+    const parsed = parseClaimLinkFragment(url)
+    expect(parsed.amountHint).toBe(LINK_NET)
+    expect(deriveAddress(parsed.mnemonic)).toBe(ephAddress)
+
+    // 3. SCAN — the ephemeral wallet now holds exactly the funded amount.
+    const ephGross = await spendableBalance(keysOf(parsed.mnemonic), sendRpc)
+    expect(ephGross).toBe(LINK_NET + SWEEP_FEE_RESERVE)
+
+    // 4. CLAIM — sweep to a DISTINCT recipient, fee paid from the output.
+    const destMnemonic = createClaimLinkMnemonic()
+    const destAddress = deriveAddress(destMnemonic)
+    const sweepNet = ephGross - MIN_TX_FEE
+    const sweepTx = await sendTx(parsed.mnemonic, destAddress, sweepNet, MIN_TX_FEE)
+    await waitForMined(sweepTx)
+
+    const destBal = await spendableBalance(keysOf(destMnemonic), sendRpc)
+    expect(destBal).toBe(sweepNet)
+    // Recipient nets at least the intended amount (reserve covered the fee).
+    expect(destBal).toBeGreaterThanOrEqual(LINK_NET)
+
+    // 5. DOUBLE-CLAIM — the ephemeral output's key image is spent; re-scan is 0.
+    const ephAfter = await spendableBalance(keysOf(parsed.mnemonic), sendRpc)
+    expect(ephAfter).toBe(0n)
+  }, 300_000)
+})

--- a/web/packages/web-wallet/src/App.tsx
+++ b/web/packages/web-wallet/src/App.tsx
@@ -3,6 +3,7 @@ import { NetworkProvider } from './contexts/network'
 import { WalletProvider } from './contexts/wallet'
 import { LandingPage } from './pages/landing'
 import { WalletPage } from './pages/wallet'
+import { ClaimPage } from './pages/claim'
 import { DocsPage } from './pages/docs'
 import { ExplorerPage } from './pages/explorer'
 
@@ -42,6 +43,7 @@ function App() {
             <Route path="/home" element={<LandingPage />} />
             <Route path="/about" element={<LandingPage />} />
             <Route path="/wallet" element={<WalletPage />} />
+            <Route path="/claim" element={<ClaimPage />} />
             <Route path="/explorer" element={<ExplorerPage />} />
             <Route path="/explorer/tx/:hash" element={<ExplorerPage />} />
             <Route path="/explorer/block/:hash" element={<ExplorerPage />} />

--- a/web/packages/web-wallet/src/components/OutstandingLinks.tsx
+++ b/web/packages/web-wallet/src/components/OutstandingLinks.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react'
+import { Button, Card } from '@botho/ui'
+import { formatBTH, shortenAddress, buildClaimLink } from '@botho/core'
+import { Link2, Copy, Check, RotateCcw, Trash2, RefreshCw } from 'lucide-react'
+import { useWallet } from '../contexts/wallet'
+
+/**
+ * P3 — Outstanding claim links (sender side, #460).
+ *
+ * Lists locally-tracked claim links with their status, lets the sender copy a
+ * link again, reclaim (refund) an unclaimed link's funds, or forget a record.
+ * Status is refreshed by re-scanning each ephemeral wallet (chain is the source
+ * of truth: a swept output reads back as "claimed").
+ */
+export function OutstandingLinks() {
+  const { claimLinks, refreshClaimLinks, refundClaimLink, forgetClaimLink } = useWallet()
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [copiedId, setCopiedId] = useState<string | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
+
+  useEffect(() => {
+    // Refresh statuses once when the list is shown.
+    setRefreshing(true)
+    refreshClaimLinks().finally(() => setRefreshing(false))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  if (claimLinks.length === 0) return null
+
+  const handleRefresh = async () => {
+    setRefreshing(true)
+    setError(null)
+    try {
+      await refreshClaimLinks()
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
+  const handleCopy = async (id: string, ephMnemonic: string, amount: bigint) => {
+    const origin =
+      typeof window !== 'undefined' && window.location?.origin
+        ? window.location.origin
+        : 'https://wallet.botho.io'
+    const url = buildClaimLink(origin, ephMnemonic, amount)
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopiedId(id)
+      setTimeout(() => setCopiedId(null), 2000)
+    } catch {
+      // ignore clipboard failures
+    }
+  }
+
+  const handleRefund = async (id: string) => {
+    setBusyId(id)
+    setError(null)
+    try {
+      await refundClaimLink(id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Refund failed')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const statusLabel = (status: string) => {
+    switch (status) {
+      case 'claimed':
+        return <span className="text-xs text-ghost">Claimed</span>
+      case 'refunded':
+        return <span className="text-xs text-ghost">Refunded</span>
+      default:
+        return <span className="text-xs text-amber-400">Outstanding</span>
+    }
+  }
+
+  return (
+    <Card className="p-4 sm:p-5">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Link2 className="text-pulse" size={18} />
+          <h3 className="font-medium text-light">Outstanding Links</h3>
+        </div>
+        <Button variant="ghost" size="sm" onClick={handleRefresh} disabled={refreshing} title="Refresh statuses">
+          <RefreshCw size={16} className={refreshing ? 'animate-spin' : ''} />
+        </Button>
+      </div>
+
+      {error && (
+        <div className="mb-3 p-2.5 rounded-lg bg-danger/10 border border-danger/20 text-danger text-xs">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {claimLinks.map((link) => (
+          <div
+            key={link.id}
+            className="flex items-center justify-between gap-3 p-3 rounded-lg bg-abyss border border-steel"
+          >
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-light font-medium">{formatBTH(link.amount)} BTH</span>
+                {statusLabel(link.status)}
+              </div>
+              <p className="text-xs text-ghost font-mono truncate">{shortenAddress(link.ephAddress)}</p>
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              <Button
+                variant="ghost"
+                size="sm"
+                title="Copy link"
+                onClick={() => handleCopy(link.id, link.ephMnemonic, link.amount)}
+              >
+                {copiedId === link.id ? <Check size={15} /> : <Copy size={15} />}
+              </Button>
+              {link.status === 'outstanding' && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  title="Reclaim funds"
+                  disabled={busyId === link.id}
+                  onClick={() => handleRefund(link.id)}
+                >
+                  {busyId === link.id ? (
+                    <RefreshCw size={15} className="animate-spin" />
+                  ) : (
+                    <RotateCcw size={15} />
+                  )}
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                title="Forget"
+                onClick={() => forgetClaimLink(link.id)}
+              >
+                <Trash2 size={15} />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  )
+}

--- a/web/packages/web-wallet/src/components/SendLinkModal.tsx
+++ b/web/packages/web-wallet/src/components/SendLinkModal.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react'
+import { Button, Card, Input } from '@botho/ui'
+import { formatBTH, parseBTH } from '@botho/core'
+import { Link2, Copy, Check, AlertCircle, Loader2, X, ShieldAlert } from 'lucide-react'
+import { useWallet, type CreatedClaimLink } from '../contexts/wallet'
+
+/**
+ * P1 — "Send via link" (claimable payment link, #460).
+ *
+ * Sender enters an amount; we fund a fresh ephemeral wallet (the link's bearer
+ * secret) and produce a shareable URL. The bearer warning is shown explicitly:
+ * anyone with the link can claim, like cash. The secret lives only in the URL
+ * fragment — never sent to a server.
+ */
+export function SendLinkModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  const { sendViaLink, balance } = useWallet()
+  const [amountStr, setAmountStr] = useState('')
+  const [isCreating, setIsCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [created, setCreated] = useState<CreatedClaimLink | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  if (!isOpen) return null
+
+  const reset = () => {
+    setAmountStr('')
+    setError(null)
+    setCreated(null)
+    setCopied(false)
+    setIsCreating(false)
+  }
+
+  const handleClose = () => {
+    reset()
+    onClose()
+  }
+
+  let amount = 0n
+  try {
+    amount = amountStr ? parseBTH(amountStr) : 0n
+  } catch {
+    amount = 0n
+  }
+  const available = balance?.available ?? 0n
+  const canCreate = amount > 0n && !isCreating
+
+  const handleCreate = async () => {
+    setError(null)
+    setIsCreating(true)
+    try {
+      const result = await sendViaLink(amount)
+      setCreated(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create link')
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  const handleCopy = async () => {
+    if (!created) return
+    try {
+      await navigator.clipboard.writeText(created.url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard may be unavailable; the URL is still selectable in the field.
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-void/80 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4 z-50">
+      <Card className="w-full sm:max-w-md p-5 sm:p-6 rounded-t-2xl sm:rounded-2xl">
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-2">
+            <Link2 className="text-pulse" size={20} />
+            <h3 className="font-display text-lg font-semibold">Send via Link</h3>
+          </div>
+          <button onClick={handleClose} className="text-ghost hover:text-light" aria-label="Close">
+            <X size={20} />
+          </button>
+        </div>
+
+        {!created ? (
+          <div className="space-y-4">
+            <p className="text-sm text-ghost">
+              Create a shareable link the recipient can claim to any address — even
+              if they don&apos;t have a wallet yet.
+            </p>
+
+            <div>
+              <label className="block text-sm text-ghost mb-1.5">Amount (BTH)</label>
+              <Input
+                type="text"
+                inputMode="decimal"
+                placeholder="0.00"
+                value={amountStr}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  setAmountStr(e.target.value)
+                  setError(null)
+                }}
+                autoFocus
+              />
+              <p className="text-xs text-ghost mt-1">
+                Available: {formatBTH(available)} BTH. A small network fee is added to
+                cover the recipient&apos;s claim.
+              </p>
+            </div>
+
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
+              <ShieldAlert size={16} className="text-amber-400 mt-0.5 shrink-0" />
+              <p className="text-xs text-amber-200/90">
+                <strong>Anyone with this link can claim these funds — share it like
+                cash.</strong> The link reveals its amount to whoever holds it. Send small
+                amounts and reclaim unclaimed links from &quot;Outstanding links.&quot;
+              </p>
+            </div>
+
+            {error && (
+              <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+                <AlertCircle size={16} className="shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+
+            <Button onClick={handleCreate} disabled={!canCreate} className="w-full justify-center">
+              {isCreating ? (
+                <><Loader2 size={16} className="mr-2 animate-spin" />Creating link…</>
+              ) : (
+                <><Link2 size={16} className="mr-2" />Create Claim Link</>
+              )}
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-success/10 border border-success/20">
+              <Check size={16} className="text-success mt-0.5 shrink-0" />
+              <p className="text-sm text-success">
+                Link created and funded with {formatBTH(created.amount)} BTH. Share it with
+                the recipient.
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm text-ghost mb-1.5">Claim link</label>
+              <div className="flex gap-2">
+                <input
+                  readOnly
+                  value={created.url}
+                  onFocus={(e) => e.currentTarget.select()}
+                  className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-abyss border border-steel font-mono text-xs text-light"
+                />
+                <Button onClick={handleCopy} size="sm" variant="secondary">
+                  {copied ? <Check size={16} /> : <Copy size={16} />}
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
+              <ShieldAlert size={16} className="text-amber-400 mt-0.5 shrink-0" />
+              <p className="text-xs text-amber-200/90">
+                Treat this link like cash. Anyone who opens it can claim the funds. If it
+                goes unclaimed you can reclaim it from &quot;Outstanding links.&quot;
+              </p>
+            </div>
+
+            <div className="flex gap-2">
+              <Button onClick={reset} variant="secondary" className="flex-1 justify-center">
+                Create another
+              </Button>
+              <Button onClick={handleClose} className="flex-1 justify-center">
+                Done
+              </Button>
+            </div>
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -8,9 +8,10 @@ import {
   type ReactNode,
 } from 'react'
 import { RemoteNodeAdapter, type WsConnectionStatus } from '@botho/adapters'
-import { AddressBook, saveWallet, loadWallet, getWalletInfo, deriveAddress, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet } from '@botho/core'
-import type { Balance, Contact, NodeInfo, Transaction } from '@botho/core'
+import { AddressBook, ClaimLinkStore, saveWallet, loadWallet, getWalletInfo, deriveAddress, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet, createClaimLinkMnemonic, buildClaimLink } from '@botho/core'
+import type { Balance, Contact, NodeInfo, Transaction, ClaimLinkRecord } from '@botho/core'
 import { buildSendTransaction, spendableBalance, buildOwnedHistory } from '@botho/wasm-signer'
+import { buildAndSubmitSend, scanEphemeral, sweepEphemeral, SWEEP_FEE_RESERVE } from '../lib/claim-link-ops'
 import { type NetworkConfig, loadSelectedNetwork, loadSelectedIngress, NETWORKS, DEFAULT_NETWORK_ID, DEFAULT_INGRESS_ID, createCustomNetwork, networkForIngress, getIngressNode } from '../config/networks'
 
 interface WalletState {
@@ -33,6 +34,23 @@ interface WalletState {
 
   // Address book
   contacts: Contact[]
+
+  // Outstanding claim links (sender side, #460)
+  claimLinks: ClaimLinkRecord[]
+}
+
+/** Result of creating a claimable payment link. */
+export interface CreatedClaimLink {
+  /** The shareable URL with the secret in the fragment. */
+  url: string
+  /** The ephemeral receiving address the funds were sent to. */
+  ephAddress: string
+  /** Net amount the recipient will receive, in picocredits. */
+  amount: bigint
+  /** Funding transaction hash. */
+  fundingTxHash: string
+  /** Local record id. */
+  id: string
 }
 
 interface WalletContextValue extends WalletState {
@@ -60,6 +78,20 @@ interface WalletContextValue extends WalletState {
   updateContact: (id: string, updates: Partial<Pick<Contact, 'name' | 'address' | 'notes'>>) => Promise<Contact>
   deleteContact: (id: string) => Promise<void>
   getContactName: (address: string) => string
+
+  // Claimable payment links (#460)
+  /**
+   * Create a claim link: fund a fresh ephemeral wallet from this wallet with
+   * `amount` + a sweep-fee reserve, persist the outstanding record, and return
+   * the shareable URL. `amount` is the NET the recipient receives.
+   */
+  sendViaLink: (amount: bigint) => Promise<CreatedClaimLink>
+  /** Refresh outstanding-link statuses by re-scanning each ephemeral wallet. */
+  refreshClaimLinks: () => Promise<void>
+  /** Reclaim an unclaimed link's funds back to this wallet. */
+  refundClaimLink: (id: string) => Promise<string>
+  /** Forget a claim-link record locally (does not touch on-chain funds). */
+  forgetClaimLink: (id: string) => Promise<void>
 }
 
 /** Encode bytes as a lowercase hex string. */
@@ -172,6 +204,7 @@ async function fetchHistory(
 const WalletContext = createContext<WalletContextValue | null>(null)
 
 const addressBook = new AddressBook()
+const claimLinkStore = new ClaimLinkStore()
 
 /** Polling interval when WebSocket is disconnected (30 seconds) */
 const FALLBACK_POLL_INTERVAL = 30000
@@ -219,6 +252,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     balance: null,
     transactions: [],
     contacts: [],
+    claimLinks: [],
   })
 
   // Store adapter in ref so we can recreate it when network changes
@@ -231,6 +265,13 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     addressBook.load().then(() => {
       setState(s => ({ ...s, contacts: addressBook.getAll() }))
+    })
+  }, [])
+
+  // Load outstanding claim links on mount
+  useEffect(() => {
+    claimLinkStore.load().then(() => {
+      setState(s => ({ ...s, claimLinks: claimLinkStore.getAll() }))
     })
   }, [])
 
@@ -579,6 +620,97 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     setState(s => ({ ...s, transactions }))
   }, [state.address])
 
+  // Claimable payment link methods (#460) ---------------------------------
+
+  const sendViaLink = useCallback(async (amount: bigint): Promise<CreatedClaimLink> => {
+    const adapter = adapterRef.current
+    if (!adapter.isConnected()) throw new Error('Not connected to a node')
+    const mnemonic = mnemonicRef.current
+    if (!mnemonic) throw new Error('Wallet is locked. Unlock it before sending.')
+    if (amount <= 0n) throw new Error('Amount must be greater than 0')
+
+    // 1. Generate the ephemeral wallet (the link's bearer secret) and its addr.
+    const ephMnemonic = createClaimLinkMnemonic()
+    const ephAddress = deriveAddress(ephMnemonic)
+
+    // 2. Fund the ephemeral address with amount + a sweep-fee reserve, so the
+    //    recipient nets `amount` after paying the sweep fee from the output.
+    const fundingAmount = amount + SWEEP_FEE_RESERVE
+    const fundingTxHash = await buildAndSubmitSend(adapter, mnemonic, ephAddress, fundingAmount)
+
+    // 3. Persist the outstanding link locally so the sender can track/refund.
+    const record = await claimLinkStore.add({
+      ephMnemonic,
+      ephAddress,
+      amount,
+      fundingTxHash,
+    })
+    setState(s => ({ ...s, claimLinks: claimLinkStore.getAll() }))
+
+    // 4. Build the shareable URL with the secret in the fragment (+ amount hint).
+    const origin =
+      typeof window !== 'undefined' && window.location?.origin
+        ? window.location.origin
+        : 'https://wallet.botho.io'
+    const url = buildClaimLink(origin, ephMnemonic, amount)
+
+    // Refresh the sender's balance opportunistically.
+    if (state.address) {
+      fetchBalance(adapter, state.address, mnemonicRef.current)
+        .then((balance) => setState((s) => ({ ...s, balance })))
+        .catch(() => {})
+    }
+
+    return { url, ephAddress, amount, fundingTxHash, id: record.id }
+  }, [state.address])
+
+  const refreshClaimLinks = useCallback(async () => {
+    const adapter = adapterRef.current
+    if (!adapter.isConnected()) return
+    const records = claimLinkStore.getAll()
+    for (const r of records) {
+      if (r.status !== 'outstanding') continue
+      try {
+        const { gross } = await scanEphemeral(adapter, r.ephMnemonic)
+        // An outstanding link whose ephemeral output is no longer spendable
+        // (gross === 0) AND whose funding has had time to confirm means it was
+        // swept by someone — mark it claimed. We only flip on a zero result to
+        // avoid racing the funding confirmation.
+        if (gross === 0n) {
+          await claimLinkStore.setStatus(r.id, 'claimed')
+        }
+      } catch {
+        // Ignore scan errors; leave status unchanged.
+      }
+    }
+    setState(s => ({ ...s, claimLinks: claimLinkStore.getAll() }))
+  }, [])
+
+  const refundClaimLink = useCallback(async (id: string): Promise<string> => {
+    const adapter = adapterRef.current
+    if (!adapter.isConnected()) throw new Error('Not connected to a node')
+    if (!state.address) throw new Error('No wallet address to refund to')
+    const record = claimLinkStore.getAll().find((r) => r.id === id)
+    if (!record) throw new Error('Claim link not found')
+
+    // Sweep the ephemeral output back to the sender's own address.
+    const { txHash } = await sweepEphemeral(adapter, record.ephMnemonic, state.address)
+    await claimLinkStore.setStatus(id, 'refunded')
+    setState(s => ({ ...s, claimLinks: claimLinkStore.getAll() }))
+
+    if (state.address) {
+      fetchBalance(adapter, state.address, mnemonicRef.current)
+        .then((balance) => setState((s) => ({ ...s, balance })))
+        .catch(() => {})
+    }
+    return txHash
+  }, [state.address])
+
+  const forgetClaimLink = useCallback(async (id: string) => {
+    await claimLinkStore.delete(id)
+    setState(s => ({ ...s, claimLinks: claimLinkStore.getAll() }))
+  }, [])
+
   // Address book methods
   const addContact = useCallback(async (name: string, address: string, notes?: string) => {
     const contact = await addressBook.add(name, address, notes)
@@ -620,6 +752,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         updateContact,
         deleteContact,
         getContactName,
+        sendViaLink,
+        refreshClaimLinks,
+        refundClaimLink,
+        forgetClaimLink,
       }}
     >
       {children}

--- a/web/packages/web-wallet/src/lib/claim-link-ops.test.ts
+++ b/web/packages/web-wallet/src/lib/claim-link-ops.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setSigner, resetSigner, type WasmSigner } from '@botho/wasm-signer'
+import { deriveAddress, createClaimLinkMnemonic } from '@botho/core'
+import { scanEphemeral, sweepEphemeral, MIN_TX_FEE, SWEEP_FEE_RESERVE } from './claim-link-ops'
+import type { RemoteNodeAdapter } from '@botho/adapters'
+
+/**
+ * Unit tests for the claim-link transaction ops (#460).
+ *
+ * Mirrors the `history.test.ts` seam: inject a fully-controlled fake
+ * `WasmSigner` via `setSigner` and a stub adapter so we can assert the net/fee
+ * math, the already-claimed / not-confirmed handling, and the sweep error paths
+ * deterministically — no real crypto or live node.
+ *
+ * The fake signer "owns" any output whose targetKey starts with "eph". A
+ * targetKey appended with ":spent" is reported spent by the adapter stub.
+ */
+
+function fakeSigner(): WasmSigner {
+  return {
+    buildAndSign: () => 'deadbeef',
+    ringSize: () => 3,
+    minFee: () => MIN_TX_FEE,
+    scanOwnedOutputs: ({ outputs }) =>
+      outputs
+        .filter((o) => o.targetKey.startsWith('eph'))
+        .map((o) => ({
+          targetKey: o.targetKey,
+          publicKey: o.publicKey,
+          amount: typeof o.amount === 'bigint' ? o.amount : BigInt(o.amount),
+          subaddressIndex: 0n,
+        })),
+    computeOwnedOutputKeyImages: ({ outputs }) =>
+      outputs.map((o) => ({
+        targetKey: o.targetKey,
+        publicKey: o.publicKey,
+        amount: o.amount,
+        subaddressIndex: o.subaddressIndex,
+        keyImage: `ki-${o.targetKey}`,
+      })),
+  }
+}
+
+interface StubOpts {
+  outputs?: Array<{ targetKey: string; publicKey: string; amount: bigint }>
+  spentKeyImages?: Set<string>
+  submitOk?: boolean
+  connected?: boolean
+}
+
+function stubAdapter(opts: StubOpts = {}): RemoteNodeAdapter {
+  const {
+    outputs = [],
+    spentKeyImages = new Set(),
+    submitOk = true,
+    connected = true,
+  } = opts
+  return {
+    isConnected: () => connected,
+    getBlockHeight: async () => 100,
+    estimateFee: async () => MIN_TX_FEE,
+    getRawOutputs: async () => outputs,
+    areKeyImagesSpent: async (keyImages: string[]) =>
+      keyImages.map((keyImage) => ({
+        keyImage,
+        spent: spentKeyImages.has(keyImage),
+        spentHeight: spentKeyImages.has(keyImage) ? 50 : null,
+        pending: false,
+      })),
+    submitTransaction: vi.fn(async () =>
+      submitOk
+        ? { success: true, txHash: 'sweeptx123' }
+        : { success: false, error: 'double-spend detected' },
+    ),
+  } as unknown as RemoteNodeAdapter
+}
+
+const EPH_MNEMONIC = createClaimLinkMnemonic()
+
+afterEach(() => resetSigner())
+
+describe('scanEphemeral', () => {
+  it('computes net = gross - fee for a funded ephemeral wallet', async () => {
+    setSigner(fakeSigner())
+    const gross = 5_000_000_000_000n + SWEEP_FEE_RESERVE
+    const adapter = stubAdapter({
+      outputs: [{ targetKey: 'eph-1', publicKey: 'pk1', amount: gross }],
+    })
+    const scan = await scanEphemeral(adapter, EPH_MNEMONIC)
+    expect(scan.gross).toBe(gross)
+    expect(scan.fee).toBe(MIN_TX_FEE)
+    expect(scan.net).toBe(gross - MIN_TX_FEE)
+  })
+
+  it('reports zero when nothing is owned (not yet confirmed)', async () => {
+    setSigner(fakeSigner())
+    const adapter = stubAdapter({
+      outputs: [{ targetKey: 'foreign-1', publicKey: 'pk', amount: 9n }],
+    })
+    const scan = await scanEphemeral(adapter, EPH_MNEMONIC)
+    expect(scan.gross).toBe(0n)
+    expect(scan.net).toBe(0n)
+  })
+
+  it('reports zero when the owned output is already spent (claimed)', async () => {
+    setSigner(fakeSigner())
+    const adapter = stubAdapter({
+      outputs: [{ targetKey: 'eph-1', publicKey: 'pk1', amount: 5_000_000_000_000n }],
+      spentKeyImages: new Set(['ki-eph-1']),
+    })
+    const scan = await scanEphemeral(adapter, EPH_MNEMONIC)
+    expect(scan.gross).toBe(0n)
+  })
+})
+
+describe('sweepEphemeral', () => {
+  const DEST = deriveAddress(createClaimLinkMnemonic())
+
+  it('sweeps a funded link and returns the net + tx hash', async () => {
+    setSigner(fakeSigner())
+    const gross = 5_000_000_000_000n + SWEEP_FEE_RESERVE
+    // Need >= ringSize-1 = 2 decoys on chain besides the input.
+    const adapter = stubAdapter({
+      outputs: [
+        { targetKey: 'eph-1', publicKey: 'pk1', amount: gross },
+        { targetKey: 'decoy-1', publicKey: 'pk2', amount: 1n },
+        { targetKey: 'decoy-2', publicKey: 'pk3', amount: 1n },
+      ],
+    })
+    const result = await sweepEphemeral(adapter, EPH_MNEMONIC, DEST)
+    expect(result.txHash).toBe('sweeptx123')
+    expect(result.net).toBe(gross - MIN_TX_FEE)
+  })
+
+  it('throws "nothing to claim" when the link is empty / already claimed', async () => {
+    setSigner(fakeSigner())
+    const adapter = stubAdapter({
+      outputs: [{ targetKey: 'eph-1', publicKey: 'pk1', amount: 5_000_000_000_000n }],
+      spentKeyImages: new Set(['ki-eph-1']),
+    })
+    await expect(sweepEphemeral(adapter, EPH_MNEMONIC, DEST)).rejects.toThrow(/nothing to claim/i)
+  })
+
+  it('surfaces a double-spend submit failure (race loser)', async () => {
+    setSigner(fakeSigner())
+    const gross = 5_000_000_000_000n + SWEEP_FEE_RESERVE
+    const adapter = stubAdapter({
+      outputs: [
+        { targetKey: 'eph-1', publicKey: 'pk1', amount: gross },
+        { targetKey: 'decoy-1', publicKey: 'pk2', amount: 1n },
+        { targetKey: 'decoy-2', publicKey: 'pk3', amount: 1n },
+      ],
+      submitOk: false,
+    })
+    await expect(sweepEphemeral(adapter, EPH_MNEMONIC, DEST)).rejects.toThrow(/double-spend/i)
+  })
+
+  it('throws when not connected', async () => {
+    setSigner(fakeSigner())
+    const adapter = stubAdapter({ connected: false })
+    await expect(sweepEphemeral(adapter, EPH_MNEMONIC, DEST)).rejects.toThrow(/connected/i)
+  })
+})

--- a/web/packages/web-wallet/src/lib/claim-link-ops.ts
+++ b/web/packages/web-wallet/src/lib/claim-link-ops.ts
@@ -1,0 +1,183 @@
+/**
+ * Claim-link transaction operations (#460).
+ *
+ * Pure client-side helpers that wire the existing wasm-signer send/scan path to
+ * an ephemeral (claim-link) wallet. NOTHING here touches the node beyond the
+ * RPCs the normal send/balance path already uses (`chain_getOutputs`,
+ * `chain_areKeyImagesSpent`, `tx_submit`). No new RPCs, no consensus change.
+ *
+ * - `fundEphemeral`: a normal CLSAG send FROM the sender's wallet TO the
+ *   ephemeral address (this is just `wallet.send`, factored to the context).
+ * - `scanEphemeral`: derive the ephemeral keys, scan its owned outputs, and
+ *   spent-filter them — exactly `spendableBalance`, but returning the gross
+ *   spendable total so the claim page can subtract the sweep fee.
+ * - `sweepEphemeral`: build a CLSAG send FROM the ephemeral keys to a chosen
+ *   destination, paying the sweep fee from the funded output.
+ */
+
+import { deriveKeypairs, parseAddress } from '@botho/core'
+import { buildSendTransaction, spendableBalance, type SendRpc } from '@botho/wasm-signer'
+import type { RemoteNodeAdapter } from '@botho/adapters'
+
+/** Signer's MIN_TX_FEE (picocredits) — mirrors wallet.tsx `send()`. */
+export const MIN_TX_FEE = 100_000_000n
+
+/**
+ * Sweep-fee reserve added when funding a link so the recipient nets the round
+ * number. The architect recommends reserving 2x MIN_TX_FEE to absorb a fee
+ * bump between create and claim (still negligible).
+ */
+export const SWEEP_FEE_RESERVE = 2n * MIN_TX_FEE
+
+function toHex(bytes: Uint8Array): string {
+  let out = ''
+  for (const b of bytes) out += b.toString(16).padStart(2, '0')
+  return out
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
+}
+
+/** Build the {@link SendRpc} accessor from a connected adapter. */
+function rpcFromAdapter(adapter: RemoteNodeAdapter): SendRpc {
+  return {
+    getChainHeight: () => adapter.getBlockHeight(),
+    getOutputs: (start, end) => adapter.getRawOutputs(start, end),
+    areKeyImagesSpent: (keyImages) => adapter.areKeyImagesSpent(keyImages),
+  }
+}
+
+/** Resolve the send fee, clamped to the consensus floor (mirrors send()). */
+async function resolveFee(adapter: RemoteNodeAdapter): Promise<bigint> {
+  let fee: bigint
+  try {
+    fee = await adapter.estimateFee(0)
+  } catch {
+    fee = 0n
+  }
+  return fee < MIN_TX_FEE ? MIN_TX_FEE : fee
+}
+
+/**
+ * Build + submit a CLSAG send from `senderMnemonic` to `recipientAddress`.
+ * Shared core for both a normal send and funding a claim link.
+ */
+export async function buildAndSubmitSend(
+  adapter: RemoteNodeAdapter,
+  senderMnemonic: string,
+  recipientAddress: string,
+  amount: bigint,
+): Promise<string> {
+  if (!adapter.isConnected()) throw new Error('Not connected to a node')
+  const kp = deriveKeypairs(senderMnemonic, 0)
+  const recipientKeys = parseAddress(recipientAddress)
+  const fee = await resolveFee(adapter)
+
+  const { txHex } = await buildSendTransaction({
+    keys: {
+      spendPrivateKey: toHex(kp.spendPrivate),
+      viewPrivateKey: toHex(kp.viewPrivate),
+    },
+    recipient: {
+      spend_public_key: toHex(recipientKeys.spendPublic),
+      view_public_key: toHex(recipientKeys.viewPublic),
+    },
+    amount,
+    fee,
+    rpc: rpcFromAdapter(adapter),
+  })
+
+  const result = await adapter.submitTransaction(hexToBytes(txHex))
+  if (!result.success || !result.txHash) {
+    throw new Error(result.error || 'Transaction submission failed')
+  }
+  return result.txHash
+}
+
+/** Result of scanning an ephemeral claim-link wallet. */
+export interface EphemeralScan {
+  /** Gross spendable picocredits owned by the ephemeral wallet. */
+  gross: bigint
+  /** Sweep fee that will be charged. */
+  fee: bigint
+  /** Net picocredits the recipient receives after the sweep fee. */
+  net: bigint
+}
+
+/**
+ * Scan an ephemeral claim-link wallet for its spendable balance.
+ *
+ * Returns gross/fee/net. `gross === 0n` means either the funding tx has not
+ * confirmed yet OR the link was already claimed (the output's key image is
+ * spent) — the caller distinguishes those two via UX/state, since both yield an
+ * empty spendable set.
+ */
+export async function scanEphemeral(
+  adapter: RemoteNodeAdapter,
+  ephMnemonic: string,
+): Promise<EphemeralScan> {
+  if (!adapter.isConnected()) throw new Error('Not connected to a node')
+  const kp = deriveKeypairs(ephMnemonic, 0)
+  const gross = await spendableBalance(
+    {
+      spendPrivateKey: toHex(kp.spendPrivate),
+      viewPrivateKey: toHex(kp.viewPrivate),
+    },
+    rpcFromAdapter(adapter),
+  )
+  const fee = await resolveFee(adapter)
+  const net = gross > fee ? gross - fee : 0n
+  return { gross, fee, net }
+}
+
+/**
+ * Sweep an ephemeral claim-link wallet's funds to `destinationAddress`.
+ *
+ * Builds a CLSAG send FROM the ephemeral keys, paying the sweep fee out of the
+ * funded output so the recipient nets `gross - fee`. Throws if there is nothing
+ * spendable (already claimed / not yet confirmed). Returns the sweep tx hash.
+ */
+export async function sweepEphemeral(
+  adapter: RemoteNodeAdapter,
+  ephMnemonic: string,
+  destinationAddress: string,
+): Promise<{ txHash: string; net: bigint }> {
+  if (!adapter.isConnected()) throw new Error('Not connected to a node')
+
+  // Re-scan to get the current gross and fee at sweep time.
+  const { gross, fee, net } = await scanEphemeral(adapter, ephMnemonic)
+  if (gross === 0n) {
+    throw new Error('Nothing to claim — the link is empty, already claimed, or not yet confirmed')
+  }
+  if (net <= 0n) {
+    throw new Error('The funded amount does not cover the sweep fee')
+  }
+
+  const kp = deriveKeypairs(ephMnemonic, 0)
+  const destKeys = parseAddress(destinationAddress)
+
+  const { txHex } = await buildSendTransaction({
+    keys: {
+      spendPrivateKey: toHex(kp.spendPrivate),
+      viewPrivateKey: toHex(kp.viewPrivate),
+    },
+    recipient: {
+      spend_public_key: toHex(destKeys.spendPublic),
+      view_public_key: toHex(destKeys.viewPublic),
+    },
+    amount: net,
+    fee,
+    rpc: rpcFromAdapter(adapter),
+  })
+
+  const result = await adapter.submitTransaction(hexToBytes(txHex))
+  if (!result.success || !result.txHash) {
+    throw new Error(result.error || 'Sweep submission failed')
+  }
+  return { txHash: result.txHash, net }
+}

--- a/web/packages/web-wallet/src/pages/claim.tsx
+++ b/web/packages/web-wallet/src/pages/claim.tsx
@@ -1,0 +1,333 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Button, Card, Input, Logo } from '@botho/ui'
+import {
+  parseClaimLinkFragment,
+  isValidAddress,
+  formatBTH,
+  createMnemonic12,
+  saveWallet,
+  deriveAddress,
+  type ClaimLinkSecret,
+} from '@botho/core'
+import {
+  Gift,
+  AlertCircle,
+  Check,
+  Loader2,
+  ArrowLeft,
+  ShieldAlert,
+  Clock,
+  Eye,
+  ExternalLink,
+} from 'lucide-react'
+import { useAdapter } from '../contexts/wallet'
+import { useNetwork } from '../contexts/network'
+import { scanEphemeral, sweepEphemeral, type EphemeralScan } from '../lib/claim-link-ops'
+
+/**
+ * P2 — Claim page for claimable payment links (#460).
+ *
+ * Reads the ephemeral secret from the URL FRAGMENT (never sent to a server),
+ * strips it from the address bar, reconstructs the ephemeral wallet, scans for
+ * its spendable output(s), and lets the recipient sweep the funds to any
+ * address — pasting an existing one or creating a brand-new wallet in-flow.
+ *
+ * Chain is the source of truth: a swept (already-claimed) or not-yet-confirmed
+ * link both scan to an empty spendable set; we distinguish via state.
+ */
+
+type ClaimState =
+  | 'parsing'
+  | 'invalid'
+  | 'scanning'
+  | 'waiting' // funding not yet confirmed
+  | 'claimable'
+  | 'already-claimed'
+  | 'sweeping'
+  | 'claimed'
+
+export function ClaimPage() {
+  const adapter = useAdapter()
+  const { network } = useNetwork()
+
+  const [state, setState] = useState<ClaimState>('parsing')
+  const [secret, setSecret] = useState<ClaimLinkSecret | null>(null)
+  const [scan, setScan] = useState<EphemeralScan | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [destination, setDestination] = useState('')
+  const [claimTxHash, setClaimTxHash] = useState<string | null>(null)
+  const [createdMnemonic, setCreatedMnemonic] = useState<string | null>(null)
+  const [showNewWallet, setShowNewWallet] = useState(false)
+
+  // Track whether we've already begun a sweep so a late re-scan can't downgrade
+  // the state out from under the user.
+  const sweepingRef = useRef(false)
+
+  // 1. Parse the fragment ONCE on mount, then strip it from the URL so the
+  //    bearer secret does not linger in the address bar / history.
+  useEffect(() => {
+    const hash = window.location.hash
+    if (!hash || hash === '#') {
+      setState('invalid')
+      setError('No claim link found. The link should look like .../claim#…')
+      return
+    }
+    try {
+      const parsed = parseClaimLinkFragment(hash)
+      setSecret(parsed)
+      // Strip the fragment so the secret is not visible/logged after reading.
+      try {
+        window.history.replaceState(null, '', window.location.pathname + window.location.search)
+      } catch {
+        // replaceState may be unavailable in some embeds; non-fatal.
+      }
+      setState('scanning')
+    } catch (err) {
+      setState('invalid')
+      setError(err instanceof Error ? err.message : 'This claim link is not valid.')
+    }
+  }, [])
+
+  const runScan = useCallback(async () => {
+    if (!secret) return
+    if (sweepingRef.current) return
+    try {
+      const result = await scanEphemeral(adapter, secret.mnemonic)
+      if (sweepingRef.current) return
+      setScan(result)
+      if (result.gross > 0n) {
+        setState('claimable')
+      } else {
+        // Empty spendable set: either not yet confirmed, or already claimed.
+        // We keep "waiting" until the user has waited a bit; default to waiting
+        // so a fresh link that's mid-confirmation shows a friendly message.
+        setState((prev) => (prev === 'claimable' ? 'already-claimed' : 'waiting'))
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to scan the link.')
+      setState('invalid')
+    }
+  }, [adapter, secret])
+
+  // 2. Scan once the secret is parsed, and re-scan on each new block while we
+  //    are still waiting for the funding to confirm.
+  useEffect(() => {
+    if (state === 'scanning' || state === 'waiting') {
+      runScan()
+    }
+  }, [state, runScan])
+
+  useEffect(() => {
+    if (state !== 'waiting') return
+    const unsub = adapter.onNewBlock(() => {
+      runScan()
+    })
+    return unsub
+  }, [state, adapter, runScan])
+
+  const handleCreateWallet = () => {
+    const m = createMnemonic12()
+    setCreatedMnemonic(m)
+    setDestination(deriveAddress(m))
+    setShowNewWallet(true)
+  }
+
+  const handleSweep = async () => {
+    if (!secret) return
+    const dest = destination.trim()
+    if (!isValidAddress(dest)) {
+      setError('Enter a valid destination address (tbotho://… or botho://…).')
+      return
+    }
+    setError(null)
+    sweepingRef.current = true
+    setState('sweeping')
+    try {
+      // If the recipient created a new wallet in-flow, persist it so they can
+      // use it afterwards in this browser.
+      if (createdMnemonic && showNewWallet) {
+        await saveWallet(createdMnemonic)
+      }
+      const { txHash } = await sweepEphemeral(adapter, secret.mnemonic, dest)
+      setClaimTxHash(txHash)
+      setState('claimed')
+    } catch (err) {
+      sweepingRef.current = false
+      const msg = err instanceof Error ? err.message : 'Claim failed.'
+      // A double-spend / empty-set error means someone else claimed first.
+      if (/already claimed|empty|double|nothing to claim|spent|insufficient/i.test(msg)) {
+        setState('already-claimed')
+      } else {
+        setError(msg)
+        setState('claimable')
+      }
+    }
+  }
+
+  const explorerTxUrl =
+    claimTxHash && network.explorerUrl ? `${network.explorerUrl}/tx/${claimTxHash}` : null
+
+  return (
+    <div className="min-h-screen">
+      <header className="border-b border-steel bg-abyss/50 backdrop-blur-md sticky top-0 z-40">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between">
+          <Link to="/" className="flex items-center gap-2 sm:gap-3">
+            <ArrowLeft size={18} className="text-ghost" />
+            <Logo size="sm" showText={false} />
+            <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">Botho Wallet</span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="py-8 sm:py-12">
+        <div className="max-w-lg mx-auto px-4 sm:px-0">
+          <Card className="p-5 sm:p-8">
+            <div className="text-center mb-6">
+              <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-pulse/10 flex items-center justify-center mx-auto mb-3 sm:mb-4">
+                <Gift className="text-pulse" size={28} />
+              </div>
+              <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">Claim Your BTH</h2>
+            </div>
+
+            {(state === 'parsing' || state === 'scanning') && (
+              <div className="flex flex-col items-center gap-3 py-6 text-ghost">
+                <Loader2 size={28} className="animate-spin text-pulse" />
+                <p className="text-sm">Reading your claim link…</p>
+              </div>
+            )}
+
+            {state === 'invalid' && (
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+                <AlertCircle size={16} className="shrink-0 mt-0.5" />
+                <span>{error ?? 'This claim link is not valid.'}</span>
+              </div>
+            )}
+
+            {state === 'waiting' && (
+              <div className="flex flex-col items-center gap-3 py-4 text-center">
+                <Clock size={28} className="text-amber-400" />
+                <p className="text-sm text-ghost">
+                  Waiting for the sender&apos;s payment to confirm on-chain. This page will
+                  update automatically — it can take a minute or two.
+                </p>
+                <Loader2 size={18} className="animate-spin text-pulse" />
+              </div>
+            )}
+
+            {state === 'already-claimed' && (
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-steel/40 border border-steel text-light text-sm">
+                <Check size={16} className="shrink-0 mt-0.5 text-ghost" />
+                <span>This link has already been claimed.</span>
+              </div>
+            )}
+
+            {(state === 'claimable' || state === 'sweeping') && scan && (
+              <div className="space-y-4">
+                <div className="text-center">
+                  <p className="text-sm text-ghost">You&apos;ve been sent</p>
+                  <p className="font-display text-3xl font-bold text-pulse">{formatBTH(scan.net)} BTH</p>
+                  <p className="text-xs text-ghost mt-1">
+                    Network fee of {formatBTH(scan.fee)} BTH covered by the sender.
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm text-ghost mb-1.5">Send to address</label>
+                  <Input
+                    type="text"
+                    placeholder="tbotho://1/…"
+                    value={destination}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                      setDestination(e.target.value)
+                      setError(null)
+                      setShowNewWallet(false)
+                    }}
+                    disabled={state === 'sweeping'}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleCreateWallet}
+                    disabled={state === 'sweeping'}
+                    className="text-xs text-pulse hover:underline mt-2"
+                  >
+                    Don&apos;t have a wallet? Create one
+                  </button>
+                </div>
+
+                {showNewWallet && createdMnemonic && (
+                  <div className="p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 space-y-2">
+                    <div className="flex items-center gap-2 text-amber-300 text-sm font-medium">
+                      <Eye size={15} /> Your new recovery phrase
+                    </div>
+                    <p className="font-mono text-xs leading-relaxed text-amber-100/90 break-words">
+                      {createdMnemonic}
+                    </p>
+                    <p className="text-xs text-amber-200/80">
+                      Write this down and keep it safe — it is the ONLY way to recover this
+                      wallet. We&apos;ll save it in this browser when you claim.
+                    </p>
+                  </div>
+                )}
+
+                {error && (
+                  <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+                    <AlertCircle size={16} className="shrink-0" />
+                    <span>{error}</span>
+                  </div>
+                )}
+
+                <Button
+                  onClick={handleSweep}
+                  disabled={state === 'sweeping' || !destination.trim()}
+                  className="w-full justify-center"
+                >
+                  {state === 'sweeping' ? (
+                    <><Loader2 size={16} className="mr-2 animate-spin" />Claiming…</>
+                  ) : (
+                    <>Claim {formatBTH(scan.net)} BTH</>
+                  )}
+                </Button>
+
+                <div className="flex items-start gap-2 text-xs text-ghost">
+                  <ShieldAlert size={14} className="shrink-0 mt-0.5" />
+                  <span>
+                    This is a bearer link — anyone with it can claim. Claim promptly so no
+                    one else does first.
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {state === 'claimed' && (
+              <div className="space-y-4">
+                <div className="flex flex-col items-center gap-2 text-center">
+                  <div className="w-12 h-12 rounded-full bg-success/10 flex items-center justify-center">
+                    <Check className="text-success" size={26} />
+                  </div>
+                  <p className="text-lg font-semibold text-light">
+                    Claimed {scan ? formatBTH(scan.net) : ''} BTH
+                  </p>
+                  <p className="text-sm text-ghost">The funds are on their way to your address.</p>
+                  {explorerTxUrl && (
+                    <a
+                      href={explorerTxUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-xs text-ghost hover:text-light"
+                    >
+                      View transaction <ExternalLink size={12} />
+                    </a>
+                  )}
+                </div>
+                <Link to="/wallet">
+                  <Button className="w-full justify-center">Go to my wallet</Button>
+                </Link>
+              </div>
+            )}
+          </Card>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/web/packages/web-wallet/src/pages/index.ts
+++ b/web/packages/web-wallet/src/pages/index.ts
@@ -1,3 +1,4 @@
 export { LandingPage } from './landing'
 export { WalletPage } from './wallet'
+export { ClaimPage } from './claim'
 export { DocsPage } from './docs'

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -7,7 +7,9 @@ import { useWallet } from '../contexts/wallet'
 import { useNetwork } from '../contexts/network'
 import { NetworkSelector } from '../components/NetworkSelector'
 import { FaucetButton } from '../components/FaucetButton'
-import { Send, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2 } from 'lucide-react'
+import { SendLinkModal } from '../components/SendLinkModal'
+import { OutstandingLinks } from '../components/OutstandingLinks'
+import { Send, Link2, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2 } from 'lucide-react'
 
 function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?: string) => void }) {
   const [showMnemonic, setShowMnemonic] = useState(false)
@@ -219,6 +221,7 @@ function WalletDashboard() {
   const { address, balance, transactions, isConnecting, isConnected, refreshBalance, refreshTransactions, resetWallet, send } = useWallet()
   const { hasFaucet } = useNetwork()
   const [sendOpen, setSendOpen] = useState(false)
+  const [sendLinkOpen, setSendLinkOpen] = useState(false)
   const [isSending, setIsSending] = useState(false)
   const [showResetConfirm, setShowResetConfirm] = useState(false)
 
@@ -256,6 +259,9 @@ function WalletDashboard() {
       <Button onClick={() => setSendOpen(true)}>
         <Send size={16} className="mr-2" />Send
       </Button>
+      <Button variant="secondary" onClick={() => setSendLinkOpen(true)}>
+        <Link2 size={16} className="mr-2" />Send via Link
+      </Button>
       <Button variant="ghost" size="sm" onClick={refreshBalance} disabled={isConnecting}>
         <RefreshCw size={16} className={isConnecting ? 'animate-spin' : ''} />
       </Button>
@@ -278,6 +284,8 @@ function WalletDashboard() {
 
       {hasFaucet && <FaucetButton />}
 
+      <OutstandingLinks />
+
       <TransactionList
         transactions={transactions}
         title="Recent Transactions"
@@ -293,6 +301,8 @@ function WalletDashboard() {
         onSend={handleSend}
         isSending={isSending}
       />
+
+      <SendLinkModal isOpen={sendLinkOpen} onClose={() => setSendLinkOpen(false)} />
 
       {showResetConfirm && (
         <div className="fixed inset-0 bg-void/80 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4 z-50">


### PR DESCRIPTION
## Summary

Implements **claimable payment links** (#460): send BTH to someone with **no wallet** via a shareable link they claim to **any address** — the headline onboarding mechanism ("send money to a friend before they've set anything up").

**100% client-side.** No node, consensus, RPC, or address-format change. Reuses the existing `@botho/wasm-signer` send/scan/spend path and `@botho/core` address derivation, exactly as the architect's design comment specified. Phases **P0 + P1 + P2 + P3** are all included.

## Mechanism (bearer instrument)

A claim link is a throwaway **ephemeral BIP39 wallet** whose 128-bit entropy *is* the link secret, carried only in the URL **fragment** (browsers never send fragments to a server):

```
https://wallet.botho.io/claim#v1.<base58(16-byte entropy)>[.<amount-hint-pc>]
```

- **Create:** generate a fresh ephemeral mnemonic → derive its address → fund it from the sender's wallet via the normal CLSAG send path, over-funded by a sweep-fee reserve (2× `MIN_TX_FEE`) so the recipient nets the round number.
- **Claim:** `/claim` reads + strips the fragment (`history.replaceState`), reconstructs the ephemeral wallet, scans its spendable outputs (spent-filtered via `chain_areKeyImagesSpent`), shows "You've been sent X BTH", then sweeps to a chosen/new address (fee paid from the funded output).
- **Double-claim:** chain is the source of truth — the first sweep spends the key image, so a later scan reads back empty → **"already claimed."** The race loser's submit is rejected and mapped to "already claimed."
- **Refund:** outstanding links are tracked in localStorage (mirrors `AddressBook`); the sender can reclaim an unclaimed link (sweep back to self) from an **Outstanding links** view.
- **Bearer UX:** explicit "anyone with this link can claim — share it like cash" warnings; 128-bit entropy via the same CSPRNG as real wallets.

## What's in each phase

- **P0 helpers (`@botho/core`):** `wallet/claim-link.ts` (createClaimLinkMnemonic / encode+parse fragment / buildClaimLink) and `storage/claim-links.ts` (`ClaimLinkStore`).
- **P1 create-link:** `components/SendLinkModal.tsx` + "Send via Link" action; `sendViaLink()` in the wallet context.
- **P2 claim page:** new `/claim` route (`App.tsx`) → `pages/claim.tsx` (scan, waiting-for-confirmation, already-claimed, create-new-wallet-in-flow, sweep, confirmation).
- **P3 outstanding links + refund:** `components/OutstandingLinks.tsx` (status refresh via re-scan, copy, reclaim, forget).
- **Shared engine:** `web-wallet/src/lib/claim-link-ops.ts` wraps `buildSendTransaction`/`spendableBalance` for an arbitrary ephemeral key.

## Tests

- 25 unit tests for link encode/decode + ephemeral-wallet derivation + store round-trip (`claim-link.test.ts`, `claim-links.test.ts`).
- 7 ops tests (net/fee math, already-claimed, not-yet-confirmed, double-spend race, disconnected) via the `setSigner` seam, mirroring `history.test.ts` (`claim-link-ops.test.ts`).
- A **gated** node-backed live test (`claim-link-live-node.test.ts`) covering create → claim → already-claimed end-to-end against a real node.

**Gates:** `pnpm typecheck` ✅, `pnpm build` (incl. `build:wasm`) ✅, full unit suite **114 passed / 5 skipped** ✅ (existing suite unaffected).

## Verification notes

- Public testnet RPC reachable but `mintingActive:false`, and the local node-backed harness does not produce blocks in this sandbox — the **existing** `send-live-node.test.ts` fails identically (`node only mined 0/N blocks`, same `node-harness.ts:218`), confirming a pre-existing environmental limitation, **not** a regression. The new live test uses the identical harness path and will run wherever `send-live-node` runs.
- Existing Playwright e2e could not be executed locally: the Playwright browser binaries cannot be downloaded in this environment (CDN blocked). My changes are additive (new `/claim` route, new buttons/components) and do not alter the routes/selectors the smoke specs exercise.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)