### PR TITLE
test(web-wallet): make wallet context tests hermetic (mock wasm-signer + deterministic cleanup)

### DIFF
--- a/web/packages/web-wallet/src/contexts/wallet.test.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.test.tsx
@@ -2,9 +2,29 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { render, screen, waitFor, act, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WalletProvider, useWallet } from './wallet'
+
+// Mock @botho/wasm-signer so these context tests never depend on the generated
+// wasm artifact (`packages/wasm-signer/pkg/`, produced by `build:wasm` and
+// git-ignored). The wallet context imports buildSendTransaction /
+// spendableBalance / buildOwnedHistory at module load; on a fresh checkout the
+// wasm pkg is absent, so anything that reaches those functions would otherwise
+// blow up with "wasm artifact not found" and poison the suite. None of the
+// assertions here exercise real signing/scanning (the adapter is mocked), so we
+// substitute inert stubs that keep the import hermetic and the suite fast.
+// buildSendTransaction is only ever reached via the encrypted-wallet claim-link
+// happy path, which is itself mocked at ../lib/claim-link-ops, so it is never
+// actually invoked — it is stubbed purely to satisfy the import.
+vi.mock('@botho/wasm-signer', () => ({
+  // No owned outputs => zero spendable balance; the context falls back to the
+  // mocked adapter balance, which is what the tests assert against.
+  spendableBalance: vi.fn().mockResolvedValue(0n),
+  // No owned outputs => empty client-side history.
+  buildOwnedHistory: vi.fn().mockResolvedValue([]),
+  buildSendTransaction: vi.fn().mockResolvedValue({ txHex: '0xstub' }),
+}))
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -102,6 +122,12 @@ describe('WalletContext', () => {
   })
 
   afterEach(() => {
+    // Explicitly unmount rendered trees between tests. Several tests in this
+    // file render the WalletProvider multiple times (and one unmounts +
+    // re-renders within a single test). Without a deterministic cleanup the
+    // mounted <div data-testid="address"> nodes accumulate in the jsdom body
+    // and screen.getByTestId('address') throws a "multiple elements" error.
+    cleanup()
     vi.clearAllMocks()
   })
 
@@ -421,6 +447,9 @@ describe('WalletContext', () => {
 
 describe('Import Wallet Integration', () => {
   beforeEach(() => {
+    // Unmount any tree left over from the previous test/suite so the
+    // data-testid="address" query stays unambiguous (see note above).
+    cleanup()
     localStorageMock.clear()
   })
 


### PR DESCRIPTION
## Summary

`web/packages/web-wallet/src/contexts/wallet.test.tsx` is now hermetic: it no longer depends on the git-ignored, `build:wasm`-generated `packages/wasm-signer/pkg/` artifact, and its `getByTestId('address')` queries are unambiguous regardless of Testing Library auto-cleanup behavior. `pnpm install && pnpm test:run` is green from a clean checkout with NO manual wasm prebuild.

## Root cause

Two latent fragilities in `wallet.test.tsx` (both pre-existing on main, not introduced by any sweep PR):

1. **wasm-signer coupling.** The wallet context (`contexts/wallet.tsx`) imports `buildSendTransaction` / `spendableBalance` / `buildOwnedHistory` from `@botho/wasm-signer` at module load. `@botho/wasm-signer`'s entry is TS source whose lazy `loadSigner()` dynamically imports the generated `pkg/bth_wasm_signer.js`. On a fresh checkout `pkg/` does not exist (it is produced by `pnpm --filter @botho/wasm-signer build:wasm` and git-ignored). Any test path that reaches those functions can throw `"wasm artifact not found"`, which is what poisons `pnpm test:run` from a clean state. The test mocked `@botho/adapters`, `@botho/core`, and `claim-link-ops`, but never `@botho/wasm-signer`.

2. **Ambiguous `getByTestId('address')`.** The test renders `<WalletProvider>` many times across its cases (one case unmounts + re-renders within a single test). It relied entirely on Testing Library's implicit auto-cleanup. When auto-cleanup is not active, the mounted `<div data-testid="address">` nodes accumulate in the jsdom body and `screen.getByTestId('address')` throws a "multiple elements" error — the exact ambiguity the issue calls out. The sibling `ReceiveModal.test.tsx` already guards against this by calling `cleanup()` explicitly; `wallet.test.tsx` did not.

## What made the suite hermetic

- Added `vi.mock('@botho/wasm-signer', ...)` to `wallet.test.tsx` returning inert stubs (`spendableBalance` -> `0n`, `buildOwnedHistory` -> `[]`, `buildSendTransaction` -> stub). The module is fully replaced, so the generated `pkg/` is never resolved or required. The stub values match what the mocked-adapter fallback path already tolerates, so no assertion is weakened or skipped.
- Added explicit `cleanup()` (from `@testing-library/react`) in the `afterEach` of the main suite and the `beforeEach` of the `Import Wallet Integration` suite, making render isolation deterministic and the `data-testid="address"` query unambiguous independent of auto-cleanup.

No app/logic changes, no consensus/Rust changes. Only the test file changed.

## Changes

- `web/packages/web-wallet/src/contexts/wallet.test.tsx`:
  - mock `@botho/wasm-signer` with inert stubs (hermetic — no wasm prebuild needed)
  - import and call `cleanup()` between tests/suites (deterministic `getByTestId('address')`)

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `pnpm install` succeeds (ERR_PNPM_IGNORED_BUILDS warning only) | ✅ | Ran in `web/`; only the ignored-builds warning |
| `pnpm test:run` GREEN from clean state (no manual wasm prebuild) | ✅ | `packages/wasm-signer/pkg/` confirmed absent; 13 files passed / 7 skipped, 206 tests passed / 10 skipped; `wallet.test.tsx` 16/16 |
| No test coverage weakened/skipped | ✅ | Same 16 assertions retained; stubs only stand in for the mocked-adapter fallback path |
| `getByTestId('address')` disambiguated | ✅ | Explicit `cleanup()` removes accumulated nodes between renders |
| `pnpm -r typecheck` green | ✅ | All 7 projects "Done" |
| `pnpm --filter @botho/web-wallet build` green | ✅ | `built in 2.60s` (the missing-pkg warning is a pre-existing non-fatal build warning, exit 0) |
| Scope: web-wallet test setup only; no app/Rust changes | ✅ | `git diff --stat` = 1 file, +30/-1 |
| Stray `.loom-managed` / `pnpm-workspace.yaml` mutations reverted | ✅ | Reverted before push; working tree clean |

## Test Plan

From a clean state (no `packages/wasm-signer/pkg/`):
```
cd web
pnpm install            # ERR_PNPM_IGNORED_BUILDS warning only
pnpm test:run           # 206 passed / 10 skipped; wallet.test.tsx 16/16
pnpm -r typecheck       # all projects Done
pnpm --filter @botho/web-wallet build   # built, exit 0
```

Closes #487