### PR TITLE
test(web): gated Playwright live-smoke e2e against deployed wallet.botho.io + live testnet

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -96,6 +96,43 @@ E2E_BROWSER_CHANNEL=chrome \
   pnpm test:e2e
 ```
 
+### Live-smoke suite (deployed wallet + live testnet)
+
+The hermetic suite above can never catch a **deploy** regression (it builds the
+app fresh and mocks `/rpc`). The live-smoke suite (`e2e/tests/live/smoke.spec.ts`)
+drives the **deployed** wallet at `https://wallet.botho.io` against the **live**
+testnet SCP nodes, catching exactly the class of bug a hermetic run misses — e.g.
+the wasm-404 when a build lands on a Pages preview instead of production and
+`/pkg/bth_wasm_signer_bg.wasm` stops being served.
+
+It is **opt-in** and uses a **separate** config
+(`e2e/playwright.live.config.ts`) that starts **no** local servers. It is NOT in
+default CI (it hits live infra + the faucet's rate limits), and the default
+`pnpm test` / `pnpm test:e2e` never run it (the default config ignores
+`tests/live/**`).
+
+```bash
+# From web/
+npx playwright install chromium   # once
+
+BOTHO_LIVE=1 npx playwright test --config e2e/playwright.live.config.ts
+```
+
+It asserts: page + title load (HTTP 200), the WASM crypto module loads with no
+wasm console error / no failed `/pkg/*` fetch, the PWA manifest + service worker
+are served, the 3-node ingress picker lists seed/seed2/faucet and switching the
+selected node updates (and persists) state, wallet create + import work entirely
+client-side (address renders), and `/claim` loads its empty/invalid state.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `BOTHO_LIVE` | _(unset)_ | Must be `1` or the whole live suite is skipped. |
+| `BOTHO_LIVE_URL` | `https://wallet.botho.io` | Override the deployed wallet URL under test. |
+
+No default on-chain steps run (testnet mints on demand + faucet rate limits +
+~30–80s block time make a full faucet→send→claim cycle flaky); any such step
+should be gated separately and kept tolerant/skippable.
+
 ## Deploy
 
 ```bash

--- a/web/e2e/playwright.config.ts
+++ b/web/e2e/playwright.config.ts
@@ -46,6 +46,12 @@ const PROXY_TARGET = FULLSTACK ? NODE_RPC_URL : RPC_MOCK_URL
  */
 export default defineConfig({
   testDir: './tests',
+  // The live-smoke suite (tests/live/**) targets the DEPLOYED wallet + live
+  // testnet and is run via a SEPARATE config (playwright.live.config.ts), gated
+  // behind BOTHO_LIVE=1. Exclude it here so the default `pnpm test` (hermetic,
+  // local-mock) never picks it up — including via the `smoke` project's
+  // `/smoke\.spec\.ts/` testMatch, which would otherwise match it.
+  testIgnore: ['**/tests/live/**'],
   // Run serially by default: the wallet/explorer specs share a single
   // vite-preview /rpc proxy to a live seed node, and running many browser
   // contexts in parallel against it caused intermittent "connecting" flakes.

--- a/web/e2e/playwright.live.config.ts
+++ b/web/e2e/playwright.live.config.ts
@@ -1,0 +1,64 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Live-smoke Playwright config — runs the deployed wallet (wallet.botho.io) +
+ * the LIVE testnet, NOT a local build/mock.
+ *
+ * This is SEPARATE from playwright.config.ts on purpose:
+ *   - It spins up NO local servers (no serve-node / serve-rpc-mock / preview):
+ *     it points at the real deployed site + real SCP nodes.
+ *   - It only runs the gated spec under tests/live/** (which itself no-ops
+ *     unless BOTHO_LIVE=1), so it is fully OPT-IN.
+ *   - The default `pnpm test` uses playwright.config.ts and never references
+ *     this file, so the hermetic local-mock suite is completely unaffected.
+ *
+ * Run it explicitly (from web/, the @botho/web-wallet package, etc.):
+ *
+ *     BOTHO_LIVE=1 npx playwright test --config e2e/playwright.live.config.ts
+ *
+ * Override the target deployment with BOTHO_LIVE_URL (default
+ * https://wallet.botho.io). This config is intentionally NOT wired into CI: it
+ * hits live infrastructure and the faucet's rate limits.
+ */
+const BASE_URL = process.env.BOTHO_LIVE_URL ?? 'https://wallet.botho.io'
+
+export default defineConfig({
+  testDir: './tests/live',
+  testMatch: /.*\.spec\.ts/,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  // Live infra is occasionally slow / cold; a retry absorbs transient flakes.
+  retries: 1,
+  workers: 1,
+  timeout: 90_000,
+
+  outputDir: '../test-results/live-artifacts',
+
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: '../test-results/live-report' }],
+  ],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: (process.env.E2E_VIDEO as 'off' | 'retain-on-failure') || 'off',
+    // Browser channel. Defaults to Playwright's bundled chromium (which uses
+    // chrome-headless-shell for headless runs). Set E2E_BROWSER_CHANNEL=chrome
+    // to use the system-installed Google Chrome, or E2E_BROWSER_CHANNEL=chromium
+    // to launch the full bundled Chromium build instead of the smaller
+    // chrome-headless-shell — handy where only the full chromium binary is
+    // available.
+    channel: process.env.E2E_BROWSER_CHANNEL || undefined,
+  },
+
+  // No webServer: we target the live deployment + live nodes directly.
+
+  projects: [
+    {
+      name: 'live-smoke',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/web/e2e/tests/live/smoke.spec.ts
+++ b/web/e2e/tests/live/smoke.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * Live-smoke e2e — runs against the DEPLOYED wallet (https://wallet.botho.io)
+ * and the LIVE testnet SCP nodes, complementing the hermetic local-mock suite.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The local-mock suite (web/e2e/tests/**) builds the app fresh and serves it
+ * with a mocked /rpc, so it can NEVER catch a *deploy* regression — e.g. the
+ * wasm-404 that happened when a build landed on a Cloudflare Pages preview
+ * instead of production, leaving `/pkg/bth_wasm_signer_bg.wasm` un-served. This
+ * spec drives the real deployed bundle + real nodes to catch exactly that class
+ * of bug (wasm not served, manifest/SW missing, node ingress down).
+ *
+ * GATING
+ * ------
+ * This spec is OPT-IN. It only runs through `playwright.live.config.ts`, which
+ * the default `pnpm test` does NOT use. Run it explicitly:
+ *
+ *     BOTHO_LIVE=1 pnpm --filter @botho/web-wallet exec \
+ *       playwright test --config e2e/playwright.live.config.ts
+ *
+ *   (or from web/e2e: `BOTHO_LIVE=1 npx playwright test --config playwright.live.config.ts`)
+ *
+ * Override the target with BOTHO_LIVE_URL (defaults to https://wallet.botho.io).
+ * Without BOTHO_LIVE=1 every test in this file is skipped, so even if this file
+ * were ever picked up by the default config it would be a no-op there.
+ *
+ * The default config's `testDir` is `./tests` and would otherwise match this
+ * file; it explicitly ignores `tests/live/**` (see playwright.config.ts
+ * testIgnore) so the hermetic suite is unaffected.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+// Opt-in flag. When unset, skip the whole file so this never runs in default
+// CI / `pnpm test` (which hits live infra + faucet rate limits).
+const LIVE = process.env.BOTHO_LIVE === '1'
+
+const BASE_URL = process.env.BOTHO_LIVE_URL ?? 'https://wallet.botho.io'
+
+// Known BIP39 test mnemonic — produces a deterministic testnet address. Never
+// holds real funds. Mirrors web/e2e/fixtures/test-data.ts TEST_MNEMONIC_12.
+const TEST_MNEMONIC_12 =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+// Live pages can be slow (cold edge cache + real network); be generous.
+const NAV_TIMEOUT = 30_000
+const UI_TIMEOUT = 20_000
+
+test.describe('Live smoke @ wallet.botho.io', () => {
+  test.skip(!LIVE, 'Set BOTHO_LIVE=1 to run the live-smoke suite (hits live infra + faucet limits).')
+
+  // The deployed bundle dynamic-imports the wasm signer from /pkg/*; a 404 there
+  // is the regression we are guarding against. Capture wasm-related console
+  // errors and failed requests so we can assert the crypto module actually loads.
+  function watchWasm(page: Page) {
+    const wasmErrors: string[] = []
+    const failedWasm: string[] = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error' && /wasm|bth_wasm_signer|\/pkg\//i.test(msg.text())) {
+        wasmErrors.push(msg.text())
+      }
+    })
+    page.on('requestfailed', (req) => {
+      if (/\.wasm($|\?)|bth_wasm_signer|\/pkg\//i.test(req.url())) {
+        failedWasm.push(`${req.url()} (${req.failure()?.errorText ?? 'failed'})`)
+      }
+    })
+    page.on('response', (resp) => {
+      if (/\.wasm($|\?)|bth_wasm_signer/i.test(resp.url()) && resp.status() >= 400) {
+        failedWasm.push(`${resp.url()} -> HTTP ${resp.status()}`)
+      }
+    })
+    return { wasmErrors, failedWasm }
+  }
+
+  test('landing page loads with correct title (HTTP 200)', async ({ page }) => {
+    const resp = await page.goto(`${BASE_URL}/`, { timeout: NAV_TIMEOUT })
+    expect(resp, 'navigation response present').toBeTruthy()
+    expect(resp!.status(), 'landing page returns 2xx').toBeLessThan(400)
+
+    await expect(page).toHaveTitle(/Botho/i)
+    // App boots past the shell: the Botho wordmark renders.
+    await expect(page.locator('text=Botho').first()).toBeVisible({ timeout: UI_TIMEOUT })
+  })
+
+  test('PWA manifest + service worker are served', async ({ page, request }) => {
+    await page.goto(`${BASE_URL}/`, { timeout: NAV_TIMEOUT })
+
+    // Manifest link is present in the document head and resolves to a 200.
+    const manifestHref = await page
+      .locator('link[rel="manifest"]')
+      .first()
+      .getAttribute('href', { timeout: UI_TIMEOUT })
+    expect(manifestHref, 'manifest <link> present').toBeTruthy()
+    const manifestUrl = new URL(manifestHref!, BASE_URL).toString()
+    const manifestResp = await request.get(manifestUrl)
+    expect(manifestResp.status(), `manifest ${manifestUrl} serves`).toBe(200)
+
+    // Service worker script is served (PWA precache). VitePWA emits /sw.js.
+    const swResp = await request.get(new URL('/sw.js', BASE_URL).toString())
+    expect(swResp.status(), 'service worker script serves').toBe(200)
+  })
+
+  test('WASM crypto module loads — no wasm console error (deploy-404 guard)', async ({ page }) => {
+    const { wasmErrors, failedWasm } = watchWasm(page)
+
+    // The wasm signer is dynamic-imported lazily; the wallet page exercises it
+    // (key derivation / address rendering), forcing the /pkg/* fetch.
+    await gotoFreshWallet(page)
+
+    // Create a wallet client-side — this path calls into the wasm signer to
+    // derive the address, so a missing/404 wasm would throw here.
+    await createWalletClientSide(page)
+
+    // The address rendering below is the positive signal the signer worked; the
+    // negative signals (no wasm console error, no failed /pkg fetch) catch the
+    // exact deploy regression this suite exists for.
+    expect(failedWasm, `wasm/pkg requests must not 404/fail:\n${failedWasm.join('\n')}`).toEqual([])
+    expect(wasmErrors, `no wasm-related console errors:\n${wasmErrors.join('\n')}`).toEqual([])
+  })
+
+  test('node ingress picker lists seed / seed2 / faucet and switching updates state', async ({
+    page,
+  }) => {
+    await gotoFreshWallet(page)
+
+    // Open the ingress (network) selector in the header. Its trigger is a button
+    // that shows the selected node's name + a "Testnet" badge.
+    const trigger = page.getByRole('button', { name: /Testnet/i }).first()
+    await expect(trigger).toBeVisible({ timeout: UI_TIMEOUT })
+    await trigger.click()
+
+    // The dropdown header + the three live ingress nodes.
+    await expect(page.getByText(/Trusted RPC ingress/i)).toBeVisible()
+    const seed = page.getByRole('button', { name: /^Seed \(validator\)/ })
+    const seed2 = page.getByRole('button', { name: /^Seed 2 \(validator\)/ })
+    const faucetNode = page.getByRole('button', { name: /^Faucet node/ })
+    await expect(seed).toBeVisible()
+    await expect(seed2).toBeVisible()
+    await expect(faucetNode).toBeVisible()
+
+    // Switch the selected ingress to seed2; the trigger label updates to reflect
+    // the new selection (state change routed through selectIngress).
+    await seed2.click()
+    await expect(
+      page.getByRole('button', { name: /Seed 2/ }).first(),
+      'trigger reflects newly selected ingress node'
+    ).toBeVisible({ timeout: UI_TIMEOUT })
+
+    // Selection persists across reload (localStorage-backed).
+    await page.reload({ timeout: NAV_TIMEOUT })
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByRole('button', { name: /Seed 2/ }).first()).toBeVisible({
+      timeout: UI_TIMEOUT,
+    })
+  })
+
+  test('wallet create is fully client-side and renders an address', async ({ page }) => {
+    await gotoFreshWallet(page)
+    await createWalletClientSide(page)
+
+    // Address renders in the dashboard (truncated testnet address).
+    const addressButton = page
+      .locator('button')
+      .filter({ has: page.locator('code.font-mono') })
+      .first()
+    await expect(addressButton).toBeVisible({ timeout: UI_TIMEOUT })
+    const addr = await addressButton.textContent()
+    expect(addr, 'address renders').toBeTruthy()
+    expect(addr).toContain('tbotho')
+  })
+
+  test('wallet import of a known mnemonic yields a deterministic address', async ({ page }) => {
+    await gotoFreshWallet(page)
+
+    await page.getByRole('button', { name: 'Import Existing' }).click()
+    const mnemonicInput = page.getByPlaceholder(/Enter your recovery phrase/i)
+    await mnemonicInput.fill(TEST_MNEMONIC_12)
+    await page.getByRole('button', { name: 'Import Wallet' }).click()
+
+    await expect(page.getByRole('button', { name: /Send/i })).toBeVisible({ timeout: UI_TIMEOUT })
+
+    const addressButton = page
+      .locator('button')
+      .filter({ has: page.locator('code.font-mono') })
+      .first()
+    const addr = await addressButton.textContent()
+    expect(addr, 'imported address renders').toBeTruthy()
+    // Deterministic: importing the same mnemonic always yields a testnet address.
+    expect(addr).toContain('tbotho')
+  })
+
+  test('/claim route loads its empty/invalid state without a secret', async ({ page }) => {
+    const resp = await page.goto(`${BASE_URL}/claim`, { timeout: NAV_TIMEOUT })
+    expect(resp!.status(), '/claim returns 2xx').toBeLessThan(400)
+
+    // With no #fragment secret the page shows its heading + a "no claim link"
+    // invalid state, never a crash.
+    await expect(page.getByRole('heading', { name: /Claim Your BTH/i })).toBeVisible({
+      timeout: UI_TIMEOUT,
+    })
+    await expect(page.getByText(/No claim link found/i)).toBeVisible({ timeout: UI_TIMEOUT })
+  })
+})
+
+/** Navigate to a fresh (cleared) wallet page on the live site. */
+async function gotoFreshWallet(page: Page) {
+  await page.goto(`${BASE_URL}/wallet`, { timeout: NAV_TIMEOUT })
+  // Clear any persisted wallet/network state so we always exercise the
+  // create/import setup flow deterministically.
+  await page.evaluate(() => {
+    try {
+      localStorage.clear()
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.reload({ timeout: NAV_TIMEOUT })
+  await page.waitForLoadState('networkidle')
+}
+
+/** Create a wallet entirely client-side (reveal mnemonic, confirm, create). */
+async function createWalletClientSide(page: Page) {
+  await page.getByText('Click to reveal').click()
+  const confirmCheckbox = page.locator('input[type="checkbox"]').first()
+  await confirmCheckbox.check()
+  await page.getByRole('button', { name: 'Create Wallet' }).click()
+  await expect(page.getByRole('button', { name: /Send/i })).toBeVisible({ timeout: UI_TIMEOUT })
+}


### PR DESCRIPTION
Closes #461

## What

Adds an **opt-in** Playwright live-smoke e2e spec that runs against the **deployed** wallet (`https://wallet.botho.io`) + the **live** testnet SCP nodes, complementing (not replacing) the hermetic local-mock suite. The local-mock suite builds the app fresh and mocks `/rpc`, so it can never catch a *deploy* regression — e.g. the wasm-404 that happened when a build landed on a Pages preview and `/pkg/bth_wasm_signer_bg.wasm` stopped being served. This spec catches exactly that class of bug.

## Files

- `web/e2e/tests/live/smoke.spec.ts` — the gated spec (7 tests).
- `web/e2e/playwright.live.config.ts` — separate config; `baseURL=wallet.botho.io`, **no** local servers, `testDir=tests/live`.
- `web/e2e/playwright.config.ts` — `testIgnore: ['**/tests/live/**']` so the default suite never picks it up.
- `web/README.md` — run instructions + gating docs.

## Gating / how to run

The whole file `test.skip`s unless `BOTHO_LIVE=1`, AND it only runs via the separate config (not referenced by `pnpm test`). So it is doubly opt-in and **not in default CI**.

\`\`\`bash
cd web
npx playwright install chromium    # once
BOTHO_LIVE=1 npx playwright test --config e2e/playwright.live.config.ts
\`\`\`

Override target with `BOTHO_LIVE_URL`. Use `E2E_BROWSER_CHANNEL=chrome` (system Chrome) or `=chromium` (full bundled build) where the headless shell isn't available.

## Assertions

1. Landing page loads (HTTP 200) + correct title.
2. **WASM crypto module loads** — no wasm console error, no failed `/pkg/*` fetch (the deploy-404 guard), exercised by a client-side wallet-create that derives the address via the signer.
3. PWA manifest `<link>` resolves + `sw.js` served.
4. 3-node ingress picker lists seed/seed2/faucet; switching to seed2 updates the trigger label and persists across reload.
5. Wallet create is fully client-side; address renders (`tbotho…`).
6. Wallet import of a known mnemonic yields a deterministic testnet address.
7. `/claim` loads its empty/invalid state ("No claim link found") without a secret.

## Verification performed

**Playwright browser could NOT be launched in this sandbox** — `playwright install` downloads reach 100% but the post-download extraction is throttled so heavily it times out (>10 min), leaving the chromium framework dylib missing (`dlopen ... no such file`). I was honest about this rather than claiming a green run.

Instead:
- **Spec correctness**: `playwright test --list` compiles the spec and lists all 7 tests cleanly under the live config; the default config lists **64 tests in 8 files with 0** from `tests/live/**` — confirming the hermetic suite is unaffected.
- **Core regression checked via curl** against the real site:
  - `GET /` → 200 text/html, title `Botho - Private Currency`
  - `GET /wallet` → 200, `GET /claim` → 200
  - `manifest.webmanifest` → 200 `application/manifest+json`
  - `sw.js` → 200 `application/javascript`
  - `pkg/bth_wasm_signer.js` → 200, **`pkg/bth_wasm_signer_bg.wasm` → 200 `application/wasm` (234738B)** ← the wasm-serving regression is verified healthy
  - `node_getStatus` on seed/seed2/faucet `.botho.io/rpc` → all HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)