### PR TITLE
feat(web-wallet): wallet lock — Lock button + inactivity auto-lock (#490)

### DIFF
--- a/web/packages/web-wallet/src/contexts/wallet-lock.test.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet-lock.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the wallet LOCK + auto-lock-on-inactivity feature (#490).
+ *
+ * Like wallet-password.test.tsx (and unlike wallet.test.tsx) this file does NOT
+ * mock @botho/core's AddressBook / ClaimLinkStore: the whole security point of
+ * locking is that the decrypted seed + session vault key are wiped from memory
+ * so the REAL encrypted address book / claim-link blobs become unreadable until
+ * an unlock re-derives the key. Only the network adapter and wasm signer are
+ * stubbed.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, waitFor, act, cleanup } from '@testing-library/react'
+import { WalletProvider, useWallet } from './wallet'
+
+// Stub the wasm signer so the module import is hermetic (no wasm artifact on a
+// fresh checkout). None of these tests exercise real signing/scanning.
+vi.mock('@botho/wasm-signer', () => ({
+  spendableBalance: vi.fn().mockResolvedValue(0n),
+  buildOwnedHistory: vi.fn().mockResolvedValue([]),
+  buildSendTransaction: vi.fn().mockResolvedValue({ txHex: '0xstub' }),
+}))
+
+// Real-backing localStorage mock so the encrypted stores actually persist blobs
+// we can inspect across lock/unlock.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+    _dump: () => ({ ...store }),
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+// Stub the adapter. isConnected returns false so unlock/create do not attempt a
+// balance fetch (which would reach the stubbed wasm path); the lock-state
+// assertions do not depend on balances.
+vi.mock('@botho/adapters', () => ({
+  RemoteNodeAdapter: class MockRemoteNodeAdapter {
+    connect = vi.fn().mockResolvedValue(undefined)
+    disconnect = vi.fn()
+    isConnected = vi.fn().mockReturnValue(false)
+    getNodeInfo = vi.fn().mockReturnValue({ version: '1.0.0', network: 'testnet' })
+    getBalance = vi.fn().mockResolvedValue({ available: 0n, pending: 0n, total: 0n })
+    getTransactionHistory = vi.fn().mockResolvedValue([])
+    onNewBlock = vi.fn().mockReturnValue(() => {})
+    onTransaction = vi.fn().mockReturnValue(() => {})
+    onMempoolUpdate = vi.fn().mockReturnValue(() => {})
+    onPeerStatus = vi.fn().mockReturnValue(() => {})
+    getWsStatus = vi.fn().mockReturnValue('disconnected')
+    onWsStatusChange = vi.fn().mockReturnValue(() => {})
+  },
+}))
+
+const TEST_MNEMONIC_12 =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+const A_CONTACT = 'tbotho://1/contactaddrabc'
+
+const STORAGE_AUTO_LOCK = 'botho-auto-lock-minutes'
+
+function Harness({ onMount }: { onMount: (w: ReturnType<typeof useWallet>) => void }) {
+  const wallet = useWallet()
+  onMount(wallet)
+  return null
+}
+
+async function mountWallet(): Promise<{ get: () => ReturnType<typeof useWallet>; unmount: () => void }> {
+  let ref: ReturnType<typeof useWallet> | null = null
+  const utils = render(
+    <WalletProvider>
+      <Harness onMount={(w) => { ref = w }} />
+    </WalletProvider>
+  )
+  await waitFor(() => expect(ref).not.toBeNull())
+  return { get: () => ref!, unmount: utils.unmount }
+}
+
+describe('wallet lock (#490)', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+  afterEach(() => {
+    cleanup()
+    localStorageMock.clear()
+    vi.useRealTimers()
+  })
+
+  it('lockWallet clears the in-memory seed + vault key and sets isLocked', async () => {
+    const { get } = await mountWallet()
+
+    await act(async () => { await get().createWallet(TEST_MNEMONIC_12, 'hunter2pw') })
+    expect(get().isEncrypted).toBe(true)
+    expect(get().isLocked).toBe(false)
+    // Seed + session key are present while unlocked.
+    expect(await get().exportWallet()).toBe(TEST_MNEMONIC_12)
+    expect(get().getVaultKey()).not.toBeNull()
+
+    await act(async () => { get().lockWallet() })
+
+    // Locked state is set.
+    expect(get().isLocked).toBe(true)
+    // SECURITY: the session vault key is wiped from memory.
+    expect(get().getVaultKey()).toBeNull()
+    // SECURITY: the decrypted seed is wiped — exportWallet now falls back to
+    // disk, which for an encrypted wallet requires a password. Without one it
+    // cannot return the seed (it throws "Password required to unlock wallet"),
+    // proving the cleartext mnemonic is no longer held in memory.
+    await expect(get().exportWallet()).rejects.toThrow(/password required/i)
+    // The wallet still exists on disk (NOT wiped) — encrypted seed blob remains.
+    expect(localStorage.getItem('botho-wallet-mnemonic')).not.toBeNull()
+    expect(localStorage.getItem('botho-wallet-encrypted')).toBe('true')
+  })
+
+  it('after lock, encrypted contacts are unreadable until unlock restores access', async () => {
+    const { get } = await mountWallet()
+
+    await act(async () => { await get().createWallet(TEST_MNEMONIC_12, 'hunter2pw') })
+    await act(async () => { await get().addContact('Alice', A_CONTACT) })
+    expect(get().contacts.map((c) => c.name)).toContain('Alice')
+
+    // Lock: contacts disappear from the context (the encrypted store reads as
+    // empty with no session key).
+    await act(async () => { get().lockWallet() })
+    expect(get().isLocked).toBe(true)
+    expect(get().contacts).toHaveLength(0)
+    // The on-disk address-book blob still exists (not wiped).
+    expect(localStorage.getItem('botho-address-book')).not.toBeNull()
+
+    // Unlock: the key is re-derived and the contact reloads.
+    await act(async () => { await get().unlockWallet('hunter2pw') })
+    expect(get().isLocked).toBe(false)
+    expect(get().getVaultKey()).not.toBeNull()
+    expect(await get().exportWallet()).toBe(TEST_MNEMONIC_12)
+    await waitFor(() => {
+      expect(get().contacts.map((c) => c.name)).toContain('Alice')
+    })
+  })
+
+  it('lockWallet is a NO-OP for a plaintext wallet (never strands it)', async () => {
+    const { get } = await mountWallet()
+
+    // Plaintext wallet: no password => no session vault key.
+    await act(async () => { await get().createWallet(TEST_MNEMONIC_12) })
+    expect(get().isEncrypted).toBe(false)
+    expect(get().getVaultKey()).toBeNull()
+    expect(await get().exportWallet()).toBe(TEST_MNEMONIC_12)
+
+    // Attempting to lock must NOT change state — the wallet has no way to unlock.
+    await act(async () => { get().lockWallet() })
+    expect(get().isLocked).toBe(false)
+    // Seed is still in memory and accessible (not stranded).
+    expect(await get().exportWallet()).toBe(TEST_MNEMONIC_12)
+  })
+
+  it('setAutoLockMinutes persists the preference; off (0) disables it', async () => {
+    const { get } = await mountWallet()
+
+    // Default preference is the sensible non-zero default (15 min).
+    expect(get().autoLockMinutes).toBeGreaterThan(0)
+
+    await act(async () => { get().setAutoLockMinutes(5) })
+    expect(get().autoLockMinutes).toBe(5)
+    expect(localStorage.getItem(STORAGE_AUTO_LOCK)).toBe('5')
+
+    await act(async () => { get().setAutoLockMinutes(0) })
+    expect(get().autoLockMinutes).toBe(0)
+    expect(localStorage.getItem(STORAGE_AUTO_LOCK)).toBe('0')
+  })
+})
+
+describe('wallet auto-lock timer (#490)', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    cleanup()
+    localStorageMock.clear()
+  })
+
+  it('fires after the configured idle timeout and locks the wallet', async () => {
+    let ref: ReturnType<typeof useWallet> | null = null
+    await act(async () => {
+      render(
+        <WalletProvider>
+          <Harness onMount={(w) => { ref = w }} />
+        </WalletProvider>
+      )
+    })
+    const get = () => ref!
+
+    // 1-minute auto-lock, encrypted wallet so locking is allowed.
+    await act(async () => { get().setAutoLockMinutes(1) })
+    await act(async () => { await get().createWallet(TEST_MNEMONIC_12, 'hunter2pw') })
+    expect(get().isLocked).toBe(false)
+
+    // Advance just under the timeout: still unlocked.
+    await act(async () => { vi.advanceTimersByTime(59_000) })
+    expect(get().isLocked).toBe(false)
+
+    // Cross the threshold: auto-lock fires.
+    await act(async () => { vi.advanceTimersByTime(2_000) })
+    expect(get().isLocked).toBe(true)
+    expect(get().getVaultKey()).toBeNull()
+  })
+
+  it('user activity resets the idle timer so it does not fire early', async () => {
+    let ref: ReturnType<typeof useWallet> | null = null
+    await act(async () => {
+      render(
+        <WalletProvider>
+          <Harness onMount={(w) => { ref = w }} />
+        </WalletProvider>
+      )
+    })
+    const get = () => ref!
+
+    await act(async () => { get().setAutoLockMinutes(1) })
+    await act(async () => { await get().createWallet(TEST_MNEMONIC_12, 'hunter2pw') })
+
+    // Advance most of the way, then simulate activity to reset the countdown.
+    await act(async () => { vi.advanceTimersByTime(50_000) })
+    expect(get().isLocked).toBe(false)
+    await act(async () => {
+      window.dispatchEvent(new Event('keydown'))
+    })
+
+    // Another 50s (total 100s from start) — would have fired without the reset,
+    // but the reset pushed the deadline out, so still unlocked.
+    await act(async () => { vi.advanceTimersByTime(50_000) })
+    expect(get().isLocked).toBe(false)
+
+    // Now let the full fresh interval elapse: it fires.
+    await act(async () => { vi.advanceTimersByTime(11_000) })
+    expect(get().isLocked).toBe(true)
+  })
+
+  it('does not auto-lock a plaintext wallet even with a timeout set', async () => {
+    let ref: ReturnType<typeof useWallet> | null = null
+    await act(async () => {
+      render(
+        <WalletProvider>
+          <Harness onMount={(w) => { ref = w }} />
+        </WalletProvider>
+      )
+    })
+    const get = () => ref!
+
+    await act(async () => { get().setAutoLockMinutes(1) })
+    // Plaintext wallet (no password).
+    await act(async () => { await get().createWallet(TEST_MNEMONIC_12) })
+
+    await act(async () => { vi.advanceTimersByTime(120_000) })
+    // Never locked — a plaintext wallet has nothing to unlock with.
+    expect(get().isLocked).toBe(false)
+    expect(await get().exportWallet()).toBe(TEST_MNEMONIC_12)
+  })
+
+  it('off (0) disables auto-lock entirely', async () => {
+    let ref: ReturnType<typeof useWallet> | null = null
+    await act(async () => {
+      render(
+        <WalletProvider>
+          <Harness onMount={(w) => { ref = w }} />
+        </WalletProvider>
+      )
+    })
+    const get = () => ref!
+
+    await act(async () => { get().setAutoLockMinutes(0) })
+    await act(async () => { await get().createWallet(TEST_MNEMONIC_12, 'hunter2pw') })
+
+    await act(async () => { vi.advanceTimersByTime(10 * 60_000) })
+    expect(get().isLocked).toBe(false)
+  })
+})

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -65,8 +65,31 @@ interface WalletContextValue extends WalletState {
   createWallet: (mnemonic: string, password?: string) => Promise<void>
   importWallet: (seedPhrase: string, password?: string) => Promise<void>
   unlockWallet: (password: string) => Promise<void>
+  /**
+   * Lock the wallet (#490): wipe the decrypted seed (`mnemonicRef`) and the
+   * session vault key (`vaultKeyRef` + the module-scope `sessionVaultKey`) from
+   * memory and set `isLocked: true`. Does NOT touch localStorage — the encrypted
+   * wallet still exists on disk; unlocking re-derives via
+   * {@link unlockWallet}. Balance/history polling is gated on `!isLocked`, so it
+   * stops once locked.
+   *
+   * SAFETY: a PLAINTEXT (no-password) wallet has no key to unlock with, so
+   * locking it would strand it in a state it could never leave. For a plaintext
+   * wallet this is a NO-OP — the caller (and the auto-lock timer) must gate on
+   * `isEncrypted` so a plaintext wallet is never locked.
+   */
+  lockWallet: () => void
   exportWallet: (password?: string) => Promise<string | null>
   resetWallet: () => void
+
+  /**
+   * Idle auto-lock timeout in MINUTES, persisted in localStorage (#490). `0`
+   * means "Off/Never" (no auto-lock). Auto-lock only applies to encrypted
+   * wallets — a plaintext wallet is never auto-locked.
+   */
+  autoLockMinutes: number
+  /** Update + persist the idle auto-lock timeout (minutes; `0` = off). */
+  setAutoLockMinutes: (minutes: number) => void
 
   /**
    * Set a password on a PLAINTEXT (no-password) wallet, upgrading it to
@@ -276,6 +299,29 @@ const addressBook = new AddressBook(new EncryptedAddressBook(() => sessionVaultK
 /** Polling interval when WebSocket is disconnected (30 seconds) */
 const FALLBACK_POLL_INTERVAL = 30000
 
+/** localStorage key for the idle auto-lock timeout preference (#490). */
+const STORAGE_AUTO_LOCK = 'botho-auto-lock-minutes'
+
+/** Default idle auto-lock timeout in minutes (#490). `0` would mean off. */
+const DEFAULT_AUTO_LOCK_MINUTES = 15
+
+/**
+ * Read the persisted idle auto-lock timeout (minutes) from localStorage (#490).
+ * Returns {@link DEFAULT_AUTO_LOCK_MINUTES} when unset; `0` means off/never.
+ * Guards against non-numeric / negative junk.
+ */
+function loadAutoLockMinutes(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_AUTO_LOCK)
+    if (raw === null) return DEFAULT_AUTO_LOCK_MINUTES
+    const n = Number(raw)
+    if (!Number.isFinite(n) || n < 0) return DEFAULT_AUTO_LOCK_MINUTES
+    return Math.floor(n)
+  } catch {
+    return DEFAULT_AUTO_LOCK_MINUTES
+  }
+}
+
 /**
  * Create adapter from network configuration
  */
@@ -333,6 +379,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   // password-derived key. Null while locked or for plaintext wallets. Cleared
   // on reset and on page refresh (in-memory only).
   const vaultKeyRef = useRef<VaultKey | null>(null)
+
+  // Idle auto-lock timeout preference in minutes (#490); 0 = off/never.
+  // Persisted to localStorage so it survives refresh.
+  const [autoLockMinutes, setAutoLockMinutesState] = useState<number>(() => loadAutoLockMinutes())
 
   /**
    * Set the session vault key in memory AND publish it to the module-scope
@@ -620,6 +670,92 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       setState(s => ({ ...s, balance, transactions }))
     }
   }, [])
+
+  const lockWallet = useCallback(() => {
+    // SAFETY (#490): never lock a wallet that cannot be unlocked. A plaintext
+    // (no-password) wallet has no vault key, so there is nothing to unlock with —
+    // locking it would strand it. Gate on the in-memory key: it is non-null only
+    // for an unlocked, encrypted wallet.
+    if (vaultKeyRef.current === null) {
+      return
+    }
+    // Wipe the decrypted seed from memory.
+    mnemonicRef.current = null
+    // Wipe the session vault key (vaultKeyRef + module-scope sessionVaultKey).
+    // Passing null also makes the encrypted claim-link store + address book read
+    // as empty until the next unlock re-derives the key.
+    void applyVaultKey(null)
+    // Show the unlock screen and stop balance/history polling (gated on
+    // !isLocked). Clear the in-memory balance/history so nothing sensitive
+    // lingers on screen behind the unlock view.
+    setState(s => ({
+      ...s,
+      isLocked: true,
+      balance: null,
+      transactions: [],
+    }))
+  }, [applyVaultKey])
+
+  const setAutoLockMinutes = useCallback((minutes: number) => {
+    const m = Number.isFinite(minutes) && minutes > 0 ? Math.floor(minutes) : 0
+    setAutoLockMinutesState(m)
+    try {
+      localStorage.setItem(STORAGE_AUTO_LOCK, String(m))
+    } catch {
+      // Best-effort persistence; the in-memory preference still applies.
+    }
+  }, [])
+
+  // Idle auto-lock (#490): when the wallet is UNLOCKED + ENCRYPTED and the user
+  // chose a timeout (> 0), lock it after `autoLockMinutes` of inactivity. Any
+  // user activity (pointer/keyboard/click/scroll) or the tab regaining focus
+  // resets the countdown; `visibilitychange` is wired so returning to the tab
+  // restarts a fresh timer. All listeners + the timer are torn down on unmount,
+  // when locked, when the wallet has no password, or when the preference is off.
+  useEffect(() => {
+    if (autoLockMinutes <= 0) return
+    if (state.isLocked || !state.isEncrypted || !state.hasWallet) return
+
+    const timeoutMs = autoLockMinutes * 60_000
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const reset = () => {
+      if (timer !== undefined) clearTimeout(timer)
+      timer = setTimeout(() => {
+        lockWallet()
+      }, timeoutMs)
+    }
+
+    const onActivity = () => reset()
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') reset()
+    }
+
+    const activityEvents: Array<keyof WindowEventMap> = [
+      'pointermove',
+      'pointerdown',
+      'keydown',
+      'click',
+      'scroll',
+      'wheel',
+      'touchstart',
+    ]
+    for (const ev of activityEvents) {
+      window.addEventListener(ev, onActivity, { passive: true })
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    // Start the initial countdown.
+    reset()
+
+    return () => {
+      if (timer !== undefined) clearTimeout(timer)
+      for (const ev of activityEvents) {
+        window.removeEventListener(ev, onActivity)
+      }
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [autoLockMinutes, state.isLocked, state.isEncrypted, state.hasWallet, lockWallet])
 
   const exportWallet = useCallback(async (password?: string) => {
     // If we have mnemonic in memory, use it
@@ -1078,8 +1214,11 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         createWallet,
         importWallet,
         unlockWallet,
+        lockWallet,
         exportWallet,
         resetWallet,
+        autoLockMinutes,
+        setAutoLockMinutes,
         setPassword,
         changePassword,
         getVaultKey,

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -11,7 +11,7 @@ import { SendLinkModal } from '../components/SendLinkModal'
 import { RequestModal } from '../components/RequestModal'
 import { ReceiveModal } from '../components/ReceiveModal'
 import { OutstandingLinks } from '../components/OutstandingLinks'
-import { Send, Link2, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2, Users, QrCode } from 'lucide-react'
+import { Send, Link2, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2, Users, QrCode, Clock } from 'lucide-react'
 
 const STRENGTH_META: Record<PasswordStrength, { label: string; bars: number; color: string }> = {
   'too-short': { label: `At least ${MIN_PASSWORD_LENGTH} characters`, bars: 0, color: 'bg-danger' },
@@ -365,8 +365,118 @@ function ImportWalletView({ onImport }: { onImport: (mnemonic: string, password?
   )
 }
 
+/** Auto-lock timeout options for the settings control (#490). 0 = Off/Never. */
+const AUTO_LOCK_OPTIONS: Array<{ minutes: number; label: string }> = [
+  { minutes: 1, label: '1 minute' },
+  { minutes: 5, label: '5 minutes' },
+  { minutes: 15, label: '15 minutes' },
+  { minutes: 30, label: '30 minutes' },
+  { minutes: 60, label: '1 hour' },
+  { minutes: 0, label: 'Off (never)' },
+]
+
+/**
+ * Settings sheet (#490): wallet security controls — auto-lock timeout, Lock now,
+ * and reset. Lock + auto-lock are only meaningful for an ENCRYPTED wallet (a
+ * plaintext wallet has no password to unlock with), so for a plaintext wallet
+ * the Lock control is disabled and routes the user to set a password first.
+ */
+function SettingsModal({
+  isEncrypted,
+  autoLockMinutes,
+  onAutoLockChange,
+  onLock,
+  onSetPassword,
+  onReset,
+  onClose,
+}: {
+  isEncrypted: boolean
+  autoLockMinutes: number
+  onAutoLockChange: (minutes: number) => void
+  onLock: () => void
+  onSetPassword: () => void
+  onReset: () => void
+  onClose: () => void
+}) {
+  return (
+    <div className="fixed inset-0 bg-void/80 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4 z-50">
+      <Card className="w-full sm:max-w-md p-5 sm:p-6 rounded-t-2xl sm:rounded-2xl">
+        <div className="text-center mb-5 sm:mb-6">
+          <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-pulse/10 flex items-center justify-center mx-auto mb-3 sm:mb-4">
+            <Settings className="text-pulse" size={28} />
+          </div>
+          <h3 className="font-display text-lg sm:text-xl font-semibold mb-2">Settings</h3>
+          <p className="text-ghost text-sm">Security and wallet controls.</p>
+        </div>
+
+        <div className="space-y-5">
+          {/* Auto-lock timeout */}
+          <div>
+            <div className="flex items-center gap-2 mb-2">
+              <Clock size={16} className="text-pulse shrink-0" />
+              <span className="text-sm font-medium text-light">Auto-lock after inactivity</span>
+            </div>
+            <select
+              value={autoLockMinutes}
+              onChange={(e) => onAutoLockChange(Number(e.target.value))}
+              disabled={!isEncrypted}
+              className="w-full p-2.5 rounded-lg bg-abyss border border-steel text-sm text-light focus:outline-none focus:ring-2 focus:ring-pulse/50 focus:border-pulse disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {AUTO_LOCK_OPTIONS.map((opt) => (
+                <option key={opt.minutes} value={opt.minutes}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-ghost mt-1">
+              {isEncrypted
+                ? 'Lock the wallet automatically when idle. Activity resets the timer.'
+                : 'Set a password to enable auto-lock.'}
+            </p>
+          </div>
+
+          {/* Lock now */}
+          <div>
+            <Button
+              variant="secondary"
+              onClick={onLock}
+              disabled={!isEncrypted}
+              className="w-full justify-center"
+              title={isEncrypted ? 'Lock wallet' : 'Set a password to enable locking'}
+            >
+              <Lock size={16} className="mr-2" />
+              Lock wallet
+            </Button>
+            {!isEncrypted && (
+              <button
+                type="button"
+                onClick={onSetPassword}
+                className="text-xs text-pulse hover:underline mt-2"
+              >
+                Set a password to enable locking
+              </button>
+            )}
+          </div>
+
+          {/* Reset */}
+          <div className="border-t border-steel pt-4">
+            <Button variant="danger" onClick={onReset} className="w-full justify-center">
+              <Trash2 size={16} className="mr-2" />
+              Reset wallet
+            </Button>
+          </div>
+
+          <Button variant="ghost" onClick={onClose} className="w-full justify-center">
+            Close
+          </Button>
+        </div>
+      </Card>
+    </div>
+  )
+}
+
 function WalletDashboard() {
-  const { address, balance, transactions, isConnecting, isConnected, refreshBalance, refreshTransactions, resetWallet, send, contacts, searchContacts, isEncrypted, setPassword, changePassword } = useWallet()
+  const { address, balance, transactions, isConnecting, isConnected, refreshBalance, refreshTransactions, resetWallet, send, contacts, searchContacts, isEncrypted, setPassword, changePassword, lockWallet, autoLockMinutes, setAutoLockMinutes } = useWallet()
 
   // Resolve a counterparty address to a saved contact name for the transaction
   // history. We auto-create blank-name "previously paid" entries when sending,
@@ -389,6 +499,7 @@ function WalletDashboard() {
   const [isSending, setIsSending] = useState(false)
   const [showResetConfirm, setShowResetConfirm] = useState(false)
   const [showPasswordModal, setShowPasswordModal] = useState(false)
+  const [showSettings, setShowSettings] = useState(false)
 
   const handleReset = () => {
     resetWallet()
@@ -441,7 +552,16 @@ function WalletDashboard() {
       <Button variant="ghost" size="sm" onClick={refreshBalance} disabled={isConnecting}>
         <RefreshCw size={16} className={isConnecting ? 'animate-spin' : ''} />
       </Button>
-      <Button variant="ghost" size="sm" onClick={() => setShowResetConfirm(true)} title="Reset wallet">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={lockWallet}
+        disabled={!isEncrypted}
+        title={isEncrypted ? 'Lock wallet' : 'Set a password to enable locking'}
+      >
+        <Lock size={16} />
+      </Button>
+      <Button variant="ghost" size="sm" onClick={() => setShowSettings(true)} title="Settings">
         <Settings size={16} />
       </Button>
     </>
@@ -515,6 +635,27 @@ function WalletDashboard() {
         onClose={() => setReceiveOpen(false)}
         onRequestLink={() => setRequestOpen(true)}
       />
+
+      {showSettings && (
+        <SettingsModal
+          isEncrypted={isEncrypted}
+          autoLockMinutes={autoLockMinutes}
+          onAutoLockChange={setAutoLockMinutes}
+          onLock={() => {
+            setShowSettings(false)
+            lockWallet()
+          }}
+          onSetPassword={() => {
+            setShowSettings(false)
+            setShowPasswordModal(true)
+          }}
+          onReset={() => {
+            setShowSettings(false)
+            setShowResetConfirm(true)
+          }}
+          onClose={() => setShowSettings(false)}
+        />
+      )}
 
       {showPasswordModal && (
         <PasswordSettingsModal


### PR DESCRIPTION
Closes #490

## Summary
Adds a real wallet lock to the web wallet. Until now `isLocked` was only set on initial load for an encrypted wallet; once unlocked the decrypted seed (`mnemonicRef`) and vault key (`vaultKeyRef`/`sessionVaultKey`) stayed in memory until a full page refresh, with no Lock button and no inactivity auto-lock.

## What changed
- **`lockWallet()` on the wallet context** (`contexts/wallet.tsx`): wipes in-memory secrets — `mnemonicRef.current = null` and `applyVaultKey(null)` (clears `vaultKeyRef` + module-scope `sessionVaultKey`) — and sets `isLocked: true`. Does NOT touch localStorage; the encrypted wallet still exists. Balance/history polling (already gated on `!isLocked`) stops. Unlock uses the existing `unlockWallet(password)`, which re-derives the key and reloads encrypted contacts/claim-links via `applyVaultKey`.
- **Plaintext safety**: `lockWallet()` is a NO-OP when there is no session vault key (plaintext wallet), so a plaintext wallet can never be stranded in a locked state it can't exit. Lock button + auto-lock are gated on `isEncrypted`.
- **Auto-lock on inactivity**: `autoLockMinutes` preference persisted in localStorage (default 15 min, `0` = Off/Never). An effect arms a `setTimeout` that calls `lockWallet()`, reset on `pointermove/pointerdown/keydown/click/scroll/wheel/touchstart` and `visibilitychange`. Listeners + timer are cleaned up on unmount, when locked, for plaintext wallets, and when off.
- **UI** (`pages/wallet.tsx`): a Lock button in the balance-card actions (disabled for plaintext) and a Settings sheet with the auto-lock timeout selector, Lock now, and Reset. Plaintext wallets are routed to "Set a password" first (reuses #489).

## How secrets are cleared
`lockWallet()` sets `mnemonicRef.current = null` (decrypted seed gone) and calls `applyVaultKey(null)` which sets `vaultKeyRef.current = null` and `setSessionVaultKey(null)` (vault key gone from both the ref and the module-scope holder the encrypted stores read). After lock, the encrypted address book / claim-link stores read as empty until unlock.

## Tests (native vitest matchers only)
New `wallet-lock.test.tsx` using real crypto (only adapter + wasm signer stubbed):
- lockWallet clears in-memory seed + vault key and sets isLocked
- encrypted contacts unreadable after lock, restored on unlock round-trip
- plaintext-wallet lock is a no-op (no lockout)
- auto-lock timer fires after timeout (fake timers), is reset by activity, is disabled for plaintext, and off (0) disables it

## Verification
- `pnpm -r typecheck` green
- `pnpm --filter @botho/web-wallet build` green
- `pnpm test:run` green (218 passed, 10 skipped)

Scope: web-wallet only. No consensus/faucet/network/Rust changes. Stray `.loom-managed` / `pnpm-workspace.yaml` mutations reverted before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)