### PR TITLE
feat(baas): P7.1 — Stripe checkout ($50/mo) + "Get a rig" frontend

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Cloudflare Worker local secrets / state (never commit real keys)
+.dev.vars
+.wrangler/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/web/packages/baas-worker/.dev.vars.example
+++ b/web/packages/baas-worker/.dev.vars.example
@@ -1,0 +1,18 @@
+# Local development secrets for `wrangler dev` (#458 §2, §7).
+#
+# Copy to `.dev.vars` (gitignored) and fill in your Stripe TEST values.
+# NEVER commit real keys. In production these are set via `wrangler secret put`,
+# not from this file.
+
+# Stripe TEST secret key. Get it from the Stripe dashboard (test mode).
+STRIPE_SECRET_KEY=sk_test_REPLACE_ME
+
+# The recurring $50/mo Price id, created once (see README "Stripe setup").
+STRIPE_PRICE_ID=price_REPLACE_ME
+
+# Redirect URLs for local dev (the Pages dev server / preview).
+CHECKOUT_SUCCESS_URL=http://localhost:5173/rig/success
+CHECKOUT_CANCEL_URL=http://localhost:5173/rig
+
+# Browser origins allowed to call /checkout during local dev.
+ALLOWED_ORIGINS=http://localhost:5173

--- a/web/packages/baas-worker/README.md
+++ b/web/packages/baas-worker/README.md
@@ -1,0 +1,112 @@
+# @botho/baas-worker
+
+Cloudflare Worker for the **Botho-as-a-Service** control plane (parent #458 §1).
+
+This package currently implements **P7.1 — the billing front door** (#458 §2,
+issue #504): a `/checkout` endpoint that creates a Stripe Checkout Session for a
+single **$50/mo subscription**, plus the env/secret contract for running it in
+Stripe **TEST mode** while on testnet (#458 §7).
+
+> Out of scope here (later phases of #458 §8):
+> - `/webhook` (Stripe signature verify → provision/deprovision) — **P7.2 (#506)**
+> - `/status` (user looks up their rig) — **P6.3**
+>
+> The frontend "Get a rig" surface that calls `/checkout` lives in
+> `@botho/web-wallet` at `/rig` (route `RigPage`).
+
+## Endpoints
+
+| Method | Path        | Purpose                                                       |
+|--------|-------------|--------------------------------------------------------------|
+| POST   | `/checkout` | Create a `mode=subscription` Stripe Checkout Session.        |
+| GET    | `/healthz`  | Liveness probe.                                              |
+
+### `POST /checkout`
+
+**Request body** (JSON):
+
+```json
+{ "region": "us-west-2", "email": "optional@example.com" }
+```
+
+- `region` (required) — desired AWS region for the rig. Must be in the
+  server-side allowlist (`REGION_ALLOWLIST`, starts as `["us-west-2"]`, #458 §5).
+  Re-validated server-side so a crafted request can never request an off-list
+  region.
+- `email` (optional) — pre-fills the Stripe checkout email.
+
+**Success response** (`200`):
+
+```json
+{ "id": "cs_test_...", "url": "https://checkout.stripe.com/c/..." }
+```
+
+The frontend redirects the browser to `url`.
+
+**Errors:** `400` invalid body / region, `405` non-POST, `500` worker not
+configured (fails closed — never calls Stripe with an empty key), `502` Stripe
+rejected the request.
+
+The created session carries:
+- `mode=subscription`, one line item = the `$50/mo` Price (`STRIPE_PRICE_ID`),
+  quantity 1 (one rig per subscription).
+- `metadata.region` **and** `subscription_data.metadata.region` so the webhook
+  (P7.2) can read the region from either the session or the subscription.
+- `success_url` with Stripe's `{CHECKOUT_SESSION_ID}` template appended for the
+  future status lookup (P6.3).
+
+## Configuration (secrets & vars)
+
+All secrets come from Worker secrets / vars — **never the repo** (#458 §2, §5).
+
+| Key                    | Kind   | Notes                                                        |
+|------------------------|--------|-------------------------------------------------------------|
+| `STRIPE_SECRET_KEY`    | secret | TEST key (`sk_test_...`) while on testnet (#458 §7).        |
+| `STRIPE_PRICE_ID`      | secret | The recurring $50/mo Price id (`price_...`). See below.     |
+| `CHECKOUT_SUCCESS_URL` | var    | Stripe success redirect (in `wrangler.toml`).               |
+| `CHECKOUT_CANCEL_URL`  | var    | Stripe cancel redirect (in `wrangler.toml`).                |
+| `ALLOWED_ORIGINS`      | var    | Comma-separated browser origins allowed to call `/checkout`.|
+
+### Stripe setup (one-time, TEST mode)
+
+In the Stripe dashboard (legal entity **2amlogic**, **test mode** while on
+testnet):
+
+1. **Product:** create "Botho Managed Rig (testnet)".
+2. **Price:** add a **recurring price = $50.00 / month** (USD). Copy its id
+   (`price_...`).
+3. Store the secret key and price id in the Worker:
+
+   ```bash
+   wrangler secret put STRIPE_SECRET_KEY   # paste sk_test_...
+   wrangler secret put STRIPE_PRICE_ID     # paste price_...
+   ```
+
+Flip to LIVE only when the maintainer decides (re-run the steps with live-mode
+values). The §6/§7 economics must be settled before charging real money.
+
+### Local development
+
+```bash
+cp .dev.vars.example .dev.vars   # fill in your Stripe TEST values
+pnpm --filter @botho/baas-worker dev
+```
+
+`.dev.vars` is gitignored. Never commit real keys.
+
+## Tests
+
+```bash
+# from web/
+pnpm test:run
+```
+
+`src/checkout.test.ts` and `src/index.test.ts` cover the session-param builder,
+input validation, the region allowlist, fail-closed config handling, and the
+`/checkout` handler — all with a mocked `fetch` (no network, no live Stripe).
+
+## Deploy
+
+```bash
+pnpm --filter @botho/baas-worker deploy   # wrangler deploy
+```

--- a/web/packages/baas-worker/package.json
+++ b/web/packages/baas-worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@botho/baas-worker",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Botho-as-a-Service control-plane Cloudflare Worker (billing front door). P7.1: /checkout creates a $50/mo subscription Stripe Checkout Session.",
+  "scripts": {
+    "dev": "wrangler dev",
+    "typecheck": "tsc --noEmit",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260617.1",
+    "typescript": "~5.9.3",
+    "wrangler": "^4.59.1"
+  }
+}

--- a/web/packages/baas-worker/src/checkout.test.ts
+++ b/web/packages/baas-worker/src/checkout.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  appendSessionIdTemplate,
+  buildCheckoutSessionParams,
+  createCheckoutSession,
+  isAllowedRegion,
+  isTestModeKey,
+  missingEnvKeys,
+  REGION_ALLOWLIST,
+  StripeCheckoutError,
+  validateCheckoutRequest,
+  type CheckoutEnv,
+} from './checkout'
+
+const ENV: CheckoutEnv = {
+  STRIPE_SECRET_KEY: 'sk_test_dummy',
+  STRIPE_PRICE_ID: 'price_test_50mo',
+  CHECKOUT_SUCCESS_URL: 'https://botho.io/rig/success',
+  CHECKOUT_CANCEL_URL: 'https://botho.io/rig',
+}
+
+describe('region allowlist', () => {
+  it('starts with only us-west-2 (#458 §5)', () => {
+    expect([...REGION_ALLOWLIST]).toEqual(['us-west-2'])
+  })
+
+  it('accepts an allowed region', () => {
+    expect(isAllowedRegion('us-west-2')).toBe(true)
+  })
+
+  it('rejects an off-list region', () => {
+    expect(isAllowedRegion('us-east-1')).toBe(false)
+    expect(isAllowedRegion('')).toBe(false)
+  })
+})
+
+describe('validateCheckoutRequest', () => {
+  it('accepts a minimal valid request', () => {
+    const r = validateCheckoutRequest({ region: 'us-west-2' })
+    expect(r.ok).toBe(true)
+    if (r.ok) {
+      expect(r.value.region).toBe('us-west-2')
+      expect(r.value.email).toBeUndefined()
+    }
+  })
+
+  it('accepts a valid email', () => {
+    const r = validateCheckoutRequest({ region: 'us-west-2', email: 'a@b.co' })
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.value.email).toBe('a@b.co')
+  })
+
+  it('rejects a non-object body', () => {
+    expect(validateCheckoutRequest(null).ok).toBe(false)
+    expect(validateCheckoutRequest('nope').ok).toBe(false)
+  })
+
+  it('rejects a missing region', () => {
+    const r = validateCheckoutRequest({})
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/region is required/)
+  })
+
+  it('rejects an off-allowlist region (defense in depth)', () => {
+    const r = validateCheckoutRequest({ region: 'eu-central-1' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/allowlist/)
+  })
+
+  it('rejects a malformed email', () => {
+    const r = validateCheckoutRequest({ region: 'us-west-2', email: 'not-an-email' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/email/)
+  })
+
+  it('treats empty-string email as absent', () => {
+    const r = validateCheckoutRequest({ region: 'us-west-2', email: '' })
+    expect(r.ok).toBe(true)
+    if (r.ok) expect(r.value.email).toBeUndefined()
+  })
+})
+
+describe('missingEnvKeys', () => {
+  it('reports nothing when fully configured', () => {
+    expect(missingEnvKeys(ENV)).toEqual([])
+  })
+
+  it('reports each missing key', () => {
+    expect(missingEnvKeys({ ...ENV, STRIPE_SECRET_KEY: '' })).toEqual(['STRIPE_SECRET_KEY'])
+    expect(missingEnvKeys({})).toEqual([
+      'STRIPE_SECRET_KEY',
+      'STRIPE_PRICE_ID',
+      'CHECKOUT_SUCCESS_URL',
+      'CHECKOUT_CANCEL_URL',
+    ])
+  })
+})
+
+describe('isTestModeKey', () => {
+  it('detects test keys', () => {
+    expect(isTestModeKey('sk_test_abc')).toBe(true)
+    expect(isTestModeKey('rk_test_abc')).toBe(true)
+  })
+  it('treats live keys as non-test', () => {
+    expect(isTestModeKey('sk_live_abc')).toBe(false)
+  })
+})
+
+describe('appendSessionIdTemplate', () => {
+  it('adds the Stripe session template with ? when no query', () => {
+    expect(appendSessionIdTemplate('https://x/y')).toBe(
+      'https://x/y?session_id={CHECKOUT_SESSION_ID}',
+    )
+  })
+  it('uses & when a query already exists', () => {
+    expect(appendSessionIdTemplate('https://x/y?a=1')).toBe(
+      'https://x/y?a=1&session_id={CHECKOUT_SESSION_ID}',
+    )
+  })
+})
+
+describe('buildCheckoutSessionParams', () => {
+  const params = buildCheckoutSessionParams({ region: 'us-west-2' }, ENV)
+
+  it('uses subscription mode', () => {
+    expect(params.get('mode')).toBe('subscription')
+  })
+
+  it('uses the env price id (not a hard-coded live id) with quantity 1', () => {
+    expect(params.get('line_items[0][price]')).toBe('price_test_50mo')
+    expect(params.get('line_items[0][quantity]')).toBe('1')
+  })
+
+  it('sets success/cancel urls and appends the session-id template', () => {
+    expect(params.get('success_url')).toBe(
+      'https://botho.io/rig/success?session_id={CHECKOUT_SESSION_ID}',
+    )
+    expect(params.get('cancel_url')).toBe('https://botho.io/rig')
+  })
+
+  it('captures region on both session and subscription metadata (#458 §3)', () => {
+    expect(params.get('metadata[region]')).toBe('us-west-2')
+    expect(params.get('subscription_data[metadata][region]')).toBe('us-west-2')
+  })
+
+  it('always creates a customer for renewals/portal', () => {
+    expect(params.get('customer_creation')).toBe('always')
+  })
+
+  it('omits customer_email when no email given', () => {
+    expect(params.has('customer_email')).toBe(false)
+  })
+
+  it('includes customer_email when provided', () => {
+    const p = buildCheckoutSessionParams({ region: 'us-west-2', email: 'a@b.co' }, ENV)
+    expect(p.get('customer_email')).toBe('a@b.co')
+  })
+})
+
+describe('createCheckoutSession', () => {
+  it('POSTs a correct request to Stripe and returns id+url', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ id: 'cs_test_123', url: 'https://checkout.stripe.com/c/123' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const result = await createCheckoutSession(
+      { region: 'us-west-2', email: 'a@b.co' },
+      ENV,
+      fetchMock as unknown as typeof fetch,
+    )
+
+    expect(result).toEqual({ id: 'cs_test_123', url: 'https://checkout.stripe.com/c/123' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [calledUrl, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(calledUrl).toBe('https://api.stripe.com/v1/checkout/sessions')
+    expect(init.method).toBe('POST')
+
+    const headers = init.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer sk_test_dummy')
+    expect(headers['Content-Type']).toBe('application/x-www-form-urlencoded')
+    expect(headers['Stripe-Version']).toBe('2024-06-20')
+
+    // Body is form-encoded and carries the key fields.
+    const sent = new URLSearchParams(init.body as string)
+    expect(sent.get('mode')).toBe('subscription')
+    expect(sent.get('line_items[0][price]')).toBe('price_test_50mo')
+    expect(sent.get('metadata[region]')).toBe('us-west-2')
+    expect(sent.get('customer_email')).toBe('a@b.co')
+  })
+
+  it('throws StripeCheckoutError on a Stripe error response', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ error: { message: 'No such price' } }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    await expect(
+      createCheckoutSession({ region: 'us-west-2' }, ENV, fetchMock as unknown as typeof fetch),
+    ).rejects.toBeInstanceOf(StripeCheckoutError)
+  })
+
+  it('throws when Stripe omits id/url even with 200', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ id: 'cs_test_1' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    await expect(
+      createCheckoutSession({ region: 'us-west-2' }, ENV, fetchMock as unknown as typeof fetch),
+    ).rejects.toBeInstanceOf(StripeCheckoutError)
+  })
+})

--- a/web/packages/baas-worker/src/checkout.ts
+++ b/web/packages/baas-worker/src/checkout.ts
@@ -1,0 +1,242 @@
+/**
+ * Stripe Checkout Session creation for Botho-as-a-Service managed rigs.
+ *
+ * This module is the pure, testable core of the `/checkout` endpoint (P7.1 of
+ * the BaaS MVP, parent #458 §2). It takes a validated checkout request plus the
+ * Worker's environment (Stripe secret key, the $50/mo price ID, success/cancel
+ * URLs) and produces the `application/x-www-form-urlencoded` body for Stripe's
+ * Checkout Sessions API — without performing any network I/O here, so it can be
+ * unit-tested by asserting on the request it builds.
+ *
+ * Design constraints (from #458 §2, §5, §7):
+ *  - mode = subscription, a single recurring $50/mo Price (id from env, never
+ *    hard-coded as a live id in the repo).
+ *  - The desired AWS region is captured in `metadata.region` for later
+ *    provisioning (#458 §3, §9.4) and constrained to a server-side allowlist
+ *    (start: us-west-2) — #458 §5.
+ *  - STRIPE_SECRET_KEY and the price id live in Worker secrets / env only.
+ *  - TEST mode while on testnet: we never assume a particular key prefix, but we
+ *    expose a helper to detect test-mode keys for honest UI copy / guard rails.
+ */
+
+/**
+ * AWS regions a managed rig may be provisioned in. Kept deliberately small and
+ * server-authoritative (#458 §5: "Region allowlist — start: us-west-2 only,
+ * expand deliberately"). The frontend dropdown is constrained to this list, and
+ * the Worker re-validates so a crafted request can never request an off-list
+ * region.
+ */
+export const REGION_ALLOWLIST = ['us-west-2'] as const
+
+export type AllowedRegion = (typeof REGION_ALLOWLIST)[number]
+
+/** Returns true if `region` is in the server-side allowlist. */
+export function isAllowedRegion(region: string): region is AllowedRegion {
+  return (REGION_ALLOWLIST as readonly string[]).includes(region)
+}
+
+/**
+ * The subset of Worker env this module needs. Bound from Worker secrets / vars
+ * (wrangler `[vars]` for the non-secret URLs, `wrangler secret put` for the
+ * Stripe key and price id). Never hard-coded in the repo.
+ */
+export interface CheckoutEnv {
+  /** Stripe secret key (TEST mode while on testnet). Worker secret. */
+  STRIPE_SECRET_KEY: string
+  /** Recurring $50/mo Price id ("price_..."). Worker secret / var. */
+  STRIPE_PRICE_ID: string
+  /** Absolute URL Stripe redirects to on success. Worker var. */
+  CHECKOUT_SUCCESS_URL: string
+  /** Absolute URL Stripe redirects to on cancel. Worker var. */
+  CHECKOUT_CANCEL_URL: string
+}
+
+/** Parsed + validated input for a checkout request. */
+export interface CheckoutRequest {
+  /** Desired AWS region for the rig; must be in REGION_ALLOWLIST. */
+  region: AllowedRegion
+  /** Optional pre-filled customer email (lets Stripe skip asking). */
+  email?: string
+}
+
+export type CheckoutValidation =
+  | { ok: true; value: CheckoutRequest }
+  | { ok: false; error: string }
+
+/**
+ * Validate an untrusted request body for the checkout endpoint.
+ *
+ * Accepts an already-parsed object (the handler decodes JSON or form data first)
+ * and enforces the region allowlist plus a light email sanity check. Returns a
+ * discriminated union so the handler can map failures to HTTP 400 without
+ * throwing.
+ */
+export function validateCheckoutRequest(body: unknown): CheckoutValidation {
+  if (typeof body !== 'object' || body === null) {
+    return { ok: false, error: 'request body must be an object' }
+  }
+  const record = body as Record<string, unknown>
+
+  const region = record.region
+  if (typeof region !== 'string' || region.length === 0) {
+    return { ok: false, error: 'region is required' }
+  }
+  if (!isAllowedRegion(region)) {
+    return { ok: false, error: `region "${region}" is not in the allowlist` }
+  }
+
+  let email: string | undefined
+  if (record.email !== undefined && record.email !== null && record.email !== '') {
+    if (typeof record.email !== 'string') {
+      return { ok: false, error: 'email must be a string' }
+    }
+    // Intentionally lax: Stripe is the source of truth for email validity. We
+    // only reject obviously malformed values to avoid passing junk to the API.
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(record.email)) {
+      return { ok: false, error: 'email is not a valid address' }
+    }
+    email = record.email
+  }
+
+  return { ok: true, value: { region, email } }
+}
+
+/**
+ * Validate that the Worker env carries the secrets/vars this module needs.
+ * Returns a list of missing keys (empty if all present) so the handler can fail
+ * closed with a 500 rather than calling Stripe with an empty key.
+ */
+export function missingEnvKeys(env: Partial<CheckoutEnv>): string[] {
+  const required: (keyof CheckoutEnv)[] = [
+    'STRIPE_SECRET_KEY',
+    'STRIPE_PRICE_ID',
+    'CHECKOUT_SUCCESS_URL',
+    'CHECKOUT_CANCEL_URL',
+  ]
+  return required.filter((k) => {
+    const v = env[k]
+    return typeof v !== 'string' || v.length === 0
+  })
+}
+
+/**
+ * True for a Stripe TEST-mode secret key (`sk_test_...` / `rk_test_...`).
+ *
+ * Used only for honest UI copy / log breadcrumbs (#458 §7) — never to gate
+ * behaviour, since Stripe itself is the source of truth for the mode.
+ */
+export function isTestModeKey(secretKey: string): boolean {
+  return /^(sk|rk)_test_/.test(secretKey)
+}
+
+/**
+ * Build the form-encoded body for Stripe's
+ * `POST /v1/checkout/sessions` call.
+ *
+ * Stripe's API consumes `application/x-www-form-urlencoded` with bracketed keys
+ * for nested objects/arrays (e.g. `line_items[0][price]`). We build that body
+ * here so it can be asserted in tests without hitting the network.
+ *
+ * The success URL carries Stripe's `{CHECKOUT_SESSION_ID}` template so the
+ * placeholder success page (#458 §4) can later look the session up.
+ */
+export function buildCheckoutSessionParams(
+  req: CheckoutRequest,
+  env: CheckoutEnv,
+): URLSearchParams {
+  const params = new URLSearchParams()
+  params.set('mode', 'subscription')
+
+  // Single $50/mo line item; quantity 1 (one rig per subscription — #458 §5).
+  params.set('line_items[0][price]', env.STRIPE_PRICE_ID)
+  params.set('line_items[0][quantity]', '1')
+
+  // Append the Stripe session-id template to the success URL so the success
+  // page can resolve which checkout completed (P6.3 wires the status lookup).
+  params.set('success_url', appendSessionIdTemplate(env.CHECKOUT_SUCCESS_URL))
+  params.set('cancel_url', env.CHECKOUT_CANCEL_URL)
+
+  // Capture the desired region for the provisioner (#458 §3, §9.4). Stored on
+  // both the session and the resulting subscription so the webhook (P7.2) can
+  // read it from `subscription.metadata` regardless of which event fires.
+  params.set('metadata[region]', req.region)
+  params.set('subscription_data[metadata][region]', req.region)
+
+  if (req.email) {
+    params.set('customer_email', req.email)
+  }
+
+  // Let Stripe create/reuse a Customer so renewals + the customer portal work.
+  params.set('customer_creation', 'always')
+  params.set('billing_address_collection', 'auto')
+
+  return params
+}
+
+/**
+ * Append Stripe's `session_id={CHECKOUT_SESSION_ID}` template parameter to a
+ * success URL, preserving any existing query string.
+ */
+export function appendSessionIdTemplate(url: string): string {
+  const sep = url.includes('?') ? '&' : '?'
+  // The braces are a Stripe-side template, not a value we encode.
+  return `${url}${sep}session_id={CHECKOUT_SESSION_ID}`
+}
+
+/** Shape returned to the frontend on success. */
+export interface CheckoutSessionResult {
+  /** Stripe Checkout Session id. */
+  id: string
+  /** Hosted Stripe Checkout URL to redirect the browser to. */
+  url: string
+}
+
+/**
+ * Create a Stripe Checkout Session by calling the Stripe REST API.
+ *
+ * `fetchImpl` is injectable so tests can supply a mock and assert on the exact
+ * request (URL, auth header, body) without any network access. In the Worker it
+ * defaults to the global `fetch`.
+ */
+export async function createCheckoutSession(
+  req: CheckoutRequest,
+  env: CheckoutEnv,
+  fetchImpl: typeof fetch = fetch,
+): Promise<CheckoutSessionResult> {
+  const body = buildCheckoutSessionParams(req, env)
+
+  const resp = await fetchImpl('https://api.stripe.com/v1/checkout/sessions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.STRIPE_SECRET_KEY}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      // Pin the API version so behaviour is reproducible across Stripe rollouts.
+      'Stripe-Version': '2024-06-20',
+    },
+    body: body.toString(),
+  })
+
+  const json = (await resp.json()) as {
+    id?: string
+    url?: string
+    error?: { message?: string }
+  }
+
+  if (!resp.ok || !json.id || !json.url) {
+    const message = json.error?.message ?? `Stripe returned HTTP ${resp.status}`
+    throw new StripeCheckoutError(message, resp.status)
+  }
+
+  return { id: json.id, url: json.url }
+}
+
+/** Error thrown when Stripe rejects the checkout-session creation. */
+export class StripeCheckoutError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message)
+    this.name = 'StripeCheckoutError'
+  }
+}

--- a/web/packages/baas-worker/src/index.test.ts
+++ b/web/packages/baas-worker/src/index.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest'
+import { handleCheckout, type Env } from './index'
+
+const ENV: Env = {
+  STRIPE_SECRET_KEY: 'sk_test_dummy',
+  STRIPE_PRICE_ID: 'price_test_50mo',
+  CHECKOUT_SUCCESS_URL: 'https://botho.io/rig/success',
+  CHECKOUT_CANCEL_URL: 'https://botho.io/rig',
+  ALLOWED_ORIGINS: 'https://botho.io',
+}
+
+function postCheckout(body: unknown, origin?: string): Request {
+  return new Request('https://control.botho.io/checkout', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(origin ? { Origin: origin } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+function stripeOk() {
+  return vi.fn(async () =>
+    new Response(JSON.stringify({ id: 'cs_test_abc', url: 'https://checkout.stripe.com/c/abc' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+}
+
+describe('handleCheckout', () => {
+  it('returns 200 with session id+url on a valid request', async () => {
+    const fetchMock = stripeOk()
+    const res = await handleCheckout(
+      postCheckout({ region: 'us-west-2' }),
+      ENV,
+      fetchMock as unknown as typeof fetch,
+    )
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { id: string; url: string }
+    expect(json.id).toBe('cs_test_abc')
+    expect(json.url).toBe('https://checkout.stripe.com/c/abc')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects non-POST with 405', async () => {
+    const req = new Request('https://control.botho.io/checkout', { method: 'GET' })
+    const res = await handleCheckout(req, ENV, stripeOk() as unknown as typeof fetch)
+    expect(res.status).toBe(405)
+  })
+
+  it('returns 400 on invalid JSON', async () => {
+    const req = new Request('https://control.botho.io/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{not json',
+    })
+    const res = await handleCheckout(req, ENV, stripeOk() as unknown as typeof fetch)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 on an off-allowlist region without calling Stripe', async () => {
+    const fetchMock = stripeOk()
+    const res = await handleCheckout(
+      postCheckout({ region: 'eu-central-1' }),
+      ENV,
+      fetchMock as unknown as typeof fetch,
+    )
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed with 500 when env is unconfigured (never calls Stripe)', async () => {
+    const fetchMock = stripeOk()
+    const badEnv = { ...ENV, STRIPE_SECRET_KEY: '' }
+    const res = await handleCheckout(
+      postCheckout({ region: 'us-west-2' }),
+      badEnv,
+      fetchMock as unknown as typeof fetch,
+    )
+    expect(res.status).toBe(500)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps a Stripe failure to 502', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ error: { message: 'No such price' } }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const res = await handleCheckout(
+      postCheckout({ region: 'us-west-2' }),
+      ENV,
+      fetchMock as unknown as typeof fetch,
+    )
+    expect(res.status).toBe(502)
+  })
+
+  it('echoes CORS headers for an allowed origin', async () => {
+    const res = await handleCheckout(
+      postCheckout({ region: 'us-west-2' }, 'https://botho.io'),
+      ENV,
+      stripeOk() as unknown as typeof fetch,
+    )
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://botho.io')
+  })
+
+  it('omits CORS headers for a disallowed origin', async () => {
+    const res = await handleCheckout(
+      postCheckout({ region: 'us-west-2' }, 'https://evil.example'),
+      ENV,
+      stripeOk() as unknown as typeof fetch,
+    )
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+})

--- a/web/packages/baas-worker/src/index.ts
+++ b/web/packages/baas-worker/src/index.ts
@@ -1,0 +1,128 @@
+/**
+ * Botho-as-a-Service control-plane Worker (#458 §1).
+ *
+ * MVP surface for P7.1 — the billing front door:
+ *   - POST /checkout  create a Stripe Checkout Session (subscription, $50/mo)
+ *   - GET  /healthz   liveness probe
+ *
+ * Out of scope here (later phases of #458 §8):
+ *   - /webhook  Stripe signature verify -> provision/deprovision  (P7.2 / #506)
+ *   - /status   user looks up their rig                            (P6.3)
+ *
+ * All secrets (Stripe key, price id) come from Worker secrets / vars — never the
+ * repo. See `wrangler.toml` and `.dev.vars.example` for the binding contract.
+ */
+
+import {
+  createCheckoutSession,
+  missingEnvKeys,
+  StripeCheckoutError,
+  validateCheckoutRequest,
+  type CheckoutEnv,
+} from './checkout'
+
+export interface Env extends CheckoutEnv {
+  /**
+   * Comma-separated list of origins allowed to call /checkout from the browser
+   * (e.g. "https://botho.io,https://wallet.botho.io"). When unset, CORS is not
+   * granted (same-origin only).
+   */
+  ALLOWED_ORIGINS?: string
+}
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' }
+
+function corsHeaders(env: Env, requestOrigin: string | null): Record<string, string> {
+  if (!requestOrigin || !env.ALLOWED_ORIGINS) return {}
+  const allowed = env.ALLOWED_ORIGINS.split(',').map((o) => o.trim())
+  if (!allowed.includes(requestOrigin)) return {}
+  return {
+    'Access-Control-Allow-Origin': requestOrigin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    Vary: 'Origin',
+  }
+}
+
+function jsonResponse(
+  body: unknown,
+  status: number,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...JSON_HEADERS, ...extraHeaders },
+  })
+}
+
+/**
+ * Handle POST /checkout. Exported for direct unit testing without a full Worker
+ * runtime; the default export's fetch() delegates to it.
+ */
+export async function handleCheckout(
+  request: Request,
+  env: Env,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const origin = request.headers.get('Origin')
+  const cors = corsHeaders(env, origin)
+
+  if (request.method !== 'POST') {
+    return jsonResponse({ error: 'method not allowed' }, 405, cors)
+  }
+
+  // Fail closed if the Worker is misconfigured — never call Stripe with an
+  // empty key, and don't leak which key is missing to the client.
+  const missing = missingEnvKeys(env)
+  if (missing.length > 0) {
+    console.error('checkout: missing env keys', missing)
+    return jsonResponse({ error: 'service not configured' }, 500, cors)
+  }
+
+  let parsed: unknown
+  try {
+    parsed = await request.json()
+  } catch {
+    return jsonResponse({ error: 'invalid JSON body' }, 400, cors)
+  }
+
+  const validation = validateCheckoutRequest(parsed)
+  if (!validation.ok) {
+    return jsonResponse({ error: validation.error }, 400, cors)
+  }
+
+  try {
+    const session = await createCheckoutSession(validation.value, env, fetchImpl)
+    return jsonResponse({ id: session.id, url: session.url }, 200, cors)
+  } catch (err) {
+    if (err instanceof StripeCheckoutError) {
+      console.error('checkout: stripe error', err.status, err.message)
+      // 402-ish upstream failures collapse to 502 — the client just retries.
+      return jsonResponse({ error: 'could not create checkout session' }, 502, cors)
+    }
+    console.error('checkout: unexpected error', err)
+    return jsonResponse({ error: 'internal error' }, 500, cors)
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+    const origin = request.headers.get('Origin')
+
+    // CORS preflight for the browser "Get a rig" surface.
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders(env, origin) })
+    }
+
+    if (url.pathname === '/healthz') {
+      return jsonResponse({ ok: true }, 200)
+    }
+
+    if (url.pathname === '/checkout') {
+      return handleCheckout(request, env)
+    }
+
+    return jsonResponse({ error: 'not found' }, 404)
+  },
+} satisfies ExportedHandler<Env>

--- a/web/packages/baas-worker/tsconfig.json
+++ b/web/packages/baas-worker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "types": ["@cloudflare/workers-types"],
+    "lib": ["ES2022", "WebWorker"]
+  },
+  "include": ["src"]
+}

--- a/web/packages/baas-worker/wrangler.toml
+++ b/web/packages/baas-worker/wrangler.toml
@@ -1,0 +1,28 @@
+# Cloudflare Worker — Botho-as-a-Service control plane (#458 §1).
+#
+# Deploy with:
+#   pnpm --filter @botho/baas-worker deploy
+# Requires CLOUDFLARE_API_TOKEN with "Workers Scripts: Edit".
+#
+# SECRETS (never in the repo — set with `wrangler secret put`):
+#   STRIPE_SECRET_KEY   Stripe secret key. Use a TEST key (sk_test_...) while on
+#                       testnet (#458 §7). LIVE key only when the maintainer
+#                       flips to live billing.
+#   STRIPE_PRICE_ID     The recurring $50/mo Price id ("price_..."). Created once
+#                       in the Stripe dashboard (see README). Kept as a secret so
+#                       no live id is committed.
+#
+# VARS below are non-secret and safe to commit (public URLs + an origin
+# allowlist). Override per-environment as needed.
+
+name = "botho-baas"
+main = "src/index.ts"
+compatibility_date = "2024-09-23"
+
+[vars]
+# Where Stripe redirects after a successful / cancelled checkout. These point at
+# the Pages site that hosts the "Get a rig" surface.
+CHECKOUT_SUCCESS_URL = "https://botho.io/rig/success"
+CHECKOUT_CANCEL_URL = "https://botho.io/rig"
+# Browser origins permitted to call /checkout (comma-separated).
+ALLOWED_ORIGINS = "https://botho.io,https://wallet.botho.io"

--- a/web/packages/web-wallet/src/App.tsx
+++ b/web/packages/web-wallet/src/App.tsx
@@ -8,6 +8,7 @@ import { PayPage } from './pages/pay'
 import { ContactsPage } from './pages/contacts'
 import { DocsPage } from './pages/docs'
 import { ExplorerPage } from './pages/explorer'
+import { RigPage, RigSuccessPage } from './pages/rig'
 
 /**
  * Decide what `/` should render.
@@ -53,6 +54,9 @@ function App() {
             <Route path="/explorer/block/:hash" element={<ExplorerPage />} />
             <Route path="/docs" element={<DocsPage />} />
             <Route path="/docs/*" element={<DocsPage />} />
+            {/* Botho-as-a-Service "Get a rig" surface (#458 §4 / #504). */}
+            <Route path="/rig" element={<RigPage />} />
+            <Route path="/rig/success" element={<RigSuccessPage />} />
           </Routes>
         </BrowserRouter>
       </WalletProvider>

--- a/web/packages/web-wallet/src/lib/rig-checkout.test.ts
+++ b/web/packages/web-wallet/src/lib/rig-checkout.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  DEFAULT_RIG_REGION,
+  RIG_REGIONS,
+  RigCheckoutError,
+  startRigCheckout,
+} from './rig-checkout'
+
+function okResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('rig region allowlist', () => {
+  it('starts with only us-west-2', () => {
+    expect(RIG_REGIONS.map((r) => r.id)).toEqual(['us-west-2'])
+    expect(DEFAULT_RIG_REGION).toBe('us-west-2')
+  })
+})
+
+describe('startRigCheckout', () => {
+  it('POSTs region (+ email) to /checkout and returns id+url', async () => {
+    const fetchMock = vi.fn(async () =>
+      okResponse({ id: 'cs_test_1', url: 'https://checkout.stripe.com/c/1' }),
+    )
+
+    const result = await startRigCheckout(
+      { region: 'us-west-2', email: 'a@b.co' },
+      fetchMock as unknown as typeof fetch,
+    )
+
+    expect(result).toEqual({ id: 'cs_test_1', url: 'https://checkout.stripe.com/c/1' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toMatch(/\/checkout$/)
+    expect(init.method).toBe('POST')
+    const sent = JSON.parse(init.body as string)
+    expect(sent).toEqual({ region: 'us-west-2', email: 'a@b.co' })
+  })
+
+  it('omits email when not provided', async () => {
+    const fetchMock = vi.fn(async () =>
+      okResponse({ id: 'cs_test_2', url: 'https://checkout.stripe.com/c/2' }),
+    )
+    await startRigCheckout({ region: 'us-west-2' }, fetchMock as unknown as typeof fetch)
+    const init = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1]
+    expect(JSON.parse(init.body as string)).toEqual({ region: 'us-west-2' })
+  })
+
+  it('throws RigCheckoutError with the server message on a 4xx', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ error: 'region not in allowlist' }, 400))
+    await expect(
+      startRigCheckout({ region: 'eu-central-1' }, fetchMock as unknown as typeof fetch),
+    ).rejects.toMatchObject({ message: 'region not in allowlist', status: 400 })
+  })
+
+  it('throws when the response lacks a url', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ id: 'cs_test_3' }, 200))
+    await expect(
+      startRigCheckout({ region: 'us-west-2' }, fetchMock as unknown as typeof fetch),
+    ).rejects.toBeInstanceOf(RigCheckoutError)
+  })
+
+  it('throws a friendly error when the network is unreachable', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('network down')
+    })
+    await expect(
+      startRigCheckout({ region: 'us-west-2' }, fetchMock as unknown as typeof fetch),
+    ).rejects.toMatchObject({ message: /Could not reach/ })
+  })
+})

--- a/web/packages/web-wallet/src/lib/rig-checkout.ts
+++ b/web/packages/web-wallet/src/lib/rig-checkout.ts
@@ -1,0 +1,92 @@
+/**
+ * Frontend client for the Botho-as-a-Service billing front door (#458 §2).
+ *
+ * The "Get a rig" surface (`RigPage`) calls `startRigCheckout()`, which POSTs to
+ * the control-plane Worker's `/checkout` endpoint (`@botho/baas-worker`) and
+ * receives a hosted Stripe Checkout URL to redirect the browser to.
+ *
+ * Keys/secrets never live here — the browser only ever talks to our Worker, which
+ * holds the Stripe secret. This module just shapes the request and surfaces
+ * errors for the UI.
+ */
+
+/**
+ * AWS regions a managed rig can be provisioned in (#458 §5). Mirrors the
+ * server-side allowlist in `@botho/baas-worker`; the Worker re-validates, so this
+ * is purely to constrain the dropdown. Start with us-west-2 only.
+ */
+export const RIG_REGIONS: ReadonlyArray<{ id: string; label: string }> = [
+  { id: 'us-west-2', label: 'US West (Oregon) — us-west-2' },
+]
+
+export const DEFAULT_RIG_REGION = RIG_REGIONS[0].id
+
+/**
+ * Base URL of the BaaS control-plane Worker. Configured at build time via
+ * `VITE_BAAS_ENDPOINT`; falls back to the production control-plane host.
+ */
+export function baasEndpoint(): string {
+  const fromEnv = import.meta.env.VITE_BAAS_ENDPOINT as string | undefined
+  return (fromEnv && fromEnv.length > 0 ? fromEnv : 'https://baas.botho.io').replace(/\/+$/, '')
+}
+
+export interface StartRigCheckoutInput {
+  /** Desired AWS region (must be one of RIG_REGIONS). */
+  region: string
+  /** Optional email to pre-fill Stripe checkout. */
+  email?: string
+}
+
+export interface RigCheckoutSession {
+  /** Stripe Checkout Session id. */
+  id: string
+  /** Hosted Stripe Checkout URL to redirect to. */
+  url: string
+}
+
+/** Error from the checkout flow, carrying an HTTP status when available. */
+export class RigCheckoutError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message)
+    this.name = 'RigCheckoutError'
+  }
+}
+
+/**
+ * Create a Stripe Checkout Session via the control-plane Worker and return its
+ * id + hosted URL. `fetchImpl` is injectable for tests.
+ */
+export async function startRigCheckout(
+  input: StartRigCheckoutInput,
+  fetchImpl: typeof fetch = fetch,
+): Promise<RigCheckoutSession> {
+  const body: Record<string, unknown> = { region: input.region }
+  if (input.email) body.email = input.email
+
+  let resp: Response
+  try {
+    resp = await fetchImpl(`${baasEndpoint()}/checkout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  } catch {
+    throw new RigCheckoutError('Could not reach the checkout service. Try again.')
+  }
+
+  let json: { id?: string; url?: string; error?: string }
+  try {
+    json = (await resp.json()) as typeof json
+  } catch {
+    throw new RigCheckoutError('Unexpected response from the checkout service.', resp.status)
+  }
+
+  if (!resp.ok || !json.url || !json.id) {
+    throw new RigCheckoutError(json.error ?? 'Could not start checkout.', resp.status)
+  }
+
+  return { id: json.id, url: json.url }
+}

--- a/web/packages/web-wallet/src/pages/landing.tsx
+++ b/web/packages/web-wallet/src/pages/landing.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Button, Logo } from '@botho/ui'
-import { Shield, Scale, Atom, Zap, ArrowRight, Github, Menu, X, FileText, Blocks } from 'lucide-react'
+import { Shield, Scale, Atom, Zap, ArrowRight, Github, Menu, X, FileText, Blocks, Server } from 'lucide-react'
 
 const features = [
   {
@@ -55,6 +55,10 @@ export function LandingPage() {
             <Link to="/docs" className="text-ghost hover:text-light transition-colors">
               Docs
             </Link>
+            <Link to="/rig" className="text-ghost hover:text-light transition-colors flex items-center gap-2">
+              <Server size={18} />
+              Get a Rig
+            </Link>
             <a
               href="/botho-whitepaper.pdf"
               target="_blank"
@@ -106,6 +110,14 @@ export function LandingPage() {
                 className="block px-4 py-3 rounded-lg text-ghost hover:text-light hover:bg-steel/50 transition-colors"
               >
                 Documentation
+              </Link>
+              <Link
+                to="/rig"
+                onClick={() => setMobileMenuOpen(false)}
+                className="flex items-center gap-2 px-4 py-3 rounded-lg text-ghost hover:text-light hover:bg-steel/50 transition-colors"
+              >
+                <Server size={18} />
+                Get a Rig
               </Link>
               <a
                 href="/botho-whitepaper.pdf"
@@ -219,14 +231,23 @@ export function LandingPage() {
             Ready to Get Started?
           </h2>
           <p className="text-sm sm:text-base text-ghost mb-6 sm:mb-8 px-2">
-            Create a wallet in seconds. No email, no KYC, no tracking.
+            Create a wallet in seconds. No email, no KYC, no tracking. Or run your
+            own always-on node with a managed rig.
           </p>
-          <Link to="/wallet">
-            <Button size="lg" className="w-full sm:w-auto justify-center">
-              Create Wallet
-              <ArrowRight className="ml-2" size={18} />
-            </Button>
-          </Link>
+          <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center px-4 sm:px-0">
+            <Link to="/wallet" className="w-full sm:w-auto">
+              <Button size="lg" className="w-full sm:w-auto justify-center">
+                Create Wallet
+                <ArrowRight className="ml-2" size={18} />
+              </Button>
+            </Link>
+            <Link to="/rig" className="w-full sm:w-auto">
+              <Button variant="secondary" size="lg" className="w-full sm:w-auto justify-center">
+                <Server className="mr-2" size={18} />
+                Get a Rig
+              </Button>
+            </Link>
+          </div>
         </div>
       </section>
 

--- a/web/packages/web-wallet/src/pages/rig.tsx
+++ b/web/packages/web-wallet/src/pages/rig.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Button, Card, Input, Logo } from '@botho/ui'
+import { Server, ArrowLeft, Loader2, AlertCircle, Check, Cpu, Globe, ShieldCheck } from 'lucide-react'
+import {
+  DEFAULT_RIG_REGION,
+  RIG_REGIONS,
+  RigCheckoutError,
+  startRigCheckout,
+} from '../lib/rig-checkout'
+
+/**
+ * P7.1 — "Get a rig" surface (#458 §2, §4; issue #504).
+ *
+ * A thin signup page that lets a user buy a managed Botho mining node for
+ * $50/mo. It collects the desired AWS region (allowlist, #458 §5), then asks the
+ * control-plane Worker (`@botho/baas-worker /checkout`) to create a Stripe
+ * Checkout Session and redirects the browser to the Stripe-hosted page.
+ *
+ * Honest testnet copy (#458 §7): the value prop today is "your own always-on
+ * node + the wallet experience + participation in mining," NOT profit. Billing
+ * runs in Stripe TEST mode while on testnet.
+ *
+ * Webhook → provisioning is P7.2 (#506); the rich status page is P6.3. After
+ * checkout, Stripe redirects to `/rig/success` (the placeholder below).
+ */
+export function RigPage() {
+  const [region, setRegion] = useState<string>(DEFAULT_RIG_REGION)
+  const [email, setEmail] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleGetRig() {
+    setError(null)
+    setSubmitting(true)
+    try {
+      const session = await startRigCheckout({
+        region,
+        email: email.trim() || undefined,
+      })
+      // Redirect the browser to the Stripe-hosted checkout page.
+      window.location.assign(session.url)
+    } catch (err) {
+      const message =
+        err instanceof RigCheckoutError
+          ? err.message
+          : 'Something went wrong starting checkout. Please try again.'
+      setError(message)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen">
+      {/* Header */}
+      <header className="fixed top-0 left-0 right-0 z-50 backdrop-blur-md bg-void/80 border-b border-steel">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between">
+          <Link to="/" className="flex items-center gap-2 sm:gap-3">
+            <Logo size="md" showText={false} />
+            <span className="font-display text-lg sm:text-xl font-semibold">Botho</span>
+          </Link>
+          <Link to="/" className="text-ghost hover:text-light transition-colors flex items-center gap-2">
+            <ArrowLeft size={18} />
+            Back
+          </Link>
+        </div>
+      </header>
+
+      <main className="pt-28 sm:pt-32 pb-16 px-4 sm:px-6">
+        <div className="max-w-3xl mx-auto">
+          {/* Hero */}
+          <div className="text-center mb-10">
+            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-steel/50 border border-muted text-xs sm:text-sm text-ghost mb-6">
+              <span className="w-2 h-2 rounded-full bg-warning" />
+              Testnet — billing runs in Stripe test mode
+            </div>
+            <div className="w-14 h-14 rounded-xl bg-pulse/10 flex items-center justify-center mx-auto mb-5">
+              <Server className="text-pulse" size={28} />
+            </div>
+            <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold mb-4">
+              Get a Managed Rig
+            </h1>
+            <p className="text-base sm:text-lg text-ghost max-w-xl mx-auto">
+              Your own always-on Botho node in the cloud — joins the testnet,
+              participates in mining, and gives you a private RPC endpoint for the
+              wallet. <span className="text-light">$50/month.</span>
+            </p>
+          </div>
+
+          {/* Honest testnet caveat (#458 §7) */}
+          <div className="mb-8 p-4 rounded-xl bg-warning/10 border border-warning/30 flex gap-3">
+            <AlertCircle className="text-warning shrink-0 mt-0.5" size={20} />
+            <p className="text-sm text-ghost">
+              <span className="text-light font-medium">Testnet, no profit promised.</span>{' '}
+              Rigs mine <span className="text-light">testnet</span> BTH, which has no
+              real-world value today. What you get now is your own always-on node,
+              the full wallet experience, and a hand in keeping the network running —
+              not income. Charges run in Stripe test mode while we validate the
+              service.
+            </p>
+          </div>
+
+          {/* What you get */}
+          <div className="grid sm:grid-cols-3 gap-3 sm:gap-4 mb-8">
+            {[
+              { icon: Cpu, title: 'Always-on node', desc: 'A t4g.medium running RandomX, joined to the testnet.' },
+              { icon: Globe, title: 'Private RPC', desc: 'Your own HTTPS endpoint to point the wallet at.' },
+              { icon: ShieldCheck, title: 'Non-custodial', desc: 'Keys stay on your device. The node never holds your funds.' },
+            ].map((f) => (
+              <div key={f.title} className="p-4 rounded-xl bg-slate/50 border border-steel">
+                <f.icon className="text-pulse mb-2" size={20} />
+                <div className="font-display font-semibold text-sm mb-1">{f.title}</div>
+                <div className="text-xs text-ghost">{f.desc}</div>
+              </div>
+            ))}
+          </div>
+
+          {/* Checkout form */}
+          <Card className="p-5 sm:p-6">
+            <label className="block text-sm font-medium text-light mb-2" htmlFor="rig-region">
+              Region
+            </label>
+            <select
+              id="rig-region"
+              value={region}
+              onChange={(e) => setRegion(e.target.value)}
+              disabled={submitting}
+              className="w-full mb-1 px-3 py-2.5 rounded-lg bg-void border border-steel text-light focus:outline-none focus:border-pulse disabled:opacity-50"
+            >
+              {RIG_REGIONS.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.label}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-ghost mb-5">
+              More regions coming soon. Your node will be provisioned here once you
+              subscribe.
+            </p>
+
+            <label className="block text-sm font-medium text-light mb-2" htmlFor="rig-email">
+              Email <span className="text-ghost font-normal">(optional)</span>
+            </label>
+            <Input
+              id="rig-email"
+              type="email"
+              placeholder="you@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={submitting}
+              className="mb-1"
+            />
+            <p className="text-xs text-ghost mb-6">
+              Pre-fills Stripe checkout and is where we'll send your node details.
+              You can also enter it on the next screen.
+            </p>
+
+            {error && (
+              <div className="mb-4 p-3 rounded-lg bg-error/10 border border-error/30 flex gap-2 text-sm text-error">
+                <AlertCircle size={18} className="shrink-0 mt-0.5" />
+                <span>{error}</span>
+              </div>
+            )}
+
+            <Button
+              size="lg"
+              className="w-full justify-center"
+              onClick={handleGetRig}
+              disabled={submitting}
+            >
+              {submitting ? (
+                <>
+                  <Loader2 className="animate-spin mr-2" size={18} />
+                  Redirecting to Stripe…
+                </>
+              ) : (
+                'Subscribe — $50/mo'
+              )}
+            </Button>
+            <p className="text-xs text-center text-ghost mt-3">
+              Secure checkout hosted by Stripe. Cancel anytime.
+            </p>
+          </Card>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+/**
+ * Placeholder success page (#458 §4). Stripe redirects here after a completed
+ * checkout (`/rig/success?session_id=...`). The full rig-status page — which
+ * shows the provisioned node's RPC URL and health — is P6.3; until then this
+ * confirms the subscription and explains what happens next.
+ */
+export function RigSuccessPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <header className="fixed top-0 left-0 right-0 z-50 backdrop-blur-md bg-void/80 border-b border-steel">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between">
+          <Link to="/" className="flex items-center gap-2 sm:gap-3">
+            <Logo size="md" showText={false} />
+            <span className="font-display text-lg sm:text-xl font-semibold">Botho</span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="flex-1 flex items-center justify-center pt-28 px-4 sm:px-6">
+        <Card className="max-w-md w-full p-6 sm:p-8 text-center">
+          <div className="w-14 h-14 rounded-full bg-success/10 flex items-center justify-center mx-auto mb-5">
+            <Check className="text-success" size={28} />
+          </div>
+          <h1 className="font-display text-2xl sm:text-3xl font-bold mb-3">
+            Subscription started
+          </h1>
+          <p className="text-sm sm:text-base text-ghost mb-6">
+            Thanks! Your managed rig is being set up. We'll provision your node and
+            send its private RPC URL shortly. A live status page is coming soon —
+            it'll show your node's address and health here.
+          </p>
+          <div className="flex flex-col gap-3">
+            <Link to="/wallet">
+              <Button size="lg" className="w-full justify-center">
+                Open Wallet
+              </Button>
+            </Link>
+            <Link to="/" className="text-sm text-ghost hover:text-light transition-colors">
+              Back to home
+            </Link>
+          </div>
+        </Card>
+      </main>
+    </div>
+  )
+}

--- a/web/packages/web-wallet/src/vite-env.d.ts
+++ b/web/packages/web-wallet/src/vite-env.d.ts
@@ -6,6 +6,8 @@ interface ImportMetaEnv {
   readonly VITE_RPC_ENDPOINT?: string
   /** Custom faucet endpoint URL (overrides default testnet faucet) */
   readonly VITE_FAUCET_ENDPOINT?: string
+  /** Base URL of the BaaS control-plane Worker (defaults to https://baas.botho.io) */
+  readonly VITE_BAAS_ENDPOINT?: string
 }
 
 interface ImportMeta {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -49,6 +49,18 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  packages/baas-worker:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260617.1
+        version: 4.20260621.1
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      wrangler:
+        specifier: ^4.59.1
+        version: 4.103.0(@cloudflare/workers-types@4.20260621.1)
+
   packages/core:
     dependencies:
       '@noble/curves':
@@ -301,7 +313,7 @@ importers:
         version: 7.4.0
       wrangler:
         specifier: ^4.59.1
-        version: 4.103.0
+        version: 4.103.0(@cloudflare/workers-types@4.20260621.1)
 
 packages:
 
@@ -876,6 +888,9 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workers-types@4.20260621.1':
+    resolution: {integrity: sha512-c4xrf4shZdDOK1ihh1UKzlS/3MDYiGThT/Oqr4Y3qR9NLCSNzHB7rt+Vk/LOp0ZSNjA+7WNJEQsOhpiQtpT2GA==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4915,6 +4930,8 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260617.1':
     optional: true
 
+  '@cloudflare/workers-types@4.20260621.1': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -8329,7 +8346,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260617.1
       '@cloudflare/workerd-windows-64': 1.20260617.1
 
-  wrangler@4.103.0:
+  wrangler@4.103.0(@cloudflare/workers-types@4.20260621.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260617.1)
@@ -8340,6 +8357,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260617.1
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260621.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
Closes #504

Implements **P7.1 of the Botho-as-a-Service MVP** (parent #458 §2, §4): the billing front door — a Stripe Checkout Session creator and a thin "Get a rig" frontend surface. Code only, Stripe **TEST mode** conventions, no deploys, no real secrets.

## What's here

### Control-plane Worker — `web/packages/baas-worker` (new package)
- **`POST /checkout`** creates a `mode=subscription` Stripe Checkout Session for a single **$50/mo Price**:
  - Price id + secret key read from **Worker secrets/env** (`STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID`) — never hard-coded. **Fails closed** (HTTP 500, no Stripe call) if unconfigured.
  - **Region** captured in `metadata.region` and `subscription_data.metadata.region` for later provisioning (#458 §3), **re-validated server-side** against an allowlist (`us-west-2`) so a crafted request can't request an off-list region (#458 §5).
  - `success_url` carries Stripe's `{CHECKOUT_SESSION_ID}` template for the future status lookup (P6.3).
  - CORS limited to an `ALLOWED_ORIGINS` allowlist.
- `GET /healthz` liveness probe.
- `wrangler.toml` (non-secret vars only), `.dev.vars.example` (placeholders), and a README documenting the one-time Stripe Product/$50 Price setup and `wrangler secret put`.

### "Get a rig" surface — `web/packages/web-wallet`
- New route **`/rig`** (`RigPage`): region selector constrained to the allowlist, optional email, **honest testnet copy** (your own always-on node + mining participation, *not* profit — #458 §7). Calls `/checkout` via `src/lib/rig-checkout.ts` and redirects to the Stripe-hosted page.
- **`/rig/success`** placeholder (full status page is P6.3).
- Linked from the landing nav (desktop + mobile) and the CTA.

## Out of scope (by design)
- Webhook → provision/deprovision is **P7.2 (#506)**.
- Rich rig-status page is **P6.3**.

## Secrets / test-mode handling
- All secrets in Worker secrets / `.dev.vars` (gitignored). Only placeholders in the repo (`sk_test_REPLACE_ME`, `price_REPLACE_ME`).
- `isTestModeKey()` helper for honest UI/log breadcrumbs; Stripe remains source of truth for the mode.
- `.gitignore` updated to exclude `.dev.vars` and `.wrangler/`.

## Tests (mocked `fetch`, no network / no live Stripe)
- `baas-worker/src/checkout.test.ts` (26) — param builder, validation, region allowlist, env checks, Stripe error handling.
- `baas-worker/src/index.test.ts` (8) — `/checkout` handler: 200/400/405/500/502, fail-closed, CORS.
- `web-wallet/src/lib/rig-checkout.test.ts` (6) — frontend client request shape + error paths.

**Results:** `pnpm test:run` → 283 passed / 10 skipped (40 new). `pnpm typecheck` clean. `pnpm build:web` succeeds. `wrangler deploy --dry-run` bundles the Worker cleanly (no deploy performed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)