### PR TITLE
feat(web-wallet): validate recipient address format in send flow

### DIFF
--- a/web/packages/features/src/wallet/components/send-modal.test.tsx
+++ b/web/packages/features/src/wallet/components/send-modal.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import type { Balance } from '@botho/core'
+import { deriveAddress } from '@botho/core'
+import { SendModal } from './send-modal'
+
+// A couple of real, valid testnet addresses derived from fixed mnemonics. Using
+// the real deriver keeps the test honest about what the production validator
+// (`@botho/core`'s isValidAddress) accepts.
+const VALID_ADDRESS = deriveAddress(
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+)
+const OTHER_ADDRESS = deriveAddress(
+  'legal winner thank year wave sausage worth useful legal winner thank yellow',
+)
+
+const BALANCE: Balance = {
+  available: 1_000_000_000_000_000n,
+  pending: 0n,
+  total: 1_000_000_000_000_000n,
+}
+
+function setup(overrides: Partial<React.ComponentProps<typeof SendModal>> = {}) {
+  const onSend = vi.fn().mockResolvedValue({ success: true, txHash: '0xabc' })
+  const props: React.ComponentProps<typeof SendModal> = {
+    isOpen: true,
+    onClose: vi.fn(),
+    balance: BALANCE,
+    estimateFee: vi.fn().mockResolvedValue(4000n),
+    onSend,
+    ...overrides,
+  }
+  render(<SendModal {...props} />)
+  return { onSend, props }
+}
+
+function getRecipientInput(): HTMLInputElement {
+  return screen.getByPlaceholderText(/tbotho:\/\//i) as HTMLInputElement
+}
+
+function getAmountInput(): HTMLInputElement {
+  return screen.getByPlaceholderText('0.00') as HTMLInputElement
+}
+
+function getSubmitButton(): HTMLButtonElement {
+  return screen.getByRole('button', { name: /Send Transaction/i }) as HTMLButtonElement
+}
+
+describe('SendModal address validation', () => {
+  beforeEach(() => cleanup())
+
+  it('does not show an error for an empty recipient, but keeps submit disabled', () => {
+    setup()
+    expect(screen.queryByText('Invalid Botho address')).toBeNull()
+    expect(getSubmitButton().disabled).toBe(true)
+  })
+
+  it('shows an inline error and disables submit for a malformed address', () => {
+    setup()
+    fireEvent.change(getRecipientInput(), { target: { value: 'not-an-address' } })
+    fireEvent.change(getAmountInput(), { target: { value: '1' } })
+
+    expect(screen.getByText('Invalid Botho address')).toBeDefined()
+    expect(getSubmitButton().disabled).toBe(true)
+  })
+
+  it('does not block a valid address', async () => {
+    const { onSend } = setup()
+    fireEvent.change(getRecipientInput(), { target: { value: VALID_ADDRESS } })
+    fireEvent.change(getAmountInput(), { target: { value: '1' } })
+
+    expect(screen.queryByText('Invalid Botho address')).toBeNull()
+    const submit = getSubmitButton()
+    expect(submit.disabled).toBe(false)
+
+    fireEvent.click(submit)
+    // onSend is invoked with the valid recipient.
+    expect(onSend).toHaveBeenCalledTimes(1)
+    expect(onSend.mock.calls[0][0].recipient).toBe(VALID_ADDRESS)
+  })
+
+  it('clicking submit with an invalid address surfaces the error and does not call onSend', () => {
+    const { onSend } = setup()
+    fireEvent.change(getRecipientInput(), { target: { value: 'garbage' } })
+    fireEvent.change(getAmountInput(), { target: { value: '1' } })
+
+    // Button is disabled, but guard handleSend defensively too.
+    fireEvent.click(getSubmitButton())
+    expect(onSend).not.toHaveBeenCalled()
+  })
+})
+
+describe('SendModal self-send guard', () => {
+  beforeEach(() => cleanup())
+
+  it('warns and blocks when recipient equals the user own address', () => {
+    const { onSend } = setup({ ownAddress: VALID_ADDRESS })
+    fireEvent.change(getRecipientInput(), { target: { value: VALID_ADDRESS } })
+    fireEvent.change(getAmountInput(), { target: { value: '1' } })
+
+    expect(screen.getByText(/your own address/i)).toBeDefined()
+    expect(getSubmitButton().disabled).toBe(true)
+
+    fireEvent.click(getSubmitButton())
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
+  it('does not flag a self-send for a different recipient', () => {
+    setup({ ownAddress: VALID_ADDRESS })
+    fireEvent.change(getRecipientInput(), { target: { value: OTHER_ADDRESS } })
+    fireEvent.change(getAmountInput(), { target: { value: '1' } })
+
+    expect(screen.queryByText(/your own address/i)).toBeNull()
+    expect(getSubmitButton().disabled).toBe(false)
+  })
+
+  it('does not run the self-send check when ownAddress is not provided', () => {
+    setup()
+    fireEvent.change(getRecipientInput(), { target: { value: VALID_ADDRESS } })
+    fireEvent.change(getAmountInput(), { target: { value: '1' } })
+
+    expect(screen.queryByText(/your own address/i)).toBeNull()
+    expect(getSubmitButton().disabled).toBe(false)
+  })
+})

--- a/web/packages/features/src/wallet/components/send-modal.tsx
+++ b/web/packages/features/src/wallet/components/send-modal.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState, useEffect } from 'react'
 import type { Balance, Contact } from '@botho/core'
-import { formatBTH, parseBTH } from '@botho/core'
+import { formatBTH, parseBTH, isValidAddress } from '@botho/core'
 import { Button, Input } from '@botho/ui'
 import { motion, AnimatePresence } from 'motion/react'
-import { ChevronDown, ChevronUp, Loader2, Send, User, X, Zap } from 'lucide-react'
+import { AlertCircle, ChevronDown, ChevronUp, Loader2, Send, ShieldAlert, User, X, Zap } from 'lucide-react'
 
 export type SendPrivacyLevel = 'standard' | 'private'
 
@@ -46,6 +46,17 @@ export interface SendModalProps {
    * filtering `contacts` locally (e.g. to delegate to the address-book search).
    */
   onSearchContacts?: (query: string) => Contact[]
+  /**
+   * The user's own wallet address. When provided, the modal warns (and blocks)
+   * if the recipient is the user's own address. Optional for back-compat.
+   */
+  ownAddress?: string | null
+  /**
+   * Optional recipient address validator. Defaults to `@botho/core`'s
+   * `isValidAddress`. Exposed as a prop mainly for testing / customisation;
+   * existing callers don't need to provide it.
+   */
+  validateAddress?: (address: string) => boolean
 }
 
 /** Truncate an address for compact display in the picker. */
@@ -66,6 +77,8 @@ export function SendModal({
   isSending = false,
   contacts,
   onSearchContacts,
+  ownAddress,
+  validateAddress = isValidAddress,
 }: SendModalProps) {
   const [recipient, setRecipient] = useState('')
   const [amount, setAmount] = useState('')
@@ -118,6 +131,18 @@ export function SendModal({
   const hasContacts = (contacts?.length ?? 0) > 0 || !!onSearchContacts
   const showPickerList = showPicker && hasContacts && matches.length > 0
 
+  // Recipient address validation. We only surface an inline error once the user
+  // has typed something — an empty field just keeps the submit button disabled.
+  const trimmedRecipient = recipient.trim()
+  const recipientValid = trimmedRecipient.length > 0 && validateAddress(trimmedRecipient)
+  const recipientInvalid = trimmedRecipient.length > 0 && !recipientValid
+  // Self-send guard: block sending to one's own address (sends are irreversible
+  // and a self-send is almost always a mistake/confusion).
+  const isSelfSend =
+    recipientValid &&
+    ownAddress != null &&
+    trimmedRecipient.toLowerCase() === ownAddress.trim().toLowerCase()
+
   // Estimate fee when amount or privacy changes
   useEffect(() => {
     if (amount) {
@@ -145,8 +170,18 @@ export function SendModal({
     setError(null)
     setSuccess(null)
 
-    if (!recipient) {
+    if (!trimmedRecipient) {
       setError('Please enter a recipient address')
+      return
+    }
+
+    if (!recipientValid) {
+      setError('Invalid Botho address')
+      return
+    }
+
+    if (isSelfSend) {
+      setError('This is your own address — you can’t send to yourself')
       return
     }
 
@@ -244,6 +279,20 @@ export function SendModal({
                 <p className="mt-1 flex items-center gap-1 text-xs text-[--color-pulse]">
                   <User className="h-3 w-3" />
                   {matchedContact.name}
+                </p>
+              )}
+              {/* Inline validation error for a malformed address */}
+              {recipientInvalid && (
+                <p className="mt-1 flex items-center gap-1 text-xs text-[--color-danger]">
+                  <AlertCircle className="h-3 w-3 shrink-0" />
+                  Invalid Botho address
+                </p>
+              )}
+              {/* Self-send warning */}
+              {isSelfSend && (
+                <p className="mt-1 flex items-center gap-1 text-xs text-[--color-danger]">
+                  <ShieldAlert className="h-3 w-3 shrink-0" />
+                  This is your own address — you can’t send to yourself.
                 </p>
               )}
               {/* Searchable contact picker */}
@@ -406,7 +455,7 @@ export function SendModal({
             {/* Submit */}
             <Button
               onClick={handleSend}
-              disabled={isSending || !recipient || !amount}
+              disabled={isSending || !recipientValid || isSelfSend || !amount}
               className="w-full"
             >
               {isSending ? (

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -449,6 +449,7 @@ function WalletDashboard() {
         isSending={isSending}
         contacts={contacts}
         onSearchContacts={searchContacts}
+        ownAddress={address}
       />
 
       <SendLinkModal isOpen={sendLinkOpen} onClose={() => setSendLinkOpen(false)} />


### PR DESCRIPTION
Closes #491

## Problem
The send form only checked the recipient was non-empty — a malformed or typo'd address could be submitted. Sends are irreversible.

## Changes
- **`@botho/features` send-modal.tsx**: validate the recipient with `@botho/core`'s `isValidAddress`. Show an inline "Invalid Botho address" error when the field is non-empty but invalid (empty stays silent), and keep the submit button disabled until the address parses (in addition to the existing amount/balance checks).
- **Self-send guard**: new optional `ownAddress` prop. When provided and the recipient matches, the modal warns ("This is your own address — you can't send to yourself.") and blocks submit. Chose **block** over allow-with-confirmation as the clearer/safer UX for an action that's almost always a mistake.
- **New optional `validateAddress` prop** (defaults to `isValidAddress`) for testability/customisation. Both new props are optional — existing callers are unaffected.
- **`web-wallet/wallet.tsx`**: wires `ownAddress={address}` from `useWallet()`.
- **Confirmation**: the fee summary (recipient name via contact match, amount, total + fee) is preserved.

## Pay flow
`pages/pay.tsx` already validates via `isValidAddress` and renders a clear "invalid recipient address" error for malformed links, plus a self-pay warning — so requirement #5 was already satisfied; no change needed.

## Notes
- Did NOT reintroduce the per-row Private badge (#468).
- `@botho/features` imports only from `@botho/core` (already a dep), never the web-wallet context.
- Reverted stray `.loom-managed` / `pnpm-workspace.yaml` tooling mutations before pushing.

## Validator
`isValidAddress(address: string): boolean` already exists/exported in `@botho/core` (`web/packages/core/src/wallet/address.ts`, wrapping `parseAddress` in try/catch). Reused as-is.

## Verification
- `pnpm install` — clean (ERR_PNPM_IGNORED_BUILDS warning only)
- `pnpm -r typecheck` — green
- `pnpm --filter @botho/web-wallet build` — green
- `pnpm test:run` — 230 passed / 10 skipped, incl. 7 new send-modal tests (invalid blocks, valid passes, self-send warned/blocked, self-send skipped without ownAddress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)