### PR TITLE
fix(ledger): fail closed on DB errors in consensus double-spend checks

### DIFF
--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -137,11 +137,47 @@ impl Ledger {
         Self::open_for_network(path, Network::Testnet)
     }
 
+    /// Test-only: open a ledger whose LMDB reader table holds exactly one slot.
+    /// Holding a single live `RoTxn` then exhausts the table, so the next
+    /// `read_txn()` (e.g. inside `is_key_image_spent`) fails with
+    /// `MdbError::ReadersFull`. Used by the M7 fail-closed tests to inject a DB
+    /// error on the consensus double-spend check.
+    #[cfg(test)]
+    pub fn open_single_reader(path: &Path) -> Result<Self, LedgerError> {
+        Self::open_internal(path, Network::Testnet, Some(1))
+    }
+
+    /// Test-only: open a read transaction against the private LMDB environment.
+    /// Combined with `open_single_reader`, holding the returned `RoTxn`
+    /// exhausts the reader table so subsequent lookups fail closed (used by
+    /// M7 tests in sibling modules such as the mempool).
+    #[cfg(test)]
+    pub fn read_txn_for_test(&self) -> Result<heed::RoTxn<'_>, LedgerError> {
+        self.env
+            .read_txn()
+            .map_err(|e| LedgerError::Database(format!("Failed to start read txn: {}", e)))
+    }
+
     /// Open or create a ledger at the given path for a specific network.
     ///
     /// The ledger will be initialized with the appropriate genesis block
     /// for the specified network if it's empty.
     pub fn open_for_network(path: &Path, network: Network) -> Result<Self, LedgerError> {
+        Self::open_internal(path, network, None)
+    }
+
+    /// Internal constructor shared by `open_for_network` and test helpers.
+    ///
+    /// `max_readers`, when `Some`, caps the LMDB reader-slot table. Production
+    /// callers pass `None` (LMDB's default of 126). Tests pass a small value so
+    /// they can deterministically exhaust the reader table and force read
+    /// transactions to return `MdbError::ReadersFull` — the only practical way
+    /// to inject a DB failure for the M7 fail-closed tests.
+    fn open_internal(
+        path: &Path,
+        network: Network,
+        max_readers: Option<u32>,
+    ) -> Result<Self, LedgerError> {
         // Create directory if needed
         fs::create_dir_all(path)
             .map_err(|e| LedgerError::Database(format!("Failed to create directory: {}", e)))?;
@@ -154,10 +190,13 @@ impl Ledger {
         // directory first, and storing the Env in the struct which owns it for
         // its lifetime.
         let env = unsafe {
-            EnvOpenOptions::new()
-                .max_dbs(7) // Increased for cluster_wealth_db
-                .map_size(1024 * 1024 * 1024) // 1GB
-                .open(path)
+            let mut opts = EnvOpenOptions::new();
+            opts.max_dbs(7) // Increased for cluster_wealth_db
+                .map_size(1024 * 1024 * 1024); // 1GB
+            if let Some(readers) = max_readers {
+                opts.max_readers(readers);
+            }
+            opts.open(path)
         }
         .map_err(|e| LedgerError::Database(format!("Failed to open environment: {}", e)))?;
 
@@ -1239,9 +1278,21 @@ impl Ledger {
 
     /// Verify all signatures in a transaction
     pub fn verify_transaction(&self, tx: &BothoTransaction) -> Result<(), LedgerError> {
-        // Verify key images haven't been spent (double-spend check)
+        // Verify key images haven't been spent (double-spend check).
+        //
+        // A DB error here is a node-local operational failure, NOT a statement
+        // that the transaction is invalid. We distinguish two outcomes and fail
+        // CLOSED on the error path (audit cycle 6, M7):
+        //   - lookup succeeds and finds the key image spent -> reject as invalid
+        //     (`LedgerError::InvalidBlock`, the existing/correct verdict)
+        //   - lookup returns Err (DB failure) -> propagate the DB error up via `?` so
+        //     the caller aborts/retries. Previously this used `if let Ok(Some(..))`,
+        //     which silently treated a DB error as "not spent" and let a double-spend
+        //     pass (fail-open). Propagating with `?` preserves the happy-path verdict
+        //     exactly while closing the fail-open hole — a DB error never gets branded
+        //     as block-invalid.
         for (i, input) in tx.inputs.clsag().iter().enumerate() {
-            if let Ok(Some(spent_height)) = self.is_key_image_spent(&input.key_image) {
+            if let Some(spent_height) = self.is_key_image_spent(&input.key_image)? {
                 return Err(LedgerError::InvalidBlock(format!(
                     "Input {} uses key image already spent at height {}",
                     i, spent_height
@@ -1341,9 +1392,18 @@ impl Ledger {
         key_image: &[u8; 32],
         height: u64,
     ) -> Result<(), LedgerError> {
-        // Check if already exists
-        if let Ok(Some(existing_height_bytes)) = self.key_images_db.get(wtxn, key_image.as_slice())
-        {
+        // Check if already exists.
+        //
+        // As with `verify_transaction`, distinguish a DB failure (node-local,
+        // propagate via `?`) from an actual collision (consensus-invalid). The
+        // previous `if let Ok(Some(..))` swallowed a DB `Err` and fell through to
+        // the `put` below, which would record the key image and let a
+        // double-spend through on a transient read error (fail-open, M7).
+        let existing = self
+            .key_images_db
+            .get(wtxn, key_image.as_slice())
+            .map_err(|e| LedgerError::Database(format!("Failed to get key image: {}", e)))?;
+        if let Some(existing_height_bytes) = existing {
             let existing_height =
                 u64::from_le_bytes(existing_height_bytes.try_into().unwrap_or([0u8; 8]));
             warn!(
@@ -2617,6 +2677,91 @@ mod tests {
             let mut wtxn = ledger.env.write_txn().unwrap();
             let result = ledger.record_key_image(&mut wtxn, &key_image, 10);
             assert!(result.is_err());
+        }
+    }
+
+    /// Build a minimal one-input transaction carrying `key_image`. The CLSAG
+    /// signature/ring are bogus, but `verify_transaction` checks the key-image
+    /// double-spend set BEFORE verifying ring signatures, so these tests only
+    /// exercise (and only need) the double-spend branch.
+    fn tx_with_key_image(key_image: [u8; 32]) -> BothoTransaction {
+        use crate::transaction::ClsagRingInput;
+        let input = ClsagRingInput {
+            ring: vec![RingMember {
+                target_key: [0u8; 32],
+                public_key: [0u8; 32],
+                commitment: [0u8; 32],
+            }],
+            key_image,
+            commitment_key_image: [0u8; 32],
+            clsag_signature: Vec::new(),
+            pseudo_output_amount: 0,
+        };
+        BothoTransaction::new(vec![input], vec![], 0, 0)
+    }
+
+    /// M7 fail-closed: when the consensus double-spend lookup hits a DB error,
+    /// `verify_transaction` must PROPAGATE the error (as a node-local
+    /// `LedgerError::Database`), not silently allow the transaction. Previously
+    /// the `if let Ok(Some(..))` pattern swallowed the error and skipped the
+    /// check, letting a double-spend pass on a transient DB failure
+    /// (fail-open).
+    ///
+    /// The DB error is injected by exhausting the LMDB reader table: the ledger
+    /// is opened with a single reader slot, that slot is held by a live read
+    /// txn, so the read txn inside `is_key_image_spent` fails with
+    /// `MdbError::ReadersFull`.
+    #[test]
+    fn test_verify_transaction_propagates_db_error_fail_closed() {
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open_single_reader(dir.path()).unwrap();
+
+        // Hold the only reader slot open so the next read_txn() fails.
+        let _held = ledger.env.read_txn().unwrap();
+
+        // Sanity: the lookup itself errors when the reader table is exhausted.
+        let probe = ledger.is_key_image_spent(&[0x11; 32]);
+        assert!(
+            matches!(probe, Err(LedgerError::Database(_))),
+            "expected reader-table exhaustion to surface a Database error, got {:?}",
+            probe
+        );
+
+        let tx = tx_with_key_image([0x22; 32]);
+        let result = ledger.verify_transaction(&tx);
+
+        // Must FAIL CLOSED: propagate the DB error, NOT return Ok (allow) and
+        // NOT brand the block invalid (which would risk a node-local fork).
+        match result {
+            Err(LedgerError::Database(_)) => {}
+            other => panic!(
+                "verify_transaction must propagate a DB error (fail closed), got {:?}",
+                other
+            ),
+        }
+    }
+
+    /// Happy path (no DB error) must be unchanged: a transaction whose key
+    /// image is genuinely recorded as spent is rejected with
+    /// `InvalidBlock`.
+    #[test]
+    fn test_verify_transaction_rejects_truly_spent_key_image() {
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        let key_image = [0x33; 32];
+        ledger.record_key_image_for_test(&key_image, 7).unwrap();
+
+        let tx = tx_with_key_image(key_image);
+        let result = ledger.verify_transaction(&tx);
+        match result {
+            Err(LedgerError::InvalidBlock(msg)) => {
+                assert!(msg.contains("already spent"), "unexpected message: {}", msg);
+            }
+            other => panic!(
+                "expected InvalidBlock for a truly-spent key image, got {:?}",
+                other
+            ),
         }
     }
 

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -56,7 +56,10 @@ use bth_transaction_types::TAG_WEIGHT_SCALE;
 ///
 /// Background (untagged) value contributes zero, matching
 /// `bth_transaction_core::validation::compute_effective_cluster_wealth`.
-fn effective_cluster_wealth_from_outputs(outputs: &[TxOutput], ledger: &Ledger) -> u64 {
+fn effective_cluster_wealth_from_outputs(
+    outputs: &[TxOutput],
+    ledger: &Ledger,
+) -> Result<u64, String> {
     let mut total_weighted_wealth: u128 = 0;
     let mut total_value: u128 = 0;
 
@@ -65,16 +68,25 @@ fn effective_cluster_wealth_from_outputs(outputs: &[TxOutput], ledger: &Ledger) 
         for entry in &output.cluster_tags.entries {
             let value_fraction =
                 (output.amount as u128 * entry.weight as u128) / (TAG_WEIGHT_SCALE as u128);
-            let global_wealth = ledger.get_cluster_wealth(entry.cluster_id.0).unwrap_or(0);
+            // Propagate DB errors instead of `unwrap_or(0)`. Defaulting a DB
+            // failure to zero wealth would lower the progressive fee (fail-open,
+            // audit cycle 6, M7), letting a wealthy cluster underpay on a
+            // transient read error. Surfacing the error fails CLOSED: the tx is
+            // rejected from the mempool with a LedgerError rather than admitted
+            // at a fee computed from bogus zero wealth. The happy path is
+            // unchanged.
+            let global_wealth = ledger
+                .get_cluster_wealth(entry.cluster_id.0)
+                .map_err(|e| format!("get_cluster_wealth({}): {}", entry.cluster_id.0, e))?;
             total_weighted_wealth += value_fraction * global_wealth as u128;
         }
     }
 
     if total_value == 0 {
-        return 0;
+        return Ok(0);
     }
 
-    (total_weighted_wealth / total_value) as u64
+    Ok((total_weighted_wealth / total_value) as u64)
 }
 
 // ============================================================================
@@ -661,7 +673,8 @@ impl Mempool {
 
         // Compute effective cluster wealth: output tags (inherited from
         // inputs) weighted against the ledger's global per-cluster wealth
-        let cluster_wealth = effective_cluster_wealth_from_outputs(&tx.outputs, ledger);
+        let cluster_wealth = effective_cluster_wealth_from_outputs(&tx.outputs, ledger)
+            .map_err(MempoolError::LedgerError)?;
         // Count outputs with encrypted memos for fee calculation
         let num_memos = tx.outputs.iter().filter(|o| o.has_memo()).count();
 
@@ -1278,7 +1291,7 @@ mod tests {
             e_memo: None,
             cluster_tags: ClusterTagVector::single(ClusterId(1)),
         };
-        let wealth = effective_cluster_wealth_from_outputs(&[small_output], &ledger);
+        let wealth = effective_cluster_wealth_from_outputs(&[small_output], &ledger).unwrap();
         assert_eq!(wealth, whale_amount);
 
         // Half-tagged output: 50% of the global wealth
@@ -1291,13 +1304,49 @@ mod tests {
             e_memo: None,
             cluster_tags: half_tags,
         };
-        let wealth = effective_cluster_wealth_from_outputs(&[half_output], &ledger);
+        let wealth = effective_cluster_wealth_from_outputs(&[half_output], &ledger).unwrap();
         assert_eq!(wealth, whale_amount / 2);
 
         // Untagged (background) outputs contribute zero cluster wealth
         let bg_output = test_output(1_000, 9);
-        let wealth = effective_cluster_wealth_from_outputs(&[bg_output], &ledger);
+        let wealth = effective_cluster_wealth_from_outputs(&[bg_output], &ledger).unwrap();
         assert_eq!(wealth, 0);
+    }
+
+    /// M7 fail-closed: when the per-cluster wealth lookup hits a DB error, the
+    /// fee-input wealth computation must PROPAGATE the error rather than
+    /// `unwrap_or(0)`. Defaulting to zero wealth would lower the progressive
+    /// fee (fail-open), letting a wealthy cluster underpay on a transient
+    /// DB error.
+    ///
+    /// The DB error is injected by exhausting the LMDB reader table: the ledger
+    /// is opened with one reader slot, held open, so `get_cluster_wealth`'s
+    /// read txn fails with `MdbError::ReadersFull`.
+    #[test]
+    fn test_effective_cluster_wealth_fails_closed_on_db_error() {
+        use crate::ledger::Ledger;
+        use bth_transaction_types::ClusterId;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open_single_reader(dir.path()).unwrap();
+
+        // Hold the only reader slot open so the next read_txn() fails.
+        let _held = ledger.read_txn_for_test().unwrap();
+
+        // A cluster-tagged output forces a get_cluster_wealth() lookup.
+        let tagged_output = TxOutput {
+            amount: 1_000,
+            target_key: [0x55; 32],
+            public_key: [0x56; 32],
+            e_memo: None,
+            cluster_tags: ClusterTagVector::single(ClusterId(1)),
+        };
+        let result = effective_cluster_wealth_from_outputs(&[tagged_output], &ledger);
+        assert!(
+            result.is_err(),
+            "wealth computation must fail closed (propagate DB error), got {:?}",
+            result
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Consensus-critical DB lookups swallowed errors and default-allowed (fail-open). A transient DB error could silently skip the double-spend check, record a key image despite a read failure, or lower the progressive fee. This makes all three checks **fail closed**: a DB error is propagated as a node-local error, never converted into an allow.

Critically, a DB error is treated as a **node-local operational failure** (propagated up so the caller aborts/retries), **not** a "block invalid" verdict. This avoids the risk of this node forking from peers that had no DB error. The normal (no-DB-error) path is byte-for-byte identical to before — only the error path changes from allow to propagate.

## Changes

- `botho/src/ledger/store.rs` — `verify_transaction`: replaced `if let Ok(Some(spent_height)) = self.is_key_image_spent(..)` with `if let Some(spent_height) = self.is_key_image_spent(..)?`. A DB `Err` now propagates (`LedgerError::Database`); a genuine spent key image still returns `LedgerError::InvalidBlock` (unchanged).
- `botho/src/ledger/store.rs` — `record_key_image`: the existence check's `if let Ok(Some(..)) = self.key_images_db.get(..)` previously let a DB `Err` fall through to the `put` (recording the key image anyway). Now reads the `Result` explicitly, propagating a DB error and only branding a genuine collision `InvalidBlock`.
- `botho/src/mempool.rs` — `effective_cluster_wealth_from_outputs`: replaced `get_cluster_wealth(..).unwrap_or(0)` (a DB error defaulted wealth to 0, lowering the fee) with error propagation. The function now returns `Result<u64, String>`; the `add_tx` call site maps the error to `MempoolError::LedgerError`. **Choice rationale:** propagating is the least-surprising option that does not lower the fee on error — the tx is rejected from the mempool rather than admitted at a fee computed from bogus zero wealth. (A "conservative HIGH wealth" fallback would invent a fee floor out of thin air; propagating surfaces the real operational fault.)
- Added a shared private `Ledger::open_internal(path, network, max_readers)` so a `#[cfg(test)]` `open_single_reader` can cap the LMDB reader table to 1, plus a `#[cfg(test)]` `read_txn_for_test` accessor — the only practical way to inject a real DB error (`MdbError::ReadersFull`) in a unit test.

## Call-stack trace

`verify_transaction` has exactly one caller: `store.rs` block application (`self.verify_transaction(tx)?`), which already propagates with `?` — the newly-returned `Err` aborts block application cleanly, no caller update needed. `record_key_image` is likewise called with `?` during block application. `effective_cluster_wealth_from_outputs` is called from `Mempool::add_tx` (now mapped to `MempoolError`) and from three tests (updated to `.unwrap()`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `verify_transaction` propagates DB error instead of allowing | ✅ | `test_verify_transaction_propagates_db_error_fail_closed` injects `ReadersFull` and asserts `Err(LedgerError::Database)` |
| `record_key_image` existence check propagates DB error | ✅ | Code reads `get(..)` Result and `?`-propagates; build + existing `test_key_image_double_spend_rejected` still green |
| `mempool` wealth lookup does not default to 0 on error | ✅ | `test_effective_cluster_wealth_fails_closed_on_db_error` asserts `Err` |
| Happy path unchanged (valid accepted, truly-spent rejected) | ✅ | `test_verify_transaction_rejects_truly_spent_key_image` returns `InvalidBlock`; full lib suite (1049 tests) passes |
| Callers handle propagated Err sanely (abort, not loop) | ✅ | Sole `verify_transaction`/`record_key_image` callers already use `?`; `add_tx` maps to `MempoolError::LedgerError` |

## Test Plan

- `cargo build -p botho` — passes (only pre-existing warnings).
- `cargo test -p botho --lib` — 1049 passed, 0 failed, 2 ignored (pre-existing).
- New tests injecting a DB error (reader-table exhaustion) confirm fail-closed propagation; happy-path tests confirm valid txs and truly-spent rejection are unchanged.

Closes #559