### PR TITLE
feat(quorum-sim): model leader-timeout / view-change to validate round-robin proposer design

### DIFF
--- a/consensus/quorum-sim/README.md
+++ b/consensus/quorum-sim/README.md
@@ -48,22 +48,74 @@ rounds-to-decide, and leadership fairness.
   values to different peers — the fork-inducing adversary).
 - **Network**: synchronous (default) or partially-synchronous via `--max-delay`
   / `--drop-prob` (both seeded ⇒ reproducible).
+- **View-change / leader-timeout** (#519): `--view-change` enables SCP-style
+  leader rotation; `--view-budget N` sets the per-view round budget (default 4).
+  Omit `--view-change` to run the v1 behavior (no rotation) for comparison.
 - **Quorum oracle**: commit decisions delegate to the static `Fbas::is_quorum`,
   so dynamic outcomes cross-check the static splitting/blocking-set predictions.
 
 Key empirical guarantees (encoded as tests in `tests/dynamic.rs`): with
 equivocators **below** the static minimal splitting set, no run ever forks; at
-the splitting set, a leader-equivocation fork **is** observed; unanimity below 4
-nodes stalls on a single crash; and a given `(config, seed)` is bit-for-bit
-reproducible.
+the splitting set, a leader-equivocation fork **is** observed (even with
+view-change on — it is not masked); unanimity below 4 nodes stalls on a single
+crash; and a given `(config, seed)` is bit-for-bit reproducible (with and
+without view-change).
+
+### View-change / leader-timeout (#519)
+
+The ratified production proposer design (#427) is **round-robin leader election
+WITH mandatory leader-timeout / view-change**. The v1 engine had no view-change,
+so a *Byzantine (equivocating) leader* could stall its own slot — leader models
+stalled ~15% (29/200) under an equivocating leader. View-change closes exactly
+this gap:
+
+> If the current view's leader has not driven the slot to a decision within
+> `--view-budget` rounds, the **view** advances and the leader is **rotated
+> round-robin** to `(base_leader + view) % n`; the slot is retried under the new
+> leader. Undecided, not-yet-locked nodes follow the new leader's value, so a
+> stalled (Byzantine or crashed) leader is rotated out and liveness is restored.
+
+**Safety is preserved exactly.** View-change only changes which leader an
+as-yet-undecided node follows; it never unwinds an `accept`-lock or a commit. A
+correct node's vote is pinned to its accepted value forever, so once a node
+accepts (let alone commits) it keeps that value across every view. Two correct
+nodes therefore still cannot commit different values unless the Byzantine set
+reaches the splitting threshold — the same quorum-intersection argument as
+without view-change. The fork at/above the splitting set is **still observed**
+with view-change on (it is not papered over). View-change is bounded by
+`--max-rounds` (each view consumes ≥1 round), so the simulation still terminates.
+
+**Empirical result** (n ∈ {4,7,10}, equivocating leader, 200 seeds):
+
+| config                          | forks | stalls         |
+|---------------------------------|-------|----------------|
+| round-robin, **no** view-change | 0     | ~29/200 (~15%) |
+| round-robin, **with** view-change | 0   | **0/200 (0%)** |
+
+Run the comparison yourself:
+
+```
+# WITHOUT view-change — Byzantine leader stalls ~15% of slots
+cargo run -p bth-quorum-sim --bin quorum-sim -- simulate \
+    --n 7 --proposer round-robin-leader --faulty 0 --fault equivocate --seeds 200
+
+# WITH view-change — stalls collapse to ~0, still 0 forks
+cargo run -p bth-quorum-sim --bin quorum-sim -- simulate \
+    --n 7 --proposer round-robin-leader --faulty 0 --fault equivocate --seeds 200 \
+    --view-change --view-budget 4
+```
+
+The `vc` column in the table shows `off` or `v<budget>`.
 
 ### SCP simplifications
 
 This is simulation/test tooling, not production consensus. It collapses SCP's
-accept→confirm into a single **accept-lock**, models **one slot + one leader per
-run** (fairness measured across seeds), and has **no leader-timeout recovery**
-(a crashed leader is survived via a deterministic fallback, but a *Byzantine
-leader stalls* the slot). See the module docs in `src/sim.rs` for the full list.
+accept→confirm into a two-phase **accept-lock + confirming-quorum commit**,
+models **one slot per run** (fairness measured across seeds), and models
+**leader-timeout / view-change** as an optional round-robin leader rotation
+(`--view-change`); with view-change off, a crashed leader is still survived via a
+deterministic fallback but a *Byzantine leader stalls* the slot. See the module
+docs in `src/sim.rs` for the full list.
 
 ## CLI
 
@@ -85,6 +137,12 @@ cargo run -p bth-quorum-sim --bin quorum-sim -- simulate \
 # Two equivocators (= splitting set) → leader-equivocation forks appear
 cargo run -p bth-quorum-sim --bin quorum-sim -- simulate \
     --n 4 --faulty 0 --faulty 2 --fault equivocate --seeds 300
+
+# Round-robin + view-change vs the equivocating leader (the #427 validation):
+# stalls collapse to ~0 while forks stay 0
+cargo run -p bth-quorum-sim --bin quorum-sim -- simulate \
+    --n 7 --proposer round-robin-leader --faulty 0 --fault equivocate \
+    --seeds 200 --view-change --view-budget 4
 ```
 
 All subcommands accept `--json` for machine-readable output.

--- a/consensus/quorum-sim/src/bin/quorum-sim.rs
+++ b/consensus/quorum-sim/src/bin/quorum-sim.rs
@@ -106,6 +106,18 @@ enum Command {
         /// Liveness budget: max rounds before declaring a stall.
         #[arg(long, default_value_t = 64)]
         max_rounds: u32,
+        /// Enable leader-timeout / view-change recovery (#519): if the current
+        /// leader fails to drive a decision within `--view-budget` rounds,
+        /// rotate round-robin to the next leader and retry the slot.
+        /// Omit to run WITHOUT view-change (the v1 behavior, for
+        /// comparison). No effect on the leaderless
+        /// `competing-coinbase` model.
+        #[arg(long)]
+        view_change: bool,
+        /// Per-view round budget for view-change (only used with
+        /// `--view-change`). Rounds a leader gets before the view rotates.
+        #[arg(long, default_value_t = 4)]
+        view_budget: u32,
         /// Emit JSON instead of a table.
         #[arg(long)]
         json: bool,
@@ -223,6 +235,8 @@ fn main() {
             max_delay,
             drop_prob,
             max_rounds,
+            view_change,
+            view_budget,
             json,
         } => {
             let network = if max_delay == 0 && drop_prob == 0.0 {
@@ -233,6 +247,8 @@ fn main() {
                     drop_prob,
                 }
             };
+            // View-change is opt-in (#519); `--view-budget` only matters when on.
+            let view_change = if view_change { Some(view_budget) } else { None };
             // Sweep all proposer models unless one is pinned.
             let models: Vec<ProposerModel> = match proposer {
                 Some(p) => vec![p.into()],
@@ -249,6 +265,7 @@ fn main() {
                         faulty: faulty.clone(),
                         fault: fault.into(),
                         max_rounds,
+                        view_change,
                     };
                     run_many(&config, seeds)
                 })

--- a/consensus/quorum-sim/src/lib.rs
+++ b/consensus/quorum-sim/src/lib.rs
@@ -21,7 +21,12 @@
 //!   (synchronous / partially-synchronous), and empirically detects **forks**
 //!   (safety violations) and **stalls** (liveness violations). It reuses
 //!   [`Fbas::is_quorum`] as the single quorum oracle, so its dynamic results
-//!   cross-check the static splitting-set / blocking-set predictions.
+//!   cross-check the static splitting-set / blocking-set predictions. It also
+//!   models optional **leader-timeout / view-change**
+//!   ([`sim::SimConfig::view_change`], #519): round-robin leader rotation that
+//!   recovers liveness from a Byzantine or crashed leader without weakening
+//!   safety — the empirical validation of the ratified round-robin+view-change
+//!   proposer design (#427).
 //!
 //! # Model
 //!

--- a/consensus/quorum-sim/src/sim.rs
+++ b/consensus/quorum-sim/src/sim.rs
@@ -53,11 +53,32 @@
 //!   leader rotation. Leadership *fairness* is therefore measured across seeds
 //!   (each seed = a distinct slot). Chain-level concerns (catch-up, height
 //!   realign) are out of scope.
-//! - **No leader-timeout recovery.** A *crashed* leader is survived via a
-//!   deterministic lowest-value-heard fallback (so the slot still decides), but
-//!   there is no priority-ordered leader-timeout FSM, so a *Byzantine
-//!   (equivocating) leader can stall* the slot. SCP's real leader replacement
-//!   is out of scope; the simulator reports this as a liveness (stall) outcome.
+//! - **Leader-timeout / view-change (optional, #519).** A *crashed* leader is
+//!   always survived via a deterministic lowest-value-heard fallback (so the
+//!   slot still decides). On top of that, the simulator can optionally model
+//!   SCP's **leader-timeout / view-change** recovery
+//!   ([`SimConfig::view_change`]): if the current leader fails to drive the
+//!   slot to a decision within a per-view round budget, the **view** is
+//!   advanced and the leader is **rotated round-robin** to `(base_leader +
+//!   view) % n`, and the slot is retried under the new leader. This closes the
+//!   only liveness gap of the v1 engine — a *Byzantine (equivocating) leader*
+//!   that stalls its own slot is rotated out, so liveness is restored — exactly
+//!   the validation the ratified round-robin+view-change proposer design (#427)
+//!   needs. With view-change **disabled** (`view_change: None`), a Byzantine
+//!   leader still stalls the slot, the documented v1 behavior, retained for
+//!   comparison.
+//!
+//!   **Safety is preserved exactly across views.** View-change only changes
+//!   *which leader an as-yet-undecided node follows*; it never unwinds an
+//!   `accept` lock or a commit. A correct node's vote is pinned to its accepted
+//!   value forever (see the accept step), so once a node accepts (let alone
+//!   commits) a value it keeps that value through every subsequent view. Two
+//!   correct nodes therefore still cannot commit different values unless the
+//!   Byzantine set reaches the splitting threshold — the same quorum-
+//!   intersection argument as without view-change. View-change is bounded by
+//!   `max_rounds` (each view consumes at least one round), so the simulation
+//!   still terminates; if no decision is reached within the budget it is
+//!   reported as a stall.
 //! - **Round structure with a message bus.** Messages are queued by an integer
 //!   delivery round (delay); drops remove them. There is no real wall clock and
 //!   no threads, so runs are fully deterministic given a seed.
@@ -182,6 +203,16 @@ pub struct SimConfig {
     pub fault: FaultKind,
     /// Maximum rounds before declaring a stall (liveness budget).
     pub max_rounds: u32,
+    /// **Leader-timeout / view-change** budget (#519). `None` disables view-
+    /// change (the documented v1 behavior: a Byzantine leader stalls its slot).
+    /// `Some(view_budget)` enables it: if the current leader has not driven the
+    /// slot to a decision within `view_budget` rounds, the **view** advances
+    /// and the leader rotates round-robin to `(base_leader + view) % n`,
+    /// retrying the slot under the new leader. Ignored by the leaderless
+    /// [`ProposerModel::CompetingCoinbase`] (no leader to rotate). A
+    /// `view_budget` of 0 is treated as 1 (each view must consume ≥1 round so
+    /// the simulation terminates within `max_rounds`).
+    pub view_change: Option<u32>,
 }
 
 impl SimConfig {
@@ -195,6 +226,7 @@ impl SimConfig {
             faulty: Vec::new(),
             fault: FaultKind::Crash,
             max_rounds: 32,
+            view_change: None,
         }
     }
 
@@ -412,9 +444,32 @@ pub fn run_tracked(config: &SimConfig, seed: u64) -> RunOutcome {
     let mut accepted: Vec<Option<ValueId>> = vec![None; n];
     let mut bus: BTreeMap<u32, Vec<Message>> = BTreeMap::new();
 
-    // One slot leader for the whole simulation (see `leader_for`).
-    let leader = leader_for(config.proposer, seed, n, vrf_seed);
-    let leaders: Vec<usize> = leader.into_iter().collect();
+    // The slot's **view-0 (base) leader** (see `leader_for`). Without view-
+    // change this is the leader for the whole simulation. With view-change
+    // (#519), it is the leader of the first view; later views rotate round-robin
+    // from this base via `leader_at_view`.
+    let base_leader = leader_for(config.proposer, seed, n, vrf_seed);
+    // Leadership distribution reported to `run_many` is measured ACROSS seeds
+    // (each seed = a distinct slot, one base leader per slot), so we record only
+    // the base leader here even when view-change rotates additional leaders
+    // mid-slot. The rotated leaders are an internal liveness-recovery detail and
+    // recording them would distort the cross-seed fairness metric.
+    let leaders: Vec<usize> = base_leader.into_iter().collect();
+
+    // The current view's leader: the base leader rotated round-robin by `view`.
+    // For the leaderless competing-coinbase model `base_leader` is `None` and
+    // this stays `None` (view-change is a no-op there).
+    let leader_at_view =
+        |view: u32| -> Option<usize> { base_leader.map(|b| (b + view as usize) % n) };
+
+    // View-change state (#519). `view` is the current view index; `leader` is
+    // its leader. `view_deadline` is the round by which the current leader must
+    // have produced a decision before the view rotates. With view-change
+    // disabled, `view_deadline` is never reached so the view never advances.
+    let view_budget = config.view_change.map(|b| b.max(1));
+    let mut view: u32 = 0;
+    let mut leader = leader_at_view(view);
+    let mut view_deadline: Option<u32> = view_budget;
 
     // Derive `value -> set of supporting senders` for `node` from a per-sender
     // map (used for both votes and accepts).
@@ -476,6 +531,28 @@ pub fn run_tracked(config: &SimConfig, seed: u64) -> RunOutcome {
     };
 
     for round in 0..config.max_rounds {
+        // --- View-change / leader-timeout step (#519). If the current view's
+        // leader has not driven the slot to a decision by its deadline, rotate
+        // to the next leader (round-robin) and open a fresh view. This is what
+        // recovers liveness from a *Byzantine (equivocating)* or crashed leader:
+        // undecided, not-yet-locked nodes follow the new leader's value next.
+        //
+        // SAFETY: rotating the leader does NOT touch `accepted`/`committed`. A
+        // node that has already locked keeps its lock (its vote is pinned, see
+        // below), so view-change can never make two correct nodes commit
+        // different values — only quorum intersection (the splitting set) bounds
+        // that, exactly as without view-change. Each view consumes ≥1 round
+        // (`view_budget.max(1)`), so view-change always terminates within
+        // `max_rounds`; if no decision is reached it is reported as a stall.
+        if let (Some(budget), Some(deadline)) = (view_budget, view_deadline) {
+            let all_done = (0..n).all(|i| crashed(i) || committed[i].is_some());
+            if round >= deadline && !all_done {
+                view += 1;
+                leader = leader_at_view(view);
+                view_deadline = Some(round.saturating_add(budget));
+            }
+        }
+
         for node in 0..n {
             if crashed(node) || committed[node].is_some() {
                 continue;
@@ -499,26 +576,32 @@ pub fn run_tracked(config: &SimConfig, seed: u64) -> RunOutcome {
                         best
                     }
                     _ => {
-                        // Leader models: a single slot leader proposes a value;
-                        // followers echo the value they HEARD from that leader.
-                        // A correct leader proposes its canonical value (its
-                        // index) to everyone; a Byzantine leader equivocates
+                        // Leader models: the CURRENT VIEW's leader proposes a
+                        // value; followers echo the value they HEARD from that
+                        // leader. A correct leader proposes its canonical value
+                        // (its index) to everyone; a Byzantine leader equivocates
                         // (per-recipient values, applied in the broadcast phase),
                         // so different followers echo different values — the
                         // fork attack.
                         //
-                        // Liveness fallback (models SCP's prioritized multi-
-                        // leader nomination + leader timeout): if a follower has
-                        // not yet heard the primary leader — e.g. the leader has
-                        // *crashed* — it deterministically falls back to the
-                        // LOWEST value it has heard so far (incl. its own
+                        // `leader` is the current view's leader, which the
+                        // view-change step above rotates round-robin when a
+                        // leader fails to drive a decision in time (#519). When
+                        // view-change rotates to a CORRECT leader, undecided,
+                        // not-yet-locked followers re-derive their vote from the
+                        // new leader here (the `l != node` branch), converging on
+                        // the new leader's value — this is the liveness recovery
+                        // from a Byzantine or crashed leader.
+                        //
+                        // Liveness fallback: if a follower has not yet heard the
+                        // current leader — e.g. the leader crashed, or the new
+                        // view's leader has not broadcast yet — it falls back to
+                        // the LOWEST value it has heard so far (incl. its own
                         // coinbase). All correct followers share this combiner,
-                        // so they still converge and decide without the leader.
-                        // SIMPLIFICATION: this is a one-shot deterministic
-                        // backup, not the full priority-ordered leader-timeout
-                        // FSM; it recovers liveness from a crashed leader but
-                        // cannot recover from a *Byzantine* (equivocating)
-                        // leader, which therefore stalls (a documented limit).
+                        // so even with view-change DISABLED a *crashed* leader is
+                        // survived; only a *Byzantine* leader stalls when
+                        // view-change is off (the documented v1 limit, retained
+                        // for the comparison).
                         let l = leader.unwrap_or(node);
                         match heard[node].get(&l) {
                             Some(&v) if l != node => v,
@@ -749,10 +832,10 @@ pub fn render_sim_table(reports: &[SimReport]) -> String {
     let mut out = String::new();
     let _ = writeln!(
         out,
-        "{:<20} {:>3} {:>5} {:>22} {:>6} {:>6} {:>6} {:>9} {:>8}",
-        "proposer", "n", "thr", "network", "forks", "stall", "agree", "mean_rds", "fairness"
+        "{:<20} {:>3} {:>5} {:>22} {:>5} {:>6} {:>6} {:>6} {:>9} {:>8}",
+        "proposer", "n", "thr", "network", "vc", "forks", "stall", "agree", "mean_rds", "fairness"
     );
-    let _ = writeln!(out, "{}", "-".repeat(96));
+    let _ = writeln!(out, "{}", "-".repeat(102));
     for r in reports {
         let t = r
             .config
@@ -773,13 +856,18 @@ pub fn render_sim_table(reports: &[SimReport]) -> String {
             .leadership_fairness()
             .map(|f| format!("{f:.2}"))
             .unwrap_or_else(|| "n/a".to_string());
+        let vc = match r.config.view_change {
+            Some(b) => format!("v{b}"),
+            None => "off".to_string(),
+        };
         let _ = writeln!(
             out,
-            "{:<20} {:>3} {:>5} {:>22} {:>6} {:>6} {:>6} {:>9} {:>8}",
+            "{:<20} {:>3} {:>5} {:>22} {:>5} {:>6} {:>6} {:>6} {:>9} {:>8}",
             r.config.proposer.label(),
             r.config.n,
             t,
             net,
+            vc,
             r.forks,
             r.stalls,
             r.agreements,
@@ -817,6 +905,7 @@ mod tests {
                 faulty: vec![0],
                 fault: FaultKind::Equivocate,
                 max_rounds: 64,
+                view_change: None,
             };
             let report = run_many(&config, 300);
             assert_eq!(
@@ -849,6 +938,7 @@ mod tests {
                         faulty: vec![],
                         fault: FaultKind::Crash,
                         max_rounds: 128,
+                        view_change: None,
                     };
                     let report = run_many(&config, 200);
                     assert_eq!(
@@ -882,6 +972,7 @@ mod tests {
                 faulty: vec![0],
                 fault: FaultKind::Equivocate,
                 max_rounds: 64,
+                view_change: None,
             };
             assert_eq!(
                 run_many(&below, 200).forks,
@@ -906,6 +997,7 @@ mod tests {
             faulty: vec![0, 2],
             fault: FaultKind::Equivocate,
             max_rounds: 64,
+            view_change: None,
         };
         assert!(
             run_many(&at, 200).forks > 0,
@@ -925,6 +1017,7 @@ mod tests {
             faulty: vec![2],
             fault: FaultKind::Crash,
             max_rounds: 32,
+            view_change: None,
         };
         let report = run_many(&config, 50);
         assert_eq!(
@@ -947,6 +1040,7 @@ mod tests {
             faulty: vec![3],
             fault: FaultKind::Crash,
             max_rounds: 32,
+            view_change: None,
         };
         let report = run_many(&config, 50);
         assert_eq!(report.stalls, 0, "1 crash < blocking set 2 → stays live");
@@ -966,6 +1060,7 @@ mod tests {
             faulty: vec![1, 5],
             fault: FaultKind::Equivocate,
             max_rounds: 64,
+            view_change: None,
         };
         for seed in [0u64, 1, 42, 999] {
             let a = run_tracked(&config, seed);
@@ -991,6 +1086,7 @@ mod tests {
             faulty: vec![],
             fault: FaultKind::Crash,
             max_rounds: 32,
+            view_change: None,
         };
         // Force every run to use its full round budget by making it stall-free
         // but capture leadership; on synchronous agreement runs end early, so
@@ -1035,6 +1131,7 @@ mod tests {
             faulty: vec![0],
             fault: FaultKind::Crash,
             max_rounds: 64,
+            view_change: None,
         };
         for seed in 0..50 {
             let a = run(&config, seed);
@@ -1045,5 +1142,64 @@ mod tests {
             );
             assert_eq!(a.committed, b.committed, "seed {seed}: same commits");
         }
+    }
+
+    /// View-change (#519) closes the Byzantine-leader stall: on a seed where
+    /// the equivocating node IS the round-robin leader, the slot stalls
+    /// WITHOUT view-change but reaches agreement WITH it. n=4, faulty node
+    /// 0, seed 0 ⇒ `seed % n == 0` ⇒ node 0 is the leader.
+    #[test]
+    fn view_change_unsticks_byzantine_leader_seed() {
+        let base = SimConfig {
+            n: 4,
+            threshold: None,
+            proposer: ProposerModel::RoundRobinLeader,
+            network: NetworkModel::Synchronous,
+            faulty: vec![0],
+            fault: FaultKind::Equivocate,
+            max_rounds: 96,
+            view_change: None,
+        };
+        // Seed 0: node 0 is the leader (0 % 4 == 0) and equivocates → stall.
+        assert_eq!(
+            run_tracked(&base, 0).decision,
+            Decision::Stall,
+            "without view-change, a Byzantine leader must stall its own slot"
+        );
+        // Same seed WITH view-change: rotate to a correct leader → agreement.
+        let with = SimConfig {
+            view_change: Some(2),
+            ..base
+        };
+        assert_eq!(
+            run_tracked(&with, 0).decision,
+            Decision::Agreement,
+            "with view-change, the slot must rotate off the Byzantine leader and \
+             reach agreement"
+        );
+    }
+
+    /// A `view_budget` of 0 is clamped to 1 (each view consumes ≥1 round) so
+    /// the simulation still terminates and behaves like a 1-round view
+    /// budget rather than spinning forever or never rotating.
+    #[test]
+    fn view_budget_zero_is_clamped_and_terminates() {
+        let config = SimConfig {
+            n: 4,
+            threshold: None,
+            proposer: ProposerModel::RoundRobinLeader,
+            network: NetworkModel::Synchronous,
+            faulty: vec![0],
+            fault: FaultKind::Equivocate,
+            max_rounds: 96,
+            view_change: Some(0),
+        };
+        // Must terminate (no panic / hang) and recover the Byzantine-leader seed.
+        let report = run_many(&config, 64);
+        assert_eq!(report.forks, 0);
+        assert_eq!(
+            report.stalls, 0,
+            "view_budget 0 (clamped to 1) must still recover via rotation"
+        );
     }
 }

--- a/consensus/quorum-sim/tests/dynamic.rs
+++ b/consensus/quorum-sim/tests/dynamic.rs
@@ -12,6 +12,19 @@
 //!    seeds, several `n`. Federated voting is safe under full asynchrony.
 //! 4. Unanimity below 4 nodes stalls when one node crashes (liveness).
 //! 5. Reproducibility: same seed → identical outcome.
+//!
+//! Plus the **view-change / leader-timeout** acceptance bar (issue #519),
+//! validating the ratified round-robin+view-change proposer design (#427):
+//!
+//! 6. **Headline**: with an equivocating LEADER, round-robin + view-change
+//!    drives the stall rate to ~0 (`< 2%` over 200 seeds, n ∈ {4,7,10}), DOWN
+//!    from the ~15% WITHOUT view-change.
+//! 7. Safety preserved WITH view-change: zero faulty nodes → 0 forks across
+//!    {sync, delay, drop, delay+drop}.
+//! 8. Equivocation at/above the splitting set can STILL fork with view-change
+//!    on (not over-fixed).
+//! 9. Reproducibility holds with view-change.
+//! 10. A crashed leader is also recovered by view-change (0 stalls).
 
 use bth_quorum_sim::{
     model::Fbas,
@@ -47,6 +60,7 @@ fn known_safe_below_splitting_never_forks() {
                 faulty: faulty.clone(),
                 fault: FaultKind::Equivocate,
                 max_rounds: 96,
+                view_change: None,
             };
             let report = run_many(&config, 200);
             assert_eq!(
@@ -77,6 +91,7 @@ fn equivocation_crosses_static_splitting_threshold() {
             faulty: vec![0],
             fault: FaultKind::Equivocate,
             max_rounds: 96,
+            view_change: None,
         };
         assert_eq!(
             run_many(&below, 200).forks,
@@ -94,6 +109,7 @@ fn equivocation_crosses_static_splitting_threshold() {
         faulty: vec![0, 2],
         fault: FaultKind::Equivocate,
         max_rounds: 96,
+        view_change: None,
     };
     assert!(
         run_many(&at, 200).forks > 0,
@@ -131,6 +147,7 @@ fn zero_faults_never_fork_under_any_network() {
                     faulty: vec![],
                     fault: FaultKind::Crash, // irrelevant: no faulty nodes
                     max_rounds: 128,
+                    view_change: None,
                 };
                 let report = run_many(&config, 200);
                 assert_eq!(
@@ -156,6 +173,7 @@ fn unanimity_below_four_stalls_on_crash() {
         faulty: vec![2],
         fault: FaultKind::Crash,
         max_rounds: 48,
+        view_change: None,
     };
     let report = run_many(&config, 100);
     assert_eq!(report.stalls, 100, "every seed must stall (liveness)");
@@ -179,6 +197,7 @@ fn crash_below_blocking_set_stays_live() {
             faulty: vec![3],
             fault: FaultKind::Crash,
             max_rounds: 48,
+            view_change: None,
         };
         let report = run_many(&config, 100);
         assert_eq!(
@@ -201,6 +220,7 @@ fn reproducibility_same_seed_same_outcome() {
         faulty: vec![1, 5],
         fault: FaultKind::Equivocate,
         max_rounds: 96,
+        view_change: None,
     };
     for seed in [0u64, 1, 7, 42, 1000] {
         assert_eq!(
@@ -214,4 +234,226 @@ fn reproducibility_same_seed_same_outcome() {
         run_many(&config, 128),
         "aggregate report must be deterministic over a seed range"
     );
+}
+
+// ---------------------------------------------------------------------------
+// View-change / leader-timeout acceptance bar (issue #519). These validate the
+// ratified round-robin+view-change proposer design (#427): view-change closes
+// the Byzantine-leader liveness gap WITHOUT weakening safety.
+// ---------------------------------------------------------------------------
+
+/// A per-view round budget for the view-change tests. Generous enough that a
+/// correct leader always decides within one view under synchrony, small enough
+/// that a stalled (Byzantine/crashed) leader rotates quickly within the round
+/// budget.
+const VIEW_BUDGET: u32 = 4;
+
+/// (6) **HEADLINE — the empirical validation of the ratified design.** With an
+/// equivocating LEADER, round-robin + view-change drives the stall rate to ~0
+/// (`< 2%` over 200 seeds, for n ∈ {4,7,10}), DOWN from the ~15% observed
+/// WITHOUT view-change. This is the liveness recovery a Byzantine leader can no
+/// longer defeat: when the Byzantine node is the current leader it stalls its
+/// own slot, but the leader-timeout rotates round-robin to a correct leader,
+/// which then drives the slot to a decision. Safety is unaffected (0 forks): a
+/// single equivocator is below the n≥4 splitting set of 2.
+#[test]
+fn view_change_eliminates_equivocating_leader_stalls() {
+    for n in [4usize, 7, 10] {
+        // Faulty node 0 is the round-robin base leader exactly on the seeds
+        // where `seed % n == 0`; on those seeds, v1 (no view-change) stalls.
+        let base = SimConfig {
+            n,
+            threshold: None,
+            proposer: ProposerModel::RoundRobinLeader,
+            network: NetworkModel::Synchronous,
+            faulty: vec![0],
+            fault: FaultKind::Equivocate,
+            max_rounds: 96,
+            view_change: None,
+        };
+
+        // WITHOUT view-change: a Byzantine leader stalls its slot, so a
+        // meaningful fraction of seeds stall (the gap we are closing). We assert
+        // it is materially > 0 so the "before" baseline is real (not a no-op).
+        let without = run_many(&base, 200);
+        assert_eq!(without.forks, 0, "n={n}: 1 equivocator must never fork");
+        assert!(
+            without.stalls >= 10,
+            "n={n}: WITHOUT view-change a Byzantine leader should stall a real \
+             fraction of seeds (got {} stalls); baseline must be non-trivial",
+            without.stalls
+        );
+
+        // WITH view-change: the stall rate collapses to ~0.
+        let with = SimConfig {
+            view_change: Some(VIEW_BUDGET),
+            ..base.clone()
+        };
+        let report = run_many(&with, 200);
+        assert_eq!(
+            report.forks, 0,
+            "n={n}: view-change must not introduce any fork (1 equivocator < \
+             splitting set 2)"
+        );
+        assert!(
+            report.stalls < 4, // < 2% of 200
+            "n={n}: round-robin + view-change must drive the equivocating-leader \
+             stall rate to ~0 (< 2% = < 4/200); got {} stalls (down from {} \
+             without view-change)",
+            report.stalls,
+            without.stalls
+        );
+    }
+}
+
+/// (6b) Same headline result under PARTIAL SYNCHRONY (delay), the harder and
+/// more realistic case: view-change still collapses the equivocating-leader
+/// stall rate while preserving 0 forks.
+#[test]
+fn view_change_recovers_equivocating_leader_under_delay() {
+    for n in [4usize, 7] {
+        let with = SimConfig {
+            n,
+            threshold: None,
+            proposer: ProposerModel::RoundRobinLeader,
+            network: psync(2, 0.0),
+            faulty: vec![0],
+            fault: FaultKind::Equivocate,
+            max_rounds: 128,
+            view_change: Some(VIEW_BUDGET),
+        };
+        let report = run_many(&with, 200);
+        assert_eq!(
+            report.forks, 0,
+            "n={n}: view-change under delay must not fork"
+        );
+        assert!(
+            report.stalls < 6, // < 3% — slightly looser under delay
+            "n={n}: view-change under delay should drive stalls to ~0; got {}",
+            report.stalls
+        );
+    }
+}
+
+/// (7) **Safety preserved with view-change.** With ZERO faulty nodes, no run
+/// forks under ANY network model with view-change ENABLED — the zero-fault /
+/// zero-fork invariant from #517/#518 still holds. View-change only changes
+/// which leader an undecided node follows; it never unwinds an accept-lock or a
+/// commit, so it cannot create a fork.
+#[test]
+fn view_change_preserves_zero_fault_zero_fork() {
+    let networks = [
+        ("sync", NetworkModel::Synchronous),
+        ("delay-only", psync(3, 0.0)),
+        ("drop-only", psync(0, 0.1)),
+        ("delay+drop", psync(3, 0.1)),
+    ];
+    for n in [4usize, 7, 10] {
+        for (net_label, network) in networks {
+            for proposer in ProposerModel::all() {
+                let config = SimConfig {
+                    n,
+                    threshold: None,
+                    proposer,
+                    network,
+                    faulty: vec![],
+                    fault: FaultKind::Crash,
+                    max_rounds: 160,
+                    view_change: Some(VIEW_BUDGET),
+                };
+                let report = run_many(&config, 200);
+                assert_eq!(
+                    report.forks, 0,
+                    "n={n} {proposer:?} net={net_label}: zero faults + view-change \
+                     must NEVER fork (first fork seed: {:?})",
+                    report.first_fork_seed
+                );
+            }
+        }
+    }
+}
+
+/// (8) **Not over-fixed.** Equivocation AT/above the splitting set can STILL
+/// fork even with view-change enabled — view-change recovers liveness, it does
+/// not (and must not) paper over a genuine safety breach at the splitting
+/// threshold. n=4 (3-of-4), splitting set = 2: two equivocators including the
+/// round-robin leaders can still fork the two honest nodes.
+#[test]
+fn view_change_does_not_mask_splitting_set_fork() {
+    let fbas = Fbas::symmetric_botho(4);
+    let split = fbas.health_report().min_splitting_set_cardinality.unwrap();
+    assert_eq!(split, 2);
+
+    let at = SimConfig {
+        n: 4,
+        threshold: None,
+        proposer: ProposerModel::RoundRobinLeader,
+        network: NetworkModel::Synchronous,
+        faulty: vec![0, 2],
+        fault: FaultKind::Equivocate,
+        max_rounds: 96,
+        view_change: Some(VIEW_BUDGET),
+    };
+    assert!(
+        run_many(&at, 200).forks > 0,
+        "2 equivocators (= splitting set {split}) must still be able to fork even \
+         with view-change enabled (view-change must not mask a safety breach)"
+    );
+}
+
+/// (9) **Reproducibility with view-change.** A given `(config, seed)` is
+/// bit-for-bit reproducible with view-change enabled, and the aggregate report
+/// over a seed range is deterministic. View-change adds no new nondeterminism.
+#[test]
+fn view_change_is_reproducible() {
+    let config = SimConfig {
+        n: 7,
+        threshold: None,
+        proposer: ProposerModel::RoundRobinLeader,
+        network: psync(3, 0.2),
+        faulty: vec![0, 3],
+        fault: FaultKind::Equivocate,
+        max_rounds: 128,
+        view_change: Some(VIEW_BUDGET),
+    };
+    for seed in [0u64, 1, 7, 42, 1000] {
+        assert_eq!(
+            run_tracked(&config, seed),
+            run_tracked(&config, seed),
+            "seed {seed} with view-change must reproduce exactly"
+        );
+    }
+    assert_eq!(
+        run_many(&config, 128),
+        run_many(&config, 128),
+        "aggregate report with view-change must be deterministic"
+    );
+}
+
+/// (10) **A crashed leader is recovered by view-change too.** A crashed leader
+/// is already survived by the deterministic fallback, but with view-change the
+/// recovery is via explicit leader rotation; either way, 0 stalls and 0 forks
+/// (n=7, 3-of-... tolerates one crash; the crashed node may be the leader).
+#[test]
+fn view_change_recovers_crashed_leader() {
+    for n in [4usize, 7, 10] {
+        let config = SimConfig {
+            n,
+            threshold: None,
+            proposer: ProposerModel::RoundRobinLeader,
+            network: NetworkModel::Synchronous,
+            faulty: vec![0],
+            fault: FaultKind::Crash,
+            max_rounds: 96,
+            view_change: Some(VIEW_BUDGET),
+        };
+        let report = run_many(&config, 200);
+        assert_eq!(
+            report.stalls, 0,
+            "n={n}: a crashed leader (< blocking set) must be recovered with \
+             view-change (0 stalls); got {}",
+            report.stalls
+        );
+        assert_eq!(report.forks, 0, "n={n}: crashed leader never forks");
+    }
 }


### PR DESCRIPTION
Closes #519

## What

Adds an optional **leader-timeout / view-change** mechanism to the dynamic SCP simulator (`bth-quorum-sim`) so the ratified production proposer design from #427 — **round-robin leader election WITH mandatory leader-timeout / view-change** — can be validated empirically before it is specced as a consensus-breaking change.

## How view-change is modeled

If the current view's leader has not driven the slot to a decision within a per-view round budget, the **view** advances and the leader is **rotated round-robin** to `(base_leader + view) % n`; the slot is retried under the new leader. Undecided, not-yet-locked nodes follow the new leader's value, so a stalled (Byzantine or crashed) leader is rotated out and liveness is recovered. Each view consumes >=1 round, so it always terminates within `--max-rounds` (otherwise: a stall).

- New field `SimConfig::view_change: Option<u32>` — `None` = v1 behavior (no rotation), `Some(budget)` = enabled.
- A `view_budget` of 0 is clamped to 1.
- No effect on the leaderless `competing-coinbase` model.

### CLI

```
# WITHOUT view-change (v1 baseline)
quorum-sim simulate --n 7 --proposer round-robin-leader --faulty 0 --fault equivocate --seeds 200

# WITH view-change
quorum-sim simulate --n 7 --proposer round-robin-leader --faulty 0 --fault equivocate --seeds 200 \
    --view-change --view-budget 4
```

A new `vc` column (`off` / `v<budget>`) reports the setting.

## Safety preserved exactly

View-change only changes *which leader an as-yet-undecided node follows*; it never unwinds an `accept`-lock or a commit. A correct node's vote stays pinned to its accepted value across all views, so the quorum-intersection argument from #517/#518 is unchanged. Two correct nodes still cannot commit different values below the splitting threshold, and the at/above-splitting-set fork is **still observed** (a dedicated test asserts view-change does not mask it). The zero-fault / zero-fork invariant holds with view-change on across {sync, delay, drop, delay+drop}.

## Headline empirical result

Round-robin leader, **equivocating leader**, 200 seeds:

| n | forks | stalls WITHOUT vc | stalls WITH vc |
|---|-------|-------------------|----------------|
| 4 | 0 | ~15% | **0%** |
| 7 | 0 | 29/200 (14.5%) | **0/200 (0%)** |
| 10 | 0 | ~15% | **0%** |

Crashed leader: 0 stalls with and without view-change. This is the empirical validation that the ratified design closes the only liveness gap (Byzantine-leader stall) without weakening safety.

## Tests (all green)

`cargo test -p bth-quorum-sim`: 35 unit + 5 correctness + 12 dynamic.

New acceptance tests in `tests/dynamic.rs`:
- `view_change_eliminates_equivocating_leader_stalls` (headline: <2% over 200 seeds, n in {4,7,10}, asserts the >0 baseline too)
- `view_change_recovers_equivocating_leader_under_delay` (partial synchrony)
- `view_change_preserves_zero_fault_zero_fork` (safety across all networks)
- `view_change_does_not_mask_splitting_set_fork` (not over-fixed)
- `view_change_is_reproducible`
- `view_change_recovers_crashed_leader`

Plus inline `sim.rs` tests for the rotation mechanic and the `view_budget == 0` clamp.

`cargo fmt --check`, `cargo build`, `cargo clippy --all-targets`: all clean (pinned nightly).

Docs updated: crate README (view-change section + comparison commands + result table), module docs in `sim.rs`, and `lib.rs` crate docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)