### PR TITLE
fix(quorum-sim): align 'two_thirds' rule label with its computation (ceil(2n/3))

### DIFF
--- a/consensus/quorum-sim/README.md
+++ b/consensus/quorum-sim/README.md
@@ -31,7 +31,7 @@ trivially fast at the targeted sizes.
   (the **liveness** buffer).
 - `minimal_splitting_sets` — smallest Byzantine sets that can fork the network
   (the **safety** buffer).
-- Threshold-rule comparison: Botho's `n − floor((n−1)/3)` vs `ceil(0.67·n)` vs
+- Threshold-rule comparison: Botho's `n − floor((n−1)/3)` vs `ceil(2n/3)` vs
   unanimity.
 - Growth/churn: curated admission and reactive-shun, flagging any action that
   breaks quorum intersection.

--- a/consensus/quorum-sim/src/analysis.rs
+++ b/consensus/quorum-sim/src/analysis.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 pub enum ThresholdRule {
     /// Botho's current `n − floor((n−1)/3)`.
     BothoBft,
-    /// `ceil(0.67·n)` two-thirds supermajority.
+    /// `ceil(2n/3)` two-thirds supermajority.
     TwoThirds,
     /// Unanimity (`n`).
     Unanimity,
@@ -34,7 +34,7 @@ impl ThresholdRule {
     pub fn label(&self) -> &'static str {
         match self {
             ThresholdRule::BothoBft => "botho_bft (n-floor((n-1)/3))",
-            ThresholdRule::TwoThirds => "two_thirds (ceil(0.67n))",
+            ThresholdRule::TwoThirds => "two_thirds (ceil(2n/3))",
             ThresholdRule::Unanimity => "unanimity (n)",
         }
     }
@@ -302,6 +302,53 @@ mod tests {
         // Cross-check fbas_analyzer semantics: splitting sets are top-tier nodes.
         for s in &report.minimal_splitting_sets {
             assert!(s.iter().all(|&i| i < 4));
+        }
+    }
+
+    /// Guard against the displayed label silently diverging from the actual
+    /// computed threshold (the bug fixed in #531: the TwoThirds rule was
+    /// labeled `ceil(0.67n)` but computed `ceil(2n/3)`, which differ at `n`
+    /// divisible by 3). For each rule we evaluate the formula embedded in its
+    /// label and assert it matches `rule.threshold(n)` over a range of `n`.
+    #[test]
+    fn label_formula_matches_computation() {
+        // Evaluate the integer formula advertised in each rule's label.
+        fn from_label(rule: ThresholdRule, n: usize) -> usize {
+            let label = rule.label();
+            match rule {
+                ThresholdRule::BothoBft => {
+                    assert!(label.contains("n-floor((n-1)/3)"), "label: {label}");
+                    if n == 0 {
+                        0
+                    } else {
+                        n - (n - 1) / 3
+                    }
+                }
+                ThresholdRule::TwoThirds => {
+                    // Must advertise ceil(2n/3), NOT the looser ceil(0.67n).
+                    assert!(label.contains("ceil(2n/3)"), "label: {label}");
+                    assert!(!label.contains("0.67"), "label still says 0.67: {label}");
+                    (2 * n).div_ceil(3)
+                }
+                ThresholdRule::Unanimity => {
+                    assert!(label.contains("(n)"), "label: {label}");
+                    n
+                }
+            }
+        }
+
+        for rule in [
+            ThresholdRule::BothoBft,
+            ThresholdRule::TwoThirds,
+            ThresholdRule::Unanimity,
+        ] {
+            for n in 0..=12 {
+                assert_eq!(
+                    from_label(rule, n),
+                    rule.threshold(n),
+                    "label formula for {rule:?} disagrees with threshold() at n={n}",
+                );
+            }
         }
     }
 

--- a/consensus/quorum-sim/src/bin/quorum-sim.rs
+++ b/consensus/quorum-sim/src/bin/quorum-sim.rs
@@ -2,7 +2,7 @@
 //! simulator.
 //!
 //! Static subcommands (#511/#512):
-//! - `compare` — threshold-rule comparison table (Botho BFT vs ceil(0.67n) vs
+//! - `compare` — threshold-rule comparison table (Botho BFT vs ceil(2n/3) vs
 //!   unanimity) over a range of federation sizes.
 //! - `analyze` — full static-health report for a single symmetric federation.
 //! - `churn` — growth/churn timeline (admit / shun) starting from a symmetric

--- a/consensus/quorum-sim/src/thresholds.rs
+++ b/consensus/quorum-sim/src/thresholds.rs
@@ -20,11 +20,13 @@ pub fn botho_bft_threshold(n: usize) -> usize {
     n - f
 }
 
-/// The classic `ceil(0.67·n)` two-thirds supermajority threshold.
+/// The classic two-thirds supermajority threshold, `ceil(2n/3)`.
 ///
-/// Computed in integer arithmetic as `ceil(2n/3) = (2n + 2) / 3` to avoid
-/// floating point. Notable values: n=1→1, n=2→2, n=3→2, n=4→3, n=5→4, n=6→4,
-/// n=7→5.
+/// Computed in integer arithmetic via [`usize::div_ceil`] to avoid floating
+/// point. This is the *exact* two-thirds ceiling, not the looser `ceil(0.67·n)`
+/// (which over-counts at `n` divisible by 3, e.g. `ceil(0.67·6) = 5` vs
+/// `ceil(2·6/3) = 4`); the display label says `ceil(2n/3)` to match what is
+/// computed. Notable values: n=1→1, n=2→2, n=3→2, n=4→3, n=5→4, n=6→4, n=7→5.
 pub fn two_thirds_threshold(n: usize) -> usize {
     // ceil(2n/3), in integer arithmetic.
     (2 * n).div_ceil(3)
@@ -97,7 +99,7 @@ mod tests {
 
     #[test]
     fn fault_tolerance_needs_four_nodes() {
-        // ceil(0.67n): f=1 tolerance requires n>=4.
+        // ceil(2n/3): f=1 tolerance requires n>=4.
         assert_eq!(supermajority_fault_tolerance(3, two_thirds_threshold(3)), 0);
         assert_eq!(supermajority_fault_tolerance(4, two_thirds_threshold(4)), 1);
         assert_eq!(supermajority_fault_tolerance(7, two_thirds_threshold(7)), 2);


### PR DESCRIPTION
Closes #531

## Problem
The quorum-sim threshold-comparison report labeled the supermajority rule `two_thirds (ceil(0.67n))`, but `two_thirds_threshold` actually computes the exact ceiling `ceil(2n/3)`. These diverge at `n` divisible by 3 — e.g. n=6: `ceil(0.67*6)=5` vs `ceil(2*6/3)=4` — which could mislead a future reader drawing threshold conclusions from the comparison table.

## Fix chosen: relabel (not recompute)
Per the issue and the #511/#512 analysis, this is purely cosmetic — we make the comparison rule's label honest, we do NOT change any threshold formula:
- Botho's own `n - floor((n-1)/3)` formula is untouched (#511/#512 concluded we keep it).
- The two-thirds rule already computes the exact `ceil(2n/3)`; only its label/docs claimed the looser `ceil(0.67n)`.

## Changes (all within `consensus/quorum-sim`)
- `src/analysis.rs`: `ThresholdRule::TwoThirds` display label and doc comment -> `ceil(2n/3)`.
- `src/thresholds.rs`: doc comment now explains the exact ceiling vs the looser `ceil(0.67n)` and why the label says `ceil(2n/3)`; updated a stale test comment.
- `README.md` and `src/bin/quorum-sim.rs`: comparison description updated to `ceil(2n/3)` for consistency.

## Test added
`analysis::tests::label_formula_matches_computation` — for each rule, evaluates the integer formula advertised in its `label()` and asserts it equals `rule.threshold(n)` for `n` in `0..=12`. It also asserts the TwoThirds label contains `ceil(2n/3)` and no longer contains `0.67`. This guards against the label and computation silently diverging again.

## Test results (pinned nightly-2025-12-03)
- `cargo fmt -p bth-quorum-sim -- --check`: clean
- `cargo build -p bth-quorum-sim`: ok
- `cargo test -p bth-quorum-sim`: 36 (lib, incl. new test) + 5 + 12 passed, 0 failed
- `cargo clippy -p bth-quorum-sim --all-targets`: no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)