### PR TITLE
chore(faucet): default dispense 1 BTH (was 10) for hundreds of testnet users

### DIFF
--- a/botho/src/config.rs
+++ b/botho/src/config.rs
@@ -474,7 +474,7 @@ pub struct FaucetConfig {
     pub enabled: bool,
 
     /// Amount to dispense per request in picocredits.
-    /// Default: 10 BTH (10_000_000_000_000 picocredits)
+    /// Default: 1 BTH (1_000_000_000_000 picocredits)
     #[serde(default = "default_faucet_amount")]
     pub amount: u64,
 
@@ -499,9 +499,9 @@ pub struct FaucetConfig {
     pub cooldown_secs: u64,
 }
 
-/// 10 BTH in picocredits
+/// 1 BTH in picocredits
 fn default_faucet_amount() -> u64 {
-    10_000_000_000_000
+    1_000_000_000_000
 }
 
 fn default_faucet_per_ip_hourly_limit() -> u32 {

--- a/infra/faucet/faucet-config.toml.template
+++ b/infra/faucet/faucet-config.toml.template
@@ -47,8 +47,8 @@ threads = 2
 
 [faucet]
 enabled = true
-# 10 BTH per request (in picocredits)
-amount = 10_000_000_000_000
+# 1 BTH per request (in picocredits)
+amount = 1_000_000_000_000
 # Rate limiting
 per_ip_hourly_limit = 5
 per_address_daily_limit = 3


### PR DESCRIPTION
Lower the default faucet dispense amount from 10 BTH → **1 BTH** so the testnet faucet supports hundreds of test users.

## Why
The faucet node mines its own funds (coinbase rewards to its wallet) and dispenses via real on-chain transfers. It buffers up to FAUCET_BALANCE_HIGH (10,000 BTH) before pausing minting, re-mining when low / on pending txs.
- At **10 BTH/call**, the ~10k BTH buffer served ~1,000 requests before re-mining.
- At **1 BTH/call**, the same buffer serves ~**10,000 requests**, and mining (~50 BTH/block = 50 requests/block) still far outpaces distribution. 1 BTH is ample for testing (a tx fee is ~0.0001 BTH → ~10,000 sends).

## Changes
- `botho/src/config.rs` `default_faucet_amount` 10 BTH → 1 BTH (+ doc comment).
- `infra/faucet/faucet-config.toml.template` amount → 1 BTH.

Already applied LIVE to faucet.botho.io (config + restart; verified dispensing 1 BTH, tx a9ce2ce0…). This persists the default so redeploys keep it. Rate limits (per-address 3/day, per-IP 5/hr, daily 10,000 BTH) unchanged — they comfortably allow hundreds of distinct users.

Closes nothing (operational tuning); relates to the testnet demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)