### PR TITLE
fix(minter): share one RandomX dataset across mining threads (N×2GB caused #539 halt) + RAM-aware thread default

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 558
-# Branch: feature/issue-558
+# Issue: 568
+# Branch: feature/issue-568
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/botho/src/node/minter.rs
+++ b/botho/src/node/minter.rs
@@ -445,11 +445,12 @@ pub struct Minter {
     /// The ONE fast-mode RandomX dataset (~2 GB) shared by every mining thread,
     /// bound to the current seed epoch. Built once (by whichever worker first
     /// reaches a new epoch) and reused by all threads via cheap per-VM clones,
-    /// so the miner needs ~2 GB total + a small per-VM scratchpad instead of the
-    /// `N × 2 GB` that OOM-halted the live testnet (#539/#568). Rebuilt only when
-    /// the seed key rotates (every [`pow::SEED_ROTATION_INTERVAL`] blocks). The
-    /// `Mutex` serializes the expensive build so two threads never race to
-    /// allocate two datasets for the same epoch.
+    /// so the miner needs ~2 GB total + a small per-VM scratchpad instead of
+    /// the `N × 2 GB` that OOM-halted the live testnet (#539/#568). Rebuilt
+    /// only when the seed key rotates (every
+    /// [`pow::SEED_ROTATION_INTERVAL`] blocks). The `Mutex` serializes the
+    /// expensive build so two threads never race to allocate two datasets
+    /// for the same epoch.
     fast_dataset: Arc<Mutex<Option<FastDataset>>>,
 }
 
@@ -846,7 +847,8 @@ fn mint_loop(
 /// same dataset (a small per-VM scratchpad). This is what turns the miner's
 /// memory footprint from `N × 2 GB` into ~2 GB + small per-VM scratchpads — the
 /// fix for the live-testnet OOM halt (#539). The previous epoch's dataset is
-/// dropped before the new one is allocated so the cell never holds two datasets.
+/// dropped before the new one is allocated so the cell never holds two
+/// datasets.
 fn obtain_shared_fast_hasher(
     fast_dataset: &Mutex<Option<FastDataset>>,
     seed_key: [u8; 32],
@@ -1162,9 +1164,9 @@ mod tests {
     }
 
     /// The RAM-aware auto thread default (#568): clamps the detected CPU count
-    /// to `[1, MAX_AUTO_MINT_THREADS]`. With one shared dataset this is no longer
-    /// a RAM lever (it was `N × 2 GB` before), so the clamp is purely an
-    /// oversubscription guard.
+    /// to `[1, MAX_AUTO_MINT_THREADS]`. With one shared dataset this is no
+    /// longer a RAM lever (it was `N × 2 GB` before), so the clamp is
+    /// purely an oversubscription guard.
     #[test]
     fn test_default_mint_threads_clamps() {
         // At least one thread even if detection reports an absurd 0.
@@ -1174,7 +1176,10 @@ mod tests {
         assert_eq!(default_mint_threads(2), 2);
         assert_eq!(default_mint_threads(8), 8);
         // The cap value itself passes through.
-        assert_eq!(default_mint_threads(MAX_AUTO_MINT_THREADS), MAX_AUTO_MINT_THREADS);
+        assert_eq!(
+            default_mint_threads(MAX_AUTO_MINT_THREADS),
+            MAX_AUTO_MINT_THREADS
+        );
         // Many-core boxes are clamped to the oversubscription cap.
         assert_eq!(default_mint_threads(128), MAX_AUTO_MINT_THREADS);
         assert_eq!(

--- a/botho/src/node/minter.rs
+++ b/botho/src/node/minter.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{
         atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         mpsc::{channel, Receiver, Sender},
-        Arc,
+        Arc, Mutex,
     },
     thread::{self, JoinHandle},
     time::Instant,
@@ -16,7 +16,7 @@ use tracing::{info, trace, warn};
 
 use crate::{
     block::{calculate_block_reward, MintingTx},
-    pow::{self, FastHasher, LightHasher, MinerHasher},
+    pow::{self, FastDataset, FastHasher, LightHasher, MinerHasher},
 };
 
 /// How many times a worker retries building the fast-mode RandomX dataset
@@ -30,6 +30,33 @@ const FAST_BUILD_ATTEMPTS: u32 = 3;
 /// out a transient failure, not to stall for long before degrading to light
 /// mode (#566, part C).
 const FAST_BUILD_BACKOFF_BASE_MS: u64 = 500;
+
+/// Upper bound on the **auto-detected** minting thread count (used only when
+/// `minting.threads == 0`).
+///
+/// With one shared RandomX dataset (#568) the thread count no longer drives
+/// memory: the miner needs ~2 GB for the single shared fast-mode dataset plus a
+/// small (~2 MB) scratchpad per thread, regardless of `N`. So this cap is NOT a
+/// RAM guard (that hazard is gone) — it only avoids oversubscribing a many-core
+/// box and starving the node's own consensus / RPC / networking work with
+/// mining threads (the in-process contention noted in #441/#444). An operator
+/// who really wants more threads sets `minting.threads` explicitly, which
+/// bypasses this cap entirely.
+pub const MAX_AUTO_MINT_THREADS: usize = 16;
+
+/// Choose the default number of minting threads when `minting.threads == 0`.
+///
+/// Returns the detected CPU count clamped to `[1, MAX_AUTO_MINT_THREADS]`.
+///
+/// This is the RAM-aware default (#568): before dataset sharing, defaulting to
+/// `num_cpus::get()` implied `N × 2 GB` of RandomX datasets and could silently
+/// exceed RAM — on the 2-core/3.8 GB faucet box that demanded ~4 GB and
+/// OOM-halted the chain at height 213 (#539). Now every thread shares ONE ~2 GB
+/// dataset, so the auto default is RAM-safe for any `N`; the clamp purely caps
+/// oversubscription on large boxes.
+pub fn default_mint_threads(detected_cpus: usize) -> usize {
+    detected_cpus.clamp(1, MAX_AUTO_MINT_THREADS)
+}
 
 /// Genesis / initial minting difficulty target for **RandomX**.
 ///
@@ -415,6 +442,15 @@ pub struct Minter {
     /// flag false so a node with a dead mining thread can never report
     /// `active:true` (#566, the truthfulness fix for the #539 silent halt).
     live_workers: Arc<AtomicUsize>,
+    /// The ONE fast-mode RandomX dataset (~2 GB) shared by every mining thread,
+    /// bound to the current seed epoch. Built once (by whichever worker first
+    /// reaches a new epoch) and reused by all threads via cheap per-VM clones,
+    /// so the miner needs ~2 GB total + a small per-VM scratchpad instead of the
+    /// `N × 2 GB` that OOM-halted the live testnet (#539/#568). Rebuilt only when
+    /// the seed key rotates (every [`pow::SEED_ROTATION_INTERVAL`] blocks). The
+    /// `Mutex` serializes the expensive build so two threads never race to
+    /// allocate two datasets for the same epoch.
+    fast_dataset: Arc<Mutex<Option<FastDataset>>>,
 }
 
 /// Decrements the live-worker count when a mint worker thread exits, and flips
@@ -489,6 +525,7 @@ impl Minter {
             work_version: Arc::new(AtomicU64::new(0)),
             health,
             live_workers: Arc::new(AtomicUsize::new(0)),
+            fast_dataset: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -527,6 +564,7 @@ impl Minter {
             let work_version = self.work_version.clone();
             let live_workers = self.live_workers.clone();
             let health = self.health.clone();
+            let fast_dataset = self.fast_dataset.clone();
 
             let handle = thread::spawn(move || {
                 // The exit guard fires on EVERY way this worker can terminate —
@@ -547,6 +585,7 @@ impl Minter {
                     tx_sender,
                     current_work,
                     work_version,
+                    fast_dataset,
                 );
             });
 
@@ -599,6 +638,7 @@ fn mint_loop(
     tx_sender: Sender<MintedMintingTx>,
     current_work: Arc<std::sync::RwLock<MintingWork>>,
     work_version: Arc<AtomicU64>,
+    fast_dataset: Arc<Mutex<Option<FastDataset>>>,
 ) {
     // Each thread starts at a different nonce to avoid overlap
     let mut nonce: u64 = (thread_id as u64) << 56;
@@ -621,7 +661,10 @@ fn mint_loop(
     // `pow::SEED_ROTATION_INTERVAL` blocks). Building it is seconds-expensive,
     // so we must NOT recreate it per hash or per block.
     //
-    // Normally this is a fast-mode hasher (~2 GB dataset, high throughput). If
+    // In fast mode the VM reads the minter-wide SHARED ~2 GB dataset
+    // (`fast_dataset`); all threads' VMs read the same dataset, so the miner's
+    // footprint is ~2 GB total + a small per-VM scratchpad, NOT `N × 2 GB` (the
+    // OOM that halted the live testnet — #539/#568). If
     // that dataset cannot be built — even after bounded retries — the miner
     // transparently falls back to a light-mode hasher (~256 MB cache, much
     // slower) and KEEPS HASHING rather than dying, so an undersized box degrades
@@ -677,7 +720,13 @@ fn mint_loop(
                     "Building RandomX mining hasher for new seed epoch (fast-mode \
                      dataset build takes a few seconds)"
                 );
-                match build_mining_hasher(thread_id, seed_key, &shutdown) {
+                // Drop this thread's previous-epoch hasher BEFORE building the
+                // next one. Its VM holds an `Arc` clone of the old shared
+                // dataset, so releasing it lets the old ~2 GB buffer free as soon
+                // as the last worker rotates, keeping the epoch-boundary peak
+                // bounded rather than stacking old+new across all threads (#568).
+                hasher = None;
+                match build_mining_hasher(thread_id, seed_key, &shutdown, &fast_dataset) {
                     Some(h) => hasher = Some(h),
                     None => {
                         // No hasher could be built (fast retries exhausted AND
@@ -789,12 +838,49 @@ fn mint_loop(
     }
 }
 
+/// Obtain a fast-mode VM over the minter-wide **shared** ~2 GB dataset for
+/// `seed_key`, (re)building the dataset at most once per seed epoch (#568).
+///
+/// The first worker to reach a new epoch pays the seconds-expensive ~2 GB build
+/// while holding the `Mutex`; every other worker then gets a cheap VM over the
+/// same dataset (a small per-VM scratchpad). This is what turns the miner's
+/// memory footprint from `N × 2 GB` into ~2 GB + small per-VM scratchpads — the
+/// fix for the live-testnet OOM halt (#539). The previous epoch's dataset is
+/// dropped before the new one is allocated so the cell never holds two datasets.
+fn obtain_shared_fast_hasher(
+    fast_dataset: &Mutex<Option<FastDataset>>,
+    seed_key: [u8; 32],
+) -> Result<FastHasher, randomx_rs::RandomXError> {
+    // Recover from a poisoned lock rather than panicking: a worker that died
+    // mid-build must not permanently wedge the rest of the miner. The dataset is
+    // immutable once built, so the contents behind a poisoned lock are sound.
+    let mut guard = fast_dataset
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let needs_build = guard
+        .as_ref()
+        .map(|d| d.seed_key() != seed_key)
+        .unwrap_or(true);
+    if needs_build {
+        // Free the stale (previous-epoch) dataset BEFORE allocating the new one
+        // so the cell holds at most one ~2 GB buffer at a time.
+        *guard = None;
+        *guard = Some(FastDataset::new(seed_key)?);
+    }
+    guard
+        .as_ref()
+        .expect("shared dataset present after build")
+        .hasher()
+}
+
 /// Build the RandomX mining hasher for `seed_key`, resiliently (#566, parts
-/// B+C).
+/// B+C) over the minter-wide shared dataset (#568).
 ///
 /// Strategy:
-/// 1. Try to build the fast-mode hasher (~2 GB dataset). On failure, retry up
-///    to [`FAST_BUILD_ATTEMPTS`] times with exponential backoff
+/// 1. Try to build a fast-mode hasher (VM) over the **shared** ~2 GB dataset
+///    (built once per epoch, see [`obtain_shared_fast_hasher`]). On failure,
+///    retry up to [`FAST_BUILD_ATTEMPTS`] times with exponential backoff
 ///    ([`FAST_BUILD_BACKOFF_BASE_MS`]) — a single transient allocation failure
 ///    must not permanently wedge the miner, but we must not busy-loop either.
 /// 2. If fast mode is still unavailable, fall back to a **light-mode** hasher
@@ -810,6 +896,7 @@ fn build_mining_hasher(
     thread_id: usize,
     seed_key: [u8; 32],
     shutdown: &AtomicBool,
+    fast_dataset: &Mutex<Option<FastDataset>>,
 ) -> Option<MinerHasher> {
     let mut last_err: Option<randomx_rs::RandomXError> = None;
 
@@ -817,7 +904,7 @@ fn build_mining_hasher(
         if shutdown.load(Ordering::Relaxed) {
             return None;
         }
-        match FastHasher::new(seed_key) {
+        match obtain_shared_fast_hasher(fast_dataset, seed_key) {
             Ok(h) => return Some(MinerHasher::Fast(h)),
             Err(e) => {
                 warn!(
@@ -1071,6 +1158,28 @@ mod tests {
         assert!(
             !health.is_active(),
             "panic-exit of the last worker must still flip active false (#566)"
+        );
+    }
+
+    /// The RAM-aware auto thread default (#568): clamps the detected CPU count
+    /// to `[1, MAX_AUTO_MINT_THREADS]`. With one shared dataset this is no longer
+    /// a RAM lever (it was `N × 2 GB` before), so the clamp is purely an
+    /// oversubscription guard.
+    #[test]
+    fn test_default_mint_threads_clamps() {
+        // At least one thread even if detection reports an absurd 0.
+        assert_eq!(default_mint_threads(0), 1);
+        // Typical small boxes pass through unchanged.
+        assert_eq!(default_mint_threads(1), 1);
+        assert_eq!(default_mint_threads(2), 2);
+        assert_eq!(default_mint_threads(8), 8);
+        // The cap value itself passes through.
+        assert_eq!(default_mint_threads(MAX_AUTO_MINT_THREADS), MAX_AUTO_MINT_THREADS);
+        // Many-core boxes are clamped to the oversubscription cap.
+        assert_eq!(default_mint_threads(128), MAX_AUTO_MINT_THREADS);
+        assert_eq!(
+            default_mint_threads(MAX_AUTO_MINT_THREADS + 1),
+            MAX_AUTO_MINT_THREADS
         );
     }
 

--- a/botho/src/node/mod.rs
+++ b/botho/src/node/mod.rs
@@ -169,13 +169,22 @@ impl Node {
             anyhow::anyhow!("Cannot mine without a wallet. Run 'botho init' to create one.")
         })?;
 
+        // `minting.threads == 0` means auto-detect. Route through
+        // `default_mint_threads` so the default is RAM-aware: with one shared
+        // RandomX dataset (#568) all threads share ONE ~2 GB dataset (not the
+        // `N × 2 GB` that OOM-halted the live testnet, #539), and the count is
+        // clamped to avoid oversubscribing a many-core box.
         let threads = if self.config.minting.threads == 0 {
-            num_cpus::get()
+            minter::default_mint_threads(num_cpus::get())
         } else {
             self.config.minting.threads as usize
         };
 
-        info!("Starting minting with {} threads", threads);
+        info!(
+            "Starting minting with {} threads (one shared ~2 GB RandomX dataset \
+             across all threads, #568)",
+            threads
+        );
 
         // Each minter owns its own shutdown flag (see `Minter::new`). We must
         // NOT pass the node-wide `self.shutdown` here: `Minter::stop` sets the

--- a/botho/src/pow.rs
+++ b/botho/src/pow.rs
@@ -158,24 +158,101 @@ pub fn fast_flags() -> RandomXFlag {
     RandomXFlag::get_recommended_flags() | RandomXFlag::FLAG_FULL_MEM
 }
 
+/// A **shared** fast-mode RandomX dataset (~2 GB) bound to a single seed epoch.
+///
+/// `randomx-rs`'s [`RandomXDataset`] is internally `Arc`-backed and is only ever
+/// *read* during hashing, so a SINGLE dataset can back many per-thread VMs at
+/// once — exactly the way Monero's miner shares one dataset across all of its
+/// mining threads. Build the dataset **once per seed epoch** and hand each
+/// mining thread a cheap VM over it via [`FastDataset::hasher`]; the total cost
+/// is then ~2 GB (the one dataset) + a small (~2 MB) scratchpad per VM, **not**
+/// `N × 2 GB`.
+///
+/// That `N × 2 GB` blow-up is precisely what wedged the live testnet: every
+/// mining thread built its *own* full dataset, so an `N`-core box demanded
+/// `N × 2 GB` of RAM. The faucet box (2 cores, 3.8 GB RAM) needed ~4 GB and
+/// OOM-halted at height 213 (see #539/#568). Sharing one dataset removes that
+/// per-thread multiplier.
+///
+/// Cloning a `FastDataset` is a cheap atomic `Arc` refcount bump that shares the
+/// same underlying ~2 GB buffer; the clone is consumed by [`RandomXVM`] and kept
+/// alive for the VM's lifetime.
+#[derive(Clone)]
+pub struct FastDataset {
+    seed_key: [u8; 32],
+    dataset: RandomXDataset,
+}
+
+// SAFETY: `randomx-rs` conservatively does not implement `Send`/`Sync` for
+// `RandomXDataset` because it holds a raw C pointer. Asserting `Send` here is
+// sound: the dataset is READ-ONLY after construction (RandomX fast mode never
+// mutates it during hashing), and `RandomXDataset` is `Arc`-backed so cloning
+// and dropping it across threads only touches an atomic refcount. Moving the
+// handle to another thread (or accessing it under a mutex from several threads
+// to mint per-thread VMs) is therefore data-race free. This is RandomX's
+// intended fast-mode sharing model — one dataset, many concurrently-reading VMs
+// (#568). Each VM owns its own `RandomXDataset` clone and never crosses threads
+// (`FastHasher`/`RandomXVM` remain `!Send`), so the concurrent reads go through
+// independent owned handles, not a shared `&`.
+unsafe impl Send for FastDataset {}
+
+impl FastDataset {
+    /// Build the shared ~2 GB fast-mode dataset for `seed_key`.
+    ///
+    /// Seconds-expensive (allocates and fills the full dataset). Do this **once**
+    /// per seed epoch, then derive every mining thread's VM from it with
+    /// [`FastDataset::hasher`] — never once per thread (that is the `N × 2 GB`
+    /// halt this type exists to prevent, #568).
+    pub fn new(seed_key: [u8; 32]) -> Result<Self, randomx_rs::RandomXError> {
+        let flags = fast_flags();
+        let cache = RandomXCache::new(flags, &seed_key)?;
+        let dataset = RandomXDataset::new(flags, cache, 0)?;
+        Ok(Self { seed_key, dataset })
+    }
+
+    /// The seed key this dataset is bound to.
+    pub fn seed_key(&self) -> [u8; 32] {
+        self.seed_key
+    }
+
+    /// Build a fast-mode [`FastHasher`] (VM) that reads **this** shared dataset.
+    ///
+    /// Cheap: it allocates only the VM's small scratchpad, not another ~2 GB
+    /// dataset. The returned hasher holds a cheap `Arc` clone of the dataset, so
+    /// the dataset stays alive for as long as any VM derived from it. Output is
+    /// byte-identical to a standalone [`FastHasher::new`] for the same
+    /// `(seed_key, preimage)` — sharing changes *memory*, never the hash.
+    pub fn hasher(&self) -> Result<FastHasher, randomx_rs::RandomXError> {
+        let flags = fast_flags();
+        let vm = RandomXVM::new(flags, None, Some(self.dataset.clone()))?;
+        Ok(FastHasher {
+            seed_key: self.seed_key,
+            vm,
+        })
+    }
+}
+
 /// A miner-side fast-mode RandomX hasher bound to a single seed epoch.
 ///
-/// Building one is seconds-expensive (allocates and fills the ~2 GB dataset),
-/// so the minter constructs it once per seed epoch and reuses it across all
-/// nonces / blocks in that epoch.
+/// Wraps one [`RandomXVM`] reading a ~2 GB fast-mode dataset. Prefer building
+/// these from a shared [`FastDataset`] (via [`FastDataset::hasher`]) when more
+/// than one thread mines the same epoch, so they share ONE dataset instead of
+/// allocating `N × 2 GB` (#568). [`FastHasher::new`] is the standalone path: it
+/// builds its own dataset and is handy for single-VM use and tests.
 pub struct FastHasher {
     seed_key: [u8; 32],
     vm: RandomXVM,
 }
 
 impl FastHasher {
-    /// Build a fast-mode hasher for the given seed key (full dataset).
+    /// Build a standalone fast-mode hasher for `seed_key`, allocating its **own**
+    /// ~2 GB dataset.
+    ///
+    /// When several threads mine the same epoch, build one [`FastDataset`] and
+    /// call [`FastDataset::hasher`] per thread instead, so they share a single
+    /// dataset rather than `N × 2 GB` (#568).
     pub fn new(seed_key: [u8; 32]) -> Result<Self, randomx_rs::RandomXError> {
-        let flags = fast_flags();
-        let cache = RandomXCache::new(flags, &seed_key)?;
-        let dataset = RandomXDataset::new(flags, cache, 0)?;
-        let vm = RandomXVM::new(flags, None, Some(dataset))?;
-        Ok(Self { seed_key, vm })
+        FastDataset::new(seed_key)?.hasher()
     }
 
     /// The seed key this hasher is bound to.
@@ -469,6 +546,60 @@ mod tests {
             light_hasher_hash, light,
             "LightHasher != verify_pow_hash — FORK RISK (#566)"
         );
+    }
+
+    /// CRITICAL (#568): multiple VMs built from ONE shared [`FastDataset`] must
+    /// produce the **byte-identical** hash that a standalone [`FastHasher`]
+    /// produces — otherwise sharing the dataset (the fix for the `N × 2 GB`
+    /// halt) would silently fork the chain.
+    ///
+    /// This is what makes the memory optimization consensus-safe: hashing over a
+    /// shared dataset is the same computation as hashing over a private one. To
+    /// avoid allocating several ~2 GB datasets, the test builds **one** dataset
+    /// and derives every VM (and the standalone comparison) from it; the
+    /// canonical light-mode verifier (`verify_pow_hash`) is the independent
+    /// ground truth that pins the expected output.
+    #[test]
+    fn test_shared_dataset_matches_standalone() {
+        let seed = seed_key_for_height(0);
+        let pre = pow_preimage(777, &[4u8; 32], &[5u8; 32], &[6u8; 32]);
+
+        // Ground truth: the canonical verifier hash (no 2 GB dataset).
+        let canonical = verify_pow_hash(&seed, &pre);
+
+        // ONE shared ~2 GB dataset, reused for every VM below.
+        let dataset = FastDataset::new(seed).expect("shared fast dataset");
+        assert_eq!(dataset.seed_key(), seed);
+
+        // Two independent VMs over the SAME shared dataset (this is exactly how
+        // N mining threads share one dataset at runtime).
+        let shared_a = dataset.hasher().expect("VM A over shared dataset");
+        let shared_b = dataset.hasher().expect("VM B over shared dataset");
+
+        let hash_a = shared_a.hash(&pre);
+        let hash_b = shared_b.hash(&pre);
+
+        // Both shared VMs agree with each other...
+        assert_eq!(
+            hash_a, hash_b,
+            "two VMs over one shared dataset disagree — FORK RISK (#568)"
+        );
+        // ...and with the standalone/canonical hash. `FastHasher::new` builds a
+        // standalone hasher the same way `FastDataset::hasher` does, and
+        // `test_light_equals_fast` pins standalone-fast == canonical, so this
+        // equality means shared == standalone without a second 2 GB allocation.
+        assert_eq!(
+            hash_a,
+            canonical,
+            "shared-dataset VM != canonical/standalone hash — FORK RISK (#568) \
+             (shared={}, canonical={})",
+            hex::encode(hash_a),
+            hex::encode(canonical),
+        );
+
+        // A different nonce must change the hash (the VM actually reads input).
+        let pre2 = pow_preimage(778, &[4u8; 32], &[5u8; 32], &[6u8; 32]);
+        assert_ne!(hash_a, shared_a.hash(&pre2));
     }
 
     // Expected output of the known-answer vector. Generated by the light-mode

--- a/botho/src/pow.rs
+++ b/botho/src/pow.rs
@@ -160,10 +160,10 @@ pub fn fast_flags() -> RandomXFlag {
 
 /// A **shared** fast-mode RandomX dataset (~2 GB) bound to a single seed epoch.
 ///
-/// `randomx-rs`'s [`RandomXDataset`] is internally `Arc`-backed and is only ever
-/// *read* during hashing, so a SINGLE dataset can back many per-thread VMs at
-/// once — exactly the way Monero's miner shares one dataset across all of its
-/// mining threads. Build the dataset **once per seed epoch** and hand each
+/// `randomx-rs`'s [`RandomXDataset`] is internally `Arc`-backed and is only
+/// ever *read* during hashing, so a SINGLE dataset can back many per-thread VMs
+/// at once — exactly the way Monero's miner shares one dataset across all of
+/// its mining threads. Build the dataset **once per seed epoch** and hand each
 /// mining thread a cheap VM over it via [`FastDataset::hasher`]; the total cost
 /// is then ~2 GB (the one dataset) + a small (~2 MB) scratchpad per VM, **not**
 /// `N × 2 GB`.
@@ -174,9 +174,9 @@ pub fn fast_flags() -> RandomXFlag {
 /// OOM-halted at height 213 (see #539/#568). Sharing one dataset removes that
 /// per-thread multiplier.
 ///
-/// Cloning a `FastDataset` is a cheap atomic `Arc` refcount bump that shares the
-/// same underlying ~2 GB buffer; the clone is consumed by [`RandomXVM`] and kept
-/// alive for the VM's lifetime.
+/// Cloning a `FastDataset` is a cheap atomic `Arc` refcount bump that shares
+/// the same underlying ~2 GB buffer; the clone is consumed by [`RandomXVM`] and
+/// kept alive for the VM's lifetime.
 #[derive(Clone)]
 pub struct FastDataset {
     seed_key: [u8; 32],
@@ -199,10 +199,10 @@ unsafe impl Send for FastDataset {}
 impl FastDataset {
     /// Build the shared ~2 GB fast-mode dataset for `seed_key`.
     ///
-    /// Seconds-expensive (allocates and fills the full dataset). Do this **once**
-    /// per seed epoch, then derive every mining thread's VM from it with
-    /// [`FastDataset::hasher`] — never once per thread (that is the `N × 2 GB`
-    /// halt this type exists to prevent, #568).
+    /// Seconds-expensive (allocates and fills the full dataset). Do this
+    /// **once** per seed epoch, then derive every mining thread's VM from
+    /// it with [`FastDataset::hasher`] — never once per thread (that is the
+    /// `N × 2 GB` halt this type exists to prevent, #568).
     pub fn new(seed_key: [u8; 32]) -> Result<Self, randomx_rs::RandomXError> {
         let flags = fast_flags();
         let cache = RandomXCache::new(flags, &seed_key)?;
@@ -215,13 +215,15 @@ impl FastDataset {
         self.seed_key
     }
 
-    /// Build a fast-mode [`FastHasher`] (VM) that reads **this** shared dataset.
+    /// Build a fast-mode [`FastHasher`] (VM) that reads **this** shared
+    /// dataset.
     ///
     /// Cheap: it allocates only the VM's small scratchpad, not another ~2 GB
-    /// dataset. The returned hasher holds a cheap `Arc` clone of the dataset, so
-    /// the dataset stays alive for as long as any VM derived from it. Output is
-    /// byte-identical to a standalone [`FastHasher::new`] for the same
-    /// `(seed_key, preimage)` — sharing changes *memory*, never the hash.
+    /// dataset. The returned hasher holds a cheap `Arc` clone of the dataset,
+    /// so the dataset stays alive for as long as any VM derived from it.
+    /// Output is byte-identical to a standalone [`FastHasher::new`] for the
+    /// same `(seed_key, preimage)` — sharing changes *memory*, never the
+    /// hash.
     pub fn hasher(&self) -> Result<FastHasher, randomx_rs::RandomXError> {
         let flags = fast_flags();
         let vm = RandomXVM::new(flags, None, Some(self.dataset.clone()))?;
@@ -245,8 +247,8 @@ pub struct FastHasher {
 }
 
 impl FastHasher {
-    /// Build a standalone fast-mode hasher for `seed_key`, allocating its **own**
-    /// ~2 GB dataset.
+    /// Build a standalone fast-mode hasher for `seed_key`, allocating its
+    /// **own** ~2 GB dataset.
     ///
     /// When several threads mine the same epoch, build one [`FastDataset`] and
     /// call [`FastDataset::hasher`] per thread instead, so they share a single
@@ -553,12 +555,12 @@ mod tests {
     /// produces — otherwise sharing the dataset (the fix for the `N × 2 GB`
     /// halt) would silently fork the chain.
     ///
-    /// This is what makes the memory optimization consensus-safe: hashing over a
-    /// shared dataset is the same computation as hashing over a private one. To
-    /// avoid allocating several ~2 GB datasets, the test builds **one** dataset
-    /// and derives every VM (and the standalone comparison) from it; the
-    /// canonical light-mode verifier (`verify_pow_hash`) is the independent
-    /// ground truth that pins the expected output.
+    /// This is what makes the memory optimization consensus-safe: hashing over
+    /// a shared dataset is the same computation as hashing over a private
+    /// one. To avoid allocating several ~2 GB datasets, the test builds
+    /// **one** dataset and derives every VM (and the standalone comparison)
+    /// from it; the canonical light-mode verifier (`verify_pow_hash`) is
+    /// the independent ground truth that pins the expected output.
     #[test]
     fn test_shared_dataset_matches_standalone() {
         let seed = seed_key_for_height(0);


### PR DESCRIPTION
Closes #568

## Problem

Each mining thread built its **own** ~2 GB RandomX fast-mode dataset, so an `N`-core box demanded `N × 2 GB` of RAM. The faucet box (2 cores, 3.8 GB RAM → ~4 GB demand) OOM-halted the live testnet at height 213 (#539). This is the proper fix for that halt.

## Root cause / API finding

`randomx-rs` 1.4.1 makes **true sharing possible** — no fallback-to-single-thread needed:

- `RandomXDataset` is `#[derive(Clone)]` and internally `inner: Arc<RandomXDatasetInner>` (atomic-refcounted, raw C dataset pointer).
- `RandomXVM::new(flags, None, Some(dataset))` *moves a `RandomXDataset` clone into the VM* (`linked_dataset`) and the dataset is **read-only** during hashing.

So one dataset can back many concurrently-reading VMs — exactly how Monero shares a single dataset across all mining threads. Cloning is a cheap `Arc` bump over the same ~2 GB buffer.

## Changes

- **`pow::FastDataset`** (new): builds the ~2 GB dataset **once per seed epoch**; `FastDataset::hasher()` returns a `FastHasher` (VM) over the *same* shared dataset — only a small (~2 MB) per-VM scratchpad. `unsafe impl Send` is justified (read-only after build, `Arc`-backed refcount; each VM owns its own clone and stays `!Send`/thread-local). `FastHasher::new()` now delegates to `FastDataset` (standalone path preserved for single-VM use / tests).
- **`Minter`** holds `Arc<Mutex<Option<FastDataset>>>`. `mint_loop` obtains/rebuilds the shared dataset on seed-epoch rotation (`SEED_ROTATION_INTERVAL = 2048`). The first worker into a new epoch pays the build under the mutex; the rest get cheap VMs over it. The previous-epoch dataset is freed before the new one allocates, so peak is bounded (≤ 2 × 2 GB at a rotation boundary, **independent of `N`**), not `N × 2 GB`.
- **RAM-aware default**: `default_mint_threads(num_cpus)` routes the `threads == 0` auto path, clamped to `[1, MAX_AUTO_MINT_THREADS=16]`. With sharing the count no longer drives memory (~2 GB regardless of `N`), so the clamp is purely an oversubscription guard for many-core boxes (in-process mining vs consensus/RPC, #441/#444). Explicit `minting.threads` bypasses it.

Memory: **startup/steady-state ~2 GB + N×~2 MB** (was `N × 2 GB`).

## Consensus safety

Memory/threading change **only**. `pow_preimage`, `seed_key_for_height`, `pow_value`, the difficulty comparison, and the seed schedule are untouched — hash output is byte-identical. Composes with #567 (`MinerHasher::Light` fallback + `WorkerExitGuard` truthful `active`) unchanged: if the shared fast dataset can't build, the light fallback still applies.

## Tests

- `pow::test_shared_dataset_matches_standalone` (new): builds **one** ~2 GB dataset, derives two VMs over it, and asserts both produce the **byte-identical** canonical (`verify_pow_hash`) hash — proving shared == standalone without multiple 2 GB allocations.
- `minter::test_default_mint_threads_clamps` (new): clamp behavior.
- Existing `test_known_answer_vector`, `test_light_equals_fast` (incl. #566 `LightHasher`) still pass.

`cargo build -p botho` ✅ · `cargo test -p botho --lib` ✅ (1053 passed, 0 failed) · `cargo clippy -p botho --lib` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)