### PR TITLE
feat(baas): /status rig lookup (magic-link) + health + PWA custom-RPC deep link

### DIFF
--- a/web/packages/baas-worker/.dev.vars.example
+++ b/web/packages/baas-worker/.dev.vars.example
@@ -21,7 +21,18 @@ STRIPE_WEBHOOK_SECRET=whsec_REPLACE_ME
 CHECKOUT_SUCCESS_URL=http://localhost:5173/rig/success
 CHECKOUT_CANCEL_URL=http://localhost:5173/rig
 
-# Browser origins allowed to call /checkout during local dev.
+# --- status page / magic-link lookup (P6.3, #458 §4/§6) -------------------
+# HMAC secret for magic-link status tokens. REQUIRED for /status and /portal.
+# Generate any long random string (e.g. `openssl rand -hex 32`). The token a
+# returning user presents is signed with this and binds to ONE Stripe customer,
+# so they can only ever see their own rig. NEVER commit a real value.
+STATUS_LINK_SECRET=REPLACE_ME_WITH_RANDOM_HEX
+# Wallet origin used to build the "open in wallet" deep link (#458 §3 step 5).
+WALLET_BASE_URL=http://localhost:5173
+# Where Stripe returns the user after they close the Customer Portal.
+PORTAL_RETURN_URL=http://localhost:5173/rig/status
+
+# Browser origins allowed to call /checkout, /status, /portal during local dev.
 ALLOWED_ORIGINS=http://localhost:5173
 
 # --- provisioner secrets (#502, #458 §3/§5) -------------------------------

--- a/web/packages/baas-worker/README.md
+++ b/web/packages/baas-worker/README.md
@@ -20,9 +20,16 @@ This package implements:
   `teardownRig` (`customer.subscription.deleted` / `invoice.payment_failed`).
   Idempotent against Stripe's retries (the provisioner dedups by
   `subscription_id`); unknown event types are a 2xx no-op.
+- **P6.3 — user→node mapping + status lookup** (#458 §3 step 5 + §4 + §6, issue
+  #507): a `/status` endpoint that, for an authenticated user (a **magic-link
+  status token** that binds to one Stripe customer), returns their rig's RPC URL,
+  lifecycle state, and a **live health summary from `node_getStatus`**. A
+  `/portal` endpoint opens a **Stripe Customer Portal** session so the user can
+  manage/cancel the subscription. Both are **authz-scoped**: the customer id only
+  ever comes from the verified token, and the D1 lookup is keyed on it, so a user
+  can only see their own rig. `/status` is read-only — it can never provision.
 
 > Out of scope here (later phases of #458 §8):
-> - `/status` (user looks up their rig) — **P6.3**
 > - tighter provisioner IAM policy + the orphan-reconciliation cron — **SEC (#508)**
 >
 > The frontend "Get a rig" surface that calls `/checkout` lives in
@@ -88,6 +95,8 @@ wrangler secret put BOTHO_BINARY_SHA256
 |--------|-------------|--------------------------------------------------------------|
 | POST   | `/checkout` | Create a `mode=subscription` Stripe Checkout Session.        |
 | POST   | `/webhook`  | Stripe-signed webhook → provision / deprovision (#506).      |
+| GET    | `/status`   | Authenticated rig lookup: RPC URL + state + health (#507).   |
+| POST   | `/portal`   | Open a Stripe Customer Portal session (manage/cancel, #507). |
 | GET    | `/healthz`  | Liveness probe.                                              |
 
 There is **no `/provision` route** — a managed rig can only be launched via the
@@ -175,6 +184,60 @@ stripe listen --forward-to localhost:8787/webhook   # prints a whsec_ for .dev.v
 stripe trigger checkout.session.completed
 ```
 
+### `GET /status` (#507 — the authenticated rig lookup)
+
+A returning user looks up their rig with a **magic-link status token** — the
+MVP identity model (#458 §4): no password, the signed link IS the credential.
+
+```
+GET /status?token=<cus_…>.<exp>.<hmac>
+```
+
+The token is `<stripeCustomerId>.<expUnixSeconds>.<HMAC-SHA256(STATUS_LINK_SECRET,
+"<customerId>.<exp>")>` (minted by `mintStatusToken`). The handler:
+
+1. Verifies the HMAC (constant-time) and the expiry. A tampered customer id or
+   forged/expired token → **401** with no data leak (`verifyStatusToken`).
+2. Takes the customer id **only from the verified token**, never from the
+   request, and looks the rig up keyed on that customer (`getByCustomer`). So a
+   valid token for customer A can never surface customer B's rig.
+3. Probes the rig's health via `node_getStatus` (only for `running` rigs; a
+   `provisioning`/`suspended`/`terminated` rig reports `health.status:"unknown"`
+   without a node call). A down node never fails the response — it reports
+   `"offline"`.
+
+**Success response** (`200`):
+
+```json
+{
+  "rigId": "abc123",
+  "rpcUrl": "https://rig-abc123.testnet.botho.io/rpc",
+  "state": "running",
+  "region": "us-west-2",
+  "health": { "status": "online", "chainHeight": 42, "synced": true },
+  "walletDeepLink": "https://wallet.botho.io/wallet?rpc=https%3A%2F%2Frig-abc123.testnet.botho.io%2Frpc"
+}
+```
+
+`walletDeepLink` opens the PWA with the rig's RPC pre-selected as the "custom
+RPC" ingress (#458 §3 step 5).
+
+**Errors:** `400` missing token, `401` invalid/expired/forged token (no leak),
+`404` token valid but the customer has no rig, `405` non-GET, `500` not
+configured (`STATUS_LINK_SECRET` / `WALLET_BASE_URL` unset).
+
+### `POST /portal` (#507 — Stripe Customer Portal)
+
+```json
+{ "token": "<cus_…>.<exp>.<hmac>" }
+```
+
+Verifies the same status token, then creates a Stripe **Billing Portal** session
+for the verified customer and returns `{ "url": "https://billing.stripe.com/…" }`
+to redirect the browser to. The customer id comes from the token, so a user can
+only open their own portal. **Errors:** `400` missing token, `401` invalid
+token, `405` non-POST, `500` not configured, `502` Stripe rejected the request.
+
 ## Configuration (secrets & vars)
 
 All secrets come from Worker secrets / vars — **never the repo** (#458 §2, §5).
@@ -184,9 +247,12 @@ All secrets come from Worker secrets / vars — **never the repo** (#458 §2, §
 | `STRIPE_SECRET_KEY`    | secret | TEST key (`sk_test_...`) while on testnet (#458 §7).        |
 | `STRIPE_PRICE_ID`      | secret | The recurring $50/mo Price id (`price_...`). See below.     |
 | `STRIPE_WEBHOOK_SECRET`| secret | Webhook signing secret (`whsec_...`). Required for `/webhook`.|
+| `STATUS_LINK_SECRET`   | secret | HMAC secret for magic-link status tokens. Required for `/status` + `/portal`.|
 | `CHECKOUT_SUCCESS_URL` | var    | Stripe success redirect (in `wrangler.toml`).               |
 | `CHECKOUT_CANCEL_URL`  | var    | Stripe cancel redirect (in `wrangler.toml`).                |
-| `ALLOWED_ORIGINS`      | var    | Comma-separated browser origins allowed to call `/checkout`.|
+| `WALLET_BASE_URL`      | var    | Wallet origin for the "open in wallet" deep link.           |
+| `PORTAL_RETURN_URL`    | var    | Where Stripe returns after the Customer Portal closes.      |
+| `ALLOWED_ORIGINS`      | var    | Comma-separated browser origins allowed to call the API.    |
 
 ### Stripe setup (one-time, TEST mode)
 
@@ -240,6 +306,14 @@ signature crypto (valid / tampered / wrong-secret / stale / missing), the
 event→action mapping, raw-body verification, idempotent replay (no double
 launch), teardown, and the unknown-event no-op — all with in-memory provisioner
 fakes (no network, no live Stripe/AWS/DNS/D1).
+
+`src/status-link.test.ts`, `src/status.test.ts`, and
+`src/status-handler.test.ts` cover the `/status` + `/portal` surface: token
+mint/verify (round-trip, tampered customer id, wrong secret, expired), the
+`node_getStatus` health summary (online/offline/never-throws), the wallet deep
+link, the **authz boundary** (a user gets their own rig, never another's → 404),
+and the HTTP handlers (200 / 400 missing token / 401 forged token / 404 no rig /
+500 unconfigured) — all with an in-memory store + mocked node/Stripe fetch.
 
 ## Deploy
 

--- a/web/packages/baas-worker/src/index.ts
+++ b/web/packages/baas-worker/src/index.ts
@@ -4,6 +4,9 @@
  * MVP surface:
  *   - POST /checkout  create a Stripe Checkout Session (subscription, $50/mo)  (P7.1)
  *   - POST /webhook   Stripe signature verify -> provision/deprovision         (P7.2 / #506)
+ *   - GET  /status    authenticated user looks up their rig (URL + state +
+ *                     live health) via a magic-link token                      (P6.3)
+ *   - POST /portal    open a Stripe Customer Portal session (manage/cancel)    (P6.3)
  *   - GET  /healthz   liveness probe
  *
  * The provisioner core (#502) lives in `provisioner.ts` and is exposed as a
@@ -11,12 +14,13 @@
  * calls. There is deliberately NO public `/provision` route: only the
  * signature-verified webhook may trigger a launch (#458 §5).
  *
- * Out of scope here (later phases of #458 §8):
- *   - /status   user looks up their rig                            (P6.3)
+ * `/status` is read-only and authz-scoped: the customer id always comes from a
+ * *verified* magic-link token (`status-link.ts`), and the D1 lookup is keyed on
+ * that id, so a user can only ever see their own rig (#458 §4, §5).
  *
- * All secrets (Stripe key, AWS creds, CF DNS token) come from Worker secrets /
- * vars — never the repo. See `wrangler.toml` and `.dev.vars.example` for the
- * binding contract.
+ * All secrets (Stripe key, AWS creds, CF DNS token, status-link secret) come
+ * from Worker secrets / vars — never the repo. See `wrangler.toml` and
+ * `.dev.vars.example` for the binding contract.
  */
 
 import {
@@ -32,6 +36,13 @@ import {
   verifyStripeSignature,
   type WebhookEnv,
 } from './webhook'
+import { verifyStatusToken } from './status-link'
+import {
+  createPortalSession,
+  lookupStatusForCustomer,
+  StripePortalError,
+} from './status'
+import { D1RigStore, type D1Like } from './rig-store'
 
 // Re-export the provisioner surface so the webhook (and any future consumer) can
 // import everything from the package entry without reaching into modules.
@@ -50,12 +61,39 @@ export {
   actionForEventType,
   type WebhookEnv,
 } from './webhook'
+export { mintStatusToken, verifyStatusToken } from './status-link'
+export {
+  lookupStatusForCustomer,
+  createPortalSession,
+  buildWalletDeepLink,
+  type StatusResponse,
+  type RigHealth,
+} from './status'
 
-export interface Env extends CheckoutEnv, ProvisionerEnv, WebhookEnv {
+/** Env keys used only by the `/status` + `/portal` surface (P6.3). */
+export interface StatusEnv {
   /**
-   * Comma-separated list of origins allowed to call /checkout from the browser
-   * (e.g. "https://botho.io,https://wallet.botho.io"). When unset, CORS is not
-   * granted (same-origin only).
+   * HMAC secret for magic-link status tokens (`status-link.ts`). Worker secret,
+   * never the repo. Required for /status and /portal.
+   */
+  STATUS_LINK_SECRET?: string
+  /**
+   * Wallet origin used to build the "open in wallet" deep link
+   * (e.g. "https://wallet.botho.io"). Worker var.
+   */
+  WALLET_BASE_URL?: string
+  /**
+   * Where Stripe returns the user after they close the Customer Portal
+   * (e.g. "https://botho.io/rig/status"). Worker var.
+   */
+  PORTAL_RETURN_URL?: string
+}
+
+export interface Env extends CheckoutEnv, ProvisionerEnv, WebhookEnv, StatusEnv {
+  /**
+   * Comma-separated list of origins allowed to call the browser-facing
+   * endpoints (/checkout, /status, /portal). When unset, CORS is not granted
+   * (same-origin only).
    */
   ALLOWED_ORIGINS?: string
 }
@@ -68,7 +106,7 @@ function corsHeaders(env: Env, requestOrigin: string | null): Record<string, str
   if (!allowed.includes(requestOrigin)) return {}
   return {
     'Access-Control-Allow-Origin': requestOrigin,
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     Vary: 'Origin',
   }
@@ -224,12 +262,161 @@ export async function handleWebhook(
   }
 }
 
+/**
+ * Build a `RigStore` from the D1 binding for the read-only `/status` + `/portal`
+ * surface. Kept separate from the provisioner's `depsFromEnv` because status
+ * needs only the store (no EC2/DNS/AWS creds), so a misconfigured provisioner
+ * never blocks a user from reading their own rig.
+ */
+function storeFromEnv(env: Env): D1RigStore {
+  if (env.DB == null) {
+    throw new Error('status: DB binding not configured')
+  }
+  return new D1RigStore(env.DB as D1Like)
+}
+
+/**
+ * Handle GET /status — the authenticated rig lookup (P6.3, #458 §4/§6).
+ *
+ * Authz model: the customer id is taken ONLY from the verified magic-link token
+ * (`?token=`), never from the request. The D1 lookup is keyed on that id, so a
+ * user can only ever see their own rig. Exported for direct unit testing.
+ *
+ *   200 -> { rigId, rpcUrl, state, region, health, walletDeepLink }
+ *   400 -> missing token
+ *   401 -> invalid / expired / forged token (no data leak)
+ *   404 -> token valid but this customer has no rig
+ *   500 -> service not configured
+ */
+export async function handleStatus(
+  request: Request,
+  env: Env,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const origin = request.headers.get('Origin')
+  const cors = corsHeaders(env, origin)
+
+  if (request.method !== 'GET') {
+    return jsonResponse({ error: 'method not allowed' }, 405, cors)
+  }
+
+  // Fail closed if the signing secret / wallet base url are unset.
+  if (!env.STATUS_LINK_SECRET || !env.WALLET_BASE_URL) {
+    console.error('status: not configured (STATUS_LINK_SECRET / WALLET_BASE_URL)')
+    return jsonResponse({ error: 'service not configured' }, 500, cors)
+  }
+
+  const url = new URL(request.url)
+  const token = url.searchParams.get('token')
+  if (!token) {
+    return jsonResponse({ error: 'token is required' }, 400, cors)
+  }
+
+  const verified = await verifyStatusToken(token, env.STATUS_LINK_SECRET)
+  if (!verified.ok) {
+    // Generic 401 — never reveal which check failed or whether a rig exists.
+    console.warn('status: token rejected:', verified.reason)
+    return jsonResponse({ error: 'unauthorized' }, 401, cors)
+  }
+
+  let store: D1RigStore
+  try {
+    store = storeFromEnv(env)
+  } catch (err) {
+    console.error('status: store unavailable', err)
+    return jsonResponse({ error: 'service not configured' }, 500, cors)
+  }
+
+  try {
+    const result = await lookupStatusForCustomer(
+      verified.customerId,
+      store,
+      env.WALLET_BASE_URL,
+      fetchImpl,
+    )
+    if (!result.ok) {
+      return jsonResponse({ error: 'no rig found' }, 404, cors)
+    }
+    return jsonResponse(result.status, 200, cors)
+  } catch (err) {
+    console.error('status: lookup error', err)
+    return jsonResponse({ error: 'internal error' }, 500, cors)
+  }
+}
+
+/**
+ * Handle POST /portal — open a Stripe Customer Portal session so the user can
+ * manage/cancel their subscription (P6.3, #458 §4). The customer id is taken
+ * from the verified status token in the JSON body (`{ token }`), never from the
+ * client directly. Exported for direct unit testing.
+ *
+ *   200 -> { url }     hosted Stripe portal URL to redirect to
+ *   400 -> missing token
+ *   401 -> invalid/expired token
+ *   500 -> service not configured
+ *   502 -> Stripe rejected the request
+ */
+export async function handlePortal(
+  request: Request,
+  env: Env,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  const origin = request.headers.get('Origin')
+  const cors = corsHeaders(env, origin)
+
+  if (request.method !== 'POST') {
+    return jsonResponse({ error: 'method not allowed' }, 405, cors)
+  }
+
+  if (!env.STATUS_LINK_SECRET || !env.STRIPE_SECRET_KEY || !env.PORTAL_RETURN_URL) {
+    console.error('portal: not configured')
+    return jsonResponse({ error: 'service not configured' }, 500, cors)
+  }
+
+  let parsed: unknown
+  try {
+    parsed = await request.json()
+  } catch {
+    return jsonResponse({ error: 'invalid JSON body' }, 400, cors)
+  }
+  const token =
+    typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>).token
+      : undefined
+  if (typeof token !== 'string' || token.length === 0) {
+    return jsonResponse({ error: 'token is required' }, 400, cors)
+  }
+
+  const verified = await verifyStatusToken(token, env.STATUS_LINK_SECRET)
+  if (!verified.ok) {
+    console.warn('portal: token rejected:', verified.reason)
+    return jsonResponse({ error: 'unauthorized' }, 401, cors)
+  }
+
+  try {
+    const session = await createPortalSession(
+      verified.customerId,
+      env.PORTAL_RETURN_URL,
+      env.STRIPE_SECRET_KEY,
+      fetchImpl,
+    )
+    return jsonResponse({ url: session.url }, 200, cors)
+  } catch (err) {
+    if (err instanceof StripePortalError) {
+      console.error('portal: stripe error', err.status, err.message)
+      return jsonResponse({ error: 'could not open portal' }, 502, cors)
+    }
+    console.error('portal: unexpected error', err)
+    return jsonResponse({ error: 'internal error' }, 500, cors)
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url)
     const origin = request.headers.get('Origin')
 
-    // CORS preflight for the browser "Get a rig" surface.
+    // CORS preflight for the browser "Get a rig" / status surfaces.
     if (request.method === 'OPTIONS') {
       return new Response(null, { status: 204, headers: corsHeaders(env, origin) })
     }
@@ -244,6 +431,14 @@ export default {
 
     if (url.pathname === '/webhook') {
       return handleWebhook(request, env)
+    }
+
+    if (url.pathname === '/status') {
+      return handleStatus(request, env)
+    }
+
+    if (url.pathname === '/portal') {
+      return handlePortal(request, env)
     }
 
     return jsonResponse({ error: 'not found' }, 404)

--- a/web/packages/baas-worker/src/rig-store.test.ts
+++ b/web/packages/baas-worker/src/rig-store.test.ts
@@ -33,6 +33,19 @@ function fakeD1(): { db: D1Like; rows: Map<string, Row> } {
           if (query.startsWith('SELECT * FROM rigs WHERE subscription_id')) {
             return (rows.get(bound[0] as string) ?? null) as T | null
           }
+          if (query.includes('WHERE stripe_customer = ?')) {
+            // Mirror the ORDER BY: live rigs before terminated, newest first.
+            const matches = [...rows.values()].filter(
+              (r) => r.stripe_customer === (bound[0] as string),
+            )
+            matches.sort((a, b) => {
+              const aTerm = a.state === 'terminated' ? 1 : 0
+              const bTerm = b.state === 'terminated' ? 1 : 0
+              if (aTerm !== bTerm) return aTerm - bTerm
+              return b.created_at - a.created_at
+            })
+            return (matches[0] ?? null) as T | null
+          }
           if (query.startsWith('SELECT COUNT(*)')) {
             const states = bound as string[]
             let n = 0
@@ -130,6 +143,31 @@ describe('D1RigStore', () => {
     const got = await store.getBySubscription('sub_1')
     expect(got?.instanceId).toBe('i-123')
     expect(got?.state).toBe('running')
+  })
+
+  it('getByCustomer returns the customer’s rig, preferring a live one', async () => {
+    const { db } = fakeD1()
+    let t = 1000
+    const store = new D1RigStore(db, () => t)
+    // Older terminated rig for the customer.
+    await store.insertProvisioning(NEW)
+    await store.setState('sub_1', 'terminated')
+    // Newer running rig for the same customer.
+    t = 2000
+    await store.insertProvisioning({
+      ...NEW,
+      subscriptionId: 'sub_2',
+      rigId: 'r2',
+      rpcUrl: 'https://rig-r2.testnet.botho.io/rpc',
+    })
+    await store.setState('sub_2', 'running')
+
+    const got = await store.getByCustomer('cus_X')
+    expect(got?.rigId).toBe('r2')
+    expect(got?.state).toBe('running')
+
+    // A different customer gets nothing (authz boundary).
+    expect(await store.getByCustomer('cus_OTHER')).toBeUndefined()
   })
 
   it('counts only active (non-terminated) rows', async () => {

--- a/web/packages/baas-worker/src/rig-store.ts
+++ b/web/packages/baas-worker/src/rig-store.ts
@@ -50,6 +50,15 @@ export interface RigStore {
   /** Idempotency lookup by Stripe subscription id. */
   getBySubscription(subscriptionId: string): Promise<RigRecord | undefined>
   /**
+   * Authz-scoped lookup for the `/status` page (#458 §4, P6.3): return the rig
+   * owned by a given Stripe customer, or undefined. The status endpoint keys the
+   * lookup on the *verified* customer id from the magic-link token so a user can
+   * only ever see their own rig — it never accepts a customer id straight from
+   * the client. When (rarely) more than one row shares a customer, the most
+   * recently created non-terminated row wins, falling back to the newest row.
+   */
+  getByCustomer(stripeCustomer: string): Promise<RigRecord | undefined>
+  /**
    * Insert a fresh `provisioning` row. MUST reject (throw) if a row with the
    * same `subscriptionId` already exists, so a race can't create two rows.
    */
@@ -126,6 +135,21 @@ export class D1RigStore implements RigStore {
     const row = await this.db
       .prepare('SELECT * FROM rigs WHERE subscription_id = ?')
       .bind(subscriptionId)
+      .first<RigRow>()
+    return row ? rowToRecord(row) : undefined
+  }
+
+  async getByCustomer(stripeCustomer: string): Promise<RigRecord | undefined> {
+    // Prefer a live rig over a terminated one, then newest. The idx_rigs_customer
+    // index (schema.sql) keeps this lookup cheap.
+    const row = await this.db
+      .prepare(
+        `SELECT * FROM rigs
+           WHERE stripe_customer = ?
+           ORDER BY (state = 'terminated') ASC, created_at DESC
+           LIMIT 1`,
+      )
+      .bind(stripeCustomer)
       .first<RigRow>()
     return row ? rowToRecord(row) : undefined
   }

--- a/web/packages/baas-worker/src/status-handler.test.ts
+++ b/web/packages/baas-worker/src/status-handler.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest'
+import worker, { handleStatus, handlePortal, type Env } from './index'
+import { mintStatusToken } from './status-link'
+import { FakeStore } from './test-fakes'
+import type { D1Like } from './rig-store'
+import type { NewRigRecord, RigState } from './rig-store'
+
+const STATUS_SECRET = 'test-status-secret'
+
+/**
+ * A FakeStore exposed through the D1-shaped `prepare()` API that handleStatus
+ * uses via D1RigStore. Rather than emulate SQL, we install a FakeStore directly
+ * by monkeypatching: handleStatus builds a D1RigStore(env.DB). We instead supply
+ * a tiny D1 shim that the queries hit. To keep the test focused on the HTTP +
+ * authz layer (the store SQL is covered in rig-store.test.ts), we back the shim
+ * with an in-memory FakeStore and translate the two SELECT shapes it issues.
+ */
+function makeD1(store: FakeStore): D1Like {
+  return {
+    prepare(query: string) {
+      let bound: unknown[] = []
+      const stmt = {
+        bind(...values: unknown[]) {
+          bound = values
+          return stmt
+        },
+        async first<T = unknown>(): Promise<T | null> {
+          if (query.includes('stripe_customer = ?')) {
+            const rec = await store.getByCustomer(String(bound[0]))
+            if (!rec) return null
+            return {
+              user: rec.user,
+              stripe_customer: rec.stripeCustomer,
+              subscription_id: rec.subscriptionId,
+              rig_id: rec.rigId,
+              instance_id: rec.instanceId,
+              region: rec.region,
+              rpc_url: rec.rpcUrl,
+              state: rec.state,
+              created_at: rec.createdAt,
+              updated_at: rec.updatedAt,
+            } as unknown as T
+          }
+          return null
+        },
+        async run() {
+          return { success: true }
+        },
+        async all<T = unknown>() {
+          return { results: [] as T[] }
+        },
+      }
+      return stmt
+    },
+  }
+}
+
+async function seed(
+  store: FakeStore,
+  over: Partial<NewRigRecord>,
+  state: RigState = 'running',
+): Promise<void> {
+  const rec: NewRigRecord = {
+    user: over.stripeCustomer ?? 'cus_A',
+    stripeCustomer: over.stripeCustomer ?? 'cus_A',
+    subscriptionId: over.subscriptionId ?? 'sub_A',
+    rigId: over.rigId ?? 'abc123',
+    region: over.region ?? 'us-west-2',
+    rpcUrl: over.rpcUrl ?? 'https://rig-abc123.testnet.botho.io/rpc',
+  }
+  await store.insertProvisioning(rec)
+  if (state !== 'provisioning') await store.setState(rec.subscriptionId, state)
+}
+
+function baseEnv(store: FakeStore): Env {
+  return {
+    STRIPE_SECRET_KEY: 'sk_test_dummy',
+    STRIPE_PRICE_ID: 'price_test',
+    CHECKOUT_SUCCESS_URL: 'https://botho.io/rig/success',
+    CHECKOUT_CANCEL_URL: 'https://botho.io/rig',
+    STATUS_LINK_SECRET: STATUS_SECRET,
+    WALLET_BASE_URL: 'https://wallet.botho.io',
+    PORTAL_RETURN_URL: 'https://botho.io/rig/status',
+    DB: makeD1(store),
+  }
+}
+
+function nodeOk() {
+  return vi.fn(async () =>
+    new Response(JSON.stringify({ result: { chainHeight: 7, synced: true } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+}
+
+function statusReq(token?: string): Request {
+  const url = token
+    ? `https://baas.botho.io/status?token=${encodeURIComponent(token)}`
+    : 'https://baas.botho.io/status'
+  return new Request(url, { method: 'GET' })
+}
+
+describe('handleStatus', () => {
+  it('returns the authenticated customer’s rig (200)', async () => {
+    const store = new FakeStore()
+    await seed(store, { stripeCustomer: 'cus_A', subscriptionId: 'sub_A' }, 'running')
+    const env = baseEnv(store)
+    const token = await mintStatusToken('cus_A', STATUS_SECRET)
+    const res = await handleStatus(statusReq(token), env, nodeOk() as unknown as typeof fetch)
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { rpcUrl: string; state: string; health: { status: string } }
+    expect(json.rpcUrl).toContain('rig-abc123')
+    expect(json.state).toBe('running')
+    expect(json.health.status).toBe('online')
+  })
+
+  it('does NOT leak another customer’s rig — 404 for a user without one', async () => {
+    const store = new FakeStore()
+    // Only cus_B has a rig.
+    await seed(store, { stripeCustomer: 'cus_B', subscriptionId: 'sub_B', rigId: 'secret' }, 'running')
+    const env = baseEnv(store)
+    // cus_A is authenticated (valid token) but owns nothing.
+    const token = await mintStatusToken('cus_A', STATUS_SECRET)
+    const res = await handleStatus(statusReq(token), env, nodeOk() as unknown as typeof fetch)
+    expect(res.status).toBe(404)
+    const body = await res.text()
+    expect(body).not.toContain('secret')
+  })
+
+  it('rejects a missing token with 400', async () => {
+    const store = new FakeStore()
+    const res = await handleStatus(statusReq(), baseEnv(store), nodeOk() as unknown as typeof fetch)
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects an invalid/forged token with 401 (no data leak)', async () => {
+    const store = new FakeStore()
+    await seed(store, { stripeCustomer: 'cus_A', subscriptionId: 'sub_A' }, 'running')
+    const env = baseEnv(store)
+    // A token signed with the wrong secret.
+    const forged = await mintStatusToken('cus_A', 'wrong-secret')
+    const res = await handleStatus(statusReq(forged), env, nodeOk() as unknown as typeof fetch)
+    expect(res.status).toBe(401)
+    const body = await res.text()
+    expect(body).not.toContain('rig-abc123')
+  })
+
+  it('fails closed with 500 when STATUS_LINK_SECRET is unset', async () => {
+    const store = new FakeStore()
+    const env = { ...baseEnv(store), STATUS_LINK_SECRET: undefined }
+    const token = await mintStatusToken('cus_A', STATUS_SECRET)
+    const res = await handleStatus(statusReq(token), env, nodeOk() as unknown as typeof fetch)
+    expect(res.status).toBe(500)
+  })
+
+  it('rejects non-GET with 405', async () => {
+    const store = new FakeStore()
+    const req = new Request('https://baas.botho.io/status', { method: 'POST' })
+    const res = await handleStatus(req, baseEnv(store), nodeOk() as unknown as typeof fetch)
+    expect(res.status).toBe(405)
+  })
+})
+
+describe('handlePortal', () => {
+  function portalReq(body: unknown): Request {
+    return new Request('https://baas.botho.io/portal', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  it('opens a portal session for a verified token (200)', async () => {
+    const store = new FakeStore()
+    const env = baseEnv(store)
+    const token = await mintStatusToken('cus_A', STATUS_SECRET)
+    const stripeMock = vi.fn(async (_u: string, init?: RequestInit) => {
+      expect(String(init?.body)).toContain('customer=cus_A')
+      return new Response(JSON.stringify({ url: 'https://billing.stripe.com/p/x' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    const res = await handlePortal(portalReq({ token }), env, stripeMock as unknown as typeof fetch)
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { url: string }
+    expect(json.url).toContain('billing.stripe.com')
+  })
+
+  it('rejects a missing token with 400', async () => {
+    const store = new FakeStore()
+    const res = await handlePortal(portalReq({}), baseEnv(store), nodeOk() as unknown as typeof fetch)
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects an invalid token with 401', async () => {
+    const store = new FakeStore()
+    const forged = await mintStatusToken('cus_A', 'wrong-secret')
+    const res = await handlePortal(
+      portalReq({ token: forged }),
+      baseEnv(store),
+      nodeOk() as unknown as typeof fetch,
+    )
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('worker routing (P6.3)', () => {
+  it('routes GET /status and POST /portal; unknown path is 404', async () => {
+    const store = new FakeStore()
+    await seed(store, { stripeCustomer: 'cus_A', subscriptionId: 'sub_A' }, 'running')
+    const env = baseEnv(store)
+
+    const notFound = await worker.fetch(
+      new Request('https://baas.botho.io/nope'),
+      env as Parameters<typeof worker.fetch>[1],
+    )
+    expect(notFound.status).toBe(404)
+
+    // /status with no token should reach the handler (400), not 404.
+    const status = await worker.fetch(
+      statusReq(),
+      env as Parameters<typeof worker.fetch>[1],
+    )
+    expect(status.status).toBe(400)
+  })
+})

--- a/web/packages/baas-worker/src/status-link.test.ts
+++ b/web/packages/baas-worker/src/status-link.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  mintStatusToken,
+  verifyStatusToken,
+  DEFAULT_STATUS_TOKEN_TTL_SECONDS,
+} from './status-link'
+
+const SECRET = 'test-status-link-secret'
+const CUSTOMER = 'cus_ABC123'
+const NOW = 1_700_000_000
+
+describe('status-link tokens', () => {
+  it('round-trips: a freshly minted token verifies and yields the customer id', async () => {
+    const token = await mintStatusToken(CUSTOMER, SECRET, { nowSeconds: NOW })
+    const result = await verifyStatusToken(token, SECRET, { nowSeconds: NOW + 10 })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.customerId).toBe(CUSTOMER)
+      expect(result.exp).toBe(NOW + DEFAULT_STATUS_TOKEN_TTL_SECONDS)
+    }
+  })
+
+  it('rejects a missing/empty token', async () => {
+    expect((await verifyStatusToken(null, SECRET)).ok).toBe(false)
+    expect((await verifyStatusToken('', SECRET)).ok).toBe(false)
+  })
+
+  it('rejects a malformed token (wrong field count)', async () => {
+    expect((await verifyStatusToken('cus_ABC123.123', SECRET)).ok).toBe(false)
+    expect((await verifyStatusToken('garbage', SECRET)).ok).toBe(false)
+  })
+
+  it('rejects a token whose customer id was tampered with (signature mismatch)', async () => {
+    const token = await mintStatusToken(CUSTOMER, SECRET, { nowSeconds: NOW })
+    const parts = token.split('.')
+    // Swap in a DIFFERENT customer id but keep the original exp + signature.
+    const forged = `cus_VICTIM999.${parts[1]}.${parts[2]}`
+    const result = await verifyStatusToken(forged, SECRET, { nowSeconds: NOW + 10 })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('signature mismatch')
+  })
+
+  it('rejects a token signed with a different secret', async () => {
+    const token = await mintStatusToken(CUSTOMER, 'other-secret', { nowSeconds: NOW })
+    const result = await verifyStatusToken(token, SECRET, { nowSeconds: NOW + 10 })
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects an expired token', async () => {
+    const token = await mintStatusToken(CUSTOMER, SECRET, {
+      ttlSeconds: 60,
+      nowSeconds: NOW,
+    })
+    const result = await verifyStatusToken(token, SECRET, { nowSeconds: NOW + 61 })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('token expired')
+  })
+
+  it('rejects an expiry-tampered token before honouring the new expiry', async () => {
+    const token = await mintStatusToken(CUSTOMER, SECRET, {
+      ttlSeconds: 60,
+      nowSeconds: NOW,
+    })
+    const parts = token.split('.')
+    // Extend the expiry far into the future without re-signing.
+    const forged = `${parts[0]}.${NOW + 999_999}.${parts[2]}`
+    const result = await verifyStatusToken(forged, SECRET, { nowSeconds: NOW + 70 })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('signature mismatch')
+  })
+
+  it('refuses to mint a token for an implausible customer id', async () => {
+    await expect(mintStatusToken('not-a-customer', SECRET)).rejects.toThrow()
+    await expect(mintStatusToken('cus_with.dot', SECRET)).rejects.toThrow()
+  })
+
+  it('returns a clear failure when the secret is unset', async () => {
+    const r = await verifyStatusToken('cus_X.1.2', '')
+    expect(r.ok).toBe(false)
+  })
+})

--- a/web/packages/baas-worker/src/status-link.ts
+++ b/web/packages/baas-worker/src/status-link.ts
@@ -1,0 +1,117 @@
+/**
+ * Magic-link status tokens for the Botho-as-a-Service `/status` lookup
+ * (P6.3 of #458, §4).
+ *
+ * Identity for the MVP is the **Stripe customer** — there is no password system
+ * (#458 §4). A returning user looks up their rig via a *signed, expiring* token
+ * that binds to exactly one Stripe customer id. The `/status` endpoint verifies
+ * the token, extracts the customer id, and looks the rig up keyed on that id, so
+ * a user can only ever see their own rig (authz — never trust a customer id
+ * straight from the client).
+ *
+ * Token format (URL-safe, single opaque string):
+ *
+ *     <customerId>.<expUnixSeconds>.<hmacHexOver("<customerId>.<exp>")>
+ *
+ * The HMAC is SHA-256 keyed on `STATUS_LINK_SECRET` (a Worker secret, never the
+ * repo). This is the same crypto primitive the Stripe webhook uses to verify
+ * signatures (`hmacSha256Hex` / `timingSafeEqualHex`), reused here so there is a
+ * single, audited HMAC implementation.
+ *
+ * The token is a bearer credential: anyone holding it can read that customer's
+ * rig URL/state. That matches the magic-link model in #458 §4 (the link is the
+ * credential, mailed to the customer's address). It deliberately grants NO
+ * write/provision capability — `/status` is read-only, and provisioning is only
+ * ever triggered by a signature-verified Stripe webhook (#458 §5).
+ */
+
+import { hmacSha256Hex, timingSafeEqualHex } from './webhook'
+
+/** Default lifetime of a freshly minted status token (seconds): 7 days. */
+export const DEFAULT_STATUS_TOKEN_TTL_SECONDS = 7 * 24 * 60 * 60
+
+/** A customer id must look like a Stripe customer (`cus_...`) and be dot-free. */
+function isPlausibleCustomerId(id: string): boolean {
+  // Stripe customer ids are `cus_` + alphanumerics. Reject anything containing a
+  // '.' (our field separator) or whitespace so the token can't be confused.
+  return /^cus_[A-Za-z0-9]+$/.test(id)
+}
+
+/**
+ * Mint a signed status token for a Stripe customer.
+ *
+ * @param customerId Stripe customer id (`cus_...`).
+ * @param secret     `STATUS_LINK_SECRET` Worker secret.
+ * @param opts       `ttlSeconds` overrides the default lifetime; `nowSeconds`
+ *                   pins the clock for deterministic tests.
+ */
+export async function mintStatusToken(
+  customerId: string,
+  secret: string,
+  opts: { ttlSeconds?: number; nowSeconds?: number } = {},
+): Promise<string> {
+  if (!secret) throw new Error('status link secret not configured')
+  if (!isPlausibleCustomerId(customerId)) {
+    throw new Error(`refusing to mint token for implausible customer id: ${customerId}`)
+  }
+  const now = opts.nowSeconds ?? Math.floor(Date.now() / 1000)
+  const ttl = opts.ttlSeconds ?? DEFAULT_STATUS_TOKEN_TTL_SECONDS
+  const exp = now + ttl
+  const payload = `${customerId}.${exp}`
+  const sig = await hmacSha256Hex(secret, payload)
+  return `${payload}.${sig}`
+}
+
+/** Outcome of verifying a status token. */
+export type StatusTokenResult =
+  | { ok: true; customerId: string; exp: number }
+  | { ok: false; reason: string }
+
+/**
+ * Verify a status token and extract its Stripe customer id.
+ *
+ * Rejects (without revealing which check failed beyond a generic reason):
+ *   - missing / malformed tokens,
+ *   - expired tokens,
+ *   - tokens whose HMAC does not match (tampered customer id / forged signature),
+ *   - implausible customer ids.
+ *
+ * The HMAC is recomputed over `"<customerId>.<exp>"` and compared in constant
+ * time, so a tampered `customerId` (e.g. swapping in another user's id) fails.
+ */
+export async function verifyStatusToken(
+  token: string | null | undefined,
+  secret: string,
+  opts: { nowSeconds?: number } = {},
+): Promise<StatusTokenResult> {
+  if (!secret) return { ok: false, reason: 'status link secret not configured' }
+  if (!token) return { ok: false, reason: 'missing token' }
+
+  // Split from the RIGHT so a customer id could in theory contain a dot; in
+  // practice we also validate the id shape below. Expect exactly 3 fields.
+  const parts = token.split('.')
+  if (parts.length !== 3) return { ok: false, reason: 'malformed token' }
+  const [customerId, expStr, sig] = parts
+
+  if (!isPlausibleCustomerId(customerId)) {
+    return { ok: false, reason: 'malformed token' }
+  }
+  const exp = Number(expStr)
+  if (!Number.isInteger(exp) || exp <= 0) {
+    return { ok: false, reason: 'malformed token' }
+  }
+
+  // Verify the signature BEFORE trusting any field. Constant-time compare.
+  const expected = await hmacSha256Hex(secret, `${customerId}.${exp}`)
+  if (!timingSafeEqualHex(expected, sig)) {
+    return { ok: false, reason: 'signature mismatch' }
+  }
+
+  // Only after the signature passes do we honour the (now-trusted) expiry.
+  const now = opts.nowSeconds ?? Math.floor(Date.now() / 1000)
+  if (now >= exp) {
+    return { ok: false, reason: 'token expired' }
+  }
+
+  return { ok: true, customerId, exp }
+}

--- a/web/packages/baas-worker/src/status.test.ts
+++ b/web/packages/baas-worker/src/status.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  buildStatusResponse,
+  buildWalletDeepLink,
+  createPortalSession,
+  fetchRigHealth,
+  lookupStatusForCustomer,
+  StripePortalError,
+} from './status'
+import { FakeStore } from './test-fakes'
+import type { NewRigRecord, RigState } from './rig-store'
+
+const WALLET = 'https://wallet.botho.io'
+
+function nodeStatusOk(result: Record<string, unknown> = { chainHeight: 42, synced: true }) {
+  return vi.fn(async () =>
+    new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+}
+
+async function seedRig(
+  store: FakeStore,
+  over: Partial<NewRigRecord> = {},
+  state: RigState = 'running',
+): Promise<void> {
+  const rec: NewRigRecord = {
+    user: over.stripeCustomer ?? 'cus_A',
+    stripeCustomer: over.stripeCustomer ?? 'cus_A',
+    subscriptionId: over.subscriptionId ?? 'sub_A',
+    rigId: over.rigId ?? 'abc123',
+    region: over.region ?? 'us-west-2',
+    rpcUrl: over.rpcUrl ?? 'https://rig-abc123.testnet.botho.io/rpc',
+  }
+  await store.insertProvisioning(rec)
+  if (state !== 'provisioning') await store.setState(rec.subscriptionId, state)
+}
+
+describe('buildWalletDeepLink', () => {
+  it('encodes the rig RPC into a /wallet?rpc= deep link', () => {
+    const link = buildWalletDeepLink(WALLET, 'https://rig-x.testnet.botho.io/rpc')
+    expect(link).toBe(
+      'https://wallet.botho.io/wallet?rpc=https%3A%2F%2Frig-x.testnet.botho.io%2Frpc',
+    )
+  })
+
+  it('strips a trailing slash on the base url', () => {
+    const link = buildWalletDeepLink('https://wallet.botho.io/', 'https://n/rpc')
+    expect(link.startsWith('https://wallet.botho.io/wallet?rpc=')).toBe(true)
+  })
+})
+
+describe('fetchRigHealth', () => {
+  it('reports online with chain height + sync from node_getStatus', async () => {
+    const fetchMock = nodeStatusOk({ chainHeight: 100, synced: false, syncProgress: 73 })
+    const health = await fetchRigHealth('https://n/rpc', fetchMock as unknown as typeof fetch)
+    expect(health.status).toBe('online')
+    expect(health.chainHeight).toBe(100)
+    expect(health.synced).toBe(false)
+    expect(health.syncProgress).toBe(73)
+  })
+
+  it('reports offline on an RPC error payload', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: -1 } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const health = await fetchRigHealth('https://n/rpc', fetchMock as unknown as typeof fetch)
+    expect(health.status).toBe('offline')
+  })
+
+  it('reports offline when the node fetch throws (never propagates)', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('network down')
+    })
+    const health = await fetchRigHealth('https://n/rpc', fetchMock as unknown as typeof fetch)
+    expect(health.status).toBe('offline')
+  })
+})
+
+describe('buildStatusResponse', () => {
+  it('probes health for a running rig', async () => {
+    const store = new FakeStore()
+    await seedRig(store, {}, 'running')
+    const rig = await store.getByCustomer('cus_A')
+    const fetchMock = nodeStatusOk()
+    const status = await buildStatusResponse(rig!, WALLET, fetchMock as unknown as typeof fetch)
+    expect(status.state).toBe('running')
+    expect(status.health.status).toBe('online')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(status.walletDeepLink).toContain('/wallet?rpc=')
+  })
+
+  it('does NOT probe a provisioning rig (health unknown, no node call)', async () => {
+    const store = new FakeStore()
+    await seedRig(store, {}, 'provisioning')
+    const rig = await store.getByCustomer('cus_A')
+    const fetchMock = nodeStatusOk()
+    const status = await buildStatusResponse(rig!, WALLET, fetchMock as unknown as typeof fetch)
+    expect(status.state).toBe('provisioning')
+    expect(status.health.status).toBe('unknown')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('lookupStatusForCustomer (authz)', () => {
+  it('returns the requesting customer’s own rig', async () => {
+    const store = new FakeStore()
+    await seedRig(store, { stripeCustomer: 'cus_A', subscriptionId: 'sub_A' }, 'running')
+    const result = await lookupStatusForCustomer(
+      'cus_A',
+      store,
+      WALLET,
+      nodeStatusOk() as unknown as typeof fetch,
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.status.rpcUrl).toContain('rig-abc123')
+  })
+
+  it('does NOT return another customer’s rig (404, no leak)', async () => {
+    const store = new FakeStore()
+    // Only customer B has a rig.
+    await seedRig(
+      store,
+      {
+        stripeCustomer: 'cus_B',
+        subscriptionId: 'sub_B',
+        rigId: 'secret',
+        rpcUrl: 'https://rig-secret.testnet.botho.io/rpc',
+      },
+      'running',
+    )
+    // Customer A (authenticated) asks for their rig — must get nothing.
+    const result = await lookupStatusForCustomer(
+      'cus_A',
+      store,
+      WALLET,
+      nodeStatusOk() as unknown as typeof fetch,
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.code).toBe('not_found')
+  })
+
+  it('prefers a live rig over a terminated one for the same customer', async () => {
+    const store = new FakeStore()
+    await seedRig(
+      store,
+      { stripeCustomer: 'cus_A', subscriptionId: 'sub_old', rigId: 'old', rpcUrl: 'https://old/rpc' },
+      'terminated',
+    )
+    await seedRig(
+      store,
+      { stripeCustomer: 'cus_A', subscriptionId: 'sub_new', rigId: 'new', rpcUrl: 'https://rig-new/rpc' },
+      'running',
+    )
+    const result = await lookupStatusForCustomer(
+      'cus_A',
+      store,
+      WALLET,
+      nodeStatusOk() as unknown as typeof fetch,
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.status.rpcUrl).toBe('https://rig-new/rpc')
+  })
+})
+
+describe('createPortalSession', () => {
+  it('posts the verified customer + return url to Stripe and returns the url', async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = String(init?.body)
+      expect(body).toContain('customer=cus_A')
+      expect(body).toContain('return_url=')
+      return new Response(JSON.stringify({ url: 'https://billing.stripe.com/p/abc' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+    const session = await createPortalSession(
+      'cus_A',
+      'https://botho.io/rig/status',
+      'sk_test_dummy',
+      fetchMock as unknown as typeof fetch,
+    )
+    expect(session.url).toBe('https://billing.stripe.com/p/abc')
+  })
+
+  it('throws StripePortalError on a Stripe failure', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ error: { message: 'No such customer' } }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    await expect(
+      createPortalSession('cus_A', 'https://r', 'sk_test_dummy', fetchMock as unknown as typeof fetch),
+    ).rejects.toBeInstanceOf(StripePortalError)
+  })
+})

--- a/web/packages/baas-worker/src/status.ts
+++ b/web/packages/baas-worker/src/status.ts
@@ -1,0 +1,215 @@
+/**
+ * `/status` lookup for the Botho-as-a-Service control plane (P6.3 of #458, §3
+ * step 5, §4, §6).
+ *
+ * Given an authenticated identity (a magic-link status token that binds to one
+ * Stripe customer — see `status-link.ts`), return that user's rig: its RPC URL,
+ * lifecycle state, and a health summary. The summary is derived live from the
+ * node's `node_getStatus` RPC (the same method the wallet's node picker and the
+ * seed scripts use, #458 §6).
+ *
+ * AUTHZ (#458 §4, §5): the customer id always comes from the *verified* token,
+ * never from the request. The D1 lookup is keyed on that customer id, so a user
+ * can only ever see their own rig — there is no code path that returns another
+ * customer's rig. A valid token for customer A can never surface customer B's
+ * data.
+ *
+ * This module is pure/injectable (a `RigStore` + a `fetch` impl) so tests use an
+ * in-memory store and a mocked node fetch — NO real D1 / node call in a test
+ * path. The Stripe customer-portal session creator (`createPortalSession`) is
+ * likewise injectable.
+ */
+
+import type { RigRecord, RigState, RigStore } from './rig-store'
+
+/** Health summary for a rig, surfaced from `node_getStatus` (#458 §6). */
+export interface RigHealth {
+  /** 'online' if node_getStatus succeeded, 'offline' on any error/timeout. */
+  status: 'online' | 'offline' | 'unknown'
+  /** Current chain height (when online). */
+  chainHeight?: number
+  /** Whether the node reports itself synced. */
+  synced?: boolean
+  /** Sync progress percentage 0-100 (when reported). */
+  syncProgress?: number
+}
+
+/** The body returned by GET /status for an authenticated user. */
+export interface StatusResponse {
+  /** Short opaque rig id (`rig-<id>`). */
+  rigId: string
+  /** HTTPS `/rpc` URL the user points the PWA at. */
+  rpcUrl: string
+  /** Lifecycle state of the rig. */
+  state: RigState
+  /** AWS region the rig runs in. */
+  region: string
+  /** Live health summary (or `unknown` while still provisioning). */
+  health: RigHealth
+  /**
+   * A deep link that opens the wallet pointed at this rig's RPC (#458 §3 step 5).
+   * Built from `WALLET_BASE_URL` so the Worker doesn't hard-code the host.
+   */
+  walletDeepLink: string
+}
+
+/** Max time (ms) to wait on a rig's node_getStatus before calling it offline. */
+const HEALTH_TIMEOUT_MS = 5000
+
+/**
+ * Query a rig's health via `node_getStatus`. Never throws — returns an
+ * 'offline' snapshot on any network/timeout/RPC error so a down rig never fails
+ * the whole `/status` response. Mirrors the wallet's `fetchNodeHealth`.
+ */
+export async function fetchRigHealth(
+  rpcUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<RigHealth> {
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS)
+    let resp: Response
+    try {
+      resp = await fetchImpl(rpcUrl, {
+        method: 'POST',
+        signal: controller.signal,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'node_getStatus',
+          params: {},
+          id: 1,
+        }),
+      })
+    } finally {
+      clearTimeout(timeoutId)
+    }
+    if (!resp.ok) return { status: 'offline' }
+    const json = (await resp.json()) as {
+      result?: { chainHeight?: number; synced?: boolean; syncProgress?: number }
+      error?: unknown
+    }
+    if (json.error || !json.result) return { status: 'offline' }
+    return {
+      status: 'online',
+      chainHeight: json.result.chainHeight,
+      synced: json.result.synced,
+      syncProgress: json.result.syncProgress,
+    }
+  } catch {
+    return { status: 'offline' }
+  }
+}
+
+/**
+ * Build the wallet deep link that pre-selects a rig's RPC endpoint (#458 §3
+ * step 5). The wallet reads the `rpc` query param and offers it as the "custom
+ * RPC" ingress. `walletBaseUrl` should be the wallet origin (e.g.
+ * `https://wallet.botho.io`); the link targets the `/wallet` route.
+ */
+export function buildWalletDeepLink(walletBaseUrl: string, rpcUrl: string): string {
+  const base = walletBaseUrl.replace(/\/+$/, '')
+  return `${base}/wallet?rpc=${encodeURIComponent(rpcUrl)}`
+}
+
+/**
+ * Build a `StatusResponse` for a rig record, querying live health unless the rig
+ * is in a pre-launch / terminal state where a health probe is meaningless.
+ *
+ * Health is only probed for `running` rigs — a `provisioning` rig has no DNS/TLS
+ * yet, and `suspended`/`terminated` rigs are intentionally not serving — so we
+ * report `unknown` rather than emit a guaranteed-failing probe.
+ */
+export async function buildStatusResponse(
+  rig: RigRecord,
+  walletBaseUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<StatusResponse> {
+  const health: RigHealth =
+    rig.state === 'running'
+      ? await fetchRigHealth(rig.rpcUrl, fetchImpl)
+      : { status: 'unknown' }
+
+  return {
+    rigId: rig.rigId,
+    rpcUrl: rig.rpcUrl,
+    state: rig.state,
+    region: rig.region,
+    health,
+    walletDeepLink: buildWalletDeepLink(walletBaseUrl, rig.rpcUrl),
+  }
+}
+
+/** Outcome of a status lookup against the store + node. */
+export type StatusLookup =
+  | { ok: true; status: StatusResponse }
+  | { ok: false; code: 'not_found' }
+
+/**
+ * Look up the rig owned by a *verified* Stripe customer and assemble its status.
+ *
+ * The caller MUST have already verified the magic-link token and pass the
+ * customer id it yielded — this function trusts `customerId` as authenticated.
+ * Returns `not_found` when the customer has no rig (so the handler answers 404,
+ * never leaking whether some *other* customer has one).
+ */
+export async function lookupStatusForCustomer(
+  customerId: string,
+  store: RigStore,
+  walletBaseUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<StatusLookup> {
+  const rig = await store.getByCustomer(customerId)
+  if (!rig) return { ok: false, code: 'not_found' }
+  const status = await buildStatusResponse(rig, walletBaseUrl, fetchImpl)
+  return { ok: true, status }
+}
+
+// --- Stripe Customer Portal -------------------------------------------------
+
+/** Error thrown when Stripe rejects the portal-session creation. */
+export class StripePortalError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message)
+    this.name = 'StripePortalError'
+  }
+}
+
+/**
+ * Create a Stripe Billing (Customer) Portal session for a verified customer so
+ * the user can manage/cancel their subscription (#458 §4 "Manage Subscription").
+ *
+ * `fetchImpl` is injectable so tests assert on the exact request without network
+ * I/O. The customer id is the *verified* one from the status token — never from
+ * the client — so a user can only open their own portal.
+ */
+export async function createPortalSession(
+  customerId: string,
+  returnUrl: string,
+  stripeSecretKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ url: string }> {
+  const body = new URLSearchParams()
+  body.set('customer', customerId)
+  body.set('return_url', returnUrl)
+
+  const resp = await fetchImpl('https://api.stripe.com/v1/billing_portal/sessions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${stripeSecretKey}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Stripe-Version': '2024-06-20',
+    },
+    body: body.toString(),
+  })
+
+  const json = (await resp.json()) as { url?: string; error?: { message?: string } }
+  if (!resp.ok || !json.url) {
+    const message = json.error?.message ?? `Stripe returned HTTP ${resp.status}`
+    throw new StripePortalError(message, resp.status)
+  }
+  return { url: json.url }
+}

--- a/web/packages/baas-worker/src/test-fakes.ts
+++ b/web/packages/baas-worker/src/test-fakes.ts
@@ -85,6 +85,20 @@ export class FakeStore implements RigStore {
     return this.rows.get(subscriptionId)
   }
 
+  async getByCustomer(stripeCustomer: string): Promise<RigRecord | undefined> {
+    // Mirror D1RigStore: live rigs before terminated, then newest createdAt.
+    const matches = [...this.rows.values()].filter(
+      (r) => r.stripeCustomer === stripeCustomer,
+    )
+    matches.sort((a, b) => {
+      const aTerm = a.state === 'terminated' ? 1 : 0
+      const bTerm = b.state === 'terminated' ? 1 : 0
+      if (aTerm !== bTerm) return aTerm - bTerm
+      return b.createdAt - a.createdAt
+    })
+    return matches[0]
+  }
+
   async insertProvisioning(rec: NewRigRecord): Promise<RigRecord> {
     if (this.rows.has(rec.subscriptionId)) {
       throw new DuplicateSubscriptionError(rec.subscriptionId)

--- a/web/packages/baas-worker/wrangler.toml
+++ b/web/packages/baas-worker/wrangler.toml
@@ -14,6 +14,11 @@
 #   STRIPE_WEBHOOK_SECRET  Webhook signing secret ("whsec_..."). The /webhook
 #                       endpoint HMAC-verifies every Stripe-Signature against this
 #                       over the RAW body before provisioning (#458 §5). Required.
+#   STATUS_LINK_SECRET  HMAC secret for magic-link status tokens (P6.3, #458 §4).
+#                       The /status + /portal endpoints verify the token against
+#                       this; it binds to ONE Stripe customer so a user only ever
+#                       sees their own rig. Any long random string. Required for
+#                       /status and /portal.
 #   --- provisioner (#502, #458 §3/§5) — a DEDICATED, tightly-scoped IAM user ---
 #   AWS_ACCESS_KEY_ID       provisioner IAM user access key.
 #   AWS_SECRET_ACCESS_KEY   provisioner IAM user secret key.
@@ -45,8 +50,14 @@ database_id = "REPLACE_WITH_D1_DATABASE_ID"
 # the Pages site that hosts the "Get a rig" surface.
 CHECKOUT_SUCCESS_URL = "https://botho.io/rig/success"
 CHECKOUT_CANCEL_URL = "https://botho.io/rig"
-# Browser origins permitted to call /checkout (comma-separated).
+# Browser origins permitted to call /checkout, /status, /portal (comma-separated).
 ALLOWED_ORIGINS = "https://botho.io,https://wallet.botho.io"
+
+# --- status page / magic-link lookup (P6.3, #458 §4/§6) -------------------
+# Wallet origin used to build the "open in wallet" deep link (#458 §3 step 5).
+WALLET_BASE_URL = "https://wallet.botho.io"
+# Where Stripe returns the user after they close the Customer Portal.
+PORTAL_RETURN_URL = "https://botho.io/rig/status"
 
 # --- provisioner non-secret config (#502) ---------------------------------
 # Compute shape (proven seed/faucet rig). Non-secret identifiers.

--- a/web/packages/web-wallet/src/App.tsx
+++ b/web/packages/web-wallet/src/App.tsx
@@ -8,7 +8,7 @@ import { PayPage } from './pages/pay'
 import { ContactsPage } from './pages/contacts'
 import { DocsPage } from './pages/docs'
 import { ExplorerPage } from './pages/explorer'
-import { RigPage, RigSuccessPage } from './pages/rig'
+import { RigPage, RigSuccessPage, RigStatusPage } from './pages/rig'
 
 /**
  * Decide what `/` should render.
@@ -57,6 +57,8 @@ function App() {
             {/* Botho-as-a-Service "Get a rig" surface (#458 §4 / #504). */}
             <Route path="/rig" element={<RigPage />} />
             <Route path="/rig/success" element={<RigSuccessPage />} />
+            {/* Rig status page reached via magic link (#458 §4 / #507). */}
+            <Route path="/rig/status" element={<RigStatusPage />} />
           </Routes>
         </BrowserRouter>
       </WalletProvider>

--- a/web/packages/web-wallet/src/contexts/network.tsx
+++ b/web/packages/web-wallet/src/contexts/network.tsx
@@ -25,6 +25,7 @@ import {
   validateRpcEndpoint,
   fetchNodeHealth,
 } from '../config/networks'
+import { parseRpcDeepLink } from '../lib/custom-rpc-link'
 
 interface NetworkState {
   /** Currently selected network (derived from the selected ingress node). */
@@ -211,6 +212,28 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
       return false
     }
   }, [])
+
+  // Custom-RPC deep link (P6.3, #458 §3 step 5): when the wallet is opened with
+  // a `?rpc=<https endpoint>` param (e.g. from the rig status page's "Open in
+  // wallet" link), pre-select it as the custom ingress. `setCustomEndpoint`
+  // validates reachability via node_getStatus before committing, and strips the
+  // param from the URL so a refresh/back doesn't reapply a stale link.
+  const deepLinkApplied = useRef(false)
+  useEffect(() => {
+    if (deepLinkApplied.current) return
+    if (typeof window === 'undefined') return
+    const parsed = parseRpcDeepLink(window.location.search)
+    if (parsed.ok !== true) return
+    deepLinkApplied.current = true
+    void setCustomEndpoint(parsed.rpcUrl)
+    try {
+      const url = new URL(window.location.href)
+      url.searchParams.delete('rpc')
+      window.history.replaceState(null, '', url.toString())
+    } catch {
+      // history API unavailable (non-browser test env) — ignore.
+    }
+  }, [setCustomEndpoint])
 
   return (
     <NetworkContext.Provider

--- a/web/packages/web-wallet/src/lib/custom-rpc-link.test.ts
+++ b/web/packages/web-wallet/src/lib/custom-rpc-link.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import {
+  RPC_PARAM,
+  buildWalletRpcLink,
+  isValidRpcUrl,
+  parseRpcDeepLink,
+} from './custom-rpc-link'
+
+describe('isValidRpcUrl', () => {
+  it('accepts https endpoints', () => {
+    expect(isValidRpcUrl('https://rig-abc.testnet.botho.io/rpc')).toBe(true)
+  })
+
+  it('accepts http only for localhost / 127.0.0.1 (dev)', () => {
+    expect(isValidRpcUrl('http://localhost:8787/rpc')).toBe(true)
+    expect(isValidRpcUrl('http://127.0.0.1/rpc')).toBe(true)
+  })
+
+  it('rejects plain http on a non-loopback host', () => {
+    expect(isValidRpcUrl('http://evil.example/rpc')).toBe(false)
+  })
+
+  it('rejects non-URLs and non-http(s) schemes', () => {
+    expect(isValidRpcUrl('not a url')).toBe(false)
+    expect(isValidRpcUrl('javascript:alert(1)')).toBe(false)
+    expect(isValidRpcUrl('ftp://host/rpc')).toBe(false)
+  })
+})
+
+describe('parseRpcDeepLink', () => {
+  it('returns absent when there is no rpc param', () => {
+    expect(parseRpcDeepLink('').ok).toBe('absent')
+    expect(parseRpcDeepLink('?foo=bar').ok).toBe('absent')
+    expect(parseRpcDeepLink('?rpc=').ok).toBe('absent')
+  })
+
+  it('parses a valid url-encoded https endpoint', () => {
+    const search = `?${RPC_PARAM}=${encodeURIComponent('https://rig-x.testnet.botho.io/rpc')}`
+    const parsed = parseRpcDeepLink(search)
+    expect(parsed.ok).toBe(true)
+    if (parsed.ok === true) {
+      expect(parsed.rpcUrl).toBe('https://rig-x.testnet.botho.io/rpc')
+    }
+  })
+
+  it('rejects a present-but-invalid rpc param', () => {
+    const parsed = parseRpcDeepLink(`?${RPC_PARAM}=${encodeURIComponent('http://evil/rpc')}`)
+    expect(parsed.ok).toBe(false)
+  })
+
+  it('preserves other params and still finds rpc', () => {
+    const search = `?session_id=abc&${RPC_PARAM}=${encodeURIComponent('https://n/rpc')}`
+    const parsed = parseRpcDeepLink(search)
+    expect(parsed.ok).toBe(true)
+  })
+})
+
+describe('buildWalletRpcLink', () => {
+  it('appends an encoded rpc param', () => {
+    expect(buildWalletRpcLink('/wallet', 'https://n/rpc')).toBe(
+      '/wallet?rpc=https%3A%2F%2Fn%2Frpc',
+    )
+  })
+
+  it('uses & when the path already has a query string', () => {
+    expect(buildWalletRpcLink('/wallet?x=1', 'https://n/rpc')).toBe(
+      '/wallet?x=1&rpc=https%3A%2F%2Fn%2Frpc',
+    )
+  })
+
+  it('round-trips through parseRpcDeepLink', () => {
+    const rpc = 'https://rig-abc.testnet.botho.io/rpc'
+    const link = buildWalletRpcLink('/wallet', rpc)
+    const search = link.slice(link.indexOf('?'))
+    const parsed = parseRpcDeepLink(search)
+    expect(parsed.ok).toBe(true)
+    if (parsed.ok === true) expect(parsed.rpcUrl).toBe(rpc)
+  })
+})

--- a/web/packages/web-wallet/src/lib/custom-rpc-link.ts
+++ b/web/packages/web-wallet/src/lib/custom-rpc-link.ts
@@ -1,0 +1,84 @@
+/**
+ * Custom-RPC deep link parsing for the Botho Web Wallet (P6.3 of #458, §3 step 5).
+ *
+ * A managed-rig owner is handed a link like:
+ *
+ *     https://wallet.botho.io/wallet?rpc=https%3A%2F%2Frig-abc.testnet.botho.io%2Frpc
+ *
+ * Opening it should point the wallet's RPC ingress at their own node. The wallet
+ * already supports a "custom RPC" ingress (see `setCustomEndpoint` in the network
+ * context + the NetworkSelector picker); this module just extracts and validates
+ * the `rpc` query param so the network context can apply it on load.
+ *
+ * Validation is deliberately strict (the endpoint is used for all read/write RPC
+ * and is taken from a URL the user clicked):
+ *   - must be a syntactically valid absolute URL,
+ *   - must be HTTPS (or http://localhost for local dev),
+ *   - we do NOT fetch it here — reachability is checked by the network context's
+ *     `setCustomEndpoint` (`node_getStatus`) before it is committed.
+ */
+
+/** The query-string key carrying a custom RPC endpoint in a deep link. */
+export const RPC_PARAM = 'rpc'
+
+export type ParsedRpcLink =
+  | { ok: true; rpcUrl: string }
+  | { ok: false; reason: string }
+  | { ok: 'absent' }
+
+/**
+ * Validate a candidate RPC endpoint URL. Returns the normalized URL on success.
+ *
+ * Accepts `https://…` anywhere, and `http://localhost`/`http://127.0.0.1` for
+ * local development. Rejects non-URLs, non-HTTP(S) schemes, and plain-`http`
+ * non-loopback hosts (which would be an insecure ingress).
+ */
+export function isValidRpcUrl(candidate: string): boolean {
+  let url: URL
+  try {
+    url = new URL(candidate)
+  } catch {
+    return false
+  }
+  if (url.protocol === 'https:') return true
+  if (url.protocol === 'http:') {
+    return url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+  }
+  return false
+}
+
+/**
+ * Parse the `rpc` deep-link param out of a query string (or full URL search).
+ *
+ * @param search The `window.location.search` value (e.g. `"?rpc=https%3A%2F..."`)
+ *               or any string `URLSearchParams` accepts.
+ * @returns `{ ok: 'absent' }` when there is no `rpc` param, `{ ok: true, rpcUrl }`
+ *          for a valid one, or `{ ok: false, reason }` for a present-but-invalid
+ *          value.
+ */
+export function parseRpcDeepLink(search: string): ParsedRpcLink {
+  let params: URLSearchParams
+  try {
+    params = new URLSearchParams(search)
+  } catch {
+    return { ok: 'absent' }
+  }
+  const raw = params.get(RPC_PARAM)
+  if (raw === null || raw.trim() === '') return { ok: 'absent' }
+
+  const candidate = raw.trim()
+  if (!isValidRpcUrl(candidate)) {
+    return { ok: false, reason: 'The rpc link is not a valid https:// endpoint.' }
+  }
+  return { ok: true, rpcUrl: candidate }
+}
+
+/**
+ * Build a wallet deep link that pre-selects a custom RPC endpoint. Mirrors the
+ * Worker's `buildWalletDeepLink` so the two never diverge. Used by the status
+ * page's "Open in wallet" button.
+ */
+export function buildWalletRpcLink(walletPath: string, rpcUrl: string): string {
+  const sep = walletPath.includes('?') ? '&' : '?'
+  return `${walletPath}${sep}${RPC_PARAM}=${encodeURIComponent(rpcUrl)}`
+}

--- a/web/packages/web-wallet/src/lib/rig-status.test.ts
+++ b/web/packages/web-wallet/src/lib/rig-status.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  RigStatusError,
+  createPortalUrl,
+  fetchRigStatus,
+  tokenFromSearch,
+  type RigStatus,
+} from './rig-status'
+
+function okResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+const SAMPLE: RigStatus = {
+  rigId: 'abc123',
+  rpcUrl: 'https://rig-abc123.testnet.botho.io/rpc',
+  state: 'running',
+  region: 'us-west-2',
+  health: { status: 'online', chainHeight: 42, synced: true },
+  walletDeepLink: 'https://wallet.botho.io/wallet?rpc=https%3A%2F%2Frig-abc123%2Frpc',
+}
+
+describe('tokenFromSearch', () => {
+  it('extracts the token param', () => {
+    expect(tokenFromSearch('?token=cus_A.1.sig')).toBe('cus_A.1.sig')
+  })
+  it('returns null when absent or empty', () => {
+    expect(tokenFromSearch('')).toBeNull()
+    expect(tokenFromSearch('?other=1')).toBeNull()
+    expect(tokenFromSearch('?token=')).toBeNull()
+  })
+})
+
+describe('fetchRigStatus', () => {
+  it('GETs /status?token= and returns the rig status', async () => {
+    const fetchMock = vi.fn(async () => okResponse(SAMPLE))
+    const result = await fetchRigStatus('cus_A.1.sig', fetchMock as unknown as typeof fetch)
+    expect(result.rpcUrl).toBe(SAMPLE.rpcUrl)
+    expect(result.health.status).toBe('online')
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toMatch(/\/status\?token=cus_A\.1\.sig$/)
+    expect(init.method).toBe('GET')
+  })
+
+  it('maps 401 to an expired/invalid link error', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ error: 'unauthorized' }, 401))
+    await expect(
+      fetchRigStatus('bad', fetchMock as unknown as typeof fetch),
+    ).rejects.toMatchObject({ status: 401 })
+  })
+
+  it('maps 404 to a "no rig yet" error', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ error: 'no rig found' }, 404))
+    await expect(
+      fetchRigStatus('cus_A.1.sig', fetchMock as unknown as typeof fetch),
+    ).rejects.toMatchObject({ status: 404 })
+  })
+
+  it('throws RigStatusError when the network is unreachable', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('network down')
+    })
+    await expect(
+      fetchRigStatus('cus_A.1.sig', fetchMock as unknown as typeof fetch),
+    ).rejects.toBeInstanceOf(RigStatusError)
+  })
+})
+
+describe('createPortalUrl', () => {
+  it('POSTs the token and returns the Stripe portal url', async () => {
+    const fetchMock = vi.fn(async (_u: string, init?: RequestInit) => {
+      expect(JSON.parse(init?.body as string)).toEqual({ token: 'cus_A.1.sig' })
+      return okResponse({ url: 'https://billing.stripe.com/p/x' })
+    })
+    const url = await createPortalUrl('cus_A.1.sig', fetchMock as unknown as typeof fetch)
+    expect(url).toBe('https://billing.stripe.com/p/x')
+    const [endpoint, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(endpoint).toMatch(/\/portal$/)
+    expect(init.method).toBe('POST')
+  })
+
+  it('throws on a non-ok portal response', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ error: 'unauthorized' }, 401))
+    await expect(
+      createPortalUrl('bad', fetchMock as unknown as typeof fetch),
+    ).rejects.toBeInstanceOf(RigStatusError)
+  })
+})

--- a/web/packages/web-wallet/src/lib/rig-status.ts
+++ b/web/packages/web-wallet/src/lib/rig-status.ts
@@ -1,0 +1,131 @@
+/**
+ * Frontend client for the Botho-as-a-Service `/status` + `/portal` endpoints
+ * (P6.3 of #458, §4/§6).
+ *
+ * A managed-rig owner returns to the status page with a **magic-link token**
+ * (the MVP identity model — #458 §4: no password, the signed link is the
+ * credential). The page calls `fetchRigStatus(token)` to get the rig's RPC URL,
+ * lifecycle state, and live health, and `openManageSubscription(token)` to jump
+ * to the Stripe Customer Portal.
+ *
+ * The browser only ever talks to our control-plane Worker, which holds the
+ * Stripe secret + the status-link signing secret. No secrets live here.
+ */
+
+import { baasEndpoint } from './rig-checkout'
+
+/** Lifecycle state of a rig (mirrors the Worker's `RigState`). */
+export type RigState = 'provisioning' | 'running' | 'suspended' | 'terminated'
+
+/** Health summary surfaced from `node_getStatus` (mirrors the Worker). */
+export interface RigHealth {
+  status: 'online' | 'offline' | 'unknown'
+  chainHeight?: number
+  synced?: boolean
+  syncProgress?: number
+}
+
+/** The `/status` response body. */
+export interface RigStatus {
+  rigId: string
+  rpcUrl: string
+  state: RigState
+  region: string
+  health: RigHealth
+  /** Deep link that opens this wallet pointed at the rig's RPC. */
+  walletDeepLink: string
+}
+
+/** Error from a status/portal call, carrying an HTTP status when available. */
+export class RigStatusError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message)
+    this.name = 'RigStatusError'
+  }
+}
+
+/** The magic-link token query-param name on the status page URL. */
+export const STATUS_TOKEN_PARAM = 'token'
+
+/**
+ * Read the magic-link token from a query string (the status page is opened as
+ * `/rig/status?token=…`). Returns null when absent.
+ */
+export function tokenFromSearch(search: string): string | null {
+  try {
+    const v = new URLSearchParams(search).get(STATUS_TOKEN_PARAM)
+    return v && v.trim() !== '' ? v.trim() : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Fetch the authenticated user's rig status from the control-plane Worker.
+ * `fetchImpl` is injectable for tests.
+ *
+ * Throws `RigStatusError` (with the HTTP status) on 4xx/5xx so the page can show
+ * a specific message — e.g. 401 → "this link has expired", 404 → "no rig yet".
+ */
+export async function fetchRigStatus(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<RigStatus> {
+  const url = `${baasEndpoint()}/status?${STATUS_TOKEN_PARAM}=${encodeURIComponent(token)}`
+  let resp: Response
+  try {
+    resp = await fetchImpl(url, { method: 'GET' })
+  } catch {
+    throw new RigStatusError('Could not reach the status service. Try again.')
+  }
+
+  if (!resp.ok) {
+    if (resp.status === 401) {
+      throw new RigStatusError('This link is invalid or has expired.', 401)
+    }
+    if (resp.status === 404) {
+      throw new RigStatusError('No rig found for this account yet.', 404)
+    }
+    throw new RigStatusError('Could not load your rig status.', resp.status)
+  }
+
+  try {
+    return (await resp.json()) as RigStatus
+  } catch {
+    throw new RigStatusError('Unexpected response from the status service.', resp.status)
+  }
+}
+
+/**
+ * Open a Stripe Customer Portal session for the authenticated user and return
+ * the hosted URL to redirect the browser to. The caller redirects.
+ */
+export async function createPortalUrl(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string> {
+  let resp: Response
+  try {
+    resp = await fetchImpl(`${baasEndpoint()}/portal`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    })
+  } catch {
+    throw new RigStatusError('Could not reach the billing portal. Try again.')
+  }
+
+  let json: { url?: string; error?: string }
+  try {
+    json = (await resp.json()) as typeof json
+  } catch {
+    throw new RigStatusError('Unexpected response from the billing portal.', resp.status)
+  }
+  if (!resp.ok || !json.url) {
+    throw new RigStatusError(json.error ?? 'Could not open the billing portal.', resp.status)
+  }
+  return json.url
+}

--- a/web/packages/web-wallet/src/pages/rig.tsx
+++ b/web/packages/web-wallet/src/pages/rig.tsx
@@ -1,13 +1,31 @@
-import { useState } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Link } from 'react-router-dom'
 import { Button, Card, Input, Logo } from '@botho/ui'
-import { Server, ArrowLeft, Loader2, AlertCircle, Check, Cpu, Globe, ShieldCheck } from 'lucide-react'
+import {
+  Server,
+  ArrowLeft,
+  Loader2,
+  AlertCircle,
+  Check,
+  Cpu,
+  Globe,
+  ShieldCheck,
+  Copy,
+  ExternalLink,
+  CreditCard,
+} from 'lucide-react'
 import {
   DEFAULT_RIG_REGION,
   RIG_REGIONS,
   RigCheckoutError,
   startRigCheckout,
 } from '../lib/rig-checkout'
+import {
+  createPortalUrl,
+  fetchRigStatus,
+  tokenFromSearch,
+  type RigStatus,
+} from '../lib/rig-status'
 
 /**
  * P7.1 — "Get a rig" surface (#458 §2, §4; issue #504).
@@ -187,13 +205,8 @@ export function RigPage() {
   )
 }
 
-/**
- * Placeholder success page (#458 §4). Stripe redirects here after a completed
- * checkout (`/rig/success?session_id=...`). The full rig-status page — which
- * shows the provisioned node's RPC URL and health — is P6.3; until then this
- * confirms the subscription and explains what happens next.
- */
-export function RigSuccessPage() {
+/** Shared page chrome (header) for the rig success / status pages. */
+function RigPageShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen flex flex-col">
       <header className="fixed top-0 left-0 right-0 z-50 backdrop-blur-md bg-void/80 border-b border-steel">
@@ -204,32 +217,219 @@ export function RigSuccessPage() {
           </Link>
         </div>
       </header>
-
       <main className="flex-1 flex items-center justify-center pt-28 px-4 sm:px-6">
-        <Card className="max-w-md w-full p-6 sm:p-8 text-center">
-          <div className="w-14 h-14 rounded-full bg-success/10 flex items-center justify-center mx-auto mb-5">
-            <Check className="text-success" size={28} />
-          </div>
-          <h1 className="font-display text-2xl sm:text-3xl font-bold mb-3">
-            Subscription started
-          </h1>
-          <p className="text-sm sm:text-base text-ghost mb-6">
-            Thanks! Your managed rig is being set up. We'll provision your node and
-            send its private RPC URL shortly. A live status page is coming soon —
-            it'll show your node's address and health here.
-          </p>
-          <div className="flex flex-col gap-3">
-            <Link to="/wallet">
-              <Button size="lg" className="w-full justify-center">
-                Open Wallet
-              </Button>
-            </Link>
-            <Link to="/" className="text-sm text-ghost hover:text-light transition-colors">
-              Back to home
-            </Link>
-          </div>
-        </Card>
+        {children}
       </main>
     </div>
+  )
+}
+
+/**
+ * Post-checkout success page (#458 §4). Stripe redirects here after a completed
+ * checkout (`/rig/success?session_id=...`). Provisioning is asynchronous (the
+ * webhook launches the node), so this confirms the subscription and points the
+ * user at the live status page once they have their magic link.
+ */
+export function RigSuccessPage() {
+  return (
+    <RigPageShell>
+      <Card className="max-w-md w-full p-6 sm:p-8 text-center">
+        <div className="w-14 h-14 rounded-full bg-success/10 flex items-center justify-center mx-auto mb-5">
+          <Check className="text-success" size={28} />
+        </div>
+        <h1 className="font-display text-2xl sm:text-3xl font-bold mb-3">
+          Subscription started
+        </h1>
+        <p className="text-sm sm:text-base text-ghost mb-6">
+          Thanks! Your managed rig is being provisioned. We'll email you a secure
+          link to your node's status page — it shows your private RPC URL, the
+          rig's health, and a one-click link to open it in the wallet.
+        </p>
+        <div className="flex flex-col gap-3">
+          <Link to="/wallet">
+            <Button size="lg" className="w-full justify-center">
+              Open Wallet
+            </Button>
+          </Link>
+          <Link to="/" className="text-sm text-ghost hover:text-light transition-colors">
+            Back to home
+          </Link>
+        </div>
+      </Card>
+    </RigPageShell>
+  )
+}
+
+/** Colored dot + label for a rig's lifecycle state. */
+function StateBadge({ state }: { state: RigStatus['state'] }) {
+  const map: Record<RigStatus['state'], { label: string; cls: string }> = {
+    provisioning: { label: 'Provisioning', cls: 'bg-warning/20 text-warning' },
+    running: { label: 'Running', cls: 'bg-success/20 text-success' },
+    suspended: { label: 'Suspended', cls: 'bg-warning/20 text-warning' },
+    terminated: { label: 'Terminated', cls: 'bg-danger/20 text-danger' },
+  }
+  const { label, cls } = map[state]
+  return <span className={`px-2 py-0.5 rounded text-xs font-medium ${cls}`}>{label}</span>
+}
+
+/** One-line health summary from node_getStatus. */
+function healthSummary(health: RigStatus['health']): string {
+  if (health.status === 'unknown') return 'Not yet reporting'
+  if (health.status === 'offline') return 'Unreachable'
+  const h = health.chainHeight != null ? `height ${health.chainHeight}` : 'online'
+  const sync = health.synced ? 'synced' : `${Math.round(health.syncProgress ?? 0)}%`
+  return `${h} · ${sync}`
+}
+
+/**
+ * Rig status page (P6.3, #458 §3 step 5 / §4 / §6). Reached via a magic link
+ * (`/rig/status?token=...`) — the MVP identity model (no password, the signed
+ * link is the credential). Shows the rig's RPC URL, state, and live health, plus
+ * an "Open in wallet" deep link (pre-selects the rig as the custom RPC ingress)
+ * and a "Manage Subscription" button (Stripe Customer Portal).
+ */
+export function RigStatusPage() {
+  const [status, setStatus] = useState<RigStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [portalBusy, setPortalBusy] = useState(false)
+
+  const token =
+    typeof window !== 'undefined' ? tokenFromSearch(window.location.search) : null
+
+  const load = useCallback(async () => {
+    if (!token) {
+      setError('This status link is missing its access token.')
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      setStatus(await fetchRigStatus(token))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load your rig status.')
+    } finally {
+      setLoading(false)
+    }
+  }, [token])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  async function handleCopy() {
+    if (!status) return
+    try {
+      await navigator.clipboard.writeText(status.rpcUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // clipboard unavailable — ignore.
+    }
+  }
+
+  async function handleManage() {
+    if (!token) return
+    setPortalBusy(true)
+    try {
+      const url = await createPortalUrl(token)
+      window.location.assign(url)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not open the billing portal.')
+      setPortalBusy(false)
+    }
+  }
+
+  return (
+    <RigPageShell>
+      <Card className="max-w-lg w-full p-6 sm:p-8">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-11 h-11 rounded-lg bg-pulse/10 flex items-center justify-center">
+            <Server className="text-pulse" size={22} />
+          </div>
+          <div>
+            <h1 className="font-display text-xl sm:text-2xl font-bold">Your managed rig</h1>
+            <p className="text-xs text-ghost">Botho-as-a-Service · testnet</p>
+          </div>
+        </div>
+
+        {loading && (
+          <div className="flex items-center gap-2 text-ghost py-8 justify-center">
+            <Loader2 className="animate-spin" size={18} />
+            Loading your rig…
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="p-4 rounded-xl bg-error/10 border border-error/30 flex gap-3 text-sm text-error">
+            <AlertCircle size={18} className="shrink-0 mt-0.5" />
+            <div>
+              <p>{error}</p>
+              {token && (
+                <button onClick={load} className="underline mt-2 text-light">
+                  Try again
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {!loading && status && (
+          <div className="flex flex-col gap-5">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-ghost">Status</span>
+              <div className="flex items-center gap-2">
+                <StateBadge state={status.state} />
+                <span className="text-xs text-ghost">{healthSummary(status.health)}</span>
+              </div>
+            </div>
+
+            <div>
+              <span className="text-sm text-ghost block mb-1.5">RPC endpoint</span>
+              <div className="flex gap-2">
+                <code className="flex-1 px-3 py-2 rounded-lg bg-void border border-steel text-xs sm:text-sm text-light break-all">
+                  {status.rpcUrl}
+                </code>
+                <Button size="sm" variant="ghost" onClick={handleCopy} aria-label="Copy RPC URL">
+                  {copied ? <Check size={16} className="text-success" /> : <Copy size={16} />}
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-ghost">Region</span>
+              <span className="text-light">{status.region}</span>
+            </div>
+
+            <div className="flex flex-col gap-3 pt-1">
+              {/* Deep link: opens the wallet with this rig pre-selected as the
+                  custom RPC ingress (#458 §3 step 5). */}
+              <a href={status.walletDeepLink}>
+                <Button size="lg" className="w-full justify-center gap-2">
+                  <ExternalLink size={18} />
+                  Open in wallet
+                </Button>
+              </a>
+              <Button
+                size="lg"
+                variant="ghost"
+                className="w-full justify-center gap-2"
+                onClick={handleManage}
+                disabled={portalBusy}
+              >
+                {portalBusy ? (
+                  <Loader2 className="animate-spin" size={18} />
+                ) : (
+                  <CreditCard size={18} />
+                )}
+                Manage subscription
+              </Button>
+            </div>
+          </div>
+        )}
+      </Card>
+    </RigPageShell>
   )
 }


### PR DESCRIPTION
## Summary

Implements **P6.3** of the Botho-as-a-Service MVP (parent #458, depends on #502/#506): a `/status` lookup that shows a managed-rig owner their node's RPC URL + lifecycle state + live health, a Stripe Customer Portal link, and a PWA **custom-RPC deep link** that opens the wallet pointed at the rig.

Code-only, test mode: no live calls, no deploy, no real secrets (Worker secret/var placeholders only).

## /status contract + authz model

**Identity = the Stripe customer (no password — #458 §4).** A returning user presents a **magic-link token**: `<cus_id>.<expUnixSeconds>.<HMAC-SHA256(STATUS_LINK_SECRET, "<cus_id>.<exp>")>`.

- `GET /status?token=…` → `{ rigId, rpcUrl, state, region, health, walletDeepLink }`
  - `400` missing token · `401` invalid/expired/forged (no leak) · `404` valid token but no rig · `405` non-GET · `500` unconfigured.
- `POST /portal` `{ token }` → `{ url }` (Stripe Billing Portal), same auth.

**Authz:** the customer id is taken **only** from the verified token, never from the request; the D1 lookup is keyed on it (`getByCustomer`). A valid token for customer A can never surface customer B's rig — covered by tests at both the core and HTTP layers. Signature is verified (constant-time) *before* the expiry is trusted, so a tampered customer id or extended expiry fails as a signature mismatch. `/status` is read-only — it can never provision (the only launch path remains the signature-verified `/webhook`).

**Health:** summarized from `node_getStatus` (#458 §6), probed only for `running` rigs (a `provisioning`/`suspended`/`terminated` rig reports `unknown` with no node call); a down node reports `offline` and never fails the response.

## Deep-link flow

The status response includes `walletDeepLink = <WALLET_BASE_URL>/wallet?rpc=<encoded rpc>`. The wallet's network context parses `?rpc=` on load, validates it (https-only; http allowed only for localhost), applies it as the **custom RPC ingress** (the existing `setCustomEndpoint`, which validates reachability via `node_getStatus`), then strips the param from the URL. The status page's "Open in wallet" button uses this link.

## Changes

- **baas-worker**: `status-link.ts` (magic-link tokens), `status.ts` (lookup core + health + Stripe portal), `index.ts` (`GET /status` + `POST /portal` routes, GET CORS), `rig-store` `getByCustomer` (D1 + fake), `wrangler.toml` / `.dev.vars.example` / `README` env + contracts.
- **web-wallet**: `lib/custom-rpc-link.ts` (deep-link parse/validate), `lib/rig-status.ts` (status/portal client), `contexts/network.tsx` (apply deep link on load), `pages/rig.tsx` (`RigStatusPage` at `/rig/status`), `App.tsx` route.

## Acceptance Criteria Verification

| Criterion (#507 / #458 §4) | Status | Verification |
|---|---|---|
| `/status` returns rpc_url, state, live health for an authed user | ✅ | `status-handler.test.ts` 200 path; health from mocked `node_getStatus` |
| Magic-link / no-password lookup + "Manage Subscription" portal | ✅ | `status-link.ts`; `POST /portal` → Stripe Billing Portal; `createPortalUrl` |
| Status UI: URL + state + health + open-in-wallet + manage-subscription | ✅ | `RigStatusPage` (`/rig/status`) |
| PWA custom-RPC option accepts + validates the deep-link param | ✅ | `custom-rpc-link.ts` + network-context effect; `custom-rpc-link.test.ts` |
| Only the requester's own rig (authz, no leak) | ✅ | core + HTTP tests: A never sees B's rig → 404 |
| Health surfaced from `node_getStatus` | ✅ | `fetchRigHealth` / `status.test.ts` |
| No funds touched (non-custodial) | ✅ | read-only status; keys stay on device |

## Test Plan

All mocked (no network / Stripe / AWS / DNS / D1):
- `pnpm typecheck` — all 8 packages clean.
- `vitest run` — **430 web + 162 baas-worker** tests pass.
- `pnpm build:web` — succeeds.
- `wrangler deploy --dry-run` — succeeds; new vars bound.

Tests: `/status` correct rig for the authed user; does NOT return another user's rig (401/404, no leak); unauthenticated/invalid → 400/401; health reflects `node_getStatus`; deep-link/custom-RPC param parsing.

Closes #507