### PR TITLE
feat(consensus): warn + expose flag when recommended quorum has < 4 nodes

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -335,6 +335,19 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     println!("Quorum mode: {}", mode_str);
     println!("Quorum status: {}", quorum_message);
 
+    // Loudly warn when a `recommended`-mode cluster is below the BFT bound
+    // (< 4 participating nodes => degenerate n-of-n quorum, zero fault
+    // tolerance). The node count includes self (#509). We do NOT block startup;
+    // small clusters remain supported, just flagged.
+    let participating_nodes = connected_peers.len() + 1;
+    if let Some(warning) = config
+        .network
+        .quorum
+        .degenerate_quorum_warning(participating_nodes)
+    {
+        warn!("{}", warning);
+    }
+
     // Build QuorumBuilder for SCP (still needed for consensus service)
     let mut quorum = QuorumBuilder::new(config.network.quorum.threshold);
     for peer in discovery.peer_table() {
@@ -368,7 +381,8 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
         node.wallet_spend_key(),
         config.network.cors_origins.clone(),
         ws_broadcaster.clone(),
-    );
+    )
+    .with_quorum(config.network.quorum.clone());
 
     // Initialize wallet for RPC (balance checking, faucet, etc.)
     if let Some(mnemonic) = config.mnemonic() {

--- a/botho/src/config.rs
+++ b/botho/src/config.rs
@@ -400,6 +400,64 @@ impl QuorumConfig {
         }
     }
 
+    /// Minimum participating node count required for genuine Byzantine-fault
+    /// tolerance (f >= 1) under the SCP 3f+1 bound.
+    ///
+    /// `3f + 1 <= n` with `f >= 1` requires `n >= 4`. Below this the quorum is
+    /// degenerate (n-of-n or a bare crash-majority) and tolerates *zero*
+    /// Byzantine faults regardless of the configured [`FaultModel`].
+    pub const MIN_BFT_NODES: usize = 4;
+
+    /// Whether a `Recommended`-mode cluster of `node_count` participating nodes
+    /// (including self) is genuinely Byzantine-fault-tolerant.
+    ///
+    /// Returns `true` only when `node_count >= 4` (the hard 3f+1 >= 4 bound for
+    /// f=1) and the node is running in `Recommended` mode. In `Explicit` mode
+    /// the operator owns the threshold/membership decision, so this always
+    /// returns `true` (no auto-derived warning).
+    ///
+    /// Below 4 nodes the auto-derived quorum is degenerate — n=2 -> 2-of-2,
+    /// n=3 -> 3-of-3 under `Bft`, or a bare crash-majority under `Crash` — and
+    /// tolerates no Byzantine (arbitrarily malicious) member. See
+    /// [`Self::is_degenerate_quorum`].
+    pub fn is_bft_fault_tolerant(&self, node_count: usize) -> bool {
+        match self.mode {
+            QuorumMode::Explicit => true,
+            QuorumMode::Recommended => node_count >= Self::MIN_BFT_NODES,
+        }
+    }
+
+    /// Whether a `Recommended`-mode cluster of `node_count` participating nodes
+    /// (including self) has a *degenerate* quorum that tolerates zero Byzantine
+    /// faults (`node_count < 4`).
+    ///
+    /// This is the inverse of [`Self::is_bft_fault_tolerant`]: it is `true`
+    /// only in `Recommended` mode with fewer than [`Self::MIN_BFT_NODES`]
+    /// nodes.
+    pub fn is_degenerate_quorum(&self, node_count: usize) -> bool {
+        matches!(self.mode, QuorumMode::Recommended) && node_count < Self::MIN_BFT_NODES
+    }
+
+    /// Build the loud operator warning for a degenerate `Recommended`-mode
+    /// quorum, or `None` when the cluster is BFT (>= 4 nodes) or in `Explicit`
+    /// mode.
+    ///
+    /// The wording is deliberately honest (#509 research, #510 Thread A): below
+    /// 4 nodes the cluster is **not Byzantine-fault-tolerant at all** — it
+    /// tolerates *zero* node failures (a degenerate n-of-n quorum), not merely
+    /// "degraded". `3f + 1 >= 4` is a hard bound for f=1.
+    pub fn degenerate_quorum_warning(&self, node_count: usize) -> Option<String> {
+        if !self.is_degenerate_quorum(node_count) {
+            return None;
+        }
+        Some(format!(
+            "WARNING: {node_count}-node cluster in recommended mode is NOT \
+             Byzantine-fault-tolerant — it tolerates ZERO node failures \
+             (degenerate {node_count}-of-{node_count} quorum, crash-stop only, \
+             not BFT). Add a 4th independent operator for f=1 BFT (3f+1>=4)."
+        ))
+    }
+
     /// Check if we can reach quorum with the given connected peers
     /// Returns (can_mine, quorum_size, threshold)
     pub fn can_reach_quorum(&self, connected_peer_ids: &[String]) -> (bool, usize, usize) {
@@ -914,6 +972,87 @@ mod tests {
         assert_eq!(quorum.effective_threshold(3), 3); // n=4: 3-of-4
         assert_eq!(quorum.effective_threshold(4), 4); // n=5: 4-of-5
         assert_eq!(quorum.effective_threshold(5), 5); // n=6: 5-of-6
+    }
+
+    #[test]
+    fn test_quorum_degenerate_below_four_recommended() {
+        // Recommended mode (default): below 4 participating nodes the quorum is
+        // degenerate (zero Byzantine-fault tolerance); >= 4 is genuinely BFT.
+        let quorum = QuorumConfig::default();
+        assert_eq!(quorum.mode, QuorumMode::Recommended);
+
+        for n in 1..=3 {
+            assert!(
+                quorum.is_degenerate_quorum(n),
+                "n={n} must be flagged degenerate in recommended mode"
+            );
+            assert!(
+                !quorum.is_bft_fault_tolerant(n),
+                "n={n} must NOT be BFT in recommended mode"
+            );
+        }
+        for n in 4..=8 {
+            assert!(
+                !quorum.is_degenerate_quorum(n),
+                "n={n} must NOT be flagged degenerate (>= 4 is BFT)"
+            );
+            assert!(
+                quorum.is_bft_fault_tolerant(n),
+                "n={n} must be BFT in recommended mode (3f+1 >= 4)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_quorum_degenerate_warning_fires_below_four() {
+        let quorum = QuorumConfig::default();
+
+        // n < 4 -> loud, honest warning naming the n-of-n quorum and BFT bound.
+        for n in 2..=3 {
+            let warning = quorum
+                .degenerate_quorum_warning(n)
+                .unwrap_or_else(|| panic!("expected warning at n={n}"));
+            assert!(warning.contains("NOT"), "warning must be loud: {warning}");
+            assert!(
+                warning.contains("Byzantine-fault-tolerant"),
+                "warning must be honest about BFT: {warning}"
+            );
+            assert!(
+                warning.contains("ZERO"),
+                "warning must state zero fault tolerance: {warning}"
+            );
+            assert!(
+                warning.contains(&format!("{n}-of-{n}")),
+                "warning must name the degenerate n-of-n quorum: {warning}"
+            );
+        }
+
+        // n >= 4 -> no warning (genuine BFT).
+        for n in 4..=6 {
+            assert!(
+                quorum.degenerate_quorum_warning(n).is_none(),
+                "no warning expected at n={n}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_quorum_degenerate_explicit_mode_never_warns() {
+        // Explicit mode: operator owns the threshold/membership, so no
+        // auto-derived degenerate-quorum warning regardless of node count.
+        let quorum = QuorumConfig {
+            mode: QuorumMode::Explicit,
+            fault_model: FaultModel::default(),
+            threshold: 2,
+            members: vec!["peer1".to_string(), "peer2".to_string()],
+            min_peers: 1,
+        };
+
+        for n in 1..=6 {
+            assert!(!quorum.is_degenerate_quorum(n));
+            assert!(quorum.is_bft_fault_tolerant(n));
+            assert!(quorum.degenerate_quorum_warning(n).is_none());
+        }
     }
 
     #[test]

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -67,6 +67,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     address::Address,
+    config::QuorumConfig,
     ledger::Ledger,
     mempool::Mempool,
     transaction::{TxOutput, MIN_TX_FEE},
@@ -160,6 +161,9 @@ pub struct RpcState {
     /// Wallet for signing faucet transactions (None if no wallet or faucet
     /// disabled)
     pub wallet: Option<Arc<Wallet>>,
+    /// Quorum configuration, used to surface Byzantine-fault-tolerance posture
+    /// in `node_getStatus` (#509). Defaults to [`QuorumConfig::default`].
+    pub quorum: QuorumConfig,
 }
 
 impl RpcState {
@@ -190,6 +194,7 @@ impl RpcState {
             rate_limiter: Arc::new(RateLimiter::new()),
             faucet: None,
             wallet: None,
+            quorum: QuorumConfig::default(),
         }
     }
 
@@ -224,6 +229,7 @@ impl RpcState {
             rate_limiter: Arc::new(RateLimiter::new()),
             faucet: None,
             wallet: None,
+            quorum: QuorumConfig::default(),
         }
     }
 
@@ -256,6 +262,7 @@ impl RpcState {
             rate_limiter: Arc::new(rate_limiter),
             faucet: None,
             wallet: None,
+            quorum: QuorumConfig::default(),
         }
     }
 
@@ -269,6 +276,13 @@ impl RpcState {
     /// Set the wallet for balance checking (without faucet)
     pub fn with_wallet(mut self, wallet: Wallet) -> Self {
         self.wallet = Some(Arc::new(wallet));
+        self
+    }
+
+    /// Set the quorum configuration so `node_getStatus` can report the
+    /// cluster's Byzantine-fault-tolerance posture (#509).
+    pub fn with_quorum(mut self, quorum: QuorumConfig) -> Self {
+        self.quorum = quorum;
         self
     }
 }
@@ -765,6 +779,13 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
     // TODO: Wire up actual sync progress from ChainSyncManager
     let sync_progress: f64 = 100.0;
 
+    // Byzantine-fault-tolerance posture (#509). Participating node count
+    // includes self, so n = scp_peers + 1. In `recommended` mode, n < 4 yields
+    // a degenerate quorum that tolerates ZERO faults; >= 4 is genuinely BFT.
+    let participating_nodes = scp_peers + 1;
+    let quorum_fault_tolerant = state.quorum.is_bft_fault_tolerant(participating_nodes);
+    let quorum_degenerate = state.quorum.is_degenerate_quorum(participating_nodes);
+
     JsonRpcResponse::success(
         id,
         json!({
@@ -786,6 +807,11 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
             "mintingActive": minting,
             "mintingThreads": if minting { state.minting_threads } else { 0 },
             "totalTransactions": chain_state.total_tx,
+            // BFT posture: `quorumFaultTolerant` is true only with >= 4
+            // participating nodes in recommended mode (3f+1 >= 4 for f=1);
+            // `quorumDegenerate` flags the n-of-n / zero-fault-tolerance regime.
+            "quorumFaultTolerant": quorum_fault_tolerant,
+            "quorumDegenerate": quorum_degenerate,
         }),
     )
 }
@@ -3006,6 +3032,78 @@ mod tests {
         assert!(arr[0]["error"].is_string());
         assert_eq!(arr[1]["spent"], json!(false));
         assert!(arr[1]["error"].is_string());
+    }
+
+    /// #509: `node_getStatus` must expose the cluster's Byzantine-fault
+    /// tolerance posture. In `recommended` mode a cluster with < 4
+    /// participating nodes (self + scpPeerCount) is degenerate (zero fault
+    /// tolerance); >= 4 nodes is genuinely BFT.
+    #[tokio::test]
+    async fn test_node_status_reports_quorum_fault_tolerance() {
+        use crate::{ledger::Ledger, mempool::Mempool};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        let state = RpcState::new(
+            ledger,
+            Mempool::new(),
+            Network::Testnet,
+            None,
+            None,
+            vec![],
+            Arc::new(WsBroadcaster::new(16)),
+        );
+        // Default quorum config is recommended mode.
+
+        // 2 SCP peers -> n = 3 -> degenerate, not fault tolerant.
+        *state.scp_peer_count.write().unwrap() = 2;
+        let resp = handle_node_status(json!(1), &state).await;
+        let result = resp.result.unwrap();
+        assert_eq!(result["scpPeerCount"], json!(2));
+        assert_eq!(result["quorumDegenerate"], json!(true));
+        assert_eq!(result["quorumFaultTolerant"], json!(false));
+
+        // 3 SCP peers -> n = 4 -> BFT, not degenerate.
+        *state.scp_peer_count.write().unwrap() = 3;
+        let resp = handle_node_status(json!(1), &state).await;
+        let result = resp.result.unwrap();
+        assert_eq!(result["scpPeerCount"], json!(3));
+        assert_eq!(result["quorumDegenerate"], json!(false));
+        assert_eq!(result["quorumFaultTolerant"], json!(true));
+    }
+
+    /// #509: in `explicit` mode the operator owns the threshold/membership, so
+    /// the status payload never flags a degenerate quorum regardless of peers.
+    #[tokio::test]
+    async fn test_node_status_explicit_mode_not_flagged() {
+        use crate::{
+            config::{QuorumConfig, QuorumMode},
+            ledger::Ledger,
+            mempool::Mempool,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        let state = RpcState::new(
+            ledger,
+            Mempool::new(),
+            Network::Testnet,
+            None,
+            None,
+            vec![],
+            Arc::new(WsBroadcaster::new(16)),
+        )
+        .with_quorum(QuorumConfig {
+            mode: QuorumMode::Explicit,
+            ..QuorumConfig::default()
+        });
+
+        // Even a lone node in explicit mode is not flagged degenerate.
+        *state.scp_peer_count.write().unwrap() = 0;
+        let resp = handle_node_status(json!(1), &state).await;
+        let result = resp.result.unwrap();
+        assert_eq!(result["quorumDegenerate"], json!(false));
+        assert_eq!(result["quorumFaultTolerant"], json!(true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
In `recommended` quorum mode, a cluster with fewer than 4 participating nodes forms a degenerate quorum (n=2 → 2-of-2, n=3 → 3-of-3 under BFT, or a bare crash-majority under Crash) that tolerates **zero** Byzantine faults. The SCP `3f+1 ≥ 4` bound for f=1 is hard. This PR surfaces that honestly: a loud startup warning and a `node_getStatus` flag. It does **not** block startup — small clusters remain supported, just loudly flagged. Maintainer decision on #427 Finding 1; honest wording per #510 Thread A.

## Changes
- `botho/src/config.rs`: add `QuorumConfig::{is_bft_fault_tolerant, is_degenerate_quorum, degenerate_quorum_warning}` and `MIN_BFT_NODES = 4`. In `Explicit` mode these never flag (operator owns the threshold). Node count includes self (`n = peers + 1`).
- `botho/src/commands/run.rs`: emit a `warn!()` at startup when `connected_peers + 1 < 4` in recommended mode.
- `botho/src/rpc/mod.rs`: `node_getStatus` now returns `quorumFaultTolerant` and `quorumDegenerate` (computed from `scpPeerCount + 1`). `RpcState` gains a `quorum` field + `with_quorum()` builder; wired up in `run.rs`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Loud startup warning fires for n < 4 in recommended mode | ✅ | `warn!()` in `run.rs`; wording asserted in `test_quorum_degenerate_warning_fires_below_four` |
| No warning at n >= 4 | ✅ | `degenerate_quorum_warning` returns `None`; asserted for n=4..6 |
| Honest wording (not BFT / zero faults / crash-stop only) | ✅ | String asserts contain `NOT`, `Byzantine-fault-tolerant`, `ZERO`, `n-of-n` |
| Status payload exposes the flag | ✅ | `quorumFaultTolerant`/`quorumDegenerate`; `test_node_status_reports_quorum_fault_tolerance` |
| Does NOT block startup / refuse quorum | ✅ | Only a `warn!()` log line; no early return added |
| Consistent with existing `test_quorum_effective_threshold_*` | ✅ | New tests live alongside them in `config::tests` |

## Test Plan
- `cargo test -p botho --lib config::` → 46 passed, 0 failed (incl. 3 new degenerate-quorum tests)
- `cargo test -p botho --lib rpc::tests::test_node_status` → 2 passed, 0 failed
- `cargo build -p botho --bin botho` → ok
- `cargo fmt --check` (pinned nightly-2025-12-03) → clean
- `cargo clippy -p botho --lib` → no errors (pre-existing warnings only)

Closes #509