### PR TITLE
feat(rpc): node_getIdentity — stable, verifiable node identity (#500)

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -28,13 +28,14 @@ use crate::{
         TransactionValidator,
     },
     network::{
-        BlockTxn, ChainSyncManager, CompactBlock, GetBlockTxn, NetworkDiscovery, NetworkEvent,
-        QuorumBuilder, ReconstructionResult, SyncAction, SyncRequest, SyncResponse,
+        default_seed_domain, BlockTxn, ChainSyncManager, CompactBlock, GetBlockTxn,
+        NetworkDiscovery, NetworkEvent, QuorumBuilder, ReconstructionResult, SyncAction,
+        SyncRequest, SyncResponse, MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION,
     },
     node::{MintedMintingTx, Node, SharedLedger},
     rpc::{
         calculate_dir_size, init_metrics, start_metrics_server, start_rpc_server, FaucetState,
-        MetricsUpdater, RpcState, WsBroadcaster, DATA_DIR_USAGE_BYTES,
+        MetricsUpdater, NodeIdentity, RpcState, WsBroadcaster, DATA_DIR_USAGE_BYTES,
     },
     transaction::Transaction,
     wallet::Wallet,
@@ -370,6 +371,19 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     let scp_peer_count = Arc::new(RwLock::new(discovery.peer_count()));
     let ws_broadcaster = Arc::new(WsBroadcaster::new(1024));
 
+    // Build the node's stable identity (#500) from the persistent libp2p key
+    // (#439/#440) so `node_getIdentity` exposes a peer ID that survives
+    // restarts, plus the deterministic SCP node-id signing key derived from it.
+    let identity_peer_id = *discovery.local_peer_id();
+    let identity_node_id = peer_id_to_node_id(&identity_peer_id);
+    let node_identity = NodeIdentity {
+        peer_id: identity_peer_id.to_string(),
+        node_id_public_key: hex::encode(AsRef::<[u8]>::as_ref(&identity_node_id.public_key)),
+        protocol_version: PROTOCOL_VERSION.to_string(),
+        min_protocol_version: MIN_SUPPORTED_PROTOCOL_VERSION.to_string(),
+        dns_seed_domain: default_seed_domain(config.network_type).to_string(),
+    };
+
     let mut rpc_state = RpcState::from_shared(
         node.shared_ledger(),
         node.shared_mempool(),
@@ -382,7 +396,8 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
         config.network.cors_origins.clone(),
         ws_broadcaster.clone(),
     )
-    .with_quorum(config.network.quorum.clone());
+    .with_quorum(config.network.quorum.clone())
+    .with_identity(node_identity);
 
     // Initialize wallet for RPC (balance checking, faucet, etc.)
     if let Some(mnemonic) = config.mnemonic() {

--- a/botho/src/network/dns_seeds.rs
+++ b/botho/src/network/dns_seeds.rs
@@ -37,6 +37,20 @@ const MAINNET_DNS_SEED: &str = "seeds.botho.io";
 /// Default DNS seed domain for testnet
 const TESTNET_DNS_SEED: &str = "seeds.testnet.botho.io";
 
+/// Return the default DNS-seed discovery domain for `network`.
+///
+/// This is the namespace queried for bootstrap peers (`seeds.botho.io` on
+/// mainnet, `seeds.testnet.botho.io` on testnet). It is exposed so the node's
+/// identity surface (`node_getIdentity`, #500) can advertise which DNS-seed
+/// namespace it belongs to, letting a thin client cross-check the node against
+/// the expected discovery domain for its network.
+pub fn default_seed_domain(network: Network) -> &'static str {
+    match network {
+        Network::Mainnet => MAINNET_DNS_SEED,
+        Network::Testnet => TESTNET_DNS_SEED,
+    }
+}
+
 /// Minimum cache TTL (prevents hammering DNS)
 const MIN_CACHE_TTL: Duration = Duration::from_secs(60);
 
@@ -84,10 +98,9 @@ impl DnsSeedDiscovery {
 
     /// Get the DNS seed domain for the current network
     fn seed_domain(&self) -> &str {
-        self.custom_domain.as_deref().unwrap_or(match self.network {
-            Network::Mainnet => MAINNET_DNS_SEED,
-            Network::Testnet => TESTNET_DNS_SEED,
-        })
+        self.custom_domain
+            .as_deref()
+            .unwrap_or_else(|| default_seed_domain(self.network))
     }
 
     /// Discover seeds via DNS, with caching and fallback
@@ -378,6 +391,25 @@ mod tests {
 
         let testnet = DnsSeedDiscovery::new(Network::Testnet);
         assert_eq!(testnet.seed_domain(), TESTNET_DNS_SEED);
+    }
+
+    #[test]
+    fn test_default_seed_domain_matches_per_network_constants() {
+        // #500: the public `default_seed_domain` helper (used by the node
+        // identity surface) must agree with the per-network constants and with
+        // the instance method's default-domain behaviour, so the advertised
+        // DNS-seed namespace matches what discovery actually queries.
+        assert_eq!(default_seed_domain(Network::Mainnet), MAINNET_DNS_SEED);
+        assert_eq!(default_seed_domain(Network::Testnet), TESTNET_DNS_SEED);
+
+        assert_eq!(
+            DnsSeedDiscovery::new(Network::Mainnet).seed_domain(),
+            default_seed_domain(Network::Mainnet)
+        );
+        assert_eq!(
+            DnsSeedDiscovery::new(Network::Testnet).seed_domain(),
+            default_seed_domain(Network::Testnet)
+        );
     }
 
     #[test]

--- a/botho/src/network/mod.rs
+++ b/botho/src/network/mod.rs
@@ -34,7 +34,7 @@ pub use discovery::{
 };
 // Re-export rate limit configuration from bth-gossip for network setup
 pub use bth_gossip::{GossipMessageType, MessageTypeLimits, PeerRateLimitConfig};
-pub use dns_seeds::{DnsSeedDiscovery, DnsSeedError};
+pub use dns_seeds::{default_seed_domain, DnsSeedDiscovery, DnsSeedError};
 pub use node_key::load_or_create_keypair;
 pub use pex::{
     PeerSource, PexEntry, PexFilter, PexManager, PexMessage, PexRateLimiter, PexSourceTracker,

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -76,6 +76,38 @@ use crate::{
 use bth_cluster_tax::{FeeConfig, TransactionType};
 use bth_transaction_types::constants::Network;
 
+/// Stable node identity material exposed by `node_getIdentity` (#500, epic
+/// #441 Phase P1).
+///
+/// A thin client (e.g. the mobile app) must be able to verify *which* node it
+/// is talking to before trusting it for the Mode-2 node-selection UX. All
+/// fields here are derived from durable node state — the persistent libp2p
+/// keypair (#439/#440) and the configured [`Network`] — rather than per-restart
+/// ephemeral values, so the identity is stable across restarts.
+///
+/// The fields are pre-computed once at startup (in `commands::run`) and stored
+/// as plain strings so the RPC layer needs no libp2p / SCP types and the
+/// handler stays trivially testable.
+#[derive(Debug, Clone, Default)]
+pub struct NodeIdentity {
+    /// libp2p peer ID derived from the persistent node keypair (#439/#440).
+    /// Stable across restarts; empty only in tests / before the network layer
+    /// has supplied it.
+    pub peer_id: String,
+    /// SCP node-id signing public key (hex), derived deterministically from the
+    /// peer ID via `peer_id_to_node_id`. This is the key the quorum machinery
+    /// identifies the node by.
+    pub node_id_public_key: String,
+    /// Wire protocol version this node speaks (e.g. `"2.0.0"`).
+    pub protocol_version: String,
+    /// Minimum protocol version this node will accept from peers.
+    pub min_protocol_version: String,
+    /// DNS-seed namespace for this node's network (e.g.
+    /// `"seeds.testnet.botho.io"`), so a thin client can cross-check that the
+    /// node belongs to the expected discovery domain.
+    pub dns_seed_domain: String,
+}
+
 /// JSON-RPC request
 #[derive(Debug, Deserialize)]
 pub struct JsonRpcRequest {
@@ -164,6 +196,10 @@ pub struct RpcState {
     /// Quorum configuration, used to surface Byzantine-fault-tolerance posture
     /// in `node_getStatus` (#509). Defaults to [`QuorumConfig::default`].
     pub quorum: QuorumConfig,
+    /// Stable node identity surfaced by `node_getIdentity` (#500). Defaults to
+    /// an empty identity; `commands::run` populates it from the persistent
+    /// node keypair once the network layer is up.
+    pub identity: NodeIdentity,
 }
 
 impl RpcState {
@@ -195,6 +231,7 @@ impl RpcState {
             faucet: None,
             wallet: None,
             quorum: QuorumConfig::default(),
+            identity: NodeIdentity::default(),
         }
     }
 
@@ -230,6 +267,7 @@ impl RpcState {
             faucet: None,
             wallet: None,
             quorum: QuorumConfig::default(),
+            identity: NodeIdentity::default(),
         }
     }
 
@@ -263,6 +301,7 @@ impl RpcState {
             faucet: None,
             wallet: None,
             quorum: QuorumConfig::default(),
+            identity: NodeIdentity::default(),
         }
     }
 
@@ -283,6 +322,12 @@ impl RpcState {
     /// cluster's Byzantine-fault-tolerance posture (#509).
     pub fn with_quorum(mut self, quorum: QuorumConfig) -> Self {
         self.quorum = quorum;
+        self
+    }
+
+    /// Set the stable node identity surfaced by `node_getIdentity` (#500).
+    pub fn with_identity(mut self, identity: NodeIdentity) -> Self {
+        self.identity = identity;
         self
     }
 }
@@ -582,6 +627,7 @@ async fn handle_rpc_method(request: &JsonRpcRequest, state: &RpcState) -> JsonRp
     match request.method.as_str() {
         // Node methods
         "node_getStatus" => handle_node_status(id, state).await,
+        "node_getIdentity" => handle_node_identity(id, state).await,
 
         // Chain methods
         "getChainInfo" => handle_chain_info(id, state).await,
@@ -812,6 +858,59 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
             // `quorumDegenerate` flags the n-of-n / zero-fault-tolerance regime.
             "quorumFaultTolerant": quorum_fault_tolerant,
             "quorumDegenerate": quorum_degenerate,
+        }),
+    )
+}
+
+/// Return the node's stable, verifiable identity (#500, epic #441 Phase P1).
+///
+/// This is the read-only surface a thin client (mobile app) calls to decide
+/// *which* node it is talking to before trusting it for the Mode-2
+/// node-selection UX. Every field is grounded in durable node state:
+///
+/// - `peerId` / `nodeId` come from the persistent libp2p keypair (#439/#440),
+///   so they are stable across restarts (an ephemeral, per-restart peer ID
+///   would let an attacker impersonate a previously-trusted node).
+/// - `network` distinguishes mainnet from testnet so a phone cannot be tricked
+///   into trusting a wrong-network node. It mirrors the `botho-<name>` form
+///   already used by `node_getStatus`.
+/// - `protocolVersion` / `minProtocolVersion` let the client check wire
+///   compatibility before depending on the node.
+/// - `dnsSeedDomain` lets the client cross-check the node against the expected
+///   DNS-seed discovery namespace (`dns_seeds.rs`).
+/// - `chainHeight` / `tipHash` are the current tip so the client can sanity-
+///   check that the node is on the chain it expects.
+///
+/// The response shape is intended to be stable enough for the mobile client to
+/// depend on; new fields may be added but existing ones will not change
+/// meaning.
+async fn handle_node_identity(id: Value, state: &RpcState) -> JsonRpcResponse {
+    let ledger = read_lock!(state.ledger, id.clone());
+    let chain_state = ledger.get_chain_state().unwrap_or_default();
+    drop(ledger);
+
+    let identity = &state.identity;
+
+    JsonRpcResponse::success(
+        id,
+        json!({
+            // Stable identity material (persistent keypair, #439/#440).
+            "peerId": identity.peer_id,
+            "nodeId": identity.node_id_public_key,
+            // Network the node belongs to: "botho-mainnet" / "botho-testnet".
+            "network": format!("botho-{}", state.network_type.name()),
+            // Wire-protocol compatibility window.
+            "protocolVersion": identity.protocol_version,
+            "minProtocolVersion": identity.min_protocol_version,
+            // Node software version + build provenance (mirrors node_getStatus).
+            "nodeVersion": env!("CARGO_PKG_VERSION"),
+            "version": env!("CARGO_PKG_VERSION"),
+            "gitCommit": option_env!("GIT_HASH").unwrap_or("unknown"),
+            // DNS-seed discovery namespace for this network.
+            "dnsSeedDomain": identity.dns_seed_domain,
+            // Current chain tip so the client can confirm the node's chain.
+            "chainHeight": chain_state.height,
+            "tipHash": hex::encode(chain_state.tip_hash),
         }),
     )
 }
@@ -3070,6 +3169,103 @@ mod tests {
         assert_eq!(result["scpPeerCount"], json!(3));
         assert_eq!(result["quorumDegenerate"], json!(false));
         assert_eq!(result["quorumFaultTolerant"], json!(true));
+    }
+
+    /// #500: `node_getIdentity` exposes the node's stable, verifiable identity
+    /// so a thin client can confirm *which* node it is talking to before
+    /// trusting it. Asserts the payload shape and that the configured identity
+    /// material is surfaced verbatim, the network is namespaced as
+    /// `botho-<name>`, and the chain tip is included.
+    #[tokio::test]
+    async fn test_node_identity_returns_expected_fields() {
+        use crate::{ledger::Ledger, mempool::Mempool};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        let identity = NodeIdentity {
+            peer_id: "12D3KooWTestPeerId".to_string(),
+            node_id_public_key: "aa".repeat(32),
+            protocol_version: "2.0.0".to_string(),
+            min_protocol_version: "2.0.0".to_string(),
+            dns_seed_domain: "seeds.testnet.botho.io".to_string(),
+        };
+
+        let state = RpcState::new(
+            ledger,
+            Mempool::new(),
+            Network::Testnet,
+            None,
+            None,
+            vec![],
+            Arc::new(WsBroadcaster::new(16)),
+        )
+        .with_identity(identity);
+
+        let resp = handle_node_identity(json!(1), &state).await;
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+        let result = resp.result.unwrap();
+
+        // Stable identity material is surfaced verbatim.
+        assert_eq!(result["peerId"], json!("12D3KooWTestPeerId"));
+        assert_eq!(result["nodeId"], json!("aa".repeat(32)));
+        assert_eq!(result["protocolVersion"], json!("2.0.0"));
+        assert_eq!(result["minProtocolVersion"], json!("2.0.0"));
+        assert_eq!(result["dnsSeedDomain"], json!("seeds.testnet.botho.io"));
+
+        // Network must be namespaced so a phone cannot trust a wrong-network
+        // node.
+        assert_eq!(result["network"], json!("botho-testnet"));
+
+        // Version + chain tip are present and well-formed.
+        assert_eq!(result["nodeVersion"], json!(env!("CARGO_PKG_VERSION")));
+        assert_eq!(result["version"], json!(env!("CARGO_PKG_VERSION")));
+        // Genesis ledger is at height 0; the tip must match the ledger's actual
+        // chain-state tip (64-char hex), confirming it is grounded in real
+        // node state rather than a fabricated value.
+        let expected = {
+            let ledger = state.ledger.read().unwrap();
+            ledger.get_chain_state().unwrap_or_default()
+        };
+        assert_eq!(result["chainHeight"], json!(expected.height));
+        let tip_hash = result["tipHash"].as_str().unwrap();
+        assert_eq!(tip_hash.len(), 64);
+        assert_eq!(tip_hash, hex::encode(expected.tip_hash));
+
+        // gitCommit is always present (defaults to "unknown" in dev builds).
+        assert!(result["gitCommit"].is_string());
+    }
+
+    /// #500: the default identity (no `with_identity`) yields empty identity
+    /// strings but still produces a well-formed, network-correct payload, so
+    /// the method never panics or omits required keys.
+    #[tokio::test]
+    async fn test_node_identity_defaults_are_well_formed() {
+        use crate::{ledger::Ledger, mempool::Mempool};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        let state = RpcState::new(
+            ledger,
+            Mempool::new(),
+            Network::Mainnet,
+            None,
+            None,
+            vec![],
+            Arc::new(WsBroadcaster::new(16)),
+        );
+
+        let resp = handle_node_identity(json!(1), &state).await;
+        assert!(resp.error.is_none());
+        let result = resp.result.unwrap();
+
+        assert_eq!(result["peerId"], json!(""));
+        assert_eq!(result["nodeId"], json!(""));
+        assert_eq!(result["network"], json!("botho-mainnet"));
+        // Required keys are always present.
+        for key in ["protocolVersion", "minProtocolVersion", "dnsSeedDomain"] {
+            assert!(result.get(key).is_some(), "missing key: {key}");
+        }
     }
 
     /// #509: in `explicit` mode the operator owns the threshold/membership, so


### PR DESCRIPTION
Closes #500

Implements **Phase P1** of epic #441: a read-only JSON-RPC surface so a thin client (mobile app) can verify *which* node it is talking to before trusting it for the Mode-2 node-selection UX.

## What changed
- **New RPC method `node_getIdentity`** (`botho/src/rpc/mod.rs`) returning identity material grounded in durable node state:
  - `peerId` / `nodeId` — from the persistent libp2p keypair (#439/#440), so they are **stable across restarts** (not per-restart ephemeral). `nodeId` is the SCP signing public key derived deterministically via `peer_id_to_node_id`.
  - `network` — `botho-mainnet` / `botho-testnet`, namespaced so a phone cannot be tricked into trusting a wrong-network node (mirrors `node_getStatus`).
  - `protocolVersion` / `minProtocolVersion` — wire-compatibility window.
  - `nodeVersion` / `version` / `gitCommit` — software provenance.
  - `dnsSeedDomain` — DNS-seed discovery namespace, so the client can cross-check the node.
  - `chainHeight` / `tipHash` — current tip, so the client can confirm the node's chain.
- **Identity plumbing**: a `NodeIdentity` struct on `RpcState` (with `with_identity` builder), populated once at startup in `commands::run` from the persistent keypair + configured `Network`. Stored as plain strings so the RPC layer needs no libp2p/SCP types and the handler stays trivially testable.
- **Discovery polish**: exposes the DNS-seed namespace via a new public `network::default_seed_domain(Network)`; the private instance `seed_domain()` now delegates to it. No behavioural change to DNS resolution or hardcoded fallback.

## Grounding
Every field is backed by real node state — persistent keypair, configured network, live ledger tip, and the discovery protocol constants. No invented fields.

## Tests
- `test_node_identity_returns_expected_fields` — payload shape + values for a configured identity, network namespacing, and tip grounded in the actual ledger chain-state.
- `test_node_identity_defaults_are_well_formed` — default (empty) identity still yields a well-formed, network-correct payload with all required keys.
- `test_default_seed_domain_matches_per_network_constants` — the public helper agrees with the per-network constants and the instance method.

All of `cargo fmt --check`, `cargo build -p botho`, `cargo clippy -p botho --lib` (no new warnings), and the rpc/dns_seeds/node_key test suites (98 passed) are green.

## Scope notes
- Changes are confined to `botho/src/` (rpc + network + commands) — no overlap with the concurrent consensus/quorum-sim work (#514).
- Out of scope (per issue): the mobile UX that consumes this (P3); any consensus/quorum changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)