### PR TITLE
feat(node): detect stalled miner and surface stuck-miner health flag

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -384,6 +384,11 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
         dns_seed_domain: default_seed_domain(config.network_type).to_string(),
     };
 
+    // Stable minter-health handle (#538). Shared between the RPC layer (for the
+    // `stalled` / `minerStalled` flags) and the periodic status loop (for the
+    // warn alarm). The handle survives minter start/stop cycles.
+    let minter_health = node.minter_health();
+
     let mut rpc_state = RpcState::from_shared(
         node.shared_ledger(),
         node.shared_mempool(),
@@ -397,7 +402,8 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
         ws_broadcaster.clone(),
     )
     .with_quorum(config.network.quorum.clone())
-    .with_identity(node_identity);
+    .with_identity(node_identity)
+    .with_minter_health(minter_health.clone());
 
     // Initialize wallet for RPC (balance checking, faucet, etc.)
     if let Some(mnemonic) = config.mnemonic() {
@@ -1450,6 +1456,18 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                     if minting_enabled { "active" } else { "inactive" },
                     quorum_status
                 );
+
+                // Stuck-miner early-warning (#538). If the miner is active but
+                // has produced 0 H/s past the grace + stall window, this emits a
+                // prominent warning so the operator catches a wedged worker
+                // immediately instead of after the chain silently halts (the
+                // ~50h live-testnet halt diagnosed in #537/#539). Detection +
+                // alarm only — we do NOT auto-restart (operator policy).
+                if let Ok(guard) = minter_health.read() {
+                    if let Some(health) = guard.as_ref() {
+                        health.check_and_warn();
+                    }
+                }
             }
 
             // Reconnect tick: if we have no peers, re-dial configured bootstrap

--- a/botho/src/node/minter.rs
+++ b/botho/src/node/minter.rs
@@ -12,7 +12,7 @@ use std::{
     thread::{self, JoinHandle},
     time::Instant,
 };
-use tracing::{info, trace};
+use tracing::{info, trace, warn};
 
 use crate::{
     block::{calculate_block_reward, MintingTx},
@@ -68,6 +68,25 @@ use crate::{
 /// hashes/block; #443 moved to RandomX).
 pub const INITIAL_DIFFICULTY: u64 = 54_000_000_000_000_000;
 
+/// How long a miner may report `active == true` while producing **zero new
+/// hashes** before it is flagged as stalled (see [`MinterHealth`]).
+///
+/// Motivation (#538, part of #537): the live testnet sat **halted for ~50h**
+/// because the faucet miner reported `active:true` at `hashrate 0.0` — a wedged
+/// RandomX worker that was alive but not hashing — and nothing surfaced it. A
+/// healthy in-process single-thread miner sustains ~68 H/s (see
+/// [`INITIAL_DIFFICULTY`]), so a full window of *no* new hashes is a strong,
+/// unambiguous wedged-worker signal. 90 s is long enough to ride out a normal
+/// difficulty/block-time stall (5 s target) yet far below the ~50h blind spot.
+pub const STUCK_MINER_SECS: u64 = 90;
+
+/// Startup grace period: a freshly-started miner builds the ~2 GB RandomX
+/// fast-mode dataset (seconds, sometimes longer under load — see [`mint_loop`])
+/// before it can hash at all. We must not flag that legitimate warm-up as a
+/// stall, so detection is suppressed until the miner has been active for at
+/// least this long. Chosen comfortably above observed dataset-build times.
+pub const STARTUP_GRACE_SECS: u64 = 60;
+
 /// Minting statistics
 #[derive(Debug, Clone)]
 pub struct MintingStats {
@@ -84,6 +103,190 @@ impl MintingStats {
         } else {
             0.0
         }
+    }
+}
+
+/// A point-in-time health snapshot of the miner, suitable for RPC payloads and
+/// the periodic stall check. Produced by [`MinterHealth::snapshot`].
+#[derive(Debug, Clone, Copy)]
+pub struct MinterHealthSnapshot {
+    /// Whether minting is currently enabled.
+    pub active: bool,
+    /// Cumulative hashes computed since the miner started.
+    pub total_hashes: u64,
+    /// Average hashrate (hashes/sec) since start.
+    pub hashrate: f64,
+    /// Seconds the miner has been active.
+    pub uptime_secs: u64,
+    /// Stall verdict: `true` iff the miner is active but has produced no new
+    /// hashes for longer than [`STUCK_MINER_SECS`], past the startup grace.
+    pub stalled: bool,
+}
+
+/// Pure stall verdict used by both the live [`MinterHealth`] handle and unit
+/// tests. Returns `true` iff the miner is **active**, past the startup grace
+/// window, and has produced **no new hashes** for at least `stuck_secs`.
+///
+/// Splitting this out keeps the detection logic deterministic and testable
+/// without spinning up a real RandomX worker (#538).
+///
+/// - `active`: whether minting is enabled.
+/// - `uptime_secs`: seconds since the miner started.
+/// - `secs_since_progress`: seconds since `total_hashes` last advanced.
+/// - `grace_secs` / `stuck_secs`: the startup grace and stall thresholds.
+pub fn evaluate_stall(
+    active: bool,
+    uptime_secs: u64,
+    secs_since_progress: u64,
+    grace_secs: u64,
+    stuck_secs: u64,
+) -> bool {
+    // Inactive miners are never "stalled" — not minting is a deliberate state,
+    // not a fault.
+    if !active {
+        return false;
+    }
+    // During warm-up (RandomX VM/dataset build) zero hashes is expected.
+    if uptime_secs < grace_secs {
+        return false;
+    }
+    secs_since_progress >= stuck_secs
+}
+
+/// Shared, cloneable health handle for a [`Minter`].
+///
+/// Holds the same `Arc`-backed counters the worker threads update, so callers
+/// (the RPC layer and the periodic status loop) observe live progress without
+/// owning the [`Minter`]. Detecting a stall requires tracking the *last* point
+/// at which `total_hashes` advanced; that bookkeeping lives here in atomics so
+/// the handle stays `Send + Sync` and cheaply `Clone`able across threads.
+#[derive(Clone)]
+pub struct MinterHealth {
+    /// Whether minting is currently enabled. Kept in sync by the node when it
+    /// starts/stops minting.
+    active: Arc<AtomicBool>,
+    /// The worker threads' cumulative hash counter (shared with [`Minter`]).
+    total_hashes: Arc<AtomicU64>,
+    /// When the miner started, for uptime/hashrate.
+    start_time: Instant,
+    /// `total_hashes` value observed at the last progress check.
+    last_observed_hashes: Arc<AtomicU64>,
+    /// Seconds-since-start at the last time progress was observed advancing.
+    last_progress_secs: Arc<AtomicU64>,
+}
+
+impl MinterHealth {
+    fn new(total_hashes: Arc<AtomicU64>, start_time: Instant) -> Self {
+        Self {
+            active: Arc::new(AtomicBool::new(false)),
+            total_hashes,
+            start_time,
+            last_observed_hashes: Arc::new(AtomicU64::new(0)),
+            last_progress_secs: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Fabricate a handle in a fully-controlled state for tests in *other*
+    /// modules (the RPC layer asserts the `stalled`/`minerStalled` flags flow
+    /// through `node_getStatus` / `minting_getStatus`). The `start_time` is
+    /// backdated by `uptime_secs` so `snapshot()` reports a deterministic
+    /// uptime and stall verdict without spinning up a real RandomX worker.
+    #[doc(hidden)]
+    pub fn for_test(active: bool, total_hashes: u64, uptime_secs: u64) -> Self {
+        let start_time = Instant::now()
+            .checked_sub(std::time::Duration::from_secs(uptime_secs))
+            .unwrap_or_else(Instant::now);
+        let h = Self::new(Arc::new(AtomicU64::new(total_hashes)), start_time);
+        h.active.store(active, Ordering::SeqCst);
+        // Pin "last progress" to start so secs_since_progress == uptime_secs:
+        // i.e. no new hashes since the (backdated) start.
+        h.last_observed_hashes.store(total_hashes, Ordering::SeqCst);
+        h.last_progress_secs.store(0, Ordering::SeqCst);
+        h
+    }
+
+    /// Mark whether minting is enabled. Resets the progress tracker on each
+    /// active→edge so a restart gets a fresh grace window rather than
+    /// inheriting a stale "no progress" timer.
+    pub fn set_active(&self, active: bool) {
+        let was_active = self.active.swap(active, Ordering::SeqCst);
+        if active && !was_active {
+            let now = self.start_time.elapsed().as_secs();
+            self.last_observed_hashes
+                .store(self.total_hashes.load(Ordering::Relaxed), Ordering::SeqCst);
+            self.last_progress_secs.store(now, Ordering::SeqCst);
+        }
+    }
+
+    /// Whether minting is currently enabled.
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    /// Advance the progress tracker and return the current health snapshot.
+    ///
+    /// This both *reads* the live counters and *updates* the "last progress"
+    /// bookkeeping, so it is the single place the stall timer advances. The
+    /// periodic status loop calls this on its tick; RPC handlers may call it
+    /// too (the update is idempotent w.r.t. the verdict for a given
+    /// instant).
+    pub fn snapshot(&self) -> MinterHealthSnapshot {
+        let active = self.active.load(Ordering::SeqCst);
+        let total_hashes = self.total_hashes.load(Ordering::Relaxed);
+        let uptime_secs = self.start_time.elapsed().as_secs();
+
+        let hashrate = {
+            let elapsed = self.start_time.elapsed().as_secs_f64();
+            if elapsed > 0.0 {
+                total_hashes as f64 / elapsed
+            } else {
+                0.0
+            }
+        };
+
+        // Update the last-progress timestamp if the counter advanced.
+        let prev = self.last_observed_hashes.load(Ordering::SeqCst);
+        if total_hashes > prev {
+            self.last_observed_hashes
+                .store(total_hashes, Ordering::SeqCst);
+            self.last_progress_secs.store(uptime_secs, Ordering::SeqCst);
+        }
+        let last_progress = self.last_progress_secs.load(Ordering::SeqCst);
+        let secs_since_progress = uptime_secs.saturating_sub(last_progress);
+
+        let stalled = evaluate_stall(
+            active,
+            uptime_secs,
+            secs_since_progress,
+            STARTUP_GRACE_SECS,
+            STUCK_MINER_SECS,
+        );
+
+        MinterHealthSnapshot {
+            active,
+            total_hashes,
+            hashrate,
+            uptime_secs,
+            stalled,
+        }
+    }
+
+    /// Take a snapshot and, if stalled, emit a prominent warning. Returns the
+    /// snapshot so callers can act on / report the verdict. Used by the
+    /// periodic status loop as the chain's early-warning alarm (#538).
+    pub fn check_and_warn(&self) -> MinterHealthSnapshot {
+        let snap = self.snapshot();
+        if snap.stalled {
+            warn!(
+                uptime_secs = snap.uptime_secs,
+                total_hashes = snap.total_hashes,
+                stuck_secs = STUCK_MINER_SECS,
+                "RandomX miner stalled: active but 0 H/s for {}s — chain will halt; \
+                 worker appears wedged (see #538). NOT auto-restarting (operator policy).",
+                STUCK_MINER_SECS,
+            );
+        }
+        snap
     }
 }
 
@@ -127,6 +330,8 @@ pub struct Minter {
     current_work: Arc<std::sync::RwLock<MintingWork>>,
     /// Signal to update work
     work_version: Arc<AtomicU64>,
+    /// Shared health handle for stall detection / RPC reporting (#538).
+    health: MinterHealth,
 }
 
 impl Minter {
@@ -151,18 +356,25 @@ impl Minter {
             total_minted: 0,
         };
 
+        let total_hashes = Arc::new(AtomicU64::new(0));
+        let start_time = Instant::now();
+        // Health handle shares the worker threads' hash counter so callers can
+        // observe live progress (and detect a stall) without owning the Minter.
+        let health = MinterHealth::new(total_hashes.clone(), start_time);
+
         Self {
             threads,
             address,
             shutdown: Arc::new(AtomicBool::new(false)),
-            total_hashes: Arc::new(AtomicU64::new(0)),
+            total_hashes,
             txs_found: Arc::new(AtomicU64::new(0)),
-            start_time: Instant::now(),
+            start_time,
             handles: Vec::new(),
             tx_sender,
             tx_receiver: Some(tx_receiver),
             current_work: Arc::new(std::sync::RwLock::new(initial_work)),
             work_version: Arc::new(AtomicU64::new(0)),
+            health,
         }
     }
 
@@ -206,15 +418,29 @@ impl Minter {
 
             self.handles.push(handle);
         }
+        // Mark the miner active for health/stall tracking (starts the grace
+        // window). Done after spawning so uptime aligns with real work.
+        self.health.set_active(true);
     }
 
     pub fn stop(self) {
+        // Mark inactive first so the stall detector immediately stops flagging.
+        self.health.set_active(false);
         // Signal shutdown to all minting threads
         self.shutdown.store(true, Ordering::SeqCst);
         // Wait for all threads to finish
         for handle in self.handles {
             let _ = handle.join();
         }
+    }
+
+    /// Clone the shared health handle for stall detection / RPC reporting.
+    ///
+    /// The handle observes live worker progress and outlives a single
+    /// start/stop cycle; the node hands a clone to the RPC layer and the
+    /// periodic status loop (#538).
+    pub fn health(&self) -> MinterHealth {
+        self.health.clone()
     }
 
     pub fn stats(&self) -> MintingStats {
@@ -419,6 +645,96 @@ fn mint_loop(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ----- Stuck-miner detector (#538) -----
+
+    /// Active + no new hashes past the stall window (and past grace) → stalled.
+    #[test]
+    fn test_stall_active_zero_hashrate_past_window() {
+        // uptime past grace, no progress for >= STUCK_MINER_SECS.
+        assert!(evaluate_stall(
+            true,
+            STARTUP_GRACE_SECS + STUCK_MINER_SECS + 5,
+            STUCK_MINER_SECS + 5,
+            STARTUP_GRACE_SECS,
+            STUCK_MINER_SECS,
+        ));
+        // Exactly at the threshold also counts as stalled.
+        assert!(evaluate_stall(
+            true,
+            STARTUP_GRACE_SECS + STUCK_MINER_SECS,
+            STUCK_MINER_SECS,
+            STARTUP_GRACE_SECS,
+            STUCK_MINER_SECS,
+        ));
+    }
+
+    /// Active + healthy progress (recent hashes) → not stalled.
+    #[test]
+    fn test_stall_active_healthy_hashrate_not_flagged() {
+        // Plenty of uptime, but progress observed just 1s ago.
+        assert!(!evaluate_stall(
+            true,
+            STARTUP_GRACE_SECS + STUCK_MINER_SECS + 100,
+            1,
+            STARTUP_GRACE_SECS,
+            STUCK_MINER_SECS,
+        ));
+    }
+
+    /// Inactive (minting disabled) → never flagged, regardless of timers.
+    #[test]
+    fn test_stall_inactive_never_flagged() {
+        assert!(!evaluate_stall(
+            false,
+            STARTUP_GRACE_SECS + STUCK_MINER_SECS + 1000,
+            STUCK_MINER_SECS + 1000,
+            STARTUP_GRACE_SECS,
+            STUCK_MINER_SECS,
+        ));
+    }
+
+    /// Within startup grace + 0 hashes → not yet flagged (RandomX warm-up).
+    #[test]
+    fn test_stall_within_startup_grace_not_flagged() {
+        // Just under the grace window with zero progress: must NOT flag.
+        assert!(!evaluate_stall(
+            true,
+            STARTUP_GRACE_SECS - 1,
+            STARTUP_GRACE_SECS - 1,
+            STARTUP_GRACE_SECS,
+            STUCK_MINER_SECS,
+        ));
+    }
+
+    /// The live `MinterHealth` handle: an inactive handle reports inactive and
+    /// unstalled; activating it starts the grace window so a brand-new miner is
+    /// not immediately flagged.
+    #[test]
+    fn test_minter_health_handle_inactive_then_active() {
+        let total_hashes = Arc::new(AtomicU64::new(0));
+        let health = MinterHealth::new(total_hashes.clone(), Instant::now());
+
+        // Fresh handle: not active, not stalled.
+        let snap = health.snapshot();
+        assert!(!snap.active);
+        assert!(!snap.stalled);
+
+        // Activate: still within grace (uptime ~0), so not stalled even at 0 H/s.
+        health.set_active(true);
+        let snap = health.snapshot();
+        assert!(snap.active);
+        assert!(!snap.stalled, "fresh active miner must not be flagged");
+
+        // Progress advances the hashrate readout.
+        total_hashes.store(1_000, Ordering::SeqCst);
+        let snap = health.snapshot();
+        assert_eq!(snap.total_hashes, 1_000);
+
+        // Deactivate: never stalled.
+        health.set_active(false);
+        assert!(!health.snapshot().stalled);
+    }
 
     /// Documents and locks the genesis difficulty calibration (#444).
     ///

--- a/botho/src/node/mod.rs
+++ b/botho/src/node/mod.rs
@@ -27,7 +27,7 @@ pub type SharedMempool = Arc<RwLock<Mempool>>;
 /// Pending transactions file name
 const PENDING_TXS_FILE: &str = "pending_txs.bin";
 
-pub use minter::{MintedMintingTx, Minter, MintingWork};
+pub use minter::{MintedMintingTx, Minter, MinterHealth, MintingWork};
 
 /// The main Botho node
 pub struct Node {
@@ -37,6 +37,12 @@ pub struct Node {
     ledger: SharedLedger,
     mempool: SharedMempool,
     minter: Option<Minter>,
+    /// Stable, shared health handle for the *current* minter, used by the RPC
+    /// layer and the periodic status loop for stuck-miner detection (#538).
+    /// `None` until minting first starts; the inner handle is replaced on each
+    /// `start_minting` and marked inactive on `stop_minting` so the flag is
+    /// always queryable, even across start/stop cycles.
+    minter_health: Arc<RwLock<Option<MinterHealth>>>,
     /// Receiver for minted minting transactions (to be submitted to consensus)
     minting_tx_receiver: Option<Receiver<MintedMintingTx>>,
     /// Directory containing config file (for finding pending_txs.bin)
@@ -89,6 +95,7 @@ impl Node {
             ledger,
             mempool,
             minter: None,
+            minter_health: Arc::new(RwLock::new(None)),
             minting_tx_receiver: None,
             config_dir,
             emission_controller,
@@ -198,6 +205,13 @@ impl Node {
         minter.update_work(work);
 
         minter.start();
+
+        // Publish this minter's health handle for RPC / stall detection (#538).
+        // `start()` has already marked it active (begins the startup grace).
+        if let Ok(mut h) = self.minter_health.write() {
+            *h = Some(minter.health());
+        }
+
         self.minter = Some(minter);
 
         Ok(())
@@ -205,8 +219,19 @@ impl Node {
 
     fn stop_minting(&mut self) {
         if let Some(minter) = self.minter.take() {
+            // `Minter::stop` marks its health inactive; the handle published in
+            // `minter_health` shares the same state, so the flag flips to
+            // inactive (and unstalled) for RPC readers too.
             minter.stop();
         }
+    }
+
+    /// Clone the shared minter-health handle for stall detection / RPC
+    /// reporting (#538). Returns the `Option`-wrapped handle: `None` inner
+    /// means minting has never started; otherwise it reflects the
+    /// current/last minter.
+    pub fn minter_health(&self) -> Arc<RwLock<Option<MinterHealth>>> {
+        self.minter_health.clone()
     }
 
     // --- Network integration methods ---

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -70,6 +70,7 @@ use crate::{
     config::QuorumConfig,
     ledger::Ledger,
     mempool::Mempool,
+    node::MinterHealth,
     transaction::{TxOutput, MIN_TX_FEE},
     wallet::Wallet,
 };
@@ -200,6 +201,11 @@ pub struct RpcState {
     /// an empty identity; `commands::run` populates it from the persistent
     /// node keypair once the network layer is up.
     pub identity: NodeIdentity,
+    /// Shared minter-health handle for stuck-miner detection (#538). `None`
+    /// until `commands::run` wires it in (or in tests / relay nodes); the inner
+    /// `Option` is `None` until minting first starts. Surfaced as `stalled` in
+    /// `minting_getStatus` and `minerStalled` in `node_getStatus`.
+    pub minter_health: Option<Arc<RwLock<Option<MinterHealth>>>>,
 }
 
 impl RpcState {
@@ -232,6 +238,7 @@ impl RpcState {
             wallet: None,
             quorum: QuorumConfig::default(),
             identity: NodeIdentity::default(),
+            minter_health: None,
         }
     }
 
@@ -268,6 +275,7 @@ impl RpcState {
             wallet: None,
             quorum: QuorumConfig::default(),
             identity: NodeIdentity::default(),
+            minter_health: None,
         }
     }
 
@@ -302,6 +310,7 @@ impl RpcState {
             wallet: None,
             quorum: QuorumConfig::default(),
             identity: NodeIdentity::default(),
+            minter_health: None,
         }
     }
 
@@ -329,6 +338,22 @@ impl RpcState {
     pub fn with_identity(mut self, identity: NodeIdentity) -> Self {
         self.identity = identity;
         self
+    }
+
+    /// Wire in the shared minter-health handle so `minting_getStatus` and
+    /// `node_getStatus` can surface live hashrate and the stuck-miner flag
+    /// (#538). `commands::run` calls this with `Node::minter_health`.
+    pub fn with_minter_health(mut self, minter_health: Arc<RwLock<Option<MinterHealth>>>) -> Self {
+        self.minter_health = Some(minter_health);
+        self
+    }
+
+    /// Read the current minter-health snapshot, if a handle is wired in and
+    /// minting has started. Returns `None` for relay nodes / pre-mint state.
+    fn minter_health_snapshot(&self) -> Option<crate::node::minter::MinterHealthSnapshot> {
+        let handle = self.minter_health.as_ref()?;
+        let guard = handle.read().ok()?;
+        guard.as_ref().map(|h| h.snapshot())
     }
 }
 
@@ -832,6 +857,14 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
     let quorum_fault_tolerant = state.quorum.is_bft_fault_tolerant(participating_nodes);
     let quorum_degenerate = state.quorum.is_degenerate_quorum(participating_nodes);
 
+    // Stuck-miner health (#538): surface the same verdict as `minting_getStatus`
+    // so dashboards/monitoring watching node health catch a wedged miner (active
+    // but 0 H/s) immediately instead of after the chain silently halts.
+    let miner_stalled = state
+        .minter_health_snapshot()
+        .map(|s| s.stalled)
+        .unwrap_or(false);
+
     JsonRpcResponse::success(
         id,
         json!({
@@ -858,6 +891,9 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
             // `quorumDegenerate` flags the n-of-n / zero-fault-tolerance regime.
             "quorumFaultTolerant": quorum_fault_tolerant,
             "quorumDegenerate": quorum_degenerate,
+            // Stuck-miner early-warning (#538): true iff this node's miner is
+            // active but producing 0 H/s past the grace + stall window.
+            "minerStalled": miner_stalled,
         }),
     )
 }
@@ -1833,17 +1869,30 @@ async fn handle_minting_status(id: Value, state: &RpcState) -> JsonRpcResponse {
     let active = *read_lock!(state.minting_active, id.clone());
     let ledger = read_lock!(state.ledger, id.clone());
     let chain_state = ledger.get_chain_state().unwrap_or_default();
+    drop(ledger);
+
+    // Live hashrate / total-hashes and the stuck-miner verdict come from the
+    // shared minter-health handle (#538). When no handle is wired in (relay
+    // nodes / tests / before minting starts) we report zeros and `stalled:
+    // false`, matching the previous placeholder behavior.
+    let snap = state.minter_health_snapshot();
+    let hashrate = snap.map(|s| s.hashrate).unwrap_or(0.0);
+    let total_hashes = snap.map(|s| s.total_hashes).unwrap_or(0);
+    let stalled = snap.map(|s| s.stalled).unwrap_or(false);
 
     JsonRpcResponse::success(
         id,
         json!({
             "active": active,
             "threads": state.minting_threads,
-            "hashrate": 0.0, // TODO: track actual hashrate
-            "totalHashes": 0,
+            "hashrate": hashrate,
+            "totalHashes": total_hashes,
             "blocksFound": 0, // TODO: track blocks found
             "currentDifficulty": chain_state.difficulty,
             "uptimeSeconds": state.start_time.elapsed().as_secs(),
+            // Stuck-miner detector (#538): true iff active but 0 H/s past the
+            // grace + stall window. Operator/monitoring early-warning.
+            "stalled": stalled,
         }),
     )
 }
@@ -3169,6 +3218,94 @@ mod tests {
         assert_eq!(result["scpPeerCount"], json!(3));
         assert_eq!(result["quorumDegenerate"], json!(false));
         assert_eq!(result["quorumFaultTolerant"], json!(true));
+    }
+
+    /// #538: the stuck-miner flag must surface in BOTH `minting_getStatus`
+    /// (`stalled`) and `node_getStatus` (`minerStalled`). A miner that is
+    /// active but producing 0 H/s past the grace + stall window is flagged;
+    /// a healthy or inactive miner is not; and with no health handle wired
+    /// in the flag defaults to `false` (present, never missing).
+    #[tokio::test]
+    async fn test_miner_stalled_flag_in_both_status_payloads() {
+        use crate::{
+            ledger::Ledger,
+            mempool::Mempool,
+            node::{
+                minter::{STARTUP_GRACE_SECS, STUCK_MINER_SECS},
+                MinterHealth,
+            },
+        };
+
+        fn fresh_state() -> RpcState {
+            let dir = tempfile::tempdir().unwrap();
+            let ledger = Ledger::open(dir.path()).unwrap();
+            // Keep the tempdir alive for the lifetime of the ledger by leaking
+            // it — fine for a unit test.
+            std::mem::forget(dir);
+            RpcState::new(
+                ledger,
+                Mempool::new(),
+                Network::Testnet,
+                None,
+                None,
+                vec![],
+                Arc::new(WsBroadcaster::new(16)),
+            )
+        }
+
+        // (1) No health handle wired in: flag present and false in both.
+        let state = fresh_state();
+        let minting = handle_minting_status(json!(1), &state)
+            .await
+            .result
+            .unwrap();
+        assert_eq!(minting["stalled"], json!(false));
+        let node = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(node["minerStalled"], json!(false));
+
+        // (2) Active + 0 H/s past the grace + stall window: stalled in both.
+        let stalled = MinterHealth::for_test(true, 0, STARTUP_GRACE_SECS + STUCK_MINER_SECS + 5);
+        let handle = Arc::new(RwLock::new(Some(stalled)));
+        let state = fresh_state().with_minter_health(handle);
+        let minting = handle_minting_status(json!(1), &state)
+            .await
+            .result
+            .unwrap();
+        assert_eq!(minting["stalled"], json!(true), "minting_getStatus.stalled");
+        let node = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(
+            node["minerStalled"],
+            json!(true),
+            "node_getStatus.minerStalled"
+        );
+
+        // (3) Active + healthy (hashes well past 0, recent progress): not stalled.
+        // `for_test` pins last-progress to start, so to model a *healthy* miner
+        // we keep uptime within the stall window after the grace.
+        let healthy = MinterHealth::for_test(true, 100_000, STARTUP_GRACE_SECS + 1);
+        let handle = Arc::new(RwLock::new(Some(healthy)));
+        let state = fresh_state().with_minter_health(handle);
+        let minting = handle_minting_status(json!(1), &state)
+            .await
+            .result
+            .unwrap();
+        assert_eq!(minting["stalled"], json!(false));
+        assert_eq!(minting["totalHashes"], json!(100_000));
+        let node = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(node["minerStalled"], json!(false));
+
+        // (4) Inactive miner: never stalled, even with a long zero-hash uptime.
+        let inactive =
+            MinterHealth::for_test(false, 0, STARTUP_GRACE_SECS + STUCK_MINER_SECS + 1000);
+        let handle = Arc::new(RwLock::new(Some(inactive)));
+        let state = fresh_state().with_minter_health(handle);
+        let minting = handle_minting_status(json!(1), &state)
+            .await
+            .result
+            .unwrap();
+        assert_eq!(minting["stalled"], json!(false));
+        let node = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(node["minerStalled"], json!(false));
     }
 
     /// #500: `node_getIdentity` exposes the node's stable, verifiable identity


### PR DESCRIPTION
## Summary

Adds a stuck-miner detector so a miner that reports `active==true` while producing **0 H/s** self-detects and alarms loudly instead of silently halting the chain. This is the code-side early-warning for the live-testnet halt diagnosed in #537/#539 (the faucet miner ran "active" at 0 H/s for ~50h, silently wedging the chain). Detection + alarm + flag only — no auto-restart (operator policy).

## Changes

- **`botho/src/node/minter.rs`**
  - New thresholds: `STUCK_MINER_SECS = 90`, `STARTUP_GRACE_SECS = 60` (grace so a miner building its ~2 GB RandomX dataset isn't falsely flagged).
  - Pure, testable `evaluate_stall(active, uptime, secs_since_progress, grace, stuck)` verdict.
  - New cloneable `MinterHealth` handle: shares the worker threads' live hash counter, tracks last-progress timestamp in atomics, produces a `MinterHealthSnapshot` (active / totalHashes / hashrate / uptime / stalled), and `check_and_warn()` emits a prominent `warn!` ("RandomX miner stalled: active but 0 H/s for Ns — chain will halt").
  - `Minter` now owns a `MinterHealth`, marks it active on `start()` / inactive on `stop()`, and exposes `health()`.
- **`botho/src/node/mod.rs`**: stable `Arc<RwLock<Option<MinterHealth>>>` published on each `start_minting` and flipped inactive on `stop_minting` (survives start/stop cycles); exposed via `Node::minter_health()`.
- **`botho/src/rpc/mod.rs`**: `RpcState::with_minter_health(...)`; `minting_getStatus` now reports `stalled` (and replaces the hardcoded `hashrate`/`totalHashes` TODOs with live values); `node_getStatus` now reports `minerStalled`. Both default to `false` when no handle is wired (relay nodes / pre-mint).
- **`botho/src/commands/run.rs`**: runs the stall check on the periodic status tick (emits the early-warning log) and wires the health handle into `RpcState`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| active + 0 hashrate past grace window → flag true + warning path | ✅ | `test_stall_active_zero_hashrate_past_window`; `check_and_warn` emits `warn!` when `snapshot().stalled` |
| active + healthy hashrate → flag false | ✅ | `test_stall_active_healthy_hashrate_not_flagged`, RPC test case (3) |
| inactive (minting disabled) → not flagged | ✅ | `test_stall_inactive_never_flagged`, RPC test case (4) |
| within startup grace + 0 hashrate → not yet flagged | ✅ | `test_stall_within_startup_grace_not_flagged` |
| Flag present in both `minting_getStatus` and `node_getStatus` | ✅ | `test_miner_stalled_flag_in_both_status_payloads` asserts `stalled` and `minerStalled` in both payloads (present + correct in all states) |
| No auto-restart | ✅ | Detector only logs / sets flag; no restart logic added |
| serde camelCase consistency | ✅ | `stalled`, `minerStalled` match existing camelCase fields |

## Test Plan

- `cargo build -p botho` — clean (pre-existing warnings only).
- `cargo test -p botho --lib` — **1014 passed, 0 failed, 2 ignored** (pre-existing slow RandomX tests).
- `cargo clippy -p botho --lib` — no new warnings from changed code (remaining warnings are all pre-existing in unrelated files).
- `cargo fmt -p botho` — applied.

Closes #538