### PR TITLE
feat(web-wallet): payment-request links — request a payment via /pay (#470)

### DIFF
--- a/web/packages/web-wallet/package.json
+++ b/web/packages/web-wallet/package.json
@@ -21,6 +21,7 @@
     "@botho/wasm-signer": "workspace:*",
     "lucide-react": "^0.562.0",
     "motion": "^12.23.26",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0",

--- a/web/packages/web-wallet/src/App.tsx
+++ b/web/packages/web-wallet/src/App.tsx
@@ -4,6 +4,7 @@ import { WalletProvider } from './contexts/wallet'
 import { LandingPage } from './pages/landing'
 import { WalletPage } from './pages/wallet'
 import { ClaimPage } from './pages/claim'
+import { PayPage } from './pages/pay'
 import { DocsPage } from './pages/docs'
 import { ExplorerPage } from './pages/explorer'
 
@@ -44,6 +45,7 @@ function App() {
             <Route path="/about" element={<LandingPage />} />
             <Route path="/wallet" element={<WalletPage />} />
             <Route path="/claim" element={<ClaimPage />} />
+            <Route path="/pay" element={<PayPage />} />
             <Route path="/explorer" element={<ExplorerPage />} />
             <Route path="/explorer/tx/:hash" element={<ExplorerPage />} />
             <Route path="/explorer/block/:hash" element={<ExplorerPage />} />

--- a/web/packages/web-wallet/src/components/RequestModal.tsx
+++ b/web/packages/web-wallet/src/components/RequestModal.tsx
@@ -1,0 +1,202 @@
+import { useState } from 'react'
+import { QRCodeSVG } from 'qrcode.react'
+import { Button, Card, Input } from '@botho/ui'
+import { formatBTH, parseBTH } from '@botho/core'
+import { Download, Copy, Check, AlertCircle, X, QrCode } from 'lucide-react'
+import { useWallet } from '../contexts/wallet'
+import { buildPaymentRequestLink } from '../lib/payment-request'
+
+/**
+ * "Request" — generate a payment-request link (#470), the *pull* complement to
+ * the *push* "Send via Link" (#460, `SendLinkModal`).
+ *
+ * The requester picks an (optional) amount and memo; we build a `/pay#…` URL
+ * carrying their PUBLIC address + the request in the URL FRAGMENT (never the
+ * query string, so it stays out of CDN/server logs). The payer opens it, the
+ * wallet pre-fills a send, and they pay via the normal send path. No secret is
+ * involved — unlike a claim link, this link cannot move anyone's money.
+ */
+export function RequestModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  const { address } = useWallet()
+  const [amountStr, setAmountStr] = useState('')
+  const [memo, setMemo] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  if (!isOpen) return null
+
+  const reset = () => {
+    setAmountStr('')
+    setMemo('')
+    setError(null)
+    setCopied(false)
+  }
+
+  const handleClose = () => {
+    reset()
+    onClose()
+  }
+
+  // Build the link live as the requester types. A blank/zero amount means
+  // "payer chooses"; an unparseable amount surfaces a friendly error and
+  // suppresses the link rather than producing a broken one.
+  let amount: bigint | undefined
+  let amountError: string | null = null
+  if (amountStr.trim()) {
+    try {
+      const parsed = parseBTH(amountStr)
+      if (parsed < 0n) {
+        amountError = 'Amount must be positive.'
+      } else if (parsed > 0n) {
+        amount = parsed
+      }
+    } catch {
+      amountError = 'Enter a valid amount.'
+    }
+  }
+
+  let url: string | null = null
+  if (address && !amountError) {
+    const origin =
+      typeof window !== 'undefined' && window.location?.origin
+        ? window.location.origin
+        : 'https://wallet.botho.io'
+    try {
+      url = buildPaymentRequestLink(origin, {
+        to: address,
+        amount,
+        memo: memo.trim() || undefined,
+      })
+    } catch (err) {
+      url = null
+      // Should not happen (address is present), but stay friendly.
+      if (!error) setError(err instanceof Error ? err.message : 'Failed to build link')
+    }
+  }
+
+  const handleCopy = async () => {
+    if (!url) return
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard may be unavailable; the URL is still selectable in the field.
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-void/80 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4 z-50">
+      <Card className="w-full sm:max-w-md p-5 sm:p-6 rounded-t-2xl sm:rounded-2xl max-h-[92vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-2">
+            <Download className="text-pulse" size={20} />
+            <h3 className="font-display text-lg font-semibold">Request Payment</h3>
+          </div>
+          <button onClick={handleClose} className="text-ghost hover:text-light" aria-label="Close">
+            <X size={20} />
+          </button>
+        </div>
+
+        {!address ? (
+          <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+            <AlertCircle size={16} className="shrink-0" />
+            <span>Unlock or create a wallet to request a payment.</span>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-sm text-ghost">
+              Create a link (or QR code) someone can open to pay you. Leave the amount
+              blank to let the payer choose. The link carries only your public address —
+              no secret, so it can never move your funds.
+            </p>
+
+            <div>
+              <label className="block text-sm text-ghost mb-1.5">Amount (BTH)</label>
+              <Input
+                type="text"
+                inputMode="decimal"
+                placeholder="Any amount"
+                value={amountStr}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  setAmountStr(e.target.value)
+                  setError(null)
+                }}
+                autoFocus
+              />
+              <p className="text-xs text-ghost mt-1">
+                Leave blank to let the payer enter the amount.
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm text-ghost mb-1.5">
+                Memo / label <span className="text-ghost/70">(optional)</span>
+              </label>
+              <Input
+                type="text"
+                placeholder="What's this for?"
+                value={memo}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  setMemo(e.target.value)
+                  setError(null)
+                }}
+              />
+            </div>
+
+            {amountError && (
+              <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+                <AlertCircle size={16} className="shrink-0" />
+                <span>{amountError}</span>
+              </div>
+            )}
+
+            {error && (
+              <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+                <AlertCircle size={16} className="shrink-0" />
+                <span>{error}</span>
+              </div>
+            )}
+
+            {url && (
+              <>
+                <div className="flex flex-col items-center gap-3">
+                  <div className="rounded-xl bg-white p-3">
+                    <QRCodeSVG value={url} size={176} level="M" />
+                  </div>
+                  <p className="text-xs text-ghost flex items-center gap-1.5">
+                    <QrCode size={13} />
+                    {amount ? (
+                      <>Scan to pay {formatBTH(amount)} BTH</>
+                    ) : (
+                      <>Scan to pay</>
+                    )}
+                  </p>
+                </div>
+
+                <div>
+                  <label className="block text-sm text-ghost mb-1.5">Payment link</label>
+                  <div className="flex gap-2">
+                    <input
+                      readOnly
+                      value={url}
+                      onFocus={(e) => e.currentTarget.select()}
+                      className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-abyss border border-steel font-mono text-xs text-light"
+                    />
+                    <Button onClick={handleCopy} size="sm" variant="secondary">
+                      {copied ? <Check size={16} /> : <Copy size={16} />}
+                    </Button>
+                  </div>
+                </div>
+
+                <Button onClick={handleClose} className="w-full justify-center">
+                  Done
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/web/packages/web-wallet/src/lib/payment-request.test.ts
+++ b/web/packages/web-wallet/src/lib/payment-request.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildPaymentRequestFragment,
+  buildPaymentRequestLink,
+  parsePaymentRequestFragment,
+  type PaymentRequest,
+} from './payment-request'
+
+const ADDR = 'tbotho://1/abcdef0123456789'
+
+/** base64url-encode a JSON value the same way the lib does, for crafting fixtures. */
+function encodeWire(value: unknown): string {
+  const json = JSON.stringify(value)
+  const bytes = new TextEncoder().encode(json)
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+describe('payment-request fragment helpers', () => {
+  describe('build / parse round-trip', () => {
+    it('round-trips an address with amount and memo', () => {
+      const req: PaymentRequest = { to: ADDR, amount: 5_000_000_000_000n, memo: 'Lunch' }
+      const parsed = parsePaymentRequestFragment(buildPaymentRequestFragment(req))
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBe(5_000_000_000_000n)
+      expect(parsed.memo).toBe('Lunch')
+    })
+
+    it('round-trips with no amount (payer chooses)', () => {
+      const parsed = parsePaymentRequestFragment(buildPaymentRequestFragment({ to: ADDR }))
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBeUndefined()
+      expect(parsed.memo).toBeUndefined()
+    })
+
+    it('round-trips with amount but no memo', () => {
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, amount: 1n }),
+      )
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBe(1n)
+      expect(parsed.memo).toBeUndefined()
+    })
+
+    it('round-trips with memo but no amount', () => {
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, memo: 'Invoice #42' }),
+      )
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBeUndefined()
+      expect(parsed.memo).toBe('Invoice #42')
+    })
+
+    it('treats a zero amount as "no amount"', () => {
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, amount: 0n }),
+      )
+      expect(parsed.amount).toBeUndefined()
+    })
+
+    it('preserves a large bigint amount exactly', () => {
+      const big = 123_456_789_012_345_678_901n
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, amount: big }),
+      )
+      expect(parsed.amount).toBe(big)
+    })
+
+    it('preserves unicode in the memo', () => {
+      const memo = 'Café ☕ — 支払い'
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, memo }),
+      )
+      expect(parsed.memo).toBe(memo)
+    })
+
+    it('parses a fragment carrying a leading #', () => {
+      const frag = buildPaymentRequestFragment({ to: ADDR, amount: 7n })
+      expect(parsePaymentRequestFragment('#' + frag).amount).toBe(7n)
+    })
+
+    it('parses a whole URL, using only the fragment portion', () => {
+      const url = buildPaymentRequestLink('https://wallet.botho.io', { to: ADDR, amount: 7n })
+      const parsed = parsePaymentRequestFragment(url)
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBe(7n)
+    })
+  })
+
+  describe('buildPaymentRequestFragment validation', () => {
+    it('rejects a missing recipient', () => {
+      expect(() => buildPaymentRequestFragment({ to: '' })).toThrow()
+      expect(() => buildPaymentRequestFragment({ to: '   ' })).toThrow()
+    })
+
+    it('rejects a negative amount', () => {
+      expect(() => buildPaymentRequestFragment({ to: ADDR, amount: -1n })).toThrow()
+    })
+
+    it('trims the recipient address', () => {
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: `  ${ADDR}  ` }),
+      )
+      expect(parsed.to).toBe(ADDR)
+    })
+  })
+
+  describe('buildPaymentRequestLink', () => {
+    it('targets /pay and carries the payload in the fragment', () => {
+      const url = buildPaymentRequestLink('https://wallet.botho.io', { to: ADDR })
+      expect(url.startsWith('https://wallet.botho.io/pay#')).toBe(true)
+      // The address must NOT appear in the query string portion.
+      const [beforeHash] = url.split('#')
+      expect(beforeHash).not.toContain('?')
+    })
+
+    it('tolerates a trailing slash on the origin', () => {
+      const url = buildPaymentRequestLink('https://wallet.botho.io/', { to: ADDR })
+      expect(url.startsWith('https://wallet.botho.io/pay#')).toBe(true)
+    })
+  })
+
+  describe('parsePaymentRequestFragment malformed input', () => {
+    it('rejects an empty fragment', () => {
+      expect(() => parsePaymentRequestFragment('')).toThrow()
+      expect(() => parsePaymentRequestFragment('#')).toThrow()
+    })
+
+    it('rejects non-base64 / non-JSON garbage', () => {
+      expect(() => parsePaymentRequestFragment('!!!not-base64!!!')).toThrow()
+    })
+
+    it('rejects valid base64 that is not JSON', () => {
+      // "hello" base64url'd is "aGVsbG8" — decodes fine but is not JSON.
+      expect(() => parsePaymentRequestFragment('aGVsbG8')).toThrow()
+    })
+
+    it('rejects JSON without a recipient', () => {
+      expect(() => parsePaymentRequestFragment(encodeWire({ amount: '5' }))).toThrow()
+    })
+
+    it('rejects a non-numeric amount', () => {
+      expect(() => parsePaymentRequestFragment(encodeWire({ to: ADDR, amount: 'abc' }))).toThrow()
+    })
+
+    it('rejects a JSON array payload', () => {
+      expect(() => parsePaymentRequestFragment(encodeWire([ADDR]))).toThrow()
+    })
+  })
+})

--- a/web/packages/web-wallet/src/lib/payment-request.ts
+++ b/web/packages/web-wallet/src/lib/payment-request.ts
@@ -1,0 +1,167 @@
+/**
+ * Payment-request links — the *pull* complement to claimable send-links (#460).
+ *
+ * A claim link PUSHES money: it carries a bearer secret, and whoever holds it
+ * can sweep the funds (#460, `@botho/core` `claim-link.ts`). A payment-request
+ * link PULLS money instead: it carries the requester's PUBLIC address plus an
+ * (optional) amount and memo. The payer opens it, the wallet pre-fills a send,
+ * they confirm, and they pay via the normal send path. There is NO secret — the
+ * link reveals nothing the requester wouldn't already hand out (their address).
+ *
+ * Link format (#470):
+ *
+ *   https://wallet.botho.io/pay#<base64url(JSON)>
+ *
+ * where the JSON is `{ to, amount?, memo? }`:
+ *   - `to`     the requester's public address (tbotho://… / botho://…).
+ *   - `amount` OPTIONAL requested amount in PICOCREDITS, serialized as a decimal
+ *              string (bigint-safe). Omitted/blank means "payer chooses".
+ *   - `memo`   OPTIONAL human label / note for the request.
+ *
+ * Why the FRAGMENT (after `#`) and not the query string: browsers never transmit
+ * the fragment to a server, so the requester's address stays out of
+ * Cloudflare/CDN/server access logs — exactly as claim links carry their payload.
+ * The pay page strips the fragment (`history.replaceState`) after reading it.
+ *
+ * Encoding is plain base64url'd JSON (not the claim link's `v1.<base58>` form):
+ * a payment request has no fixed-width secret, just a small structured record,
+ * so base64'd JSON keeps it readable, versionable, and trivially round-trippable.
+ */
+
+/** A payment request: who to pay, optionally how much, optionally why. */
+export interface PaymentRequest {
+  /** The requester's PUBLIC address (tbotho://… / botho://…). */
+  to: string
+  /**
+   * OPTIONAL requested amount in picocredits. When omitted the payer enters the
+   * amount themselves on the pay page.
+   */
+  amount?: bigint
+  /** OPTIONAL human-readable label / note for the request. */
+  memo?: string
+}
+
+/** The shape we actually serialize to JSON (bigint -> decimal string). */
+interface PaymentRequestWire {
+  to: string
+  amount?: string
+  memo?: string
+}
+
+/**
+ * base64url-encode a UTF-8 string (no padding).
+ *
+ * `btoa`/`atob` are globals in every environment this wallet runs in (browsers,
+ * jsdom, and Node 16+), so we rely on them directly. `btoa` is latin1-only, so
+ * we UTF-8 encode first to preserve unicode in memos.
+ */
+function base64UrlEncode(input: string): string {
+  const bytes = new TextEncoder().encode(input)
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  const b64 = btoa(binary)
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/** Decode a base64url string back into its UTF-8 source. Throws if malformed. */
+function base64UrlDecode(input: string): string {
+  const b64 = input.replace(/-/g, '+').replace(/_/g, '/')
+  const binary = atob(b64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return new TextDecoder().decode(bytes)
+}
+
+/**
+ * Encode a payment request into a URL fragment payload.
+ *
+ * Returns the fragment WITHOUT the leading `#`, i.e. the base64url'd JSON.
+ *
+ * @throws if `to` is missing/blank, or `amount` is negative.
+ */
+export function buildPaymentRequestFragment(req: PaymentRequest): string {
+  const to = (req.to ?? '').trim()
+  if (!to) throw new Error('A payment request needs a recipient address')
+
+  const wire: PaymentRequestWire = { to }
+  if (req.amount !== undefined) {
+    if (req.amount < 0n) throw new Error('amount must be non-negative')
+    // A zero amount is treated the same as "no amount" (payer chooses).
+    if (req.amount > 0n) wire.amount = req.amount.toString()
+  }
+  const memo = req.memo?.trim()
+  if (memo) wire.memo = memo
+
+  return base64UrlEncode(JSON.stringify(wire))
+}
+
+/**
+ * Build the full shareable payment-request URL.
+ *
+ * @param origin e.g. `https://wallet.botho.io` (trailing slash tolerated)
+ * @param req    the payment request
+ */
+export function buildPaymentRequestLink(origin: string, req: PaymentRequest): string {
+  const base = origin.replace(/\/$/, '')
+  return `${base}/pay#${buildPaymentRequestFragment(req)}`
+}
+
+/**
+ * Parse a payment-request fragment back into a {@link PaymentRequest}.
+ *
+ * Accepts the fragment with or without a leading `#`, and accepts a full URL
+ * (only the part after `#` is used). Throws on a malformed/unsupported payload.
+ */
+export function parsePaymentRequestFragment(fragment: string): PaymentRequest {
+  let raw = (fragment ?? '').trim()
+  // Allow passing a whole URL — take only the fragment portion.
+  const hashIdx = raw.indexOf('#')
+  if (hashIdx >= 0) raw = raw.slice(hashIdx + 1)
+  if (raw.startsWith('#')) raw = raw.slice(1)
+  if (!raw) throw new Error('Empty payment-request link')
+
+  let json: string
+  try {
+    json = base64UrlDecode(raw)
+  } catch {
+    throw new Error('This payment-request link is not valid.')
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch {
+    throw new Error('This payment-request link is not valid.')
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('This payment-request link is not valid.')
+  }
+  const wire = parsed as Record<string, unknown>
+
+  const to = typeof wire.to === 'string' ? wire.to.trim() : ''
+  if (!to) throw new Error('This payment-request link is missing a recipient address.')
+
+  const req: PaymentRequest = { to }
+
+  if (wire.amount !== undefined && wire.amount !== null && wire.amount !== '') {
+    if (typeof wire.amount !== 'string' && typeof wire.amount !== 'number') {
+      throw new Error('This payment-request link has an invalid amount.')
+    }
+    let amount: bigint
+    try {
+      amount = BigInt(wire.amount)
+    } catch {
+      throw new Error('This payment-request link has an invalid amount.')
+    }
+    if (amount < 0n) throw new Error('This payment-request link has an invalid amount.')
+    if (amount > 0n) req.amount = amount
+  }
+
+  if (typeof wire.memo === 'string') {
+    const memo = wire.memo.trim()
+    if (memo) req.memo = memo
+  }
+
+  return req
+}

--- a/web/packages/web-wallet/src/pages/pay.tsx
+++ b/web/packages/web-wallet/src/pages/pay.tsx
@@ -1,0 +1,548 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Button, Card, Input, Logo } from '@botho/ui'
+import { formatBTH, parseBTH, isValidAddress, createMnemonic12 } from '@botho/core'
+import {
+  Send,
+  AlertCircle,
+  Check,
+  Loader2,
+  ArrowLeft,
+  Lock,
+  Eye,
+  ExternalLink,
+  ShieldAlert,
+} from 'lucide-react'
+import { useWallet } from '../contexts/wallet'
+import { useNetwork } from '../contexts/network'
+import { parsePaymentRequestFragment, type PaymentRequest } from '../lib/payment-request'
+
+/**
+ * Pay page for payment-request links (#470) — the *pull* complement to the
+ * claim page (#460, `claim.tsx`).
+ *
+ * Reads the requester's PUBLIC address + optional amount/memo from the URL
+ * FRAGMENT (never sent to a server), strips it from the address bar, and — if a
+ * wallet is unlocked — pre-fills a send to the requester. The payer confirms and
+ * pays via the existing `send()` path. Unlike a claim link there is no secret:
+ * this link cannot move anyone's money; it only suggests a payment.
+ *
+ * If there's no wallet (or it's locked), the page prompts the visitor to
+ * create / import / unlock first, then resumes the pay flow with the parsed
+ * request preserved in component state (the fragment is already stripped).
+ */
+
+type ParseState = 'parsing' | 'invalid' | 'ready'
+type SetupMode = 'unlock' | 'create' | 'import'
+
+export function PayPage() {
+  const {
+    hasWallet,
+    isLocked,
+    address,
+    getContactName,
+    send,
+    refreshBalance,
+    refreshTransactions,
+    createWallet,
+    importWallet,
+    unlockWallet,
+    balance,
+  } = useWallet()
+  const { network } = useNetwork()
+
+  const [parseState, setParseState] = useState<ParseState>('parsing')
+  const [request, setRequest] = useState<PaymentRequest | null>(null)
+  const [parseError, setParseError] = useState<string | null>(null)
+
+  // 1. Parse the fragment ONCE on mount, then strip it from the URL so the
+  //    requester's address does not linger in the address bar / history / logs.
+  useEffect(() => {
+    const hash = window.location.hash
+    if (!hash || hash === '#') {
+      setParseState('invalid')
+      setParseError('No payment request found. The link should look like .../pay#…')
+      return
+    }
+    try {
+      const parsed = parsePaymentRequestFragment(hash)
+      setRequest(parsed)
+      try {
+        window.history.replaceState(null, '', window.location.pathname + window.location.search)
+      } catch {
+        // replaceState may be unavailable in some embeds; non-fatal.
+      }
+      setParseState('ready')
+    } catch (err) {
+      setParseState('invalid')
+      setParseError(err instanceof Error ? err.message : 'This payment-request link is not valid.')
+    }
+  }, [])
+
+  const explorerBase = network.explorerUrl
+
+  return (
+    <div className="min-h-screen">
+      <header className="border-b border-steel bg-abyss/50 backdrop-blur-md sticky top-0 z-40">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between">
+          <Link to="/" className="flex items-center gap-2 sm:gap-3">
+            <ArrowLeft size={18} className="text-ghost" />
+            <Logo size="sm" showText={false} />
+            <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">
+              Botho Wallet
+            </span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="py-8 sm:py-12">
+        <div className="max-w-lg mx-auto px-4 sm:px-0">
+          <Card className="p-5 sm:p-8">
+            <div className="text-center mb-6">
+              <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-pulse/10 flex items-center justify-center mx-auto mb-3 sm:mb-4">
+                <Send className="text-pulse" size={26} />
+              </div>
+              <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">Send a Payment</h2>
+            </div>
+
+            {parseState === 'parsing' && (
+              <div className="flex flex-col items-center gap-3 py-6 text-ghost">
+                <Loader2 size={28} className="animate-spin text-pulse" />
+                <p className="text-sm">Reading the payment request…</p>
+              </div>
+            )}
+
+            {parseState === 'invalid' && (
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+                <AlertCircle size={16} className="shrink-0 mt-0.5" />
+                <span>{parseError ?? 'This payment-request link is not valid.'}</span>
+              </div>
+            )}
+
+            {parseState === 'ready' && request && (
+              <>
+                {!hasWallet || isLocked ? (
+                  <WalletGate
+                    isLocked={isLocked}
+                    onCreate={createWallet}
+                    onImport={importWallet}
+                    onUnlock={unlockWallet}
+                  />
+                ) : (
+                  <PayConfirm
+                    request={request}
+                    ownAddress={address}
+                    balance={balance}
+                    getContactName={getContactName}
+                    send={send}
+                    refreshBalance={refreshBalance}
+                    refreshTransactions={refreshTransactions}
+                    explorerBase={explorerBase}
+                  />
+                )}
+              </>
+            )}
+          </Card>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+/**
+ * The actual pay confirmation, shown once a wallet is unlocked. Pre-fills the
+ * recipient (from the request) and amount (editable, defaulting to the requested
+ * amount), and pays via the existing `send()` path.
+ */
+function PayConfirm({
+  request,
+  ownAddress,
+  balance,
+  getContactName,
+  send,
+  refreshBalance,
+  refreshTransactions,
+  explorerBase,
+}: {
+  request: PaymentRequest
+  ownAddress: string | null
+  balance: import('@botho/core').Balance | null
+  getContactName: (address: string) => string
+  send: (to: string, amount: bigint, memo?: string) => Promise<string>
+  refreshBalance: () => Promise<void>
+  refreshTransactions: () => Promise<void>
+  explorerBase?: string
+}) {
+  const [amountStr, setAmountStr] = useState(
+    request.amount !== undefined ? formatBTH(request.amount, { separators: false }) : '',
+  )
+  const [isSending, setIsSending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [txHash, setTxHash] = useState<string | null>(null)
+
+  const contactName = useMemo(() => {
+    const name = getContactName(request.to)
+    // getContactName falls back to a shortened address when unknown; only show a
+    // "name" when it differs from the raw address (i.e. an actual contact).
+    return name && name !== request.to ? name : null
+  }, [getContactName, request.to])
+
+  const addressValid = isValidAddress(request.to)
+  const isSelfPay = ownAddress != null && ownAddress === request.to
+
+  let amount = 0n
+  let amountError: string | null = null
+  if (amountStr.trim()) {
+    try {
+      amount = parseBTH(amountStr)
+      if (amount <= 0n) amountError = 'Amount must be greater than 0.'
+    } catch {
+      amountError = 'Enter a valid amount.'
+    }
+  }
+
+  const canPay = addressValid && amount > 0n && !amountError && !isSending
+
+  const handlePay = async () => {
+    if (!canPay) return
+    setError(null)
+    setIsSending(true)
+    try {
+      const hash = await send(request.to, amount, request.memo)
+      setTxHash(hash)
+      await Promise.allSettled([refreshBalance(), refreshTransactions()])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Payment failed.')
+    } finally {
+      setIsSending(false)
+    }
+  }
+
+  if (txHash) {
+    const explorerTxUrl = explorerBase ? `${explorerBase}/tx/${txHash}` : null
+    return (
+      <div className="space-y-4">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <div className="w-12 h-12 rounded-full bg-success/10 flex items-center justify-center">
+            <Check className="text-success" size={26} />
+          </div>
+          <p className="text-lg font-semibold text-light">Payment sent</p>
+          <p className="text-sm text-ghost">
+            Sent {formatBTH(amount)} BTH to {contactName ?? 'the requester'}.
+          </p>
+          {explorerTxUrl && (
+            <a
+              href={explorerTxUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-ghost hover:text-light"
+            >
+              View transaction <ExternalLink size={12} />
+            </a>
+          )}
+        </div>
+        <Link to="/wallet">
+          <Button className="w-full justify-center">Go to my wallet</Button>
+        </Link>
+      </div>
+    )
+  }
+
+  if (!addressValid) {
+    return (
+      <div className="flex items-start gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+        <AlertCircle size={16} className="shrink-0 mt-0.5" />
+        <span>This payment-request link has an invalid recipient address.</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="text-center">
+        <p className="text-sm text-ghost">You&apos;re paying</p>
+        <p className="font-display text-lg font-semibold text-light break-words">
+          {contactName ?? 'a Botho address'}
+        </p>
+        <p className="text-xs text-ghost mt-1 font-mono break-all">{request.to}</p>
+      </div>
+
+      {isSelfPay && (
+        <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 text-amber-200/90 text-xs">
+          <ShieldAlert size={15} className="text-amber-400 shrink-0 mt-0.5" />
+          <span>This request is for your own address — you&apos;d be paying yourself.</span>
+        </div>
+      )}
+
+      {request.memo && (
+        <div>
+          <label className="block text-sm text-ghost mb-1.5">Memo</label>
+          <div className="px-3 py-2 rounded-lg bg-abyss border border-steel text-sm text-light break-words">
+            {request.memo}
+          </div>
+        </div>
+      )}
+
+      <div>
+        <div className="flex items-center justify-between mb-1.5">
+          <label className="block text-sm text-ghost">Amount (BTH)</label>
+          {balance && (
+            <button
+              type="button"
+              onClick={() => setAmountStr(formatBTH(balance.available, { separators: false }))}
+              className="text-xs text-pulse hover:underline"
+            >
+              Max: {formatBTH(balance.available)} BTH
+            </button>
+          )}
+        </div>
+        <Input
+          type="text"
+          inputMode="decimal"
+          placeholder="0.00"
+          value={amountStr}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setAmountStr(e.target.value)
+            setError(null)
+          }}
+          autoFocus={request.amount === undefined}
+        />
+        {request.amount === undefined && (
+          <p className="text-xs text-ghost mt-1">
+            The requester didn&apos;t specify an amount — enter how much to send.
+          </p>
+        )}
+      </div>
+
+      {amountError && (
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+          <AlertCircle size={16} className="shrink-0" />
+          <span>{amountError}</span>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+          <AlertCircle size={16} className="shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <Button onClick={handlePay} disabled={!canPay} className="w-full justify-center">
+        {isSending ? (
+          <>
+            <Loader2 size={16} className="mr-2 animate-spin" />
+            Sending…
+          </>
+        ) : (
+          <>
+            <Send size={16} className="mr-2" />
+            Pay {amount > 0n ? `${formatBTH(amount)} BTH` : ''}
+          </>
+        )}
+      </Button>
+    </div>
+  )
+}
+
+/**
+ * Gate shown when there's no wallet, or the wallet is locked. Lets the visitor
+ * unlock / create / import in-flow; the parsed request is preserved in the
+ * parent's state, so the pay confirmation appears as soon as a wallet is ready.
+ */
+function WalletGate({
+  isLocked,
+  onCreate,
+  onImport,
+  onUnlock,
+}: {
+  isLocked: boolean
+  onCreate: (mnemonic: string, password?: string) => Promise<void>
+  onImport: (seedPhrase: string, password?: string) => Promise<void>
+  onUnlock: (password: string) => Promise<void>
+}) {
+  const [mode, setMode] = useState<SetupMode>(isLocked ? 'unlock' : 'create')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // unlock
+  const [password, setPassword] = useState('')
+  // create
+  const newMnemonic = useMemo(() => createMnemonic12(), [])
+  const [revealed, setRevealed] = useState(false)
+  const [confirmed, setConfirmed] = useState(false)
+  // import
+  const [seedPhrase, setSeedPhrase] = useState('')
+
+  const handleUnlock = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await onUnlock(password)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unlock failed.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleCreate = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await onCreate(newMnemonic)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not create wallet.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleImport = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await onImport(seedPhrase)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const wordCount = seedPhrase.trim().split(/\s+/).filter(Boolean).length
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-ghost text-center">
+        {isLocked
+          ? 'Unlock your wallet to pay this request.'
+          : 'You need a wallet to pay this request.'}
+      </p>
+
+      {!isLocked && (
+        <div className="flex rounded-lg bg-abyss border border-steel p-1">
+          <button
+            onClick={() => {
+              setMode('create')
+              setError(null)
+            }}
+            className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
+              mode === 'create' ? 'bg-steel text-light' : 'text-ghost hover:text-light'
+            }`}
+          >
+            Create New
+          </button>
+          <button
+            onClick={() => {
+              setMode('import')
+              setError(null)
+            }}
+            className={`flex-1 py-2 px-4 rounded-md text-sm font-medium transition-colors ${
+              mode === 'import' ? 'bg-steel text-light' : 'text-ghost hover:text-light'
+            }`}
+          >
+            Import Existing
+          </button>
+        </div>
+      )}
+
+      {mode === 'unlock' && (
+        <div className="space-y-3">
+          <div className="flex justify-center">
+            <Lock className="text-pulse" size={24} />
+          </div>
+          <Input
+            type="password"
+            placeholder="Enter password"
+            value={password}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setPassword(e.target.value)
+              setError(null)
+            }}
+            onKeyDown={(e: React.KeyboardEvent) => {
+              if (e.key === 'Enter' && password) handleUnlock()
+            }}
+            autoFocus
+          />
+          <Button onClick={handleUnlock} disabled={!password || busy} className="w-full justify-center">
+            {busy ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}
+            Unlock
+          </Button>
+        </div>
+      )}
+
+      {mode === 'create' && (
+        <div className="space-y-3">
+          <div className="relative">
+            <div
+              className={`p-3 rounded-lg bg-abyss border border-steel font-mono text-xs leading-relaxed ${
+                revealed ? '' : 'blur-sm select-none'
+              }`}
+            >
+              {newMnemonic}
+            </div>
+            {!revealed && (
+              <button
+                onClick={() => setRevealed(true)}
+                className="absolute inset-0 flex items-center justify-center gap-2 text-ghost hover:text-light"
+              >
+                <Eye size={18} />
+                <span className="text-sm">Click to reveal</span>
+              </button>
+            )}
+          </div>
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={confirmed}
+              onChange={(e) => setConfirmed(e.target.checked)}
+              className="mt-1 w-4 h-4 accent-pulse"
+            />
+            <span className="text-xs text-ghost">
+              I&apos;ve written down my recovery phrase and stored it safely.
+            </span>
+          </label>
+          <Button
+            onClick={handleCreate}
+            disabled={!revealed || !confirmed || busy}
+            className="w-full justify-center"
+          >
+            {busy ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}
+            Create &amp; Continue
+          </Button>
+        </div>
+      )}
+
+      {mode === 'import' && (
+        <div className="space-y-3">
+          <textarea
+            value={seedPhrase}
+            onChange={(e) => {
+              setSeedPhrase(e.target.value)
+              setError(null)
+            }}
+            placeholder="Enter your 12 or 24 word recovery phrase…"
+            rows={3}
+            className="w-full p-3 rounded-lg bg-abyss border border-steel font-mono text-xs leading-relaxed resize-none focus:outline-none focus:ring-2 focus:ring-pulse/50 focus:border-pulse placeholder:text-ghost/50"
+          />
+          <Button
+            onClick={handleImport}
+            disabled={(wordCount !== 12 && wordCount !== 24) || busy}
+            className="w-full justify-center"
+          >
+            {busy ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}
+            Import &amp; Continue
+          </Button>
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+          <AlertCircle size={16} className="shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -8,8 +8,9 @@ import { useNetwork } from '../contexts/network'
 import { NetworkSelector } from '../components/NetworkSelector'
 import { FaucetButton } from '../components/FaucetButton'
 import { SendLinkModal } from '../components/SendLinkModal'
+import { RequestModal } from '../components/RequestModal'
 import { OutstandingLinks } from '../components/OutstandingLinks'
-import { Send, Link2, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2 } from 'lucide-react'
+import { Send, Link2, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2 } from 'lucide-react'
 
 function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?: string) => void }) {
   const [showMnemonic, setShowMnemonic] = useState(false)
@@ -222,6 +223,7 @@ function WalletDashboard() {
   const { hasFaucet } = useNetwork()
   const [sendOpen, setSendOpen] = useState(false)
   const [sendLinkOpen, setSendLinkOpen] = useState(false)
+  const [requestOpen, setRequestOpen] = useState(false)
   const [isSending, setIsSending] = useState(false)
   const [showResetConfirm, setShowResetConfirm] = useState(false)
 
@@ -261,6 +263,9 @@ function WalletDashboard() {
       </Button>
       <Button variant="secondary" onClick={() => setSendLinkOpen(true)}>
         <Link2 size={16} className="mr-2" />Send via Link
+      </Button>
+      <Button variant="secondary" onClick={() => setRequestOpen(true)}>
+        <Download size={16} className="mr-2" />Request
       </Button>
       <Button variant="ghost" size="sm" onClick={refreshBalance} disabled={isConnecting}>
         <RefreshCw size={16} className={isConnecting ? 'animate-spin' : ''} />
@@ -302,6 +307,8 @@ function WalletDashboard() {
       />
 
       <SendLinkModal isOpen={sendLinkOpen} onClose={() => setSendLinkOpen(false)} />
+
+      <RequestModal isOpen={requestOpen} onClose={() => setRequestOpen(false)} />
 
       {showResetConfirm && (
         <div className="fixed inset-0 bg-void/80 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4 z-50">

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       motion:
         specifier: ^12.23.26
         version: 12.23.26(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -3463,6 +3466,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -7457,6 +7465,10 @@ snapshots:
   property-information@7.1.0: {}
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   randombytes@2.1.0:
     dependencies:


### PR DESCRIPTION
Closes #470

## Summary

Adds **payment-request links** — the *pull* complement to claimable send-links (#460). A claim link pushes money (bearer secret); a payment-request link pulls money: it carries the requester's **public** address + an optional amount/memo, the payer opens it, the wallet pre-fills a send, they confirm and pay. **No secret involved.**

Modeled closely on the existing claim-link feature for consistency (`SendLinkModal`, `claim.tsx` fragment-parse-then-strip, `wallet.tsx` send path).

## What's included

- **`lib/payment-request.ts`** — `buildPaymentRequestFragment` / `parsePaymentRequestFragment` (+ `buildPaymentRequestLink`) encoding `{ to, amount?, memo? }` as base64url'd JSON in the URL **fragment**. Amounts are bigint-safe (decimal-string serialized); zero/blank amount means "payer chooses".
- **`payment-request.test.ts`** — 20 unit tests: round-trip with/without amount, with/without memo, large bigints, unicode memos, leading-`#` and whole-URL inputs; validation (missing recipient, negative amount); malformed input (empty, non-base64, non-JSON, no recipient, non-numeric amount, array payload).
- **`RequestModal`** + a **"Request"** button on the wallet page — amount (BTH, blank allowed) + optional memo → live `/pay#…` URL with a **Copy** button and a **QR code** (`qrcode.react` added).
- **`/pay` → `PayPage`** — parses the fragment, **strips it** (`replaceState`, like `claim.tsx`), then:
  - **unlocked wallet** → "Pay <contact-or-address>" confirmation, recipient from `to`, editable amount defaulting to the requested amount, memo, pays via the existing `useWallet().send()` path; success/explorer-link UI mirroring SendModal.
  - **no wallet / locked** → create / import / unlock gate that resumes the pay flow (request preserved in state).
  - Edge cases: missing/invalid fragment → friendly error; omitted amount → payer enters it; self-pay → warn but allow.

## Design points honored

- Requester address travels in the **fragment**, never the query string, and is stripped after read (keeps it out of CDN/server logs).
- Reuses the existing `send()` path — no transaction-building reimplementation.
- Link building uses `window.location.origin` (falls back to `https://wallet.botho.io`), as claim links do.
- Scope: web-wallet only (+ a `qrcode.react` dependency). No consensus/faucet/network-config/Rust changes. Reverted the stray `.loom-managed` and `pnpm-workspace.yaml` mutations.

## Verification

- `pnpm install` — ok (only the `ERR_PNPM_IGNORED_BUILDS` warning)
- `pnpm -r typecheck` — **green**
- `pnpm --filter @botho/web-wallet build` — **green** (PWA SW generated)
- `pnpm test:run` — **green** (137 passed, 10 live-node tests skipped; includes the 20 new payment-request tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)