### PR TITLE
fix(rpc): wire node_getStatus sync trio to real ChainSyncManager state

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -30,7 +30,8 @@ use crate::{
     network::{
         default_seed_domain, BlockTxn, ChainSyncManager, CompactBlock, GetBlockTxn,
         NetworkDiscovery, NetworkEvent, QuorumBuilder, ReconstructionResult, SyncAction,
-        SyncRequest, SyncResponse, MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION,
+        SyncRequest, SyncResponse, SyncStatusSnapshot, MIN_SUPPORTED_PROTOCOL_VERSION,
+        PROTOCOL_VERSION,
     },
     node::{MintedMintingTx, Node, SharedLedger},
     rpc::{
@@ -389,6 +390,12 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // warn alarm). The handle survives minter start/stop cycles.
     let minter_health = node.minter_health();
 
+    // Shared sync-status handle (#541). The sync loop publishes a cheap snapshot
+    // of the live `ChainSyncManager` here on each tick; the RPC layer reads it
+    // so `node_getStatus` reports honest `synced`/`syncStatus`/`syncProgress`
+    // instead of always claiming to be synced.
+    let sync_status: Arc<RwLock<Option<SyncStatusSnapshot>>> = Arc::new(RwLock::new(None));
+
     let mut rpc_state = RpcState::from_shared(
         node.shared_ledger(),
         node.shared_mempool(),
@@ -403,7 +410,8 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     )
     .with_quorum(config.network.quorum.clone())
     .with_identity(node_identity)
-    .with_minter_health(minter_health.clone());
+    .with_minter_health(minter_health.clone())
+    .with_sync_status(sync_status.clone());
 
     // Initialize wallet for RPC (balance checking, faucet, etc.)
     if let Some(mnemonic) = config.mnemonic() {
@@ -1530,6 +1538,13 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             // in the SyncResponse arm); Wait is advisory.
                         }
                     }
+                }
+
+                // Publish the post-tick sync state so `node_getStatus` reports
+                // honest sync info (#541). Done after `tick` so any state
+                // transition the tick performed is reflected immediately.
+                if let Ok(mut guard) = sync_status.write() {
+                    *guard = Some(sync_manager.status_snapshot());
                 }
             }
 

--- a/botho/src/network/mod.rs
+++ b/botho/src/network/mod.rs
@@ -46,8 +46,8 @@ pub use reputation::{PeerReputation, ReputationManager};
 pub use seeds::{fallback_seeds, include_regional_seeds};
 pub use sync::{
     create_sync_behaviour, ChainSyncManager, SyncAction, SyncCodec, SyncRateLimiter, SyncRequest,
-    SyncResponse, SyncState, BLOCKS_PER_REQUEST, MAX_REQUESTS_PER_MINUTE, MAX_REQUEST_SIZE,
-    MAX_RESPONSE_SIZE,
+    SyncResponse, SyncState, SyncStatusSnapshot, BLOCKS_PER_REQUEST, MAX_REQUESTS_PER_MINUTE,
+    MAX_REQUEST_SIZE, MAX_RESPONSE_SIZE,
 };
 pub use transport::{
     negotiate_transport_initiator,

--- a/botho/src/network/sync.rs
+++ b/botho/src/network/sync.rs
@@ -351,6 +351,47 @@ pub struct PeerStatus {
     pub last_updated: Instant,
 }
 
+/// Cheap, owned snapshot of sync progress for surfacing over the RPC layer
+/// (#541). The event loop owns the live [`ChainSyncManager`] without a lock; it
+/// publishes one of these into a shared `Arc<RwLock<_>>` on each sync tick so
+/// `node_getStatus` can report honest sync state instead of a hardcoded
+/// "always synced". All fields are plain values so reading is allocation-free
+/// apart from the status string.
+#[derive(Debug, Clone)]
+pub struct SyncStatusSnapshot {
+    /// True iff the sync state machine is in [`SyncState::Synced`].
+    pub synced: bool,
+    /// Coarse status string derived from [`SyncState`]: one of
+    /// "discovering", "syncing", "synced", "stalled".
+    pub status: &'static str,
+    /// Our current local chain height.
+    pub local_height: u64,
+    /// Best-known network tip height, if any peer status / download target is
+    /// known. `None` when we have no peer information yet (Discovery with no
+    /// responses), in which case a true progress percentage cannot be computed.
+    pub target_height: Option<u64>,
+}
+
+impl SyncStatusSnapshot {
+    /// Progress toward the best-known tip as a percentage clamped to `0..=100`.
+    ///
+    /// Returns `Some(100.0)` when synced. Returns `None` when no target tip is
+    /// known (so callers can avoid fabricating a number). Otherwise computes
+    /// `local_height / target_height * 100`.
+    pub fn progress_percent(&self) -> Option<f64> {
+        if self.synced {
+            return Some(100.0);
+        }
+        let target = self.target_height?;
+        if target == 0 {
+            // Nothing to sync to; treat as fully caught up.
+            return Some(100.0);
+        }
+        let pct = (self.local_height as f64 / target as f64) * 100.0;
+        Some(pct.clamp(0.0, 100.0))
+    }
+}
+
 /// Action to take based on sync state
 #[derive(Debug)]
 pub enum SyncAction {
@@ -424,6 +465,36 @@ impl ChainSyncManager {
     /// Check if we're synced
     pub fn is_synced(&self) -> bool {
         matches!(self.state, SyncState::Synced)
+    }
+
+    /// Produce a cheap, owned [`SyncStatusSnapshot`] for the RPC layer (#541).
+    ///
+    /// `target_height` is the best honest estimate of the network tip:
+    /// - while `Downloading`, the download `target_height`;
+    /// - otherwise, the max height across known (non-banned) peers. `None` when
+    ///   no peer status is known yet, so callers can avoid reporting a
+    ///   fabricated progress percentage.
+    pub fn status_snapshot(&self) -> SyncStatusSnapshot {
+        let status = match &self.state {
+            SyncState::Discovery => "discovering",
+            SyncState::Downloading { .. } => "syncing",
+            SyncState::Synced => "synced",
+            SyncState::Failed { .. } => "stalled",
+        };
+
+        // Best-known network tip. Prefer the active download target; otherwise
+        // fall back to the highest known peer height.
+        let target_height = match &self.state {
+            SyncState::Downloading { target_height, .. } => Some(*target_height),
+            _ => self.best_peer().map(|(_, status)| status.height),
+        };
+
+        SyncStatusSnapshot {
+            synced: matches!(self.state, SyncState::Synced),
+            status,
+            local_height: self.local_height,
+            target_height,
+        }
     }
 
     /// Update local chain height
@@ -1713,5 +1784,72 @@ mod tests {
 
         assert!(manager.is_synced());
         assert_eq!(height, target);
+    }
+
+    /// #541: `status_snapshot` must track the live state machine so the RPC
+    /// layer can report honest sync info. Covers Discovery (no target),
+    /// Downloading (target + sub-100% progress), and Synced (100%).
+    #[test]
+    fn test_status_snapshot_tracks_state_machine() {
+        let mut manager = ChainSyncManager::new(50);
+        let peer = make_peer_id();
+
+        // Discovery with no peer status: not synced, no target tip known, so a
+        // true progress percentage cannot be computed.
+        let snap = manager.status_snapshot();
+        assert!(!snap.synced);
+        assert_eq!(snap.status, "discovering");
+        assert_eq!(snap.target_height, None);
+        assert_eq!(snap.progress_percent(), None);
+
+        // Learn a peer is far ahead -> Downloading; target tip is its height.
+        manager.on_status(peer, 100, [7u8; 32]);
+        assert!(matches!(manager.state(), SyncState::Downloading { .. }));
+        let snap = manager.status_snapshot();
+        assert!(!snap.synced);
+        assert_eq!(snap.status, "syncing");
+        assert_eq!(snap.local_height, 50);
+        assert_eq!(snap.target_height, Some(100));
+        assert_eq!(snap.progress_percent(), Some(50.0));
+
+        // Apply blocks up to the target -> Synced; progress pins to 100.
+        manager.on_blocks_added(100);
+        assert!(manager.is_synced());
+        let snap = manager.status_snapshot();
+        assert!(snap.synced);
+        assert_eq!(snap.status, "synced");
+        assert_eq!(snap.progress_percent(), Some(100.0));
+    }
+
+    /// #541: `progress_percent` must clamp to 0..=100 and never fabricate a
+    /// number when no target tip is known.
+    #[test]
+    fn test_progress_percent_clamps_and_honest() {
+        // Synced always 100 regardless of heights.
+        let s = SyncStatusSnapshot {
+            synced: true,
+            status: "synced",
+            local_height: 0,
+            target_height: None,
+        };
+        assert_eq!(s.progress_percent(), Some(100.0));
+
+        // No target tip and not synced -> None (do not fabricate).
+        let s = SyncStatusSnapshot {
+            synced: false,
+            status: "discovering",
+            local_height: 10,
+            target_height: None,
+        };
+        assert_eq!(s.progress_percent(), None);
+
+        // Local ahead of (stale) target clamps to 100, never overshoots.
+        let s = SyncStatusSnapshot {
+            synced: false,
+            status: "syncing",
+            local_height: 120,
+            target_height: Some(100),
+        };
+        assert_eq!(s.progress_percent(), Some(100.0));
     }
 }

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -70,6 +70,7 @@ use crate::{
     config::QuorumConfig,
     ledger::Ledger,
     mempool::Mempool,
+    network::SyncStatusSnapshot,
     node::MinterHealth,
     transaction::{TxOutput, MIN_TX_FEE},
     wallet::Wallet,
@@ -206,6 +207,13 @@ pub struct RpcState {
     /// `Option` is `None` until minting first starts. Surfaced as `stalled` in
     /// `minting_getStatus` and `minerStalled` in `node_getStatus`.
     pub minter_health: Option<Arc<RwLock<Option<MinterHealth>>>>,
+    /// Shared sync-status handle for honest sync reporting (#541). `None` until
+    /// `commands::run` wires it in (or in tests / single-node setups); the
+    /// inner `Option` is `None` until the sync loop publishes its first
+    /// snapshot. When absent, `node_getStatus` falls back to assuming a
+    /// caught-up node. Surfaced as `synced`, `syncStatus`, and
+    /// `syncProgress` in `node_getStatus`.
+    pub sync_status: Option<Arc<RwLock<Option<SyncStatusSnapshot>>>>,
 }
 
 impl RpcState {
@@ -239,6 +247,7 @@ impl RpcState {
             quorum: QuorumConfig::default(),
             identity: NodeIdentity::default(),
             minter_health: None,
+            sync_status: None,
         }
     }
 
@@ -276,6 +285,7 @@ impl RpcState {
             quorum: QuorumConfig::default(),
             identity: NodeIdentity::default(),
             minter_health: None,
+            sync_status: None,
         }
     }
 
@@ -311,6 +321,7 @@ impl RpcState {
             quorum: QuorumConfig::default(),
             identity: NodeIdentity::default(),
             minter_health: None,
+            sync_status: None,
         }
     }
 
@@ -354,6 +365,27 @@ impl RpcState {
         let handle = self.minter_health.as_ref()?;
         let guard = handle.read().ok()?;
         guard.as_ref().map(|h| h.snapshot())
+    }
+
+    /// Wire in the shared sync-status handle so `node_getStatus` can report
+    /// honest `synced`/`syncStatus`/`syncProgress` from the live
+    /// `ChainSyncManager` (#541). `commands::run` calls this with the handle
+    /// the sync loop publishes into.
+    pub fn with_sync_status(
+        mut self,
+        sync_status: Arc<RwLock<Option<SyncStatusSnapshot>>>,
+    ) -> Self {
+        self.sync_status = Some(sync_status);
+        self
+    }
+
+    /// Read the current sync-status snapshot, if a handle is wired in and the
+    /// sync loop has published at least once. Returns `None` for single-node /
+    /// pre-sync state, in which case `node_getStatus` assumes a caught-up node.
+    fn sync_status_snapshot(&self) -> Option<SyncStatusSnapshot> {
+        let handle = self.sync_status.as_ref()?;
+        let guard = handle.read().ok()?;
+        guard.clone()
     }
 }
 
@@ -846,9 +878,22 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
     let peers = *read_lock!(state.peer_count, id.clone());
     let scp_peers = *read_lock!(state.scp_peer_count, id.clone());
 
-    // Calculate sync progress: 100.0 if synced, otherwise based on chain state
-    // TODO: Wire up actual sync progress from ChainSyncManager
-    let sync_progress: f64 = 100.0;
+    // Honest sync reporting wired to the live ChainSyncManager (#541). A node
+    // must not claim to be fully synced mid-download: the thin-client trust UX
+    // (#503) and readiness probes rely on these fields.
+    //
+    // When no sync handle is wired in (single-node setups, tests) or the sync
+    // loop has not yet published a snapshot, fall back to the caught-up
+    // assumption — a lone node with no peers has nothing to sync against.
+    let sync_snapshot = state.sync_status_snapshot();
+    let synced = sync_snapshot.as_ref().map(|s| s.synced).unwrap_or(true);
+    let sync_status: &str = sync_snapshot.as_ref().map(|s| s.status).unwrap_or("synced");
+    // Real percentage when a best-known tip is available; 100.0 when synced or
+    // when we have no peer to compare against (nothing to catch up to).
+    let sync_progress: f64 = match sync_snapshot.as_ref() {
+        Some(s) => s.progress_percent().unwrap_or(100.0),
+        None => 100.0,
+    };
 
     // Byzantine-fault-tolerance posture (#509). Participating node count
     // includes self, so n = scp_peers + 1. In `recommended` mode, n < 4 yields
@@ -875,9 +920,9 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
             "buildTime": option_env!("BUILD_TIME").unwrap_or("unknown"),
             "network": format!("botho-{}", state.network_type.name()),
             "uptimeSeconds": state.start_time.elapsed().as_secs(),
-            "syncStatus": "synced",
+            "syncStatus": sync_status,
             "syncProgress": sync_progress,
-            "synced": true,
+            "synced": synced,
             "chainHeight": chain_state.height,
             "tipHash": hex::encode(chain_state.tip_hash),
             "peerCount": peers,
@@ -3218,6 +3263,87 @@ mod tests {
         assert_eq!(result["scpPeerCount"], json!(3));
         assert_eq!(result["quorumDegenerate"], json!(false));
         assert_eq!(result["quorumFaultTolerant"], json!(true));
+    }
+
+    /// #541: `node_getStatus` must report honest sync state wired to the live
+    /// `ChainSyncManager`, not a hardcoded "always synced". This covers BOTH
+    /// states: a node mid-download must report `synced=false`,
+    /// `syncStatus="syncing"`, and a sub-100 progress percentage; a caught-up
+    /// node must report `synced=true`, `syncStatus="synced"`, progress 100.0.
+    #[tokio::test]
+    async fn test_node_status_reports_real_sync_state() {
+        use crate::{ledger::Ledger, mempool::Mempool, network::SyncStatusSnapshot};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        let sync_handle = Arc::new(RwLock::new(None));
+        let state = RpcState::new(
+            ledger,
+            Mempool::new(),
+            Network::Testnet,
+            None,
+            None,
+            vec![],
+            Arc::new(WsBroadcaster::new(16)),
+        )
+        .with_sync_status(sync_handle.clone());
+
+        // --- Behind: downloading, local 50 of best-known 100. ---
+        *sync_handle.write().unwrap() = Some(SyncStatusSnapshot {
+            synced: false,
+            status: "syncing",
+            local_height: 50,
+            target_height: Some(100),
+        });
+        let resp = handle_node_status(json!(1), &state).await;
+        let result = resp.result.unwrap();
+        assert_eq!(result["synced"], json!(false));
+        assert_eq!(result["syncStatus"], json!("syncing"));
+        assert_eq!(
+            result["syncProgress"].as_f64().unwrap(),
+            50.0,
+            "50/100 should be 50%"
+        );
+
+        // --- Caught up: synced, progress pinned to 100. ---
+        *sync_handle.write().unwrap() = Some(SyncStatusSnapshot {
+            synced: true,
+            status: "synced",
+            local_height: 100,
+            target_height: Some(100),
+        });
+        let resp = handle_node_status(json!(1), &state).await;
+        let result = resp.result.unwrap();
+        assert_eq!(result["synced"], json!(true));
+        assert_eq!(result["syncStatus"], json!("synced"));
+        assert_eq!(result["syncProgress"].as_f64().unwrap(), 100.0);
+    }
+
+    /// #541: when no sync handle is wired in (single-node setups / tests), the
+    /// node falls back to the caught-up assumption rather than erroring — a
+    /// lone node with no peers has nothing to sync against.
+    #[tokio::test]
+    async fn test_node_status_sync_fallback_when_no_handle() {
+        use crate::{ledger::Ledger, mempool::Mempool};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        let state = RpcState::new(
+            ledger,
+            Mempool::new(),
+            Network::Testnet,
+            None,
+            None,
+            vec![],
+            Arc::new(WsBroadcaster::new(16)),
+        );
+
+        let resp = handle_node_status(json!(1), &state).await;
+        let result = resp.result.unwrap();
+        assert_eq!(result["synced"], json!(true));
+        assert_eq!(result["syncStatus"], json!("synced"));
+        assert_eq!(result["syncProgress"].as_f64().unwrap(), 100.0);
     }
 
     /// #538: the stuck-miner flag must surface in BOTH `minting_getStatus`


### PR DESCRIPTION
## Summary
`node_getStatus` hardcoded the sync trio — `syncProgress: 100.0`, `syncStatus: "synced"`, `synced: true` — so a node **always claimed to be fully synced**, even during initial sync. This misled the thin-client trust UX (#503) and load-balancer / readiness probes.

This wires all three fields to the live `ChainSyncManager`.

## How each field is now sourced
- **`synced`** = `ChainSyncManager::is_synced()` (i.e. `SyncState::Synced`), surfaced via the snapshot.
- **`syncStatus`** = string derived from `SyncState`: `"discovering"` (Discovery), `"syncing"` (Downloading), `"synced"` (Synced), `"stalled"` (Failed).
- **`syncProgress`** = `local_height / target_height * 100`, clamped `0..=100`; `100.0` when synced. Target tip = the active download target, else the max height across known (non-banned) peers.

## Plumbing (mirrors existing `minter_health` pattern)
- New `SyncStatusSnapshot` + `ChainSyncManager::status_snapshot()` in `network/sync.rs`.
- Shared `Arc<RwLock<Option<SyncStatusSnapshot>>>` created in `commands/run.rs`, published by the sync loop on each tick (after `tick()` so state transitions are reflected), read by the RPC layer via `RpcState::with_sync_status()` / `sync_status_snapshot()`.
- Read-only snapshot; no new locks on the RPC hot path beyond the existing pattern.
- When no handle is wired (single-node setups / tests) the handler falls back to the caught-up assumption — a lone node with no peers has nothing to sync against.

## Honesty guarantee
`progress_percent()` returns `None` (not a fabricated number) when no target tip is known. A true percentage is computed whenever a best-known tip exists (download target or highest peer height), so real progress reporting works today — no follow-on needed for the percentage itself.

## Tests
- `test_node_status_reports_real_sync_state` — behind: `synced=false`, `"syncing"`, 50%; caught-up: `synced=true`, `"synced"`, 100%.
- `test_node_status_sync_fallback_when_no_handle` — no handle → caught-up fallback.
- `test_status_snapshot_tracks_state_machine` — Discovery (no target) → Downloading (50%) → Synced (100%).
- `test_progress_percent_clamps_and_honest` — clamps to 100, returns `None` without a tip.

fmt / `cargo build -p botho` / relevant tests / `cargo clippy -p botho --lib` all pass.

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)