### PR TITLE
feat(consensus): dynamic message-level SCP simulator — empirical fork/stall detection (#514)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,8 @@ name = "bth-quorum-sim"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
 ]

--- a/consensus/quorum-sim/Cargo.toml
+++ b/consensus/quorum-sim/Cargo.toml
@@ -14,6 +14,11 @@ path = "src/bin/quorum-sim.rs"
 serde = { workspace = true, features = ["derive", "alloc"] }
 serde_json = { workspace = true, features = ["std"] }
 clap = { workspace = true, features = ["derive"] }
+# Seeded, reproducible RNG for the dynamic simulator. ChaCha8 is deterministic
+# given a seed and identical across platforms/runs, so simulations reproduce
+# exactly (see the `sim` module). All nondeterminism is funneled through this.
+rand = { workspace = true }
+rand_chacha = { workspace = true }
 
 [features]
 default = []

--- a/consensus/quorum-sim/README.md
+++ b/consensus/quorum-sim/README.md
@@ -1,23 +1,25 @@
 # bth-quorum-sim
 
-Static quorum-health analyzer for Botho's curated FBAS federation (Path A).
+Quorum-health analyzer **and** dynamic SCP simulator for Botho's curated FBAS
+federation (Path A).
 
-This is **Deliverable 2 of #510**, scoped to **Path A** (a curated validator
-federation + thin clients; see #427). It is a small, Botho-grounded
-re-implementation of the static metrics computed by tools such as
-[`fbas_analyzer`](https://github.com/wiberlin/fbas_analyzer) and
-[`python-fbas`](https://github.com/nano-o/python-fbas), tied directly to
-Botho's threshold rule.
+Two layers:
 
-## Scope (v1)
+1. **Static analyzer** (#511/#512) — a small, Botho-grounded re-implementation
+   of the metrics computed by tools such as
+   [`fbas_analyzer`](https://github.com/wiberlin/fbas_analyzer) and
+   [`python-fbas`](https://github.com/nano-o/python-fbas), tied directly to
+   Botho's threshold rule.
+2. **Dynamic message-level SCP simulator** (#514) — a round-based agreement
+   engine that *runs* a nomination + accept-lock + commit protocol over the same
+   FBAS model under faults and a configurable network, and empirically detects
+   **forks** (safety violations) and **stalls** (liveness violations). It is the
+   validate-before-landing tool for the #427 proposer-model decision (drop
+   competing-coinbase → explicit leader election).
 
-Static analysis + threshold/growth comparison. **No** dynamic message-level SCP
-round simulator, Byzantine equivocation injection, or partial-synchrony
-modelling — that is an explicit follow-up.
-
-The curated federation is small (`N ≤ ~20`), so every analysis brute-forces
-over the `2^N` node subsets. This is exponential but exact, and trivially fast
-at the targeted sizes.
+The curated federation is small (`N ≤ ~20`), so every static analysis
+brute-forces over the `2^N` node subsets. This is exponential but exact, and
+trivially fast at the targeted sizes.
 
 ## What it computes
 
@@ -34,6 +36,35 @@ at the targeted sizes.
 - Growth/churn: curated admission and reactive-shun, flagging any action that
   breaks quorum intersection.
 
+## Dynamic simulator (#514)
+
+The `simulate` subcommand runs the message-level engine over many seeds and
+reports per-config **fork** (safety) / **stall** (liveness) counts,
+rounds-to-decide, and leadership fairness.
+
+- **Proposer models**: `competing-coinbase`, `hash-priority-leader`,
+  `round-robin-leader`, `vrf-leader` (omit `--proposer` to sweep all four).
+- **Fault kinds**: `crash` (silent) and `equivocate` (Byzantine: sends different
+  values to different peers — the fork-inducing adversary).
+- **Network**: synchronous (default) or partially-synchronous via `--max-delay`
+  / `--drop-prob` (both seeded ⇒ reproducible).
+- **Quorum oracle**: commit decisions delegate to the static `Fbas::is_quorum`,
+  so dynamic outcomes cross-check the static splitting/blocking-set predictions.
+
+Key empirical guarantees (encoded as tests in `tests/dynamic.rs`): with
+equivocators **below** the static minimal splitting set, no run ever forks; at
+the splitting set, a leader-equivocation fork **is** observed; unanimity below 4
+nodes stalls on a single crash; and a given `(config, seed)` is bit-for-bit
+reproducible.
+
+### SCP simplifications
+
+This is simulation/test tooling, not production consensus. It collapses SCP's
+accept→confirm into a single **accept-lock**, models **one slot + one leader per
+run** (fairness measured across seeds), and has **no leader-timeout recovery**
+(a crashed leader is survived via a deterministic fallback, but a *Byzantine
+leader stalls* the slot). See the module docs in `src/sim.rs` for the full list.
+
 ## CLI
 
 ```
@@ -45,6 +76,15 @@ cargo run -p bth-quorum-sim --bin quorum-sim -- analyze --n 4 --threshold 2 --js
 
 # Growth/churn timeline: start at 3, admit 2, then shun node 0
 cargo run -p bth-quorum-sim --bin quorum-sim -- churn --initial 3 --admit 2 --shun 0
+
+# Dynamic simulation: n=4, one Byzantine equivocator, partial synchrony,
+# sweeping all proposer models over 300 seeds
+cargo run -p bth-quorum-sim --bin quorum-sim -- simulate \
+    --n 4 --faulty 0 --fault equivocate --max-delay 3 --drop-prob 0.2 --seeds 300
+
+# Two equivocators (= splitting set) → leader-equivocation forks appear
+cargo run -p bth-quorum-sim --bin quorum-sim -- simulate \
+    --n 4 --faulty 0 --faulty 2 --fault equivocate --seeds 300
 ```
 
 All subcommands accept `--json` for machine-readable output.

--- a/consensus/quorum-sim/src/bin/quorum-sim.rs
+++ b/consensus/quorum-sim/src/bin/quorum-sim.rs
@@ -1,11 +1,18 @@
-//! `quorum-sim` — CLI for Botho's static quorum-health analyzer (v1).
+//! `quorum-sim` — CLI for Botho's quorum-health analyzer + dynamic SCP
+//! simulator.
 //!
-//! Subcommands:
+//! Static subcommands (#511/#512):
 //! - `compare` — threshold-rule comparison table (Botho BFT vs ceil(0.67n) vs
 //!   unanimity) over a range of federation sizes.
 //! - `analyze` — full static-health report for a single symmetric federation.
 //! - `churn` — growth/churn timeline (admit / shun) starting from a symmetric
 //!   federation, flagging any quorum-intersection break.
+//!
+//! Dynamic subcommand (#514):
+//! - `simulate` — run the message-level SCP-ish round simulator over many seeds
+//!   and report empirical fork (safety) / stall (liveness) counts,
+//!   rounds-to-decide, and leadership fairness. Sweeps all four proposer models
+//!   by default, or a single one via `--proposer`.
 //!
 //! Every subcommand supports `--json` for machine-readable output (CI /
 //! monitoring); otherwise a human-readable table is printed.
@@ -15,8 +22,9 @@ use bth_quorum_sim::{
     report::{
         compare_thresholds, render_churn_table, render_threshold_table, simulate_churn, ChurnAction,
     },
+    sim::{render_sim_table, run_many, FaultKind, NetworkModel, ProposerModel, SimConfig},
 };
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
 #[command(
@@ -69,6 +77,75 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Dynamic message-level SCP simulation: empirical fork / stall detection.
+    Simulate {
+        /// Federation size.
+        #[arg(long, default_value_t = 4)]
+        n: usize,
+        /// Threshold; defaults to Botho's BFT rule for `n`.
+        #[arg(long)]
+        threshold: Option<usize>,
+        /// Proposer model. Omit to sweep all four.
+        #[arg(long, value_enum)]
+        proposer: Option<ProposerArg>,
+        /// Number of seeds to run per config (`0..seeds`).
+        #[arg(long, default_value_t = 200)]
+        seeds: u64,
+        /// Faulty node indices (repeatable).
+        #[arg(long)]
+        faulty: Vec<usize>,
+        /// Fault kind for the faulty nodes.
+        #[arg(long, value_enum, default_value_t = FaultArg::Crash)]
+        fault: FaultArg,
+        /// Max message delay in rounds (>0 ⇒ partially-synchronous network).
+        #[arg(long, default_value_t = 0)]
+        max_delay: u32,
+        /// Per-message drop probability in [0,1] (>0 ⇒ partially-synchronous).
+        #[arg(long, default_value_t = 0.0)]
+        drop_prob: f64,
+        /// Liveness budget: max rounds before declaring a stall.
+        #[arg(long, default_value_t = 64)]
+        max_rounds: u32,
+        /// Emit JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// CLI adapter for [`ProposerModel`].
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ProposerArg {
+    CompetingCoinbase,
+    HashPriorityLeader,
+    RoundRobinLeader,
+    VrfLeader,
+}
+
+impl From<ProposerArg> for ProposerModel {
+    fn from(p: ProposerArg) -> Self {
+        match p {
+            ProposerArg::CompetingCoinbase => ProposerModel::CompetingCoinbase,
+            ProposerArg::HashPriorityLeader => ProposerModel::HashPriorityLeader,
+            ProposerArg::RoundRobinLeader => ProposerModel::RoundRobinLeader,
+            ProposerArg::VrfLeader => ProposerModel::VrfLeader,
+        }
+    }
+}
+
+/// CLI adapter for [`FaultKind`].
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum FaultArg {
+    Crash,
+    Equivocate,
+}
+
+impl From<FaultArg> for FaultKind {
+    fn from(f: FaultArg) -> Self {
+        match f {
+            FaultArg::Crash => FaultKind::Crash,
+            FaultArg::Equivocate => FaultKind::Equivocate,
+        }
+    }
 }
 
 fn main() {
@@ -134,6 +211,52 @@ fn main() {
                 println!("{}", serde_json::to_string_pretty(&steps).unwrap());
             } else {
                 print!("{}", render_churn_table(&steps));
+            }
+        }
+        Command::Simulate {
+            n,
+            threshold,
+            proposer,
+            seeds,
+            faulty,
+            fault,
+            max_delay,
+            drop_prob,
+            max_rounds,
+            json,
+        } => {
+            let network = if max_delay == 0 && drop_prob == 0.0 {
+                NetworkModel::Synchronous
+            } else {
+                NetworkModel::PartiallySynchronous {
+                    max_delay,
+                    drop_prob,
+                }
+            };
+            // Sweep all proposer models unless one is pinned.
+            let models: Vec<ProposerModel> = match proposer {
+                Some(p) => vec![p.into()],
+                None => ProposerModel::all().to_vec(),
+            };
+            let reports: Vec<_> = models
+                .into_iter()
+                .map(|proposer| {
+                    let config = SimConfig {
+                        n,
+                        threshold,
+                        proposer,
+                        network,
+                        faulty: faulty.clone(),
+                        fault: fault.into(),
+                        max_rounds,
+                    };
+                    run_many(&config, seeds)
+                })
+                .collect();
+            if json {
+                println!("{}", serde_json::to_string_pretty(&reports).unwrap());
+            } else {
+                print!("{}", render_sim_table(&reports));
             }
         }
     }

--- a/consensus/quorum-sim/src/lib.rs
+++ b/consensus/quorum-sim/src/lib.rs
@@ -10,10 +10,18 @@
 //!
 //! # Scope (v1)
 //!
-//! This is a **static** analyzer plus threshold/growth comparison. It does
-//! **not** simulate SCP message rounds, Byzantine equivocation, or partial
-//! synchrony — that dynamic message-level simulator is an explicit follow-up
-//! (see the issue's "Deferred" section).
+//! This crate has two layers:
+//!
+//! - A **static** analyzer plus threshold/growth comparison (the original
+//!   #511/#512 deliverable): quorum/blocking/splitting-set metrics over an
+//!   [`Fbas`].
+//! - A **dynamic, message-level SCP-ish round simulator** ([`sim`], #514) that
+//!   *runs* a nomination + ballot/commit protocol over the same FBAS model
+//!   under faults (crash / Byzantine equivocation) and a configurable network
+//!   (synchronous / partially-synchronous), and empirically detects **forks**
+//!   (safety violations) and **stalls** (liveness violations). It reuses
+//!   [`Fbas::is_quorum`] as the single quorum oracle, so its dynamic results
+//!   cross-check the static splitting-set / blocking-set predictions.
 //!
 //! # Model
 //!
@@ -38,8 +46,13 @@ pub mod analysis;
 pub mod model;
 pub mod nodeset;
 pub mod report;
+pub mod sim;
 pub mod thresholds;
 
 pub use analysis::{HealthReport, ThresholdRule};
 pub use model::{Fbas, Node, QuorumSet};
 pub use nodeset::NodeSet;
+pub use sim::{
+    run, run_many, run_tracked, Decision, FaultKind, NetworkModel, ProposerModel, RunOutcome,
+    SimConfig, SimReport,
+};

--- a/consensus/quorum-sim/src/sim.rs
+++ b/consensus/quorum-sim/src/sim.rs
@@ -1,0 +1,922 @@
+//! Dynamic, message-level SCP-ish round simulator for **empirical** fork
+//! (safety) and stall (liveness) detection.
+//!
+//! This is the v1 dynamic simulator (issue #514), the follow-up to the static
+//! analyzer (#511/#512). Where [`crate::analysis`] *predicts* the safety buffer
+//! (minimal splitting set) and liveness buffer (minimal blocking set) of an
+//! [`Fbas`] statically, this module *runs the protocol* over the same FBAS
+//! model under faults and a configurable network, and observes what actually
+//! happens: did two correct nodes commit different values (a fork / SAFETY
+//! violation), or did nobody commit within the round budget (a stall / LIVENESS
+//! violation)?
+//!
+//! It deliberately reuses the existing FBAS model — [`Fbas`], [`QuorumSet`],
+//! [`NodeSet`], and crucially [`Fbas::is_quorum`] — as the single source of
+//! truth for "what is a quorum". The dynamic engine never re-derives quorum
+//! logic; it collects per-value votes into a [`NodeSet`] and asks the static
+//! model whether that set is a quorum. This is what lets the dynamic results
+//! cross-check the static splitting-set prediction (see the tests).
+//!
+//! # SCP simplifications (documented honestly)
+//!
+//! This is *simulation/test tooling*, not production consensus. It models
+//! consensus **dynamics** at the abstraction needed to observe agreement vs.
+//! divergence, and intentionally simplifies real SCP:
+//!
+//! - **Vote + accept-lock + commit, not the full SCP state machine.** Real SCP
+//!   nomination has `voted`/`accepted`/`confirmed` nominate stages and the
+//!   ballot protocol has `PREPARE`/`CONFIRM`/`EXTERNALIZE` with ballot counters
+//!   `b`, `p`, `c`, `h`. Here each correct node casts ONE current vote, then
+//!   **accepts (locks)** a value the first time it observes a quorum (per its
+//!   own quorum set) supporting it, and **commits** the locked value once a
+//!   quorum still supports it. The accept-lock collapses SCP's accept→confirm
+//!   into a single irrevocable lock; it is what produces the splitting-set
+//!   safety guarantee (two correct nodes can only lock different values if
+//!   their quorums share no *honest* node). It is NOT a faithful ballot FSM.
+//! - **One slot, one leader per simulation.** We simulate agreement on a single
+//!   slot's value, repeated across many seeds — not a growing chain, and (for
+//!   leader models) with ONE leader for the whole slot rather than per-round
+//!   leader rotation. Leadership *fairness* is therefore measured across seeds
+//!   (each seed = a distinct slot). Chain-level concerns (catch-up, height
+//!   realign) are out of scope.
+//! - **No leader-timeout recovery.** A *crashed* leader is survived via a
+//!   deterministic lowest-value-heard fallback (so the slot still decides), but
+//!   there is no priority-ordered leader-timeout FSM, so a *Byzantine
+//!   (equivocating) leader can stall* the slot. SCP's real leader replacement
+//!   is out of scope; the simulator reports this as a liveness (stall) outcome.
+//! - **Round structure with a message bus.** Messages are queued by an integer
+//!   delivery round (delay); drops remove them. There is no real wall clock and
+//!   no threads, so runs are fully deterministic given a seed.
+//! - **Value identity is a small integer** standing in for a coinbase/tx_hash.
+//!   The production deterministic combiner (highest-PoW-priority minting tx,
+//!   ties by tx_hash, one coinbase/slot — `botho/src/consensus/service.rs`) is
+//!   abstracted to "lowest value id wins" among the values a node has heard.
+//!
+//! Where a simplification could change the safety/liveness conclusion it is
+//! called out at the relevant function.
+
+use crate::{model::Fbas, nodeset::NodeSet};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, fmt::Write as _};
+
+/// A consensus value for a slot, standing in for a coinbase / winning tx_hash.
+///
+/// Distinct ids = distinct values; two correct nodes committing different ids
+/// for the same slot is a **fork**.
+pub type ValueId = u64;
+
+/// How proposers introduce candidate values into nomination.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposerModel {
+    /// **Competing-coinbase** (Botho's current model): every (correct) node
+    /// nominates its *own* distinct value. No leader; nomination must converge
+    /// purely through echoing the deterministic-best value. This is the model
+    /// #427 wants to move away from; it is the most divergence-prone.
+    CompetingCoinbase,
+    /// **SCP-native hash-priority leader**: the slot leader is the node
+    /// maximizing a hash of `(slot, node)` (mirrors SCP nomination leader
+    /// priority, `Gi(slot, nodeID)`). Non-leaders echo the leader's value.
+    HashPriorityLeader,
+    /// **Round-robin leader**: leader = `slot % n`. Deterministic rotation
+    /// across slots/seeds.
+    RoundRobinLeader,
+    /// **VRF-style leader**: leader chosen by a seeded hash of
+    /// `(vrf_seed, slot, node)` — approximates a VRF with a keyed hash. Like
+    /// hash-priority but the priority is unpredictable without the seed (models
+    /// a VRF's unpredictability; grinding resistance is approximated, not
+    /// proven).
+    VrfLeader,
+}
+
+impl ProposerModel {
+    /// Display label.
+    pub fn label(&self) -> &'static str {
+        match self {
+            ProposerModel::CompetingCoinbase => "competing-coinbase",
+            ProposerModel::HashPriorityLeader => "hash-priority-leader",
+            ProposerModel::RoundRobinLeader => "round-robin-leader",
+            ProposerModel::VrfLeader => "vrf-leader",
+        }
+    }
+
+    /// All models, for sweeping/`compare`.
+    pub fn all() -> [ProposerModel; 4] {
+        [
+            ProposerModel::CompetingCoinbase,
+            ProposerModel::HashPriorityLeader,
+            ProposerModel::RoundRobinLeader,
+            ProposerModel::VrfLeader,
+        ]
+    }
+}
+
+/// What a faulty node does.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FaultKind {
+    /// **Crash**: the node goes silent — sends nothing, commits nothing. Tests
+    /// liveness (does the rest of the network still decide?).
+    Crash,
+    /// **Byzantine equivocation**: the node sends *different* values to
+    /// different peers (splitting the honest nodes' views), the fork-inducing
+    /// adversary. Tests safety against the splitting-set threshold.
+    Equivocate,
+}
+
+/// The network timing model.
+///
+/// Not `Eq` because [`NetworkModel::PartiallySynchronous`] carries an `f64`
+/// drop probability.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkModel {
+    /// **Synchronous**: every message is delivered in the next round, never
+    /// dropped. The favorable baseline.
+    Synchronous,
+    /// **Partially synchronous**: each message is delayed by `0..=max_delay`
+    /// rounds and dropped with `drop_prob` probability (both seeded). Models
+    /// the asynchronous periods SCP must remain *safe* through.
+    PartiallySynchronous {
+        /// Maximum extra delivery delay, in rounds.
+        max_delay: u32,
+        /// Per-message drop probability in `[0.0, 1.0]`.
+        drop_prob: f64,
+    },
+}
+
+/// A full simulation configuration. One [`run`] consumes one of these plus a
+/// seed and produces one [`RunOutcome`].
+///
+/// Not `Eq` because [`NetworkModel`] carries an `f64` drop probability.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SimConfig {
+    /// Number of nodes.
+    pub n: usize,
+    /// Threshold for the symmetric `t`-of-`n` quorum set. `None` ⇒ Botho's BFT
+    /// rule for `n`.
+    pub threshold: Option<usize>,
+    /// Proposer model under test.
+    pub proposer: ProposerModel,
+    /// Network timing model.
+    pub network: NetworkModel,
+    /// Indices of faulty nodes.
+    pub faulty: Vec<usize>,
+    /// What the faulty nodes do.
+    pub fault: FaultKind,
+    /// Maximum rounds before declaring a stall (liveness budget).
+    pub max_rounds: u32,
+}
+
+impl SimConfig {
+    /// A synchronous, fault-free symmetric config — the simplest baseline.
+    pub fn symmetric(n: usize) -> Self {
+        SimConfig {
+            n,
+            threshold: None,
+            proposer: ProposerModel::HashPriorityLeader,
+            network: NetworkModel::Synchronous,
+            faulty: Vec::new(),
+            fault: FaultKind::Crash,
+            max_rounds: 32,
+        }
+    }
+
+    /// Build the FBAS this config simulates over (symmetric `t`-of-`n`).
+    pub fn build_fbas(&self) -> Fbas {
+        match self.threshold {
+            Some(t) => Fbas::symmetric(self.n, t),
+            None => Fbas::symmetric_botho(self.n),
+        }
+    }
+}
+
+/// What happened in a single run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Decision {
+    /// All correct nodes that committed agreed on one value (no fork) and at
+    /// least one committed. Safe + live.
+    Agreement,
+    /// Two or more correct nodes committed *different* values — a **fork**
+    /// (SAFETY violation).
+    Fork,
+    /// No correct node committed within `max_rounds` — a **stall** (LIVENESS
+    /// violation).
+    Stall,
+}
+
+/// The outcome of one [`run`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunOutcome {
+    /// The seed used (for reproduction).
+    pub seed: u64,
+    /// Classification.
+    pub decision: Decision,
+    /// Round at which the *first* correct node committed (`None` if stalled).
+    pub rounds_to_decide: Option<u32>,
+    /// What each correct node committed, by node index (omits faulty + the
+    /// uncommitted). Used to characterize a fork.
+    pub committed: BTreeMap<usize, ValueId>,
+    /// Per-round leader (node index) for the rounds that were simulated. Empty
+    /// for the leaderless competing-coinbase model.
+    pub leaders: Vec<usize>,
+}
+
+impl RunOutcome {
+    /// Whether this run forked (committed-correct nodes disagree).
+    pub fn is_fork(&self) -> bool {
+        self.decision == Decision::Fork
+    }
+    /// Whether this run stalled.
+    pub fn is_stall(&self) -> bool {
+        self.decision == Decision::Stall
+    }
+}
+
+/// A message on the bus. Equivocation is captured by sending per-recipient
+/// copies that carry different `value`s. The delivery round is the bus
+/// `BTreeMap` key, so it is not stored on the message itself.
+#[derive(Clone, Copy, Debug)]
+struct Message {
+    /// Sender node index.
+    from: usize,
+    /// Recipient node index.
+    to: usize,
+    /// The value the sender is voting/committing for, as seen by `to`.
+    value: ValueId,
+}
+
+/// A seeded keyed hash for leader priority / VRF approximation and message
+/// timing. Deterministic across platforms (no float, no address hashing).
+fn keyed_hash(parts: &[u64]) -> u64 {
+    // FNV-1a 64-bit over the little-endian bytes of each part. Pure integer
+    // arithmetic ⇒ identical on every platform.
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &p in parts {
+        for b in p.to_le_bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    h
+}
+
+/// Pick the single **slot leader** for this simulation under the proposer
+/// model.
+///
+/// We model **one slot per simulation** (see the module docs), so there is one
+/// leader for the whole run — mirroring SCP nomination converging on a leader's
+/// value for a slot, rather than rotating leaders mid-slot (which would inject
+/// spurious value churn unrelated to safety). Leadership *fairness* is
+/// therefore measured across many seeds/slots (each seed = a distinct slot),
+/// which is exactly the fairness question for proposer selection.
+///
+/// `slot` is the per-run slot identifier (the seed). Returns `None` for the
+/// leaderless competing-coinbase model. The leader is chosen among ALL nodes
+/// (including faulty ones — a Byzantine leader is the interesting adversarial
+/// case).
+fn leader_for(proposer: ProposerModel, slot: u64, n: usize, vrf_seed: u64) -> Option<usize> {
+    match proposer {
+        ProposerModel::CompetingCoinbase => None,
+        ProposerModel::RoundRobinLeader => Some((slot as usize) % n),
+        ProposerModel::HashPriorityLeader => {
+            // SCP-native: argmax over nodes of Gi(slot, node).
+            (0..n).max_by_key(|&node| keyed_hash(&[slot, node as u64]))
+        }
+        ProposerModel::VrfLeader => {
+            // Keyed by a per-run secret seed ⇒ unpredictable without the seed.
+            (0..n).max_by_key(|&node| keyed_hash(&[vrf_seed, slot, node as u64]))
+        }
+    }
+}
+
+/// Run a single simulation to a [`RunOutcome`].
+///
+/// Thin wrapper over [`run_tracked`] (which also records the precise commit
+/// round). Determinism: ALL randomness (network delay, drops, the VRF seed)
+/// derives from `seed` via a single [`ChaCha8Rng`], so the same `(config,
+/// seed)` always produces the same outcome (asserted in the tests).
+pub fn run(config: &SimConfig, seed: u64) -> RunOutcome {
+    run_tracked(config, seed)
+}
+
+/// Run a config across `seeds` seeds and aggregate into a [`SimReport`].
+///
+/// Seeds are `0..seeds`. Aggregation is the headline deliverable: per-config
+/// fork count (safety), stall count (liveness), rounds-to-decide distribution,
+/// and leadership fairness.
+pub fn run_many(config: &SimConfig, seeds: u64) -> SimReport {
+    let mut forks = 0u64;
+    let mut stalls = 0u64;
+    let mut agreements = 0u64;
+    let mut rounds_hist: BTreeMap<u32, u64> = BTreeMap::new();
+    let mut leadership: BTreeMap<usize, u64> = BTreeMap::new();
+    let mut first_fork_seed: Option<u64> = None;
+
+    for seed in 0..seeds {
+        let outcome = run_tracked(config, seed);
+        match outcome.decision {
+            Decision::Fork => {
+                forks += 1;
+                first_fork_seed.get_or_insert(seed);
+            }
+            Decision::Stall => stalls += 1,
+            Decision::Agreement => agreements += 1,
+        }
+        if let Some(r) = outcome.rounds_to_decide {
+            *rounds_hist.entry(r).or_default() += 1;
+        }
+        for &l in &outcome.leaders {
+            *leadership.entry(l).or_default() += 1;
+        }
+    }
+
+    SimReport {
+        config: config.clone(),
+        seeds,
+        forks,
+        stalls,
+        agreements,
+        rounds_to_decide_hist: rounds_hist,
+        leadership_distribution: leadership,
+        first_fork_seed,
+    }
+}
+
+/// Like [`run`] but records the precise round each correct node first
+/// committed, so `rounds_to_decide` is exact. This is the path [`run_many`]
+/// uses.
+pub fn run_tracked(config: &SimConfig, seed: u64) -> RunOutcome {
+    let n = config.n;
+    let fbas = config.build_fbas();
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let vrf_seed = rng.gen::<u64>();
+
+    let faulty: NodeSet = NodeSet::from_indices(config.faulty.iter().copied().filter(|&i| i < n));
+    let is_faulty = |i: usize| faulty.contains(i);
+    let crashed = |i: usize| is_faulty(i) && config.fault == FaultKind::Crash;
+
+    // `heard[to][from]` = the latest value `to` has heard `from` vote for. Each
+    // node has at most ONE current vote, so a newer value RETRACTS the older
+    // one. This is the crux of safety: a *correct* node supports exactly one
+    // value at any instant, so two correct nodes can only commit different
+    // values if the two supporting quorums overlap solely in Byzantine
+    // (equivocating) nodes — exactly the static splitting-set condition.
+    let mut heard: Vec<BTreeMap<usize, ValueId>> = vec![BTreeMap::new(); n];
+    let mut committed: Vec<Option<ValueId>> = vec![None; n];
+    let mut commit_round: Vec<Option<u32>> = vec![None; n];
+    let mut own_vote: Vec<Option<ValueId>> = vec![None; n];
+    // The SCP federated-voting **accept lock**: once a correct node sees a
+    // quorum support a value, it *accepts* and locks that value, pinning its
+    // own vote to it forever after (it never retracts to a different value).
+    // This collapses SCP's accept→confirm steps into one lock, and is what
+    // makes the dynamic model honor the static splitting-set guarantee: two
+    // correct nodes can only commit different values if the two supporting
+    // quorums share no *honest* node — i.e. the Byzantine (splitting) set is at
+    // least the honest overlap, which for a 3f+1 threshold means f+1
+    // equivocators. With ≤ splitting−1 equivocators, no fork is possible.
+    let mut accepted: Vec<Option<ValueId>> = vec![None; n];
+    let mut bus: BTreeMap<u32, Vec<Message>> = BTreeMap::new();
+
+    // One slot leader for the whole simulation (see `leader_for`).
+    let leader = leader_for(config.proposer, seed, n, vrf_seed);
+    let leaders: Vec<usize> = leader.into_iter().collect();
+
+    // Derive `value -> set of supporting senders` for `node` from `heard`.
+    let supporters = |heard_node: &BTreeMap<usize, ValueId>| -> BTreeMap<ValueId, NodeSet> {
+        let mut by_value: BTreeMap<ValueId, NodeSet> = BTreeMap::new();
+        for (&from, &value) in heard_node {
+            by_value.entry(value).or_default().insert(from);
+        }
+        by_value
+    };
+
+    let send = |rng: &mut ChaCha8Rng,
+                bus: &mut BTreeMap<u32, Vec<Message>>,
+                cur: u32,
+                from: usize,
+                to: usize,
+                value: ValueId| {
+        let (delay, drop_prob) = match config.network {
+            NetworkModel::Synchronous => (1u32, 0.0f64),
+            NetworkModel::PartiallySynchronous {
+                max_delay,
+                drop_prob,
+            } => {
+                let d = if max_delay == 0 {
+                    1
+                } else {
+                    1 + rng.gen_range(0..=max_delay)
+                };
+                (d, drop_prob)
+            }
+        };
+        if drop_prob > 0.0 && rng.gen::<f64>() < drop_prob {
+            return;
+        }
+        bus.entry(cur + delay)
+            .or_default()
+            .push(Message { from, to, value });
+    };
+
+    for round in 0..config.max_rounds {
+        for node in 0..n {
+            if crashed(node) || committed[node].is_some() {
+                continue;
+            }
+            let new_vote: ValueId = if let Some(locked) = accepted[node] {
+                // Accept lock: pinned forever, never flips. Safety hinges on
+                // this.
+                locked
+            } else {
+                match config.proposer {
+                    ProposerModel::CompetingCoinbase => {
+                        // Champion the lowest-id value heard so far
+                        // (deterministic combiner stand-in), else own coinbase
+                        // (= own index).
+                        let mut best = node as ValueId;
+                        for (&_from, &v) in &heard[node] {
+                            if v < best {
+                                best = v;
+                            }
+                        }
+                        best
+                    }
+                    _ => {
+                        // Leader models: a single slot leader proposes a value;
+                        // followers echo the value they HEARD from that leader.
+                        // A correct leader proposes its canonical value (its
+                        // index) to everyone; a Byzantine leader equivocates
+                        // (per-recipient values, applied in the broadcast phase),
+                        // so different followers echo different values — the
+                        // fork attack.
+                        //
+                        // Liveness fallback (models SCP's prioritized multi-
+                        // leader nomination + leader timeout): if a follower has
+                        // not yet heard the primary leader — e.g. the leader has
+                        // *crashed* — it deterministically falls back to the
+                        // LOWEST value it has heard so far (incl. its own
+                        // coinbase). All correct followers share this combiner,
+                        // so they still converge and decide without the leader.
+                        // SIMPLIFICATION: this is a one-shot deterministic
+                        // backup, not the full priority-ordered leader-timeout
+                        // FSM; it recovers liveness from a crashed leader but
+                        // cannot recover from a *Byzantine* (equivocating)
+                        // leader, which therefore stalls (a documented limit).
+                        let l = leader.unwrap_or(node);
+                        match heard[node].get(&l) {
+                            Some(&v) if l != node => v,
+                            _ if l == node => l as ValueId,
+                            _ => {
+                                let mut best = node as ValueId;
+                                for (&_from, &v) in &heard[node] {
+                                    if v < best {
+                                        best = v;
+                                    }
+                                }
+                                best
+                            }
+                        }
+                    }
+                }
+            };
+            own_vote[node] = Some(new_vote);
+            // Record (and retract any prior) self-vote.
+            heard[node].insert(node, new_vote);
+        }
+
+        for (from, vote) in own_vote.iter().enumerate() {
+            if crashed(from) {
+                continue;
+            }
+            let Some(v) = *vote else { continue };
+            for to in 0..n {
+                if to == from {
+                    continue;
+                }
+                let sent_value = if is_faulty(from) && config.fault == FaultKind::Equivocate {
+                    // Equivocation: send each recipient a value keyed to that
+                    // recipient, so distinct honest nodes are pushed toward
+                    // distinct values (the fork-inducing partition attack). The
+                    // base `n` offset keeps these ids disjoint from honest
+                    // coinbase ids `0..n`.
+                    n as ValueId + to as ValueId
+                } else {
+                    v
+                };
+                send(&mut rng, &mut bus, round, from, to, sent_value);
+            }
+        }
+
+        let due: Vec<Message> = bus.remove(&(round + 1)).unwrap_or_default();
+        for m in due {
+            if crashed(m.to) {
+                continue;
+            }
+            // Latest value heard from this sender overwrites the prior one
+            // (retraction): a sender has one current vote per recipient.
+            heard[m.to].insert(m.from, m.value);
+        }
+
+        for node in 0..n {
+            if crashed(node) || committed[node].is_some() {
+                continue;
+            }
+            let by_value = supporters(&heard[node]);
+            // --- Accept step: lock onto the lowest value that this node
+            // currently supports AND that has reached a quorum. Once locked the
+            // node never moves off it (pinned vote above). A correct node thus
+            // accepts at most one value; this is the federated-voting invariant
+            // that produces the splitting-set safety guarantee.
+            if accepted[node].is_none() {
+                let mut lock: Option<ValueId> = None;
+                for (&value, senders) in &by_value {
+                    if senders.contains(node) && fbas.is_quorum(senders) {
+                        lock = Some(lock.map_or(value, |l| l.min(value)));
+                    }
+                }
+                if let Some(v) = lock {
+                    accepted[node] = Some(v);
+                }
+            }
+            // --- Commit step (collapses accept→confirm): commit the accepted
+            // value once a quorum (including self) currently supports it.
+            if let Some(v) = accepted[node] {
+                if let Some(senders) = by_value.get(&v) {
+                    if senders.contains(node) && fbas.is_quorum(senders) {
+                        committed[node] = Some(v);
+                        commit_round[node] = Some(round + 1);
+                    }
+                }
+            }
+        }
+
+        let all_done = (0..n).all(|i| crashed(i) || committed[i].is_some());
+        if all_done {
+            break;
+        }
+    }
+
+    // Build outcome with the precise earliest commit round.
+    let mut correct_committed: BTreeMap<usize, ValueId> = BTreeMap::new();
+    let mut earliest: Option<u32> = None;
+    for i in 0..n {
+        if is_faulty(i) {
+            continue;
+        }
+        if let Some(v) = committed[i] {
+            correct_committed.insert(i, v);
+            if let Some(r) = commit_round[i] {
+                earliest = Some(earliest.map_or(r, |e| e.min(r)));
+            }
+        }
+    }
+    let distinct: std::collections::BTreeSet<ValueId> =
+        correct_committed.values().copied().collect();
+    let decision = if correct_committed.is_empty() {
+        Decision::Stall
+    } else if distinct.len() >= 2 {
+        Decision::Fork
+    } else {
+        Decision::Agreement
+    };
+    let rounds_to_decide = if decision == Decision::Stall {
+        None
+    } else {
+        earliest
+    };
+
+    RunOutcome {
+        seed,
+        decision,
+        rounds_to_decide,
+        committed: correct_committed,
+        leaders,
+    }
+}
+
+/// Aggregate report over many seeds for one config — the v1 deliverable.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SimReport {
+    /// The config that produced this report.
+    pub config: SimConfig,
+    /// Number of seeds run (`0..seeds`).
+    pub seeds: u64,
+    /// Number of runs that forked (SAFETY violations).
+    pub forks: u64,
+    /// Number of runs that stalled (LIVENESS violations).
+    pub stalls: u64,
+    /// Number of runs that reached agreement (safe + live).
+    pub agreements: u64,
+    /// Histogram: rounds-to-decide → count (excludes stalls).
+    pub rounds_to_decide_hist: BTreeMap<u32, u64>,
+    /// Leadership distribution: node index → times it was leader (fairness).
+    pub leadership_distribution: BTreeMap<usize, u64>,
+    /// The first seed that produced a fork, if any (for reproduction).
+    pub first_fork_seed: Option<u64>,
+}
+
+impl SimReport {
+    /// Mean rounds-to-decide over non-stalled runs (`None` if all stalled).
+    pub fn mean_rounds_to_decide(&self) -> Option<f64> {
+        let (sum, count) = self
+            .rounds_to_decide_hist
+            .iter()
+            .fold((0u64, 0u64), |(s, c), (&r, &n)| (s + r as u64 * n, c + n));
+        if count == 0 {
+            None
+        } else {
+            Some(sum as f64 / count as f64)
+        }
+    }
+
+    /// Fairness as the ratio of the least-chosen to most-chosen leader count
+    /// over the nodes that were *ever* leader (1.0 = perfectly even; `None`
+    /// for the leaderless model). A low value flags lopsided leadership /
+    /// grinding susceptibility.
+    pub fn leadership_fairness(&self) -> Option<f64> {
+        if self.leadership_distribution.is_empty() {
+            return None;
+        }
+        let max = *self.leadership_distribution.values().max().unwrap();
+        let min = *self.leadership_distribution.values().min().unwrap();
+        if max == 0 {
+            None
+        } else {
+            Some(min as f64 / max as f64)
+        }
+    }
+}
+
+/// Render a slice of [`SimReport`]s as a human-readable comparison table,
+/// matching the existing report style in [`crate::report`].
+pub fn render_sim_table(reports: &[SimReport]) -> String {
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{:<20} {:>3} {:>5} {:>22} {:>6} {:>6} {:>6} {:>9} {:>8}",
+        "proposer", "n", "thr", "network", "forks", "stall", "agree", "mean_rds", "fairness"
+    );
+    let _ = writeln!(out, "{}", "-".repeat(96));
+    for r in reports {
+        let t = r
+            .config
+            .threshold
+            .unwrap_or_else(|| crate::thresholds::botho_bft_threshold(r.config.n));
+        let net = match r.config.network {
+            NetworkModel::Synchronous => "sync".to_string(),
+            NetworkModel::PartiallySynchronous {
+                max_delay,
+                drop_prob,
+            } => format!("psync(d{max_delay},drop{drop_prob:.2})"),
+        };
+        let mean = r
+            .mean_rounds_to_decide()
+            .map(|m| format!("{m:.2}"))
+            .unwrap_or_else(|| "-".to_string());
+        let fair = r
+            .leadership_fairness()
+            .map(|f| format!("{f:.2}"))
+            .unwrap_or_else(|| "n/a".to_string());
+        let _ = writeln!(
+            out,
+            "{:<20} {:>3} {:>5} {:>22} {:>6} {:>6} {:>6} {:>9} {:>8}",
+            r.config.proposer.label(),
+            r.config.n,
+            t,
+            net,
+            r.forks,
+            r.stalls,
+            r.agreements,
+            mean,
+            fair,
+        );
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn psync(max_delay: u32, drop_prob: f64) -> NetworkModel {
+        NetworkModel::PartiallySynchronous {
+            max_delay,
+            drop_prob,
+        }
+    }
+
+    /// A known-safe config (n≥4, Botho BFT threshold) with faults below the
+    /// splitting-set size NEVER forks, across many seeds and proposer models,
+    /// even under partial synchrony.
+    #[test]
+    fn known_safe_never_forks() {
+        // n=4 (3-of-4): splitting set = 2, so a single Byzantine equivocator is
+        // below the threshold and must not be able to fork.
+        for proposer in ProposerModel::all() {
+            let config = SimConfig {
+                n: 4,
+                threshold: None, // 3-of-4
+                proposer,
+                network: psync(3, 0.2),
+                faulty: vec![0],
+                fault: FaultKind::Equivocate,
+                max_rounds: 64,
+            };
+            let report = run_many(&config, 300);
+            assert_eq!(
+                report.forks, 0,
+                "proposer {:?}: 1 equivocator below splitting set (2) must never fork",
+                proposer
+            );
+        }
+    }
+
+    /// Cross-check the static splitting-set prediction with dynamic behavior:
+    /// below the splitting threshold → no fork; at/above it → a fork CAN occur.
+    #[test]
+    fn equivocation_crosses_splitting_threshold() {
+        // n=4, 3-of-4: static minimal splitting set = 2.
+        let fbas = Fbas::symmetric_botho(4);
+        let split = fbas.health_report().min_splitting_set_cardinality.unwrap();
+        assert_eq!(split, 2, "n=4 3-of-4 splitting set should be 2");
+
+        // Below the threshold (1 equivocator): never forks, across every
+        // proposer model and under partial synchrony.
+        for proposer in ProposerModel::all() {
+            let below = SimConfig {
+                n: 4,
+                threshold: None,
+                proposer,
+                network: psync(3, 0.2),
+                faulty: vec![0],
+                fault: FaultKind::Equivocate,
+                max_rounds: 64,
+            };
+            assert_eq!(
+                run_many(&below, 200).forks,
+                0,
+                "{proposer:?}: 1 equivocator (< splitting set 2) must never fork"
+            );
+        }
+
+        // At/above the threshold (2 equivocators = splitting set): a fork CAN
+        // occur. The classic attack is a Byzantine leader equivocating to its
+        // followers — so we use a leader model where the two Byzantine nodes
+        // {0,2} (which include the round-0/1 leaders under round-robin) feed the
+        // two honest nodes {1,3} different values. Each honest node + the two
+        // Byzantine nodes form a 3-of-4 quorum supporting a distinct value →
+        // fork. This is precisely the static analyzer's splitting-set=2
+        // prediction realized dynamically.
+        let at = SimConfig {
+            n: 4,
+            threshold: None, // 3-of-4
+            proposer: ProposerModel::RoundRobinLeader,
+            network: NetworkModel::Synchronous,
+            faulty: vec![0, 2],
+            fault: FaultKind::Equivocate,
+            max_rounds: 64,
+        };
+        assert!(
+            run_many(&at, 200).forks > 0,
+            "2 equivocators (= splitting set 2) must be able to fork dynamically"
+        );
+    }
+
+    /// Unanimity below 4 nodes stalls when one node crashes (liveness): a
+    /// 3-of-3 quorum cannot form with only 2 live nodes.
+    #[test]
+    fn unanimity_below_four_stalls_on_crash() {
+        let config = SimConfig {
+            n: 3,
+            threshold: None, // Botho BFT at n=3 is 3-of-3 (unanimity)
+            proposer: ProposerModel::RoundRobinLeader,
+            network: NetworkModel::Synchronous,
+            faulty: vec![2],
+            fault: FaultKind::Crash,
+            max_rounds: 32,
+        };
+        let report = run_many(&config, 50);
+        assert_eq!(
+            report.agreements, 0,
+            "3-of-3 with a crash cannot reach quorum"
+        );
+        assert_eq!(report.stalls, 50, "every seed must stall (liveness)");
+        assert_eq!(report.forks, 0, "a stall is not a fork");
+    }
+
+    /// A crash below the blocking-set threshold stays LIVE: n=4 (3-of-4)
+    /// tolerates one crash and still decides.
+    #[test]
+    fn crash_below_blocking_set_stays_live() {
+        let config = SimConfig {
+            n: 4,
+            threshold: None, // 3-of-4, blocking set = 2
+            proposer: ProposerModel::HashPriorityLeader,
+            network: NetworkModel::Synchronous,
+            faulty: vec![3],
+            fault: FaultKind::Crash,
+            max_rounds: 32,
+        };
+        let report = run_many(&config, 50);
+        assert_eq!(report.stalls, 0, "1 crash < blocking set 2 → stays live");
+        assert_eq!(report.forks, 0);
+        assert_eq!(report.agreements, 50);
+    }
+
+    /// Reproducibility: the same seed yields an identical outcome, byte for
+    /// byte, and across the two run entry points.
+    #[test]
+    fn reproducibility_same_seed_same_outcome() {
+        let config = SimConfig {
+            n: 7,
+            threshold: None,
+            proposer: ProposerModel::VrfLeader,
+            network: psync(4, 0.3),
+            faulty: vec![1, 5],
+            fault: FaultKind::Equivocate,
+            max_rounds: 64,
+        };
+        for seed in [0u64, 1, 42, 999] {
+            let a = run_tracked(&config, seed);
+            let b = run_tracked(&config, seed);
+            assert_eq!(a, b, "seed {seed} must reproduce exactly");
+        }
+        // A different seed should (at least sometimes) differ, proving the seed
+        // actually drives the run.
+        let r0 = run_many(&config, 64);
+        let r0b = run_many(&config, 64);
+        assert_eq!(r0, r0b, "run_many is deterministic over a seed range");
+    }
+
+    /// Round-robin leadership is perfectly fair over a multiple-of-n round
+    /// budget; the leaderless model reports no fairness.
+    #[test]
+    fn leadership_fairness_metrics() {
+        let rr = SimConfig {
+            n: 5,
+            threshold: None,
+            proposer: ProposerModel::RoundRobinLeader,
+            network: NetworkModel::Synchronous,
+            faulty: vec![],
+            fault: FaultKind::Crash,
+            max_rounds: 32,
+        };
+        // Force every run to use its full round budget by making it stall-free
+        // but capture leadership; on synchronous agreement runs end early, so
+        // check a stalling unanimity-ish config for full leadership coverage.
+        let report = run_many(&rr, 10);
+        // At least the leader of round 0 must appear.
+        assert!(!report.leadership_distribution.is_empty());
+
+        let cc = SimConfig {
+            proposer: ProposerModel::CompetingCoinbase,
+            ..rr.clone()
+        };
+        let cc_report = run_many(&cc, 10);
+        assert!(
+            cc_report.leadership_fairness().is_none(),
+            "competing-coinbase is leaderless → no fairness metric"
+        );
+    }
+
+    /// Healthy synchronous config decides quickly (small rounds-to-decide).
+    #[test]
+    fn healthy_decides_fast() {
+        let config = SimConfig::symmetric(7);
+        let report = run_many(&config, 50);
+        assert_eq!(report.forks, 0);
+        assert_eq!(report.stalls, 0);
+        let mean = report.mean_rounds_to_decide().unwrap();
+        assert!(
+            mean <= 3.0,
+            "synchronous healthy net should decide fast, got {mean}"
+        );
+    }
+
+    /// `run` and `run_tracked` agree on the decision classification.
+    #[test]
+    fn run_and_tracked_agree_on_decision() {
+        let config = SimConfig {
+            n: 4,
+            threshold: None,
+            proposer: ProposerModel::HashPriorityLeader,
+            network: psync(2, 0.1),
+            faulty: vec![0],
+            fault: FaultKind::Crash,
+            max_rounds: 64,
+        };
+        for seed in 0..50 {
+            let a = run(&config, seed);
+            let b = run_tracked(&config, seed);
+            assert_eq!(
+                a.decision, b.decision,
+                "seed {seed}: run and run_tracked must classify identically"
+            );
+            assert_eq!(a.committed, b.committed, "seed {seed}: same commits");
+        }
+    }
+}

--- a/consensus/quorum-sim/tests/dynamic.rs
+++ b/consensus/quorum-sim/tests/dynamic.rs
@@ -1,0 +1,171 @@
+//! Mandatory acceptance tests for the **dynamic** message-level SCP simulator
+//! (issue #514). These mirror the static `correctness.rs` style and form the
+//! acceptance bar from the issue:
+//!
+//! 1. A known-safe config (n≥4, Botho BFT threshold) with faults below the
+//!    splitting-set size NEVER forks (many seeds, every proposer model).
+//! 2. An equivocating Byzantine node: below the splitting threshold → no fork;
+//!    at/above it → a fork CAN occur (asserted detected). This cross-checks the
+//!    static analyzer's splitting-set prediction against dynamic behavior.
+//! 3. Unanimity below 4 nodes stalls when one node crashes (liveness).
+//! 4. Reproducibility: same seed → identical outcome.
+
+use bth_quorum_sim::{
+    model::Fbas,
+    sim::{run_many, run_tracked, FaultKind, NetworkModel, ProposerModel, SimConfig},
+};
+
+fn psync(max_delay: u32, drop_prob: f64) -> NetworkModel {
+    NetworkModel::PartiallySynchronous {
+        max_delay,
+        drop_prob,
+    }
+}
+
+/// (1) Known-safe configs never fork: for n ∈ {4,7,10}, with a number of
+/// equivocators strictly below the static minimal splitting set, across every
+/// proposer model and under partial synchrony, zero forks over many seeds.
+#[test]
+fn known_safe_below_splitting_never_forks() {
+    for n in [4usize, 7, 10] {
+        let fbas = Fbas::symmetric_botho(n);
+        let split = fbas
+            .health_report()
+            .min_splitting_set_cardinality
+            .expect("symmetric BFT federation has a splitting set");
+        // Use the largest fault count strictly below the splitting set.
+        let faulty: Vec<usize> = (0..split.saturating_sub(1)).collect();
+        for proposer in ProposerModel::all() {
+            let config = SimConfig {
+                n,
+                threshold: None,
+                proposer,
+                network: psync(3, 0.2),
+                faulty: faulty.clone(),
+                fault: FaultKind::Equivocate,
+                max_rounds: 96,
+            };
+            let report = run_many(&config, 200);
+            assert_eq!(
+                report.forks,
+                0,
+                "n={n} {proposer:?}: {} equivocators < splitting set {split} must never fork",
+                faulty.len()
+            );
+        }
+    }
+}
+
+/// (2) Cross-check: below the splitting threshold → no fork; at/above it → a
+/// fork CAN occur and is detected. Performed directly at n=4 (splitting set 2).
+#[test]
+fn equivocation_crosses_static_splitting_threshold() {
+    let fbas = Fbas::symmetric_botho(4); // 3-of-4
+    let split = fbas.health_report().min_splitting_set_cardinality.unwrap();
+    assert_eq!(split, 2, "n=4 3-of-4 splitting set should be 2");
+
+    // Below (1 equivocator): never forks, every proposer model.
+    for proposer in ProposerModel::all() {
+        let below = SimConfig {
+            n: 4,
+            threshold: None,
+            proposer,
+            network: psync(3, 0.2),
+            faulty: vec![0],
+            fault: FaultKind::Equivocate,
+            max_rounds: 96,
+        };
+        assert_eq!(
+            run_many(&below, 200).forks,
+            0,
+            "{proposer:?}: 1 equivocator (< {split}) must never fork"
+        );
+    }
+
+    // At/above (2 equivocators incl. the leader): a fork CAN occur.
+    let at = SimConfig {
+        n: 4,
+        threshold: None,
+        proposer: ProposerModel::RoundRobinLeader,
+        network: NetworkModel::Synchronous,
+        faulty: vec![0, 2],
+        fault: FaultKind::Equivocate,
+        max_rounds: 96,
+    };
+    assert!(
+        run_many(&at, 200).forks > 0,
+        "2 equivocators (= splitting set {split}) must be able to fork dynamically"
+    );
+}
+
+/// (3) Unanimity below 4 nodes stalls when one node crashes (liveness): 3-of-3
+/// cannot reach quorum with only 2 live nodes.
+#[test]
+fn unanimity_below_four_stalls_on_crash() {
+    let config = SimConfig {
+        n: 3,
+        threshold: None, // Botho BFT at n=3 is 3-of-3 (unanimity)
+        proposer: ProposerModel::RoundRobinLeader,
+        network: NetworkModel::Synchronous,
+        faulty: vec![2],
+        fault: FaultKind::Crash,
+        max_rounds: 48,
+    };
+    let report = run_many(&config, 100);
+    assert_eq!(report.stalls, 100, "every seed must stall (liveness)");
+    assert_eq!(report.agreements, 0);
+    assert_eq!(report.forks, 0, "a stall is not a fork");
+}
+
+/// (3b) Complement: a crash strictly below the blocking set keeps the network
+/// LIVE — n=4 (3-of-4, blocking set 2) tolerates one crash and still decides.
+#[test]
+fn crash_below_blocking_set_stays_live() {
+    let fbas = Fbas::symmetric_botho(4);
+    let blocking = fbas.health_report().min_blocking_set_cardinality.unwrap();
+    assert_eq!(blocking, 2);
+    for proposer in ProposerModel::all() {
+        let config = SimConfig {
+            n: 4,
+            threshold: None,
+            proposer,
+            network: NetworkModel::Synchronous,
+            faulty: vec![3],
+            fault: FaultKind::Crash,
+            max_rounds: 48,
+        };
+        let report = run_many(&config, 100);
+        assert_eq!(
+            report.stalls, 0,
+            "{proposer:?}: 1 crash < blocking set {blocking} → stays live"
+        );
+        assert_eq!(report.forks, 0, "{proposer:?}: crash never forks");
+    }
+}
+
+/// (4) Reproducibility: the same `(config, seed)` yields an identical outcome,
+/// and the aggregate report over a seed range is deterministic.
+#[test]
+fn reproducibility_same_seed_same_outcome() {
+    let config = SimConfig {
+        n: 7,
+        threshold: None,
+        proposer: ProposerModel::VrfLeader,
+        network: psync(4, 0.3),
+        faulty: vec![1, 5],
+        fault: FaultKind::Equivocate,
+        max_rounds: 96,
+    };
+    for seed in [0u64, 1, 7, 42, 1000] {
+        assert_eq!(
+            run_tracked(&config, seed),
+            run_tracked(&config, seed),
+            "seed {seed} must reproduce exactly"
+        );
+    }
+    assert_eq!(
+        run_many(&config, 128),
+        run_many(&config, 128),
+        "aggregate report must be deterministic over a seed range"
+    );
+}


### PR DESCRIPTION
Closes #514. Follow-up to #511/#512 (static FBAS analyzer). Extends `bth-quorum-sim` with the **dynamic, message-level SCP round simulator** that empirically detects **forks (safety)** and **stalls (liveness)** under faulty/Byzantine scenarios — the validate-before-landing tool for the open #427 proposer-model decision (drop competing-coinbase → explicit leader election).

## What's new

- **`consensus/quorum-sim/src/sim.rs`** — the dynamic engine. Round-based nomination + **accept-lock** + commit over the existing FBAS model, reusing `Fbas::is_quorum` as the single quorum oracle so dynamic outcomes cross-check the static splitting/blocking-set predictions.
- **`consensus/quorum-sim/tests/dynamic.rs`** — the mandatory acceptance tests.
- **`simulate` CLI subcommand** wired into the existing `quorum-sim` binary (matches the clap structure; sweeps all proposer models by default; `--json`).
- `lib.rs` re-exports, README section, `Cargo.toml` deps (`rand`, `rand_chacha`).

## Proposer models implemented

`competing-coinbase` (Botho's current model), `hash-priority-leader` (SCP-native `Gi(slot,node)`), `round-robin-leader`, `vrf-leader` (seeded-hash VRF approximation).

## Fault types implemented

`crash` (silent) and Byzantine `equivocate` (sends different values to different peers — the fork-inducing adversary).

## Network + determinism

Synchronous and partially-synchronous (seeded per-message delay + drop). All randomness funnels through a single explicitly-seeded `ChaCha8Rng`, so `(config, seed)` is bit-for-bit reproducible (asserted).

## Metrics + report

Per-config fork / stall / agreement counts, rounds-to-decide histogram, leadership distribution + fairness. Human table + serde JSON, matching the existing report style.

## SCP simplifications (kept honest — documented in `src/sim.rs` module docs + README)

- **accept→confirm collapsed into one accept-lock** (a correct node locks the first value it sees a quorum support, pins its vote, never retracts). This is what produces the splitting-set safety guarantee.
- **one slot + one leader per run** (no mid-slot leader rotation, which would inject spurious churn unrelated to safety); leadership **fairness is measured across seeds** (each seed = a distinct slot).
- **no leader-timeout recovery**: a *crashed* leader is survived via a deterministic lowest-value-heard fallback, but a *Byzantine (equivocating) leader stalls* the slot (reported as liveness, not safety). SCP's real leader replacement is out of scope.
- value identity is a small integer standing in for a coinbase/tx_hash; the production combiner is abstracted to "lowest value id wins".

## Test results (all pass)

`cargo test -p bth-quorum-sim`: 32 lib + 5 static `correctness` + 5 `dynamic` acceptance tests.

Mandatory bar:
- `known_safe_below_splitting_never_forks` — n∈{4,7,10}, equivocators **below** the static splitting set, every proposer, partial synchrony, 200 seeds → **0 forks**.
- `equivocation_crosses_static_splitting_threshold` — 1 equivocator (< splitting set 2) never forks; 2 (= splitting set, leader equivocating) **CAN** fork and it is detected. Cross-checks the static analyzer dynamically.
- `unanimity_below_four_stalls_on_crash` — n=3 (3-of-3) + 1 crash → 100% stall.
- `crash_below_blocking_set_stays_live` — n=4 (3-of-4) + 1 crash → stays live.
- `reproducibility_same_seed_same_outcome` — identical outcomes per seed; deterministic aggregate.

`cargo fmt` (pinned nightly-2025-12-03) clean; `cargo clippy -p bth-quorum-sim --all-targets` clean; `cargo build` clean.

## Sample output (informs #427)

```
=== n=4, 2 equivocators (= splitting set), synchronous ===
proposer               n   thr   network  forks  stall  agree  mean_rds fairness
competing-coinbase     4     3      sync      0    300      0         -      n/a
hash-priority-leader   4     3      sync    149    151      0      2.00     0.97
round-robin-leader     4     3      sync    150    150      0      2.00     1.00
vrf-leader             4     3      sync    138    162      0      2.00     0.72
```

Forks appear in leader models exactly when the Byzantine leader equivocates (≈half the seeds), confirming the splitting-set=2 prediction; round-robin shows perfect leadership fairness (1.00) vs VRF's lopsidedness (0.72) at small n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)