### PR TITLE
feat(network): count raw wire bytes (Noise/yamux framing) in network_getInfo

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 552
-# Branch: feature/issue-552
+# Issue: 550
+# Branch: feature/issue-550
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/botho/src/network/discovery.rs
+++ b/botho/src/network/discovery.rs
@@ -18,6 +18,7 @@
 //!   and seed nodes to broadcast upcoming network upgrades.
 
 use libp2p::{
+    core::Transport as _,
     gossipsub::{self, IdentTopic, MessageAuthenticity},
     identify, identity, noise,
     request_response::{self, InboundRequestId, OutboundRequestId, ResponseChannel},
@@ -358,12 +359,26 @@ pub struct BothoBehaviour {
 ///   *inbound*. Counted on first establishment to a peer and decremented when
 ///   the last connection to that peer closes.
 ///
-/// ## Known gaps (intentional — see #542)
+/// ## Wire-level byte counters (#550)
 ///
-/// - Transport framing overhead (Noise handshake, yamux framing, TCP headers)
-///   is NOT counted; these are payload counters, not raw wire counters (#550,
-///   still open).
+/// In addition to the application-payload counters above, `NetworkStats` also
+/// exposes **raw wire-level** counters ([`wire_bytes_sent`] /
+/// [`wire_bytes_received`]). These are fed by a counting transport wrapper
+/// installed *below* the Noise and yamux upgrades (see
+/// [`wire_counter`](crate::network::wire_counter)), so they include **all**
+/// framing overhead: the Noise handshake, yamux stream framing, and every byte
+/// of multiplexed payload — i.e. true bytes-on-wire over TCP (the only
+/// remaining piece not measured is the kernel-level TCP/IP header itself, which
+/// is invisible to a user-space byte stream).
 ///
+/// The application-payload counters remain the right tool for "is useful
+/// traffic flowing"; the wire counters answer "how much bandwidth did this node
+/// actually consume" (e.g. for bandwidth-billing a managed rig). Both are
+/// surfaced by `network_getInfo` — payload as `bytesSent` / `bytesReceived` and
+/// wire as `wireBytesSent` / `wireBytesReceived`.
+///
+/// [`wire_bytes_sent`]: NetworkStats::wire_bytes_sent
+/// [`wire_bytes_received`]: NetworkStats::wire_bytes_received
 /// [`SyncCodec`]: crate::network::sync::SyncCodec
 #[derive(Debug, Default)]
 pub struct NetworkStats {
@@ -371,6 +386,8 @@ pub struct NetworkStats {
     bytes_received: AtomicU64,
     inbound_count: AtomicU64,
     outbound_count: AtomicU64,
+    wire_bytes_sent: AtomicU64,
+    wire_bytes_received: AtomicU64,
 }
 
 impl NetworkStats {
@@ -440,6 +457,33 @@ impl NetworkStats {
     /// Current number of outbound (locally-dialed) connections.
     pub fn outbound_count(&self) -> u64 {
         self.outbound_count.load(Ordering::Relaxed)
+    }
+
+    /// Record `n` raw bytes written to the transport (#550).
+    ///
+    /// Called from the counting transport wrapper that sits below the Noise and
+    /// yamux upgrades, so `n` includes all framing overhead (Noise handshake,
+    /// yamux framing, multiplexed payload).
+    pub fn record_wire_sent(&self, n: u64) {
+        self.wire_bytes_sent.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Record `n` raw bytes read from the transport (#550). Includes all
+    /// framing overhead — see [`record_wire_sent`](Self::record_wire_sent).
+    pub fn record_wire_received(&self, n: u64) {
+        self.wire_bytes_received.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Total raw wire bytes sent since startup, including Noise/yamux framing
+    /// (#550). Zero if the counting transport wrapper is not installed.
+    pub fn wire_bytes_sent(&self) -> u64 {
+        self.wire_bytes_sent.load(Ordering::Relaxed)
+    }
+
+    /// Total raw wire bytes received since startup, including Noise/yamux
+    /// framing (#550). Zero if the counting transport wrapper is not installed.
+    pub fn wire_bytes_received(&self) -> u64 {
+        self.wire_bytes_received.load(Ordering::Relaxed)
     }
 }
 
@@ -673,13 +717,30 @@ impl NetworkDiscovery {
         // closure can hand them to the sync codec without borrowing `self`
         // (#549).
         let stats = Arc::clone(&self.stats);
+        // Build the TCP transport manually (rather than via `with_tcp`) so we
+        // can install a raw byte-counting wrapper *below* the Noise and yamux
+        // upgrades (#550). Counting at the base TCP stream means the
+        // `wireBytesSent` / `wireBytesReceived` totals include all framing
+        // overhead (Noise handshake, yamux frames) — true bytes-on-wire — which
+        // the application-payload counters from #542 deliberately omit. The
+        // upgrade chain below mirrors exactly what `with_tcp` builds internally
+        // (V1Lazy upgrade → Noise authentication → yamux multiplexing).
+        let wire_stats = Arc::clone(&self.stats);
         let mut swarm = libp2p::SwarmBuilder::with_existing_identity(self.keypair.clone())
             .with_tokio()
-            .with_tcp(
-                tcp::Config::default(),
-                noise::Config::new,
-                yamux::Config::default,
-            )?
+            .with_other_transport(move |key| {
+                let base = tcp::tokio::Transport::new(tcp::Config::default());
+                let counted =
+                    super::wire_counter::with_wire_counting(base, Arc::clone(&wire_stats));
+                let noise = noise::Config::new(key)
+                    .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+                Ok::<_, Box<dyn std::error::Error + Send + Sync>>(
+                    counted
+                        .upgrade(libp2p::core::upgrade::Version::V1Lazy)
+                        .authenticate(noise)
+                        .multiplex(yamux::Config::default()),
+                )
+            })?
             .with_behaviour(|key| {
                 // Configure gossipsub with message size limits
                 // Use MAX_BLOCK_SIZE as the limit since blocks are the largest messages

--- a/botho/src/network/mod.rs
+++ b/botho/src/network/mod.rs
@@ -20,6 +20,7 @@ mod reputation;
 mod seeds;
 mod sync;
 pub mod transport;
+mod wire_counter;
 
 pub use compact_block::{
     BlockTxn, CompactBlock, GetBlockTxn, PrefilledTx, ReconstructionResult, ShortId,

--- a/botho/src/network/wire_counter.rs
+++ b/botho/src/network/wire_counter.rs
@@ -1,0 +1,226 @@
+// Copyright (c) 2024 Botho Foundation
+
+//! Wire-level byte counting for the libp2p transport (#550).
+//!
+//! The application-payload counters from #542/#548/#549 (gossipsub publish/
+//! receive and sync request/response codec) count only the *useful* bytes a
+//! node exchanges. They deliberately ignore transport framing overhead: the
+//! Noise handshake, yamux stream framing, and protocol negotiation. For "is
+//! traffic flowing" diagnostics that is exactly right, but it cannot answer
+//! "how much bandwidth did this node actually consume" — the question you need
+//! for bandwidth-billing a managed rig.
+//!
+//! This module closes that gap with a thin counting wrapper installed *below*
+//! the Noise and yamux upgrades. Because it sits on the raw TCP byte stream,
+//! every byte it observes is a true byte-on-wire: Noise handshake bytes, yamux
+//! frame headers, and all multiplexed payload. The only thing it cannot see is
+//! the kernel-level TCP/IP header, which never reaches user space.
+//!
+//! ## Design
+//!
+//! [`CountingStream`] wraps any [`AsyncRead`] + [`AsyncWrite`] stream and feeds
+//! every successful read/write into the shared [`NetworkStats`] wire counters.
+//! [`with_wire_counting`] applies that wrapper to a raw TCP transport via
+//! [`Transport::map`], yielding a transport whose connections are counted but
+//! that is otherwise identical to the one libp2p's [`SwarmBuilder::with_tcp`]
+//! builds internally.
+//!
+//! [`SwarmBuilder::with_tcp`]: libp2p::SwarmBuilder::with_tcp
+
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures::{AsyncRead, AsyncWrite};
+use libp2p::core::transport::Transport;
+
+use super::discovery::NetworkStats;
+
+/// An [`AsyncRead`] + [`AsyncWrite`] stream that records every byte it reads or
+/// writes into a shared [`NetworkStats`] as raw wire traffic (#550).
+///
+/// The wrapper is intentionally transparent: it forwards every poll to the
+/// inner stream unchanged and only increments a counter on the bytes that were
+/// actually transferred (`Poll::Ready(Ok(n))`). Errors and pending polls move
+/// no bytes and so move no counters.
+#[derive(Debug)]
+pub struct CountingStream<S> {
+    inner: S,
+    stats: Arc<NetworkStats>,
+}
+
+impl<S> CountingStream<S> {
+    /// Wrap `inner`, recording its traffic into `stats`.
+    pub fn new(inner: S, stats: Arc<NetworkStats>) -> Self {
+        Self { inner, stats }
+    }
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for CountingStream<S> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let poll = Pin::new(&mut self.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(n)) = &poll {
+            self.stats.record_wire_received(*n as u64);
+        }
+        poll
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for CountingStream<S> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let poll = Pin::new(&mut self.inner).poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = &poll {
+            self.stats.record_wire_sent(*n as u64);
+        }
+        poll
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_close(cx)
+    }
+}
+
+/// Wrap a raw (pre-upgrade) transport so each connection it produces counts its
+/// raw wire bytes into `stats` (#550).
+///
+/// Apply this to the base TCP transport *before* authenticating with Noise and
+/// multiplexing with yamux, so the counting stream sees framing overhead too.
+/// The returned transport has the same output stream type wrapped in a
+/// [`CountingStream`]; it can be fed straight into
+/// `.upgrade(...).authenticate(...).multiplex(...)`.
+pub fn with_wire_counting<T>(
+    transport: T,
+    stats: Arc<NetworkStats>,
+) -> impl Transport<
+    Output = CountingStream<T::Output>,
+    Error = T::Error,
+    Dial = impl Send,
+    ListenerUpgrade = impl Send,
+>
+where
+    T: Transport,
+    T::Output: AsyncRead + AsyncWrite + Unpin,
+    T::Dial: Send,
+    T::ListenerUpgrade: Send,
+{
+    transport.map(move |output, _endpoint| CountingStream::new(output, Arc::clone(&stats)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{AsyncReadExt, AsyncWriteExt};
+
+    /// An in-memory duplex stream backed by two byte vectors, used to drive the
+    /// counting wrapper without real sockets.
+    struct MockStream {
+        to_read: std::collections::VecDeque<u8>,
+        written: Vec<u8>,
+    }
+
+    impl AsyncRead for MockStream {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<std::io::Result<usize>> {
+            let n = self.to_read.len().min(buf.len());
+            for slot in buf.iter_mut().take(n) {
+                *slot = self.to_read.pop_front().unwrap();
+            }
+            Poll::Ready(Ok(n))
+        }
+    }
+
+    impl AsyncWrite for MockStream {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            self.written.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn counts_bytes_written() {
+        let stats = Arc::new(NetworkStats::new());
+        let inner = MockStream {
+            to_read: Default::default(),
+            written: Vec::new(),
+        };
+        let mut stream = CountingStream::new(inner, Arc::clone(&stats));
+
+        stream.write_all(&[1, 2, 3, 4, 5]).await.unwrap();
+        stream.write_all(&[6, 7, 8]).await.unwrap();
+
+        assert_eq!(stats.wire_bytes_sent(), 8);
+        assert_eq!(
+            stats.wire_bytes_received(),
+            0,
+            "writes must not touch the receive counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn counts_bytes_read() {
+        let stats = Arc::new(NetworkStats::new());
+        let inner = MockStream {
+            to_read: (0u8..10).collect(),
+            written: Vec::new(),
+        };
+        let mut stream = CountingStream::new(inner, Arc::clone(&stats));
+
+        let mut buf = [0u8; 4];
+        stream.read_exact(&mut buf).await.unwrap();
+        assert_eq!(buf, [0, 1, 2, 3]);
+        stream.read_exact(&mut buf).await.unwrap();
+        assert_eq!(buf, [4, 5, 6, 7]);
+
+        assert_eq!(stats.wire_bytes_received(), 8);
+        assert_eq!(
+            stats.wire_bytes_sent(),
+            0,
+            "reads must not touch the send counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn counters_are_independent_and_cumulative() {
+        let stats = Arc::new(NetworkStats::new());
+        let inner = MockStream {
+            to_read: (0u8..6).collect(),
+            written: Vec::new(),
+        };
+        let mut stream = CountingStream::new(inner, Arc::clone(&stats));
+
+        stream.write_all(&[9, 9]).await.unwrap();
+        let mut buf = [0u8; 6];
+        stream.read_exact(&mut buf).await.unwrap();
+        stream.write_all(&[9]).await.unwrap();
+
+        assert_eq!(stats.wire_bytes_sent(), 3);
+        assert_eq!(stats.wire_bytes_received(), 6);
+    }
+}

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -2025,15 +2025,22 @@ async fn handle_network_info(id: Value, state: &RpcState) -> JsonRpcResponse {
     // network loop) we fall back to the previous placeholder behavior:
     // `inboundCount: 0` and `outboundCount: peerCount`, so the endpoint shape is
     // unchanged for those callers.
-    let (inbound, outbound, bytes_sent, bytes_received) = match state.network_stats.as_ref() {
-        Some(stats) => (
-            stats.inbound_count(),
-            stats.outbound_count(),
-            stats.bytes_sent(),
-            stats.bytes_received(),
-        ),
-        None => (0, peers as u64, 0, 0),
-    };
+    // `bytesSent` / `bytesReceived` are application-layer payload totals (#542);
+    // `wireBytesSent` / `wireBytesReceived` are raw bytes-on-wire including
+    // Noise/yamux framing, fed by the counting transport wrapper (#550). The
+    // wire totals are always >= the payload totals once any traffic flows.
+    let (inbound, outbound, bytes_sent, bytes_received, wire_sent, wire_received) =
+        match state.network_stats.as_ref() {
+            Some(stats) => (
+                stats.inbound_count(),
+                stats.outbound_count(),
+                stats.bytes_sent(),
+                stats.bytes_received(),
+                stats.wire_bytes_sent(),
+                stats.wire_bytes_received(),
+            ),
+            None => (0, peers as u64, 0, 0, 0, 0),
+        };
 
     JsonRpcResponse::success(
         id,
@@ -2043,6 +2050,8 @@ async fn handle_network_info(id: Value, state: &RpcState) -> JsonRpcResponse {
             "outboundCount": outbound,
             "bytesSent": bytes_sent,
             "bytesReceived": bytes_received,
+            "wireBytesSent": wire_sent,
+            "wireBytesReceived": wire_received,
             "uptimeSeconds": state.start_time.elapsed().as_secs(),
         }),
     )
@@ -4205,12 +4214,19 @@ mod tests {
         );
         assert_eq!(result["bytesSent"], json!(0));
         assert_eq!(result["bytesReceived"], json!(0));
+        // #550: wire counters also default to zero with no handle.
+        assert_eq!(result["wireBytesSent"], json!(0));
+        assert_eq!(result["wireBytesReceived"], json!(0));
 
         // (2) Stats handle wired in: real values surfaced. Simulate the network
         // event loop having recorded traffic + connections.
         let stats = Arc::new(NetworkStats::new());
         stats.record_sent(4096);
         stats.record_received(8192);
+        // #550: simulate the counting transport recording raw wire bytes
+        // (always >= payload once framing overhead is included).
+        stats.record_wire_sent(5000);
+        stats.record_wire_received(9000);
         // Two inbound, one outbound (record_connection_opened: inbound flag).
         stats.record_connection_opened(true);
         stats.record_connection_opened(true);
@@ -4224,6 +4240,12 @@ mod tests {
         assert_eq!(result["outboundCount"], json!(1), "real outbound count");
         assert_eq!(result["bytesSent"], json!(4096));
         assert_eq!(result["bytesReceived"], json!(8192));
+        assert_eq!(result["wireBytesSent"], json!(5000), "real wire bytes sent");
+        assert_eq!(
+            result["wireBytesReceived"],
+            json!(9000),
+            "real wire bytes received"
+        );
 
         // (3) Genuine zero: handle present but nothing sent / no inbound.
         let empty_stats = Arc::new(NetworkStats::new());
@@ -4231,6 +4253,8 @@ mod tests {
         let result = handle_network_info(json!(1), &state).await.result.unwrap();
         assert_eq!(result["bytesSent"], json!(0));
         assert_eq!(result["bytesReceived"], json!(0));
+        assert_eq!(result["wireBytesSent"], json!(0));
+        assert_eq!(result["wireBytesReceived"], json!(0));
         assert_eq!(result["inboundCount"], json!(0));
         assert_eq!(result["outboundCount"], json!(0));
     }


### PR DESCRIPTION
## Summary

Closes the known gap documented on `NetworkStats` since #542: the `network_getInfo` byte counters (`bytesSent` / `bytesReceived`) count only **application-layer payload** and ignore transport framing. This adds a counting wrapper at the transport layer so the node can also report **true bytes-on-wire** (including the Noise handshake and yamux framing) — the figure you need for bandwidth-billing a managed rig.

The implementation takes the issue's first acceptable approach (a counting wrapper around the transport) rather than `with_bandwidth_metrics`, because the latter requires pulling in libp2p's `metrics` feature plus a Prometheus `Registry` and bridging gauges back into atomics. The wrapper is self-contained, adds no new dependency, and writes directly to the same `NetworkStats` atomics that already back `network_getInfo`.

## Changes

- **New `botho/src/network/wire_counter.rs`**: `CountingStream<S>` wraps any `AsyncRead`/`AsyncWrite` stream and records every successfully transferred byte into the shared `NetworkStats`. `with_wire_counting` applies it to a raw transport via `Transport::map`.
- **`discovery::start`**: builds the TCP transport manually via `with_other_transport`, mirroring exactly what `with_tcp` builds internally (`V1Lazy` upgrade -> Noise authentication -> yamux multiplexing), but with the counting wrapper inserted on the raw TCP stream *below* the upgrades. Counting there means the totals include all framing overhead.
- **`NetworkStats`**: adds `wire_bytes_sent` / `wire_bytes_received` atomics with `record_wire_sent` / `record_wire_received` and reader methods; updated the type's doc comment (the prior comment listed wire framing as an open gap).
- **`network_getInfo`**: emits `wireBytesSent` / `wireBytesReceived` alongside the existing payload counters. No handle (tests / relay nodes) falls back to `0`, preserving the endpoint shape.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Wire bytes include Noise/yamux/TCP framing | ✅ | Counter sits on the raw TCP byte stream below the Noise + yamux upgrades, so every observed byte is a true on-wire byte (only the kernel TCP/IP header, never visible to user space, is excluded — documented). |
| Minimal & well-contained | ✅ | One new ~230-line module + a transport-build swap in `discovery::start`; no new crate dependency, no Prometheus registry. |
| Bridges into the atomics backing `network_getInfo` | ✅ | Wrapper writes to the same `NetworkStats` `Arc` the RPC layer already reads. |
| Code preserved per CLAUDE.md | ✅ | The old `with_tcp` upgrade chain is reproduced (not deleted) inline; no behavior change to the upgrade path. |

## Test Plan

- `cargo build` — passes.
- `cargo test -p botho --lib wire_counter` — 3 new unit tests pass (counts writes, counts reads, independent/cumulative counters).
- `cargo test -p botho --lib network_info` — extended `test_network_info_surfaces_real_counters` to assert the new `wireBytesSent` / `wireBytesReceived` fields in all three scenarios (no handle, wired handle, genuine zero); passes.
- `cargo test -p botho --lib network::` — all 694 network tests pass (no regression).
- `cargo clippy -p botho --lib` — no errors on changed code.

Closes #550