### PR TITLE
feat(baas): SEC hardening — scoped provisioner IAM + orphan-reaping reconciliation cron + caps (#508)

### DIFF
--- a/web/packages/baas-worker/README.md
+++ b/web/packages/baas-worker/README.md
@@ -29,9 +29,14 @@ This package implements:
   ever comes from the verified token, and the D1 lookup is keyed on it, so a user
   can only see their own rig. `/status` is read-only — it can never provision.
 
-> Out of scope here (later phases of #458 §8):
-> - tighter provisioner IAM policy + the orphan-reconciliation cron — **SEC (#508)**
->
+- **SEC — security hardening** (#458 §5, issue #508): a **dedicated,
+  least-privilege provisioner IAM policy** (committed at `iam/provisioner-policy.json`
+  + `iam/README.md`), an **orphan-terminating reconciliation cron** (a scheduled
+  Worker that lists every `botho:managed-rig=true` EC2 instance, cross-checks each
+  `botho:subscription` against Stripe, and **terminates orphans** — the cost-bleed
+  safety net behind the webhook teardown), and an **explicit per-subscription cap**
+  cross-checked against EC2 tags before launch. See "Security hardening" below.
+
 > The frontend "Get a rig" surface that calls `/checkout` lives in
 > `@botho/web-wallet` at `/rig` (route `RigPage`).
 
@@ -238,13 +243,92 @@ to redirect the browser to. The customer id comes from the token, so a user can
 only open their own portal. **Errors:** `400` missing token, `401` invalid
 token, `405` non-POST, `500` not configured, `502` Stripe rejected the request.
 
+## Security hardening (SEC / #508, #458 §5)
+
+This package's threat model: the control plane holds **AWS creds that launch
+instances** and **Stripe secrets that move money**. The risks are
+provisioning-without-paying, cost-runaway/abuse, AWS-cred blast radius, and
+**cost-bleed from un-torn-down rigs**. The hardening:
+
+### 1. Scoped provisioner IAM policy (`iam/provisioner-policy.json`)
+
+A **dedicated, least-privilege** IAM policy (tighter than `botho-deploy`) granting
+**only** `ec2:RunInstances` / `ec2:TerminateInstances` / `ec2:DescribeInstances` /
+`ec2:CreateTags` — **no IAM, no S3, no broad EC2**. Constrained by: instance-type
+`t4g.medium`, region `us-west-2`, the required tag `botho:managed-rig=true`, the
+specific AMI/SG/subnet/key-pair, and — critically — **`ec2:TerminateInstances`
+restricted to resources tagged `botho:managed-rig=true`**, so the credential can
+**never** terminate the seed/seed2/faucet nodes. `CreateTags` is allowed only as
+tag-on-create, so the tag can't be forged onto a non-managed instance. Full
+rationale + apply steps in `iam/README.md`. Validated by `src/iam-policy.test.ts`.
+
+### 2. Reconciliation cron (the cost-bleed safety net)
+
+A scheduled Worker (`[triggers].crons` in `wrangler.toml`, every 15 min →
+`scheduled()` → `handleScheduled` → `reconcileOnce`) that:
+
+1. lists every `botho:managed-rig=true` EC2 instance (`describeManagedRigs`, the
+   same tag IAM gates terminate on — so it can only ever see/act on managed rigs),
+2. reads each instance's `botho:subscription` tag and asks Stripe "is this
+   subscription still **active**?" (`SubscriptionChecker`),
+3. **terminates orphans** — terminate the instance, delete its DNS record, mark
+   the D1 row `terminated` — for: cancelled / unpaid / absent subscriptions, a
+   managed rig with no subscription tag, and **stuck-provisioning** rigs (never
+   reached `running` past `STUCK_PROVISIONING_MS`),
+4. leaves rigs with an **active** subscription strictly alone, and
+5. **skips** (never reaps) a rig when the Stripe lookup errors transiently — a
+   Stripe hiccup can never reap a paying customer's box.
+
+Same injectable pattern as the provisioner (EC2 / DNS / D1 / Stripe are
+interfaces), so the whole sweep is unit-tested with in-memory fakes in
+`src/reconcile.test.ts` + `src/scheduled-handler.test.ts` — **no real call in a
+test path**.
+
+### 3. Caps (region / instance-type / per-subscription / global fleet)
+
+- **Region allowlist** (`us-west-2`) + **instance-type allowlist** (`t4g.medium`),
+  fail-closed, in `rig-config.ts` (#502, re-verified here).
+- **Global fleet cap** (`FLEET_CAP`, default 25) circuit breaker.
+- **Explicit per-subscription cap**: `MAX_INSTANCES_PER_SUBSCRIPTION` (=1) is now
+  enforced as a counted check (provisioner step 5b) that re-counts live instances
+  carrying this `botho:subscription` tag in EC2 immediately before `RunInstances`
+  and **adopts** the existing instance instead of launching a second — closing the
+  narrow concurrent-launch window on top of the structural `subscription_id`-UNIQUE
+  guarantee. (This wires in the previously-dead `MAX_INSTANCES_PER_SUBSCRIPTION` /
+  `per_subscription_cap` symbols the prior review flagged; the latter remains in
+  the error-code union as a documented alternative to the adopt policy.)
+- **SigV4 known-good reference-vector test** (`src/aws-sigv4.test.ts`): the signer
+  core is pinned against AWS's published Signature Version 4 worked example (the
+  IAM `ListUsers` GET) — empty-payload hash, canonical-request hash, and final
+  signature all byte-exact AWS's documented values.
+
+### LIVE-mode go/no-go checklist (#458 §7)
+
+Complete ALL before flipping Stripe from TEST to LIVE / charging real money:
+
+- [ ] The dedicated provisioner IAM user has **only** `iam/provisioner-policy.json`
+      attached (verify no extra inline/managed policies; not `botho-deploy`).
+- [ ] `ec2:TerminateInstances` is confirmed tag-conditioned (the policy test passes
+      AND a manual `aws iam simulate-principal-policy` denies terminate on a
+      seed/faucet instance).
+- [ ] The reconciliation cron is deployed and a TEST sweep correctly reaped a
+      cancelled-subscription rig in staging (and left active ones alone).
+- [ ] All secrets (`STRIPE_*`, `AWS_*`, `CF_DNS_*`, `STATUS_LINK_SECRET`) are
+      Worker secrets, rotatable, and **absent from the repo / `.dev.vars` is
+      gitignored**.
+- [ ] The webhook is the **only** launch trigger (no public `/provision`) and
+      signature verification is enforced (#506).
+- [ ] The `$50`-vs-cost economics (#441 open item a) are settled.
+
 ## Configuration (secrets & vars)
 
 All secrets come from Worker secrets / vars — **never the repo** (#458 §2, §5).
 
 | Key                    | Kind   | Notes                                                        |
 |------------------------|--------|-------------------------------------------------------------|
-| `STRIPE_SECRET_KEY`    | secret | TEST key (`sk_test_...`) while on testnet (#458 §7).        |
+| `STRIPE_SECRET_KEY`    | secret | TEST key (`sk_test_...`) while on testnet (#458 §7). Also used by the reconciliation cron to check subscription status (#508). |
+| `RECONCILE_REGIONS`    | var    | Comma-separated regions the SEC cron sweeps (default = launch allowlist). |
+| `STUCK_PROVISIONING_MS`| var    | Age (ms) after which a not-yet-running rig is reaped as stuck (default 30 min). |
 | `STRIPE_PRICE_ID`      | secret | The recurring $50/mo Price id (`price_...`). See below.     |
 | `STRIPE_WEBHOOK_SECRET`| secret | Webhook signing secret (`whsec_...`). Required for `/webhook`.|
 | `STATUS_LINK_SECRET`   | secret | HMAC secret for magic-link status tokens. Required for `/status` + `/portal`.|
@@ -314,6 +398,19 @@ mint/verify (round-trip, tampered customer id, wrong secret, expired), the
 link, the **authz boundary** (a user gets their own rig, never another's → 404),
 and the HTTP handlers (200 / 400 missing token / 401 forged token / 404 no rig /
 500 unconfigured) — all with an in-memory store + mocked node/Stripe fetch.
+
+**SEC (#508):** `src/reconcile.test.ts` + `src/scheduled-handler.test.ts` cover
+the reconciliation sweep — an instance whose subscription is cancelled/absent →
+terminated, an active subscription → left alone, stuck-provisioning past the
+threshold → terminated, a tag-less managed rig → terminated, a transient Stripe
+error → **skipped** (never reaps a paying rig), already-terminating instances
+ignored, and the guarantee it **never touches non-managed-rig instances** — all
+with in-memory EC2/DNS/D1/Stripe fakes. `src/stripe-subscriptions.test.ts` covers
+the subscription-status client (active/cancelled/404/transient-throw) with a
+mocked fetch. `src/aws-sigv4.test.ts` adds the **known-good SigV4 reference-vector
+test** (pinned against AWS's published worked example). `src/iam-policy.test.ts`
+asserts `iam/provisioner-policy.json` is valid and its `TerminateInstances`
+statement is tag-conditioned to `botho:managed-rig=true`.
 
 ## Deploy
 

--- a/web/packages/baas-worker/iam/README.md
+++ b/web/packages/baas-worker/iam/README.md
@@ -1,0 +1,80 @@
+# Provisioner IAM policy (SEC / #508, #458 §5)
+
+`provisioner-policy.json` is the **dedicated, least-privilege IAM policy** for the
+Botho-as-a-Service control-plane provisioner. It is deliberately **tighter than
+`botho-deploy`** and is the committed source of truth for what the worker's AWS
+credential may do.
+
+## How to apply
+
+Create a **dedicated IAM user** (not `botho-deploy`), attach this policy, mint an
+access key, and store it as Worker secrets:
+
+```bash
+# Replace the placeholders in provisioner-policy.json first (see below).
+aws iam create-user --user-name botho-baas-provisioner
+aws iam put-user-policy \
+  --user-name botho-baas-provisioner \
+  --policy-name BothoBaasProvisionerLeastPrivilege \
+  --policy-document file://provisioner-policy.json
+aws iam create-access-key --user-name botho-baas-provisioner
+
+# then, in web/packages/baas-worker:
+wrangler secret put AWS_ACCESS_KEY_ID
+wrangler secret put AWS_SECRET_ACCESS_KEY
+```
+
+### Placeholders to replace
+
+- `ACCOUNT_ID` — your 12-digit AWS account id.
+- `SUBNET_ID` — the subnet the seed/faucet rigs run in (e.g. `subnet-0abc…`).
+
+The `us-west-2` region, the `t4g.medium` instance type, the AMI
+(`ami-012798e88aebdba5c`), the security group (`sg-0dd3fc95ec3916a4a`), and the
+key-pair (`botho-nodes`) match the proven recipe and `rig-config.ts`. Expand the
+region/AMI deliberately if the allowlist grows.
+
+## What it allows — and what it forbids
+
+Only **four EC2 verbs** plus tag-on-create. **No IAM, no S3, no broad EC2.** The
+Cloudflare DNS write is a separate Cloudflare API token (`CF_DNS_API_TOKEN`), not
+an AWS permission, so it is out of scope for this IAM policy.
+
+| Sid | Action | Constraint |
+|-----|--------|------------|
+| `DescribeManagedRigs` | `ec2:DescribeInstances` | `Resource: *` (AWS cannot resource-scope Describe). Read-only; the worker further filters on the `botho:managed-rig` tag. |
+| `RunManagedRigConstrained` | `ec2:RunInstances` | `ec2:InstanceType == t4g.medium`, `ec2:Region == us-west-2`, **required tag** `aws:RequestTag/botho:managed-rig == true`, and `aws:TagKeys` restricted to the four `botho:*` tags. |
+| `RunManagedRigSupportingResources` | `ec2:RunInstances` | Pinned to the specific **AMI / security-group / subnet / key-pair** ARNs (plus the ENIs/volumes a launch creates). Off-recipe launches are denied. |
+| `TagOnlyAtLaunch` | `ec2:CreateTags` | Allowed **only** when `ec2:CreateAction == RunInstances` (tag-on-create). The worker cannot re-tag arbitrary existing resources. |
+| `TerminateOnlyManagedRigs` | `ec2:TerminateInstances` | **`ec2:ResourceTag/botho:managed-rig == true`** — terminate is restricted to instances already carrying the managed-rig tag. |
+
+### Why the seed / seed2 / faucet nodes are safe
+
+This is the single most important property (#458 §5):
+
+1. **Terminate is tag-conditioned.** `TerminateOnlyManagedRigs` only permits
+   `ec2:TerminateInstances` on resources where `ec2:ResourceTag/botho:managed-rig`
+   is `true`. The seed, seed2, and faucet nodes do **not** carry that tag, so this
+   credential can **never** terminate them — even if the worker is fully
+   compromised.
+2. **The tag cannot be forged onto them.** `CreateTags` is allowed **only** as
+   part of a `RunInstances` call (`ec2:CreateAction == RunInstances`). The
+   provisioner therefore cannot add `botho:managed-rig=true` to an existing
+   seed/faucet node to make it terminable.
+3. **The reconciliation sweep only sees managed rigs.** `describeManagedRigs`
+   (the cron's only listing) filters on `tag:botho:managed-rig=true`, so the
+   sweep cannot even enumerate the seed/faucet nodes, let alone reap one.
+
+Together these are belt-and-suspenders: IAM forbids it, the tag can't be forged,
+and the application code never targets a non-managed instance.
+
+## Tests
+
+`src/iam-policy.test.ts` loads this file and asserts:
+
+- it is valid JSON with the IAM policy shape (`Version`, `Statement[]`),
+- the action set is exactly the four allowed EC2 verbs (no IAM/S3/broad EC2),
+- the `TerminateInstances` statement carries the
+  `ec2:ResourceTag/botho:managed-rig == true` condition (the load-bearing
+  guarantee), and
+- `RunInstances` is constrained to `t4g.medium` + `us-west-2` + the required tag.

--- a/web/packages/baas-worker/iam/provisioner-policy.json
+++ b/web/packages/baas-worker/iam/provisioner-policy.json
@@ -1,0 +1,68 @@
+{
+  "Version": "2012-10-17",
+  "Id": "BothoBaasProvisionerLeastPrivilege",
+  "Statement": [
+    {
+      "Sid": "DescribeManagedRigs",
+      "Effect": "Allow",
+      "Action": ["ec2:DescribeInstances"],
+      "Resource": "*"
+    },
+    {
+      "Sid": "RunManagedRigConstrained",
+      "Effect": "Allow",
+      "Action": ["ec2:RunInstances"],
+      "Resource": ["arn:aws:ec2:us-west-2:ACCOUNT_ID:instance/*"],
+      "Condition": {
+        "StringEquals": {
+          "ec2:InstanceType": "t4g.medium",
+          "ec2:Region": "us-west-2",
+          "aws:RequestTag/botho:managed-rig": "true"
+        },
+        "ForAnyValue:StringEquals": {
+          "aws:TagKeys": [
+            "botho:managed-rig",
+            "botho:subscription",
+            "botho:user",
+            "botho:rig-id"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "RunManagedRigSupportingResources",
+      "Effect": "Allow",
+      "Action": ["ec2:RunInstances"],
+      "Resource": [
+        "arn:aws:ec2:us-west-2:ACCOUNT_ID:image/ami-012798e88aebdba5c",
+        "arn:aws:ec2:us-west-2:ACCOUNT_ID:security-group/sg-0dd3fc95ec3916a4a",
+        "arn:aws:ec2:us-west-2:ACCOUNT_ID:subnet/SUBNET_ID",
+        "arn:aws:ec2:us-west-2:ACCOUNT_ID:network-interface/*",
+        "arn:aws:ec2:us-west-2:ACCOUNT_ID:volume/*",
+        "arn:aws:ec2:us-west-2:ACCOUNT_ID:key-pair/botho-nodes"
+      ]
+    },
+    {
+      "Sid": "TagOnlyAtLaunch",
+      "Effect": "Allow",
+      "Action": ["ec2:CreateTags"],
+      "Resource": "arn:aws:ec2:us-west-2:ACCOUNT_ID:*/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "RunInstances"
+        }
+      }
+    },
+    {
+      "Sid": "TerminateOnlyManagedRigs",
+      "Effect": "Allow",
+      "Action": ["ec2:TerminateInstances"],
+      "Resource": "arn:aws:ec2:us-west-2:ACCOUNT_ID:instance/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:ResourceTag/botho:managed-rig": "true"
+        }
+      }
+    }
+  ]
+}

--- a/web/packages/baas-worker/src/aws-sigv4.test.ts
+++ b/web/packages/baas-worker/src/aws-sigv4.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { amzDate, dateStamp, signAwsRequest } from './aws-sigv4'
+import {
+  amzDate,
+  computeSigV4,
+  dateStamp,
+  hashHex,
+  signAwsRequest,
+} from './aws-sigv4'
 
 const FIXED = new Date('2026-06-21T12:00:00.000Z')
 
@@ -76,5 +82,83 @@ describe('signAwsRequest', () => {
     const a = await signAwsRequest({ ...base, body: 'Action=A' })
     const b = await signAwsRequest({ ...base, body: 'Action=B' })
     expect(a.headers.Authorization).not.toBe(b.headers.Authorization)
+  })
+})
+
+/**
+ * Known-good reference-vector test (#508 — requested by the #526 Judge).
+ *
+ * AWS publishes a fully worked SigV4 example in "Create a signed AWS API request"
+ * (docs.aws.amazon.com): a `GET` to `iam.amazonaws.com` for
+ * `Action=ListUsers&Version=2010-05-08` with the canonical example credentials.
+ * AWS documents EVERY intermediate value, so it is a true external oracle (not a
+ * self-comparison) that pins our SigV4 algorithm against AWS's own arithmetic.
+ *
+ * If `computeSigV4` ever drifts (wrong canonicalization, key derivation, or
+ * string-to-sign), these byte-exact assertions fail.
+ */
+describe('SigV4 known-good reference vector (AWS docs ListUsers example)', () => {
+  // The canonical example identity AWS uses throughout its SigV4 documentation.
+  const ACCESS_KEY = 'AKIDEXAMPLE'
+  const SECRET_KEY = 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY'
+  const AMZ_DATE = '20150830T123600Z'
+  const REGION = 'us-east-1'
+  const SERVICE = 'iam'
+
+  // AWS-published expected values for this exact request.
+  const EXPECTED_EMPTY_PAYLOAD_HASH =
+    'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+  const EXPECTED_CANONICAL_REQUEST_HASH =
+    'f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59'
+  const EXPECTED_SIGNATURE =
+    '5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7'
+
+  it('hashes an empty payload to the documented value', async () => {
+    expect(await hashHex('')).toBe(EXPECTED_EMPTY_PAYLOAD_HASH)
+  })
+
+  it('produces the canonical-request hash and signature AWS publishes', async () => {
+    const payloadHash = await hashHex('') // GET, empty body
+    const result = await computeSigV4({
+      method: 'GET',
+      path: '/',
+      canonicalQuery: 'Action=ListUsers&Version=2010-05-08',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded; charset=utf-8',
+        host: 'iam.amazonaws.com',
+        'x-amz-date': AMZ_DATE,
+      },
+      payloadHash,
+      region: REGION,
+      service: SERVICE,
+      amzDate: AMZ_DATE,
+      secretAccessKey: SECRET_KEY,
+    })
+
+    expect(result.signedHeaders).toBe('content-type;host;x-amz-date')
+    // The hash of the canonical request must equal AWS's documented value.
+    expect(await hashHex(result.canonicalRequest)).toBe(
+      EXPECTED_CANONICAL_REQUEST_HASH,
+    )
+    // And the final signature must be byte-exact AWS's documented value.
+    expect(result.signature).toBe(EXPECTED_SIGNATURE)
+  })
+
+  it('the production signer reuses the same verified core (Authorization carries the vector)', async () => {
+    // Sanity: signAwsRequest delegates to computeSigV4. A POST body request with
+    // the example creds yields a 64-hex signature in the Authorization header,
+    // and the credential scope is exactly as AWS formats it.
+    const signed = await signAwsRequest({
+      endpoint: `https://${SERVICE}.amazonaws.com/`,
+      region: REGION,
+      service: SERVICE,
+      body: 'Action=ListUsers&Version=2010-05-08',
+      credentials: { accessKeyId: ACCESS_KEY, secretAccessKey: SECRET_KEY },
+      date: new Date('2015-08-30T12:36:00.000Z'),
+    })
+    expect(signed.headers.Authorization).toContain(
+      `Credential=${ACCESS_KEY}/20150830/${REGION}/${SERVICE}/aws4_request`,
+    )
+    expect(signed.headers.Authorization).toMatch(/Signature=[0-9a-f]{64}/)
   })
 })

--- a/web/packages/baas-worker/src/aws-sigv4.ts
+++ b/web/packages/baas-worker/src/aws-sigv4.ts
@@ -72,20 +72,101 @@ export function dateStamp(date: Date): string {
   return amzDate(date).slice(0, 8)
 }
 
+// NOTE (#508): the standalone `signingKey(secretAccessKey, date, region, service)`
+// helper was folded into `computeSigV4` (below), which now derives the signing
+// key inline from the date stamp so the production signer and the
+// reference-vector test share one code path. Preserved here (commented out per
+// CLAUDE.md) in case a Date-based key derivation is needed again:
+//
+// async function signingKey(
+//   secretAccessKey: string,
+//   date: Date,
+//   region: string,
+//   service: string,
+// ): Promise<ArrayBuffer> {
+//   const kDate = await hmac(encoder.encode(`AWS4${secretAccessKey}`), dateStamp(date))
+//   const kRegion = await hmac(kDate, region)
+//   const kService = await hmac(kRegion, service)
+//   return hmac(kService, 'aws4_request')
+// }
+
 /**
- * Derive the SigV4 signing key for `date`/`region`/`service` from the secret
- * access key.
+ * Explicit inputs to the canonical-request → signature computation. Exposed so
+ * the SigV4 implementation can be exercised directly against AWS's published
+ * "known-good" Signature Version 4 worked examples (#508 — the #526 Judge asked
+ * for a reference-vector test). Pure (no fetch, no network), so the signer is
+ * proven correct without any AWS call.
  */
-async function signingKey(
-  secretAccessKey: string,
-  date: Date,
-  region: string,
-  service: string,
-): Promise<ArrayBuffer> {
-  const kDate = await hmac(encoder.encode(`AWS4${secretAccessKey}`), dateStamp(date))
-  const kRegion = await hmac(kDate, region)
-  const kService = await hmac(kRegion, service)
-  return hmac(kService, 'aws4_request')
+export interface CanonicalRequestInput {
+  method: string
+  /** Canonical URI path (already URI-encoded), e.g. "/". */
+  path: string
+  /** Canonical query string (sorted, URI-encoded), or "" for a body request. */
+  canonicalQuery: string
+  /** Header name (lowercase) → value, exactly as they will be signed. */
+  headers: Record<string, string>
+  /** Hex SHA-256 of the request payload (empty body = SHA-256 of ""). */
+  payloadHash: string
+  region: string
+  service: string
+  /** SigV4 amz-date `YYYYMMDDTHHMMSSZ`. */
+  amzDate: string
+  secretAccessKey: string
+}
+
+/** Intermediate + final products of a SigV4 computation (for assertions). */
+export interface SigV4Computation {
+  canonicalRequest: string
+  signedHeaders: string
+  stringToSign: string
+  signature: string
+}
+
+/**
+ * Compute the SigV4 canonical request, string-to-sign, and final hex signature
+ * for an explicit set of inputs. This is the algorithmic core that `signAwsRequest`
+ * is built on; exposing it lets a test pin the implementation against AWS's
+ * published worked examples (a true external oracle, not a self-comparison).
+ */
+export async function computeSigV4(
+  input: CanonicalRequestInput,
+): Promise<SigV4Computation> {
+  const stamp = input.amzDate.slice(0, 8)
+  const sortedHeaderNames = Object.keys(input.headers).sort()
+  const canonicalHeaders = sortedHeaderNames
+    .map((n) => `${n}:${input.headers[n]}\n`)
+    .join('')
+  const signedHeaders = sortedHeaderNames.join(';')
+
+  const canonicalRequest = [
+    input.method,
+    input.path,
+    input.canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    input.payloadHash,
+  ].join('\n')
+
+  const scope = `${stamp}/${input.region}/${input.service}/aws4_request`
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    input.amzDate,
+    scope,
+    await sha256Hex(canonicalRequest),
+  ].join('\n')
+
+  const kDate = await hmac(encoder.encode(`AWS4${input.secretAccessKey}`), stamp)
+  const kRegion = await hmac(kDate, input.region)
+  const kService = await hmac(kRegion, input.service)
+  const key = await hmac(kService, 'aws4_request')
+  const signature = toHex(await hmac(key, stringToSign))
+
+  return { canonicalRequest, signedHeaders, stringToSign, signature }
+}
+
+/** Hex SHA-256 of a string. Exported for reference-vector tests (empty body etc). */
+export async function hashHex(data: string): Promise<string> {
+  return sha256Hex(data)
 }
 
 /**
@@ -124,31 +205,21 @@ export async function signAwsRequest(opts: {
     baseHeaders['x-amz-security-token'] = credentials.sessionToken
   }
 
-  const sortedHeaderNames = Object.keys(baseHeaders).sort()
-  const canonicalHeaders =
-    sortedHeaderNames.map((n) => `${n}:${baseHeaders[n]}\n`).join('')
-  const signedHeaders = sortedHeaderNames.join(';')
-
-  const canonicalRequest = [
-    'POST',
-    url.pathname || '/',
-    url.search.replace(/^\?/, ''), // canonical query string (empty for body POST)
-    canonicalHeaders,
-    signedHeaders,
+  // Delegate to the shared SigV4 core so the production signer and the
+  // reference-vector test exercise the EXACT same algorithm (#508).
+  const { signedHeaders, signature } = await computeSigV4({
+    method: 'POST',
+    path: url.pathname || '/',
+    canonicalQuery: url.search.replace(/^\?/, ''), // empty for a body POST
+    headers: baseHeaders,
     payloadHash,
-  ].join('\n')
+    region,
+    service,
+    amzDate: amz,
+    secretAccessKey: credentials.secretAccessKey,
+  })
 
   const scope = `${stamp}/${region}/${service}/aws4_request`
-  const stringToSign = [
-    'AWS4-HMAC-SHA256',
-    amz,
-    scope,
-    await sha256Hex(canonicalRequest),
-  ].join('\n')
-
-  const key = await signingKey(credentials.secretAccessKey, date, region, service)
-  const signature = toHex(await hmac(key, stringToSign))
-
   const authorization =
     `AWS4-HMAC-SHA256 Credential=${credentials.accessKeyId}/${scope}, ` +
     `SignedHeaders=${signedHeaders}, Signature=${signature}`

--- a/web/packages/baas-worker/src/ec2.test.ts
+++ b/web/packages/baas-worker/src/ec2.test.ts
@@ -88,6 +88,35 @@ describe('parseDescribeInstancesResponse', () => {
     expect(list[0].subscriptionTag).toBe('sub_ABC')
   })
 
+  it('extracts the botho:rig-id tag and parses launchTime to epoch ms', () => {
+    const xml = `<DescribeInstancesResponse><reservationSet><item>
+      <instancesSet>
+        <item>
+          <instanceId>i-222</instanceId>
+          <instanceState><name>pending</name></instanceState>
+          <launchTime>2026-06-21T12:00:00.000Z</launchTime>
+          <tagSet>
+            <item><key>botho:managed-rig</key><value>true</value></item>
+            <item><key>botho:subscription</key><value>sub_DEF</value></item>
+            <item><key>botho:rig-id</key><value>def456</value></item>
+          </tagSet>
+        </item>
+      </instancesSet>
+    </item></reservationSet></DescribeInstancesResponse>`
+    const list = parseDescribeInstancesResponse(xml)
+    expect(list).toHaveLength(1)
+    expect(list[0].subscriptionTag).toBe('sub_DEF')
+    expect(list[0].rigIdTag).toBe('def456')
+    expect(list[0].launchTimeMs).toBe(Date.parse('2026-06-21T12:00:00.000Z'))
+  })
+
+  it('leaves launchTimeMs undefined when the field is absent', () => {
+    const xml = `<instancesSet><item><instanceId>i-333</instanceId>
+      <instanceState><name>running</name></instanceState></item></instancesSet>`
+    const list = parseDescribeInstancesResponse(xml)
+    expect(list[0].launchTimeMs).toBeUndefined()
+  })
+
   it('returns an empty array when nothing matches', () => {
     expect(parseDescribeInstancesResponse('<Response/>')).toEqual([])
   })
@@ -124,6 +153,20 @@ describe('HttpEc2Client (mocked fetch — no real AWS)', () => {
     expect(url).toBe('https://ec2.us-west-2.amazonaws.com/')
     const headers = init.headers as Record<string, string>
     expect(headers.Authorization).toContain('AWS4-HMAC-SHA256')
+  })
+
+  it('describeManagedRigs filters on the botho:managed-rig=true tag', async () => {
+    let sentBody = ''
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      sentBody = String(init.body)
+      return new Response('<DescribeInstancesResponse/>', { status: 200 })
+    })
+    const client = new HttpEc2Client(creds, fetchMock as unknown as typeof fetch)
+    await client.describeManagedRigs('us-west-2')
+    const params = new URLSearchParams(sentBody)
+    expect(params.get('Action')).toBe('DescribeInstances')
+    expect(params.get('Filter.1.Name')).toBe('tag:botho:managed-rig')
+    expect(params.get('Filter.1.Value.1')).toBe('true')
   })
 
   it('throws Ec2Error on an AWS error response', async () => {

--- a/web/packages/baas-worker/src/ec2.ts
+++ b/web/packages/baas-worker/src/ec2.ts
@@ -6,11 +6,12 @@
  * makes a real AWS call in a test code path (#502 test requirement).
  *
  * The real implementation (`HttpEc2Client`) signs requests with SigV4
- * (`aws-sigv4.ts`) and talks to the EC2 query API. Only the three verbs the
- * provisioner/teardown need are implemented:
+ * (`aws-sigv4.ts`) and talks to the EC2 query API. Only the verbs the
+ * provisioner/teardown/reconciler need are implemented:
  *   - RunInstances        (launch a managed rig)
- *   - DescribeInstances   (idempotency reconcile by the botho:subscription tag)
- *   - TerminateInstances  (teardown)
+ *   - DescribeInstances   (idempotency reconcile by the botho:subscription tag,
+ *                          AND the SEC sweep listing ALL botho:managed-rig=true)
+ *   - TerminateInstances  (teardown / orphan reaping)
  *
  * Tags applied to every launch (#458 §3 step 1, §5):
  *   botho:managed-rig=true, botho:subscription=<sub>, botho:user=<user>,
@@ -28,6 +29,14 @@ export interface Ec2Instance {
   publicIp?: string
   /** Value of the `botho:subscription` tag, if present. */
   subscriptionTag?: string
+  /** Value of the `botho:rig-id` tag, if present (for DNS cleanup on reap). */
+  rigIdTag?: string
+  /**
+   * EC2 `<launchTime>` parsed to epoch ms. Used by the reconciliation sweep
+   * (#508) to detect "stuck-provisioning" rigs that never reached `running`
+   * within a threshold. Undefined if the field was absent in the response.
+   */
+  launchTimeMs?: number
 }
 
 /** Parameters for launching one managed rig. */
@@ -56,7 +65,15 @@ export interface Ec2Client {
    * in `region`. Used to reconcile idempotency against AWS itself, not just D1.
    */
   describeBySubscription(region: string, subscriptionId: string): Promise<Ec2Instance[]>
-  /** Terminate an instance (teardown). Safe to call if already terminated. */
+  /**
+   * List ALL instances tagged `botho:managed-rig=true` in `region`. This is the
+   * input to the SEC reconciliation sweep (#508 / #458 §5): it enumerates every
+   * managed rig EC2 knows about so the sweep can cross-check each against Stripe
+   * and reap orphans. The `botho:managed-rig=true` filter means the sweep can
+   * only ever SEE managed rigs — never the seed/seed2/faucet nodes.
+   */
+  describeManagedRigs(region: string): Promise<Ec2Instance[]>
+  /** Terminate an instance (teardown / orphan reaping). Safe if already gone. */
   terminateInstance(region: string, instanceId: string): Promise<void>
 }
 
@@ -149,7 +166,18 @@ export function parseDescribeInstancesResponse(xml: string): Ec2Instance[] {
       block,
       /<key>botho:subscription<\/key>\s*<value>([^<]+)<\/value>/,
     )
-    out.push({ instanceId: starts[i].id, state, publicIp, subscriptionTag })
+    const rigIdTag = pick(block, /<key>botho:rig-id<\/key>\s*<value>([^<]+)<\/value>/)
+    const launchTimeRaw = pick(block, /<launchTime>([^<]+)<\/launchTime>/)
+    const parsed = launchTimeRaw ? Date.parse(launchTimeRaw) : NaN
+    const launchTimeMs = Number.isNaN(parsed) ? undefined : parsed
+    out.push({
+      instanceId: starts[i].id,
+      state,
+      publicIp,
+      subscriptionTag,
+      rigIdTag,
+      launchTimeMs,
+    })
   }
   return out
 }
@@ -213,6 +241,19 @@ export class HttpEc2Client implements Ec2Client {
     body.set('Version', EC2_API_VERSION)
     body.set('Filter.1.Name', 'tag:botho:subscription')
     body.set('Filter.1.Value.1', subscriptionId)
+    const xml = await this.send(region, body)
+    return parseDescribeInstancesResponse(xml)
+  }
+
+  async describeManagedRigs(region: string): Promise<Ec2Instance[]> {
+    const body = new URLSearchParams()
+    body.set('Action', 'DescribeInstances')
+    body.set('Version', EC2_API_VERSION)
+    // Scope the listing to managed rigs ONLY. This is the same tag IAM uses to
+    // gate TerminateInstances, so the sweep can never even enumerate (let alone
+    // terminate) the seed/seed2/faucet nodes (#458 §5).
+    body.set('Filter.1.Name', 'tag:botho:managed-rig')
+    body.set('Filter.1.Value.1', 'true')
     const xml = await this.send(region, body)
     return parseDescribeInstancesResponse(xml)
   }

--- a/web/packages/baas-worker/src/iam-policy.test.ts
+++ b/web/packages/baas-worker/src/iam-policy.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import policy from '../iam/provisioner-policy.json'
+
+/**
+ * Validates the committed provisioner IAM policy (#508, #458 §5). The policy is a
+ * deliverable artifact; these checks assert it stays valid JSON AND keeps the
+ * load-bearing security properties — most importantly that TerminateInstances is
+ * tag-conditioned to `botho:managed-rig=true` so the credential can NEVER
+ * terminate the seed/seed2/faucet nodes.
+ *
+ * The JSON is imported as a module (resolveJsonModule), so a parse failure or a
+ * shape regression is caught at type-check time too — no fs/node dependency.
+ */
+
+interface Statement {
+  Sid?: string
+  Effect: string
+  Action: string | string[]
+  Resource: string | string[]
+  Condition?: Record<string, Record<string, unknown>>
+}
+
+const statements = policy.Statement as unknown as Statement[]
+
+function actionsOf(s: Statement): string[] {
+  return Array.isArray(s.Action) ? s.Action : [s.Action]
+}
+
+describe('provisioner IAM policy', () => {
+  it('has the IAM policy shape', () => {
+    expect(policy.Version).toBe('2012-10-17')
+    expect(Array.isArray(statements)).toBe(true)
+    expect(statements.length).toBeGreaterThan(0)
+    for (const s of statements) {
+      expect(s.Effect).toBe('Allow')
+      expect(s.Action).toBeDefined()
+      expect(s.Resource).toBeDefined()
+    }
+  })
+
+  it('does NOT contain IAM "Comment" keys (IAM would reject them)', () => {
+    const raw = JSON.stringify(policy)
+    expect(raw).not.toContain('"Comment"')
+  })
+
+  it('grants ONLY the four allowed EC2 verbs (no IAM, no S3, no broad EC2)', () => {
+    const allActions = new Set(statements.flatMap(actionsOf))
+    expect(allActions).toEqual(
+      new Set([
+        'ec2:DescribeInstances',
+        'ec2:RunInstances',
+        'ec2:CreateTags',
+        'ec2:TerminateInstances',
+      ]),
+    )
+    for (const a of allActions) {
+      expect(a.startsWith('iam:')).toBe(false)
+      expect(a.startsWith('s3:')).toBe(false)
+      expect(a).not.toBe('ec2:*')
+      expect(a).not.toBe('*')
+    }
+  })
+
+  it('restricts TerminateInstances to botho:managed-rig=true resources (CRITICAL)', () => {
+    const term = statements.find((s) =>
+      actionsOf(s).includes('ec2:TerminateInstances'),
+    )
+    expect(term).toBeDefined()
+    const cond = term?.Condition?.StringEquals as Record<string, unknown> | undefined
+    expect(cond).toBeDefined()
+    // The load-bearing guarantee: terminate is gated on the managed-rig tag, so
+    // the seed/seed2/faucet nodes (which lack it) can never be terminated.
+    expect(cond?.['ec2:ResourceTag/botho:managed-rig']).toBe('true')
+  })
+
+  it('constrains RunInstances to t4g.medium + us-west-2 + the required tag', () => {
+    const runStmts = statements.filter((s) =>
+      actionsOf(s).includes('ec2:RunInstances'),
+    )
+    expect(runStmts.length).toBeGreaterThan(0)
+    const constrained = runStmts.find((s) => s.Condition?.StringEquals !== undefined)
+    expect(constrained).toBeDefined()
+    const eq = constrained?.Condition?.StringEquals as Record<string, unknown>
+    expect(eq['ec2:InstanceType']).toBe('t4g.medium')
+    expect(eq['ec2:Region']).toBe('us-west-2')
+    expect(eq['aws:RequestTag/botho:managed-rig']).toBe('true')
+  })
+
+  it('allows CreateTags ONLY as part of a RunInstances launch (tag-on-create)', () => {
+    const tag = statements.find((s) => actionsOf(s).includes('ec2:CreateTags'))
+    expect(tag).toBeDefined()
+    const eq = tag?.Condition?.StringEquals as Record<string, unknown> | undefined
+    expect(eq?.['ec2:CreateAction']).toBe('RunInstances')
+  })
+})

--- a/web/packages/baas-worker/src/index.ts
+++ b/web/packages/baas-worker/src/index.ts
@@ -43,6 +43,12 @@ import {
   StripePortalError,
 } from './status'
 import { D1RigStore, type D1Like } from './rig-store'
+import { reconcileOnce } from './reconcile'
+import {
+  missingReconcileEnv,
+  reconcileDepsFromEnv,
+  type ReconcileEnv,
+} from './reconcile-env'
 
 // Re-export the provisioner surface so the webhook (and any future consumer) can
 // import everything from the package entry without reaching into modules.
@@ -62,6 +68,24 @@ export {
   type WebhookEnv,
 } from './webhook'
 export { mintStatusToken, verifyStatusToken } from './status-link'
+export {
+  reconcileOnce,
+  type ReconcileDeps,
+  type ReconcileReport,
+  type ReconcileItem,
+  type ReconcileDisposition,
+} from './reconcile'
+export {
+  missingReconcileEnv,
+  reconcileDepsFromEnv,
+  reconcileRegions,
+  type ReconcileEnv,
+} from './reconcile-env'
+export {
+  isActiveSubscriptionStatus,
+  HttpSubscriptionChecker,
+  type SubscriptionChecker,
+} from './stripe-subscriptions'
 export {
   lookupStatusForCustomer,
   createPortalSession,
@@ -89,7 +113,12 @@ export interface StatusEnv {
   PORTAL_RETURN_URL?: string
 }
 
-export interface Env extends CheckoutEnv, ProvisionerEnv, WebhookEnv, StatusEnv {
+export interface Env
+  extends CheckoutEnv,
+    ProvisionerEnv,
+    WebhookEnv,
+    StatusEnv,
+    ReconcileEnv {
   /**
    * Comma-separated list of origins allowed to call the browser-facing
    * endpoints (/checkout, /status, /portal). When unset, CORS is not granted
@@ -411,6 +440,45 @@ export async function handlePortal(
   }
 }
 
+/**
+ * Handle the scheduled (cron) trigger — the SEC reconciliation sweep (#508,
+ * #458 §5). Lists every `botho:managed-rig=true` EC2 instance, cross-checks each
+ * `botho:subscription` against Stripe, and reaps orphans (cancelled / unpaid /
+ * absent / stuck-provisioning). The cost-bleed safety net behind the webhook.
+ *
+ * Fails closed: if the reconciler env is unconfigured it logs and no-ops (never
+ * touches infra with partial creds). `depsFor` is injectable so tests supply
+ * in-memory fakes; in production it builds real EC2/DNS/D1/Stripe clients. NO
+ * real call happens in a test code path.
+ */
+export async function handleScheduled(
+  env: Env,
+  depsFor: (env: Env) => ReturnType<typeof reconcileDepsFromEnv> = (e) =>
+    reconcileDepsFromEnv(e),
+): Promise<void> {
+  const missing = missingReconcileEnv(env)
+  if (missing.length > 0) {
+    console.error('reconcile: not configured, skipping sweep', missing)
+    return
+  }
+  let deps: ReturnType<typeof reconcileDepsFromEnv>
+  try {
+    deps = depsFor(env)
+  } catch (err) {
+    console.error('reconcile: failed to build deps', err)
+    return
+  }
+  try {
+    const report = await reconcileOnce(deps)
+    console.log(
+      `reconcile: scanned=${report.scanned} reaped=${report.reaped} skipped=${report.skipped}`,
+    )
+  } catch (err) {
+    // A sweep error is logged; the next scheduled run retries (idempotent).
+    console.error('reconcile: sweep error', err)
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url)
@@ -442,5 +510,14 @@ export default {
     }
 
     return jsonResponse({ error: 'not found' }, 404)
+  },
+
+  // Cron trigger (wrangler.toml [triggers].crons) — the reconciliation sweep.
+  async scheduled(
+    _event: ScheduledController,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    ctx.waitUntil(handleScheduled(env))
   },
 } satisfies ExportedHandler<Env>

--- a/web/packages/baas-worker/src/provisioner.test.ts
+++ b/web/packages/baas-worker/src/provisioner.test.ts
@@ -156,10 +156,15 @@ describe('idempotency (#458 §3, §5)', () => {
     const { deps, ec2, store } = makeDeps()
     ec2.runPublicIp = '203.0.113.10'
     await provisionRig(REQ, deps)
+    // A real teardown terminates the EC2 instance AND marks D1 terminated. The
+    // explicit per-sub cap (#508 step 5b) cross-checks EC2, so a terminated D1
+    // row alone must not be enough to re-launch while a live box still exists —
+    // teardown must have actually removed it. Simulate that here.
+    ec2.bySubscription.delete('sub_ABC123')
     await store.setState('sub_ABC123', 'terminated')
 
-    // A brand-new subscription id would be the real-world case, but a terminated
-    // row must not block a fresh launch for the same id either.
+    // With both D1 terminated AND the EC2 instance gone, a fresh launch for the
+    // same id is allowed (state machine).
     const again = await provisionRig(REQ, deps)
     expect(again.ok).toBe(true)
     expect(ec2.runCalls).toHaveLength(2)
@@ -215,6 +220,39 @@ describe('safety caps (#458 §5)', () => {
     await provisionRig(REQ, deps)
     await provisionRig(REQ, deps)
     expect(ec2.runCalls).toHaveLength(1)
+  })
+
+  it('explicit per-sub cap (#508 step 5b): adopts a live tagged instance instead of launching a second, even when the D1 row has no instance id', async () => {
+    const { deps, ec2, store } = makeDeps({ fleetCap: 100 })
+    // A provisioning row exists with NO instance id...
+    await store.insertProvisioning({
+      user: 'cus_XYZ',
+      stripeCustomer: 'cus_XYZ',
+      subscriptionId: 'sub_ABC123',
+      rigId: 'abc123',
+      region: 'us-west-2',
+      rpcUrl: 'https://rig-abc123.testnet.botho.io/rpc',
+    })
+    // ...and EC2 already has a LIVE instance carrying this subscription tag.
+    ec2.bySubscription.set('sub_ABC123', [
+      {
+        instanceId: 'i-existing',
+        state: 'running',
+        publicIp: '203.0.113.77',
+        subscriptionTag: 'sub_ABC123',
+        rigIdTag: 'abc123',
+      },
+    ])
+
+    const out = await provisionRig(REQ, deps)
+    expect(out.ok).toBe(true)
+    // The explicit MAX_INSTANCES_PER_SUBSCRIPTION cap means NO second launch.
+    expect(ec2.runCalls).toHaveLength(0)
+    if (out.ok) {
+      expect(out.record.instanceId).toBe('i-existing')
+      expect(out.created).toBe(false)
+    }
+    expect(store.rows.get('sub_ABC123')?.state).toBe('running')
   })
 
   it('rejects a missing subscriptionId / customerId', async () => {

--- a/web/packages/baas-worker/src/provisioner.ts
+++ b/web/packages/baas-worker/src/provisioner.ts
@@ -33,6 +33,7 @@ import {
   DEFAULT_RIG_DOMAIN,
   isAllowedInstanceType,
   isAllowedRegion,
+  MAX_INSTANCES_PER_SUBSCRIPTION,
   rigHostname,
   rigRpcUrl,
   TAG_MANAGED_RIG,
@@ -91,6 +92,11 @@ export type ProvisionErrorCode =
   | 'region_not_allowed'
   | 'instance_type_not_allowed'
   | 'fleet_cap_reached'
+  // `per_subscription_cap` is retained for callers that prefer to treat a
+  // would-be-second launch as an error rather than an adopt. The provisioner's
+  // own policy is to ADOPT the existing instance (step 5b) — idempotent and
+  // safer than failing — so it does not currently return this code, but the
+  // explicit `MAX_INSTANCES_PER_SUBSCRIPTION` cap that backs it is now enforced.
   | 'per_subscription_cap'
   | 'invalid_request'
   | 'launch_failed'
@@ -215,6 +221,35 @@ export async function provisionRig(
       region: req.region,
       rpcUrl,
     })
+  }
+
+  // --- 5b. EXPLICIT per-subscription cap (#508, #458 §5) --------------------
+  // The 1-per-subscription guarantee is *structural* (subscription_id is UNIQUE
+  // in D1, and steps 2-3 adopt any pre-existing/orphaned instance rather than
+  // launching a second). SEC adds the cap as an EXPLICIT, counted defense in
+  // depth: immediately before RunInstances we re-count live instances carrying
+  // this `botho:subscription` tag in EC2 and refuse to launch if the cap is
+  // already met. This wires in `MAX_INSTANCES_PER_SUBSCRIPTION` (previously a
+  // dead symbol the #526 Judge flagged) and closes the narrow window where a
+  // concurrent in-flight launch could otherwise double-provision.
+  const liveForSub = (
+    await deps.ec2.describeBySubscription(req.region, req.subscriptionId)
+  ).filter((i) => isLiveInstanceState(i.state))
+  if (liveForSub.length >= MAX_INSTANCES_PER_SUBSCRIPTION) {
+    // Adopt the existing instance instead of launching another.
+    const adopt = liveForSub[0]
+    await deps.store.setInstanceId(req.subscriptionId, adopt.instanceId)
+    let state = record.state
+    if (adopt.publicIp) {
+      await deps.dns.upsertARecord(hostname, adopt.publicIp)
+      await deps.store.setState(req.subscriptionId, 'running')
+      state = 'running'
+    }
+    return {
+      ok: true,
+      record: { ...record, instanceId: adopt.instanceId, state },
+      created: false,
+    }
   }
 
   // --- 6. Launch the instance (tagged) with rig-bootstrap user-data ---------

--- a/web/packages/baas-worker/src/reconcile-env.ts
+++ b/web/packages/baas-worker/src/reconcile-env.ts
@@ -1,0 +1,111 @@
+/**
+ * Build `ReconcileDeps` from the Worker environment for the SEC reconciliation
+ * cron (#508, #458 §5). Kept separate from `reconcile.ts` so the sweep logic
+ * stays pure/testable with fakes while this thin adapter wires the production
+ * clients (the same split as `provisioner-env.ts`).
+ *
+ * The scheduled handler calls `reconcileOnce(reconcileDepsFromEnv(env))`.
+ *
+ * SECRETS (Worker secrets, never the repo — #458 §5):
+ *   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, (optional) AWS_SESSION_TOKEN
+ *   CF_DNS_API_TOKEN, CF_DNS_ZONE_ID, STRIPE_SECRET_KEY
+ * VARS (non-secret): RIG_DOMAIN, RECONCILE_REGIONS, STUCK_PROVISIONING_MS.
+ * BINDING: DB (D1).
+ */
+
+import { HttpDnsClient } from './cloudflare-dns'
+import { HttpEc2Client } from './ec2'
+import type { ProvisionerEnv } from './provisioner-env'
+import {
+  DEFAULT_RIG_DOMAIN,
+  REGION_ALLOWLIST,
+} from './rig-config'
+import { DEFAULT_STUCK_PROVISIONING_MS, type ReconcileDeps } from './reconcile'
+import { D1RigStore, type D1Like } from './rig-store'
+import { HttpSubscriptionChecker } from './stripe-subscriptions'
+
+/** Worker env keys the reconciler needs beyond the provisioner's. */
+export interface ReconcileEnv extends ProvisionerEnv {
+  /**
+   * Stripe secret key (TEST while on testnet) — used to check subscription
+   * status. Typed `string` to match `CheckoutEnv` so the combined Worker `Env`
+   * can extend both; `missingReconcileEnv` still guards against an empty value.
+   */
+  STRIPE_SECRET_KEY: string
+  /**
+   * Comma-separated regions to sweep. Defaults to the provisioner's
+   * REGION_ALLOWLIST (the only regions a rig can be launched in).
+   */
+  RECONCILE_REGIONS?: string
+  /** Override the stuck-provisioning threshold (ms). */
+  STUCK_PROVISIONING_MS?: string
+}
+
+/** Required keys for the reconciler; returns the missing ones (fail closed). */
+export function missingReconcileEnv(env: ReconcileEnv): string[] {
+  const required: (keyof ReconcileEnv)[] = [
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
+    'CF_DNS_API_TOKEN',
+    'CF_DNS_ZONE_ID',
+    'STRIPE_SECRET_KEY',
+    'DB',
+  ]
+  return required.filter((k) => {
+    const v = env[k]
+    if (k === 'DB') return v == null
+    return typeof v !== 'string' || v.length === 0
+  })
+}
+
+/** Parse the regions list, falling back to the launch allowlist. */
+export function reconcileRegions(env: ReconcileEnv): string[] {
+  if (env.RECONCILE_REGIONS && env.RECONCILE_REGIONS.trim().length > 0) {
+    return env.RECONCILE_REGIONS.split(',')
+      .map((r) => r.trim())
+      .filter((r) => r.length > 0)
+  }
+  return [...REGION_ALLOWLIST]
+}
+
+/**
+ * Construct production `ReconcileDeps` from the env. Throws if a required
+ * secret/binding is missing (call `missingReconcileEnv` first to fail closed).
+ * `fetchImpl` is injectable for integration tests.
+ */
+export function reconcileDepsFromEnv(
+  env: ReconcileEnv,
+  fetchImpl: typeof fetch = fetch,
+): ReconcileDeps {
+  const missing = missingReconcileEnv(env)
+  if (missing.length > 0) {
+    throw new Error(`reconciler not configured; missing: ${missing.join(', ')}`)
+  }
+  const ec2 = new HttpEc2Client(
+    {
+      accessKeyId: env.AWS_ACCESS_KEY_ID as string,
+      secretAccessKey: env.AWS_SECRET_ACCESS_KEY as string,
+      sessionToken: env.AWS_SESSION_TOKEN,
+    },
+    fetchImpl,
+  )
+  const dns = new HttpDnsClient(
+    env.CF_DNS_API_TOKEN as string,
+    env.CF_DNS_ZONE_ID as string,
+    fetchImpl,
+  )
+  const store = new D1RigStore(env.DB as D1Like)
+  const stripe = new HttpSubscriptionChecker(env.STRIPE_SECRET_KEY as string, fetchImpl)
+
+  return {
+    ec2,
+    dns,
+    store,
+    stripe,
+    regions: reconcileRegions(env),
+    rigDomain: env.RIG_DOMAIN || DEFAULT_RIG_DOMAIN,
+    stuckProvisioningMs: env.STUCK_PROVISIONING_MS
+      ? Number(env.STUCK_PROVISIONING_MS)
+      : DEFAULT_STUCK_PROVISIONING_MS,
+  }
+}

--- a/web/packages/baas-worker/src/reconcile.test.ts
+++ b/web/packages/baas-worker/src/reconcile.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest'
+import { reconcileOnce, type ReconcileDeps } from './reconcile'
+import type { Ec2Instance } from './ec2'
+import { rigHostname, TAG_MANAGED_RIG } from './rig-config'
+import {
+  FakeDns,
+  FakeEc2,
+  FakeStore,
+  FakeSubscriptionChecker,
+} from './test-fakes'
+
+const REGION = 'us-west-2'
+const NOW = 1_700_000_000_000
+
+function makeDeps(overrides: Partial<ReconcileDeps> = {}): {
+  deps: ReconcileDeps
+  ec2: FakeEc2
+  dns: FakeDns
+  store: FakeStore
+  stripe: FakeSubscriptionChecker
+} {
+  const ec2 = new FakeEc2()
+  const dns = new FakeDns()
+  const store = new FakeStore()
+  const stripe = new FakeSubscriptionChecker()
+  const deps: ReconcileDeps = {
+    ec2,
+    dns,
+    store,
+    stripe,
+    regions: [REGION],
+    now: () => NOW,
+    ...overrides,
+  }
+  return { deps, ec2, dns, store, stripe }
+}
+
+/** Build a managed-rig EC2 instance fixture. */
+function rig(partial: Partial<Ec2Instance> & { instanceId: string }): Ec2Instance {
+  return {
+    state: 'running',
+    subscriptionTag: undefined,
+    rigIdTag: undefined,
+    publicIp: '1.2.3.4',
+    launchTimeMs: NOW - 60_000,
+    ...partial,
+  }
+}
+
+describe('reconcileOnce', () => {
+  it('leaves an instance whose subscription is ACTIVE strictly alone', async () => {
+    const { deps, ec2, stripe } = makeDeps()
+    ec2.managedByRegion.set(REGION, [
+      rig({ instanceId: 'i-active', subscriptionTag: 'sub_active', rigIdTag: 'active1' }),
+    ])
+    stripe.active.add('sub_active')
+
+    const report = await reconcileOnce(deps)
+
+    expect(ec2.terminateCalls).toEqual([])
+    expect(report.reaped).toBe(0)
+    expect(report.items[0].disposition).toBe('active')
+    expect(report.items[0].reaped).toBe(false)
+  })
+
+  it('terminates an instance whose subscription is CANCELLED/absent in Stripe', async () => {
+    const { deps, ec2, dns, store } = makeDeps()
+    // Seed D1 so we can assert it is marked terminated.
+    await store.insertProvisioning({
+      user: 'cus_1',
+      stripeCustomer: 'cus_1',
+      subscriptionId: 'sub_dead',
+      rigId: 'dead1',
+      region: REGION,
+      rpcUrl: 'https://rig-dead1.testnet.botho.io/rpc',
+    })
+    await store.setInstanceId('sub_dead', 'i-dead')
+    ec2.managedByRegion.set(REGION, [
+      rig({ instanceId: 'i-dead', subscriptionTag: 'sub_dead', rigIdTag: 'dead1' }),
+    ])
+    // stripe.active is empty → sub_dead is NOT active.
+
+    const report = await reconcileOnce(deps)
+
+    expect(ec2.terminateCalls).toEqual([{ region: REGION, instanceId: 'i-dead' }])
+    expect(dns.deleteCalls).toContain(rigHostname('dead1'))
+    expect((await store.getBySubscription('sub_dead'))?.state).toBe('terminated')
+    expect(report.reaped).toBe(1)
+    expect(report.items[0].disposition).toBe('orphan_cancelled')
+  })
+
+  it('terminates a STUCK-PROVISIONING rig past the threshold (inactive sub)', async () => {
+    const { deps, ec2 } = makeDeps({ stuckProvisioningMs: 30 * 60 * 1000 })
+    ec2.managedByRegion.set(REGION, [
+      rig({
+        instanceId: 'i-stuck',
+        subscriptionTag: 'sub_stuck',
+        rigIdTag: 'stuck1',
+        state: 'pending', // never reached running
+        publicIp: undefined,
+        launchTimeMs: NOW - 60 * 60 * 1000, // launched an hour ago
+      }),
+    ])
+    // sub_stuck not active
+
+    const report = await reconcileOnce(deps)
+
+    expect(ec2.terminateCalls).toEqual([{ region: REGION, instanceId: 'i-stuck' }])
+    expect(report.items[0].disposition).toBe('orphan_stuck_provisioning')
+    expect(report.reaped).toBe(1)
+  })
+
+  it('terminates a managed rig with NO subscription tag (orphan by definition)', async () => {
+    const { deps, ec2, stripe } = makeDeps()
+    ec2.managedByRegion.set(REGION, [
+      rig({ instanceId: 'i-notag', subscriptionTag: undefined, rigIdTag: 'notag1' }),
+    ])
+
+    const report = await reconcileOnce(deps)
+
+    expect(ec2.terminateCalls).toEqual([{ region: REGION, instanceId: 'i-notag' }])
+    expect(report.items[0].disposition).toBe('orphan_no_subscription_tag')
+    // Stripe is never consulted for a tag-less rig.
+    expect(stripe.calls).toEqual([])
+  })
+
+  it('SKIPS (does not reap) a rig when the Stripe lookup errors transiently', async () => {
+    const { deps, ec2, stripe } = makeDeps()
+    ec2.managedByRegion.set(REGION, [
+      rig({ instanceId: 'i-hiccup', subscriptionTag: 'sub_hiccup', rigIdTag: 'hiccup1' }),
+    ])
+    stripe.throwFor.add('sub_hiccup')
+
+    const report = await reconcileOnce(deps)
+
+    // Never reap a (possibly paying) rig on a Stripe outage.
+    expect(ec2.terminateCalls).toEqual([])
+    expect(report.reaped).toBe(0)
+    expect(report.skipped).toBe(1)
+    expect(report.items[0].disposition).toBe('skipped_stripe_error')
+  })
+
+  it('NEVER touches non-managed-rig instances (only describeManagedRigs is consulted)', async () => {
+    const { deps, ec2 } = makeDeps()
+    // describeManagedRigs is the ONLY listing the sweep uses, and it is filtered
+    // by botho:managed-rig=true. Seed-node-like instances are simply never
+    // returned by it, so they can never be terminated. Assert the sweep only
+    // ever terminates what describeManagedRigs yields.
+    ec2.managedByRegion.set(REGION, [
+      rig({ instanceId: 'i-managed-dead', subscriptionTag: 'sub_dead', rigIdTag: 'd1' }),
+    ])
+    // A "seed node" the test deliberately does NOT put in managedByRegion:
+    ec2.bySubscription.set('seed', [
+      rig({ instanceId: 'i-seed-node', subscriptionTag: undefined }),
+    ])
+
+    const report = await reconcileOnce(deps)
+
+    const terminated = ec2.terminateCalls.map((c) => c.instanceId)
+    expect(terminated).toEqual(['i-managed-dead'])
+    expect(terminated).not.toContain('i-seed-node')
+    expect(report.scanned).toBe(1)
+  })
+
+  it('ignores instances already terminating/terminated', async () => {
+    const { deps, ec2 } = makeDeps()
+    ec2.managedByRegion.set(REGION, [
+      rig({ instanceId: 'i-gone', subscriptionTag: 'sub_x', state: 'terminated' }),
+      rig({ instanceId: 'i-going', subscriptionTag: 'sub_y', state: 'shutting-down' }),
+    ])
+
+    const report = await reconcileOnce(deps)
+
+    expect(ec2.terminateCalls).toEqual([])
+    expect(report.items.every((i) => i.disposition === 'skipped_not_live')).toBe(true)
+  })
+
+  it('continues the sweep when one region cannot be listed', async () => {
+    const { deps, ec2, stripe } = makeDeps({ regions: ['us-west-2', 'us-east-1'] })
+    // us-west-2 listing throws; us-east-1 still gets swept.
+    ec2.describeManagedRigsError = undefined
+    const original = ec2.describeManagedRigs.bind(ec2)
+    ec2.describeManagedRigs = async (region: string) => {
+      if (region === 'us-west-2') throw new Error('throttled')
+      return original(region)
+    }
+    ec2.managedByRegion.set('us-east-1', [
+      rig({ instanceId: 'i-east-dead', subscriptionTag: 'sub_dead', rigIdTag: 'e1' }),
+    ])
+
+    const report = await reconcileOnce(deps)
+
+    expect(ec2.terminateCalls).toEqual([
+      { region: 'us-east-1', instanceId: 'i-east-dead' },
+    ])
+    expect(report.scanned).toBe(1)
+    void stripe
+  })
+
+  it('reaps an active-then-cancelled rig only after Stripe reports inactive', async () => {
+    const { deps, ec2, stripe } = makeDeps()
+    ec2.managedByRegion.set(REGION, [
+      rig({ instanceId: 'i-a', subscriptionTag: 'sub_a', rigIdTag: 'a1' }),
+      rig({ instanceId: 'i-b', subscriptionTag: 'sub_b', rigIdTag: 'b1' }),
+    ])
+    stripe.active.add('sub_a') // a stays, b reaped
+
+    const report = await reconcileOnce(deps)
+
+    expect(ec2.terminateCalls).toEqual([{ region: REGION, instanceId: 'i-b' }])
+    expect(report.reaped).toBe(1)
+    const dispById = Object.fromEntries(report.items.map((i) => [i.instanceId, i.disposition]))
+    expect(dispById['i-a']).toBe('active')
+    expect(dispById['i-b']).toBe('orphan_cancelled')
+  })
+})
+
+describe('reconcile filter discipline', () => {
+  it('the sweep listing is gated on the botho:managed-rig tag', () => {
+    // Documents the structural guarantee asserted in the EC2 client + sweep.
+    expect(TAG_MANAGED_RIG).toBe('botho:managed-rig')
+  })
+})

--- a/web/packages/baas-worker/src/reconcile.ts
+++ b/web/packages/baas-worker/src/reconcile.ts
@@ -1,0 +1,247 @@
+/**
+ * SEC reconciliation sweep (#508, #458 §5) — the cost-bleed safety net.
+ *
+ * Reliable de-provisioning on cancel/payment-failure is critical: a rig left
+ * running after a subscription ends bleeds AWS cost indefinitely. The webhook
+ * (#506) tears down on the cancel/payment-failed events, but webhooks can be
+ * missed, mis-delivered, or race a crashed Queue consumer. This scheduled sweep
+ * is the belt-and-suspenders backstop:
+ *
+ *   1. List EVERY EC2 instance tagged `botho:managed-rig=true` (the same tag IAM
+ *      uses to gate TerminateInstances — so the sweep can only ever see/act on
+ *      managed rigs, NEVER the seed/seed2/faucet nodes).
+ *   2. For each, read its `botho:subscription` tag and cross-check it against
+ *      Stripe: is that subscription still ACTIVE?
+ *   3. Reap orphans — terminate the instance, delete its DNS record, mark the D1
+ *      row `terminated`:
+ *        - subscription cancelled / unpaid / absent in Stripe → orphan
+ *        - "stuck provisioning": never reached `running` within a threshold AND
+ *          (defensively) carries no/active subscription tag → orphan
+ *   4. Leave instances whose subscription is still active strictly alone.
+ *   5. On a TRANSIENT Stripe lookup error, SKIP that instance this cycle (never
+ *      reap a paying customer's rig because Stripe was briefly unreachable).
+ *
+ * Everything is injectable (EC2 / DNS / D1 / Stripe are interfaces), so the
+ * sweep is unit-tested with in-memory fakes and NO real AWS/Stripe/DNS/D1 call
+ * happens in a test code path.
+ */
+
+import type { DnsClient } from './cloudflare-dns'
+import type { Ec2Client, Ec2Instance } from './ec2'
+import { isLiveInstanceState } from './ec2'
+import {
+  DEFAULT_RIG_DOMAIN,
+  rigHostname,
+  TAG_MANAGED_RIG,
+} from './rig-config'
+import type { RigStore } from './rig-store'
+import {
+  StripeSubscriptionError,
+  type SubscriptionChecker,
+} from './stripe-subscriptions'
+
+/** Default age after which a not-yet-`running` rig is considered stuck. */
+export const DEFAULT_STUCK_PROVISIONING_MS = 30 * 60 * 1000 // 30 minutes
+
+/** Why a given instance was reaped (or left), for observability + tests. */
+export type ReconcileDisposition =
+  | 'active' // subscription active → left running
+  | 'orphan_cancelled' // subscription cancelled/unpaid/absent → reaped
+  | 'orphan_no_subscription_tag' // managed rig with no sub tag → reaped
+  | 'orphan_stuck_provisioning' // never reached running past threshold → reaped
+  | 'skipped_stripe_error' // transient Stripe error → skipped this cycle
+  | 'skipped_not_live' // already terminating/terminated → ignored
+
+/** Per-instance outcome of one sweep. */
+export interface ReconcileItem {
+  instanceId: string
+  region: string
+  subscriptionId?: string
+  disposition: ReconcileDisposition
+  reaped: boolean
+}
+
+/** Aggregate result of one full sweep. */
+export interface ReconcileReport {
+  scanned: number
+  reaped: number
+  skipped: number
+  items: ReconcileItem[]
+}
+
+/** Everything the reconciler needs, injected for testability. */
+export interface ReconcileDeps {
+  ec2: Ec2Client
+  dns: DnsClient
+  store: RigStore
+  stripe: SubscriptionChecker
+  /** Regions to sweep. The provisioner only launches in the allowlist. */
+  regions: string[]
+  /** Zone for rig hostnames (DNS cleanup). Default: testnet.botho.io. */
+  rigDomain?: string
+  /** Age (ms) after which a non-`running` rig is reaped as stuck. */
+  stuckProvisioningMs?: number
+  /** Injectable clock (epoch ms) so the stuck threshold is deterministic in tests. */
+  now?: () => number
+}
+
+/**
+ * Run one reconciliation sweep across all configured regions. Never throws on a
+ * single-instance failure: each instance is handled independently and its
+ * outcome recorded, so one bad row can't abort the whole sweep.
+ */
+export async function reconcileOnce(deps: ReconcileDeps): Promise<ReconcileReport> {
+  const rigDomain = deps.rigDomain ?? DEFAULT_RIG_DOMAIN
+  const stuckMs = deps.stuckProvisioningMs ?? DEFAULT_STUCK_PROVISIONING_MS
+  const now = deps.now ? deps.now() : Date.now()
+
+  const items: ReconcileItem[] = []
+
+  for (const region of deps.regions) {
+    let instances: Ec2Instance[]
+    try {
+      instances = await deps.ec2.describeManagedRigs(region)
+    } catch (err) {
+      // Can't list this region this cycle — skip it entirely (next cycle retries).
+      console.error('reconcile: describeManagedRigs failed', region, String(err))
+      continue
+    }
+
+    for (const inst of instances) {
+      const item = await reconcileInstance(inst, region, deps, {
+        rigDomain,
+        stuckMs,
+        now,
+      })
+      items.push(item)
+    }
+  }
+
+  const reaped = items.filter((i) => i.reaped).length
+  const skipped = items.filter(
+    (i) => i.disposition === 'skipped_stripe_error' || i.disposition === 'skipped_not_live',
+  ).length
+  return { scanned: items.length, reaped, skipped, items }
+}
+
+/** Classify + (if needed) reap a single managed-rig instance. */
+async function reconcileInstance(
+  inst: Ec2Instance,
+  region: string,
+  deps: ReconcileDeps,
+  cfg: { rigDomain: string; stuckMs: number; now: number },
+): Promise<ReconcileItem> {
+  const subscriptionId = inst.subscriptionTag
+
+  // Already terminating/terminated: nothing to do.
+  if (!isLiveInstanceState(inst.state)) {
+    return {
+      instanceId: inst.instanceId,
+      region,
+      subscriptionId,
+      disposition: 'skipped_not_live',
+      reaped: false,
+    }
+  }
+
+  // A managed rig with NO subscription tag can never map to a paying customer —
+  // it is an orphan by definition (e.g. a launch that lost its tag, or a manual
+  // box that wrongly carries botho:managed-rig). Reap it.
+  if (!subscriptionId) {
+    await reap(inst, region, deps, cfg.rigDomain)
+    return {
+      instanceId: inst.instanceId,
+      region,
+      disposition: 'orphan_no_subscription_tag',
+      reaped: true,
+    }
+  }
+
+  // Cross-check the subscription against Stripe.
+  let active: boolean
+  try {
+    active = await deps.stripe.isActive(subscriptionId)
+  } catch (err) {
+    // Transient Stripe error → SKIP (never reap a paying rig on a Stripe hiccup).
+    if (!(err instanceof StripeSubscriptionError)) {
+      console.error('reconcile: unexpected Stripe error', subscriptionId, String(err))
+    }
+    return {
+      instanceId: inst.instanceId,
+      region,
+      subscriptionId,
+      disposition: 'skipped_stripe_error',
+      reaped: false,
+    }
+  }
+
+  if (active) {
+    // Paying customer — leave it strictly alone, even if "stuck" (a slow boot
+    // for an active subscription is not an orphan; teardown only on non-active).
+    return {
+      instanceId: inst.instanceId,
+      region,
+      subscriptionId,
+      disposition: 'active',
+      reaped: false,
+    }
+  }
+
+  // Subscription is NOT active (cancelled / unpaid / absent). Reap.
+  await reap(inst, region, deps, cfg.rigDomain)
+
+  // Distinguish a stuck-provisioning reap (never reached running past the
+  // threshold) from a plain cancelled one, for observability.
+  const stuck =
+    inst.state !== 'running' &&
+    inst.launchTimeMs !== undefined &&
+    cfg.now - inst.launchTimeMs > cfg.stuckMs
+  return {
+    instanceId: inst.instanceId,
+    region,
+    subscriptionId,
+    disposition: stuck ? 'orphan_stuck_provisioning' : 'orphan_cancelled',
+    reaped: true,
+  }
+}
+
+/**
+ * Terminate an instance, delete its DNS record, and mark the D1 row terminated.
+ * Best-effort and independent: a failure in one step is logged but does not
+ * abort the others or the sweep. The terminate is the cost-critical step.
+ */
+async function reap(
+  inst: Ec2Instance,
+  region: string,
+  deps: ReconcileDeps,
+  rigDomain: string,
+): Promise<void> {
+  // 1. Terminate (the cost-bleed stopper). IAM restricts TerminateInstances to
+  //    botho:managed-rig=true resources, so this can never hit a seed/faucet node.
+  try {
+    await deps.ec2.terminateInstance(region, inst.instanceId)
+  } catch (err) {
+    console.error('reconcile: terminate failed', inst.instanceId, String(err))
+  }
+
+  // 2. Delete the DNS record if we can derive the hostname from the rig-id tag.
+  if (inst.rigIdTag) {
+    try {
+      await deps.dns.deleteARecord(rigHostname(inst.rigIdTag, rigDomain))
+    } catch (err) {
+      console.error('reconcile: dns delete failed', inst.rigIdTag, String(err))
+    }
+  }
+
+  // 3. Mark the D1 row terminated (idempotent; no-op if the row is absent).
+  if (inst.subscriptionTag) {
+    try {
+      await deps.store.setState(inst.subscriptionTag, 'terminated')
+    } catch (err) {
+      console.error('reconcile: D1 setState failed', inst.subscriptionTag, String(err))
+    }
+  }
+}
+
+/** The managed-rig tag the sweep filters on (re-exported for callers/docs). */
+export const MANAGED_RIG_TAG = TAG_MANAGED_RIG

--- a/web/packages/baas-worker/src/scheduled-handler.test.ts
+++ b/web/packages/baas-worker/src/scheduled-handler.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Integration tests for the scheduled (cron) handler `handleScheduled`
+ * (index.ts) — the SEC reconciliation sweep wiring (#508, #458 §5).
+ *
+ * Exercises the full handler path with injected in-memory fakes: env-gating
+ * (fail closed when unconfigured) and dispatch into `reconcileOnce`. No real
+ * AWS / Stripe / DNS / D1 is touched.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { handleScheduled, type Env } from './index'
+import {
+  FakeDns,
+  FakeEc2,
+  FakeStore,
+  FakeSubscriptionChecker,
+} from './test-fakes'
+import type { ReconcileDeps } from './reconcile'
+
+const ENV: Env = {
+  STRIPE_SECRET_KEY: 'sk_test_dummy',
+  STRIPE_PRICE_ID: 'price_test',
+  CHECKOUT_SUCCESS_URL: 'https://botho.io/rig/success',
+  CHECKOUT_CANCEL_URL: 'https://botho.io/rig',
+  AWS_ACCESS_KEY_ID: 'AKIA_TEST',
+  AWS_SECRET_ACCESS_KEY: 'secret',
+  CF_DNS_API_TOKEN: 'cf_token',
+  CF_DNS_ZONE_ID: 'zone',
+  DB: {} as never,
+}
+
+function makeDeps(): {
+  deps: ReconcileDeps & {
+    ec2: FakeEc2
+    dns: FakeDns
+    store: FakeStore
+    stripe: FakeSubscriptionChecker
+  }
+  depsFor: () => ReconcileDeps
+} {
+  const ec2 = new FakeEc2()
+  const dns = new FakeDns()
+  const store = new FakeStore()
+  const stripe = new FakeSubscriptionChecker()
+  const deps = { ec2, dns, store, stripe, regions: ['us-west-2'] }
+  return { deps, depsFor: () => deps }
+}
+
+describe('handleScheduled (cron reconciliation)', () => {
+  it('reaps an orphan and leaves an active rig (full sweep wiring)', async () => {
+    const { deps, depsFor } = makeDeps()
+    deps.ec2.managedByRegion.set('us-west-2', [
+      {
+        instanceId: 'i-active',
+        state: 'running',
+        subscriptionTag: 'sub_ok',
+        rigIdTag: 'ok1',
+        publicIp: '1.1.1.1',
+      },
+      {
+        instanceId: 'i-orphan',
+        state: 'running',
+        subscriptionTag: 'sub_dead',
+        rigIdTag: 'dead1',
+        publicIp: '2.2.2.2',
+      },
+    ])
+    deps.stripe.active.add('sub_ok')
+
+    await handleScheduled(ENV, depsFor)
+
+    expect(deps.ec2.terminateCalls).toEqual([
+      { region: 'us-west-2', instanceId: 'i-orphan' },
+    ])
+  })
+
+  it('fails closed (no-op) when the reconciler env is unconfigured', async () => {
+    const { deps, depsFor } = makeDeps()
+    deps.ec2.managedByRegion.set('us-west-2', [
+      { instanceId: 'i-x', state: 'running', subscriptionTag: 'sub_dead' },
+    ])
+    // Strip a required secret so missingReconcileEnv() trips.
+    const badEnv: Env = { ...ENV, AWS_ACCESS_KEY_ID: '' }
+
+    await handleScheduled(badEnv, depsFor)
+
+    // The sweep never ran — nothing terminated.
+    expect(deps.ec2.terminateCalls).toEqual([])
+  })
+
+  it('does not throw when a sweep step errors (logs + continues)', async () => {
+    const { deps, depsFor } = makeDeps()
+    deps.ec2.describeManagedRigsError = 'boom'
+    await expect(handleScheduled(ENV, depsFor)).resolves.toBeUndefined()
+  })
+})

--- a/web/packages/baas-worker/src/stripe-subscriptions.test.ts
+++ b/web/packages/baas-worker/src/stripe-subscriptions.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  HttpSubscriptionChecker,
+  StripeSubscriptionError,
+  isActiveSubscriptionStatus,
+} from './stripe-subscriptions'
+
+/** Build a fetch stub that returns a single canned response. */
+function fetchStub(status: number, body: unknown): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+}
+
+describe('isActiveSubscriptionStatus', () => {
+  it('treats active and trialing as active', () => {
+    expect(isActiveSubscriptionStatus('active')).toBe(true)
+    expect(isActiveSubscriptionStatus('trialing')).toBe(true)
+  })
+  it('treats everything else as inactive', () => {
+    for (const s of [
+      'canceled',
+      'unpaid',
+      'past_due',
+      'incomplete',
+      'incomplete_expired',
+      'paused',
+      undefined,
+    ]) {
+      expect(isActiveSubscriptionStatus(s as string)).toBe(false)
+    }
+  })
+})
+
+describe('HttpSubscriptionChecker', () => {
+  const KEY = 'sk_test_x'
+
+  it('returns true for an active subscription', async () => {
+    const checker = new HttpSubscriptionChecker(KEY, fetchStub(200, { status: 'active' }))
+    expect(await checker.isActive('sub_1')).toBe(true)
+  })
+
+  it('returns false for a cancelled subscription', async () => {
+    const checker = new HttpSubscriptionChecker(KEY, fetchStub(200, { status: 'canceled' }))
+    expect(await checker.isActive('sub_1')).toBe(false)
+  })
+
+  it('returns false for a 404 (subscription does not exist)', async () => {
+    const checker = new HttpSubscriptionChecker(
+      KEY,
+      fetchStub(404, { error: { message: 'No such subscription' } }),
+    )
+    expect(await checker.isActive('sub_missing')).toBe(false)
+  })
+
+  it('THROWS on a transient (non-404) error so the sweep skips, not reaps', async () => {
+    const checker = new HttpSubscriptionChecker(
+      KEY,
+      fetchStub(503, { error: { message: 'service unavailable' } }),
+    )
+    await expect(checker.isActive('sub_1')).rejects.toBeInstanceOf(
+      StripeSubscriptionError,
+    )
+  })
+
+  it('sends the Bearer token and hits the subscriptions endpoint', async () => {
+    let seenUrl = ''
+    let seenAuth = ''
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      seenUrl = url
+      seenAuth = (init?.headers as Record<string, string>)?.Authorization ?? ''
+      return new Response(JSON.stringify({ status: 'active' }), { status: 200 })
+    }) as unknown as typeof fetch
+    const checker = new HttpSubscriptionChecker(KEY, fetchImpl)
+    await checker.isActive('sub_abc')
+    expect(seenUrl).toBe('https://api.stripe.com/v1/subscriptions/sub_abc')
+    expect(seenAuth).toBe(`Bearer ${KEY}`)
+  })
+})

--- a/web/packages/baas-worker/src/stripe-subscriptions.ts
+++ b/web/packages/baas-worker/src/stripe-subscriptions.ts
@@ -1,0 +1,110 @@
+/**
+ * Stripe subscription-status client for the SEC reconciliation sweep (#508,
+ * #458 §5).
+ *
+ * The reconciliation cron needs to answer one question per managed rig: "is the
+ * `botho:subscription` tag on this EC2 instance still an ACTIVE Stripe
+ * subscription?" If not (cancelled, unpaid, or never existed), the rig is an
+ * orphan and must be reaped to stop cost bleed.
+ *
+ * The reconciler depends on the `SubscriptionChecker` *interface* — never the
+ * concrete implementation — so tests use an in-memory fake and NO real Stripe
+ * call happens in a test code path (mirrors the EC2/DNS/D1 injectable pattern).
+ *
+ * Secrets: the Stripe secret key comes from a Worker secret — never the repo.
+ */
+
+/**
+ * Stripe subscription `status` values. A subscription only entitles a running
+ * rig while it is in an ACTIVE state. `trialing` counts as active (the customer
+ * is in a paid relationship); everything else means "stop the rig".
+ *
+ * Reference: Stripe Subscription.status.
+ */
+export const ACTIVE_SUBSCRIPTION_STATUSES = new Set([
+  'active',
+  'trialing',
+])
+
+/** True if a Stripe subscription status still entitles a running rig. */
+export function isActiveSubscriptionStatus(status: string | undefined): boolean {
+  return status !== undefined && ACTIVE_SUBSCRIPTION_STATUSES.has(status)
+}
+
+/**
+ * Injectable Stripe surface for the reconciler. The single method answers
+ * "should the rig backed by this subscription keep running?".
+ */
+export interface SubscriptionChecker {
+  /**
+   * Return whether `subscriptionId` is an ACTIVE Stripe subscription. A
+   * cancelled/unpaid/absent subscription returns false (→ reap the rig). MUST be
+   * conservative on transient lookup errors: see `HttpSubscriptionChecker`,
+   * which throws so the sweep can SKIP that rig rather than wrongly reaping a
+   * paying customer's box on a Stripe hiccup.
+   */
+  isActive(subscriptionId: string): Promise<boolean>
+}
+
+/** Error from the Stripe subscriptions API (transient / non-404). */
+export class StripeSubscriptionError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message)
+    this.name = 'StripeSubscriptionError'
+  }
+}
+
+/**
+ * Real Stripe subscription checker. `fetchImpl` is injectable (defaults to
+ * global fetch); the reconciler's tests use the fake instead, so this code path
+ * never runs under test.
+ *
+ * Behavior:
+ *   - 200 + an active status  → true
+ *   - 200 + a non-active status (canceled/unpaid/past_due/incomplete...) → false
+ *   - 404 (no such subscription) → false (definitely an orphan)
+ *   - any other non-2xx → THROW (transient): the sweep treats a throw as
+ *     "skip this rig this cycle" so a Stripe outage never reaps paying rigs.
+ */
+export class HttpSubscriptionChecker implements SubscriptionChecker {
+  constructor(
+    private readonly stripeSecretKey: string,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async isActive(subscriptionId: string): Promise<boolean> {
+    const resp = await this.fetchImpl(
+      `https://api.stripe.com/v1/subscriptions/${encodeURIComponent(subscriptionId)}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.stripeSecretKey}`,
+          'Stripe-Version': '2024-06-20',
+        },
+      },
+    )
+
+    if (resp.status === 404) {
+      // The subscription does not exist in Stripe at all → orphan.
+      return false
+    }
+
+    const json = (await resp.json().catch(() => ({}))) as {
+      status?: string
+      error?: { message?: string }
+    }
+
+    if (!resp.ok) {
+      // Transient / auth / rate-limit error — do NOT treat as "inactive".
+      throw new StripeSubscriptionError(
+        json.error?.message ?? `Stripe returned HTTP ${resp.status}`,
+        resp.status,
+      )
+    }
+
+    return isActiveSubscriptionStatus(json.status)
+  }
+}

--- a/web/packages/baas-worker/src/test-fakes.ts
+++ b/web/packages/baas-worker/src/test-fakes.ts
@@ -13,6 +13,10 @@ import {
   type RigState,
   type RigStore,
 } from './rig-store'
+import {
+  StripeSubscriptionError,
+  type SubscriptionChecker,
+} from './stripe-subscriptions'
 
 /** Records each call so tests can assert on the request that was built. */
 export class FakeEc2 implements Ec2Client {
@@ -20,6 +24,15 @@ export class FakeEc2 implements Ec2Client {
   terminateCalls: { region: string; instanceId: string }[] = []
   /** Instances keyed by subscription tag, seeded by tests for reconcile paths. */
   bySubscription = new Map<string, Ec2Instance[]>()
+  /**
+   * All managed rigs per region, seeded by tests for the reconciliation sweep
+   * (#508). `describeManagedRigs(region)` returns this list. When a test does
+   * not seed it, falls back to every instance tracked via runInstance so the
+   * existing provisioner tests need no change.
+   */
+  managedByRegion = new Map<string, Ec2Instance[]>()
+  /** If set, describeManagedRigs throws for this region (transient-error tests). */
+  describeManagedRigsError: string | undefined
   private seq = 0
   /** Public IP returned by runInstance (undefined => not yet assigned). */
   runPublicIp: string | undefined
@@ -32,6 +45,7 @@ export class FakeEc2 implements Ec2Client {
       state: 'pending',
       publicIp: this.runPublicIp,
       subscriptionTag: params.tags['botho:subscription'],
+      rigIdTag: params.tags['botho:rig-id'],
     }
     const sub = params.tags['botho:subscription']
     const list = this.bySubscription.get(sub) ?? []
@@ -47,8 +61,44 @@ export class FakeEc2 implements Ec2Client {
     return this.bySubscription.get(subscriptionId) ?? []
   }
 
+  async describeManagedRigs(region: string): Promise<Ec2Instance[]> {
+    if (this.describeManagedRigsError) {
+      throw new Error(this.describeManagedRigsError)
+    }
+    if (this.managedByRegion.has(region)) {
+      return this.managedByRegion.get(region) ?? []
+    }
+    // Fallback: every instance ever launched (used when a test only seeds via
+    // runInstance and doesn't care about the per-region managed list).
+    const all: Ec2Instance[] = []
+    for (const list of this.bySubscription.values()) all.push(...list)
+    return all
+  }
+
   async terminateInstance(region: string, instanceId: string): Promise<void> {
     this.terminateCalls.push({ region, instanceId })
+  }
+}
+
+/**
+ * In-memory Stripe subscription checker for reconciliation tests. Seed
+ * `active` with the subscription ids that should be treated as active; any id
+ * not present is inactive (orphan). Set `throwFor` to simulate a transient
+ * Stripe error for specific subscription ids.
+ */
+export class FakeSubscriptionChecker implements SubscriptionChecker {
+  active = new Set<string>()
+  throwFor = new Set<string>()
+  calls: string[] = []
+
+  async isActive(subscriptionId: string): Promise<boolean> {
+    this.calls.push(subscriptionId)
+    if (this.throwFor.has(subscriptionId)) {
+      // Mirror HttpSubscriptionChecker: a transient error throws so the sweep
+      // skips the rig rather than reaping it.
+      throw new StripeSubscriptionError('simulated transient error', 503)
+    }
+    return this.active.has(subscriptionId)
   }
 }
 

--- a/web/packages/baas-worker/tsconfig.json
+++ b/web/packages/baas-worker/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "types": ["@cloudflare/workers-types"],
-    "lib": ["ES2022", "WebWorker"]
+    "lib": ["ES2022", "WebWorker"],
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }

--- a/web/packages/baas-worker/wrangler.toml
+++ b/web/packages/baas-worker/wrangler.toml
@@ -36,6 +36,14 @@ name = "botho-baas"
 main = "src/index.ts"
 compatibility_date = "2024-09-23"
 
+# --- SEC reconciliation cron (#508, #458 §5) -------------------------------
+# Scheduled sweep that lists every botho:managed-rig=true EC2 instance,
+# cross-checks each botho:subscription against Stripe, and TERMINATES orphans
+# (cancelled / unpaid / absent / stuck-provisioning). The cost-bleed safety net
+# behind the webhook teardown. Runs every 15 minutes.
+[triggers]
+crons = ["*/15 * * * *"]
+
 # D1 — the user<->rig mapping (#458 §3 step 4). Apply schema.sql before first
 # use. The `database_id` below is a PLACEHOLDER: replace it with the real id from
 # `wrangler d1 create botho-baas` (the id is an account-scoped uuid, not a
@@ -70,3 +78,13 @@ RIG_DOMAIN = "testnet.botho.io"
 FLEET_CAP = "25"
 # Where the instance fetches the bootstrap script at first boot (#499/#521).
 BOOTSTRAP_SCRIPT_URL = "https://raw.githubusercontent.com/botho-project/botho/main/infra/baas/rig-bootstrap.sh"
+
+# --- SEC reconciliation cron config (#508) --------------------------------
+# Regions the sweep scans. Defaults to the launch allowlist (us-west-2) when
+# unset; expand in lockstep with REGION_ALLOWLIST in rig-config.ts.
+RECONCILE_REGIONS = "us-west-2"
+# Age (ms) after which a not-yet-running rig with a non-active subscription is
+# reaped as "stuck provisioning". Default 1_800_000 (30 min).
+STUCK_PROVISIONING_MS = "1800000"
+# NOTE: the cron also needs STRIPE_SECRET_KEY (already a required secret for
+# /checkout) to query subscription status. No new secret is introduced.


### PR DESCRIPTION
Closes #508

Security hardening for the Botho-as-a-Service control plane (#458 §5) — the cross-cutting **SEC** issue that must land before Stripe can ever flip to **LIVE**. **Code/config/docs only**: no live calls, no deploy, no real secrets, test mode. Built on the #502/#506/#507 injectable-interface + mocked-test pattern, so **no real AWS/Stripe/DNS/D1 call runs in any test path**.

## 1. Scoped provisioner IAM policy (deliverable artifact)
- `iam/provisioner-policy.json` + `iam/README.md` — dedicated least-privilege policy, tighter than `botho-deploy`. **Only** `ec2:RunInstances` / `ec2:TerminateInstances` / `ec2:DescribeInstances` / `ec2:CreateTags`. **No IAM, no S3, no broad EC2.**
- `RunInstances` constrained to `t4g.medium` + `us-west-2` + required `botho:managed-rig=true` tag + pinned AMI/SG/subnet/key-pair.
- **CRITICAL:** `ec2:TerminateInstances` restricted by `ec2:ResourceTag/botho:managed-rig=true` → the credential can **never** terminate the seed/seed2/faucet nodes. `CreateTags` is tag-on-create only, so the tag can't be forged onto a non-managed instance.
- `src/iam-policy.test.ts` validates the JSON shape, the exact 4-verb action set, and asserts the **tag-conditioned terminate** + constrained run.

## 2. Reconciliation cron (cost-bleed safety net)
- `src/reconcile.ts` + `src/reconcile-env.ts`: scheduled sweep — list all `botho:managed-rig=true` EC2 instances → cross-check each `botho:subscription` against Stripe → **terminate orphans** (cancelled / unpaid / absent / stuck-provisioning), delete DNS, mark D1 `terminated`. Active subs **left alone**; transient Stripe errors **SKIP** (never reap a paying rig); already-terminating instances ignored; **never touches non-managed-rig instances** (the listing is tag-filtered).
- `src/stripe-subscriptions.ts`: injectable `SubscriptionChecker` (+ HTTP impl; 404 → orphan, transient → throw/skip).
- Wired as the Worker `scheduled()` handler (`handleScheduled`) with `wrangler.toml` `[triggers].crons = "*/15 * * * *"`.
- `ec2.ts`: `describeManagedRigs(region)` (tag-filtered) + `launchTime`/`rig-id` tag parsing.

## 3. Caps + SigV4 reference vector
- Confirmed region / instance-type / global-fleet caps; added an **explicit counted per-subscription cap** (provisioner step 5b) cross-checked against EC2 tags right before `RunInstances` — adopts the existing instance instead of double-launching.
- Extracted `computeSigV4` core; `src/aws-sigv4.test.ts` adds the **known-good reference-vector test** pinned against AWS's published SigV4 worked example (empty-payload hash, canonical-request hash, and final signature all byte-exact: `5d672d79…`).

## 4. Dead-symbol resolution
Wired `MAX_INSTANCES_PER_SUBSCRIPTION` into the new explicit cap; kept `per_subscription_cap` in the error-code union as a documented alternative to the adopt policy (rationale in code + README).

## LIVE-mode go/no-go checklist
Added to the README (#458 §7).

## Tests
- `pnpm --filter @botho/baas-worker typecheck` — clean.
- baas-worker: **195 passed** (was 162; +33).
- Full web suite: **463 passed, 10 skipped, 0 failed**.
- `wrangler deploy --dry-run` — OK (cron trigger + all bindings valid).

All changes are confined to `web/packages/baas-worker` (+ the `iam/` policy doc). No Rust/`botho/` or `mobile/` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)