### PR TITLE
feat(baas): P6.1 — parameterize rig bootstrap by RIG_ID/REGION/TIER + pin to release artifact

### DIFF
--- a/infra/baas/README.md
+++ b/infra/baas/README.md
@@ -26,9 +26,11 @@ recipe in `infra/seed/` and `infra/faucet/`:
 ## What it does (idempotent, logged to `/var/log/botho-rig-bootstrap.log`)
 
 1. **Install deps** — nginx, certbot, curl, jq, ca-certificates.
-2. **Obtain the `botho` linux-aarch64 binary** from `BOTHO_BINARY_URL`
-   (preferred over building on a t4g box, which is slow / OOM-prone). Optional
-   `BOTHO_BINARY_SHA256` is verified; the file is checked to be `aarch64`.
+2. **Download the prebuilt `botho` linux-aarch64 binary** from
+   `BOTHO_BINARY_URL` (the `binaries-linux-aarch64` release artifact; never
+   built from source on the box, which is slow / OOM-prone). Optional
+   `BOTHO_BINARY_SHA256` (the `linux-aarch64` line from the `release-checksums`
+   artifact) is verified; the file is checked to be `aarch64`.
 3. **Generate identity + config** — a per-rig 24-word wallet mnemonic and
    `~/.botho/testnet/config.toml` (testnet, RandomX minting on, faucet off,
    `quorum.mode = recommended` / `min_peers = 1`, `bootstrap_peers = []`,
@@ -54,9 +56,13 @@ recipe in `infra/seed/` and `infra/faucet/`:
 
 | Variable              | Required | Default            | Purpose |
 |-----------------------|----------|--------------------|---------|
-| `BOTHO_BINARY_URL`    | yes\*    | —                  | URL to a linux-aarch64 `botho` binary (see **Binary source** below). \*Not required on an idempotent re-run if `/usr/local/bin/botho` already exists. |
-| `BOTHO_BINARY_SHA256` | no       | —                  | Expected sha256; verified if set. |
-| `RIG_HOSTNAME`        | no       | —                  | Public hostname, e.g. `rig-abc123.testnet.botho.io`. If unset, public nginx/TLS is skipped (RPC still on `localhost:17101`). |
+| `BOTHO_BINARY_URL`    | yes\*    | —                  | URL to the prebuilt linux-aarch64 `botho` binary — the `binaries-linux-aarch64` release artifact (see **Binary source** below). \*Not required on an idempotent re-run if `/usr/local/bin/botho` already exists. |
+| `BOTHO_BINARY_SHA256` | no       | —                  | Expected sha256; verified if set. Pass the `linux-aarch64` line from the release's `release-checksums` artifact to pin the exact published build. |
+| `RIG_ID`              | no       | —                  | Short opaque rig id (e.g. `abc123`). When set and `RIG_HOSTNAME` is unset, the hostname is derived as `rig-<RIG_ID>.<RIG_DOMAIN>`. Recorded in `rig-info.txt`. |
+| `RIG_DOMAIN`          | no       | `testnet.botho.io` | Zone for `rig-<RIG_ID>` hostnames; combined with `RIG_ID` to derive `RIG_HOSTNAME`. |
+| `RIG_HOSTNAME`        | no       | —                  | Public hostname, e.g. `rig-abc123.testnet.botho.io`. Takes precedence over `RIG_ID`/`RIG_DOMAIN`. If neither is set, public nginx/TLS is skipped (RPC still on `localhost:17101`). |
+| `REGION`              | no       | —                  | AWS region the rig launched in (informational; the provisioner picks it at run-instances time). Recorded in `rig-info.txt`. |
+| `TIER`                | no       | `t4g.medium`       | Instance type/tier (informational; MVP is t4g.medium-only). Recorded in `rig-info.txt`. |
 | `NETWORK`             | no       | `testnet`          | Only `testnet` is supported in this slice. |
 | `BOOTSTRAP_PEERS`     | no       | DNS-seed discovery | Comma-separated **resolved** multiaddrs (`/ip4/.../tcp/<port>/p2p/<peer_id>`). Default empty -> DNS-seed discovery (the working path; bare `/dns4` is unsupported). |
 | `MINT_THREADS`        | no       | `1`                | RandomX threads (t4g.medium = 2 vCPU). |
@@ -68,7 +74,8 @@ recipe in `infra/seed/` and `infra/faucet/`:
 
 - `/var/log/botho-rig-bootstrap.log` — full provisioning log.
 - `~ubuntu/.botho/testnet/config.toml` — node config incl. mnemonic (chmod 600).
-- `~ubuntu/rig-info.txt` — RPC URL, public IP, binary version, helper commands.
+- `~ubuntu/rig-info.txt` — rig id, region, tier, RPC URL, public IP, binary
+  version, helper commands.
 - `botho.service` running and mining; `rig-status` read-back helper.
 
 Read back at any time:
@@ -83,26 +90,36 @@ journalctl -u botho -f
 
 ### 1. Binary source (`BOTHO_BINARY_URL`)
 
-There is currently **no published GitHub release binary** — the latest release
-(`v0.2.0`) ships **no assets**, and the release workflow builds artifacts but
-the operator hasn't attached/uploaded one. So the bootstrap **cannot fetch a
-binary on its own**; it consumes `BOTHO_BINARY_URL`.
+The rig **downloads the prebuilt arm64 binary** — it never builds from source on
+the box (t4g release builds are slow and RandomX-linked crates can OOM). The
+canonical source is the **`binaries-linux-aarch64`** artifact built by
+`.github/workflows/release.yml` (target `aarch64-unknown-linux-gnu`), and the
+matching checksum is the `linux-aarch64/...` line in the **`release-checksums`**
+artifact (`all-checksums.txt`).
 
-**#458 must publish the current `linux-aarch64` `botho` release artifact and
-pass its URL**, for example:
+However, the latest GitHub release (`v0.2.0`) ships **no downloadable asset** —
+the workflow produces the artifact, but the operator hasn't attached/mirrored a
+GET-able copy. So the bootstrap **cannot resolve a URL on its own**; it consumes
+`BOTHO_BINARY_URL` (and, ideally, `BOTHO_BINARY_SHA256`).
 
+**#458 (P6.2) must publish the current `linux-aarch64` `botho` artifact and pass
+its URL + checksum**, for example:
+
+- On a release tag, attach the `binaries-linux-aarch64` binary to the GitHub
+  release and use the asset's download URL; pass the matching `linux-aarch64`
+  sha256 from `release-checksums` as `BOTHO_BINARY_SHA256`; or
 - Build via `scripts/build-release.sh` (or the `release.yml` workflow on a tag),
-  then upload `target/.../botho` to an S3/R2 object the rig can `GET`, and pass
-  that object URL as `BOTHO_BINARY_URL`; or
-- Attach the binary to the GitHub release and use the asset's download URL.
+  then mirror `target/aarch64-unknown-linux-gnu/release/botho` to an S3/R2 object
+  the rig can `GET`, and pass that object URL as `BOTHO_BINARY_URL`.
 
 Interim stand-in (used for the live verification of this PR): copy the binary
 already running on a live seed (it is the exact network build) to a temporary
 HTTP location and pass that URL — see the verification notes in the PR.
 
-### 2. DNS pre-creation (`RIG_HOSTNAME`)
+### 2. DNS pre-creation (`RIG_HOSTNAME` / `RIG_ID`)
 
-The provisioner must create the `RIG_HOSTNAME` A record pointing at the
+The provisioner must create the `RIG_HOSTNAME` (or the derived
+`rig-<RIG_ID>.<RIG_DOMAIN>`) A record pointing at the
 instance's public IP **before/at boot** so Let's Encrypt (`webroot`/
 `standalone`) can validate. If DNS isn't ready when the script runs, certbot is
 skipped gracefully and nginx serves HTTP-only `/rpc`; re-running the script
@@ -113,12 +130,17 @@ DNS-less local testing use `TLS_MODE=skip`.
 
 ```bash
 #!/usr/bin/env bash
-export RIG_HOSTNAME="rig-abc123.testnet.botho.io"
+export RIG_ID="abc123"                 # -> rig-abc123.testnet.botho.io
+export REGION="us-west-2"
+export TIER="t4g.medium"
 export BOTHO_BINARY_URL="https://artifacts.botho.io/botho/<rev>/botho-aarch64"
-export BOTHO_BINARY_SHA256="<sha256>"
+export BOTHO_BINARY_SHA256="<linux-aarch64 sha256 from release-checksums>"
 export MINT_THREADS=1
 # ... then the contents of rig-bootstrap.sh ...
 ```
+
+(Pass `RIG_HOSTNAME` directly instead of `RIG_ID`/`RIG_DOMAIN` if you want a
+fully custom hostname.)
 
 (In practice the provisioner concatenates the exports + `rig-bootstrap.sh` into
 the instance's user-data. cloud-init runs it as root on first boot.)

--- a/infra/baas/rig-bootstrap.sh
+++ b/infra/baas/rig-bootstrap.sh
@@ -20,9 +20,12 @@
 # exports below) into the instance launch's "User data" field. cloud-init runs
 # it as root on first boot. It is also safe to run by hand:
 #
-#     sudo RIG_HOSTNAME=rig-demo.testnet.botho.io \
+#     sudo RIG_ID=demo REGION=us-west-2 TIER=t4g.medium \
 #          BOTHO_BINARY_URL=https://example.com/botho-aarch64 \
+#          BOTHO_BINARY_SHA256=<sha256 from release-checksums> \
 #          ./rig-bootstrap.sh
+#
+# (RIG_ID=demo derives RIG_HOSTNAME=rig-demo.testnet.botho.io.)
 #
 # Re-running is safe (idempotent): each step checks current state first.
 #
@@ -30,18 +33,43 @@
 # PARAMETERS (environment variables / user-data exports)
 # ---------------------------------------------------------------------------
 #   BOTHO_BINARY_URL   (REQUIRED unless a binary is already installed)
-#                      URL to a linux-aarch64 `botho` binary. The provisioner
-#                      (#458) must publish the current release artifact (e.g.
-#                      upload to S3/R2) and pass its URL here. There is no
-#                      public GitHub release asset yet — see BINARY SOURCE note
-#                      at the bottom of this file and infra/baas/README.md.
-#   BOTHO_BINARY_SHA256 (optional) expected sha256 of the downloaded binary;
-#                      verified if set.
+#                      URL to the prebuilt linux-aarch64 `botho` binary. This is
+#                      the `binaries-linux-aarch64` artifact produced by
+#                      .github/workflows/release.yml (target
+#                      aarch64-unknown-linux-gnu) — the rig is arm64, so it
+#                      DOWNLOADS this prebuilt binary rather than building from
+#                      source on the box. The provisioner (#458 P6.2) resolves a
+#                      GET-able URL (GitHub release asset, or a mirror in S3/R2)
+#                      and passes it here. See BINARY SOURCE note at the bottom
+#                      of this file and infra/baas/README.md.
+#   BOTHO_BINARY_SHA256 (optional) expected sha256 of the downloaded binary.
+#                      Verified if set. The provisioner should pass the
+#                      linux-aarch64 checksum from the release's
+#                      `release-checksums` artifact (all-checksums.txt) so each
+#                      rig pins the exact published build.
+#   RIG_ID             (optional) short opaque rig identifier (e.g. abc123),
+#                      assigned by the provisioner / Stripe subscription mapping.
+#                      When set and RIG_HOSTNAME is unset, the public hostname is
+#                      derived as rig-<RIG_ID>.<RIG_DOMAIN>. Recorded in
+#                      rig-info.txt for control-plane traceability.
+#   RIG_DOMAIN         (optional, default "testnet.botho.io") the zone under
+#                      which rig-<RIG_ID> hostnames live; combined with RIG_ID to
+#                      derive RIG_HOSTNAME when the latter is not given directly.
 #   RIG_HOSTNAME       (optional) public hostname for this rig, e.g.
-#                      rig-abc123.testnet.botho.io. The provisioner pre-creates
-#                      the DNS A record -> this instance's public IP BEFORE
-#                      boot. If unset, TLS/nginx public setup is skipped and the
-#                      node still serves RPC on localhost:17101.
+#                      rig-abc123.testnet.botho.io. Takes precedence over
+#                      RIG_ID/RIG_DOMAIN. The provisioner pre-creates the DNS A
+#                      record -> this instance's public IP BEFORE boot. If
+#                      neither RIG_HOSTNAME nor RIG_ID is set, TLS/nginx public
+#                      setup is skipped and the node still serves RPC on
+#                      localhost:17101.
+#   REGION             (optional) AWS region the rig was launched in (e.g.
+#                      us-west-2). Informational here — the instance is already
+#                      in its region by the time user-data runs; the provisioner
+#                      (#458 P6.2) picks the region at run-instances time.
+#                      Recorded in rig-info.txt.
+#   TIER               (optional, default "t4g.medium") instance type / tier the
+#                      provisioner launched. Informational; recorded in
+#                      rig-info.txt. The MVP is t4g.medium-only (#458 §5).
 #   NETWORK            (optional, default "testnet"). Only "testnet" is
 #                      supported by this slice.
 #   BOOTSTRAP_PEERS    (optional) comma-separated libp2p multiaddrs to use as
@@ -90,7 +118,11 @@ log "=== Botho rig bootstrap starting ==="
 # Parameters & defaults
 # ---------------------------------------------------------------------------
 NETWORK="${NETWORK:-testnet}"
+RIG_ID="${RIG_ID:-}"
+RIG_DOMAIN="${RIG_DOMAIN:-testnet.botho.io}"
 RIG_HOSTNAME="${RIG_HOSTNAME:-}"
+REGION="${REGION:-}"
+TIER="${TIER:-t4g.medium}"
 BOTHO_BINARY_URL="${BOTHO_BINARY_URL:-}"
 BOTHO_BINARY_SHA256="${BOTHO_BINARY_SHA256:-}"
 BOOTSTRAP_PEERS="${BOOTSTRAP_PEERS:-}"
@@ -113,7 +145,19 @@ GOSSIP_PORT=17100
 [[ "$NETWORK" == "testnet" ]] || fail "Only NETWORK=testnet is supported in this slice (got '$NETWORK')."
 id "$RUN_USER" >/dev/null 2>&1 || fail "Expected user '$RUN_USER' to exist (Ubuntu arm64 AMI)."
 
-log "Params: NETWORK=$NETWORK RIG_HOSTNAME='${RIG_HOSTNAME:-<none>}' TLS_MODE=$TLS_MODE MINT_THREADS=$MINT_THREADS"
+# Derive the public hostname from RIG_ID when RIG_HOSTNAME was not given
+# directly. The provisioner (#458 P6.2) assigns RIG_ID per subscription and
+# creates the DNS A record for rig-<RIG_ID>.<RIG_DOMAIN> before boot.
+if [[ -z "$RIG_HOSTNAME" && -n "$RIG_ID" ]]; then
+    # Allow RIG_ID to be either the bare id (abc123) or a full "rig-abc123".
+    case "$RIG_ID" in
+        rig-*) RIG_HOSTNAME="${RIG_ID}.${RIG_DOMAIN}" ;;
+        *)     RIG_HOSTNAME="rig-${RIG_ID}.${RIG_DOMAIN}" ;;
+    esac
+    log "Derived RIG_HOSTNAME='$RIG_HOSTNAME' from RIG_ID='$RIG_ID' RIG_DOMAIN='$RIG_DOMAIN'"
+fi
+
+log "Params: NETWORK=$NETWORK RIG_ID='${RIG_ID:-<none>}' RIG_HOSTNAME='${RIG_HOSTNAME:-<none>}' REGION='${REGION:-<unset>}' TIER=$TIER TLS_MODE=$TLS_MODE MINT_THREADS=$MINT_THREADS"
 log "Binary source: ${BOTHO_BINARY_URL:-<none, will require existing $BIN_PATH>}"
 
 # ===========================================================================
@@ -566,7 +610,10 @@ fi
 cat > "${RUN_HOME}/rig-info.txt" <<EOF
 # Botho rig provisioned by rig-bootstrap.sh on $(ts)
 network        = ${NETWORK}
+rig_id         = ${RIG_ID:-<none>}
 rig_hostname   = ${RIG_HOSTNAME:-<none>}
+region         = ${REGION:-<unset>}
+tier           = ${TIER}
 public_ip      = ${PUBLIC_IP}
 binary_version = ${BIN_VERSION}
 rpc_url        = ${RPC_URL}
@@ -589,10 +636,21 @@ log "Read back any time: sudo rig-status   |   cat ${RUN_HOME}/rig-info.txt"
 # ---------------------------------------------------------------------------
 # BINARY SOURCE NOTE (for #458)
 # ---------------------------------------------------------------------------
-# As of this writing the latest GitHub release (v0.2.0) has NO published
-# binary asset, so this bootstrap cannot fetch one from a public URL on its
-# own. The provisioner (#458) MUST publish the current linux-aarch64 `botho`
-# release artifact (e.g. upload to S3/R2 or attach it to the GitHub release)
-# and pass its URL as BOTHO_BINARY_URL. See infra/baas/README.md for the
-# recommended distribution flow and the interim "copy from a live seed"
-# stand-in used during verification.
+# This bootstrap DOWNLOADS the prebuilt arm64 binary (it never builds from
+# source on the box — t4g release builds are slow and RandomX-linked crates can
+# OOM). The canonical source is the `binaries-linux-aarch64` artifact built by
+# .github/workflows/release.yml (target aarch64-unknown-linux-gnu), with its
+# checksum in the `release-checksums` artifact (all-checksums.txt, the
+# `linux-aarch64/...` line). Pass:
+#     BOTHO_BINARY_URL=<GET-able URL to the aarch64 botho binary>
+#     BOTHO_BINARY_SHA256=<that binary's sha256 from release-checksums>
+#
+# As of this writing the latest GitHub release (v0.2.0) has NO published binary
+# ASSET (the workflow produces the artifact, but the operator hasn't attached a
+# downloadable release asset / mirror yet), so the bootstrap cannot resolve a
+# public URL on its own. The provisioner (#458 P6.2) MUST publish the current
+# linux-aarch64 `botho` artifact (attach it to the GitHub release, or mirror to
+# S3/R2) and pass its URL as BOTHO_BINARY_URL (and the checksum as
+# BOTHO_BINARY_SHA256). See infra/baas/README.md for the recommended
+# distribution flow and the interim "copy from a live seed" stand-in used
+# during verification.


### PR DESCRIPTION
## Summary

Closes #499.

P6.1 of the Botho-as-a-Service MVP (#458, epic #441). **Important context for the reviewer:** the core P6.1 deliverable — `infra/baas/rig-bootstrap.sh`, the parameterized cloud-init/user-data bootstrap that turns a fresh Ubuntu-24-arm64 EC2 box into a working testnet mining node with zero SSH — **already landed in PR #464** (merged 2026-06-20, closing #462), and was live-verified on a throwaway `t4g.medium`. #499 was filed the next day with the same scope.

Rather than rewrite a proven, network-verified script (per CLAUDE.md: prefer additive transforms over rewrites), this PR makes the existing bootstrap satisfy #499's **explicit parameter contract** additively. All config/peering/TLS/systemd/RPC-verification behavior is unchanged from #464.

## What changed

- **`RIG_ID` + `RIG_DOMAIN`** — #499 asks for a `RIG_ID` parameter driving the `rig-<id>.testnet.botho.io` hostname. When `RIG_HOSTNAME` is unset, the script now derives `rig-<RIG_ID>.<RIG_DOMAIN>` (default zone `testnet.botho.io`). `RIG_HOSTNAME` still takes precedence for custom hostnames. Accepts a bare id (`abc123`) or a full `rig-abc123`.
- **`REGION` + `TIER`** (default `t4g.medium`) — recorded in `~ubuntu/rig-info.txt` for control-plane traceability. Informational: the provisioner (#458 P6.2) actually picks region/type at `run-instances` time; by the time user-data runs the instance is already in its region.
- **Binary source pinned to the release artifact** — docs now state precisely that the rig DOWNLOADS the prebuilt `binaries-linux-aarch64` artifact (target `aarch64-unknown-linux-gnu`, from `.github/workflows/release.yml`) and pins via `BOTHO_BINARY_SHA256` taken from the `release-checksums` artifact (`all-checksums.txt`, the `linux-aarch64/...` line) — never building from source on the box.
- README + header usage examples updated for the new params and the release-artifact flow.

## Already satisfied by #464 (unchanged here)

- Per-rig `config.toml`: `network_type="testnet"`, `[network.quorum] mode="recommended"`, `[minting] enabled=true`, generated per-rig 24-word BIP39 mnemonic (bring-your-own via `RIG_WALLET_MNEMONIC`).
- systemd unit (transformed from `infra/seed/botho-seed.service`, `--mint`) + RPC verification on `localhost:17101` (`node_getStatus`).
- nginx + Let's Encrypt for the rig hostname (transformed from `infra/seed/seed-nginx.conf`; `webroot`/`standalone`/`skip` modes).
- Idempotent, logged, transform of the proven `infra/seed`/`infra/faucet` recipe.

> Peering note (from #464's live verification): the libp2p transport rejects bare `/dns4` `bootstrap_peers` entries, so the default path is DNS-seed discovery (empty `bootstrap_peers` + `dns_seeds.enabled`). Unchanged.

## Constraints honored

Script/config only. **No cloud resources provisioned, no AWS calls, no real secrets.** Testable by inspection.

## Verification

- `shellcheck infra/baas/rig-bootstrap.sh` → clean (exit 0)
- `bash -n infra/baas/rig-bootstrap.sh` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)