### PR TITLE
feat(web-wallet): transaction history polish (pending/confirming, contact names, relative time)

### DIFF
--- a/web/packages/core/src/format.test.ts
+++ b/web/packages/core/src/format.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { formatRelativeTime, formatAbsoluteTime } from './format'
+
+describe('formatRelativeTime', () => {
+  // Fixed "now" so the relative output is deterministic.
+  const nowMs = 1_700_000_000_000
+  const nowSec = Math.floor(nowMs / 1000)
+
+  const at = (secondsAgo: number) => formatRelativeTime(nowSec - secondsAgo, nowMs)
+
+  it('shows "just now" for very recent timestamps', () => {
+    expect(at(0)).toBe('just now')
+    expect(at(10)).toBe('just now')
+    expect(at(44)).toBe('just now')
+  })
+
+  it('treats future timestamps (clock skew) as "just now"', () => {
+    expect(formatRelativeTime(nowSec + 30, nowMs)).toBe('just now')
+  })
+
+  it('shows minutes', () => {
+    expect(at(60)).toBe('1m ago')
+    expect(at(120)).toBe('2m ago')
+    expect(at(59 * 60)).toBe('59m ago')
+  })
+
+  it('shows hours', () => {
+    expect(at(60 * 60)).toBe('1h ago')
+    expect(at(3 * 60 * 60)).toBe('3h ago')
+  })
+
+  it('shows "yesterday" for ~1 day ago', () => {
+    expect(at(24 * 60 * 60 + 60)).toBe('yesterday')
+  })
+
+  it('shows days for the rest of the week', () => {
+    expect(at(3 * 24 * 60 * 60)).toBe('3d ago')
+  })
+
+  it('falls back to an absolute date for older than a week', () => {
+    const old = nowSec - 30 * 24 * 60 * 60
+    expect(formatRelativeTime(old, nowMs)).toBe(
+      new Date(old * 1000).toLocaleDateString()
+    )
+  })
+})
+
+describe('formatAbsoluteTime', () => {
+  const ts = 1_700_000_000
+
+  it('renders a full date/time by default', () => {
+    expect(formatAbsoluteTime(ts)).toBe(new Date(ts * 1000).toLocaleString())
+  })
+
+  it('renders date only when requested', () => {
+    expect(formatAbsoluteTime(ts, { dateOnly: true })).toBe(
+      new Date(ts * 1000).toLocaleDateString()
+    )
+  })
+})

--- a/web/packages/core/src/format.ts
+++ b/web/packages/core/src/format.ts
@@ -98,3 +98,64 @@ export function formatSignedBTH(picocredits: bigint, isPositive: boolean): strin
   const prefix = isPositive ? '+' : '-'
   return `${prefix}${formatBTH(picocredits)}`
 }
+
+// ============================================================================
+// Time Formatting Utilities
+// ============================================================================
+
+const MINUTE = 60
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+/**
+ * Format a Unix timestamp (in seconds) as a short relative time string, e.g.
+ * "just now", "2m ago", "3h ago", "yesterday", "4d ago". Falls back to an
+ * absolute date for anything older than a week.
+ *
+ * @param timestampSeconds - Unix timestamp in seconds
+ * @param nowMs - Current time in ms (override for testing; defaults to Date.now())
+ */
+export function formatRelativeTime(timestampSeconds: number, nowMs: number = Date.now()): string {
+  const deltaSeconds = Math.round(nowMs / 1000 - timestampSeconds)
+
+  // Future timestamps (clock skew) read as "just now".
+  if (deltaSeconds < 45) {
+    return 'just now'
+  }
+  if (deltaSeconds < 90) {
+    return '1m ago'
+  }
+  if (deltaSeconds < HOUR) {
+    return `${Math.round(deltaSeconds / MINUTE)}m ago`
+  }
+  if (deltaSeconds < 2 * HOUR) {
+    return '1h ago'
+  }
+  if (deltaSeconds < DAY) {
+    return `${Math.round(deltaSeconds / HOUR)}h ago`
+  }
+  if (deltaSeconds < 2 * DAY) {
+    return 'yesterday'
+  }
+  if (deltaSeconds < 7 * DAY) {
+    return `${Math.round(deltaSeconds / DAY)}d ago`
+  }
+
+  // Older than a week: fall back to an absolute date.
+  return formatAbsoluteTime(timestampSeconds, { dateOnly: true })
+}
+
+/**
+ * Format a Unix timestamp (in seconds) as an absolute local date/time string,
+ * suitable for a tooltip / `title` attribute.
+ *
+ * @param timestampSeconds - Unix timestamp in seconds
+ * @param options.dateOnly - When true, omit the time component
+ */
+export function formatAbsoluteTime(
+  timestampSeconds: number,
+  options: { dateOnly?: boolean } = {}
+): string {
+  const date = new Date(timestampSeconds * 1000)
+  return options.dateOnly ? date.toLocaleDateString() : date.toLocaleString()
+}

--- a/web/packages/features/src/wallet/components/transaction-list.test.tsx
+++ b/web/packages/features/src/wallet/components/transaction-list.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import type { Transaction } from '@botho/core'
+import { TransactionList } from './transaction-list'
+
+const SENDER = 'btho1qaliceaddress0000000000000000000000000000000000aaaa'
+
+function makeTx(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'tx-1',
+    type: 'send',
+    amount: 1_500_000_000_000n,
+    fee: 4000n,
+    privacyLevel: 'private',
+    cryptoType: 'clsag',
+    status: 'confirmed',
+    timestamp: Math.floor(Date.now() / 1000),
+    confirmations: 12,
+    counterparty: SENDER,
+    ...overrides,
+  }
+}
+
+describe('TransactionList', () => {
+  beforeEach(() => cleanup())
+
+  it('renders a friendly empty state when there are no transactions', () => {
+    render(<TransactionList transactions={[]} />)
+    expect(screen.getByText('No transactions yet')).toBeDefined()
+    // The hint text is present too.
+    expect(screen.getByText(/Transactions will appear here/i)).toBeDefined()
+    // No rows rendered.
+    expect(document.querySelector('.space-y-2')).toBeNull()
+  })
+
+  it('shows the truncated address when no name resolver is provided', () => {
+    render(<TransactionList transactions={[makeTx()]} showChevron={false} />)
+    expect(screen.getByText(SENDER)).toBeDefined()
+  })
+
+  it('shows a resolved contact name instead of the raw address', () => {
+    const resolveName = (addr: string) => (addr === SENDER ? 'Alice' : undefined)
+    render(
+      <TransactionList
+        transactions={[makeTx()]}
+        resolveName={resolveName}
+        showChevron={false}
+      />
+    )
+    expect(screen.getByText('Alice')).toBeDefined()
+    // Raw address no longer shown as the label.
+    expect(screen.queryByText(SENDER)).toBeNull()
+  })
+
+  it('falls back to the raw address when the resolver returns undefined', () => {
+    const resolveName = () => undefined
+    render(
+      <TransactionList
+        transactions={[makeTx()]}
+        resolveName={resolveName}
+        showChevron={false}
+      />
+    )
+    expect(screen.getByText(SENDER)).toBeDefined()
+  })
+
+  it('renders a pending indicator for in-flight sends', () => {
+    render(
+      <TransactionList
+        transactions={[makeTx({ status: 'pending', confirmations: 0 })]}
+        showChevron={false}
+      />
+    )
+    expect(screen.getByText('Pending')).toBeDefined()
+  })
+
+  it('renders a confirming indicator for shallow confirmations', () => {
+    render(
+      <TransactionList
+        transactions={[makeTx({ status: 'confirmed', confirmations: 1 })]}
+        showChevron={false}
+      />
+    )
+    expect(screen.getByText('Confirming')).toBeDefined()
+  })
+
+  it('renders a confirmation count for settled transactions', () => {
+    render(
+      <TransactionList
+        transactions={[makeTx({ status: 'confirmed', confirmations: 12 })]}
+        showChevron={false}
+      />
+    )
+    expect(screen.getByText('12 conf')).toBeDefined()
+  })
+
+  it('shows an absolute time tooltip on the relative timestamp', () => {
+    const ts = 1_700_000_000
+    const { container } = render(
+      <TransactionList transactions={[makeTx({ timestamp: ts })]} showChevron={false} />
+    )
+    const titled = container.querySelector(
+      `[title="${new Date(ts * 1000).toLocaleString()}"]`
+    )
+    expect(titled).not.toBeNull()
+  })
+
+  it('reports the transaction count in the header', () => {
+    render(<TransactionList transactions={[makeTx(), makeTx({ id: 'tx-2' })]} />)
+    expect(screen.getByText('2 transactions')).toBeDefined()
+  })
+})

--- a/web/packages/features/src/wallet/components/transaction-list.tsx
+++ b/web/packages/features/src/wallet/components/transaction-list.tsx
@@ -15,6 +15,12 @@ export interface TransactionListProps {
   showPrivacy?: boolean
   /** Whether to show chevrons for clickable rows */
   showChevron?: boolean
+  /**
+   * Optional lookup that maps a counterparty address to a friendly display name
+   * (e.g. an address-book contact). Forwarded to each {@link TransactionRow}.
+   * Kept optional for back-compat with callers that have no address book.
+   */
+  resolveName?: (address: string) => string | undefined
   /** Click handler for transaction rows */
   onTransactionClick?: (tx: Transaction) => void
   /** Custom class name */
@@ -29,6 +35,7 @@ export function TransactionList({
   title = 'Transaction History',
   showPrivacy = false,
   showChevron = true,
+  resolveName,
   onTransactionClick,
   className = '',
 }: TransactionListProps) {
@@ -65,6 +72,7 @@ export function TransactionList({
                 index={i}
                 showPrivacy={showPrivacy}
                 showChevron={showChevron}
+                resolveName={resolveName}
                 onClick={onTransactionClick}
               />
             ))}

--- a/web/packages/features/src/wallet/components/transaction-row.tsx
+++ b/web/packages/features/src/wallet/components/transaction-row.tsx
@@ -1,16 +1,22 @@
 import type { Transaction } from '@botho/core'
-import { formatBTH } from '@botho/core'
+import { formatBTH, formatRelativeTime, formatAbsoluteTime } from '@botho/core'
 import { motion } from 'motion/react'
 import {
   ArrowDownLeft,
   ArrowUpRight,
   Check,
   ChevronRight,
-  Clock,
+  Loader2,
   Sparkles,
   X,
 } from 'lucide-react'
 import { PrivacyBadge } from './privacy-badge'
+
+/**
+ * Number of confirmations a transaction needs before it is treated as fully
+ * settled. Below this (but already in a block) we surface a "Confirming" state.
+ */
+const CONFIRMED_THRESHOLD = 6
 
 export interface TransactionRowProps {
   /** Transaction data */
@@ -25,6 +31,13 @@ export interface TransactionRowProps {
   showPrivacy?: boolean
   /** Whether to show chevron for clickable rows */
   showChevron?: boolean
+  /**
+   * Optional lookup that maps a counterparty address to a friendly display name
+   * (e.g. an address-book contact). Return `undefined` when the address is not
+   * known so the row falls back to the truncated address. Kept optional so
+   * existing callers without an address book stay unchanged.
+   */
+  resolveName?: (address: string) => string | undefined
   /** Click handler */
   onClick?: (tx: Transaction) => void
   /** Custom class name */
@@ -39,17 +52,29 @@ export function TransactionRow({
   index = 0,
   showPrivacy = false,
   showChevron = true,
+  resolveName,
   onClick,
   className = '',
 }: TransactionRowProps) {
   const isReceive = tx.type === 'receive' || tx.type === 'minting'
   const Icon = tx.type === 'minting' ? Sparkles : isReceive ? ArrowDownLeft : ArrowUpRight
 
+  // Treat an in-block-but-not-yet-deep transaction as "confirming". A pending
+  // transaction is still propagating / unmined.
+  const isConfirming =
+    tx.status === 'confirmed' && tx.confirmations < CONFIRMED_THRESHOLD
+
   const statusConfig = {
-    pending: { color: 'text-[--color-warning]', icon: Clock },
-    confirmed: { color: 'text-[--color-success]', icon: Check },
-    failed: { color: 'text-[--color-danger]', icon: X },
-  }[tx.status]
+    pending: { color: 'text-[--color-warning]', icon: Loader2, label: 'Pending', spin: true },
+    confirming: { color: 'text-[--color-warning]', icon: Loader2, label: 'Confirming', spin: true },
+    confirmed: {
+      color: 'text-[--color-success]',
+      icon: Check,
+      label: `${tx.confirmations} conf`,
+      spin: false,
+    },
+    failed: { color: 'text-[--color-danger]', icon: X, label: 'Failed', spin: false },
+  }[tx.status === 'confirmed' && isConfirming ? 'confirming' : tx.status]
 
   const StatusIcon = statusConfig.icon
 
@@ -62,6 +87,11 @@ export function TransactionRow({
 
   const label =
     tx.type === 'minting' ? 'Minting Reward' : isReceive ? 'Received' : 'Sent'
+
+  // Prefer a friendly contact name for the counterparty, falling back to the
+  // raw address (truncated via CSS) and finally the tx id.
+  const counterpartyName = tx.counterparty ? resolveName?.(tx.counterparty) : undefined
+  const counterparty = counterpartyName || tx.counterparty || tx.id
 
   return (
     <motion.div
@@ -85,12 +115,18 @@ export function TransactionRow({
           {showPrivacy && <PrivacyBadge cryptoType={tx.cryptoType} />}
         </div>
         <div className="mt-0.5 flex items-center gap-2">
-          <span className="max-w-[180px] truncate font-mono text-xs text-[--color-dim]">
-            {tx.counterparty || tx.id}
+          <span
+            className={`max-w-[180px] truncate text-xs text-[--color-dim] ${counterpartyName ? '' : 'font-mono'}`}
+            title={tx.counterparty}
+          >
+            {counterparty}
           </span>
           <span className="text-[--color-muted]">•</span>
-          <span className="text-xs text-[--color-dim]">
-            {new Date(tx.timestamp * 1000).toLocaleDateString()}
+          <span
+            className="text-xs text-[--color-dim]"
+            title={formatAbsoluteTime(tx.timestamp)}
+          >
+            {formatRelativeTime(tx.timestamp)}
           </span>
         </div>
       </div>
@@ -103,9 +139,11 @@ export function TransactionRow({
           {isReceive ? '+' : '-'}
           {formatBTH(tx.amount)} BTH
         </div>
-        <div className={`flex items-center justify-end gap-1 text-xs ${statusConfig.color}`}>
-          <StatusIcon className="h-3 w-3" />
-          {tx.status === 'confirmed' ? `${tx.confirmations} conf` : tx.status}
+        <div
+          className={`flex items-center justify-end gap-1 text-xs ${statusConfig.color}`}
+        >
+          <StatusIcon className={`h-3 w-3 ${statusConfig.spin ? 'animate-spin' : ''}`} />
+          {statusConfig.label}
         </div>
       </div>
 

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -260,6 +260,20 @@ function ImportWalletView({ onImport }: { onImport: (mnemonic: string, password?
 
 function WalletDashboard() {
   const { address, balance, transactions, isConnecting, isConnected, refreshBalance, refreshTransactions, resetWallet, send, contacts, searchContacts } = useWallet()
+
+  // Resolve a counterparty address to a saved contact name for the transaction
+  // history. We auto-create blank-name "previously paid" entries when sending,
+  // so only surface contacts that actually have a non-empty name. Returns
+  // `undefined` for unknown/unnamed addresses so the row falls back to the
+  // truncated address.
+  const resolveName = useMemo(() => {
+    const byAddress = new Map(
+      contacts
+        .filter((c) => c.name.trim().length > 0)
+        .map((c) => [c.address.toLowerCase(), c.name] as const)
+    )
+    return (addr: string): string | undefined => byAddress.get(addr.toLowerCase())
+  }, [contacts])
   const { hasFaucet } = useNetwork()
   const [sendOpen, setSendOpen] = useState(false)
   const [sendLinkOpen, setSendLinkOpen] = useState(false)
@@ -344,6 +358,7 @@ function WalletDashboard() {
         transactions={transactions}
         title="Recent Transactions"
         showChevron={false}
+        resolveName={resolveName}
       />
 
       <SendModal


### PR DESCRIPTION
Closes #478

Polishes the wallet transaction history (`@botho/features` TransactionList/TransactionRow + `pages/wallet.tsx`).

## What changed
- **Empty state** — kept the existing friendly "No transactions yet" + hint.
- **Pending / Confirming indicators** — in-flight sends (`status: 'pending'`) render an animated "Pending" spinner; confirmed-but-shallow transactions (< 6 confirmations) render "Confirming"; settled transactions keep the `N conf` count.
- **Contact names** — known counterparties show their address-book name (#472) instead of the truncated address (raw address moved to the `title` tooltip). Unknown/unnamed addresses fall back to the truncated address.
- **Relative timestamps** — "just now" / "2m ago" / "yesterday" / "3d ago", with the absolute date/time on hover via a `title` attribute. Older than a week falls back to an absolute date.

Did **not** reintroduce the per-row "Private" badge (intentionally removed in #468).

## New optional props (back-compat)
Added to both `TransactionListProps` and `TransactionRowProps`:

```ts
/** Maps a counterparty address to a friendly display name; undefined => fall back to address. */
resolveName?: (address: string) => string | undefined
```

`@botho/features` does not import the web-wallet context. `wallet.tsx` builds the resolver from the wallet context's `contacts` (only contacts with a non-empty name, since blank "previously paid" entries are auto-created on send) and passes it to `TransactionList`.

A shared `formatRelativeTime` / `formatAbsoluteTime` helper was added to `@botho/core/format.ts`.

## Tests
- `web/packages/core/src/format.test.ts` — relative/absolute time formatting (deterministic `now`).
- `web/packages/features/src/wallet/components/transaction-list.test.tsx` — empty state, name resolution (resolved + fallback), pending/confirming/settled indicators, absolute-time tooltip, count header. Uses native vitest matchers only (no jest-dom).

## Verification
- `pnpm install` — exit 0 (only the ERR_PNPM_IGNORED_BUILDS warning)
- `pnpm -r typecheck` — green
- `pnpm --filter @botho/web-wallet build` — green
- `pnpm test:run` — green (206 passed, 10 skipped)

Scope: web-wallet + @botho/features + @botho/core (shared time formatter only). No Rust/consensus/faucet/network changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)