### PR TITLE
feat(rpc): report real blocksFound in minting_getStatus

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -672,6 +672,11 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             if let Err(e) = node.add_block_from_network(&block) {
                                 warn!("Failed to add network block: {}", e);
                             } else {
+                                // Count toward blocksFound if this node won the
+                                // slot but the block came back via gossip before
+                                // our own externalize landed it (#543).
+                                count_won_block(&minter_health, &block);
+
                                 // Record block processing time
                                 metrics_updater.observe_block_processing(block_start.elapsed().as_secs_f64());
                                 metrics_updater.inc_blocks_processed();
@@ -960,6 +965,11 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                                                 break;
                                             }
                                             applied_any = true;
+                                            // Count toward blocksFound if a synced
+                                            // block carries this node's coinbase
+                                            // (e.g. re-syncing our own past blocks
+                                            // after a restart) (#543).
+                                            count_won_block(&minter_health, block);
                                             // Record for dynamic timing
                                             consensus.record_block(block.header.timestamp, block.transactions.len());
                                         }
@@ -1090,6 +1100,10 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                                         // machine will backfill the gap.
                                         warn!("Failed to add reconstructed block: {} (catch-up handles non-contiguous gaps)", e);
                                     } else {
+                                        // Count toward blocksFound if this node's
+                                        // coinbase won (#543).
+                                        count_won_block(&minter_health, &block);
+
                                         // Record for dynamic timing
                                         consensus.record_block(block.header.timestamp, block.transactions.len());
 
@@ -1225,6 +1239,10 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                                         if let Err(e) = node.add_block_from_network(&block) {
                                             warn!("Failed to add completed block: {}", e);
                                         } else {
+                                            // Count toward blocksFound if this
+                                            // node's coinbase won (#543).
+                                            count_won_block(&minter_health, &block);
+
                                             // Record for dynamic timing
                                             consensus.record_block(block.header.timestamp, block.transactions.len());
 
@@ -1394,6 +1412,10 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                                             warn!("Failed to add consensus block: {}", e);
                                         }
                                     } else {
+                                        // Count toward blocksFound if this node
+                                        // won the slot (its coinbase) (#543).
+                                        count_won_block(&minter_health, &block);
+
                                         // Record for dynamic timing
                                         consensus.record_block(block.header.timestamp, block.transactions.len());
 
@@ -1921,6 +1943,39 @@ fn peer_id_to_node_id(peer_id: &libp2p::PeerId) -> NodeID {
 }
 
 /// Build a block from externalized consensus values
+/// Count a block toward this node's `blocksFound` tally if its winning
+/// coinbase belongs to this node's minter (#543).
+///
+/// Called at every site that *successfully* appends a block to the ledger —
+/// the local externalize path and the gossip/sync apply paths — so a block we
+/// won is counted exactly once regardless of whether our own externalize landed
+/// it or a peer gossiped it back first. Each append site fires only after a
+/// genuinely-new block is added (duplicate-height applies are skipped before we
+/// get here), so there is no double counting.
+///
+/// The coinbase carries the minter's view/spend public keys; we compare them
+/// against the keys captured in the shared `MinterHealth` handle. A relay node
+/// (no minter) or a block won by a peer simply does not match, so nothing is
+/// counted.
+fn count_won_block(
+    minter_health: &Arc<RwLock<Option<crate::node::MinterHealth>>>,
+    block: &crate::block::Block,
+) {
+    if let Ok(guard) = minter_health.read() {
+        if let Some(health) = guard.as_ref() {
+            let mt = &block.minting_tx;
+            if health.owns_coinbase(&mt.minter_view_key, &mt.minter_spend_key) {
+                health.increment_blocks_found();
+                info!(
+                    height = block.height(),
+                    "Won block (this node's coinbase externalized) — blocksFound={}",
+                    health.blocks_found()
+                );
+            }
+        }
+    }
+}
+
 fn build_block_from_externalized(
     values: &[crate::consensus::ConsensusValue],
     consensus: &ConsensusService,

--- a/botho/src/node/minter.rs
+++ b/botho/src/node/minter.rs
@@ -121,6 +121,13 @@ pub struct MinterHealthSnapshot {
     /// Stall verdict: `true` iff the miner is active but has produced no new
     /// hashes for longer than [`STUCK_MINER_SECS`], past the startup grace.
     pub stalled: bool,
+    /// Number of blocks this node has *won* — i.e. externalized blocks whose
+    /// winning coinbase was minted by this node's address (#543). Distinct from
+    /// `total_hashes`: a node can hash continuously yet win zero blocks if it
+    /// is always out-PoW'd, so this is the positive "am I actually
+    /// producing blocks?" signal that complements the stuck-miner detector
+    /// (#538).
+    pub blocks_found: u64,
 }
 
 /// Pure stall verdict used by both the live [`MinterHealth`] handle and unit
@@ -173,16 +180,42 @@ pub struct MinterHealth {
     last_observed_hashes: Arc<AtomicU64>,
     /// Seconds-since-start at the last time progress was observed advancing.
     last_progress_secs: Arc<AtomicU64>,
+    /// Count of blocks won by this node — incremented exactly once per
+    /// externalized block whose winning coinbase belongs to this node's
+    /// address (#543). The increment site is the externalize hook in
+    /// `commands::run`, gated by [`MinterHealth::owns_coinbase`].
+    blocks_found: Arc<AtomicU64>,
+    /// This minter's view public key, captured at construction from the
+    /// reward address. Used to decide whether an externalized block's coinbase
+    /// was minted by *this* node (vs another node winning the slot).
+    minter_view_key: [u8; 32],
+    /// This minter's spend public key (see `minter_view_key`).
+    minter_spend_key: [u8; 32],
 }
 
 impl MinterHealth {
     fn new(total_hashes: Arc<AtomicU64>, start_time: Instant) -> Self {
+        Self::with_address(total_hashes, start_time, [0u8; 32], [0u8; 32])
+    }
+
+    /// Construct a health handle bound to a specific minter address. The
+    /// view/spend keys let the externalize hook attribute a won block to this
+    /// node (#543).
+    fn with_address(
+        total_hashes: Arc<AtomicU64>,
+        start_time: Instant,
+        minter_view_key: [u8; 32],
+        minter_spend_key: [u8; 32],
+    ) -> Self {
         Self {
             active: Arc::new(AtomicBool::new(false)),
             total_hashes,
             start_time,
             last_observed_hashes: Arc::new(AtomicU64::new(0)),
             last_progress_secs: Arc::new(AtomicU64::new(0)),
+            blocks_found: Arc::new(AtomicU64::new(0)),
+            minter_view_key,
+            minter_spend_key,
         }
     }
 
@@ -221,6 +254,36 @@ impl MinterHealth {
     /// Whether minting is currently enabled.
     pub fn is_active(&self) -> bool {
         self.active.load(Ordering::SeqCst)
+    }
+
+    /// Whether the given coinbase keys belong to this node's minter address.
+    ///
+    /// The winning coinbase of an externalized block carries the minter's
+    /// view/spend public keys ([`MintingTx::minter_view_key`] /
+    /// [`MintingTx::minter_spend_key`]). Comparing both against this handle's
+    /// captured keys tells us whether *this* node won the slot — the
+    /// precondition for counting a block as "found" (#543).
+    ///
+    /// Returns `false` for an uninitialized (all-zero) key pair, so a handle
+    /// not bound to a real address (e.g. the legacy [`MinterHealth::new`] path)
+    /// never spuriously claims another node's coinbase.
+    pub fn owns_coinbase(&self, view_key: &[u8; 32], spend_key: &[u8; 32]) -> bool {
+        if self.minter_view_key == [0u8; 32] && self.minter_spend_key == [0u8; 32] {
+            return false;
+        }
+        self.minter_view_key == *view_key && self.minter_spend_key == *spend_key
+    }
+
+    /// Record that this node won a block. Increments the `blocks_found` counter
+    /// surfaced in `minting_getStatus` (#543). Call exactly once per
+    /// externalized block whose coinbase satisfies [`Self::owns_coinbase`].
+    pub fn increment_blocks_found(&self) {
+        self.blocks_found.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Current count of blocks won by this node (#543).
+    pub fn blocks_found(&self) -> u64 {
+        self.blocks_found.load(Ordering::SeqCst)
     }
 
     /// Advance the progress tracker and return the current health snapshot.
@@ -268,6 +331,7 @@ impl MinterHealth {
             hashrate,
             uptime_secs,
             stalled,
+            blocks_found: self.blocks_found.load(Ordering::SeqCst),
         }
     }
 
@@ -360,7 +424,14 @@ impl Minter {
         let start_time = Instant::now();
         // Health handle shares the worker threads' hash counter so callers can
         // observe live progress (and detect a stall) without owning the Minter.
-        let health = MinterHealth::new(total_hashes.clone(), start_time);
+        // It also captures this minter's view/spend keys so the externalize
+        // hook can attribute won blocks to this node (#543).
+        let health = MinterHealth::with_address(
+            total_hashes.clone(),
+            start_time,
+            address.view_public_key().to_bytes(),
+            address.spend_public_key().to_bytes(),
+        );
 
         Self {
             threads,
@@ -734,6 +805,46 @@ mod tests {
         // Deactivate: never stalled.
         health.set_active(false);
         assert!(!health.snapshot().stalled);
+    }
+
+    /// `blocks_found` starts at 0 and is advanced only by
+    /// `increment_blocks_found`, and the count is reflected in the snapshot
+    /// (#543).
+    #[test]
+    fn test_minter_health_blocks_found_counter() {
+        let health = MinterHealth::new(Arc::new(AtomicU64::new(0)), Instant::now());
+        assert_eq!(health.snapshot().blocks_found, 0, "fresh handle => 0");
+
+        health.increment_blocks_found();
+        health.increment_blocks_found();
+        assert_eq!(health.blocks_found(), 2);
+        assert_eq!(health.snapshot().blocks_found, 2);
+    }
+
+    /// `owns_coinbase` matches this node's address keys and rejects others; an
+    /// unbound (all-zero key) handle never claims ownership (#543).
+    #[test]
+    fn test_minter_health_owns_coinbase() {
+        let mine_view = [7u8; 32];
+        let mine_spend = [9u8; 32];
+        let health = MinterHealth::with_address(
+            Arc::new(AtomicU64::new(0)),
+            Instant::now(),
+            mine_view,
+            mine_spend,
+        );
+
+        // Exact match on both keys => owned.
+        assert!(health.owns_coinbase(&mine_view, &mine_spend));
+        // Another node's coinbase => not owned.
+        assert!(!health.owns_coinbase(&[1u8; 32], &[2u8; 32]));
+        // Right view key but wrong spend key => not owned (both must match).
+        assert!(!health.owns_coinbase(&mine_view, &[2u8; 32]));
+
+        // Unbound handle (legacy `new` path => zero keys) never claims a
+        // coinbase, even one with all-zero keys.
+        let unbound = MinterHealth::new(Arc::new(AtomicU64::new(0)), Instant::now());
+        assert!(!unbound.owns_coinbase(&[0u8; 32], &[0u8; 32]));
     }
 
     /// Documents and locks the genesis difficulty calibration (#444).

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -1924,6 +1924,11 @@ async fn handle_minting_status(id: Value, state: &RpcState) -> JsonRpcResponse {
     let hashrate = snap.map(|s| s.hashrate).unwrap_or(0.0);
     let total_hashes = snap.map(|s| s.total_hashes).unwrap_or(0);
     let stalled = snap.map(|s| s.stalled).unwrap_or(false);
+    // Blocks won by this node (#543): read from the same shared minter-health
+    // handle. The externalize hook increments it once per block whose winning
+    // coinbase belongs to this node's address. No handle (relay/tests/before
+    // minting) => 0, matching the previous placeholder.
+    let blocks_found = snap.map(|s| s.blocks_found).unwrap_or(0);
 
     JsonRpcResponse::success(
         id,
@@ -1932,7 +1937,7 @@ async fn handle_minting_status(id: Value, state: &RpcState) -> JsonRpcResponse {
             "threads": state.minting_threads,
             "hashrate": hashrate,
             "totalHashes": total_hashes,
-            "blocksFound": 0, // TODO: track blocks found
+            "blocksFound": blocks_found,
             "currentDifficulty": chain_state.difficulty,
             "uptimeSeconds": state.start_time.elapsed().as_secs(),
             // Stuck-miner detector (#538): true iff active but 0 H/s past the
@@ -3432,6 +3437,62 @@ mod tests {
         assert_eq!(minting["stalled"], json!(false));
         let node = handle_node_status(json!(1), &state).await.result.unwrap();
         assert_eq!(node["minerStalled"], json!(false));
+    }
+
+    /// #543: `minting_getStatus.blocksFound` reflects the live count from the
+    /// shared minter-health handle. With no handle wired in it is 0; after the
+    /// externalize hook records won blocks (`increment_blocks_found`) the count
+    /// is surfaced verbatim.
+    #[tokio::test]
+    async fn test_blocks_found_in_minting_status() {
+        use crate::{
+            ledger::Ledger,
+            mempool::Mempool,
+            node::{minter::STARTUP_GRACE_SECS, MinterHealth},
+        };
+
+        fn fresh_state() -> RpcState {
+            let dir = tempfile::tempdir().unwrap();
+            let ledger = Ledger::open(dir.path()).unwrap();
+            std::mem::forget(dir);
+            RpcState::new(
+                ledger,
+                Mempool::new(),
+                Network::Testnet,
+                None,
+                None,
+                vec![],
+                Arc::new(WsBroadcaster::new(16)),
+            )
+        }
+
+        // (1) No health handle wired in: blocksFound present and 0.
+        let state = fresh_state();
+        let minting = handle_minting_status(json!(1), &state)
+            .await
+            .result
+            .unwrap();
+        assert_eq!(minting["blocksFound"], json!(0), "no handle => 0");
+
+        // (2) Nothing won yet (fresh handle): still 0.
+        let health = MinterHealth::for_test(true, 100_000, STARTUP_GRACE_SECS + 1);
+        let handle = Arc::new(RwLock::new(Some(health.clone())));
+        let state = fresh_state().with_minter_health(handle);
+        let minting = handle_minting_status(json!(1), &state)
+            .await
+            .result
+            .unwrap();
+        assert_eq!(minting["blocksFound"], json!(0), "no blocks won yet => 0");
+
+        // (3) After the externalize hook records two won blocks, the RPC reads
+        // the live count from the shared handle (same Arc-backed counter).
+        health.increment_blocks_found();
+        health.increment_blocks_found();
+        let minting = handle_minting_status(json!(1), &state)
+            .await
+            .result
+            .unwrap();
+        assert_eq!(minting["blocksFound"], json!(2), "two blocks won => 2");
     }
 
     /// #500: `node_getIdentity` exposes the node's stable, verifiable identity


### PR DESCRIPTION
## Summary
`minting_getStatus` hardcoded `blocksFound: 0` (rpc/mod.rs, TODO "track blocks found"). After #540 wired live hashrate/totalHashes through a shared `MinterHealth` handle, a miner operator still couldn't tell whether their node was actually *winning* blocks (vs just hashing). This wires a real per-node "blocks won" counter using that same Arc-shared-atomic pattern.

## Changes
- **`node/minter.rs`**: Added an `Arc<AtomicU64>` `blocks_found` counter plus the minter's captured view/spend public keys to `MinterHealth`; surfaced `blocks_found` in `MinterHealthSnapshot`. New methods: `owns_coinbase(view, spend)` (matches a coinbase's minter keys against this node's address; an unbound/all-zero handle never claims ownership), `increment_blocks_found()`, `blocks_found()`. `Minter::new` now captures the reward address keys into the handle.
- **`commands/run.rs`**: Added `count_won_block()` helper and call it at every site that *successfully* appends a block (local SCP externalize, gossip `NewBlock`, block-sync, compact-block + BlockTxn reconstruction). It increments only when `owns_coinbase` matches — so a won block is counted exactly once on finalize, never on propose, never for a peer's coinbase.
- **`rpc/mod.rs`**: `minting_getStatus.blocksFound` now reads from the shared snapshot (0 when no handle is wired in — relay nodes / tests / before minting).

### Where/how it increments
The winning coinbase (`MintingTx`) carries `minter_view_key` / `minter_spend_key`. The shared `MinterHealth` handle captures this node's address keys at minter construction. On each successful `add_block_from_network`, `count_won_block` compares the block's coinbase keys to the handle's keys via `owns_coinbase`; on a match it calls `increment_blocks_found`. Increment happens on **externalize/finalize** (block added to ledger), gated to **this node's** coinbase only.

## Acceptance Criteria Verification
| Criterion | Status | Verification |
|-----------|--------|--------------|
| Increment when this node's coinbase externalizes | ✅ | `count_won_block` at every append site, gated by `owns_coinbase`; unit test `test_minter_health_blocks_found_counter` |
| Does NOT increment for another node's coinbase | ✅ | `owns_coinbase` requires both keys match; unit test `test_minter_health_owns_coinbase` (rejects other keys + unbound handle) |
| Reflected in `minting_getStatus` | ✅ | RPC test `test_blocks_found_in_minting_status` |
| 0 when nothing mined / no handle wired | ✅ | RPC test cases (1) no handle => 0, (2) fresh handle => 0 |

## Test Plan
- `cargo build -p botho` (lib + bin) — clean
- `cargo test -p botho --lib minter::` — new tests pass
- `cargo test -p botho --lib -- rpc::tests::test_blocks_found_in_minting_status rpc::tests::test_miner_stalled_flag_in_both_status_payloads` — pass
- `cargo clippy -p botho --lib` — no new warnings; nightly `cargo fmt` applied

Closes #543