### PR TITLE
feat(web-wallet): address-book UX (annotate previously-paid + send picker) + share-my-address links

### DIFF
--- a/web/packages/core/src/storage/address-book.test.ts
+++ b/web/packages/core/src/storage/address-book.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { AddressBook } from './address-book'
+import type { Address, Timestamp } from '../types'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+const ADDR = 'tbotho://1/recipient' as Address
+
+/**
+ * The record-payment UPSERT used by the wallet context's `send()` /
+ * `recordPayment`: if the recipient isn't a contact, create a minimal blank-name
+ * entry (labelable later), then bump txCount/lastTxAt exactly once. If it
+ * already exists, just record the transaction. Kept here so the no-double-count
+ * and unnamed-then-named behaviors are unit-tested against the real backend.
+ */
+async function recordPayment(book: AddressBook, address: Address): Promise<void> {
+  const now = Math.floor(Date.now() / 1000) as Timestamp
+  if (!book.findByAddress(address)) {
+    await book.add('', address)
+  }
+  await book.recordTransaction(address, now)
+}
+
+describe('AddressBook', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+  })
+
+  describe('basic CRUD', () => {
+    it('adds, finds, updates and deletes a contact', async () => {
+      const book = new AddressBook()
+      await book.load()
+
+      const c = await book.add('Alice', ADDR, 'a friend')
+      expect(c.name).toBe('Alice')
+      expect(c.txCount).toBe(0)
+      expect(book.findByAddress(ADDR)?.id).toBe(c.id)
+
+      const updated = await book.update(c.id, { name: 'Alice B', notes: 'best friend' })
+      expect(updated.name).toBe('Alice B')
+      expect(updated.notes).toBe('best friend')
+
+      await book.delete(c.id)
+      expect(book.findByAddress(ADDR)).toBeUndefined()
+    })
+
+    it('rejects a duplicate address', async () => {
+      const book = new AddressBook()
+      await book.load()
+      await book.add('Alice', ADDR)
+      await expect(book.add('Alice 2', ADDR)).rejects.toThrow(/already exists/)
+    })
+
+    it('search matches by name and address, case-insensitively', async () => {
+      const book = new AddressBook()
+      await book.load()
+      await book.add('Alice', 'tbotho://1/alice' as Address)
+      await book.add('Bob', 'tbotho://1/bob' as Address)
+
+      expect(book.search('ALICE').map((c) => c.name)).toEqual(['Alice'])
+      expect(book.search('tbotho://1/bob').map((c) => c.name)).toEqual(['Bob'])
+      expect(book.search('tbotho').length).toBe(2)
+    })
+  })
+
+  describe('record-payment upsert (send → address book)', () => {
+    it('creates a blank-name "previously paid" entry for a new recipient', async () => {
+      const book = new AddressBook()
+      await book.load()
+
+      await recordPayment(book, ADDR)
+
+      const c = book.findByAddress(ADDR)
+      expect(c).toBeDefined()
+      expect(c!.name).toBe('') // unnamed — labelable later
+      expect(c!.txCount).toBe(1)
+      expect(c!.lastTxAt).toBeGreaterThan(0)
+    })
+
+    it('does NOT double-count: one payment bumps txCount by exactly one', async () => {
+      const book = new AddressBook()
+      await book.load()
+
+      await recordPayment(book, ADDR)
+      expect(book.findByAddress(ADDR)!.txCount).toBe(1)
+
+      await recordPayment(book, ADDR)
+      expect(book.findByAddress(ADDR)!.txCount).toBe(2)
+
+      // Still only a single contact entry for the address.
+      expect(book.search('tbotho').filter((c) => c.address === ADDR).length).toBe(1)
+    })
+
+    it('bumps an EXISTING named contact instead of creating a duplicate', async () => {
+      const book = new AddressBook()
+      await book.load()
+      const existing = await book.add('Alice', ADDR)
+
+      await recordPayment(book, ADDR)
+
+      const c = book.findByAddress(ADDR)!
+      expect(c.id).toBe(existing.id) // same entry
+      expect(c.name).toBe('Alice') // name preserved
+      expect(c.txCount).toBe(1)
+    })
+
+    it('lets an unnamed previously-paid entry be renamed (label later)', async () => {
+      const book = new AddressBook()
+      await book.load()
+
+      await recordPayment(book, ADDR)
+      const unnamed = book.findByAddress(ADDR)!
+      expect(unnamed.name).toBe('')
+      expect(unnamed.txCount).toBe(1)
+
+      const renamed = await book.update(unnamed.id, { name: 'Alice', notes: 'from a payment' })
+      expect(renamed.name).toBe('Alice')
+      expect(renamed.notes).toBe('from a payment')
+      // Renaming preserves the recorded payment history (no double-count / reset).
+      expect(renamed.txCount).toBe(1)
+      expect(book.findByAddress(ADDR)!.name).toBe('Alice')
+    })
+
+    it('persists across reloads (localStorage)', async () => {
+      const book1 = new AddressBook()
+      await book1.load()
+      await recordPayment(book1, ADDR)
+      await book1.update(book1.findByAddress(ADDR)!.id, { name: 'Alice' })
+
+      const book2 = new AddressBook()
+      await book2.load()
+      const c = book2.findByAddress(ADDR)
+      expect(c?.name).toBe('Alice')
+      expect(c?.txCount).toBe(1)
+    })
+  })
+
+  describe('getDisplayName', () => {
+    it('returns the contact name when known', async () => {
+      const book = new AddressBook()
+      await book.load()
+      await book.add('Alice', ADDR)
+      expect(book.getDisplayName(ADDR)).toBe('Alice')
+    })
+
+    it('truncates an unknown address', async () => {
+      const book = new AddressBook()
+      await book.load()
+      const long = ('tbotho://1/' + 'a'.repeat(40)) as Address
+      const shown = book.getDisplayName(long)
+      expect(shown).toContain('...')
+      expect(shown.length).toBeLessThan(long.length)
+    })
+  })
+})

--- a/web/packages/features/src/wallet/components/send-modal.tsx
+++ b/web/packages/features/src/wallet/components/send-modal.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react'
-import type { Balance } from '@botho/core'
+import { useMemo, useState, useEffect } from 'react'
+import type { Balance, Contact } from '@botho/core'
 import { formatBTH, parseBTH } from '@botho/core'
 import { Button, Input } from '@botho/ui'
 import { motion, AnimatePresence } from 'motion/react'
-import { ChevronDown, ChevronUp, Loader2, Send, X, Zap } from 'lucide-react'
+import { ChevronDown, ChevronUp, Loader2, Send, User, X, Zap } from 'lucide-react'
 
 export type SendPrivacyLevel = 'standard' | 'private'
 
@@ -35,6 +35,23 @@ export interface SendModalProps {
   onSend: (data: SendFormData) => Promise<SendResult>
   /** Whether a send is in progress */
   isSending?: boolean
+  /**
+   * Saved address-book contacts, used to power the recipient picker and to show
+   * a known contact's name inline. Optional for back-compat — when omitted, the
+   * recipient field behaves as a plain text input.
+   */
+  contacts?: Contact[]
+  /**
+   * Optional search callback for contacts. When provided it's used instead of
+   * filtering `contacts` locally (e.g. to delegate to the address-book search).
+   */
+  onSearchContacts?: (query: string) => Contact[]
+}
+
+/** Truncate an address for compact display in the picker. */
+function shortAddress(address: string, len = 8): string {
+  if (address.length <= len * 2 + 3) return address
+  return `${address.slice(0, len)}…${address.slice(-len)}`
 }
 
 /**
@@ -47,6 +64,8 @@ export function SendModal({
   estimateFee,
   onSend,
   isSending = false,
+  contacts,
+  onSearchContacts,
 }: SendModalProps) {
   const [recipient, setRecipient] = useState('')
   const [amount, setAmount] = useState('')
@@ -58,6 +77,7 @@ export function SendModal({
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [useCustomFee, setUseCustomFee] = useState(false)
   const [customFeeInput, setCustomFeeInput] = useState('')
+  const [showPicker, setShowPicker] = useState(false)
 
   // Reset form when modal closes
   useEffect(() => {
@@ -70,8 +90,33 @@ export function SendModal({
       setShowAdvanced(false)
       setUseCustomFee(false)
       setCustomFeeInput('')
+      setShowPicker(false)
     }
   }, [isOpen])
+
+  // Contact picker: matches for the current recipient query. Prefer the
+  // injected search callback; otherwise filter the provided contacts locally.
+  const matches = useMemo<Contact[]>(() => {
+    const all = contacts ?? []
+    if (all.length === 0 && !onSearchContacts) return []
+    const q = recipient.trim().toLowerCase()
+    if (!q) return all
+    if (onSearchContacts) return onSearchContacts(q)
+    return all.filter(
+      (c) =>
+        c.name.toLowerCase().includes(q) || c.address.toLowerCase().includes(q),
+    )
+  }, [contacts, onSearchContacts, recipient])
+
+  // If the entered recipient exactly matches a known contact, surface its name.
+  const matchedContact = useMemo<Contact | null>(() => {
+    const r = recipient.trim().toLowerCase()
+    if (!r) return null
+    return (contacts ?? []).find((c) => c.address.toLowerCase() === r) ?? null
+  }, [contacts, recipient])
+
+  const hasContacts = (contacts?.length ?? 0) > 0 || !!onSearchContacts
+  const showPickerList = showPicker && hasContacts && matches.length > 0
 
   // Estimate fee when amount or privacy changes
   useEffect(() => {
@@ -180,16 +225,50 @@ export function SendModal({
           {/* Form */}
           <div className="space-y-4">
             {/* Recipient */}
-            <div>
+            <div className="relative">
               <label className="mb-1.5 block text-sm font-medium text-[--color-ghost]">
                 Recipient Address
               </label>
               <Input
-                placeholder="tbotho://1/..."
+                placeholder="tbotho://1/... or search contacts"
                 value={recipient}
-                onChange={(e) => setRecipient(e.target.value)}
+                onChange={(e) => {
+                  setRecipient(e.target.value)
+                  setShowPicker(true)
+                }}
+                onFocus={() => setShowPicker(true)}
                 className="font-mono text-sm"
               />
+              {/* Inline contact name when the recipient matches a saved contact */}
+              {matchedContact && matchedContact.name.trim() && (
+                <p className="mt-1 flex items-center gap-1 text-xs text-[--color-pulse]">
+                  <User className="h-3 w-3" />
+                  {matchedContact.name}
+                </p>
+              )}
+              {/* Searchable contact picker */}
+              {showPickerList && (
+                <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-56 overflow-y-auto rounded-lg border border-[--color-steel] bg-[--color-abyss] shadow-xl">
+                  {matches.map((c) => (
+                    <button
+                      key={c.id}
+                      type="button"
+                      onClick={() => {
+                        setRecipient(c.address)
+                        setShowPicker(false)
+                      }}
+                      className="flex w-full flex-col items-start gap-0.5 border-b border-[--color-steel]/50 px-3 py-2 text-left transition-colors last:border-b-0 hover:bg-[--color-steel]/40"
+                    >
+                      <span className="text-sm text-[--color-light]">
+                        {c.name.trim() || 'Unnamed contact'}
+                      </span>
+                      <span className="font-mono text-xs text-[--color-dim]">
+                        {shortAddress(c.address)}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
 
             {/* Amount */}

--- a/web/packages/web-wallet/src/App.tsx
+++ b/web/packages/web-wallet/src/App.tsx
@@ -5,6 +5,7 @@ import { LandingPage } from './pages/landing'
 import { WalletPage } from './pages/wallet'
 import { ClaimPage } from './pages/claim'
 import { PayPage } from './pages/pay'
+import { ContactsPage } from './pages/contacts'
 import { DocsPage } from './pages/docs'
 import { ExplorerPage } from './pages/explorer'
 
@@ -46,6 +47,7 @@ function App() {
             <Route path="/wallet" element={<WalletPage />} />
             <Route path="/claim" element={<ClaimPage />} />
             <Route path="/pay" element={<PayPage />} />
+            <Route path="/contacts" element={<ContactsPage />} />
             <Route path="/explorer" element={<ExplorerPage />} />
             <Route path="/explorer/tx/:hash" element={<ExplorerPage />} />
             <Route path="/explorer/block/:hash" element={<ExplorerPage />} />

--- a/web/packages/web-wallet/src/components/RequestModal.tsx
+++ b/web/packages/web-wallet/src/components/RequestModal.tsx
@@ -16,20 +16,27 @@ import { buildPaymentRequestLink } from '../lib/payment-request'
  * wallet pre-fills a send, and they pay via the normal send path. No secret is
  * involved — unlike a claim link, this link cannot move anyone's money.
  */
+/** Which kind of receive link the requester wants to share. */
+type RequestMode = 'amount' | 'address'
+
 export function RequestModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
   const { address } = useWallet()
+  const [mode, setMode] = useState<RequestMode>('amount')
   const [amountStr, setAmountStr] = useState('')
   const [memo, setMemo] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const [copiedAddr, setCopiedAddr] = useState(false)
 
   if (!isOpen) return null
 
   const reset = () => {
+    setMode('amount')
     setAmountStr('')
     setMemo('')
     setError(null)
     setCopied(false)
+    setCopiedAddr(false)
   }
 
   const handleClose = () => {
@@ -37,12 +44,16 @@ export function RequestModal({ isOpen, onClose }: { isOpen: boolean; onClose: ()
     onClose()
   }
 
+  const shareAddressOnly = mode === 'address'
+
   // Build the link live as the requester types. A blank/zero amount means
   // "payer chooses"; an unparseable amount surfaces a friendly error and
-  // suppresses the link rather than producing a broken one.
+  // suppresses the link rather than producing a broken one. In "Share my
+  // address" mode the amount/memo are ignored entirely — the link carries only
+  // the address (a pure receive link).
   let amount: bigint | undefined
   let amountError: string | null = null
-  if (amountStr.trim()) {
+  if (!shareAddressOnly && amountStr.trim()) {
     try {
       const parsed = parseBTH(amountStr)
       if (parsed < 0n) {
@@ -62,11 +73,12 @@ export function RequestModal({ isOpen, onClose }: { isOpen: boolean; onClose: ()
         ? window.location.origin
         : 'https://wallet.botho.io'
     try {
-      url = buildPaymentRequestLink(origin, {
-        to: address,
-        amount,
-        memo: memo.trim() || undefined,
-      })
+      url = buildPaymentRequestLink(
+        origin,
+        shareAddressOnly
+          ? { to: address }
+          : { to: address, amount, memo: memo.trim() || undefined },
+      )
     } catch (err) {
       url = null
       // Should not happen (address is present), but stay friendly.
@@ -82,6 +94,17 @@ export function RequestModal({ isOpen, onClose }: { isOpen: boolean; onClose: ()
       setTimeout(() => setCopied(false), 2000)
     } catch {
       // Clipboard may be unavailable; the URL is still selectable in the field.
+    }
+  }
+
+  const handleCopyAddress = async () => {
+    if (!address) return
+    try {
+      await navigator.clipboard.writeText(address)
+      setCopiedAddr(true)
+      setTimeout(() => setCopiedAddr(false), 2000)
+    } catch {
+      // Clipboard may be unavailable; the address is still selectable.
     }
   }
 
@@ -105,44 +128,91 @@ export function RequestModal({ isOpen, onClose }: { isOpen: boolean; onClose: ()
           </div>
         ) : (
           <div className="space-y-4">
+            {/* Mode toggle: request a specific amount vs. just share my address */}
+            <div className="flex rounded-lg bg-abyss border border-steel p-1">
+              <button
+                onClick={() => {
+                  setMode('amount')
+                  setError(null)
+                }}
+                className={`flex-1 py-2 px-3 rounded-md text-xs sm:text-sm font-medium transition-colors ${
+                  mode === 'amount' ? 'bg-steel text-light' : 'text-ghost hover:text-light'
+                }`}
+              >
+                Request an amount
+              </button>
+              <button
+                onClick={() => {
+                  setMode('address')
+                  setError(null)
+                }}
+                className={`flex-1 py-2 px-3 rounded-md text-xs sm:text-sm font-medium transition-colors ${
+                  mode === 'address' ? 'bg-steel text-light' : 'text-ghost hover:text-light'
+                }`}
+              >
+                Just share my address
+              </button>
+            </div>
+
             <p className="text-sm text-ghost">
-              Create a link (or QR code) someone can open to pay you. Leave the amount
-              blank to let the payer choose. The link carries only your public address —
-              no secret, so it can never move your funds.
+              {shareAddressOnly
+                ? 'Share your public address so anyone can pay you any amount. The link carries only your address — no amount, no memo, no secret.'
+                : 'Create a link (or QR code) someone can open to pay you. Leave the amount blank to let the payer choose. The link carries only your public address — no secret, so it can never move your funds.'}
             </p>
 
-            <div>
-              <label className="block text-sm text-ghost mb-1.5">Amount (BTH)</label>
-              <Input
-                type="text"
-                inputMode="decimal"
-                placeholder="Any amount"
-                value={amountStr}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  setAmountStr(e.target.value)
-                  setError(null)
-                }}
-                autoFocus
-              />
-              <p className="text-xs text-ghost mt-1">
-                Leave blank to let the payer enter the amount.
-              </p>
-            </div>
+            {shareAddressOnly && (
+              <div>
+                <label className="block text-sm text-ghost mb-1.5">Your address</label>
+                <div className="flex gap-2">
+                  <input
+                    readOnly
+                    value={address}
+                    onFocus={(e) => e.currentTarget.select()}
+                    className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-abyss border border-steel font-mono text-xs text-light"
+                  />
+                  <Button onClick={handleCopyAddress} size="sm" variant="secondary">
+                    {copiedAddr ? <Check size={16} /> : <Copy size={16} />}
+                  </Button>
+                </div>
+              </div>
+            )}
 
-            <div>
-              <label className="block text-sm text-ghost mb-1.5">
-                Memo / label <span className="text-ghost/70">(optional)</span>
-              </label>
-              <Input
-                type="text"
-                placeholder="What's this for?"
-                value={memo}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  setMemo(e.target.value)
-                  setError(null)
-                }}
-              />
-            </div>
+            {!shareAddressOnly && (
+              <div>
+                <label className="block text-sm text-ghost mb-1.5">Amount (BTH)</label>
+                <Input
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="Any amount"
+                  value={amountStr}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    setAmountStr(e.target.value)
+                    setError(null)
+                  }}
+                  autoFocus
+                />
+                <p className="text-xs text-ghost mt-1">
+                  Leave blank to let the payer enter the amount.
+                </p>
+              </div>
+            )}
+
+            {!shareAddressOnly && (
+              <div>
+                <label className="block text-sm text-ghost mb-1.5">
+                  Memo / label <span className="text-ghost/70">(optional)</span>
+                </label>
+                <Input
+                  type="text"
+                  placeholder="What's this for?"
+                  value={memo}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    setMemo(e.target.value)
+                    setError(null)
+                  }}
+                />
+              </div>
+            )}
 
             {amountError && (
               <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
@@ -166,7 +236,9 @@ export function RequestModal({ isOpen, onClose }: { isOpen: boolean; onClose: ()
                   </div>
                   <p className="text-xs text-ghost flex items-center gap-1.5">
                     <QrCode size={13} />
-                    {amount ? (
+                    {shareAddressOnly ? (
+                      <>Scan to pay me</>
+                    ) : amount ? (
                       <>Scan to pay {formatBTH(amount)} BTH</>
                     ) : (
                       <>Scan to pay</>
@@ -175,7 +247,9 @@ export function RequestModal({ isOpen, onClose }: { isOpen: boolean; onClose: ()
                 </div>
 
                 <div>
-                  <label className="block text-sm text-ghost mb-1.5">Payment link</label>
+                  <label className="block text-sm text-ghost mb-1.5">
+                    {shareAddressOnly ? 'Receive link' : 'Payment link'}
+                  </label>
                   <div className="flex gap-2">
                     <input
                       readOnly

--- a/web/packages/web-wallet/src/contexts/wallet.test.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.test.tsx
@@ -49,6 +49,9 @@ vi.mock('@botho/core', async (importOriginal) => {
       update = vi.fn().mockResolvedValue({ id: '1', name: 'Updated', address: 'tbotho://1/test' })
       delete = vi.fn().mockResolvedValue(undefined)
       getDisplayName = vi.fn().mockReturnValue('Unknown')
+      findByAddress = vi.fn().mockReturnValue(undefined)
+      recordTransaction = vi.fn().mockResolvedValue(undefined)
+      search = vi.fn().mockReturnValue([])
     },
   }
 })
@@ -284,6 +287,31 @@ describe('WalletContext', () => {
       })
 
       expect(screen.getByTestId('isEncrypted').textContent).toBe('yes')
+    })
+  })
+
+  describe('address book wiring', () => {
+    it('exposes recordPayment and searchContacts on the context', async () => {
+      let walletRef: ReturnType<typeof useWallet> | null = null
+
+      render(
+        <WalletProvider>
+          <TestConsumer onMount={(w) => { walletRef = w }} />
+        </WalletProvider>
+      )
+
+      await waitFor(() => {
+        expect(walletRef).not.toBeNull()
+      })
+
+      expect(typeof walletRef!.recordPayment).toBe('function')
+      expect(typeof walletRef!.searchContacts).toBe('function')
+
+      // recordPayment is a non-throwing upsert; searchContacts returns an array.
+      await act(async () => {
+        await walletRef!.recordPayment('tbotho://1/test')
+      })
+      expect(Array.isArray(walletRef!.searchContacts('test'))).toBe(true)
     })
   })
 

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import { RemoteNodeAdapter, type WsConnectionStatus } from '@botho/adapters'
 import { AddressBook, ClaimLinkStore, saveWallet, loadWallet, getWalletInfo, deriveAddress, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet, createClaimLinkMnemonic, buildClaimLink } from '@botho/core'
-import type { Balance, Contact, NodeInfo, Transaction, ClaimLinkRecord } from '@botho/core'
+import type { Balance, Contact, NodeInfo, Transaction, ClaimLinkRecord, Timestamp } from '@botho/core'
 import { buildSendTransaction, spendableBalance, buildOwnedHistory } from '@botho/wasm-signer'
 import { buildAndSubmitSend, scanEphemeral, sweepEphemeral, SWEEP_FEE_RESERVE } from '../lib/claim-link-ops'
 import { type NetworkConfig, loadSelectedNetwork, loadSelectedIngress, NETWORKS, DEFAULT_NETWORK_ID, DEFAULT_INGRESS_ID, createCustomNetwork, networkForIngress, getIngressNode } from '../config/networks'
@@ -78,6 +78,15 @@ interface WalletContextValue extends WalletState {
   updateContact: (id: string, updates: Partial<Pick<Contact, 'name' | 'address' | 'notes'>>) => Promise<Contact>
   deleteContact: (id: string) => Promise<void>
   getContactName: (address: string) => string
+  /**
+   * Upsert + bump a "previously-paid" address book entry. If the address is not
+   * yet a contact, create a minimal (blank-name) entry so it can be labelled
+   * later, then record the payment; if it already exists, just bump its
+   * txCount/lastTxAt. Idempotent per call (no double-count).
+   */
+  recordPayment: (address: string) => Promise<void>
+  /** Search saved contacts by name or address (case-insensitive substring). */
+  searchContacts: (query: string) => Contact[]
 
   // Claimable payment links (#460)
   /**
@@ -596,6 +605,20 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       throw new Error(result.error || 'Transaction submission failed')
     }
 
+    // Persist the recipient in the address book so it appears as "previously
+    // paid" and can be labelled/annotated later. Upsert: create a blank-name
+    // entry if new, then bump txCount/lastTxAt. Best-effort; never fail a send.
+    try {
+      const now = Math.floor(Date.now() / 1000) as Timestamp
+      if (!addressBook.findByAddress(to)) {
+        await addressBook.add('', to)
+      }
+      await addressBook.recordTransaction(to, now)
+      setState((s) => ({ ...s, contacts: addressBook.getAll() }))
+    } catch {
+      // Address-book persistence is non-critical; ignore failures.
+    }
+
     // Refresh balance/history opportunistically; ignore failures.
     if (state.address) {
       fetchBalance(adapter, state.address, mnemonicRef.current)
@@ -733,6 +756,23 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     return addressBook.getDisplayName(address)
   }, [])
 
+  const recordPayment = useCallback(async (address: string) => {
+    const now = Math.floor(Date.now() / 1000) as Timestamp
+    const existing = addressBook.findByAddress(address)
+    if (!existing) {
+      // Create a minimal, blank-name "previously paid" entry so the user can
+      // label/annotate it later. `add` initializes txCount to 0.
+      await addressBook.add('', address)
+    }
+    // Bump txCount/lastTxAt exactly once for this payment.
+    await addressBook.recordTransaction(address, now)
+    setState(s => ({ ...s, contacts: addressBook.getAll() }))
+  }, [])
+
+  const searchContacts = useCallback((query: string) => {
+    return addressBook.search(query)
+  }, [])
+
   return (
     <WalletContext.Provider
       value={{
@@ -752,6 +792,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         updateContact,
         deleteContact,
         getContactName,
+        recordPayment,
+        searchContacts,
         sendViaLink,
         refreshClaimLinks,
         refundClaimLink,

--- a/web/packages/web-wallet/src/pages/contacts.tsx
+++ b/web/packages/web-wallet/src/pages/contacts.tsx
@@ -1,0 +1,413 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Button, Card, Input, Logo } from '@botho/ui'
+import { isValidAddress } from '@botho/core'
+import type { Contact } from '@botho/core'
+import {
+  ArrowLeft,
+  Users,
+  Search,
+  Plus,
+  Pencil,
+  Trash2,
+  X,
+  Check,
+  AlertCircle,
+  Tag,
+} from 'lucide-react'
+import { useWallet } from '../contexts/wallet'
+
+type SortBy = 'name' | 'lastTx' | 'txCount'
+
+const SORT_LABELS: Record<SortBy, string> = {
+  name: 'Name',
+  lastTx: 'Recent',
+  txCount: 'Most paid',
+}
+
+/** Truncate an address for compact display. */
+function shortAddress(address: string, len = 10): string {
+  if (address.length <= len * 2 + 3) return address
+  return `${address.slice(0, len)}…${address.slice(-len)}`
+}
+
+/**
+ * Sort + filter the contact list for display. Mirrors `AddressBook.getAll`
+ * sorting and `AddressBook.search` filtering, but works on the reactive
+ * `contacts` array from the wallet context so the list updates live.
+ */
+function arrange(contacts: Contact[], sortBy: SortBy, query: string): Contact[] {
+  const q = query.trim().toLowerCase()
+  const filtered = q
+    ? contacts.filter(
+        (c) =>
+          c.name.toLowerCase().includes(q) ||
+          c.address.toLowerCase().includes(q),
+      )
+    : contacts.slice()
+
+  switch (sortBy) {
+    case 'name':
+      // Unnamed (blank) entries sort last so labelled contacts lead.
+      return filtered.sort((a, b) => {
+        const an = a.name.trim()
+        const bn = b.name.trim()
+        if (!an && bn) return 1
+        if (an && !bn) return -1
+        return an.localeCompare(bn)
+      })
+    case 'lastTx':
+      return filtered.sort((a, b) => (b.lastTxAt ?? 0) - (a.lastTxAt ?? 0))
+    case 'txCount':
+      return filtered.sort((a, b) => b.txCount - a.txCount)
+    default:
+      return filtered
+  }
+}
+
+/**
+ * Contacts manager (#472). Lists saved/previously-paid addresses, lets the user
+ * sort (name / recent / most-paid), search (name + address), and add / edit /
+ * delete with an editable name + notes annotation. Unnamed "previously paid"
+ * entries (auto-created on send) show as "Unnamed — tap to label".
+ */
+export function ContactsPage() {
+  const { contacts, addContact, updateContact, deleteContact } = useWallet()
+
+  const [sortBy, setSortBy] = useState<SortBy>('name')
+  const [query, setQuery] = useState('')
+  const [editing, setEditing] = useState<Contact | null>(null)
+  const [adding, setAdding] = useState(false)
+
+  const arranged = useMemo(
+    () => arrange(contacts, sortBy, query),
+    [contacts, sortBy, query],
+  )
+
+  return (
+    <div className="min-h-screen">
+      <header className="border-b border-steel bg-abyss/50 backdrop-blur-md sticky top-0 z-40">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between">
+          <Link to="/wallet" className="flex items-center gap-2 sm:gap-3">
+            <ArrowLeft size={18} className="text-ghost" />
+            <Logo size="sm" showText={false} />
+            <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">
+              Botho Wallet
+            </span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="py-6 sm:py-8 md:py-12">
+        <div className="max-w-2xl mx-auto px-4 sm:px-0 space-y-4 sm:space-y-6">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Users className="text-pulse" size={22} />
+              <h1 className="font-display text-xl sm:text-2xl font-bold">Contacts</h1>
+            </div>
+            <Button onClick={() => setAdding(true)}>
+              <Plus size={16} className="mr-2" />Add
+            </Button>
+          </div>
+
+          {/* Search */}
+          <div className="relative">
+            <Search
+              size={16}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-ghost"
+            />
+            <Input
+              type="text"
+              placeholder="Search by name or address…"
+              value={query}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setQuery(e.target.value)
+              }
+              className="pl-9"
+            />
+          </div>
+
+          {/* Sort toggle */}
+          <div className="flex rounded-lg bg-abyss border border-steel p-1">
+            {(Object.keys(SORT_LABELS) as SortBy[]).map((key) => (
+              <button
+                key={key}
+                onClick={() => setSortBy(key)}
+                className={`flex-1 py-2 px-3 rounded-md text-xs sm:text-sm font-medium transition-colors ${
+                  sortBy === key
+                    ? 'bg-steel text-light'
+                    : 'text-ghost hover:text-light'
+                }`}
+              >
+                {SORT_LABELS[key]}
+              </button>
+            ))}
+          </div>
+
+          {/* List */}
+          {arranged.length === 0 ? (
+            <Card className="p-6 text-center text-ghost text-sm">
+              {contacts.length === 0
+                ? 'No contacts yet. Addresses you pay will appear here, ready to label.'
+                : 'No contacts match your search.'}
+            </Card>
+          ) : (
+            <div className="space-y-2">
+              {arranged.map((c) => (
+                <ContactRow
+                  key={c.id}
+                  contact={c}
+                  onEdit={() => setEditing(c)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+
+      {adding && (
+        <ContactEditor
+          mode="add"
+          onClose={() => setAdding(false)}
+          onSave={async ({ name, address, notes }) => {
+            await addContact(name, address, notes)
+          }}
+        />
+      )}
+
+      {editing && (
+        <ContactEditor
+          mode="edit"
+          contact={editing}
+          onClose={() => setEditing(null)}
+          onSave={async ({ name, address, notes }) => {
+            await updateContact(editing.id, { name, address, notes })
+          }}
+          onDelete={async () => {
+            await deleteContact(editing.id)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+function ContactRow({
+  contact,
+  onEdit,
+}: {
+  contact: Contact
+  onEdit: () => void
+}) {
+  const named = contact.name.trim().length > 0
+  return (
+    <Card className="p-3 sm:p-4 flex items-center justify-between gap-3">
+      <button
+        onClick={onEdit}
+        className="flex-1 min-w-0 text-left"
+        title={named ? 'Edit contact' : 'Tap to label this address'}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className={`font-medium truncate ${
+              named ? 'text-light' : 'text-ghost italic'
+            }`}
+          >
+            {named ? contact.name : 'Unnamed — tap to label'}
+          </span>
+          {contact.txCount > 0 && (
+            <span className="shrink-0 text-[11px] text-ghost bg-abyss border border-steel rounded-full px-2 py-0.5">
+              {contact.txCount}× paid
+            </span>
+          )}
+        </div>
+        <p className="font-mono text-xs text-ghost mt-0.5 truncate">
+          {shortAddress(contact.address)}
+        </p>
+        {contact.notes && (
+          <p className="text-xs text-ghost/80 mt-1 truncate">{contact.notes}</p>
+        )}
+      </button>
+      <Button variant="ghost" size="sm" onClick={onEdit} title="Edit">
+        {named ? <Pencil size={16} /> : <Tag size={16} />}
+      </Button>
+    </Card>
+  )
+}
+
+function ContactEditor({
+  mode,
+  contact,
+  onClose,
+  onSave,
+  onDelete,
+}: {
+  mode: 'add' | 'edit'
+  contact?: Contact
+  onClose: () => void
+  onSave: (data: { name: string; address: string; notes?: string }) => Promise<void>
+  onDelete?: () => Promise<void>
+}) {
+  const [name, setName] = useState(contact?.name ?? '')
+  const [address, setAddress] = useState(contact?.address ?? '')
+  const [notes, setNotes] = useState(contact?.notes ?? '')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+
+  // In edit mode the address is fixed (it's the identity of the entry); editing
+  // it could collide with another contact. Allow editing only when adding.
+  const addressEditable = mode === 'add'
+
+  const handleSave = async () => {
+    setError(null)
+    if (!address.trim()) {
+      setError('Enter an address.')
+      return
+    }
+    if (!isValidAddress(address.trim())) {
+      setError('That does not look like a valid Botho address.')
+      return
+    }
+    setBusy(true)
+    try {
+      await onSave({
+        name: name.trim(),
+        address: address.trim(),
+        notes: notes.trim() || undefined,
+      })
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save contact.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!onDelete) return
+    setBusy(true)
+    try {
+      await onDelete()
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not delete contact.')
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-void/80 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4 z-50">
+      <Card className="w-full sm:max-w-md p-5 sm:p-6 rounded-t-2xl sm:rounded-2xl max-h-[92vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-5">
+          <h3 className="font-display text-lg font-semibold">
+            {mode === 'add' ? 'Add contact' : 'Edit contact'}
+          </h3>
+          <button onClick={onClose} className="text-ghost hover:text-light" aria-label="Close">
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm text-ghost mb-1.5">Name</label>
+            <Input
+              type="text"
+              placeholder="e.g. Alice"
+              value={name}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setName(e.target.value)
+                setError(null)
+              }}
+              autoFocus
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm text-ghost mb-1.5">Address</label>
+            <Input
+              type="text"
+              placeholder="tbotho://1/…"
+              value={address}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                setAddress(e.target.value)
+                setError(null)
+              }}
+              disabled={!addressEditable}
+              className="font-mono text-xs"
+            />
+            {!addressEditable && (
+              <p className="text-xs text-ghost/70 mt-1">
+                The address can&apos;t be changed for an existing contact.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm text-ghost mb-1.5">
+              Notes <span className="text-ghost/70">(optional)</span>
+            </label>
+            <textarea
+              value={notes}
+              onChange={(e) => {
+                setNotes(e.target.value)
+                setError(null)
+              }}
+              placeholder="Anything to remember about this contact…"
+              rows={3}
+              className="w-full p-3 rounded-lg bg-abyss border border-steel text-sm leading-relaxed resize-none focus:outline-none focus:ring-2 focus:ring-pulse/50 focus:border-pulse placeholder:text-ghost/50"
+            />
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+              <AlertCircle size={16} className="shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          <Button onClick={handleSave} disabled={busy} className="w-full justify-center">
+            <Check size={16} className="mr-2" />
+            {mode === 'add' ? 'Add contact' : 'Save changes'}
+          </Button>
+
+          {mode === 'edit' && onDelete && (
+            confirmDelete ? (
+              <div className="space-y-2">
+                <p className="text-xs text-ghost text-center">
+                  Remove this contact? This only deletes the local label, not any
+                  payments.
+                </p>
+                <div className="flex gap-2">
+                  <Button
+                    variant="danger"
+                    onClick={handleDelete}
+                    disabled={busy}
+                    className="flex-1 justify-center"
+                  >
+                    <Trash2 size={16} className="mr-2" />Delete
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={() => setConfirmDelete(false)}
+                    className="flex-1 justify-center"
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Button
+                variant="ghost"
+                onClick={() => setConfirmDelete(true)}
+                className="w-full justify-center text-danger"
+              >
+                <Trash2 size={16} className="mr-2" />Delete contact
+              </Button>
+            )
+          )}
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -10,7 +10,7 @@ import { FaucetButton } from '../components/FaucetButton'
 import { SendLinkModal } from '../components/SendLinkModal'
 import { RequestModal } from '../components/RequestModal'
 import { OutstandingLinks } from '../components/OutstandingLinks'
-import { Send, Link2, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2 } from 'lucide-react'
+import { Send, Link2, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2, Users } from 'lucide-react'
 
 function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?: string) => void }) {
   const [showMnemonic, setShowMnemonic] = useState(false)
@@ -219,7 +219,7 @@ function ImportWalletView({ onImport }: { onImport: (mnemonic: string, password?
 }
 
 function WalletDashboard() {
-  const { address, balance, transactions, isConnecting, isConnected, refreshBalance, refreshTransactions, resetWallet, send } = useWallet()
+  const { address, balance, transactions, isConnecting, isConnected, refreshBalance, refreshTransactions, resetWallet, send, contacts, searchContacts } = useWallet()
   const { hasFaucet } = useNetwork()
   const [sendOpen, setSendOpen] = useState(false)
   const [sendLinkOpen, setSendLinkOpen] = useState(false)
@@ -267,6 +267,11 @@ function WalletDashboard() {
       <Button variant="secondary" onClick={() => setRequestOpen(true)}>
         <Download size={16} className="mr-2" />Request
       </Button>
+      <Link to="/contacts">
+        <Button variant="secondary">
+          <Users size={16} className="mr-2" />Contacts
+        </Button>
+      </Link>
       <Button variant="ghost" size="sm" onClick={refreshBalance} disabled={isConnecting}>
         <RefreshCw size={16} className={isConnecting ? 'animate-spin' : ''} />
       </Button>
@@ -304,6 +309,8 @@ function WalletDashboard() {
         estimateFee={estimateFee}
         onSend={handleSend}
         isSending={isSending}
+        contacts={contacts}
+        onSearchContacts={searchContacts}
       />
 
       <SendLinkModal isOpen={sendLinkOpen} onClose={() => setSendLinkOpen(false)} />


### PR DESCRIPTION
Implements #472 — address-book UX + "share my address" receive links. UI + wiring only; reuses the existing address-book backend and `send()` path.

## Part A — Address-book UX
- **Record who you pay.** `send()` (and a new `recordPayment(address)` context method) now UPSERT the recipient on a successful send: if not yet a contact, create a minimal blank-name entry (labelable later), then bump `txCount`/`lastTxAt` exactly once. Best-effort — never fails a send. No double-count.
- **Contacts manager.** New `/contacts` route + `pages/contacts.tsx`, reachable from a new "Contacts" nav button on the wallet. Lists contacts with a sort toggle (Name / Recent / Most paid), a name+address search box, and add/edit/delete with editable name + notes. Unnamed previously-paid entries render "Unnamed — tap to label".
- **Contact picker in Send.** `SendModal` gains NEW OPTIONAL props `contacts?: Contact[]` and `onSearchContacts?` (back-compat). Typing in the recipient field shows matching saved contacts to fill; a known recipient shows its contact name inline. Wired from `wallet.tsx`. `@botho/features` does NOT import the web-wallet context — only the `Contact` type from `@botho/core`; data flows via props. (pay.tsx already shows the contact name for the request recipient.)

## Part B — "Just share my address" receive link
- `RequestModal` gets a clear mode toggle: **"Request an amount"** vs **"Just share my address"**. Address mode builds a `/pay#…` link carrying ONLY the address (no amount/memo) — a pure receive link — and shows the address + QR + Copy. `PayPage` already handles an omitted amount, so the payer chooses the amount; no payer-side change. Link still uses the fragment (consistent with #471).

## Tests
- New `web/packages/core/src/storage/address-book.test.ts` (10 tests): record-payment upsert — blank-name creation, **no-double-count**, existing-contact bump, **unnamed-then-named rename** (history preserved), persistence across reloads; plus CRUD/search/getDisplayName.
- `wallet.test.tsx`: asserts `recordPayment`/`searchContacts` are exposed and non-throwing.

## Verification
- `pnpm -r typecheck` — green
- `pnpm --filter @botho/web-wallet build` — green (PWA SW generated)
- `pnpm test:run` — green (148 passed, 10 skipped live-node)

Scope: web-wallet + @botho/features + @botho/core (new test only). No consensus/faucet/network/Rust changes. Stray `.loom-managed` / `pnpm-workspace.yaml` mutations reverted before pushing.

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)