### PR TITLE
test(network): pass Arc<NetworkStats> to create_sync_behaviour in integration test

### DIFF
--- a/botho/tests/network_integration.rs
+++ b/botho/tests/network_integration.rs
@@ -9,7 +9,7 @@
 //! - Synchronize chain state
 //! - Handle peer disconnections gracefully
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use futures::StreamExt;
 use libp2p::{
@@ -24,8 +24,9 @@ use tokio::time::timeout;
 use botho::{
     block::Block,
     network::{
-        create_sync_behaviour, ChainSyncManager, ReputationManager, SyncAction, SyncCodec,
-        SyncRateLimiter, SyncRequest, SyncResponse, BLOCKS_PER_REQUEST, MAX_REQUESTS_PER_MINUTE,
+        create_sync_behaviour, ChainSyncManager, NetworkStats, ReputationManager, SyncAction,
+        SyncCodec, SyncRateLimiter, SyncRequest, SyncResponse, BLOCKS_PER_REQUEST,
+        MAX_REQUESTS_PER_MINUTE,
     },
 };
 
@@ -61,7 +62,7 @@ async fn create_test_swarm() -> (Swarm<TestBehaviour>, PeerId, Multiaddr) {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
             .unwrap();
 
-            let sync = create_sync_behaviour();
+            let sync = create_sync_behaviour(Arc::new(NetworkStats::new()));
 
             Ok(TestBehaviour { gossipsub, sync })
         })


### PR DESCRIPTION
## Summary
The `network_integration` integration-test target stopped compiling on `main` after `create_sync_behaviour` gained a `stats: Arc<NetworkStats>` parameter during the NetworkStats byte-counting work (#548/#551). The test helper `create_test_swarm` still called it with zero arguments, so the target silently failed to build — protecting nothing (a false-green). This PR updates the test to match the current production signature.

## Changes
- `botho/tests/network_integration.rs`:
  - `create_sync_behaviour()` -> `create_sync_behaviour(Arc::new(NetworkStats::new()))` (the only drifted call site, at the old line 64).
  - Added `std::sync::Arc` to the imports.
  - Added `NetworkStats` to the `botho::network` import group (re-exported from `botho::network`).
- Test-only change. No production network code was modified.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Update `create_sync_behaviour` call to pass `Arc<NetworkStats>` | Done | Line now passes `Arc::new(NetworkStats::new())` |
| Sweep file for other signature drift from #542/#548/#549/#551 | Done | `grep` confirmed only one `create_sync_behaviour()` call; full target now compiles, so no other drift remains |
| `cargo test -p botho --test network_integration` builds and passes | Done | Target compiles (only pre-existing warnings); 18/18 tests pass |

## Test Plan
```
cargo test -p botho --test network_integration
...
running 18 tests
test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.06s
```
All deterministic and swarm-based tests passed; no flakiness observed on this run.

Closes #561