### PR TITLE
ci: add path-filtered Web CI (typecheck + vitest + worker dry-run)

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,78 @@
+name: Web CI
+
+# Runs the pnpm web workspace checks (typecheck + vitest + worker dry-run) on
+# PRs that touch web/**. The repo's root `check:ci` is a stub and no other
+# workflow exercises the ~460 web/baas-worker tests, so without this job a
+# change to the BaaS provisioner/webhook/checkout/status code (or the wallet)
+# could ship a broken test suite with no red signal (#530).
+#
+# Path-filtered so Rust-only PRs don't pay the pnpm install/test cost.
+# Everything here is offline/mocked and `--dry-run` only: NO secrets required.
+
+on:
+  pull_request:
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-ci.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-ci.yml'
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref to keep the queue fast.
+concurrency:
+  group: web-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  web-ci:
+    name: typecheck + vitest + worker dry-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # The pnpm workspace is rooted at web/, not the repo root.
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # pnpm must be installed before setup-node so its cache resolver can find
+      # the pnpm store. Pin to the major used locally (lockfileVersion 9.0).
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Typecheck every workspace package (tsc --noEmit), including the worker
+      # and the wallet.
+      - name: Typecheck
+        run: pnpm -r typecheck
+
+      # The root vitest config (web/vitest.config.ts) collects every
+      # packages/**/*.test.ts(x) — this is the web-wallet suite AND the
+      # ~195 @botho/baas-worker tests in a single run.
+      - name: Run web + baas-worker tests
+        run: pnpm test:run
+
+      # Validate the worker still bundles/deploys without actually shipping it.
+      # --dry-run needs no Cloudflare token and contacts no network.
+      - name: Worker deploy dry-run
+        run: pnpm --filter @botho/baas-worker exec wrangler deploy --dry-run

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "private": true,
   "scripts": {
     "worktree:return": "./.loom/scripts/worktree-return.sh",
-    "check:ci": "echo 'No CI checks configured. Customize this script for your project.' && exit 0",
-    "check:all": "echo 'No checks configured. Customize this script for your project.' && exit 0",
-    "test": "echo 'No tests configured. Customize this script for your project.' && exit 0",
-    "lint": "echo 'No linter configured. Customize this script for your project.' && exit 0"
+    "check:ci": "pnpm -C web install --frozen-lockfile && pnpm -C web run check:ci",
+    "check:all": "pnpm -C web install --frozen-lockfile && pnpm -C web run check:ci",
+    "test": "pnpm -C web test:run",
+    "lint": "pnpm -C web run typecheck"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "build:desktop": "pnpm --filter @botho/desktop build",
     "preview": "pnpm --filter @botho/web-wallet preview",
     "typecheck": "pnpm -r typecheck",
+    "check:ci": "pnpm -r typecheck && pnpm test:run && pnpm --filter @botho/baas-worker exec wrangler deploy --dry-run",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary
The root `check:ci` was a stub (`echo ... && exit 0`) and no GitHub Actions workflow ran the ~460 web/baas-worker tests on PRs. A regression in the BaaS provisioner/webhook/checkout/status code (or the wallet) could ship with no red signal. This adds a path-filtered Web CI workflow that exercises the full web suite, plus a consolidated `check:ci` script.

## Changes
- **`.github/workflows/web-ci.yml`** (new): on PRs touching `web/**` (and pushes to `main`, plus `workflow_dispatch`), sets up pnpm + Node, installs with `--frozen-lockfile`, then runs:
  - `pnpm -r typecheck` — every workspace package (`tsc --noEmit`)
  - `pnpm test:run` — the root `web/vitest.config.ts` suite, which collects `packages/**/*.test.ts(x)` = web-wallet **and** the `@botho/baas-worker` tests in one run
  - `wrangler deploy --dry-run` for `@botho/baas-worker` — bundle/deploy validation, **no secrets, no network**
  - Path-filtered so Rust-only PRs skip it; adds `concurrency` with `cancel-in-progress` and a 15-minute timeout. `permissions: contents: read`.
- **`web/package.json`**: added a `check:ci` script (single source of truth running the same three checks).
- **`package.json`** (root): wired `check:ci`/`check:all`/`test`/`lint` to delegate to the web workspace instead of no-op echoes.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Workflow runs on `web/**` PRs | done | `on.pull_request.paths` includes `web/**`; `working-directory: web` |
| Runs typecheck + vitest (web-wallet + baas-worker) + wrangler dry-run | done | Three steps; vitest config globs both packages |
| Runs the ~195 baas-worker + web-wallet tests | done | Local `pnpm test:run`: **463 passed, 10 skipped** (39 files) |
| No secrets required | done | `--dry-run` only; tests offline/mocked; dry-run succeeded with no token |
| Fast / path-filtered (Rust-only PRs skip) | done | Path filter excludes non-`web/**`; concurrency cancels superseded runs |
| Workflow YAML valid | done | `actionlint v1.7.7` clean; `yaml.safe_load` OK |
| Underlying commands green on current main | done | typecheck (8 projects), vitest (463 pass), `wrangler deploy --dry-run` all pass locally |

## Test Plan
Ran in the worktree against current `main`:
- `pnpm -C web install --frozen-lockfile` — OK
- `pnpm -r typecheck` — 8 projects pass
- `pnpm test:run` — 463 passed, 10 skipped
- `pnpm --filter @botho/baas-worker exec wrangler deploy --dry-run` — succeeds, no secrets
- `pnpm run check:ci` (consolidated) — all three pass
- `actionlint .github/workflows/web-ci.yml` — clean

Closes #530