### PR TITLE
feat(web-wallet): drop per-tx Private badges, auto-reload PWA on update

### DIFF
--- a/web/packages/features/src/wallet/components/transaction-list.tsx
+++ b/web/packages/features/src/wallet/components/transaction-list.tsx
@@ -8,7 +8,10 @@ export interface TransactionListProps {
   transactions: Transaction[]
   /** Title for the card (default: "Transaction History") */
   title?: string
-  /** Whether to show privacy badges */
+  /**
+   * Whether to show per-row privacy badges. Defaults to `false`: every Botho
+   * transfer is private, so a per-transaction "Private" chip is redundant noise.
+   */
   showPrivacy?: boolean
   /** Whether to show chevrons for clickable rows */
   showChevron?: boolean
@@ -24,7 +27,7 @@ export interface TransactionListProps {
 export function TransactionList({
   transactions,
   title = 'Transaction History',
-  showPrivacy = true,
+  showPrivacy = false,
   showChevron = true,
   onTransactionClick,
   className = '',

--- a/web/packages/features/src/wallet/components/transaction-row.tsx
+++ b/web/packages/features/src/wallet/components/transaction-row.tsx
@@ -17,7 +17,11 @@ export interface TransactionRowProps {
   transaction: Transaction
   /** Animation index for staggered entrance */
   index?: number
-  /** Whether to show privacy badge */
+  /**
+   * Whether to show a per-row privacy badge. Defaults to `false`: every Botho
+   * transfer is private, so a per-transaction "Private" chip is redundant noise
+   * in the wallet's transaction history.
+   */
   showPrivacy?: boolean
   /** Whether to show chevron for clickable rows */
   showChevron?: boolean
@@ -33,7 +37,7 @@ export interface TransactionRowProps {
 export function TransactionRow({
   transaction: tx,
   index = 0,
-  showPrivacy = true,
+  showPrivacy = false,
   showChevron = true,
   onClick,
   className = '',

--- a/web/packages/web-wallet/package.json
+++ b/web/packages/web-wallet/package.json
@@ -36,6 +36,7 @@
     "typescript": "~5.9.3",
     "vite": "^7.2.4",
     "vite-plugin-pwa": "^1.2.0",
+    "workbox-window": "^7.4.0",
     "wrangler": "^4.59.1"
   }
 }

--- a/web/packages/web-wallet/src/main.tsx
+++ b/web/packages/web-wallet/src/main.tsx
@@ -1,7 +1,26 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { registerSW } from 'virtual:pwa-register'
 import App from './App'
 import '@botho/ui/styles/theme.css'
+
+// Auto-update the PWA after a deploy.
+//
+// vite-plugin-pwa is configured with `registerType: 'autoUpdate'`, so this
+// generated `registerSW` automatically applies any new service worker it finds
+// (the SW also uses skipWaiting + clientsClaim). When the new worker takes
+// control the browser fires `controllerchange`; we reload exactly once so the
+// visitor gets the freshly deployed app within one navigation — no manual hard
+// refresh. The module-level `reloading` guard prevents a reload loop.
+if ('serviceWorker' in navigator) {
+  let reloading = false
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (reloading) return
+    reloading = true
+    window.location.reload()
+  })
+  registerSW({ immediate: true })
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -289,7 +289,6 @@ function WalletDashboard() {
       <TransactionList
         transactions={transactions}
         title="Recent Transactions"
-        showPrivacy={true}
         showChevron={false}
       />
 

--- a/web/packages/web-wallet/src/vite-env.d.ts
+++ b/web/packages/web-wallet/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
 
 interface ImportMetaEnv {
   /** Custom RPC endpoint URL (overrides default testnet endpoint) */

--- a/web/packages/web-wallet/vite.config.ts
+++ b/web/packages/web-wallet/vite.config.ts
@@ -82,6 +82,13 @@ export default defineConfig({
     wasmSignerPkgPlugin(),
     VitePWA({
       registerType: 'autoUpdate',
+      // We register the service worker ourselves via the `virtual:pwa-register`
+      // module in `src/main.tsx` so we can auto-reload the page once a new SW
+      // takes control after a deploy. The default injected registration does
+      // NOT reload, leaving users on the stale cached app until a manual hard
+      // refresh. Setting this to `null` disables the auto-injected registration
+      // so we don't register the SW twice.
+      injectRegister: null,
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'mask-icon.svg'],
       manifest: {
         name: 'Botho Wallet',

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       vite-plugin-pwa:
         specifier: ^1.2.0
         version: 1.2.0(vite@7.3.0(@types/node@22.19.21)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
+      workbox-window:
+        specifier: ^7.4.0
+        version: 7.4.0
       wrangler:
         specifier: ^4.59.1
         version: 4.103.0


### PR DESCRIPTION
## Summary
Two wallet UX fixes from live use of wallet.botho.io:

1. **Remove redundant per-transaction "Private" badges.** Every Botho value transfer is private (CLSAG rings + confidential amounts), so a per-row "Private" chip is pure noise in the wallet transaction history.
2. **PWA auto-reload on update.** The wallet used `registerType: 'autoUpdate'` but the default injected registration never reloads, so after a deploy visitors kept seeing the OLD cached app until a manual hard refresh. Now an existing visitor auto-updates within one navigation.

## Changes
- `transaction-row.tsx` / `transaction-list.tsx`: default `showPrivacy` to `false` (was `true`). `PrivacyBadge` is still imported and rendered when `showPrivacy` is explicitly enabled, and stays exported for send-modal / explorer.
- `web-wallet/src/pages/wallet.tsx`: stop passing `showPrivacy={true}` to the recent-transactions list, so no per-row Private chip renders.
- `web-wallet/vite.config.ts`: set `injectRegister: null` so we register the SW ourselves (avoids double registration).
- `web-wallet/src/main.tsx`: register the SW via `virtual:pwa-register` with `immediate: true`, and add a one-time `controllerchange` reload guarded by a module-level `reloading` boolean (no reload loop).
- `web-wallet/src/vite-env.d.ts`: add `vite-plugin-pwa/client` type reference for the virtual module.
- `web-wallet/package.json` + `pnpm-lock.yaml`: add explicit `workbox-window` devDependency required by the virtual register module at build time.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Wallet tx list shows NO per-row "Private" badge | done | `showPrivacy` defaults to `false` and wallet no longer passes it; badge is gated behind `showPrivacy && <PrivacyBadge>` |
| PrivacyBadge still available where genuinely used | done | Component + export untouched; still imported/rendered in `transaction-row.tsx` when `showPrivacy` is set; explorer/send-modal unaffected |
| After-deploy auto-update path with reload-loop guard | done | `virtual:pwa-register` immediate registration + single `controllerchange` reload guarded by module-level `reloading` flag; generated `sw.js` has skipWaiting/clientsClaim |
| typecheck + build green | done | `pnpm -r typecheck` and `pnpm --filter @botho/web-wallet build` both pass |
| existing unit tests green | done | `pnpm test:run`: 117 passed, 10 skipped (live-node) |

## Test Plan
- `pnpm install` (added workbox-window)
- `pnpm -r typecheck` — all 7 projects pass
- `pnpm --filter @botho/web-wallet build` — green; SW + workbox-window chunk generated, precache 17 entries
- `pnpm test:run` — 117 passed, 10 skipped (live-node tests requiring a running node)

Note: the Playwright web e2e (`smoke`/`fullstack`) requires a local node + faucet + RPC mock and is not part of the automated CI gate (the `e2e-tests.yml` workflow runs Rust consensus suites only); web CI gating is typecheck + build + vitest, all green here.

Closes #468