### PR TITLE
feat(web-wallet): active-node-offline banner + extended wallet e2e

### DIFF
--- a/web/e2e/fixtures/wallet-setup.ts
+++ b/web/e2e/fixtures/wallet-setup.ts
@@ -137,3 +137,63 @@ export async function readDashboardAddress(page: Page): Promise<string> {
   const addressButton = page.locator('button').filter({ has: page.locator('code.font-mono') }).first()
   return (await addressButton.textContent())?.trim() ?? ''
 }
+
+/**
+ * Open the Send modal from the dashboard. Assumes an unlocked wallet (the
+ * dashboard's "Send" button is visible).
+ */
+export async function openSendModal(page: Page): Promise<void> {
+  await page.getByRole('button', { name: /^Send$/i }).click()
+  await page.getByRole('heading', { name: /Send BTH/i }).waitFor({
+    state: 'visible',
+    timeout: TIMEOUTS.WALLET_SYNC,
+  })
+}
+
+/**
+ * Lock the wallet from the dashboard header (#490). Clicks the header Lock
+ * button (the icon-only button, disabled for plaintext wallets — but every
+ * wallet created via the helpers is encrypted) and waits for the Unlock screen.
+ */
+export async function lockWallet(page: Page): Promise<void> {
+  // The header has an icon-only Lock button (title "Lock wallet"). Click it and
+  // wait for the unlock view to replace the dashboard.
+  await page.getByRole('button', { name: 'Lock wallet' }).first().click()
+  await page.getByRole('heading', { name: /Unlock Wallet/i }).waitFor({
+    state: 'visible',
+    timeout: TIMEOUTS.WALLET_SYNC,
+  })
+}
+
+/** Unlock the wallet from the Unlock screen with `password` (#490). */
+export async function unlockWallet(page: Page, password = E2E_PASSWORD): Promise<void> {
+  await page.getByPlaceholder('Enter password').fill(password)
+  await page.getByRole('button', { name: /^Unlock$/i }).click()
+  await page.getByRole('button', { name: /^Send$/i }).waitFor({
+    state: 'visible',
+    timeout: TIMEOUTS.WALLET_SYNC,
+  })
+}
+
+/**
+ * Change the wallet's password via the dashboard "Change password" flow (#489).
+ * Opens the password settings modal in change mode, fills current + new + confirm
+ * and submits. Resolves once the modal closes (success).
+ */
+export async function changeWalletPassword(
+  page: Page,
+  oldPassword: string,
+  newPassword: string,
+): Promise<void> {
+  // The dashboard "Change password" trigger and the modal's submit button share
+  // the same label, so scope the modal interactions to the modal overlay.
+  await page.getByRole('button', { name: /Change password/i }).first().click()
+  const modal = page.locator('div.fixed.inset-0').filter({
+    has: page.getByRole('heading', { name: /Change password/i }),
+  })
+  await modal.getByRole('heading', { name: /Change password/i }).waitFor({ state: 'visible' })
+  await modal.getByPlaceholder('Current password').fill(oldPassword)
+  await modal.getByPlaceholder(/^Password \(min/).fill(newPassword)
+  await modal.getByPlaceholder('Confirm password').fill(newPassword)
+  await modal.getByRole('button', { name: /^Change password$/i }).click()
+}

--- a/web/e2e/tests/wallet/claim-link.spec.ts
+++ b/web/e2e/tests/wallet/claim-link.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Claim-link (send-via-link -> claim) e2e (#492, feature #460/#474).
+ *
+ * Two halves of the bearer-link round-trip, both hermetic against the mock RPC:
+ *
+ *   SENDER: creating a claim link now requires an ENCRYPTED wallet (#474) — the
+ *   bearer secret can only be persisted under a vault key. Wallets created via
+ *   the helpers are encrypted by default (#475), so the "Send via Link" modal
+ *   opens with the create action primed for a valid amount. The mock RPC has NO
+ *   `tx_submit` and the e2e preview build ships without the wasm signer, so —
+ *   like the request->pay spec — we assert up to the PRIMED/CONFIRM state rather
+ *   than on-chain funding.
+ *
+ *   RECIPIENT: a link built in the sender's exact wire format (`buildClaimLink`)
+ *   is opened at `/claim#…`. We assert the claim page RECOGNISES the bearer
+ *   secret (reads the link, strips the secret from the address bar so it does not
+ *   linger in history) and that a malformed fragment is rejected as invalid. The
+ *   on-chain sweep/settlement is covered by the full-stack path, not the mock.
+ */
+import { test, expect } from '@playwright/test'
+import { buildClaimLink, createClaimLinkMnemonic, parseBTH } from '@botho/core'
+import { URLS, TIMEOUTS } from '../../fixtures/test-data'
+import { createWalletOnDashboard } from '../../fixtures/wallet-setup'
+
+test.describe('Claim link', () => {
+  test('send-via-link modal primes the create action for an encrypted wallet', async ({
+    page,
+    context,
+  }) => {
+    await createWalletOnDashboard(page, context)
+
+    await page.getByRole('button', { name: /Send via Link/i }).click()
+    await expect(page.getByRole('heading', { name: /Send via Link/i })).toBeVisible()
+
+    // Bearer warning is shown ("share it like cash").
+    await expect(page.getByText(/Anyone with this link can claim/i)).toBeVisible()
+
+    // With no amount the create button is disabled; a valid amount primes it.
+    const createBtn = page.getByRole('button', { name: /Create Claim Link/i })
+    await expect(createBtn).toBeDisabled()
+
+    await page.getByPlaceholder('0.00').fill('1.0')
+    await expect(createBtn).toBeEnabled()
+  })
+
+  test('claim page recognises a valid bearer link and strips the secret', async ({ page }) => {
+    // Build a link in the sender's exact wire format, then open it as a claimer.
+    const ephMnemonic = createClaimLinkMnemonic()
+    const link = buildClaimLink('http://localhost:4173', ephMnemonic, parseBTH('2'))
+    const claimPath = link.slice(link.indexOf('/claim#'))
+
+    await page.goto(`${URLS.LANDING.replace(/\/$/, '')}${claimPath}`, {
+      timeout: TIMEOUTS.PAGE_LOAD,
+    })
+
+    // The claim view renders and recognises the link (no malformed-fragment
+    // error). The page reads the secret on mount.
+    await expect(page.getByRole('heading', { name: /Claim Your BTH/i })).toBeVisible({
+      timeout: TIMEOUTS.WALLET_SYNC,
+    })
+    await expect(page.getByText(/not valid|Unsupported claim-link|missing its secret/i)).toHaveCount(
+      0,
+    )
+
+    // The bearer secret is stripped from the address bar so it does not linger
+    // in history (a security-critical claim-page behavior).
+    await expect.poll(() => page.evaluate(() => window.location.hash)).toBe('')
+  })
+
+  test('claim page rejects a malformed link', async ({ page }) => {
+    await page.goto(`${URLS.LANDING.replace(/\/$/, '')}/claim#not-a-real-claim-link`, {
+      timeout: TIMEOUTS.PAGE_LOAD,
+    })
+
+    await expect(page.getByRole('heading', { name: /Claim Your BTH/i })).toBeVisible({
+      timeout: TIMEOUTS.WALLET_SYNC,
+    })
+    // A malformed fragment surfaces the invalid-link error.
+    await expect(page.getByText(/not valid|Unsupported claim-link|valid base58/i)).toBeVisible({
+      timeout: TIMEOUTS.WALLET_SYNC,
+    })
+  })
+})

--- a/web/e2e/tests/wallet/lock.spec.ts
+++ b/web/e2e/tests/wallet/lock.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Lock / unlock e2e (#492, feature #490).
+ *
+ * The wallet is encrypted by default (#475), so every wallet created via the
+ * helpers can be locked. This spec drives the real lock/unlock cycle against the
+ * hermetic mock RPC:
+ *   - the header Lock button clears the session and shows the Unlock screen;
+ *   - unlocking with the correct password restores the SAME wallet (same address);
+ *   - a wrong password surfaces an error and keeps the wallet locked.
+ */
+import { test, expect } from '@playwright/test'
+import { TIMEOUTS } from '../../fixtures/test-data'
+import {
+  createWalletOnDashboard,
+  lockWallet,
+  unlockWallet,
+  readDashboardAddress,
+  E2E_PASSWORD,
+} from '../../fixtures/wallet-setup'
+
+test.describe('Lock / unlock', () => {
+  test('lock clears the session, unlock restores the same wallet', async ({ page, context }) => {
+    await createWalletOnDashboard(page, context)
+    const addressBefore = await readDashboardAddress(page)
+    expect(addressBefore).toBeTruthy()
+
+    // Lock -> Unlock screen.
+    await lockWallet(page)
+    await expect(page.getByRole('heading', { name: /Unlock Wallet/i })).toBeVisible()
+    // The dashboard's Send button is gone while locked.
+    await expect(page.getByRole('button', { name: /^Send$/i })).toHaveCount(0)
+
+    // Unlock -> dashboard restored with the same address.
+    await unlockWallet(page, E2E_PASSWORD)
+    const addressAfter = await readDashboardAddress(page)
+    expect(addressAfter).toBe(addressBefore)
+  })
+
+  test('a wrong password is rejected and the wallet stays locked', async ({ page, context }) => {
+    await createWalletOnDashboard(page, context)
+    await lockWallet(page)
+
+    await page.getByPlaceholder('Enter password').fill('definitely-the-wrong-password')
+    await page.getByRole('button', { name: /^Unlock$/i }).click()
+
+    // An error is shown and we remain on the Unlock screen.
+    await expect(page.getByText(/incorrect|invalid|unlock failed|wrong/i)).toBeVisible({
+      timeout: TIMEOUTS.WALLET_SYNC,
+    })
+    await expect(page.getByRole('heading', { name: /Unlock Wallet/i })).toBeVisible()
+  })
+})

--- a/web/e2e/tests/wallet/password.spec.ts
+++ b/web/e2e/tests/wallet/password.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Change-password e2e (#492, feature #489).
+ *
+ * Wallets are encrypted by default (#475), so the dashboard offers "Change
+ * password" (password ROTATION) rather than a plaintext->encrypted upgrade. This
+ * spec drives the real rotation flow against the hermetic mock RPC:
+ *   - a wrong CURRENT password is rejected with an inline error (modal stays open);
+ *   - a correct rotation completes (modal closes); afterwards the NEW password
+ *     unlocks the wallet and the OLD password no longer does.
+ */
+import { test, expect } from '@playwright/test'
+import { TIMEOUTS } from '../../fixtures/test-data'
+import {
+  createWalletOnDashboard,
+  changeWalletPassword,
+  lockWallet,
+  unlockWallet,
+  readDashboardAddress,
+  E2E_PASSWORD,
+} from '../../fixtures/wallet-setup'
+
+const NEW_PASSWORD = 'rotated-password-456'
+
+test.describe('Change password', () => {
+  test('rejects a wrong current password', async ({ page, context }) => {
+    await createWalletOnDashboard(page, context)
+
+    // Trigger and submit share the "Change password" label; scope to the modal.
+    await page.getByRole('button', { name: /Change password/i }).first().click()
+    const modal = page.locator('div.fixed.inset-0').filter({
+      has: page.getByRole('heading', { name: /Change password/i }),
+    })
+    await expect(modal.getByRole('heading', { name: /Change password/i })).toBeVisible()
+
+    await modal.getByPlaceholder('Current password').fill('the-wrong-current-password')
+    await modal.getByPlaceholder(/^Password \(min/).fill(NEW_PASSWORD)
+    await modal.getByPlaceholder('Confirm password').fill(NEW_PASSWORD)
+    await modal.getByRole('button', { name: /^Change password$/i }).click()
+
+    // The modal surfaces the wrong-current-password error and stays open.
+    await expect(page.getByText(/incorrect current password/i)).toBeVisible({
+      timeout: TIMEOUTS.WALLET_SYNC,
+    })
+    await expect(modal.getByRole('heading', { name: /Change password/i })).toBeVisible()
+  })
+
+  test('rotates the password: new password unlocks, old no longer does', async ({ page, context }) => {
+    await createWalletOnDashboard(page, context)
+    const addressBefore = await readDashboardAddress(page)
+
+    // Rotate E2E_PASSWORD -> NEW_PASSWORD; the modal closes on success.
+    await changeWalletPassword(page, E2E_PASSWORD, NEW_PASSWORD)
+    await expect(page.getByRole('heading', { name: /Change password/i })).toBeHidden({
+      timeout: TIMEOUTS.WALLET_SYNC,
+    })
+
+    // Lock, then confirm the OLD password is now rejected.
+    await lockWallet(page)
+    await page.getByPlaceholder('Enter password').fill(E2E_PASSWORD)
+    await page.getByRole('button', { name: /^Unlock$/i }).click()
+    await expect(page.getByText(/incorrect|invalid|unlock failed|wrong/i)).toBeVisible({
+      timeout: TIMEOUTS.WALLET_SYNC,
+    })
+    await expect(page.getByRole('heading', { name: /Unlock Wallet/i })).toBeVisible()
+
+    // The NEW password unlocks the SAME wallet.
+    await unlockWallet(page, NEW_PASSWORD)
+    expect(await readDashboardAddress(page)).toBe(addressBefore)
+  })
+})

--- a/web/e2e/tests/wallet/send.spec.ts
+++ b/web/e2e/tests/wallet/send.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Send-flow e2e (#492, feature #491 address validation).
+ *
+ * Drives the Send modal through the real UI against the hermetic mock RPC:
+ *   - an INVALID recipient address is blocked with an inline error and keeps the
+ *     Send button disabled;
+ *   - a VALID recipient + amount primes the confirm (Send button enabled) and the
+ *     entered values stick.
+ *
+ * The mock RPC has NO `tx_submit`, so — like the request->pay spec — we assert up
+ * to the PRIMED/CONFIRM state rather than on-chain settlement. The real submit
+ * path is covered by tests/fullstack/send.spec.ts against a live local node.
+ */
+import { test, expect } from '@playwright/test'
+import { deriveAddress } from '@botho/core'
+import { TEST_MNEMONIC_24 } from '../../fixtures/test-data'
+import { createWalletOnDashboard, openSendModal } from '../../fixtures/wallet-setup'
+
+// A valid, deterministic testnet recipient (derived, so it stays correct if the
+// address format changes).
+const VALID_RECIPIENT = deriveAddress(TEST_MNEMONIC_24, 'testnet')
+
+test.describe('Send flow', () => {
+  test('blocks an invalid recipient address with an inline error', async ({ page, context }) => {
+    await createWalletOnDashboard(page, context)
+    await openSendModal(page)
+
+    const recipient = page.getByPlaceholder(/tbotho:\/\/1\/\.\.\. or search contacts/i)
+    await recipient.fill('not-a-valid-address')
+
+    // Inline validation error appears for a malformed address.
+    await expect(page.getByText(/Invalid Botho address/i)).toBeVisible()
+
+    // The Send button stays disabled while the recipient is invalid.
+    await expect(page.getByRole('button', { name: /Send Transaction/i })).toBeDisabled()
+  })
+
+  test('a valid recipient + amount primes the confirm', async ({ page, context }) => {
+    await createWalletOnDashboard(page, context)
+    await openSendModal(page)
+
+    const recipient = page.getByPlaceholder(/tbotho:\/\/1\/\.\.\. or search contacts/i)
+    await recipient.fill(VALID_RECIPIENT)
+
+    // No inline error for a valid address.
+    await expect(page.getByText(/Invalid Botho address/i)).toHaveCount(0)
+
+    // Enter an amount.
+    await page.getByPlaceholder('0.00').first().fill('1.5')
+
+    // The recipient + amount stick, and the Send button is primed (enabled).
+    await expect(recipient).toHaveValue(VALID_RECIPIENT)
+    await expect(page.getByPlaceholder('0.00').first()).toHaveValue('1.5')
+    await expect(page.getByRole('button', { name: /Send Transaction/i })).toBeEnabled()
+  })
+})

--- a/web/packages/web-wallet/src/components/NetworkSelector.tsx
+++ b/web/packages/web-wallet/src/components/NetworkSelector.tsx
@@ -47,6 +47,14 @@ export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
   // The landing page does not render the selector, so it makes no node calls.
   useEffect(() => startHealthPolling(), [startHealthPolling])
 
+  // Open the dropdown when another component (e.g. the offline banner, #492)
+  // asks to switch nodes via the `open-network-selector` event.
+  useEffect(() => {
+    const open = () => setIsOpen(true)
+    window.addEventListener('open-network-selector', open)
+    return () => window.removeEventListener('open-network-selector', open)
+  }, [])
+
   // Close dropdown when clicking outside
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {

--- a/web/packages/web-wallet/src/components/OfflineBanner.test.tsx
+++ b/web/packages/web-wallet/src/components/OfflineBanner.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the active-node-offline banner logic (#492):
+ *   - the pure raw-offline derivation + debounce accumulator
+ *   - the OfflineBanner component: shows only AFTER the debounce threshold,
+ *     hides when the node is online, and is dismissible.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import type { NodeHealth } from '../config/networks'
+import {
+  advanceDebounce,
+  initialDebounceState,
+  isActiveNodeOfflineRaw,
+  OFFLINE_DEBOUNCE_TICKS,
+} from '../lib/active-node-offline'
+import { OfflineBanner } from './OfflineBanner'
+
+// --- Mock the two contexts the banner reads --------------------------------
+const useNetworkMock = vi.fn()
+const useWalletMock = vi.fn()
+vi.mock('../contexts/network', () => ({ useNetwork: () => useNetworkMock() }))
+vi.mock('../contexts/wallet', () => ({ useWallet: () => useWalletMock() }))
+
+const ONLINE: NodeHealth = { status: 'online', chainHeight: 100, synced: true }
+const OFFLINE: NodeHealth = { status: 'offline' }
+const CHECKING: NodeHealth = { status: 'checking' }
+
+describe('active-node-offline pure logic', () => {
+  it('reports offline for a selected node whose health is offline', () => {
+    expect(
+      isActiveNodeOfflineRaw({
+        ingressId: 'seed',
+        nodeHealth: { seed: OFFLINE },
+        isConnected: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('reports online for a selected node whose health is online', () => {
+    expect(
+      isActiveNodeOfflineRaw({
+        ingressId: 'seed',
+        nodeHealth: { seed: ONLINE },
+        isConnected: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('only looks at the SELECTED node, ignoring others', () => {
+    // seed2 is offline but seed (selected) is online -> not offline.
+    expect(
+      isActiveNodeOfflineRaw({
+        ingressId: 'seed',
+        nodeHealth: { seed: ONLINE, seed2: OFFLINE },
+        isConnected: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('defers a not-yet-probed (checking) node to the connection state', () => {
+    expect(
+      isActiveNodeOfflineRaw({ ingressId: 'seed', nodeHealth: { seed: CHECKING }, isConnected: true }),
+    ).toBe(false)
+    expect(
+      isActiveNodeOfflineRaw({ ingressId: 'seed', nodeHealth: { seed: CHECKING }, isConnected: false }),
+    ).toBe(true)
+  })
+
+  it('falls back to the connection state for a custom endpoint (no health entry)', () => {
+    expect(
+      isActiveNodeOfflineRaw({ ingressId: 'custom', nodeHealth: {}, isConnected: false }),
+    ).toBe(true)
+    expect(
+      isActiveNodeOfflineRaw({ ingressId: 'custom', nodeHealth: {}, isConnected: true }),
+    ).toBe(false)
+  })
+
+  it('debounces transient offline blips: a single tick does not show the banner', () => {
+    let s = initialDebounceState()
+    expect(s.shown).toBe(false)
+    s = advanceDebounce(s, true) // 1 of OFFLINE_DEBOUNCE_TICKS
+    expect(OFFLINE_DEBOUNCE_TICKS).toBeGreaterThan(1)
+    expect(s.shown).toBe(false)
+  })
+
+  it('shows the banner once offline persists for the debounce threshold', () => {
+    let s = initialDebounceState()
+    for (let i = 0; i < OFFLINE_DEBOUNCE_TICKS; i++) s = advanceDebounce(s, true)
+    expect(s.shown).toBe(true)
+  })
+
+  it('a single online observation immediately resets + hides (recovery not debounced)', () => {
+    let s = initialDebounceState()
+    for (let i = 0; i < OFFLINE_DEBOUNCE_TICKS; i++) s = advanceDebounce(s, true)
+    expect(s.shown).toBe(true)
+    s = advanceDebounce(s, false)
+    expect(s.shown).toBe(false)
+    expect(s.consecutiveOffline).toBe(0)
+  })
+})
+
+describe('OfflineBanner component', () => {
+  beforeEach(() => {
+    cleanup()
+    useNetworkMock.mockReset()
+    useWalletMock.mockReset()
+  })
+
+  function setup(health: Record<string, NodeHealth>, isConnected: boolean, ingressId = 'seed') {
+    useNetworkMock.mockReturnValue({ ingressId, nodeHealth: health })
+    useWalletMock.mockReturnValue({ isConnected })
+  }
+
+  it('is hidden while the active node is online', () => {
+    setup({ seed: ONLINE }, true)
+    render(<OfflineBanner />)
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('does NOT show on the first offline observation (debounced)', () => {
+    setup({ seed: OFFLINE }, true)
+    render(<OfflineBanner />)
+    // First mount = first observation; below the threshold -> still hidden.
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('shows after the active node stays offline across the debounce threshold', () => {
+    setup({ seed: OFFLINE }, true)
+    const { rerender } = render(<OfflineBanner />)
+    // Re-render once per additional poll tick (nodeHealth identity changes each
+    // poll); after OFFLINE_DEBOUNCE_TICKS observations the banner appears.
+    for (let i = 1; i < OFFLINE_DEBOUNCE_TICKS; i++) {
+      useNetworkMock.mockReturnValue({ ingressId: 'seed', nodeHealth: { seed: { ...OFFLINE } } })
+      rerender(<OfflineBanner />)
+    }
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByText(/unreachable/i)).toBeTruthy()
+    expect(screen.getByRole('button', { name: /switch node/i })).toBeTruthy()
+  })
+
+  it('can be dismissed', () => {
+    setup({ seed: OFFLINE }, true)
+    const { rerender } = render(<OfflineBanner />)
+    for (let i = 1; i < OFFLINE_DEBOUNCE_TICKS; i++) {
+      useNetworkMock.mockReturnValue({ ingressId: 'seed', nodeHealth: { seed: { ...OFFLINE } } })
+      rerender(<OfflineBanner />)
+    }
+    expect(screen.getByRole('alert')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('"Switch node" dispatches the open-network-selector event', () => {
+    setup({ seed: OFFLINE }, true)
+    const onOpen = vi.fn()
+    window.addEventListener('open-network-selector', onOpen)
+    const { rerender } = render(<OfflineBanner />)
+    for (let i = 1; i < OFFLINE_DEBOUNCE_TICKS; i++) {
+      useNetworkMock.mockReturnValue({ ingressId: 'seed', nodeHealth: { seed: { ...OFFLINE } } })
+      rerender(<OfflineBanner />)
+    }
+    fireEvent.click(screen.getByRole('button', { name: /switch node/i }))
+    expect(onOpen).toHaveBeenCalled()
+    window.removeEventListener('open-network-selector', onOpen)
+  })
+})

--- a/web/packages/web-wallet/src/components/OfflineBanner.tsx
+++ b/web/packages/web-wallet/src/components/OfflineBanner.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from 'react'
+import { AlertTriangle, X } from 'lucide-react'
+import { useNetwork } from '../contexts/network'
+import { useWallet } from '../contexts/wallet'
+import {
+  advanceDebounce,
+  initialDebounceState,
+  isActiveNodeOfflineRaw,
+  type OfflineDebounceState,
+} from '../lib/active-node-offline'
+
+/**
+ * Debounced "is the active ingress node offline?" hook (#492).
+ *
+ * Reuses the EXISTING per-node health polling in NetworkContext (no second poll
+ * loop) plus the wallet's `isConnected` to compute a raw verdict, then debounces
+ * it so a single transient blip does not flap the banner. The health poll
+ * updates `nodeHealth` on its cadence; each such update (and each connection /
+ * selection change) is one debounce "tick".
+ *
+ * Returns the debounced `offline` flag. Switching ingress resets the debounce so
+ * the banner does not carry over a stale verdict to a freshly selected node.
+ */
+export function useActiveNodeOffline(): boolean {
+  const { ingressId, nodeHealth } = useNetwork()
+  const { isConnected } = useWallet()
+
+  const stateRef = useRef<OfflineDebounceState>(initialDebounceState())
+  const [offline, setOffline] = useState(false)
+
+  // Reset the debounce when the selected ingress changes: a new node starts with
+  // a clean slate (no inherited "offline" streak from the previous selection).
+  useEffect(() => {
+    stateRef.current = initialDebounceState()
+    setOffline(false)
+  }, [ingressId])
+
+  useEffect(() => {
+    const rawOffline = isActiveNodeOfflineRaw({ ingressId, nodeHealth, isConnected })
+    stateRef.current = advanceDebounce(stateRef.current, rawOffline)
+    setOffline(stateRef.current.shown)
+  }, [ingressId, nodeHealth, isConnected])
+
+  return offline
+}
+
+/**
+ * Dismissible banner shown at the top of the wallet view when the user's
+ * currently selected ingress node is offline/unreachable (#492).
+ *
+ * Offers a one-click "Switch node" action that opens the NetworkSelector (the
+ * node picker lives in the header). Dismiss hides the banner until the node
+ * recovers and goes offline again — recovery clears the dismissal so a later
+ * outage re-surfaces it.
+ */
+export function OfflineBanner() {
+  const offline = useActiveNodeOffline()
+  const [dismissed, setDismissed] = useState(false)
+
+  // Once the node recovers (banner condition clears), drop the dismissal so a
+  // FUTURE outage re-surfaces the banner instead of staying silenced forever.
+  useEffect(() => {
+    if (!offline) setDismissed(false)
+  }, [offline])
+
+  if (!offline || dismissed) return null
+
+  const handleSwitch = () => {
+    // The node picker (NetworkSelector) lives in the wallet header. Nudge the
+    // user to it; dispatch an event the selector can choose to react to (open),
+    // and scroll the header into view as a no-JS-coupling fallback.
+    window.dispatchEvent(new CustomEvent('open-network-selector'))
+    if (typeof document !== 'undefined') {
+      document.querySelector('header')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-3 rounded-lg border border-danger/30 bg-danger/10 p-3 sm:p-4"
+    >
+      <AlertTriangle size={18} className="text-danger mt-0.5 shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-light">Your node is unreachable</p>
+        <p className="text-xs text-ghost mt-1">
+          The node this wallet is connected to isn&apos;t responding. Balances and history
+          may be out of date. Switch to a healthy node to keep using your wallet.
+        </p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          onClick={handleSwitch}
+          className="rounded-md bg-danger/20 px-3 py-1.5 text-xs font-medium text-light hover:bg-danger/30 transition-colors whitespace-nowrap"
+        >
+          Switch node
+        </button>
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss"
+          className="text-ghost hover:text-light transition-colors"
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/packages/web-wallet/src/lib/active-node-offline.ts
+++ b/web/packages/web-wallet/src/lib/active-node-offline.ts
@@ -1,0 +1,104 @@
+/**
+ * Active-node-offline detection for the wallet's offline banner (#492).
+ *
+ * The wallet routes all RPC through ONE selected "ingress" node. The
+ * NetworkSelector already polls per-node health (`node_getStatus`) on a fixed
+ * cadence and stores a {@link NodeHealth} snapshot per ingress id. When the
+ * user's CURRENTLY SELECTED ingress goes unreachable mid-use there is otherwise
+ * no prominent prompt — the dashboard just silently stops updating.
+ *
+ * This module derives a single boolean "is the active node offline?" signal from
+ * the existing health polling (no second poll loop) plus the wallet's
+ * `isConnected` / `wsStatus`, and DEBOUNCES it so a single transient blip does
+ * not flap the banner on/off.
+ */
+import type { NodeHealth } from '../config/networks'
+
+/** Inputs to the raw (pre-debounce) offline check. */
+export interface ActiveNodeOfflineInput {
+  /** The selected ingress id (or 'custom'), from NetworkContext. */
+  ingressId: string
+  /** Per-ingress health snapshots, from NetworkContext's existing polling. */
+  nodeHealth: Record<string, NodeHealth>
+  /** Whether the wallet adapter believes it is connected to a node. */
+  isConnected: boolean
+}
+
+/**
+ * RAW (un-debounced) "is the active node offline?" decision.
+ *
+ * Truthy only when we are CONFIDENT the active ingress is unreachable, so a
+ * not-yet-probed ('checking') node never trips the banner:
+ *
+ *   - Known ingress: trust the polled health snapshot. `offline` => offline;
+ *     `online` => not offline; `checking`/absent => unknown, defer to the
+ *     connection state below (so a never-probed node that also failed to connect
+ *     still surfaces, but a freshly-mounted selector that has not polled yet does
+ *     not flash the banner just because health is 'checking').
+ *   - Custom endpoint ('custom'): there is no health entry, so fall back purely
+ *     to the adapter connection state.
+ */
+export function isActiveNodeOfflineRaw({
+  ingressId,
+  nodeHealth,
+  isConnected,
+}: ActiveNodeOfflineInput): boolean {
+  const health = nodeHealth[ingressId]
+
+  // Known node with a definitive health verdict wins.
+  if (health) {
+    if (health.status === 'offline') return true
+    if (health.status === 'online') return false
+    // status === 'checking' -> fall through to connection state.
+  }
+
+  // No definitive health (custom endpoint, or not yet probed): the node is
+  // offline only if the adapter has positively failed to connect.
+  return !isConnected
+}
+
+/**
+ * Number of consecutive RAW-offline observations required before the banner is
+ * shown. With the 20s health poll cadence this is ~one extra poll cycle of
+ * confirmation, so a single dropped probe does not flap the banner.
+ */
+export const OFFLINE_DEBOUNCE_TICKS = 2
+
+/** Internal debounce accumulator. */
+export interface OfflineDebounceState {
+  /** Count of consecutive raw-offline observations (capped). */
+  consecutiveOffline: number
+  /** The debounced, user-facing "show the banner" verdict. */
+  shown: boolean
+}
+
+/** Fresh debounce state: nothing observed, banner hidden. */
+export function initialDebounceState(): OfflineDebounceState {
+  return { consecutiveOffline: 0, shown: false }
+}
+
+/**
+ * Advance the debounce state by one observation.
+ *
+ * - A raw-offline observation increments the streak; once it reaches
+ *   {@link OFFLINE_DEBOUNCE_TICKS} the banner is shown.
+ * - A raw-online observation immediately resets the streak AND hides the banner
+ *   (recovery is not debounced — as soon as the node is reachable again we stop
+ *   nagging).
+ *
+ * Pure: returns a NEW state; callers store it (e.g. in a ref/state) across ticks.
+ */
+export function advanceDebounce(
+  prev: OfflineDebounceState,
+  rawOffline: boolean,
+  ticks: number = OFFLINE_DEBOUNCE_TICKS,
+): OfflineDebounceState {
+  if (!rawOffline) {
+    return { consecutiveOffline: 0, shown: false }
+  }
+  const consecutiveOffline = Math.min(prev.consecutiveOffline + 1, ticks)
+  return {
+    consecutiveOffline,
+    shown: prev.shown || consecutiveOffline >= ticks,
+  }
+}

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -11,6 +11,7 @@ import { SendLinkModal } from '../components/SendLinkModal'
 import { RequestModal } from '../components/RequestModal'
 import { ReceiveModal } from '../components/ReceiveModal'
 import { OutstandingLinks } from '../components/OutstandingLinks'
+import { OfflineBanner } from '../components/OfflineBanner'
 import { PasswordFields, PasswordSettingsModal, isPasswordValid } from '../components/PasswordSettingsModal'
 import { Send, Link2, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2, Users, QrCode, Clock } from 'lucide-react'
 
@@ -394,6 +395,10 @@ function WalletDashboard() {
 
   return (
     <div className="max-w-4xl mx-auto space-y-4 sm:space-y-6 px-4 sm:px-0">
+      {/* Active-node-offline prompt (#492): surfaces when the selected ingress
+          node goes unreachable mid-use, with a one-click switch action. */}
+      <OfflineBanner />
+
       <BalanceCard
         balance={balance}
         address={address}


### PR DESCRIPTION
## Summary
Rounds out wallet resilience + test coverage (the last issue of the wallet sweep). Adds a dismissible **active-node-offline banner** that prompts the user to switch nodes when their selected ingress goes unreachable mid-use, and **extends the hermetic Playwright e2e suite** to cover the send-validation / claim-link / lock-unlock / change-password flows that just landed.

## Changes

### (a) Active-node-offline banner + switch prompt
- `web/packages/web-wallet/src/lib/active-node-offline.ts` — pure, testable logic: `isActiveNodeOfflineRaw()` derives the raw verdict from the EXISTING per-node health polling (`nodeHealth[ingressId]`) plus the wallet's `isConnected` (no second poll loop); `advanceDebounce()` is a pure accumulator requiring `OFFLINE_DEBOUNCE_TICKS` (2) consecutive offline observations before showing, with immediate (un-debounced) recovery.
- `web/packages/web-wallet/src/components/OfflineBanner.tsx` — `useActiveNodeOffline()` hook (ticks the debounce on each health/connection change; resets on ingress switch) + the dismissible `OfflineBanner` with a one-click **Switch node** action that dispatches `open-network-selector`. Dismissal clears on recovery so a later outage re-surfaces it.
- `NetworkSelector.tsx` — opens its dropdown on the `open-network-selector` event.
- `wallet.tsx` — renders `<OfflineBanner />` at the top of the dashboard.

### (b) Extended hermetic e2e (mock RPC, no live node)
- `send.spec.ts` — invalid recipient blocked with inline error (#491); valid recipient + amount primes the confirm.
- `lock.spec.ts` — Lock clears session -> Unlock screen -> unlock restores the same wallet; wrong password rejected (#490).
- `password.spec.ts` — change-password rotation; wrong current password rejected; new password unlocks and old no longer does (#489).
- `claim-link.spec.ts` — send-via-link create primed for an encrypted wallet (#474); claim page recognises a valid bearer link and strips the secret; malformed link rejected.
- New `wallet-setup.ts` helpers: `openSendModal`, `lockWallet`, `unlockWallet`, `changeWalletPassword`. All specs assert up to the primed/confirm state (the mock has no `tx_submit`), matching the existing request-pay spec.

### Unit tests
- `OfflineBanner.test.tsx` — covers the pure logic + the component (shows after debounce, hidden when online, dismissible, switch dispatches the event).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Offline banner appears for an unreachable active node, with a switch action | ✅ | Unit + component tests; banner renders in dashboard |
| Doesn't flap on transient blips (debounced) | ✅ | `advanceDebounce` requires 2 consecutive offline ticks; unit-tested |
| Dismissible | ✅ | Unit test clicks Dismiss; re-surfaces on next outage |
| Reuses existing health polling (no second loop) | ✅ | Derives from NetworkContext `nodeHealth` + wallet `isConnected` |
| New e2e specs pass against the mock | ✅ | 8 new specs green |
| Full wallet e2e suite green | ✅ | 33/33 passed |
| typecheck + build + vitest green | ✅ | See Test Plan |
| Scope: web-wallet + e2e infra only | ✅ | No Rust/consensus/faucet changes; reverted stray `.loom-managed`/`pnpm-workspace.yaml` |

## Test Plan
- `pnpm -r typecheck` — green
- `pnpm --filter @botho/web-wallet build` — green
- `pnpm test:run` — 243 passed (incl. 13 new OfflineBanner tests)
- Full wallet e2e (bundled chromium unavailable in this env, ran with system Chrome):
  `E2E_BROWSER_CHANNEL=chrome E2E_VIDEO=off pnpm exec playwright test --config=e2e/playwright.config.ts --project=web-wallet e2e/tests/wallet/`
  → **33 passed** (8 new + all pre-existing).

Closes #492