### PR TITLE
feat(mobile): P3 — thin-client node-selection / trust UX (add-by-URL + identity verify)

### DIFF
--- a/mobile/app/.eslintrc.js
+++ b/mobile/app/.eslintrc.js
@@ -1,0 +1,16 @@
+// ESLint configuration for the Botho mobile app.
+//
+// Uses the Expo shared config (eslint-config-expo) which bundles the
+// React / React-Native / TypeScript rules appropriate for an Expo Router app.
+// ESLint 8 resolves this `.eslintrc.js` (eslintrc format).
+module.exports = {
+  root: true,
+  extends: ["expo"],
+  ignorePatterns: [
+    "node_modules/",
+    "ios/",
+    "android/",
+    ".expo/",
+    "dist/",
+  ],
+};

--- a/mobile/app/app/_layout.tsx
+++ b/mobile/app/app/_layout.tsx
@@ -15,11 +15,14 @@ const queryClient = new QueryClient();
 export default function RootLayout() {
   const checkSession = useWalletStore((state) => state.checkSession);
   const hydrateNodeUrl = useWalletStore((state) => state.hydrateNodeUrl);
+  const hydrateNodes = useWalletStore((state) => state.hydrateNodes);
 
-  // Apply the persisted node selection to the bridge before anything else.
+  // Load the user-managed node list and apply the persisted node selection to
+  // the bridge before anything else.
   useEffect(() => {
+    hydrateNodes();
     hydrateNodeUrl();
-  }, [hydrateNodeUrl]);
+  }, [hydrateNodes, hydrateNodeUrl]);
 
   // Check session on app mount and periodically
   useEffect(() => {

--- a/mobile/app/app/node-picker.tsx
+++ b/mobile/app/app/node-picker.tsx
@@ -1,10 +1,24 @@
 /**
- * Node Picker Screen (pick 1 of 3 testnet nodes)
+ * Node Picker Screen — thin-client node selection / trust UX (epic #441 P3).
  *
- * Lets the user choose the trusted node the thin wallet uses as RPC ingress.
- * The selection is persisted (keychain) and pushed to the rust-bridge via
- * `setNodeUrl`; node health (height / sync / peers) is shown via
- * `get_node_status`.
+ * The wallet is a thin client: it scans and submits transactions through a
+ * single trusted node (its RPC ingress). This screen lets the user:
+ *
+ *   - Pick from a user-managed list of trusted nodes (seeded with the testnet
+ *     defaults, no longer limited to 3 hardcoded entries).
+ *   - Add a node by RPC URL after verifying its identity (`node_getIdentity`,
+ *     #500): the app shows the node's peer ID / network / chain tip and refuses
+ *     to trust a node on the wrong network or an incompatible protocol unless
+ *     the user explicitly overrides a soft warning. Network mismatch is blocked.
+ *   - Remove user-added nodes.
+ *
+ * Selection is persisted (secure store) and pushed to the rust-bridge via
+ * `setNodeUrl`; per-node health (height / sync / peers) is shown via
+ * `get_node_status` (same probe pattern as before).
+ *
+ * Privacy boundary (epic §5(c)): pointing at a node leaks which outputs are
+ * the user's via the scan RPCs, so the screen surfaces a clear
+ * "only point at nodes you trust" notice.
  */
 
 import { useEffect, useState } from "react";
@@ -15,11 +29,15 @@ import {
   TouchableOpacity,
   ScrollView,
   ActivityIndicator,
+  TextInput,
+  Alert,
 } from "react-native";
 import { useRouter } from "expo-router";
-import { useWalletStore } from "../src/store/walletStore";
-import { TESTNET_NODES, type NodeOption } from "../src/config/nodes";
+import { useWalletStore, type VerifyNodeResult } from "../src/store/walletStore";
+import type { ManagedNode } from "../src/config/nodes";
 import { NativeWallet } from "../src/native/walletModule";
+import { NodeIdentityError } from "../src/native/nodeIdentity";
+import { EXPECTED_NETWORK } from "../src/config/network";
 import type { NodeStatusInfo } from "../src/types/wallet";
 
 /** Per-node health probe result. */
@@ -29,18 +47,38 @@ type Health =
   | { state: "ok"; status: NodeStatusInfo }
   | { state: "error"; message: string };
 
+/** Identity-verification flow state for the "add node" form. */
+type Verify =
+  | { state: "idle" }
+  | { state: "verifying" }
+  | { state: "error"; message: string }
+  | { state: "confirm"; result: VerifyNodeResult };
+
 export default function NodePickerScreen() {
   const router = useRouter();
-  const { nodeUrl, setNodeUrl } = useWalletStore();
+  const {
+    nodeUrl,
+    nodes,
+    setNodeUrl,
+    verifyNode,
+    addVerifiedNode,
+    removeNode,
+  } = useWalletStore();
+
   const [health, setHealth] = useState<Record<string, Health>>({});
   const [applying, setApplying] = useState<string | null>(null);
 
-  // Probe every node's health on mount so the user can compare.
+  // Add-by-URL form state.
+  const [draftUrl, setDraftUrl] = useState("");
+  const [draftLabel, setDraftLabel] = useState("");
+  const [verify, setVerify] = useState<Verify>({ state: "idle" });
+
+  // Probe every node's health on mount (and whenever the list grows).
   useEffect(() => {
     let cancelled = false;
 
     const probeAll = async () => {
-      for (const node of TESTNET_NODES) {
+      for (const node of nodes) {
         if (cancelled) return;
         setHealth((h) => ({ ...h, [node.id]: { state: "loading" } }));
         try {
@@ -73,11 +111,11 @@ export default function NodePickerScreen() {
     return () => {
       cancelled = true;
     };
-    // Probe once on mount.
+    // Re-probe when the node list changes (e.g. after adding a node).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [nodes.length]);
 
-  const handleSelect = async (node: NodeOption) => {
+  const handleSelect = async (node: ManagedNode) => {
     setApplying(node.id);
     try {
       await setNodeUrl(node.url);
@@ -85,6 +123,51 @@ export default function NodePickerScreen() {
     } finally {
       setApplying(null);
     }
+  };
+
+  const handleRemove = (node: ManagedNode) => {
+    Alert.alert(
+      "Remove node",
+      `Remove "${node.label}" from your trusted nodes?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Remove",
+          style: "destructive",
+          onPress: () => {
+            removeNode(node.id);
+          },
+        },
+      ]
+    );
+  };
+
+  // Step 1: verify the candidate node's identity before trusting it.
+  const handleVerify = async () => {
+    setVerify({ state: "verifying" });
+    try {
+      const result = await verifyNode(draftUrl);
+      setVerify({ state: "confirm", result });
+    } catch (error) {
+      const message =
+        error instanceof NodeIdentityError || error instanceof Error
+          ? error.message
+          : "Could not verify node.";
+      setVerify({ state: "error", message });
+    }
+  };
+
+  // Step 2: user has reviewed the identity and confirmed trust.
+  const handleConfirmAdd = async (result: VerifyNodeResult) => {
+    await addVerifiedNode(result, draftLabel);
+    // Reset the form.
+    setDraftUrl("");
+    setDraftLabel("");
+    setVerify({ state: "idle" });
+  };
+
+  const handleCancelVerify = () => {
+    setVerify({ state: "idle" });
   };
 
   return (
@@ -97,7 +180,17 @@ export default function NodePickerScreen() {
         submits transactions through this node.
       </Text>
 
-      {TESTNET_NODES.map((node) => {
+      {/* Privacy boundary notice (epic §5(c)). */}
+      <View style={styles.privacyBanner}>
+        <Text style={styles.privacyTitle}>Only connect to nodes you trust</Text>
+        <Text style={styles.privacyText}>
+          Your wallet asks this node which outputs belong to you, so a malicious
+          node can learn your balance and activity. Add only nodes you operate
+          or trust.
+        </Text>
+      </View>
+
+      {nodes.map((node) => {
         const selected = node.url === nodeUrl;
         const h = health[node.id] ?? { state: "idle" };
         return (
@@ -113,10 +206,20 @@ export default function NodePickerScreen() {
               {node.isFaucet && (
                 <Text style={styles.faucetBadge}>FAUCET</Text>
               )}
+              {node.source === "user" && (
+                <Text style={styles.userBadge}>ADDED</Text>
+              )}
             </View>
 
             <Text style={styles.nodeUrl}>{node.url}</Text>
             <Text style={styles.nodeDescription}>{node.description}</Text>
+
+            {node.verifiedIdentity && (
+              <Text style={styles.identityLine} numberOfLines={1}>
+                {node.verifiedIdentity.network} • peer{" "}
+                {node.verifiedIdentity.peerId.slice(0, 12)}…
+              </Text>
+            )}
 
             <View style={styles.healthRow}>
               {h.state === "loading" && (
@@ -144,6 +247,16 @@ export default function NodePickerScreen() {
               )}
             </View>
 
+            {node.source === "user" && (
+              <TouchableOpacity
+                style={styles.removeButton}
+                onPress={() => handleRemove(node)}
+                disabled={applying != null}
+              >
+                <Text style={styles.removeButtonText}>Remove</Text>
+              </TouchableOpacity>
+            )}
+
             {applying === node.id && (
               <ActivityIndicator
                 style={styles.applying}
@@ -154,7 +267,160 @@ export default function NodePickerScreen() {
           </TouchableOpacity>
         );
       })}
+
+      {/* Add-by-URL section. */}
+      <View style={styles.addSection}>
+        <Text style={styles.addTitle}>Add a node</Text>
+        <Text style={styles.addHelp}>
+          Enter a node&apos;s RPC URL. We&apos;ll verify its identity before you
+          trust it.
+        </Text>
+
+        <TextInput
+          style={styles.input}
+          placeholder="https://node.example.com"
+          placeholderTextColor="#555"
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="url"
+          value={draftUrl}
+          onChangeText={(t) => {
+            setDraftUrl(t);
+            if (verify.state === "error") setVerify({ state: "idle" });
+          }}
+          editable={verify.state !== "verifying"}
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Label (optional)"
+          placeholderTextColor="#555"
+          autoCapitalize="none"
+          value={draftLabel}
+          onChangeText={setDraftLabel}
+          editable={verify.state !== "verifying"}
+        />
+
+        {verify.state === "error" && (
+          <Text style={styles.verifyError}>{verify.message}</Text>
+        )}
+
+        <TouchableOpacity
+          style={[
+            styles.verifyButton,
+            (draftUrl.trim() === "" || verify.state === "verifying") &&
+              styles.verifyButtonDisabled,
+          ]}
+          onPress={handleVerify}
+          disabled={draftUrl.trim() === "" || verify.state === "verifying"}
+        >
+          {verify.state === "verifying" ? (
+            <ActivityIndicator size="small" color="#1a1a2e" />
+          ) : (
+            <Text style={styles.verifyButtonText}>Verify identity</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+
+      {/* Identity confirmation card (shown after a successful verify). */}
+      {verify.state === "confirm" && (
+        <IdentityConfirm
+          result={verify.result}
+          onConfirm={() => handleConfirmAdd(verify.result)}
+          onCancel={handleCancelVerify}
+        />
+      )}
     </ScrollView>
+  );
+}
+
+/** Identity confirmation card: shows the verified identity + trust decision. */
+function IdentityConfirm({
+  result,
+  onConfirm,
+  onCancel,
+}: {
+  result: VerifyNodeResult;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const { identity, networkMatches, protocolCompatible } = result;
+  // Network mismatch is a hard block (wrong chain entirely). Protocol
+  // incompatibility is a soft warning the user can override.
+  const blocked = !networkMatches;
+
+  return (
+    <View style={styles.confirmCard}>
+      <Text style={styles.confirmTitle}>Verify this node</Text>
+      <Text style={styles.confirmUrl}>{result.url}</Text>
+
+      <IdentityRow label="Network" value={identity.network} />
+      <IdentityRow label="Peer ID" value={identity.peerId} mono />
+      <IdentityRow label="Node ID" value={identity.nodeId} mono />
+      <IdentityRow
+        label="Protocol"
+        value={`${identity.protocolVersion} (min ${identity.minProtocolVersion})`}
+      />
+      <IdentityRow
+        label="Software"
+        value={`${identity.nodeVersion} @ ${identity.gitCommit}`}
+      />
+      <IdentityRow
+        label="Chain tip"
+        value={`height ${identity.chainHeight}`}
+      />
+
+      {!networkMatches && (
+        <Text style={styles.confirmDanger}>
+          This node is on &quot;{identity.network || "an unknown network"}&quot;,
+          but your wallet expects &quot;{EXPECTED_NETWORK}&quot;. Adding it is
+          blocked to protect your funds.
+        </Text>
+      )}
+      {networkMatches && !protocolCompatible && (
+        <Text style={styles.confirmWarn}>
+          This node&apos;s protocol version may be incompatible with this app.
+          Some operations could fail.
+        </Text>
+      )}
+
+      <View style={styles.confirmActions}>
+        <TouchableOpacity style={styles.cancelButton} onPress={onCancel}>
+          <Text style={styles.cancelButtonText}>Cancel</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.trustButton, blocked && styles.trustButtonDisabled]}
+          onPress={onConfirm}
+          disabled={blocked}
+        >
+          <Text style={styles.trustButtonText}>
+            {protocolCompatible ? "Trust & add" : "Add anyway"}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+/** One labeled identity field row. */
+function IdentityRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <View style={styles.idRow}>
+      <Text style={styles.idLabel}>{label}</Text>
+      <Text
+        style={[styles.idValue, mono && styles.idValueMono]}
+        numberOfLines={1}
+      >
+        {value || "—"}
+      </Text>
+    </View>
   );
 }
 
@@ -169,8 +435,27 @@ const styles = StyleSheet.create({
   intro: {
     color: "#888",
     fontSize: 14,
-    marginBottom: 20,
+    marginBottom: 12,
     lineHeight: 20,
+  },
+  privacyBanner: {
+    backgroundColor: "#2a1f3d",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#5a3fb0",
+    padding: 12,
+    marginBottom: 20,
+  },
+  privacyTitle: {
+    color: "#c9b6ff",
+    fontSize: 13,
+    fontWeight: "700",
+    marginBottom: 4,
+  },
+  privacyText: {
+    color: "#a99cc7",
+    fontSize: 12,
+    lineHeight: 17,
   },
   nodeCard: {
     backgroundColor: "#16213e",
@@ -206,6 +491,12 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     marginLeft: 8,
   },
+  userBadge: {
+    color: "#ffb347",
+    fontSize: 10,
+    fontWeight: "700",
+    marginLeft: 8,
+  },
   nodeUrl: {
     color: "#00d9ff",
     fontSize: 13,
@@ -215,7 +506,13 @@ const styles = StyleSheet.create({
   nodeDescription: {
     color: "#888",
     fontSize: 13,
-    marginBottom: 12,
+    marginBottom: 8,
+  },
+  identityLine: {
+    color: "#7a8aa0",
+    fontSize: 11,
+    fontFamily: "Courier",
+    marginBottom: 8,
   },
   healthRow: {
     flexDirection: "row",
@@ -243,7 +540,150 @@ const styles = StyleSheet.create({
     fontSize: 12,
     flex: 1,
   },
+  removeButton: {
+    marginTop: 12,
+    alignSelf: "flex-start",
+  },
+  removeButtonText: {
+    color: "#ff6666",
+    fontSize: 13,
+    fontWeight: "600",
+  },
   applying: {
     marginTop: 12,
+  },
+  addSection: {
+    backgroundColor: "#16213e",
+    borderRadius: 12,
+    padding: 16,
+    marginTop: 8,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: "#0f3460",
+  },
+  addTitle: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "600",
+    marginBottom: 4,
+  },
+  addHelp: {
+    color: "#888",
+    fontSize: 12,
+    lineHeight: 17,
+    marginBottom: 12,
+  },
+  input: {
+    backgroundColor: "#0f1830",
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#0f3460",
+    color: "#fff",
+    fontSize: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    marginBottom: 10,
+  },
+  verifyError: {
+    color: "#ff6666",
+    fontSize: 12,
+    marginBottom: 10,
+  },
+  verifyButton: {
+    backgroundColor: "#00d9ff",
+    borderRadius: 8,
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  verifyButtonDisabled: {
+    opacity: 0.4,
+  },
+  verifyButtonText: {
+    color: "#1a1a2e",
+    fontSize: 15,
+    fontWeight: "700",
+  },
+  confirmCard: {
+    backgroundColor: "#16213e",
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 24,
+    borderWidth: 1,
+    borderColor: "#00d9ff",
+  },
+  confirmTitle: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "700",
+    marginBottom: 4,
+  },
+  confirmUrl: {
+    color: "#00d9ff",
+    fontSize: 13,
+    fontFamily: "Courier",
+    marginBottom: 12,
+  },
+  idRow: {
+    flexDirection: "row",
+    marginBottom: 6,
+  },
+  idLabel: {
+    color: "#888",
+    fontSize: 12,
+    width: 80,
+  },
+  idValue: {
+    color: "#fff",
+    fontSize: 12,
+    flex: 1,
+  },
+  idValueMono: {
+    fontFamily: "Courier",
+  },
+  confirmDanger: {
+    color: "#ff6666",
+    fontSize: 13,
+    lineHeight: 18,
+    marginTop: 10,
+  },
+  confirmWarn: {
+    color: "#ffb347",
+    fontSize: 13,
+    lineHeight: 18,
+    marginTop: 10,
+  },
+  confirmActions: {
+    flexDirection: "row",
+    marginTop: 16,
+  },
+  cancelButton: {
+    flex: 1,
+    paddingVertical: 12,
+    alignItems: "center",
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#0f3460",
+    marginRight: 8,
+  },
+  cancelButtonText: {
+    color: "#888",
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  trustButton: {
+    flex: 1,
+    backgroundColor: "#00ff88",
+    paddingVertical: 12,
+    alignItems: "center",
+    borderRadius: 8,
+    marginLeft: 8,
+  },
+  trustButtonDisabled: {
+    opacity: 0.4,
+  },
+  trustButtonText: {
+    color: "#1a1a2e",
+    fontSize: 15,
+    fontWeight: "700",
   },
 });

--- a/mobile/app/babel.config.js
+++ b/mobile/app/babel.config.js
@@ -1,0 +1,11 @@
+// Babel configuration for the Botho mobile app (Expo Router).
+//
+// `babel-preset-expo` provides the React-Native + TypeScript + Expo Router
+// transforms. This config is required both for the Metro bundler and for the
+// `jest-expo` test preset to transform `.ts` / `.tsx` sources.
+module.exports = function babelConfig(api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+  };
+};

--- a/mobile/app/package.json
+++ b/mobile/app/package.json
@@ -12,23 +12,30 @@
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },
+  "jest": {
+    "preset": "jest-expo",
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|zustand))"
+    ]
+  },
   "dependencies": {
+    "@react-navigation/native": "^6.1.0",
+    "@tanstack/react-query": "^5.0.0",
     "expo": "~50.0.0",
+    "expo-local-authentication": "~14.0.0",
     "expo-modules-core": "~1.11.0",
     "expo-router": "~3.4.0",
-    "expo-status-bar": "~1.11.0",
     "expo-secure-store": "~13.0.0",
-    "expo-local-authentication": "~14.0.0",
+    "expo-status-bar": "~1.11.0",
     "react": "18.2.0",
     "react-native": "0.73.0",
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.29.0",
-    "@react-navigation/native": "^6.1.0",
-    "@tanstack/react-query": "^5.0.0",
     "zustand": "^4.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@types/jest": "^29.5.14",
     "@types/react": "~18.2.0",
     "eslint": "^8.0.0",
     "eslint-config-expo": "~7.0.0",

--- a/mobile/app/src/config/network.test.ts
+++ b/mobile/app/src/config/network.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for the thin-client network trust comparisons (epic #441 P3).
+ */
+
+import {
+  EXPECTED_NETWORK,
+  compareNetwork,
+  isProtocolCompatible,
+} from "./network";
+
+describe("compareNetwork", () => {
+  it("matches the expected network exactly", () => {
+    expect(compareNetwork(EXPECTED_NETWORK)).toBe("match");
+  });
+
+  it("trims surrounding whitespace before comparing", () => {
+    expect(compareNetwork(`  ${EXPECTED_NETWORK}  `)).toBe("match");
+  });
+
+  it("flags a different network as a mismatch", () => {
+    expect(compareNetwork("botho-mainnet")).toBe("mismatch");
+  });
+
+  it("treats missing / empty networks as unknown", () => {
+    expect(compareNetwork(undefined)).toBe("unknown");
+    expect(compareNetwork(null)).toBe("unknown");
+    expect(compareNetwork("")).toBe("unknown");
+    expect(compareNetwork("   ")).toBe("unknown");
+  });
+});
+
+describe("isProtocolCompatible", () => {
+  it("accepts a node whose major version matches the client", () => {
+    // CLIENT_PROTOCOL_VERSION is 2.x; node speaks 2.x and accepts down to 2.x.
+    expect(isProtocolCompatible("2.0.0", "2.0.0")).toBe(true);
+    expect(isProtocolCompatible("2.3.1", "2.0.0")).toBe(true);
+  });
+
+  it("accepts when the client falls inside the node's accepted window", () => {
+    // Node speaks 3.x but accepts down to 2.x -> client 2.x is fine.
+    expect(isProtocolCompatible("3.0.0", "2.0.0")).toBe(true);
+  });
+
+  it("rejects when the node requires a newer protocol than the client", () => {
+    expect(isProtocolCompatible("3.0.0", "3.0.0")).toBe(false);
+  });
+
+  it("rejects when the node is older than the client", () => {
+    expect(isProtocolCompatible("1.0.0", "1.0.0")).toBe(false);
+  });
+
+  it("rejects when the node's protocol version is missing/unparsable", () => {
+    expect(isProtocolCompatible(undefined, undefined)).toBe(false);
+    expect(isProtocolCompatible("", "")).toBe(false);
+    expect(isProtocolCompatible("abc", "2.0.0")).toBe(false);
+  });
+
+  it("defaults the min to the node's own major when min is absent", () => {
+    expect(isProtocolCompatible("2.0.0", undefined)).toBe(true);
+    expect(isProtocolCompatible("3.0.0", undefined)).toBe(false);
+  });
+});

--- a/mobile/app/src/config/network.ts
+++ b/mobile/app/src/config/network.ts
@@ -1,0 +1,80 @@
+/**
+ * Network identity expectations for the thin client.
+ *
+ * A thin wallet (this app) is a Mode-2 client: it points at *some* node and
+ * trusts that node for RPC ingress. Before trusting a node the app must verify
+ * that the node belongs to the network the wallet expects and speaks a
+ * compatible wire protocol. This module holds those expectations and the pure
+ * comparison helpers used by the node-selection / trust UX (epic #441 P3).
+ *
+ * Keeping these as plain constants + pure functions makes the trust decision
+ * unit-testable without any native bridge or network access.
+ */
+
+/**
+ * The network this build of the wallet is for.
+ *
+ * The node's `node_getIdentity` reports `network` as `"botho-<name>"`
+ * (e.g. `"botho-testnet"` / `"botho-mainnet"`), so this must match exactly.
+ * This is currently a testnet build; flipping it to mainnet is the single
+ * switch a mainnet build flips.
+ */
+export const EXPECTED_NETWORK = "botho-testnet";
+
+/**
+ * Wire-protocol version this client speaks. The node advertises its own
+ * `protocolVersion` plus the `minProtocolVersion` it will accept from peers;
+ * we treat a node as compatible when our version is within that node's
+ * accepted window (major version match, see `isProtocolCompatible`).
+ */
+export const CLIENT_PROTOCOL_VERSION = "2.0.0";
+
+/** Outcome of comparing a node's reported network against this build. */
+export type NetworkMatch = "match" | "mismatch" | "unknown";
+
+/**
+ * Compare a node-reported network string against the build's expected network.
+ *
+ * Returns `"unknown"` when the node did not report a network (older node or a
+ * field we couldn't parse) so the UI can warn rather than hard-block.
+ */
+export function compareNetwork(reported: string | undefined | null): NetworkMatch {
+  if (reported == null || reported.trim() === "") return "unknown";
+  return reported.trim() === EXPECTED_NETWORK ? "match" : "mismatch";
+}
+
+/** Parse the leading integer (major) component of a dotted version string. */
+function majorOf(version: string): number | null {
+  const head = version.trim().split(".")[0];
+  if (head === "") return null;
+  const n = Number.parseInt(head, 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Decide whether this client's protocol version is compatible with a node.
+ *
+ * Compatibility rule (conservative, matches the node's own major-version gate):
+ * the client major version must be >= the node's advertised `minProtocolVersion`
+ * major and <= the node's advertised `protocolVersion` major. Missing/unparsable
+ * fields are treated as "unknown" -> not provably compatible, so the UI warns.
+ */
+export function isProtocolCompatible(
+  nodeProtocolVersion: string | undefined | null,
+  nodeMinProtocolVersion: string | undefined | null
+): boolean {
+  const clientMajor = majorOf(CLIENT_PROTOCOL_VERSION);
+  if (clientMajor == null) return false;
+
+  const nodeMajor = nodeProtocolVersion ? majorOf(nodeProtocolVersion) : null;
+  if (nodeMajor == null) return false;
+
+  // If the node reports a minimum it accepts, honor it; otherwise assume the
+  // node accepts down to its own major.
+  const nodeMinMajor = nodeMinProtocolVersion
+    ? majorOf(nodeMinProtocolVersion)
+    : null;
+  const minMajor = nodeMinMajor ?? nodeMajor;
+
+  return clientMajor >= minMajor && clientMajor <= nodeMajor;
+}

--- a/mobile/app/src/config/nodes.test.ts
+++ b/mobile/app/src/config/nodes.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the user-managed node-list helpers (epic #441 P3).
+ */
+
+import {
+  seedNodes,
+  TESTNET_NODES,
+  findManagedByUrl,
+  nodeIdForUrl,
+  labelFromUrl,
+} from "./nodes";
+
+describe("seedNodes", () => {
+  it("returns one managed entry per testnet node, marked as a seed", () => {
+    const seeds = seedNodes();
+    expect(seeds).toHaveLength(TESTNET_NODES.length);
+    for (const node of seeds) {
+      expect(node.source).toBe("seed");
+    }
+  });
+
+  it("preserves the testnet URLs and faucet flag", () => {
+    const seeds = seedNodes();
+    const faucet = seeds.find((n) => n.isFaucet);
+    expect(faucet?.url).toBe("https://faucet.botho.io");
+  });
+
+  it("returns a fresh array each call (no shared mutation)", () => {
+    const a = seedNodes();
+    const b = seedNodes();
+    expect(a).not.toBe(b);
+    a[0].label = "mutated";
+    expect(b[0].label).not.toBe("mutated");
+  });
+});
+
+describe("findManagedByUrl", () => {
+  it("finds a node by exact URL", () => {
+    const nodes = seedNodes();
+    const found = findManagedByUrl(nodes, "https://seed.botho.io");
+    expect(found?.id).toBe("seed");
+  });
+
+  it("returns undefined when no node matches", () => {
+    expect(findManagedByUrl(seedNodes(), "https://nope.example")).toBeUndefined();
+  });
+});
+
+describe("nodeIdForUrl", () => {
+  it("derives a deterministic id from the URL", () => {
+    expect(nodeIdForUrl("https://a.example")).toBe(
+      nodeIdForUrl("https://a.example")
+    );
+    expect(nodeIdForUrl("https://a.example")).not.toBe(
+      nodeIdForUrl("https://b.example")
+    );
+  });
+});
+
+describe("labelFromUrl", () => {
+  it("uses the host as the default label", () => {
+    expect(labelFromUrl("https://node.example.com:8080/rpc")).toBe(
+      "node.example.com:8080"
+    );
+  });
+
+  it("falls back to the raw string for an unparsable URL", () => {
+    expect(labelFromUrl("not a url")).toBe("not a url");
+  });
+});

--- a/mobile/app/src/config/nodes.ts
+++ b/mobile/app/src/config/nodes.ts
@@ -1,11 +1,24 @@
 /**
- * Testnet node configuration.
+ * Node configuration + user-managed node list.
  *
- * The three live testnet nodes for the demo. The user picks one trusted node
- * as the wallet's RPC ingress (the wallet is a thin client: it scans and
- * submits via this node). The faucet node hosts the `faucet_request` RPC, so
- * faucet requests should be pointed at it.
+ * The wallet is a thin client: it scans and submits transactions through a
+ * single trusted node (its RPC ingress). Historically the user could only pick
+ * one of three hardcoded testnet nodes; epic #441 P3 replaces that with a
+ * user-managed list of trusted nodes:
+ *
+ *   - The 3 live testnet nodes are *seeded* into the list as defaults (so the
+ *     app works out of the box), but they are no longer the only options.
+ *   - The user can add any node by RPC URL after verifying its identity
+ *     (`node_getIdentity`, #500) and explicitly confirming trust.
+ *   - The list is persisted (secure store) and the active node drives
+ *     `setNodeUrl` into the native bridge.
+ *
+ * `ManagedNode` is the persisted shape; `NodeOption` remains the static config
+ * shape for the seed entries (kept for backwards-compatibility with callers
+ * such as the faucet flow).
  */
+
+import type { NodeIdentity } from "../types/wallet";
 
 export interface NodeOption {
   /** Stable id for persistence + selection. */
@@ -18,6 +31,31 @@ export interface NodeOption {
   description: string;
   /** Whether this node serves the faucet RPC. */
   isFaucet: boolean;
+}
+
+/**
+ * A user-managed trusted node entry (persisted).
+ *
+ * Seed entries (`source: "seed"`) ship with the app; `source: "user"` entries
+ * are added by the user after identity verification. `verifiedIdentity` records
+ * the identity the user confirmed at add-time so the picker can display it and
+ * later flag drift (e.g. the node now reports a different network / peer ID).
+ */
+export interface ManagedNode {
+  /** Stable id for persistence + selection. */
+  id: string;
+  /** Human-readable label shown in the picker. */
+  label: string;
+  /** RPC base URL passed to `setNodeUrl`. */
+  url: string;
+  /** Short description of the node's role. */
+  description: string;
+  /** Whether this node serves the faucet RPC. */
+  isFaucet: boolean;
+  /** Where this entry came from. Seed entries cannot be removed. */
+  source: "seed" | "user";
+  /** Identity confirmed by the user when the node was added (if verified). */
+  verifiedIdentity?: NodeIdentity;
 }
 
 /**
@@ -51,12 +89,49 @@ export const TESTNET_NODES: NodeOption[] = [
 /** Default node selection (used until the user picks one). */
 export const DEFAULT_NODE = TESTNET_NODES[0];
 
-/** Find a node option by its URL. */
+/**
+ * Seed node list used to initialize a user's managed list on first run (or when
+ * no persisted list exists). These remain selectable but are no longer the only
+ * options — the user can add their own nodes alongside them.
+ */
+export function seedNodes(): ManagedNode[] {
+  return TESTNET_NODES.map((n) => ({ ...n, source: "seed" as const }));
+}
+
+/** Find a seed node option by its URL. */
 export function findNodeByUrl(url: string): NodeOption | undefined {
   return TESTNET_NODES.find((n) => n.url === url);
 }
 
-/** The faucet node, if configured. */
+/** Find a managed node by URL within a list. */
+export function findManagedByUrl(
+  nodes: ManagedNode[],
+  url: string
+): ManagedNode | undefined {
+  return nodes.find((n) => n.url === url);
+}
+
+/** The faucet seed node, if configured. */
 export function faucetNode(): NodeOption | undefined {
   return TESTNET_NODES.find((n) => n.isFaucet);
+}
+
+/**
+ * Derive a stable id for a user-added node from its URL. Reusing the URL keeps
+ * ids deterministic and prevents accidental duplicates in the persisted list.
+ */
+export function nodeIdForUrl(url: string): string {
+  return `user:${url}`;
+}
+
+/**
+ * Derive a short, human-friendly label from a node URL (its hostname), used as
+ * the default label when the user adds a node without naming it.
+ */
+export function labelFromUrl(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
 }

--- a/mobile/app/src/native/keychain.ts
+++ b/mobile/app/src/native/keychain.ts
@@ -8,6 +8,7 @@
 
 import * as SecureStore from "expo-secure-store";
 import * as LocalAuthentication from "expo-local-authentication";
+import type { ManagedNode } from "../config/nodes";
 
 /** Keychain key for encrypted wallet data */
 const WALLET_KEY = "botho_encrypted_wallet";
@@ -15,8 +16,11 @@ const WALLET_KEY = "botho_encrypted_wallet";
 /** Keychain key for sync height */
 const SYNC_HEIGHT_KEY = "botho_sync_height";
 
-/** Keychain key for node URL preference */
+/** Keychain key for node URL preference (the active/selected node). */
 const NODE_URL_KEY = "botho_node_url";
+
+/** Keychain key for the user-managed list of trusted nodes. */
+const NODE_LIST_KEY = "botho_node_list";
 
 /** Stored wallet data structure */
 export interface StoredWallet {
@@ -182,4 +186,34 @@ export async function saveNodeUrl(url: string): Promise<void> {
  */
 export async function loadNodeUrl(): Promise<string | null> {
   return SecureStore.getItemAsync(NODE_URL_KEY);
+}
+
+/**
+ * Save the user-managed list of trusted nodes.
+ *
+ * Stored as JSON in the secure store (no biometric prompt: node URLs/identity
+ * are not secrets, but they belong in secure store alongside the rest of the
+ * wallet preferences and out of any cloud backup).
+ */
+export async function saveNodeList(nodes: ManagedNode[]): Promise<void> {
+  await SecureStore.setItemAsync(NODE_LIST_KEY, JSON.stringify(nodes));
+}
+
+/**
+ * Load the user-managed list of trusted nodes.
+ *
+ * Returns `null` when no list has been persisted yet (first run), so callers
+ * can fall back to the seed node list.
+ */
+export async function loadNodeList(): Promise<ManagedNode[] | null> {
+  try {
+    const data = await SecureStore.getItemAsync(NODE_LIST_KEY);
+    if (!data) return null;
+    const parsed: unknown = JSON.parse(data);
+    if (!Array.isArray(parsed)) return null;
+    return parsed as ManagedNode[];
+  } catch (error) {
+    console.error("Failed to load node list:", error);
+    return null;
+  }
 }

--- a/mobile/app/src/native/nodeIdentity.test.ts
+++ b/mobile/app/src/native/nodeIdentity.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for the node-identity URL normalizer (epic #441 P3).
+ *
+ * Only the pure URL-normalization logic is unit-tested here; the network
+ * `fetch` path is exercised at integration / runtime.
+ */
+
+import { normalizeNodeUrl, NodeIdentityError } from "./nodeIdentity";
+
+describe("normalizeNodeUrl", () => {
+  it("keeps a well-formed https URL", () => {
+    expect(normalizeNodeUrl("https://node.example.com")).toBe(
+      "https://node.example.com"
+    );
+  });
+
+  it("defaults a scheme-less host to https", () => {
+    expect(normalizeNodeUrl("node.example.com")).toBe(
+      "https://node.example.com"
+    );
+  });
+
+  it("preserves an explicit http scheme", () => {
+    expect(normalizeNodeUrl("http://10.0.0.1:8332")).toBe(
+      "http://10.0.0.1:8332"
+    );
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normalizeNodeUrl("https://node.example.com///")).toBe(
+      "https://node.example.com"
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeNodeUrl("  https://node.example.com  ")).toBe(
+      "https://node.example.com"
+    );
+  });
+
+  it("throws on empty input", () => {
+    expect(() => normalizeNodeUrl("")).toThrow(NodeIdentityError);
+    expect(() => normalizeNodeUrl("   ")).toThrow(NodeIdentityError);
+  });
+
+  it("throws on an unparsable URL", () => {
+    expect(() => normalizeNodeUrl("https://")).toThrow(NodeIdentityError);
+  });
+});

--- a/mobile/app/src/native/nodeIdentity.ts
+++ b/mobile/app/src/native/nodeIdentity.ts
@@ -1,0 +1,168 @@
+/**
+ * Node identity probe (app-side JSON-RPC, no native bridge).
+ *
+ * Trust UX for thin clients (epic #441 P3): before the user marks a node as
+ * trusted and points the wallet's RPC ingress at it, the app fetches the
+ * node's verifiable identity via the `node_getIdentity` RPC (#500) and shows it
+ * for confirmation.
+ *
+ * This deliberately talks to the candidate node over plain JSON-RPC HTTP
+ * instead of going through the rust-bridge `setNodeUrl` -> bridge-call path:
+ *
+ *   1. Identity verification must run against an *un-trusted candidate* URL.
+ *      Repointing the shared native bridge at an unverified node just to read
+ *      its identity would be a footgun (subsequent bridge ops could hit it).
+ *   2. `node_getIdentity` is a public, unauthenticated, read-only endpoint, so
+ *      a thin `fetch` is sufficient and keeps this entirely in the app layer
+ *      (the rust-bridge does not yet expose a getNodeIdentity method).
+ *
+ * Only the active/selected node is ever handed to the bridge via `setNodeUrl`.
+ */
+
+import type { NodeIdentity } from "../types/wallet";
+
+/** How long to wait for a candidate node before treating it as unreachable. */
+const IDENTITY_TIMEOUT_MS = 8000;
+
+/** JSON-RPC method that returns the node's verifiable identity (#500). */
+const IDENTITY_METHOD = "node_getIdentity";
+
+/** Error thrown when a node cannot be probed or returns a bad response. */
+export class NodeIdentityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NodeIdentityError";
+  }
+}
+
+/** Normalize a user-entered URL into an RPC base (https default, no trailing /). */
+export function normalizeNodeUrl(raw: string): string {
+  let url = raw.trim();
+  if (url === "") {
+    throw new NodeIdentityError("Enter a node URL.");
+  }
+  // Default to https:// when the user omits a scheme (thin clients should not
+  // talk to nodes over plaintext http).
+  if (!/^https?:\/\//i.test(url)) {
+    url = `https://${url}`;
+  }
+  // Drop trailing slashes so we can append the RPC path deterministically.
+  url = url.replace(/\/+$/, "");
+
+  try {
+    // Validate it parses as a URL; throws for garbage input.
+    // eslint-disable-next-line no-new
+    new URL(url);
+  } catch {
+    throw new NodeIdentityError(`"${raw}" is not a valid URL.`);
+  }
+  return url;
+}
+
+/** Coerce a JSON value that may be a number or numeric string to a number. */
+function toNumber(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  }
+  return 0;
+}
+
+/** Coerce a JSON value to a string (empty when absent). */
+function toStr(value: unknown): string {
+  return typeof value === "string" ? value : value == null ? "" : String(value);
+}
+
+/** Map the raw `node_getIdentity` result object onto the typed `NodeIdentity`. */
+function adaptIdentity(result: Record<string, unknown>): NodeIdentity {
+  return {
+    peerId: toStr(result.peerId),
+    nodeId: toStr(result.nodeId),
+    network: toStr(result.network),
+    protocolVersion: toStr(result.protocolVersion),
+    minProtocolVersion: toStr(result.minProtocolVersion),
+    nodeVersion: toStr(result.nodeVersion ?? result.version),
+    gitCommit: toStr(result.gitCommit),
+    dnsSeedDomain: toStr(result.dnsSeedDomain),
+    chainHeight: toNumber(result.chainHeight),
+    tipHash: toStr(result.tipHash),
+  };
+}
+
+/**
+ * Fetch and verify a node's identity over JSON-RPC.
+ *
+ * @param rawUrl user-entered node URL (scheme optional).
+ * @returns the parsed {@link NodeIdentity}.
+ * @throws {NodeIdentityError} on bad URL, timeout, transport error, JSON-RPC
+ *   error, or a node that does not implement `node_getIdentity`.
+ */
+export async function fetchNodeIdentity(rawUrl: string): Promise<NodeIdentity> {
+  const url = normalizeNodeUrl(rawUrl);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), IDENTITY_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(`${url}/rpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: IDENTITY_METHOD,
+        params: {},
+        id: 1,
+      }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    clearTimeout(timer);
+    const aborted = error instanceof Error && error.name === "AbortError";
+    throw new NodeIdentityError(
+      aborted
+        ? "Node did not respond in time."
+        : `Could not reach ${url}. Check the URL and your connection.`
+    );
+  }
+  clearTimeout(timer);
+
+  if (!response.ok) {
+    throw new NodeIdentityError(
+      `Node responded with HTTP ${response.status}.`
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new NodeIdentityError("Node returned a non-JSON response.");
+  }
+
+  if (typeof body !== "object" || body === null) {
+    throw new NodeIdentityError("Node returned an unexpected response.");
+  }
+
+  const rpc = body as { error?: { message?: string }; result?: unknown };
+  if (rpc.error) {
+    throw new NodeIdentityError(
+      rpc.error.message ??
+        "Node does not support identity verification (node_getIdentity)."
+    );
+  }
+  if (typeof rpc.result !== "object" || rpc.result === null) {
+    throw new NodeIdentityError(
+      "Node did not return an identity. It may be running an older version."
+    );
+  }
+
+  const identity = adaptIdentity(rpc.result as Record<string, unknown>);
+  if (identity.peerId === "" && identity.network === "") {
+    throw new NodeIdentityError(
+      "Node returned an empty identity. It may not be a Botho node."
+    );
+  }
+  return identity;
+}

--- a/mobile/app/src/store/walletStore.ts
+++ b/mobile/app/src/store/walletStore.ts
@@ -19,8 +19,22 @@ import type {
   NodeStatusInfo,
 } from "../types/wallet";
 import { NativeWallet } from "../native/walletModule";
-import { DEFAULT_NODE } from "../config/nodes";
-import { saveNodeUrl, loadNodeUrl } from "../native/keychain";
+import {
+  DEFAULT_NODE,
+  seedNodes,
+  nodeIdForUrl,
+  labelFromUrl,
+  type ManagedNode,
+} from "../config/nodes";
+import {
+  saveNodeUrl,
+  loadNodeUrl,
+  saveNodeList,
+  loadNodeList,
+} from "../native/keychain";
+import { fetchNodeIdentity, normalizeNodeUrl } from "../native/nodeIdentity";
+import type { NodeIdentity } from "../types/wallet";
+import { compareNetwork, isProtocolCompatible } from "../config/network";
 
 /** Extract a user-facing message from a thrown bridge error. */
 function errorMessage(error: unknown, fallback: string): string {
@@ -48,6 +62,21 @@ interface WalletState {
   nodeUrl: string;
   isConnected: boolean;
   nodeStatus: NodeStatusInfo | null;
+
+  // User-managed list of trusted nodes (seeded with the testnet defaults).
+  nodes: ManagedNode[];
+}
+
+/** Result of verifying a candidate node before adding it. */
+export interface VerifyNodeResult {
+  /** Normalized URL that was probed. */
+  url: string;
+  /** The identity the node reported. */
+  identity: NodeIdentity;
+  /** Whether the node's network matches the wallet's expected network. */
+  networkMatches: boolean;
+  /** Whether the node's protocol is compatible with this client. */
+  protocolCompatible: boolean;
 }
 
 /** Wallet actions */
@@ -56,6 +85,15 @@ interface WalletActions {
   setNodeUrl: (url: string) => Promise<void>;
   refreshNodeStatus: () => Promise<void>;
   hydrateNodeUrl: () => Promise<void>;
+
+  // User-managed trusted node list
+  hydrateNodes: () => Promise<void>;
+  verifyNode: (url: string) => Promise<VerifyNodeResult>;
+  addVerifiedNode: (
+    result: VerifyNodeResult,
+    label?: string
+  ) => Promise<ManagedNode>;
+  removeNode: (id: string) => Promise<void>;
 
   // Session management
   unlock: (mnemonic: string) => Promise<void>;
@@ -97,6 +135,8 @@ export const useWalletStore = create<WalletStore>((set, get) => ({
   nodeUrl: DEFAULT_NODE_URL,
   isConnected: false,
   nodeStatus: null,
+  // Seeded with the testnet defaults; replaced by the persisted list on hydrate.
+  nodes: seedNodes(),
 
   // Set node URL: persist it, push it to the native bridge, and refresh health.
   setNodeUrl: async (url: string) => {
@@ -121,6 +161,104 @@ export const useWalletStore = create<WalletStore>((set, get) => ({
     } catch (error) {
       // Fall back to the default; surface but do not block startup.
       set({ error: errorMessage(error, "Failed to load node selection") });
+    }
+  },
+
+  // Load the persisted user-managed node list (or seed defaults on first run).
+  hydrateNodes: async () => {
+    try {
+      const stored = await loadNodeList();
+      if (stored && stored.length > 0) {
+        set({ nodes: stored });
+      } else {
+        // First run: seed with the testnet defaults and persist them so the
+        // user can edit the list from a stable starting point.
+        const seeds = seedNodes();
+        set({ nodes: seeds });
+        await saveNodeList(seeds);
+      }
+    } catch (error) {
+      // Non-fatal: keep the in-memory seed list.
+      set({ error: errorMessage(error, "Failed to load node list") });
+    }
+  },
+
+  // Verify a candidate node's identity (node_getIdentity) before trusting it.
+  // Throws NodeIdentityError on unreachable / non-Botho / older nodes so the UI
+  // can show an inline error; on success returns the identity plus the
+  // network/protocol compatibility flags for the confirmation step.
+  verifyNode: async (url: string): Promise<VerifyNodeResult> => {
+    const normalized = normalizeNodeUrl(url);
+    const identity = await fetchNodeIdentity(normalized);
+    return {
+      url: normalized,
+      identity,
+      networkMatches: compareNetwork(identity.network) === "match",
+      protocolCompatible: isProtocolCompatible(
+        identity.protocolVersion,
+        identity.minProtocolVersion
+      ),
+    };
+  },
+
+  // Add a node the user has verified and chosen to trust. Persists the updated
+  // list. If a node with the same URL already exists it is updated in place
+  // (re-verification refreshes the stored identity) rather than duplicated.
+  addVerifiedNode: async (
+    result: VerifyNodeResult,
+    label?: string
+  ): Promise<ManagedNode> => {
+    const entry: ManagedNode = {
+      id: nodeIdForUrl(result.url),
+      label: label?.trim() || labelFromUrl(result.url),
+      url: result.url,
+      description: "User-added trusted node",
+      isFaucet: false,
+      source: "user",
+      verifiedIdentity: result.identity,
+    };
+
+    const existing = get().nodes;
+    const idx = existing.findIndex((n) => n.url === result.url);
+    const next =
+      idx >= 0
+        ? existing.map((n, i) =>
+            i === idx ? { ...n, ...entry, source: n.source } : n
+          )
+        : [...existing, entry];
+
+    set({ nodes: next });
+    try {
+      await saveNodeList(next);
+    } catch (error) {
+      set({ error: errorMessage(error, "Failed to save node") });
+    }
+    return entry;
+  },
+
+  // Remove a user-added node. Seed nodes cannot be removed (they are the
+  // app's known-good defaults). If the removed node is the active one, fall
+  // back to the first remaining node.
+  removeNode: async (id: string): Promise<void> => {
+    const existing = get().nodes;
+    const target = existing.find((n) => n.id === id);
+    if (!target || target.source === "seed") return;
+
+    const next = existing.filter((n) => n.id !== id);
+    set({ nodes: next });
+
+    // If we removed the active node, switch to a remaining one.
+    if (target.url === get().nodeUrl) {
+      const fallback = next[0];
+      if (fallback) {
+        await get().setNodeUrl(fallback.url);
+      }
+    }
+
+    try {
+      await saveNodeList(next);
+    } catch (error) {
+      set({ error: errorMessage(error, "Failed to remove node") });
     }
   },
 

--- a/mobile/app/src/types/wallet.ts
+++ b/mobile/app/src/types/wallet.ts
@@ -84,6 +84,38 @@ export interface NodeStatusInfo {
   peerCount: number;
 }
 
+/**
+ * Verifiable node identity returned by the `node_getIdentity` RPC (#500, epic
+ * #441 Phase P1). A thin client fetches this for a candidate node *before*
+ * trusting it for RPC ingress, so the user can confirm which node they are
+ * talking to and the app can reject network / protocol mismatches.
+ *
+ * Field names mirror the JSON keys emitted by the node's RPC handler
+ * (`botho/src/rpc/mod.rs::handle_node_identity`).
+ */
+export interface NodeIdentity {
+  /** libp2p peer ID derived from the node's persistent keypair (stable). */
+  peerId: string;
+  /** SCP node-id signing public key (hex), derived from the peer ID. */
+  nodeId: string;
+  /** Network the node belongs to (e.g. "botho-testnet" / "botho-mainnet"). */
+  network: string;
+  /** Wire-protocol version the node speaks (e.g. "2.0.0"). */
+  protocolVersion: string;
+  /** Minimum protocol version the node will accept from peers. */
+  minProtocolVersion: string;
+  /** Node software version (e.g. "0.2.0"). */
+  nodeVersion: string;
+  /** Build provenance (git commit short hash, or "unknown"). */
+  gitCommit: string;
+  /** DNS-seed discovery namespace for the node's network. */
+  dnsSeedDomain: string;
+  /** Current chain tip height the node reports. */
+  chainHeight: number;
+  /** Current chain tip hash (hex). */
+  tipHash: string;
+}
+
 /** Wallet error types (matching Rust MobileWalletError) */
 export type WalletErrorType =
   | "WalletLocked"


### PR DESCRIPTION
Closes #503

Implements **epic #441 Phase P3**: replaces the hardcoded 1-of-3 testnet node picker with a **user-managed list of trusted nodes**, gated by **node-identity verification** (`node_getIdentity`, #500 / PR #515).

## UX added

**Add-by-URL + identity verify (two-step trust flow)**
1. User enters a node RPC URL (scheme optional; defaults to `https`).
2. App calls `node_getIdentity` against the candidate and shows **peer ID / node ID / network / protocol (+min) / software+commit / chain tip**.
3. Trust decision:
   - **Network mismatch → hard block** (compared against `EXPECTED_NETWORK = "botho-testnet"`). "Trust & add" is disabled.
   - **Incompatible protocol → soft warning**, override-able ("Add anyway").
   - Match → "Trust & add".

**Persisted, user-managed list**
- Trusted nodes stored in secure store (`saveNodeList` / `loadNodeList`), hydrated on app start.
- The 3 testnet nodes **seed** the list on first run (`source: "seed"`, non-removable) rather than being the only options.
- User-added nodes (`source: "user"`) show an `ADDED` badge, their verified identity line, and a **Remove** action.
- Active node still drives `setNodeUrl` → native bridge; removing the active node falls back to the first remaining node.

**Health + privacy**
- Per-node health (height / sync / peers) reuses the existing `get_node_status` probe pattern.
- Privacy boundary surfaced in-UI: "only connect to nodes you trust" notice (epic §5(c)).

## Design note — why the identity probe is app-side

The candidate node is *un-trusted* at verification time. Rather than pointing the shared native bridge at it (which subsequent bridge ops could then hit), the app verifies via a direct JSON-RPC `fetch` to `<url>/rpc` (`src/native/nodeIdentity.ts`). This also keeps the change **entirely within `mobile/app` + shared TS — `mobile/rust-bridge` is untouched** (it does not yet expose a `getNodeIdentity` method, and another builder owns that crate).

## Files changed

- `app/node-picker.tsx` — rewritten: managed list, add-by-URL form, identity-confirmation card, remove, privacy notice.
- `app/_layout.tsx` — hydrate the node list on startup.
- `src/config/network.ts` *(new)* — `EXPECTED_NETWORK`, `compareNetwork`, `isProtocolCompatible`.
- `src/config/nodes.ts` — `ManagedNode`, `seedNodes`, `findManagedByUrl`, `nodeIdForUrl`, `labelFromUrl`.
- `src/native/nodeIdentity.ts` *(new)* — `fetchNodeIdentity`, `normalizeNodeUrl`, `NodeIdentityError`.
- `src/native/keychain.ts` — `saveNodeList` / `loadNodeList`.
- `src/store/walletStore.ts` — `nodes` state + `hydrateNodes` / `verifyNode` / `addVerifiedNode` / `removeNode`.
- `src/types/wallet.ts` — `NodeIdentity` type.
- **Tooling** — `.eslintrc.js`, `babel.config.js`, jest preset in `package.json`, `@types/jest`. These configs were **missing** (lint/test could not run at all); added minimally so the gates work.

## Tests / lint

- `npm run typecheck` — passes.
- `npm run lint` — passes (0 errors; 2 pre-existing warnings in `unlock.tsx`, left untouched per scope).
- `npm test` — **25 passed** across network/protocol comparison, node-list helpers, and URL normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)