### PR TITLE
feat(web-wallet): show receive-address QR for in-person scan-to-pay

### DIFF
--- a/web/packages/web-wallet/src/components/ReceiveModal.test.tsx
+++ b/web/packages/web-wallet/src/components/ReceiveModal.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ReceiveModal } from './ReceiveModal'
+
+const TEST_ADDRESS = 'btho1qexampleaddress000000000000000000000000000deadbeef'
+
+// Mock the wallet context so the component is self-contained.
+const useWalletMock = vi.fn()
+vi.mock('../contexts/wallet', () => ({
+  useWallet: () => useWalletMock(),
+}))
+
+describe('ReceiveModal', () => {
+  beforeEach(() => {
+    cleanup()
+    useWalletMock.mockReset()
+    useWalletMock.mockReturnValue({ address: TEST_ADDRESS })
+  })
+
+  it('renders nothing when closed', () => {
+    const { container } = render(<ReceiveModal isOpen={false} onClose={() => {}} />)
+    expect(container.childElementCount).toBe(0)
+  })
+
+  it('shows the address and a scannable QR when open', () => {
+    render(<ReceiveModal isOpen onClose={() => {}} />)
+
+    // The full raw address is shown in the read-only field.
+    const field = screen.getByDisplayValue(TEST_ADDRESS)
+    expect(field).toBeDefined()
+
+    // qrcode.react renders an <svg>; assert one is present (the QR).
+    const qr = document.querySelector('svg[aria-label="Receiving address QR code"]')
+    expect(qr).not.toBeNull()
+  })
+
+  it('encodes the raw address in the QR (not a /pay link)', () => {
+    render(<ReceiveModal isOpen onClose={() => {}} />)
+    const field = screen.getByDisplayValue(TEST_ADDRESS) as HTMLInputElement
+    // Raw address — distinct from RequestModal's /pay#… share link.
+    expect(field.value).toBe(TEST_ADDRESS)
+    expect(field.value).not.toContain('/pay')
+  })
+
+  it('prompts to unlock when there is no wallet', () => {
+    useWalletMock.mockReturnValue({ address: null })
+    render(<ReceiveModal isOpen onClose={() => {}} />)
+    expect(screen.getByText(/Unlock or create a wallet/i)).toBeDefined()
+  })
+})

--- a/web/packages/web-wallet/src/components/ReceiveModal.tsx
+++ b/web/packages/web-wallet/src/components/ReceiveModal.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react'
+import { QRCodeSVG } from 'qrcode.react'
+import { Button, Card } from '@botho/ui'
+import { QrCode, Copy, Check, AlertCircle, X, Link2 } from 'lucide-react'
+import { useWallet } from '../contexts/wallet'
+
+/**
+ * "Receive" — show the wallet's OWN public address as a scannable QR so someone
+ * can pay you in person (#477). The QR encodes the RAW address only, so any
+ * wallet that can scan an address will work — no Botho-specific link parsing
+ * required.
+ *
+ * This is intentionally distinct from "Request Payment" (#470, `RequestModal`),
+ * which builds a `/pay#…` *link* carrying an optional amount/memo and only opens
+ * in a Botho wallet. Here there is no amount and no link — just "this is my
+ * address, scan it to pay me". A button is offered to jump to the richer
+ * request-a-link flow when an amount/memo is wanted.
+ */
+export function ReceiveModal({
+  isOpen,
+  onClose,
+  onRequestLink,
+}: {
+  isOpen: boolean
+  onClose: () => void
+  /** Optional: switch over to the richer "Request a link" flow (#470). */
+  onRequestLink?: () => void
+}) {
+  const { address } = useWallet()
+  const [copied, setCopied] = useState(false)
+
+  if (!isOpen) return null
+
+  const handleClose = () => {
+    setCopied(false)
+    onClose()
+  }
+
+  const handleCopy = async () => {
+    if (!address) return
+    try {
+      await navigator.clipboard.writeText(address)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard may be unavailable; the address is still selectable in the field.
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-void/80 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4 z-50">
+      <Card className="w-full sm:max-w-md p-5 sm:p-6 rounded-t-2xl sm:rounded-2xl max-h-[92vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-2">
+            <QrCode className="text-pulse" size={20} />
+            <h3 className="font-display text-lg font-semibold">Receive</h3>
+          </div>
+          <button onClick={handleClose} className="text-ghost hover:text-light" aria-label="Close">
+            <X size={20} />
+          </button>
+        </div>
+
+        {!address ? (
+          <div className="flex items-center gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
+            <AlertCircle size={16} className="shrink-0" />
+            <span>Unlock or create a wallet to receive a payment.</span>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-sm text-ghost">
+              Let someone scan this to pay you in person. The QR is your public address — no amount,
+              no link, no secret. Anyone can send you any amount.
+            </p>
+
+            <div className="flex flex-col items-center gap-3">
+              <div className="rounded-xl bg-white p-3">
+                <QRCodeSVG value={address} size={200} level="M" aria-label="Receiving address QR code" />
+              </div>
+              <p className="text-xs text-ghost flex items-center gap-1.5">
+                <QrCode size={13} />
+                Scan to pay me
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm text-ghost mb-1.5">Your address</label>
+              <div className="flex gap-2">
+                <input
+                  readOnly
+                  value={address}
+                  onFocus={(e) => e.currentTarget.select()}
+                  className="flex-1 min-w-0 px-3 py-2 rounded-lg bg-abyss border border-steel font-mono text-xs text-light"
+                />
+                <Button onClick={handleCopy} size="sm" variant="secondary" aria-label="Copy address">
+                  {copied ? <Check size={16} /> : <Copy size={16} />}
+                </Button>
+              </div>
+            </div>
+
+            {onRequestLink && (
+              <button
+                onClick={() => {
+                  handleClose()
+                  onRequestLink()
+                }}
+                className="flex w-full items-center justify-center gap-1.5 text-sm text-ghost hover:text-light transition-colors"
+              >
+                <Link2 size={14} />
+                Request a specific amount instead
+              </button>
+            )}
+
+            <Button onClick={handleClose} className="w-full justify-center">
+              Done
+            </Button>
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -9,8 +9,9 @@ import { NetworkSelector } from '../components/NetworkSelector'
 import { FaucetButton } from '../components/FaucetButton'
 import { SendLinkModal } from '../components/SendLinkModal'
 import { RequestModal } from '../components/RequestModal'
+import { ReceiveModal } from '../components/ReceiveModal'
 import { OutstandingLinks } from '../components/OutstandingLinks'
-import { Send, Link2, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2, Users } from 'lucide-react'
+import { Send, Link2, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2, Users, QrCode } from 'lucide-react'
 
 const STRENGTH_META: Record<PasswordStrength, { label: string; bars: number; color: string }> = {
   'too-short': { label: `At least ${MIN_PASSWORD_LENGTH} characters`, bars: 0, color: 'bg-danger' },
@@ -263,6 +264,7 @@ function WalletDashboard() {
   const [sendOpen, setSendOpen] = useState(false)
   const [sendLinkOpen, setSendLinkOpen] = useState(false)
   const [requestOpen, setRequestOpen] = useState(false)
+  const [receiveOpen, setReceiveOpen] = useState(false)
   const [isSending, setIsSending] = useState(false)
   const [showResetConfirm, setShowResetConfirm] = useState(false)
 
@@ -299,6 +301,9 @@ function WalletDashboard() {
     <>
       <Button onClick={() => setSendOpen(true)}>
         <Send size={16} className="mr-2" />Send
+      </Button>
+      <Button variant="secondary" onClick={() => setReceiveOpen(true)}>
+        <QrCode size={16} className="mr-2" />Receive
       </Button>
       <Button variant="secondary" onClick={() => setSendLinkOpen(true)}>
         <Link2 size={16} className="mr-2" />Send via Link
@@ -355,6 +360,12 @@ function WalletDashboard() {
       <SendLinkModal isOpen={sendLinkOpen} onClose={() => setSendLinkOpen(false)} />
 
       <RequestModal isOpen={requestOpen} onClose={() => setRequestOpen(false)} />
+
+      <ReceiveModal
+        isOpen={receiveOpen}
+        onClose={() => setReceiveOpen(false)}
+        onRequestLink={() => setRequestOpen(true)}
+      />
 
       {showResetConfirm && (
         <div className="fixed inset-0 bg-void/80 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4 z-50">


### PR DESCRIPTION
Closes #477

## What

Adds a **Receive** surface to the wallet dashboard so people can scan your address to pay you in person.

- New `ReceiveModal` (`web/packages/web-wallet/src/components/ReceiveModal.tsx`) shows:
  - a scannable **QR of the raw receiving address** (`useWallet().address`),
  - the full address in a read-only field, and
  - a **Copy** button.
- A new **Receive** action button in the wallet dashboard (`pages/wallet.tsx`) opens it.

## Distinct from "Request Payment" (#470/#472)

The QR here encodes the **raw address only**, so *any* wallet that scans an address can pay — no Botho link parsing needed. This is intentionally separate from the existing `RequestModal`, which builds a `/pay#…` *link* (optional amount/memo) that opens in a Botho wallet. The Receive modal offers a "Request a specific amount instead" link that jumps to that richer flow, reusing rather than duplicating it.

## Reuse / scope

- Reuses `QRCodeSVG` from `qrcode.react` (already a dependency — no new deps).
- Scope: `web-wallet` only (no `@botho/features` changes were needed since `qrcode.react` is not a `features` dependency). No consensus/faucet/network/Rust changes.

## Verification

- `pnpm install` — ok (ERR_PNPM_IGNORED_BUILDS warning only)
- `pnpm -r typecheck` — green
- `pnpm --filter @botho/web-wallet build` — green
- `pnpm test:run` — green (188 passed, 10 skipped); added `ReceiveModal.test.tsx` (4 tests) asserting the receive view renders the address + a QR `<svg>`, encodes the raw address (not a `/pay` link), and prompts to unlock when there is no wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)