### PR TITLE
feat(consensus): quorum-health analyzer for curated FBAS federation (#511)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bth-quorum-sim"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bth-transaction-clsag"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "gossip",
     "account-keys/types",
     "common",
+    "consensus/quorum-sim",
     "consensus/scp",
     "consensus/scp/play",
     "consensus/scp/types",

--- a/consensus/quorum-sim/Cargo.toml
+++ b/consensus/quorum-sim/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bth-quorum-sim"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+rust-version = { workspace = true }
+description = "Static quorum-health analyzer for Botho's curated FBAS federation (Path A)"
+
+[[bin]]
+name = "quorum-sim"
+path = "src/bin/quorum-sim.rs"
+
+[dependencies]
+serde = { workspace = true, features = ["derive", "alloc"] }
+serde_json = { workspace = true, features = ["std"] }
+clap = { workspace = true, features = ["derive"] }
+
+[features]
+default = []

--- a/consensus/quorum-sim/README.md
+++ b/consensus/quorum-sim/README.md
@@ -1,0 +1,56 @@
+# bth-quorum-sim
+
+Static quorum-health analyzer for Botho's curated FBAS federation (Path A).
+
+This is **Deliverable 2 of #510**, scoped to **Path A** (a curated validator
+federation + thin clients; see #427). It is a small, Botho-grounded
+re-implementation of the static metrics computed by tools such as
+[`fbas_analyzer`](https://github.com/wiberlin/fbas_analyzer) and
+[`python-fbas`](https://github.com/nano-o/python-fbas), tied directly to
+Botho's threshold rule.
+
+## Scope (v1)
+
+Static analysis + threshold/growth comparison. **No** dynamic message-level SCP
+round simulator, Byzantine equivocation injection, or partial-synchrony
+modelling — that is an explicit follow-up.
+
+The curated federation is small (`N ≤ ~20`), so every analysis brute-forces
+over the `2^N` node subsets. This is exponential but exact, and trivially fast
+at the targeted sizes.
+
+## What it computes
+
+- `is_quorum` — the FBAS quorum predicate.
+- `has_quorum_intersection` — do all quorums pairwise intersect? `false` ⇒ a
+  fork is possible.
+- `minimal_quorums` — smallest quorums by set inclusion.
+- `minimal_blocking_sets` — smallest crash-fault sets that halt the network
+  (the **liveness** buffer).
+- `minimal_splitting_sets` — smallest Byzantine sets that can fork the network
+  (the **safety** buffer).
+- Threshold-rule comparison: Botho's `n − floor((n−1)/3)` vs `ceil(0.67·n)` vs
+  unanimity.
+- Growth/churn: curated admission and reactive-shun, flagging any action that
+  breaks quorum intersection.
+
+## CLI
+
+```
+# Threshold-rule comparison table (N = 2..=12)
+cargo run -p bth-quorum-sim --bin quorum-sim -- compare --min 2 --max 12
+
+# Full static-health report for one symmetric federation (JSON for CI)
+cargo run -p bth-quorum-sim --bin quorum-sim -- analyze --n 4 --threshold 2 --json
+
+# Growth/churn timeline: start at 3, admit 2, then shun node 0
+cargo run -p bth-quorum-sim --bin quorum-sim -- churn --initial 3 --admit 2 --shun 0
+```
+
+All subcommands accept `--json` for machine-readable output.
+
+## Grounding
+
+- `botho/src/config.rs` — `QuorumConfig::effective_threshold` (the formula under
+  test) and `test_quorum_effective_threshold_*`.
+- #510 research (Threads A+B) — metric definitions and expected values.

--- a/consensus/quorum-sim/src/analysis.rs
+++ b/consensus/quorum-sim/src/analysis.rs
@@ -5,9 +5,7 @@
 //! and, at the curated-federation sizes Path A targets (`N ≤ ~20`), fast. The
 //! coNP-complete quorum-intersection check is decided exactly the same way.
 
-use crate::model::Fbas;
-use crate::nodeset::NodeSet;
-use crate::thresholds;
+use crate::{model::Fbas, nodeset::NodeSet, thresholds};
 use serde::{Deserialize, Serialize};
 
 /// Which threshold rule a [`ThresholdComparisonRow`] describes.

--- a/consensus/quorum-sim/src/analysis.rs
+++ b/consensus/quorum-sim/src/analysis.rs
@@ -1,0 +1,322 @@
+//! Static FBAS analysis: quorum enumeration, intersection, and the minimal
+//! quorum / blocking / splitting set metrics.
+//!
+//! All functions here brute-force over the `2^N` node subsets. This is exact
+//! and, at the curated-federation sizes Path A targets (`N ≤ ~20`), fast. The
+//! coNP-complete quorum-intersection check is decided exactly the same way.
+
+use crate::model::Fbas;
+use crate::nodeset::NodeSet;
+use crate::thresholds;
+use serde::{Deserialize, Serialize};
+
+/// Which threshold rule a [`ThresholdComparisonRow`] describes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThresholdRule {
+    /// Botho's current `n − floor((n−1)/3)`.
+    BothoBft,
+    /// `ceil(0.67·n)` two-thirds supermajority.
+    TwoThirds,
+    /// Unanimity (`n`).
+    Unanimity,
+}
+
+impl ThresholdRule {
+    /// The threshold this rule assigns to a federation of size `n`.
+    pub fn threshold(&self, n: usize) -> usize {
+        match self {
+            ThresholdRule::BothoBft => thresholds::botho_bft_threshold(n),
+            ThresholdRule::TwoThirds => thresholds::two_thirds_threshold(n),
+            ThresholdRule::Unanimity => thresholds::unanimity_threshold(n),
+        }
+    }
+
+    /// Display label.
+    pub fn label(&self) -> &'static str {
+        match self {
+            ThresholdRule::BothoBft => "botho_bft (n-floor((n-1)/3))",
+            ThresholdRule::TwoThirds => "two_thirds (ceil(0.67n))",
+            ThresholdRule::Unanimity => "unanimity (n)",
+        }
+    }
+}
+
+impl Fbas {
+    /// Iterate over every non-empty quorum (every subset that satisfies
+    /// [`Fbas::is_quorum`]).
+    pub fn all_quorums(&self) -> Vec<NodeSet> {
+        let n = self.len();
+        let mut quorums = Vec::new();
+        if n == 0 {
+            return quorums;
+        }
+        let total = 1u32 << n;
+        for mask in 1..total {
+            let set = NodeSet(mask);
+            if self.is_quorum(&set) {
+                quorums.push(set);
+            }
+        }
+        quorums
+    }
+
+    /// Whether the FBAS enjoys **quorum intersection**: every pair of quorums
+    /// shares at least one node.
+    ///
+    /// A `false` result means two disjoint quorums exist and the network can
+    /// fork (the safety prerequisite is violated). It suffices to check the
+    /// *minimal* quorums pairwise, since any quorum contains a minimal one.
+    pub fn has_quorum_intersection(&self) -> bool {
+        let minimal = self.minimal_quorums();
+        for (i, a) in minimal.iter().enumerate() {
+            for b in &minimal[i + 1..] {
+                if !a.intersects(b) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Enumerate the **minimal quorums**: quorums with no proper subset that is
+    /// also a quorum.
+    pub fn minimal_quorums(&self) -> Vec<NodeSet> {
+        let quorums = self.all_quorums();
+        let mut minimal = Vec::new();
+        for &q in &quorums {
+            let has_smaller = quorums
+                .iter()
+                .any(|&other| other != q && other.is_subset_of(&q));
+            if !has_smaller {
+                minimal.push(q);
+            }
+        }
+        minimal
+    }
+
+    /// Enumerate the **minimal blocking sets**: minimal sets of nodes whose
+    /// removal leaves no quorum among the survivors (i.e. halting the network).
+    ///
+    /// A set `B` is *blocking* iff the complement `all \ B` contains no quorum.
+    /// The cardinality of the smallest blocking set is the **liveness buffer**:
+    /// how many nodes must fail (crash) before the network can no longer make
+    /// progress.
+    pub fn minimal_blocking_sets(&self) -> Vec<NodeSet> {
+        let n = self.len();
+        if n == 0 {
+            return Vec::new();
+        }
+        let all = self.all_nodes();
+        let total = 1u32 << n;
+        let mut blocking = Vec::new();
+        for mask in 1..total {
+            let b = NodeSet(mask);
+            let survivors = all.difference(&b);
+            // Blocking iff survivors contain no quorum.
+            if !self.contains_quorum(&survivors) {
+                blocking.push(b);
+            }
+        }
+        minimize(blocking)
+    }
+
+    /// Enumerate the **minimal splitting sets**: minimal sets of nodes whose
+    /// Byzantine misbehaviour can split the network into two non-intersecting
+    /// quorums.
+    ///
+    /// A set `S` is *splitting* iff there exist two quorums `Q1`, `Q2` whose
+    /// intersection is contained in `S` (`Q1 ∩ Q2 ⊆ S`). The smallest such
+    /// `S` is the **safety buffer**: how many nodes must be Byzantine before a
+    /// fork becomes possible. If the FBAS has quorum intersection, the empty
+    /// set is never splitting and the minimal cardinality is `≥ 1`; if it lacks
+    /// quorum intersection, the empty set is splitting (cardinality 0).
+    pub fn minimal_splitting_sets(&self) -> Vec<NodeSet> {
+        let minimal_quorums = self.minimal_quorums();
+        let mut splitting = Vec::new();
+        // Every pairwise intersection of quorums is a splitting set (and any
+        // superset of one is too). Minimizing afterwards keeps only the
+        // smallest. We include the (Q,Q) diagonal so a degenerate single
+        // minimal quorum is handled, but its self-intersection is the quorum
+        // itself, which is never minimal against cross pairs.
+        for (i, a) in minimal_quorums.iter().enumerate() {
+            for b in &minimal_quorums[i..] {
+                let inter = a.intersect(b);
+                if a != b {
+                    splitting.push(inter);
+                }
+            }
+        }
+        // If there is a single minimal quorum, a split needs disabling it
+        // entirely; represent that by its own membership.
+        if minimal_quorums.len() == 1 {
+            splitting.push(minimal_quorums[0]);
+        }
+        minimize(splitting)
+    }
+
+    /// Whether `set` contains any quorum as a subset.
+    fn contains_quorum(&self, set: &NodeSet) -> bool {
+        if set.is_empty() {
+            return false;
+        }
+        let members: Vec<usize> = set.iter().collect();
+        let k = members.len();
+        let total = 1u32 << k;
+        // Enumerate subsets of `set` and test the quorum predicate. Equivalent
+        // to checking is_quorum over the masked space.
+        for sub in 1..total {
+            let mut candidate = NodeSet::new();
+            for (bit, &node) in members.iter().enumerate() {
+                if (sub >> bit) & 1 == 1 {
+                    candidate.insert(node);
+                }
+            }
+            if self.is_quorum(&candidate) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Compute the [`HealthReport`] for this FBAS.
+    pub fn health_report(&self) -> HealthReport {
+        let minimal_quorums = self.minimal_quorums();
+        let minimal_blocking = self.minimal_blocking_sets();
+        let minimal_splitting = self.minimal_splitting_sets();
+        let quorum_intersection = self.has_quorum_intersection();
+
+        let min_blocking_card = minimal_blocking.iter().map(|s| s.len()).min();
+        let min_splitting_card = minimal_splitting.iter().map(|s| s.len()).min();
+        let min_quorum_card = minimal_quorums.iter().map(|s| s.len()).min();
+
+        HealthReport {
+            n: self.len(),
+            quorum_intersection,
+            min_quorum_cardinality: min_quorum_card,
+            min_blocking_set_cardinality: min_blocking_card,
+            min_splitting_set_cardinality: min_splitting_card,
+            num_minimal_quorums: minimal_quorums.len(),
+            num_minimal_blocking_sets: minimal_blocking.len(),
+            num_minimal_splitting_sets: minimal_splitting.len(),
+            minimal_quorums: minimal_quorums.iter().map(|s| s.to_vec()).collect(),
+            minimal_blocking_sets: minimal_blocking.iter().map(|s| s.to_vec()).collect(),
+            minimal_splitting_sets: minimal_splitting.iter().map(|s| s.to_vec()).collect(),
+        }
+    }
+}
+
+/// Reduce a collection of sets to those that are minimal under set inclusion,
+/// de-duplicating in the process.
+fn minimize(mut sets: Vec<NodeSet>) -> Vec<NodeSet> {
+    sets.sort_by_key(|s| (s.len(), s.0));
+    sets.dedup();
+    let mut minimal: Vec<NodeSet> = Vec::new();
+    for &s in &sets {
+        if s.is_empty() {
+            // An empty set is the unique minimum; it dominates everything.
+            return vec![NodeSet::EMPTY];
+        }
+        if !minimal.iter().any(|m| m.is_subset_of(&s)) {
+            minimal.push(s);
+        }
+    }
+    minimal
+}
+
+/// Aggregate static-health metrics for an FBAS, serializable to JSON.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthReport {
+    /// Number of nodes.
+    pub n: usize,
+    /// Whether all quorums pairwise intersect (safety prerequisite).
+    pub quorum_intersection: bool,
+    /// Cardinality of the smallest quorum (`None` if no quorum exists).
+    pub min_quorum_cardinality: Option<usize>,
+    /// Cardinality of the smallest blocking set — the **liveness** buffer
+    /// (crash faults to halt the network). `None` if no node can block.
+    pub min_blocking_set_cardinality: Option<usize>,
+    /// Cardinality of the smallest splitting set — the **safety** buffer
+    /// (Byzantine faults to fork the network). `None` if not computable.
+    pub min_splitting_set_cardinality: Option<usize>,
+    /// Number of minimal quorums.
+    pub num_minimal_quorums: usize,
+    /// Number of minimal blocking sets.
+    pub num_minimal_blocking_sets: usize,
+    /// Number of minimal splitting sets.
+    pub num_minimal_splitting_sets: usize,
+    /// The minimal quorums, as node-index lists.
+    pub minimal_quorums: Vec<Vec<usize>>,
+    /// The minimal blocking sets, as node-index lists.
+    pub minimal_blocking_sets: Vec<Vec<usize>>,
+    /// The minimal splitting sets, as node-index lists.
+    pub minimal_splitting_sets: Vec<Vec<usize>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::QuorumSet;
+
+    #[test]
+    fn symmetric_3of4_quorums() {
+        let fbas = Fbas::symmetric(4, 3);
+        // Minimal quorums are the four 3-subsets.
+        let mq = fbas.minimal_quorums();
+        assert_eq!(mq.len(), 4);
+        assert!(mq.iter().all(|q| q.len() == 3));
+        assert!(fbas.has_quorum_intersection());
+    }
+
+    #[test]
+    fn disjoint_quorums_2of4() {
+        // 2-of-4 symmetric: {A,B} and {C,D} are both quorums and disjoint.
+        let fbas = Fbas::symmetric(4, 2);
+        assert!(fbas.is_quorum(&NodeSet::from_indices([0, 1])));
+        assert!(fbas.is_quorum(&NodeSet::from_indices([2, 3])));
+        assert!(!fbas.has_quorum_intersection());
+    }
+
+    #[test]
+    fn blocking_set_unanimity() {
+        // 3-of-3 unanimity: any single node blocks (its absence kills quorum).
+        let fbas = Fbas::symmetric(3, 3);
+        let report = fbas.health_report();
+        assert_eq!(report.min_blocking_set_cardinality, Some(1));
+    }
+
+    #[test]
+    fn blocking_set_3of4() {
+        // 3-of-4: need to remove 2 nodes (leaving 2 < 3) to halt.
+        let fbas = Fbas::symmetric(4, 3);
+        let report = fbas.health_report();
+        assert_eq!(report.min_blocking_set_cardinality, Some(2));
+    }
+
+    #[test]
+    fn splitting_set_top_tier() {
+        // 3-of-4: minimal quorums are 3-subsets; any two intersect in 2 nodes.
+        // The minimal splitting set is the smallest such intersection.
+        let fbas = Fbas::symmetric(4, 3);
+        let report = fbas.health_report();
+        // Two 3-subsets of 4 elements always share exactly 2 nodes.
+        assert_eq!(report.min_splitting_set_cardinality, Some(2));
+        // Cross-check fbas_analyzer semantics: splitting sets are top-tier nodes.
+        for s in &report.minimal_splitting_sets {
+            assert!(s.iter().all(|&i| i < 4));
+        }
+    }
+
+    #[test]
+    fn arbitrary_slices_quorum() {
+        // Asymmetric: node 0 trusts only itself (1-of-1) -> {0} is a quorum.
+        let fbas = Fbas::from_quorum_sets([
+            QuorumSet::new(1, vec![0]),
+            QuorumSet::new(2, vec![0, 1, 2]),
+            QuorumSet::new(2, vec![0, 1, 2]),
+        ]);
+        assert!(fbas.is_quorum(&NodeSet::from_indices([0])));
+        let mq = fbas.minimal_quorums();
+        assert!(mq.iter().any(|q| *q == NodeSet::from_indices([0])));
+    }
+}

--- a/consensus/quorum-sim/src/bin/quorum-sim.rs
+++ b/consensus/quorum-sim/src/bin/quorum-sim.rs
@@ -1,0 +1,139 @@
+//! `quorum-sim` — CLI for Botho's static quorum-health analyzer (v1).
+//!
+//! Subcommands:
+//! - `compare` — threshold-rule comparison table (Botho BFT vs ceil(0.67n) vs
+//!   unanimity) over a range of federation sizes.
+//! - `analyze` — full static-health report for a single symmetric federation.
+//! - `churn` — growth/churn timeline (admit / shun) starting from a symmetric
+//!   federation, flagging any quorum-intersection break.
+//!
+//! Every subcommand supports `--json` for machine-readable output (CI /
+//! monitoring); otherwise a human-readable table is printed.
+
+use bth_quorum_sim::model::Fbas;
+use bth_quorum_sim::report::{
+    compare_thresholds, render_churn_table, render_threshold_table, simulate_churn, ChurnAction,
+};
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(
+    name = "quorum-sim",
+    about = "Static quorum-health analyzer for Botho's curated FBAS federation (v1)"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Compare threshold rules over n = min..=max.
+    Compare {
+        /// Smallest federation size to evaluate.
+        #[arg(long, default_value_t = 2)]
+        min: usize,
+        /// Largest federation size to evaluate.
+        #[arg(long, default_value_t = 12)]
+        max: usize,
+        /// Emit JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Full static-health report for a single symmetric federation.
+    Analyze {
+        /// Federation size.
+        #[arg(long)]
+        n: usize,
+        /// Threshold; defaults to Botho's BFT rule for `n`.
+        #[arg(long)]
+        threshold: Option<usize>,
+        /// Emit JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Growth/churn timeline starting from a symmetric Botho-BFT federation.
+    Churn {
+        /// Initial federation size.
+        #[arg(long, default_value_t = 3)]
+        initial: usize,
+        /// Number of validators to admit (applied first).
+        #[arg(long, default_value_t = 0)]
+        admit: usize,
+        /// Node indices to shun, applied after admissions (repeatable).
+        #[arg(long)]
+        shun: Vec<usize>,
+        /// Emit JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Compare { min, max, json } => {
+            let rows = compare_thresholds(min..=max);
+            if json {
+                println!("{}", serde_json::to_string_pretty(&rows).unwrap());
+            } else {
+                print!("{}", render_threshold_table(&rows));
+            }
+        }
+        Command::Analyze {
+            n,
+            threshold,
+            json,
+        } => {
+            let fbas = match threshold {
+                Some(t) => Fbas::symmetric(n, t),
+                None => Fbas::symmetric_botho(n),
+            };
+            let report = fbas.health_report();
+            if json {
+                println!("{}", serde_json::to_string_pretty(&report).unwrap());
+            } else {
+                println!("symmetric federation n={n}");
+                println!("  quorum_intersection:   {}", report.quorum_intersection);
+                println!("  min quorum card:       {:?}", report.min_quorum_cardinality);
+                println!(
+                    "  min blocking card:     {:?}  (liveness buffer)",
+                    report.min_blocking_set_cardinality
+                );
+                println!(
+                    "  min splitting card:    {:?}  (safety buffer)",
+                    report.min_splitting_set_cardinality
+                );
+                println!("  #minimal quorums:      {}", report.num_minimal_quorums);
+                println!(
+                    "  #minimal blocking:     {}",
+                    report.num_minimal_blocking_sets
+                );
+                println!(
+                    "  #minimal splitting:    {}",
+                    report.num_minimal_splitting_sets
+                );
+            }
+        }
+        Command::Churn {
+            initial,
+            admit,
+            shun,
+            json,
+        } => {
+            let mut actions: Vec<ChurnAction> = Vec::new();
+            for _ in 0..admit {
+                actions.push(ChurnAction::AdmitSymmetric);
+            }
+            for idx in shun {
+                actions.push(ChurnAction::ShunSymmetric(idx));
+            }
+            let steps = simulate_churn(initial, &actions);
+            if json {
+                println!("{}", serde_json::to_string_pretty(&steps).unwrap());
+            } else {
+                print!("{}", render_churn_table(&steps));
+            }
+        }
+    }
+}

--- a/consensus/quorum-sim/src/bin/quorum-sim.rs
+++ b/consensus/quorum-sim/src/bin/quorum-sim.rs
@@ -10,9 +10,11 @@
 //! Every subcommand supports `--json` for machine-readable output (CI /
 //! monitoring); otherwise a human-readable table is printed.
 
-use bth_quorum_sim::model::Fbas;
-use bth_quorum_sim::report::{
-    compare_thresholds, render_churn_table, render_threshold_table, simulate_churn, ChurnAction,
+use bth_quorum_sim::{
+    model::Fbas,
+    report::{
+        compare_thresholds, render_churn_table, render_threshold_table, simulate_churn, ChurnAction,
+    },
 };
 use clap::{Parser, Subcommand};
 
@@ -80,11 +82,7 @@ fn main() {
                 print!("{}", render_threshold_table(&rows));
             }
         }
-        Command::Analyze {
-            n,
-            threshold,
-            json,
-        } => {
+        Command::Analyze { n, threshold, json } => {
             let fbas = match threshold {
                 Some(t) => Fbas::symmetric(n, t),
                 None => Fbas::symmetric_botho(n),
@@ -95,7 +93,10 @@ fn main() {
             } else {
                 println!("symmetric federation n={n}");
                 println!("  quorum_intersection:   {}", report.quorum_intersection);
-                println!("  min quorum card:       {:?}", report.min_quorum_cardinality);
+                println!(
+                    "  min quorum card:       {:?}",
+                    report.min_quorum_cardinality
+                );
                 println!(
                     "  min blocking card:     {:?}  (liveness buffer)",
                     report.min_blocking_set_cardinality

--- a/consensus/quorum-sim/src/lib.rs
+++ b/consensus/quorum-sim/src/lib.rs
@@ -26,8 +26,8 @@
 //! # Key metrics
 //!
 //! - [`Fbas::is_quorum`] — quorum predicate.
-//! - [`Fbas::has_quorum_intersection`] — do all quorums pairwise intersect?
-//!   (A `false` here means a fork is possible.)
+//! - [`Fbas::has_quorum_intersection`] — do all quorums pairwise intersect? (A
+//!   `false` here means a fork is possible.)
 //! - [`Fbas::minimal_quorums`] — the smallest quorums (by set inclusion).
 //! - [`Fbas::minimal_blocking_sets`] — smallest sets whose failure halts the
 //!   network (the **liveness** buffer).

--- a/consensus/quorum-sim/src/lib.rs
+++ b/consensus/quorum-sim/src/lib.rs
@@ -1,0 +1,45 @@
+//! Static quorum-health analyzer for Botho's curated FBAS federation.
+//!
+//! This crate is **Deliverable 2 of #510**, scoped to **Path A** (a curated
+//! validator federation + thin clients; see #427). It provides a small,
+//! Botho-grounded re-implementation of the static metrics computed by tools
+//! such as [`fbas_analyzer`](https://github.com/wiberlin/fbas_analyzer) and
+//! [`python-fbas`](https://github.com/nano-o/python-fbas), tied directly to
+//! Botho's threshold rule (`effective_threshold = n − floor((n−1)/3)`, see
+//! [`botho/src/config.rs`]).
+//!
+//! # Scope (v1)
+//!
+//! This is a **static** analyzer plus threshold/growth comparison. It does
+//! **not** simulate SCP message rounds, Byzantine equivocation, or partial
+//! synchrony — that dynamic message-level simulator is an explicit follow-up
+//! (see the issue's "Deferred" section).
+//!
+//! # Model
+//!
+//! An [`Fbas`] is a set of nodes, each with a [`QuorumSet`] (a threshold over a
+//! list of validator members). Botho's curated federation is small
+//! (`N ≤ ~20`), so every analysis here brute-forces over node subsets using
+//! bitsets ([`NodeSet`]). This is exponential in `N` but exact, and trivially
+//! fast at the sizes Path A targets.
+//!
+//! # Key metrics
+//!
+//! - [`Fbas::is_quorum`] — quorum predicate.
+//! - [`Fbas::has_quorum_intersection`] — do all quorums pairwise intersect?
+//!   (A `false` here means a fork is possible.)
+//! - [`Fbas::minimal_quorums`] — the smallest quorums (by set inclusion).
+//! - [`Fbas::minimal_blocking_sets`] — smallest sets whose failure halts the
+//!   network (the **liveness** buffer).
+//! - [`Fbas::minimal_splitting_sets`] — smallest sets whose Byzantine
+//!   misbehaviour can fork the network (the **safety** buffer).
+
+pub mod analysis;
+pub mod model;
+pub mod nodeset;
+pub mod report;
+pub mod thresholds;
+
+pub use analysis::{HealthReport, ThresholdRule};
+pub use model::{Fbas, Node, QuorumSet};
+pub use nodeset::NodeSet;

--- a/consensus/quorum-sim/src/model.rs
+++ b/consensus/quorum-sim/src/model.rs
@@ -1,7 +1,6 @@
 //! The FBAS model: nodes with threshold-based quorum sets.
 
-use crate::nodeset::NodeSet;
-use crate::thresholds::botho_bft_threshold;
+use crate::{nodeset::NodeSet, thresholds::botho_bft_threshold};
 use serde::{Deserialize, Serialize};
 
 /// A quorum set: a threshold over a list of validator member indices.
@@ -145,8 +144,8 @@ impl Fbas {
         idx
     }
 
-    /// Admit a validator into a symmetric top-tier federation, re-deriving every
-    /// node's quorum set with Botho's BFT threshold for the new `n`.
+    /// Admit a validator into a symmetric top-tier federation, re-deriving
+    /// every node's quorum set with Botho's BFT threshold for the new `n`.
     ///
     /// Returns the new node's index.
     pub fn admit_symmetric(&mut self) -> usize {
@@ -168,10 +167,10 @@ impl Fbas {
     /// nodes and rewriting every quorum set to drop the removed member and
     /// renumber the survivors.
     ///
-    /// In a symmetric federation this also reduces each node's threshold via the
-    /// shared rule, because [`shun`](Fbas::shun) does not itself recompute
-    /// thresholds — use [`shun_symmetric`](Fbas::shun_symmetric) for symmetric
-    /// federations.
+    /// In a symmetric federation this also reduces each node's threshold via
+    /// the shared rule, because [`shun`](Fbas::shun) does not itself
+    /// recompute thresholds — use [`shun_symmetric`](Fbas::shun_symmetric)
+    /// for symmetric federations.
     pub fn shun(&mut self, idx: usize) {
         if idx >= self.nodes.len() {
             return;

--- a/consensus/quorum-sim/src/model.rs
+++ b/consensus/quorum-sim/src/model.rs
@@ -1,0 +1,300 @@
+//! The FBAS model: nodes with threshold-based quorum sets.
+
+use crate::nodeset::NodeSet;
+use crate::thresholds::botho_bft_threshold;
+use serde::{Deserialize, Serialize};
+
+/// A quorum set: a threshold over a list of validator member indices.
+///
+/// This is a flat, single-level slice (a threshold over concrete members),
+/// which is sufficient for the symmetric top-tier and arbitrary per-node
+/// constructions in scope for v1. Nested/inner quorum sets (as in full Stellar
+/// `QuorumSet`s) are out of scope.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuorumSet {
+    /// Number of members that must agree.
+    pub threshold: usize,
+    /// Member node indices this node trusts.
+    pub members: Vec<usize>,
+}
+
+impl QuorumSet {
+    /// Construct a quorum set, clamping `threshold` into `0..=members.len()`.
+    pub fn new(threshold: usize, members: Vec<usize>) -> Self {
+        let threshold = threshold.min(members.len());
+        QuorumSet { threshold, members }
+    }
+
+    /// Whether `set` satisfies this quorum set (contains at least `threshold`
+    /// of its members).
+    pub fn is_satisfied_by(&self, set: &NodeSet) -> bool {
+        let count = self.members.iter().filter(|&&m| set.contains(m)).count();
+        count >= self.threshold
+    }
+}
+
+/// A single node in the FBAS.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Node {
+    /// Human-readable identifier (e.g. "A", "seed", a public-key prefix).
+    pub id: String,
+    /// This node's quorum set.
+    pub quorum_set: QuorumSet,
+}
+
+/// A Federated Byzantine Agreement System: an ordered list of nodes.
+///
+/// Node *index* is the position in [`Fbas::nodes`]; that index is what
+/// [`NodeSet`] addresses. The same index appears in other nodes' quorum-set
+/// `members` lists.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Fbas {
+    /// The nodes, in index order.
+    pub nodes: Vec<Node>,
+}
+
+impl Fbas {
+    /// Empty FBAS.
+    pub fn new() -> Self {
+        Fbas { nodes: Vec::new() }
+    }
+
+    /// Number of nodes.
+    pub fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Whether the FBAS has no nodes.
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
+    /// The set of all node indices.
+    pub fn all_nodes(&self) -> NodeSet {
+        NodeSet::full(self.len())
+    }
+
+    /// Build a **symmetric top-tier** FBAS: `n` nodes that all share the same
+    /// quorum set — a `threshold`-of-`n` over every node (including self).
+    ///
+    /// This mirrors a curated federation where every validator trusts every
+    /// other equally (the simplest and most robust Path A construction).
+    pub fn symmetric(n: usize, threshold: usize) -> Self {
+        let members: Vec<usize> = (0..n).collect();
+        let qs = QuorumSet::new(threshold, members);
+        let nodes = (0..n)
+            .map(|i| Node {
+                id: node_label(i),
+                quorum_set: qs.clone(),
+            })
+            .collect();
+        Fbas { nodes }
+    }
+
+    /// Build a symmetric FBAS of `n` nodes using **Botho's BFT threshold rule**
+    /// (`effective_threshold = n − floor((n−1)/3)`), matching
+    /// `QuorumConfig::effective_threshold` in `botho/src/config.rs`.
+    pub fn symmetric_botho(n: usize) -> Self {
+        Self::symmetric(n, botho_bft_threshold(n))
+    }
+
+    /// Build an FBAS from explicit, arbitrary per-node quorum sets.
+    pub fn from_quorum_sets<I>(quorum_sets: I) -> Self
+    where
+        I: IntoIterator<Item = QuorumSet>,
+    {
+        let nodes = quorum_sets
+            .into_iter()
+            .enumerate()
+            .map(|(i, quorum_set)| Node {
+                id: node_label(i),
+                quorum_set,
+            })
+            .collect();
+        Fbas { nodes }
+    }
+
+    /// Whether `set` is a quorum: non-empty, and every member's quorum set is
+    /// satisfied by `set` itself.
+    ///
+    /// This is the standard FBAS quorum definition: a quorum is a set of nodes
+    /// that contains a slice for each of its members.
+    pub fn is_quorum(&self, set: &NodeSet) -> bool {
+        if set.is_empty() {
+            return false;
+        }
+        set.iter().all(|i| {
+            // Indices outside the node range cannot be in a valid quorum.
+            i < self.len() && self.nodes[i].quorum_set.is_satisfied_by(set)
+        })
+    }
+
+    // ----- Growth / churn (Path A curated admission + reactive-shun) -----
+
+    /// Admit a new validator with the given quorum set, returning its index.
+    ///
+    /// The caller is responsible for any updates to *existing* nodes' quorum
+    /// sets; [`admit_symmetric`](Fbas::admit_symmetric) handles the common
+    /// "everyone trusts everyone" case.
+    pub fn admit(&mut self, id: impl Into<String>, quorum_set: QuorumSet) -> usize {
+        let idx = self.nodes.len();
+        self.nodes.push(Node {
+            id: id.into(),
+            quorum_set,
+        });
+        idx
+    }
+
+    /// Admit a validator into a symmetric top-tier federation, re-deriving every
+    /// node's quorum set with Botho's BFT threshold for the new `n`.
+    ///
+    /// Returns the new node's index.
+    pub fn admit_symmetric(&mut self) -> usize {
+        let n = self.len() + 1;
+        let new = Fbas::symmetric_botho(n);
+        // Preserve existing ids; adopt the freshly-derived quorum sets.
+        let new_idx = self.len();
+        for (i, node) in new.nodes.iter().enumerate() {
+            if i < self.nodes.len() {
+                self.nodes[i].quorum_set = node.quorum_set.clone();
+            } else {
+                self.nodes.push(node.clone());
+            }
+        }
+        new_idx
+    }
+
+    /// Reactively shun (remove) a node by index, re-indexing the remaining
+    /// nodes and rewriting every quorum set to drop the removed member and
+    /// renumber the survivors.
+    ///
+    /// In a symmetric federation this also reduces each node's threshold via the
+    /// shared rule, because [`shun`](Fbas::shun) does not itself recompute
+    /// thresholds — use [`shun_symmetric`](Fbas::shun_symmetric) for symmetric
+    /// federations.
+    pub fn shun(&mut self, idx: usize) {
+        if idx >= self.nodes.len() {
+            return;
+        }
+        self.nodes.remove(idx);
+        // Rewrite member indices: drop `idx`, decrement anything above it.
+        for node in &mut self.nodes {
+            let mut new_members: Vec<usize> = Vec::with_capacity(node.quorum_set.members.len());
+            for &m in &node.quorum_set.members {
+                if m == idx {
+                    continue;
+                }
+                new_members.push(if m > idx { m - 1 } else { m });
+            }
+            let new_threshold = node.quorum_set.threshold.min(new_members.len());
+            node.quorum_set = QuorumSet::new(new_threshold, new_members);
+        }
+    }
+
+    /// Reactively shun a node from a symmetric top-tier federation, re-deriving
+    /// every survivor's quorum set with Botho's BFT threshold for the new `n`.
+    pub fn shun_symmetric(&mut self, idx: usize) {
+        if idx >= self.nodes.len() {
+            return;
+        }
+        let ids: Vec<String> = self
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != idx)
+            .map(|(_, n)| n.id.clone())
+            .collect();
+        let n = ids.len();
+        let mut new = Fbas::symmetric_botho(n);
+        for (node, id) in new.nodes.iter_mut().zip(ids) {
+            node.id = id;
+        }
+        *self = new;
+    }
+}
+
+impl Default for Fbas {
+    fn default() -> Self {
+        Fbas::new()
+    }
+}
+
+/// Generate a stable label for node index `i`: A..Z, then n26, n27, ...
+fn node_label(i: usize) -> String {
+    if i < 26 {
+        ((b'A' + i as u8) as char).to_string()
+    } else {
+        format!("n{i}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quorum_set_satisfaction() {
+        let qs = QuorumSet::new(2, vec![0, 1, 2]);
+        assert!(qs.is_satisfied_by(&NodeSet::from_indices([0, 1])));
+        assert!(qs.is_satisfied_by(&NodeSet::from_indices([0, 1, 2])));
+        assert!(!qs.is_satisfied_by(&NodeSet::from_indices([0])));
+    }
+
+    #[test]
+    fn quorum_set_threshold_clamped() {
+        let qs = QuorumSet::new(5, vec![0, 1]);
+        assert_eq!(qs.threshold, 2);
+    }
+
+    #[test]
+    fn symmetric_is_quorum() {
+        // 3-of-4 symmetric: any 3 nodes form a quorum, any 2 do not.
+        let fbas = Fbas::symmetric(4, 3);
+        assert!(fbas.is_quorum(&NodeSet::from_indices([0, 1, 2])));
+        assert!(fbas.is_quorum(&NodeSet::full(4)));
+        assert!(!fbas.is_quorum(&NodeSet::from_indices([0, 1])));
+        assert!(!fbas.is_quorum(&NodeSet::EMPTY));
+    }
+
+    #[test]
+    fn node_labels() {
+        let fbas = Fbas::symmetric(3, 2);
+        assert_eq!(fbas.nodes[0].id, "A");
+        assert_eq!(fbas.nodes[1].id, "B");
+        assert_eq!(fbas.nodes[2].id, "C");
+    }
+
+    #[test]
+    fn admit_symmetric_grows_threshold() {
+        // Start 3-of-3, admit one -> 3-of-4.
+        let mut fbas = Fbas::symmetric_botho(3);
+        assert_eq!(fbas.nodes[0].quorum_set.threshold, 3);
+        fbas.admit_symmetric();
+        assert_eq!(fbas.len(), 4);
+        assert_eq!(fbas.nodes[0].quorum_set.threshold, 3); // 4 - floor(3/3) = 3
+        assert_eq!(fbas.nodes[3].quorum_set.threshold, 3);
+    }
+
+    #[test]
+    fn shun_reindexes_members() {
+        // 4 nodes, arbitrary slices referencing each other.
+        let mut fbas = Fbas::from_quorum_sets([
+            QuorumSet::new(2, vec![0, 1, 2]),
+            QuorumSet::new(2, vec![1, 2, 3]),
+            QuorumSet::new(2, vec![0, 2, 3]),
+            QuorumSet::new(2, vec![0, 1, 3]),
+        ]);
+        fbas.shun(1); // remove node index 1
+        assert_eq!(fbas.len(), 3);
+        // Old index 2 -> 1, old index 3 -> 2; index 1 dropped.
+        assert_eq!(fbas.nodes[0].quorum_set.members, vec![0, 1]); // was [0,1,2]->[0,_,1]
+    }
+
+    #[test]
+    fn shun_symmetric_shrinks() {
+        let mut fbas = Fbas::symmetric_botho(4); // 3-of-4
+        fbas.shun_symmetric(0);
+        assert_eq!(fbas.len(), 3);
+        assert_eq!(fbas.nodes[0].quorum_set.threshold, 3); // 3-of-3
+    }
+}

--- a/consensus/quorum-sim/src/nodeset.rs
+++ b/consensus/quorum-sim/src/nodeset.rs
@@ -1,0 +1,190 @@
+//! A compact set of node indices backed by a `u32` bitmask.
+//!
+//! Botho's curated federation is small (`N ≤ ~20`), so a single `u32` is more
+//! than enough to address every node and lets us iterate over the `2^N` subsets
+//! by simply counting from `0` to `(1 << n) - 1`.
+
+use core::fmt;
+
+/// Maximum number of nodes addressable by a [`NodeSet`].
+///
+/// Bounded by the `u32` backing store. Brute-force enumeration over `2^N`
+/// subsets is only practical well below this limit; callers should keep
+/// `N ≤ ~20` (the realistic curated-federation size).
+pub const MAX_NODES: usize = 32;
+
+/// A set of node indices, represented as a bitmask over node positions.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct NodeSet(pub u32);
+
+impl NodeSet {
+    /// The empty set.
+    pub const EMPTY: NodeSet = NodeSet(0);
+
+    /// Create an empty set.
+    #[inline]
+    pub const fn new() -> Self {
+        NodeSet(0)
+    }
+
+    /// The full set of `n` nodes (indices `0..n`).
+    #[inline]
+    pub fn full(n: usize) -> Self {
+        debug_assert!(n <= MAX_NODES);
+        if n == 0 {
+            NodeSet(0)
+        } else if n >= 32 {
+            NodeSet(u32::MAX)
+        } else {
+            NodeSet((1u32 << n) - 1)
+        }
+    }
+
+    /// Build a set from an iterator of node indices.
+    pub fn from_indices<I: IntoIterator<Item = usize>>(indices: I) -> Self {
+        let mut s = NodeSet::new();
+        for i in indices {
+            s.insert(i);
+        }
+        s
+    }
+
+    /// Insert a node index.
+    #[inline]
+    pub fn insert(&mut self, idx: usize) {
+        debug_assert!(idx < MAX_NODES);
+        self.0 |= 1u32 << idx;
+    }
+
+    /// Remove a node index.
+    #[inline]
+    pub fn remove(&mut self, idx: usize) {
+        debug_assert!(idx < MAX_NODES);
+        self.0 &= !(1u32 << idx);
+    }
+
+    /// Whether `idx` is a member.
+    #[inline]
+    pub fn contains(&self, idx: usize) -> bool {
+        debug_assert!(idx < MAX_NODES);
+        (self.0 >> idx) & 1 == 1
+    }
+
+    /// Number of members.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.count_ones() as usize
+    }
+
+    /// Whether the set is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
+    /// Set intersection.
+    #[inline]
+    pub fn intersect(&self, other: &NodeSet) -> NodeSet {
+        NodeSet(self.0 & other.0)
+    }
+
+    /// Set union.
+    #[inline]
+    pub fn union(&self, other: &NodeSet) -> NodeSet {
+        NodeSet(self.0 | other.0)
+    }
+
+    /// Set difference (`self \ other`).
+    #[inline]
+    pub fn difference(&self, other: &NodeSet) -> NodeSet {
+        NodeSet(self.0 & !other.0)
+    }
+
+    /// Whether `self` and `other` share any member.
+    #[inline]
+    pub fn intersects(&self, other: &NodeSet) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    /// Whether every member of `self` is also in `other`.
+    #[inline]
+    pub fn is_subset_of(&self, other: &NodeSet) -> bool {
+        self.0 & other.0 == self.0
+    }
+
+    /// Iterate over the member indices in ascending order.
+    pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
+        (0..MAX_NODES).filter(move |&i| self.contains(i))
+    }
+
+    /// Collect members into a `Vec<usize>`.
+    pub fn to_vec(&self) -> Vec<usize> {
+        self.iter().collect()
+    }
+}
+
+impl Default for NodeSet {
+    fn default() -> Self {
+        NodeSet::new()
+    }
+}
+
+impl fmt::Debug for NodeSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        for (n, i) in self.iter().enumerate() {
+            if n > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{i}")?;
+        }
+        write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_ops() {
+        let mut s = NodeSet::new();
+        assert!(s.is_empty());
+        s.insert(0);
+        s.insert(3);
+        assert_eq!(s.len(), 2);
+        assert!(s.contains(0));
+        assert!(s.contains(3));
+        assert!(!s.contains(1));
+        s.remove(0);
+        assert!(!s.contains(0));
+        assert_eq!(s.len(), 1);
+    }
+
+    #[test]
+    fn full_set() {
+        assert_eq!(NodeSet::full(0).len(), 0);
+        assert_eq!(NodeSet::full(4).len(), 4);
+        assert!(NodeSet::full(4).contains(3));
+        assert!(!NodeSet::full(4).contains(4));
+    }
+
+    #[test]
+    fn set_algebra() {
+        let a = NodeSet::from_indices([0, 1]);
+        let b = NodeSet::from_indices([1, 2]);
+        assert_eq!(a.intersect(&b), NodeSet::from_indices([1]));
+        assert_eq!(a.union(&b), NodeSet::from_indices([0, 1, 2]));
+        assert_eq!(a.difference(&b), NodeSet::from_indices([0]));
+        assert!(a.intersects(&b));
+        assert!(!NodeSet::from_indices([0]).intersects(&NodeSet::from_indices([1])));
+        assert!(NodeSet::from_indices([1]).is_subset_of(&a));
+        assert!(!b.is_subset_of(&a));
+    }
+
+    #[test]
+    fn iteration_order() {
+        let s = NodeSet::from_indices([3, 0, 5]);
+        assert_eq!(s.to_vec(), vec![0, 3, 5]);
+    }
+}

--- a/consensus/quorum-sim/src/report.rs
+++ b/consensus/quorum-sim/src/report.rs
@@ -1,0 +1,244 @@
+//! Higher-level reports: threshold-rule comparison and growth/churn timelines,
+//! with human-readable table and JSON (serde) rendering.
+
+use crate::analysis::ThresholdRule;
+use crate::model::Fbas;
+use serde::{Deserialize, Serialize};
+use std::fmt::Write as _;
+
+/// One row of the threshold-rule comparison: a single `(rule, n)` pair.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThresholdComparisonRow {
+    /// Federation size.
+    pub n: usize,
+    /// Which threshold rule.
+    pub rule: ThresholdRule,
+    /// The threshold this rule yields at `n`.
+    pub threshold: usize,
+    /// Min blocking-set cardinality (failures-to-halt; liveness buffer).
+    pub min_blocking_set_cardinality: Option<usize>,
+    /// Min splitting-set cardinality (faults-to-fork; safety buffer).
+    pub min_splitting_set_cardinality: Option<usize>,
+    /// Whether disjoint (non-intersecting) quorums exist (fork risk).
+    pub disjoint_quorums_exist: bool,
+    /// Liveness margin `m − t + 1`, where `m` is the quorum (top-tier) size and
+    /// `t` the threshold: how many of the `m` members may be down while a
+    /// quorum can still form. (`= m − t + 1`; clamps at 0.)
+    pub liveness_margin: usize,
+}
+
+/// Compare the threshold rules over a range of federation sizes.
+///
+/// For each `n` in `sizes` and each rule, build the symmetric `t`-of-`n` FBAS
+/// and record its static-health metrics.
+pub fn compare_thresholds(sizes: impl IntoIterator<Item = usize>) -> Vec<ThresholdComparisonRow> {
+    let rules = [
+        ThresholdRule::BothoBft,
+        ThresholdRule::TwoThirds,
+        ThresholdRule::Unanimity,
+    ];
+    let mut rows = Vec::new();
+    for n in sizes {
+        for rule in rules {
+            let t = rule.threshold(n);
+            let fbas = Fbas::symmetric(n, t);
+            let report = fbas.health_report();
+            // For a symmetric top-tier the quorum is the whole tier (size n),
+            // so the liveness margin is n − t + 1.
+            let liveness_margin = (n + 1).saturating_sub(t);
+            rows.push(ThresholdComparisonRow {
+                n,
+                rule,
+                threshold: t,
+                min_blocking_set_cardinality: report.min_blocking_set_cardinality,
+                min_splitting_set_cardinality: report.min_splitting_set_cardinality,
+                disjoint_quorums_exist: !report.quorum_intersection,
+                liveness_margin,
+            });
+        }
+    }
+    rows
+}
+
+/// Render the threshold comparison as a human-readable table.
+pub fn render_threshold_table(rows: &[ThresholdComparisonRow]) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{:>3}  {:<30} {:>5} {:>10} {:>10} {:>8} {:>9}",
+        "n", "rule", "thr", "blocking", "splitting", "disjoint", "live_marg"
+    );
+    let _ = writeln!(out, "{}", "-".repeat(82));
+    let mut last_n = None;
+    for r in rows {
+        if last_n.is_some() && last_n != Some(r.n) {
+            let _ = writeln!(out);
+        }
+        last_n = Some(r.n);
+        let _ = writeln!(
+            out,
+            "{:>3}  {:<30} {:>5} {:>10} {:>10} {:>8} {:>9}",
+            r.n,
+            r.rule.label(),
+            r.threshold,
+            opt(r.min_blocking_set_cardinality),
+            opt(r.min_splitting_set_cardinality),
+            if r.disjoint_quorums_exist {
+                "YES(fork)"
+            } else {
+                "no"
+            },
+            r.liveness_margin,
+        );
+    }
+    out
+}
+
+/// One step in a growth/churn timeline.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChurnStep {
+    /// What happened at this step (e.g. "admit C", "shun A", "initial").
+    pub action: String,
+    /// Federation size after the action.
+    pub n: usize,
+    /// Min blocking-set cardinality after the action.
+    pub min_blocking_set_cardinality: Option<usize>,
+    /// Min splitting-set cardinality after the action.
+    pub min_splitting_set_cardinality: Option<usize>,
+    /// Whether quorum intersection still holds.
+    pub quorum_intersection: bool,
+    /// Set `true` when this action *broke* quorum intersection (was holding
+    /// before, no longer holds after) — a hard safety regression.
+    pub broke_quorum_intersection: bool,
+}
+
+/// Simulate a sequence of curated admissions / reactive-shuns over a symmetric
+/// federation, recording how the safety/liveness buffers evolve and flagging
+/// any action that breaks quorum intersection.
+///
+/// `actions` is a list of [`ChurnAction`]s applied in order, starting from a
+/// symmetric Botho-BFT federation of size `initial_n`.
+pub fn simulate_churn(initial_n: usize, actions: &[ChurnAction]) -> Vec<ChurnStep> {
+    let mut fbas = Fbas::symmetric_botho(initial_n);
+    let mut steps = Vec::new();
+
+    let record = |action: String, fbas: &Fbas, prev_qi: bool| -> ChurnStep {
+        let report = fbas.health_report();
+        let qi = report.quorum_intersection;
+        ChurnStep {
+            action,
+            n: fbas.len(),
+            min_blocking_set_cardinality: report.min_blocking_set_cardinality,
+            min_splitting_set_cardinality: report.min_splitting_set_cardinality,
+            quorum_intersection: qi,
+            broke_quorum_intersection: prev_qi && !qi,
+        }
+    };
+
+    let mut prev_qi = fbas.health_report().quorum_intersection;
+    steps.push(record("initial".to_string(), &fbas, prev_qi));
+    prev_qi = steps.last().unwrap().quorum_intersection;
+
+    for action in actions {
+        let label = match action {
+            ChurnAction::AdmitSymmetric => {
+                let idx = fbas.admit_symmetric();
+                format!("admit {}", fbas.nodes[idx].id)
+            }
+            ChurnAction::ShunSymmetric(idx) => {
+                let id = fbas
+                    .nodes
+                    .get(*idx)
+                    .map(|n| n.id.clone())
+                    .unwrap_or_else(|| format!("#{idx}"));
+                fbas.shun_symmetric(*idx);
+                format!("shun {id}")
+            }
+        };
+        let step = record(label, &fbas, prev_qi);
+        prev_qi = step.quorum_intersection;
+        steps.push(step);
+    }
+    steps
+}
+
+/// A curated growth/churn action over a symmetric federation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ChurnAction {
+    /// Admit one validator (re-derives the symmetric Botho-BFT threshold).
+    AdmitSymmetric,
+    /// Reactively shun the node at the given index.
+    ShunSymmetric(usize),
+}
+
+/// Render a churn timeline as a human-readable table.
+pub fn render_churn_table(steps: &[ChurnStep]) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{:<14} {:>3} {:>10} {:>10} {:>7} {:>8}",
+        "action", "n", "blocking", "splitting", "qi", "flag"
+    );
+    let _ = writeln!(out, "{}", "-".repeat(56));
+    for s in steps {
+        let _ = writeln!(
+            out,
+            "{:<14} {:>3} {:>10} {:>10} {:>7} {:>8}",
+            s.action,
+            s.n,
+            opt(s.min_blocking_set_cardinality),
+            opt(s.min_splitting_set_cardinality),
+            if s.quorum_intersection { "ok" } else { "BROKEN" },
+            if s.broke_quorum_intersection {
+                "FORK!"
+            } else {
+                ""
+            },
+        );
+    }
+    out
+}
+
+fn opt(v: Option<usize>) -> String {
+    match v {
+        Some(x) => x.to_string(),
+        None => "-".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn threshold_comparison_flags_unanimity_below_4() {
+        let rows = compare_thresholds(2..=4);
+        // Botho rule at n=3 is unanimity -> min blocking 1.
+        let r = rows
+            .iter()
+            .find(|r| r.n == 3 && r.rule == ThresholdRule::BothoBft)
+            .unwrap();
+        assert_eq!(r.threshold, 3);
+        assert_eq!(r.min_blocking_set_cardinality, Some(1));
+        assert!(!r.disjoint_quorums_exist);
+    }
+
+    #[test]
+    fn churn_grows_buffers() {
+        // 3 -> admit -> 4: blocking buffer goes 1 -> 2.
+        let steps = simulate_churn(3, &[ChurnAction::AdmitSymmetric]);
+        assert_eq!(steps[0].min_blocking_set_cardinality, Some(1)); // 3-of-3
+        assert_eq!(steps[1].min_blocking_set_cardinality, Some(2)); // 3-of-4
+        assert!(steps.iter().all(|s| !s.broke_quorum_intersection));
+    }
+
+    #[test]
+    fn render_smoke() {
+        let rows = compare_thresholds(2..=5);
+        let table = render_threshold_table(&rows);
+        assert!(table.contains("botho_bft"));
+        let steps = simulate_churn(4, &[ChurnAction::ShunSymmetric(0)]);
+        let t = render_churn_table(&steps);
+        assert!(t.contains("shun"));
+    }
+}

--- a/consensus/quorum-sim/src/report.rs
+++ b/consensus/quorum-sim/src/report.rs
@@ -1,8 +1,7 @@
 //! Higher-level reports: threshold-rule comparison and growth/churn timelines,
 //! with human-readable table and JSON (serde) rendering.
 
-use crate::analysis::ThresholdRule;
-use crate::model::Fbas;
+use crate::{analysis::ThresholdRule, model::Fbas};
 use serde::{Deserialize, Serialize};
 use std::fmt::Write as _;
 
@@ -188,7 +187,11 @@ pub fn render_churn_table(steps: &[ChurnStep]) -> String {
             s.n,
             opt(s.min_blocking_set_cardinality),
             opt(s.min_splitting_set_cardinality),
-            if s.quorum_intersection { "ok" } else { "BROKEN" },
+            if s.quorum_intersection {
+                "ok"
+            } else {
+                "BROKEN"
+            },
             if s.broke_quorum_intersection {
                 "FORK!"
             } else {

--- a/consensus/quorum-sim/src/thresholds.rs
+++ b/consensus/quorum-sim/src/thresholds.rs
@@ -1,0 +1,105 @@
+//! Threshold rules under comparison.
+//!
+//! These three rules map a federation size `n` to a quorum threshold `t`
+//! (the number of nodes, including self, required to form a quorum in a
+//! symmetric top-tier construction).
+
+/// Botho's current BFT quorum threshold: `t = n − floor((n−1)/3)`.
+///
+/// This is exactly `QuorumConfig::effective_threshold` in
+/// `botho/src/config.rs` under `FaultModel::Bft`, expressed in terms of the
+/// total node count `n` (the config takes `connected_count = n − 1`).
+///
+/// Notable values: n=1→1, n=2→2, n=3→3 (unanimity below 4), n=4→3, n=5→4,
+/// n=6→5, n=7→5.
+pub fn botho_bft_threshold(n: usize) -> usize {
+    if n == 0 {
+        return 0;
+    }
+    let f = (n - 1) / 3;
+    n - f
+}
+
+/// The classic `ceil(0.67·n)` two-thirds supermajority threshold.
+///
+/// Computed in integer arithmetic as `ceil(2n/3) = (2n + 2) / 3` to avoid
+/// floating point. Notable values: n=1→1, n=2→2, n=3→2, n=4→3, n=5→4, n=6→4,
+/// n=7→5.
+pub fn two_thirds_threshold(n: usize) -> usize {
+    // ceil(2n/3), in integer arithmetic.
+    (2 * n).div_ceil(3)
+}
+
+/// Unanimity: every node must agree (`t = n`).
+pub fn unanimity_threshold(n: usize) -> usize {
+    n
+}
+
+/// Maximum number of faulty nodes a `t`-of-`n` symmetric quorum can tolerate
+/// while keeping safety, under the standard `n ≥ 3f + 1` / `t ≥ 2f + 1`
+/// reading: the largest `f` with `t ≥ 2f + 1` **and** `n ≥ 3f + 1`.
+///
+/// This is a convenience for the threshold comparison report; the authoritative
+/// fault tolerance for an arbitrary FBAS comes from the minimal blocking /
+/// splitting set cardinalities in [`crate::analysis`].
+pub fn supermajority_fault_tolerance(n: usize, t: usize) -> usize {
+    let mut f = 0;
+    loop {
+        let next = f + 1;
+        // Safety needs t >= 2f+1; the 3f+1 reading needs n >= 3f+1.
+        // (Written with `>` to satisfy clippy::int_plus_one.)
+        if t > 2 * next && n > 3 * next {
+            f = next;
+        } else {
+            break;
+        }
+    }
+    f
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn botho_matches_config_table() {
+        // Mirror of test_quorum_effective_threshold_bft in botho/src/config.rs,
+        // expressed in total-node terms (config uses connected_count = n - 1).
+        assert_eq!(botho_bft_threshold(1), 1); // n=1: 1-of-1
+        assert_eq!(botho_bft_threshold(2), 2); // n=2: 2-of-2
+        assert_eq!(botho_bft_threshold(3), 3); // n=3: 3-of-3
+        assert_eq!(botho_bft_threshold(4), 3); // n=4: 3-of-4
+        assert_eq!(botho_bft_threshold(5), 4); // n=5: 4-of-5
+        assert_eq!(botho_bft_threshold(6), 5); // n=6: 5-of-6
+    }
+
+    #[test]
+    fn botho_degenerates_to_unanimity_below_4() {
+        for n in 1..=3 {
+            assert_eq!(
+                botho_bft_threshold(n),
+                unanimity_threshold(n),
+                "n={n} should be unanimous"
+            );
+        }
+        assert_ne!(botho_bft_threshold(4), unanimity_threshold(4));
+    }
+
+    #[test]
+    fn two_thirds_ceiling() {
+        assert_eq!(two_thirds_threshold(1), 1);
+        assert_eq!(two_thirds_threshold(2), 2); // ceil(4/3) = 2
+        assert_eq!(two_thirds_threshold(3), 2); // ceil(6/3) = 2
+        assert_eq!(two_thirds_threshold(4), 3); // ceil(8/3) = 3
+        assert_eq!(two_thirds_threshold(6), 4); // ceil(12/3) = 4
+        assert_eq!(two_thirds_threshold(9), 6); // ceil(18/3) = 6
+    }
+
+    #[test]
+    fn fault_tolerance_needs_four_nodes() {
+        // ceil(0.67n): f=1 tolerance requires n>=4.
+        assert_eq!(supermajority_fault_tolerance(3, two_thirds_threshold(3)), 0);
+        assert_eq!(supermajority_fault_tolerance(4, two_thirds_threshold(4)), 1);
+        assert_eq!(supermajority_fault_tolerance(7, two_thirds_threshold(7)), 2);
+    }
+}

--- a/consensus/quorum-sim/tests/correctness.rs
+++ b/consensus/quorum-sim/tests/correctness.rs
@@ -3,10 +3,10 @@
 //! These are the acceptance bar for issue #511. Each asserts a known FBAS /
 //! threshold result that the analyzer must reproduce.
 
-use bth_quorum_sim::model::Fbas;
-use bth_quorum_sim::nodeset::NodeSet;
-use bth_quorum_sim::thresholds::{
-    botho_bft_threshold, supermajority_fault_tolerance, two_thirds_threshold,
+use bth_quorum_sim::{
+    model::Fbas,
+    nodeset::NodeSet,
+    thresholds::{botho_bft_threshold, supermajority_fault_tolerance, two_thirds_threshold},
 };
 
 /// #510: Botho's current formula degenerates to unanimity at n ≤ 3, so the
@@ -39,8 +39,14 @@ fn current_formula_unanimous_below_4_blocking_one() {
 #[test]
 fn two_of_four_disjoint_quorums_no_intersection() {
     let fbas = Fbas::symmetric(4, 2);
-    assert!(fbas.is_quorum(&NodeSet::from_indices([0, 1])), "{{A,B}} quorum");
-    assert!(fbas.is_quorum(&NodeSet::from_indices([2, 3])), "{{C,D}} quorum");
+    assert!(
+        fbas.is_quorum(&NodeSet::from_indices([0, 1])),
+        "{{A,B}} quorum"
+    );
+    assert!(
+        fbas.is_quorum(&NodeSet::from_indices([2, 3])),
+        "{{C,D}} quorum"
+    );
     assert!(
         !fbas.has_quorum_intersection(),
         "2-of-4 must NOT have quorum intersection (disjoint {{A,B}}/{{C,D}})"

--- a/consensus/quorum-sim/tests/correctness.rs
+++ b/consensus/quorum-sim/tests/correctness.rs
@@ -1,0 +1,127 @@
+//! Mandatory correctness tests encoding the verified #510 research.
+//!
+//! These are the acceptance bar for issue #511. Each asserts a known FBAS /
+//! threshold result that the analyzer must reproduce.
+
+use bth_quorum_sim::model::Fbas;
+use bth_quorum_sim::nodeset::NodeSet;
+use bth_quorum_sim::thresholds::{
+    botho_bft_threshold, supermajority_fault_tolerance, two_thirds_threshold,
+};
+
+/// #510: Botho's current formula degenerates to unanimity at n ≤ 3, so the
+/// minimal blocking-set cardinality is 1 (any single node halts the network →
+/// zero crash-fault tolerance).
+#[test]
+fn current_formula_unanimous_below_4_blocking_one() {
+    for n in 1..=3 {
+        let fbas = Fbas::symmetric_botho(n);
+        let report = fbas.health_report();
+        assert_eq!(
+            report.min_blocking_set_cardinality,
+            Some(1),
+            "n={n}: Botho rule should be unanimous → min blocking set = 1"
+        );
+        // And it really is unanimity:
+        assert_eq!(fbas.nodes[0].quorum_set.threshold, n);
+    }
+    // n=4 is the first non-degenerate case (3-of-4): blocking buffer = 2.
+    let fbas4 = Fbas::symmetric_botho(4);
+    assert_eq!(
+        fbas4.health_report().min_blocking_set_cardinality,
+        Some(2),
+        "n=4 (3-of-4) should tolerate 1 crash → min blocking set = 2"
+    );
+}
+
+/// #510: a 2-of-4 threshold admits disjoint quorums {A,B} and {C,D}, so
+/// quorum_intersection() must be FALSE (a fork is possible).
+#[test]
+fn two_of_four_disjoint_quorums_no_intersection() {
+    let fbas = Fbas::symmetric(4, 2);
+    assert!(fbas.is_quorum(&NodeSet::from_indices([0, 1])), "{{A,B}} quorum");
+    assert!(fbas.is_quorum(&NodeSet::from_indices([2, 3])), "{{C,D}} quorum");
+    assert!(
+        !fbas.has_quorum_intersection(),
+        "2-of-4 must NOT have quorum intersection (disjoint {{A,B}}/{{C,D}})"
+    );
+    // The empty intersection also surfaces as a zero-cardinality splitting set.
+    assert_eq!(
+        fbas.health_report().min_splitting_set_cardinality,
+        Some(0),
+        "no quorum intersection → empty splitting set (cardinality 0)"
+    );
+}
+
+/// #510: under ceil(0.67·n), tolerating f=1 requires n ≥ 4, and the liveness
+/// margin m − t + 1 matches expectation (m = n for the symmetric top tier).
+#[test]
+fn two_thirds_f1_requires_n_at_least_4() {
+    // f=1 tolerance only from n=4 up.
+    assert_eq!(supermajority_fault_tolerance(3, two_thirds_threshold(3)), 0);
+    assert_eq!(supermajority_fault_tolerance(4, two_thirds_threshold(4)), 1);
+
+    // Liveness margin m - t + 1 for the symmetric tier (m = n).
+    // n=4, t = ceil(8/3) = 3  ->  margin = 4 - 3 + 1 = 2.
+    let (n, t) = (4usize, two_thirds_threshold(4));
+    assert_eq!(t, 3);
+    let margin = n - t + 1;
+    assert_eq!(margin, 2, "n=4 two-thirds liveness margin");
+
+    // The margin equals (min blocking cardinality) for a symmetric tier:
+    // blocking needs to drop survivors below t, i.e. remove n - t + 1 nodes.
+    let fbas = Fbas::symmetric(n, t);
+    assert_eq!(
+        fbas.health_report().min_blocking_set_cardinality,
+        Some(margin),
+        "min blocking cardinality should equal the liveness margin"
+    );
+}
+
+/// #510: with fewer than 4 distinct entities, real fault tolerance is
+/// effectively 1 (min blocking-set cardinality 1 → zero genuine tolerance)
+/// across every threshold rule (since the strongest non-trivial threshold at
+/// n=3 is still unanimity-or-weaker and cannot reach 3f+1 with f≥1).
+#[test]
+fn fewer_than_four_entities_have_no_real_tolerance() {
+    for n in 2..=3 {
+        // Botho rule (unanimity here).
+        let botho = Fbas::symmetric(n, botho_bft_threshold(n));
+        assert_eq!(
+            botho.health_report().min_blocking_set_cardinality,
+            Some(1),
+            "n={n} botho rule: blocking cardinality 1 (no real tolerance)"
+        );
+        // No threshold choice at n<4 yields f>=1 fault tolerance.
+        for t in 1..=n {
+            assert_eq!(
+                supermajority_fault_tolerance(n, t),
+                0,
+                "n={n}, t={t}: cannot tolerate a fault below 4 entities"
+            );
+        }
+    }
+}
+
+/// Cross-check fbas_analyzer semantics: in a symmetric top-tier federation, the
+/// minimal blocking and splitting sets consist exclusively of top-tier nodes.
+#[test]
+fn minimal_sets_are_top_tier_nodes() {
+    let fbas = Fbas::symmetric_botho(7); // 5-of-7
+    let report = fbas.health_report();
+    for s in &report.minimal_blocking_sets {
+        assert!(
+            s.iter().all(|&i| i < 7),
+            "blocking set should be top-tier nodes"
+        );
+    }
+    for s in &report.minimal_splitting_sets {
+        assert!(
+            s.iter().all(|&i| i < 7),
+            "splitting set should be top-tier nodes"
+        );
+    }
+    // 5-of-7 has quorum intersection and a healthy buffer.
+    assert!(report.quorum_intersection);
+    assert_eq!(report.min_blocking_set_cardinality, Some(3)); // remove 3 -> 4<5
+}


### PR DESCRIPTION
Closes #511. Deliverable 2 of #510, scoped to Path A (curated validator federation + thin clients; see #427).

## What v1 covers

New crate `consensus/quorum-sim/` (`bth-quorum-sim`), added to the workspace members, with a `quorum-sim` CLI. A static, Botho-grounded re-implementation of the `fbas_analyzer` metric set, tied to Botho's threshold rule `effective_threshold = n − floor((n−1)/3)` (`botho/src/config.rs`).

Modules:
- **nodeset** — `NodeSet` (u32 bitset) for `N ≤ ~20`; lets us brute-force over `2^N` subsets exactly.
- **model** — `Fbas`/`Node`/`QuorumSet`; symmetric top-tier construction (`symmetric_botho` ties to the config formula) AND arbitrary per-node slices; `is_quorum`; curated `admit`/`admit_symmetric` and reactive `shun`/`shun_symmetric` growth dynamics.
- **analysis** — `has_quorum_intersection` (fork check), `minimal_quorums`, `minimal_blocking_sets` (liveness buffer), `minimal_splitting_sets` (safety buffer); serde `HealthReport`.
- **thresholds** — `botho_bft` vs `ceil(0.67·n)` vs `unanimity`, plus supermajority fault tolerance.
- **report** — threshold-rule comparison (N=2..12) and admission/shun churn timeline; human-readable tables + JSON; flags any add/remove that breaks quorum intersection.
- **bin/quorum-sim** — `compare` / `analyze` / `churn` subcommands, all with `--json`.

## Mandatory #510 correctness tests (`tests/correctness.rs`) — all pass

- Current formula degenerates to unanimity at n≤3 → min blocking-set cardinality == 1.
- 2-of-4 admits disjoint quorums {A,B}/{C,D} → `quorum_intersection() == false`.
- `ceil(0.67·n)`: f=1 tolerance requires n≥4; liveness margin `m−t+1` verified.
- <4 distinct entities → no real fault tolerance (blocking cardinality 1).
- Cross-check against `fbas_analyzer` semantics: minimal blocking/splitting sets are top-tier nodes.

## Test results

`cargo test -p bth-quorum-sim`: **29 passed, 0 failed** (24 unit + 5 correctness). `cargo clippy -p bth-quorum-sim --all-targets` clean.

## Explicitly out of scope (deferred follow-up)

- The dynamic **message-level SCP round simulator** with Byzantine/equivocation fault injection for empirical fork/stall detection under partial synchrony.
- Explicit leader-election (SCP-native vs VRF) modelling — pending the proposer-model decision in #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)