### PR TITLE
ci: compile-check all workspace test targets so integration tests can't silently rot

### DIFF
--- a/.github/workflows/workspace-build.yml
+++ b/.github/workflows/workspace-build.yml
@@ -5,10 +5,23 @@ name: Workspace Build
 # feature-unification break that only manifests on Linux (#361). This job
 # exists to give that bug — and any future Linux-only feature-unification
 # regression — a red/green signal so it can be fixed and stay fixed.
+#
+# It ALSO compile-checks every test target in the workspace (see the
+# `cargo test --workspace --no-run` step). `cargo build --workspace` does NOT
+# compile `[[test]]` / integration targets, so before this an integration test
+# under `botho/tests/` could silently stop compiling and CI stayed green — that
+# is exactly what happened to `network_integration` when the
+# `create_sync_behaviour` signature changed in #551 (fixed in #563). The
+# compile-check below makes that class of signature drift fail CI (#562).
+#
+# Trigger note: `**.rs` is included so a pure source change (no Cargo.toml/lock
+# edit, like #551) still exercises the compile-check. Without it this workflow
+# would not even run for the change that originally rotted the target.
 
 on:
   pull_request:
     paths:
+      - '**.rs'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - 'crypto/**'
@@ -54,3 +67,14 @@ jobs:
 
       - name: Build workspace
         run: cargo build --workspace
+
+      # Compile (but do NOT run) every test target in the workspace, including
+      # the integration tests under `botho/tests/` (network_integration,
+      # byzantine_integration, etc.). `cargo build --workspace` above skips
+      # `[[test]]` targets, so this is what actually catches integration-test
+      # signature drift. `--no-run` is deliberate: the integration/e2e suites
+      # are slow and some are network-flaky (they run on demand via
+      # e2e-tests.yml), so we gate on COMPILE here, not execution, to keep this
+      # required check fast and deterministic while still failing on rot (#562).
+      - name: Compile-check all test targets (no run)
+        run: cargo test --workspace --no-run


### PR DESCRIPTION
## Summary
The `network_integration` integration-test target silently stopped compiling on `main` (signature change in #551, fixed in #563) and CI never went red. Root cause: the only PR-gating Rust build job, `workspace-build.yml`, runs `cargo build --workspace`, which does **not** compile `[[test]]`/integration targets. No PR-triggered workflow compiled the integration tests, so they could rot invisibly.

This adds a `cargo test --workspace --no-run` compile-check to the Workspace Build job so that any signature drift in an integration target fails CI.

## Changes
- `.github/workflows/workspace-build.yml`:
  - Add a **Compile-check all test targets (no run)** step: `cargo test --workspace --no-run`. This compiles every test target (including `botho/tests/network_integration.rs` and the other 24 integration suites) without executing them.
  - Broaden the `pull_request` path filter to include `**.rs`. The #551 change touched only `.rs` files (no `Cargo.toml`/`Cargo.lock` edit), so the old path filter would not have triggered this workflow at all — `**.rs` ensures source signature changes are actually exercised.
  - Document the chosen scope and the `--no-run` rationale inline in the workflow header and step comment.

## Why `--no-run` instead of running the tests
Per the issue's CONSTRAINTS: the integration/e2e suites are slow and some are network-flaky. They already run on demand via `e2e-tests.yml` (`workflow_dispatch`). Introducing them into the required PR path would add flakiness. `--no-run` gates on **compile**, which is exactly what catches the rot class (signature drift) while keeping the required check fast and deterministic.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A PR that breaks an integration target's compile (like #551) now fails CI | ✅ | `cargo test --workspace --no-run` compiles all 25 `botho/tests/*` targets incl. `network_integration`; a signature mismatch there is a compile error → step fails. The `**.rs` trigger ensures the workflow runs for `.rs`-only changes like #551. |
| CI builds all test targets including integration tests under `botho/tests/` | ✅ | Verified locally: the `--no-run` build emits executables for all integration targets (network_integration, byzantine_integration, e2e_consensus_integration, etc.). |
| Chosen scope documented in the workflow | ✅ | Header comment + step comment explain the compile-check intent and the `--no-run` choice. |

## Test Plan
Ran locally on this branch (with #563 merged into main):
- `cargo test -p botho --tests --no-run` → compiles all 25 `botho/tests/*` targets cleanly, including `network_integration`.
- `cargo test --workspace --no-run` → compiles cleanly across the entire workspace (all crates' test targets). This is the exact command CI will run.
- `python3 -c "import yaml; yaml.safe_load(...)"` → workflow YAML is valid.

Closes #562