### PR TITLE
build(H2-B2): floor cluster factor at the integer ring-centroid-implied factor

### DIFF
--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -254,8 +254,9 @@ impl Ledger {
         self.cluster_wealth_db
             .put(&mut wtxn, cluster_key.as_slice(), &wealth.to_le_bytes())
             .map_err(|e| LedgerError::Database(format!("Failed to set cluster wealth: {}", e)))?;
-        wtxn.commit()
-            .map_err(|e| LedgerError::Database(format!("Failed to commit cluster wealth: {}", e)))?;
+        wtxn.commit().map_err(|e| {
+            LedgerError::Database(format!("Failed to commit cluster wealth: {}", e))
+        })?;
         Ok(())
     }
 
@@ -2002,15 +2003,15 @@ impl Ledger {
     /// outputs as background (factor 1x) and pay ~zero demurrage. This raises
     /// it to at least the factor implied by the RING MEMBERS' own (public,
     /// inherited) cluster tags, which the spender cannot rewrite — so fresh
-    /// background decoys can no longer drive the demurrage factor below what the
-    /// ring composition implies. The floor can only ever RAISE the factor; a
-    /// genuinely-background ring leaves a 1x claim unchanged.
+    /// background decoys can no longer drive the demurrage factor below what
+    /// the ring composition implies. The floor can only ever RAISE the
+    /// factor; a genuinely-background ring leaves a 1x claim unchanged.
     ///
-    /// Per-cluster wealth is resolved from the ledger **fail-closed**: a DB read
-    /// error propagates as `LedgerError` rather than silently defaulting to zero
-    /// wealth (which would lower the floor — matching the M7 fail-closed fix).
-    /// The factor math is the consensus-safe, integer-only,
-    /// node-local-state-free helper
+    /// Per-cluster wealth is resolved from the ledger **fail-closed**: a DB
+    /// read error propagates as `LedgerError` rather than silently
+    /// defaulting to zero wealth (which would lower the floor — matching
+    /// the M7 fail-closed fix). The factor math is the consensus-safe,
+    /// integer-only, node-local-state-free helper
     /// [`bth_cluster_tax::ring_centroid_implied_factor`], which the consensus
     /// fee-floor enforcement (item B4) can reuse unchanged.
     ///
@@ -2767,8 +2768,8 @@ mod tests {
     }
 
     /// Attack case: the spender claims a background (1x) factor from output
-    /// tags, but the ring members carry a wealthy cluster's tags. The floor must
-    /// raise the demurrage factor to the ring-implied value.
+    /// tags, but the ring members carry a wealthy cluster's tags. The floor
+    /// must raise the demurrage factor to the ring-implied value.
     #[test]
     fn test_ring_centroid_floor_raises_understated_factor() {
         let dir = tempdir().unwrap();
@@ -2804,15 +2805,17 @@ mod tests {
 
         let curve = bth_cluster_tax::ClusterFactorCurve::default_params();
         let bg = ClusterTagVector::empty();
-        let ring_members: Vec<(u64, &ClusterTagVector)> =
-            vec![(1_000_000, &bg), (1_000_000, &bg)];
+        let ring_members: Vec<(u64, &ClusterTagVector)> = vec![(1_000_000, &bg), (1_000_000, &bg)];
 
         let claimed_factor = 1_000; // 1x background
         let floored = ledger
             .ring_centroid_floored_factor(claimed_factor, &ring_members, &curve)
             .unwrap();
 
-        assert_eq!(floored, claimed_factor, "background spend must be unaffected");
+        assert_eq!(
+            floored, claimed_factor,
+            "background spend must be unaffected"
+        );
     }
 
     /// The floor can only raise: a claim already above the ring-implied factor

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -237,6 +237,28 @@ impl Ledger {
             .map_err(|e| LedgerError::Database(format!("Failed to start read txn: {}", e)))
     }
 
+    /// Test-only: set the total wealth attributed to a cluster directly,
+    /// bypassing the per-output accumulation path. Used to seed cluster wealth
+    /// for the ring-centroid factor-floor tests.
+    #[cfg(test)]
+    pub fn set_cluster_wealth_for_test(
+        &self,
+        cluster_id: u64,
+        wealth: u64,
+    ) -> Result<(), LedgerError> {
+        let mut wtxn = self
+            .env
+            .write_txn()
+            .map_err(|e| LedgerError::Database(format!("Failed to start write txn: {}", e)))?;
+        let cluster_key = cluster_id.to_le_bytes();
+        self.cluster_wealth_db
+            .put(&mut wtxn, cluster_key.as_slice(), &wealth.to_le_bytes())
+            .map_err(|e| LedgerError::Database(format!("Failed to set cluster wealth: {}", e)))?;
+        wtxn.commit()
+            .map_err(|e| LedgerError::Database(format!("Failed to commit cluster wealth: {}", e)))?;
+        Ok(())
+    }
+
     /// Open or create a ledger at the given path for a specific network.
     ///
     /// The ledger will be initialized with the appropriate genesis block
@@ -1972,6 +1994,59 @@ impl Ledger {
         }
     }
 
+    /// Floor a spender-claimed cluster factor at the factor implied by the ring
+    /// centroid (audit cycle 6 H2, design #574 item B2).
+    ///
+    /// The `claimed_factor` is derived from a transaction's spender-authored
+    /// OUTPUT tags, so on its own it is gameable: a wealthy spender can tag
+    /// outputs as background (factor 1x) and pay ~zero demurrage. This raises
+    /// it to at least the factor implied by the RING MEMBERS' own (public,
+    /// inherited) cluster tags, which the spender cannot rewrite — so fresh
+    /// background decoys can no longer drive the demurrage factor below what the
+    /// ring composition implies. The floor can only ever RAISE the factor; a
+    /// genuinely-background ring leaves a 1x claim unchanged.
+    ///
+    /// Per-cluster wealth is resolved from the ledger **fail-closed**: a DB read
+    /// error propagates as `LedgerError` rather than silently defaulting to zero
+    /// wealth (which would lower the floor — matching the M7 fail-closed fix).
+    /// The factor math is the consensus-safe, integer-only,
+    /// node-local-state-free helper
+    /// [`bth_cluster_tax::ring_centroid_implied_factor`], which the consensus
+    /// fee-floor enforcement (item B4) can reuse unchanged.
+    ///
+    /// # Arguments
+    /// * `claimed_factor` - The cluster factor implied by the spender's output
+    ///   tags, in FACTOR_SCALE units.
+    /// * `ring_members` - The resolved `(value, cluster_tags)` of every ring
+    ///   member across all inputs (public chain data).
+    /// * `curve` - The progressive cluster factor curve.
+    ///
+    /// # Returns
+    /// `max(claimed_factor, ring_centroid_implied_factor)` in FACTOR_SCALE
+    /// units.
+    pub fn ring_centroid_floored_factor(
+        &self,
+        claimed_factor: u64,
+        ring_members: &[(u64, &ClusterTagVector)],
+        curve: &bth_cluster_tax::ClusterFactorCurve,
+    ) -> Result<u64, LedgerError> {
+        // Resolve each ring member's value-normalized effective cluster wealth
+        // (Σ_tag weight × W_global / TAG_WEIGHT_SCALE), fail-closed.
+        let mut members: Vec<(u64, u64)> = Vec::with_capacity(ring_members.len());
+        for (value, tags) in ring_members {
+            let mut member_wealth: u128 = 0;
+            for entry in &tags.entries {
+                let global_wealth = self.get_cluster_wealth(entry.cluster_id.0)?;
+                member_wealth +=
+                    (entry.weight as u128 * global_wealth as u128) / TAG_WEIGHT_SCALE as u128;
+            }
+            members.push((*value, member_wealth.min(u64::MAX as u128) as u64));
+        }
+
+        let implied = bth_cluster_tax::ring_centroid_implied_factor(&members, curve);
+        Ok(claimed_factor.max(implied))
+    }
+
     /// Compute effective cluster wealth for a set of UTXOs identified by
     /// target keys.
     ///
@@ -2679,6 +2754,85 @@ mod tests {
     use super::*;
     use bth_transaction_types::ClusterTagVector;
     use tempfile::tempdir;
+
+    // ========================================================================
+    // Ring-centroid cluster-factor floor (audit cycle 6 H2, design #574 B2)
+    // ========================================================================
+
+    fn cluster_tags(cluster_id: u64) -> ClusterTagVector {
+        ClusterTagVector::from_pairs(&[(
+            bth_transaction_types::ClusterId(cluster_id),
+            TAG_WEIGHT_SCALE,
+        )])
+    }
+
+    /// Attack case: the spender claims a background (1x) factor from output
+    /// tags, but the ring members carry a wealthy cluster's tags. The floor must
+    /// raise the demurrage factor to the ring-implied value.
+    #[test]
+    fn test_ring_centroid_floor_raises_understated_factor() {
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        // Seed a wealthy cluster.
+        ledger.set_cluster_wealth_for_test(1, 100_000_000).unwrap();
+
+        let curve = bth_cluster_tax::ClusterFactorCurve::default_params();
+        let wealthy = cluster_tags(1);
+        let ring_members: Vec<(u64, &ClusterTagVector)> =
+            vec![(1_000_000, &wealthy), (1_000_000, &wealthy)];
+
+        let claimed_factor = 1_000; // 1x background claim
+        let floored = ledger
+            .ring_centroid_floored_factor(claimed_factor, &ring_members, &curve)
+            .unwrap();
+
+        assert!(
+            floored > claimed_factor,
+            "floor must raise the understated factor: {floored} > {claimed_factor}"
+        );
+        // Matches the factor the wealthy centroid implies directly.
+        assert_eq!(floored, curve.factor(100_000_000));
+    }
+
+    /// Legitimate background spend: the ring is also background (no seeded
+    /// cluster wealth), so the floor leaves the 1x claim unchanged.
+    #[test]
+    fn test_ring_centroid_floor_leaves_background_unchanged() {
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        let curve = bth_cluster_tax::ClusterFactorCurve::default_params();
+        let bg = ClusterTagVector::empty();
+        let ring_members: Vec<(u64, &ClusterTagVector)> =
+            vec![(1_000_000, &bg), (1_000_000, &bg)];
+
+        let claimed_factor = 1_000; // 1x background
+        let floored = ledger
+            .ring_centroid_floored_factor(claimed_factor, &ring_members, &curve)
+            .unwrap();
+
+        assert_eq!(floored, claimed_factor, "background spend must be unaffected");
+    }
+
+    /// The floor can only raise: a claim already above the ring-implied factor
+    /// is preserved.
+    #[test]
+    fn test_ring_centroid_floor_never_lowers_claim() {
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        let curve = bth_cluster_tax::ClusterFactorCurve::default_params();
+        let bg = ClusterTagVector::empty();
+        let ring_members: Vec<(u64, &ClusterTagVector)> = vec![(1_000_000, &bg)];
+
+        let claimed_factor = 6_000; // 6x
+        let floored = ledger
+            .ring_centroid_floored_factor(claimed_factor, &ring_members, &curve)
+            .unwrap();
+
+        assert_eq!(floored, 6_000);
+    }
 
     /// Issue #451 (Test B, apply side): the deterministic backstop must flag a
     /// block containing a transfer tx that is too old relative to the block's

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -642,7 +642,7 @@ impl Mempool {
             .map_err(|e| MempoolError::InvalidTransaction(e.to_string()))?;
 
         // Validate inputs (all transactions use CLSAG ring signatures)
-        let (input_sum, ring_members) =
+        let (input_sum, ring_members, ring_tags) =
             self.validate_clsag_inputs(tx.inputs.clsag(), &tx, ledger)?;
 
         // Validate outputs + fee <= inputs
@@ -698,6 +698,15 @@ impl Mempool {
         // heights (the real input dominates its own ring's centroid); the
         // factor term means factor-1 (background/commerce) spends pay zero.
         // See docs/design/cluster-tilted-redistribution.md.
+        // Cluster factor for demurrage. The factor from the spender-authored
+        // output tags (`cluster_wealth`) is only a CLAIM; floor it at the
+        // factor implied by the ring members' own public tags so fresh
+        // background decoys cannot drag demurrage to zero (audit cycle 6 H2,
+        // design #574 item B2).
+        let claimed_factor = self.fee_config.cluster_factor(cluster_wealth);
+        let demurrage_factor =
+            self.ring_centroid_floored_factor(&ring_tags, claimed_factor, ledger)?;
+
         let demurrage = {
             let policy = crate::monetary::mainnet_policy();
             let chain_height = ledger.get_chain_state().map(|s| s.height).unwrap_or(0);
@@ -705,7 +714,7 @@ impl Mempool {
             let blocks_per_year = (365 * 24 * 60 * 60) / policy.target_block_time_secs.max(1);
             bth_cluster_tax::demurrage_charge(
                 output_sum,
-                self.fee_config.cluster_factor(cluster_wealth),
+                demurrage_factor,
                 elapsed,
                 policy.demurrage_rate_bps(chain_height),
                 blocks_per_year,
@@ -771,15 +780,25 @@ impl Mempool {
 
     /// Validate CLSAG (standard-private) transaction inputs.
     ///
-    /// Returns the potential input sum and the public (value, creation
-    /// height) of every resolved ring member — the latter feeds the
-    /// demurrage elapsed-time centroid.
+    /// Returns the potential input sum, the public (value, creation
+    /// height) of every resolved ring member (which feeds the demurrage
+    /// elapsed-time centroid), and the (cluster tags, value) of every resolved
+    /// ring member (which feeds the cluster-factor floor — see
+    /// [`Mempool::ring_centroid_floored_factor`]).
+    #[allow(clippy::type_complexity)]
     fn validate_clsag_inputs(
         &self,
         clsag_inputs: &[crate::transaction::ClsagRingInput],
         tx: &Transaction,
         ledger: &Ledger,
-    ) -> Result<(u64, Vec<(u64, u64)>), MempoolError> {
+    ) -> Result<
+        (
+            u64,
+            Vec<(u64, u64)>,
+            Vec<(bth_transaction_types::ClusterTagVector, u64)>,
+        ),
+        MempoolError,
+    > {
         // Check for double-spends via key images (mempool)
         for input in clsag_inputs {
             if self.spent_key_images.contains_key(&input.key_image) {
@@ -869,7 +888,43 @@ impl Mempool {
             });
         }
 
-        Ok((potential_input_sum, ring_members))
+        Ok((potential_input_sum, ring_members, all_ring_tags))
+    }
+
+    /// Floor a spender-claimed cluster factor at the factor implied by the
+    /// ring centroid (audit cycle 6 H2, design #574 item B2).
+    ///
+    /// The `claimed_factor` is derived from the transaction's spender-authored
+    /// OUTPUT tags, so on its own it is gameable: a wealthy spender can tag
+    /// outputs as background and pay ~zero demurrage. This raises it to at least
+    /// the factor implied by the RING MEMBERS' own (public, inherited) cluster
+    /// tags, which the spender cannot rewrite. Fresh background decoys can no
+    /// longer drive the factor below what the ring composition implies.
+    ///
+    /// Per-cluster wealth is resolved from the ledger **fail-closed** (a DB read
+    /// error propagates as `LedgerError` rather than silently defaulting to zero
+    /// wealth, which would lower the floor — matching the M7 fix in
+    /// [`effective_cluster_wealth_from_outputs`]). The factor math is the
+    /// consensus-safe, integer-only, node-local-state-free helper
+    /// [`bth_cluster_tax::ring_centroid_implied_factor`] (via the shared
+    /// [`Ledger::ring_centroid_floored_factor`]), which item B4 can reuse on the
+    /// consensus path.
+    fn ring_centroid_floored_factor(
+        &self,
+        ring_tags: &[(bth_transaction_types::ClusterTagVector, u64)],
+        claimed_factor: u64,
+        ledger: &Ledger,
+    ) -> Result<u64, MempoolError> {
+        let ring_members: Vec<(u64, &bth_transaction_types::ClusterTagVector)> =
+            ring_tags.iter().map(|(tags, value)| (*value, tags)).collect();
+
+        ledger
+            .ring_centroid_floored_factor(
+                claimed_factor,
+                &ring_members,
+                &self.fee_config.cluster_curve,
+            )
+            .map_err(|e| MempoolError::LedgerError(e.to_string()))
     }
 
     /// Remove a transaction from the mempool and clear its key images.

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -896,27 +896,30 @@ impl Mempool {
     ///
     /// The `claimed_factor` is derived from the transaction's spender-authored
     /// OUTPUT tags, so on its own it is gameable: a wealthy spender can tag
-    /// outputs as background and pay ~zero demurrage. This raises it to at least
-    /// the factor implied by the RING MEMBERS' own (public, inherited) cluster
-    /// tags, which the spender cannot rewrite. Fresh background decoys can no
-    /// longer drive the factor below what the ring composition implies.
+    /// outputs as background and pay ~zero demurrage. This raises it to at
+    /// least the factor implied by the RING MEMBERS' own (public,
+    /// inherited) cluster tags, which the spender cannot rewrite. Fresh
+    /// background decoys can no longer drive the factor below what the ring
+    /// composition implies.
     ///
-    /// Per-cluster wealth is resolved from the ledger **fail-closed** (a DB read
-    /// error propagates as `LedgerError` rather than silently defaulting to zero
-    /// wealth, which would lower the floor — matching the M7 fix in
-    /// [`effective_cluster_wealth_from_outputs`]). The factor math is the
-    /// consensus-safe, integer-only, node-local-state-free helper
-    /// [`bth_cluster_tax::ring_centroid_implied_factor`] (via the shared
-    /// [`Ledger::ring_centroid_floored_factor`]), which item B4 can reuse on the
-    /// consensus path.
+    /// Per-cluster wealth is resolved from the ledger **fail-closed** (a DB
+    /// read error propagates as `LedgerError` rather than silently
+    /// defaulting to zero wealth, which would lower the floor — matching
+    /// the M7 fix in [`effective_cluster_wealth_from_outputs`]). The factor
+    /// math is the consensus-safe, integer-only, node-local-state-free
+    /// helper [`bth_cluster_tax::ring_centroid_implied_factor`] (via the
+    /// shared [`Ledger::ring_centroid_floored_factor`]), which item B4 can
+    /// reuse on the consensus path.
     fn ring_centroid_floored_factor(
         &self,
         ring_tags: &[(bth_transaction_types::ClusterTagVector, u64)],
         claimed_factor: u64,
         ledger: &Ledger,
     ) -> Result<u64, MempoolError> {
-        let ring_members: Vec<(u64, &bth_transaction_types::ClusterTagVector)> =
-            ring_tags.iter().map(|(tags, value)| (*value, tags)).collect();
+        let ring_members: Vec<(u64, &bth_transaction_types::ClusterTagVector)> = ring_tags
+            .iter()
+            .map(|(tags, value)| (*value, tags))
+            .collect();
 
         ledger
             .ring_centroid_floored_factor(

--- a/cluster-tax/src/demurrage.rs
+++ b/cluster-tax/src/demurrage.rs
@@ -334,16 +334,16 @@ mod tests {
         ];
         let implied = ring_centroid_implied_factor(&members, &curve);
         // Centroid wealth ~ 100M × 100M / 100.001M ≈ 99.999M -> still high.
-        assert!(implied >= 5_000, "value-weighted implied factor = {implied}");
+        assert!(
+            implied >= 5_000,
+            "value-weighted implied factor = {implied}"
+        );
     }
 
     #[test]
     fn test_ring_centroid_implied_factor_empty() {
         let curve = ClusterFactorCurve::default_params();
-        assert_eq!(
-            ring_centroid_implied_factor(&[], &curve),
-            curve.factor(0)
-        );
+        assert_eq!(ring_centroid_implied_factor(&[], &curve), curve.factor(0));
     }
 
     #[test]

--- a/cluster-tax/src/demurrage.rs
+++ b/cluster-tax/src/demurrage.rs
@@ -122,9 +122,70 @@ pub fn ring_elapsed_centroid(members: &[(u64, u64)], current_height: u64) -> u64
     (weighted / total_value) as u64
 }
 
+/// Compute the cluster factor implied by the value-weighted centroid of a
+/// ring's own cluster wealth.
+///
+/// This is the wealth/factor analog of [`ring_elapsed_centroid`]: where that
+/// function takes the value-weighted centroid of ring members' public creation
+/// AGES, this takes the value-weighted centroid of their effective cluster
+/// WEALTH and maps it through the progressive fee curve.
+///
+/// # Why this exists (audit cycle 6 H2, design #574 item B2)
+///
+/// The cluster factor that drives the demurrage charge (and the progressive
+/// fee) is otherwise derived from the transaction's spender-authored OUTPUT
+/// tags. A wealthy spender can tag every output as "background" (factor 1x) and
+/// pay ~zero demurrage, even while spending coins that inherited a wealthy
+/// cluster's tags — picking fresh background-tagged decoys to drag the implied
+/// factor toward 1.
+///
+/// The ring members' tags, by contrast, are public chain state the spender
+/// cannot rewrite. The real input is one of the ring members and carries its
+/// inherited (wealthy) tags, so the factor the ring composition implies is a
+/// floor the spender cannot claim below. There is no free or empirical
+/// parameter: the floor is a pure function of public ring data and the chain's
+/// per-cluster wealth.
+///
+/// # Arguments
+/// * `members` - `(value, member_effective_cluster_wealth)` for each ring
+///   member. `member_effective_cluster_wealth` is the member's value-normalized
+///   cluster wealth (`Σ_tag weight × W_global / TAG_WEIGHT_SCALE`), resolved by
+///   the caller from public per-cluster wealth state.
+/// * `curve` - The progressive cluster factor curve.
+///
+/// # Returns
+/// The implied cluster factor in FACTOR_SCALE units (1000 = 1x .. 6000 = 6x).
+/// Background-only rings (zero centroid wealth) imply exactly the 1x floor.
+///
+/// # Determinism
+/// CONSENSUS-CRITICAL: pure integer arithmetic, ordered-slice input, no
+/// HashMap/HashSet iteration order, no node-local state. Safe for the consensus
+/// fee-floor enforcement (item B4) to reuse unchanged.
+pub fn ring_centroid_implied_factor(
+    members: &[(u64, u64)],
+    curve: &crate::fee_curve::ClusterFactorCurve,
+) -> u64 {
+    let mut weighted: u128 = 0;
+    let mut total_value: u128 = 0;
+
+    for &(value, member_wealth) in members {
+        weighted += value as u128 * member_wealth as u128;
+        total_value += value as u128;
+    }
+
+    let centroid_wealth = if total_value == 0 {
+        0
+    } else {
+        (weighted / total_value).min(u64::MAX as u128) as u64
+    };
+
+    curve.factor(centroid_wealth)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fee_curve::ClusterFactorCurve;
 
     const BLOCKS_PER_YEAR: u64 = 6_307_200; // 5s blocks
 
@@ -238,6 +299,79 @@ mod tests {
     fn test_ring_centroid_empty_and_zero_value() {
         assert_eq!(ring_elapsed_centroid(&[], 1000), 0);
         assert_eq!(ring_elapsed_centroid(&[(0, 0)], 1000), 0);
+    }
+
+    #[test]
+    fn test_ring_centroid_implied_factor_wealthy_ring() {
+        // Every member carries a wealthy cluster's wealth -> high implied factor.
+        let curve = ClusterFactorCurve::default_params();
+        // (value, member_effective_wealth)
+        let members = [(1_000_000u64, 100_000_000u64), (1_000_000, 100_000_000)];
+        let implied = ring_centroid_implied_factor(&members, &curve);
+        // Wealthy centroid maps near the curve maximum, well above 1x.
+        assert!(implied >= 5_000, "wealthy ring implied factor = {implied}");
+        assert_eq!(implied, curve.factor(100_000_000));
+    }
+
+    #[test]
+    fn test_ring_centroid_implied_factor_background_ring() {
+        // Zero member wealth (background ring) -> exactly the 1x floor.
+        let curve = ClusterFactorCurve::default_params();
+        let members = [(1_000_000u64, 0u64), (2_000_000, 0)];
+        let implied = ring_centroid_implied_factor(&members, &curve);
+        assert_eq!(implied, curve.factor(0));
+        assert_eq!(implied, FACTOR_SCALE); // 1x
+    }
+
+    #[test]
+    fn test_ring_centroid_implied_factor_value_weighted() {
+        // A large-value wealthy member dominates the centroid; a small fresh
+        // background decoy barely moves it.
+        let curve = ClusterFactorCurve::default_params();
+        let members = [
+            (100_000_000u64, 100_000_000u64), // big wealthy real input
+            (1_000, 0),                       // tiny fresh background decoy
+        ];
+        let implied = ring_centroid_implied_factor(&members, &curve);
+        // Centroid wealth ~ 100M × 100M / 100.001M ≈ 99.999M -> still high.
+        assert!(implied >= 5_000, "value-weighted implied factor = {implied}");
+    }
+
+    #[test]
+    fn test_ring_centroid_implied_factor_empty() {
+        let curve = ClusterFactorCurve::default_params();
+        assert_eq!(
+            ring_centroid_implied_factor(&[], &curve),
+            curve.factor(0)
+        );
+    }
+
+    #[test]
+    fn test_ring_centroid_floor_changes_demurrage_outcome() {
+        // End-to-end: a background-claimed factor pays zero demurrage, but the
+        // ring-floored factor produces a real charge. The spender can no longer
+        // escape demurrage by understating the output tags.
+        let curve = ClusterFactorCurve::default_params();
+        let members = [(1_000_000u64, 100_000_000u64), (1_000_000, 100_000_000)];
+
+        let claimed_factor = FACTOR_SCALE; // 1x background claim
+        let charge_claimed = demurrage_charge(
+            1_000_000,
+            claimed_factor,
+            BLOCKS_PER_YEAR,
+            200,
+            BLOCKS_PER_YEAR,
+        );
+        assert_eq!(charge_claimed, 0, "background claim pays no demurrage");
+
+        let implied = ring_centroid_implied_factor(&members, &curve);
+        let floored = claimed_factor.max(implied);
+        let charge_floored =
+            demurrage_charge(1_000_000, floored, BLOCKS_PER_YEAR, 200, BLOCKS_PER_YEAR);
+        assert!(
+            charge_floored > 0,
+            "ring-floored factor must produce a real demurrage charge: {charge_floored}"
+        );
     }
 
     #[test]

--- a/cluster-tax/src/lib.rs
+++ b/cluster-tax/src/lib.rs
@@ -95,7 +95,7 @@ pub use crypto::{
     ENTROPY_SCALE,
     MIN_ENTROPY_THRESHOLD_SCALED,
 };
-pub use demurrage::{demurrage_charge, ring_elapsed_centroid};
+pub use demurrage::{demurrage_charge, ring_centroid_implied_factor, ring_elapsed_centroid};
 pub use dynamic_fee::{DynamicFeeBase, DynamicFeeState, FeeSuggestion};
 pub use entropy_decay::{
     apply_entropy_decay, calculate_entropy_decay, compare_decay_modes, conservative_entropy_delta,


### PR DESCRIPTION
## Summary

Decomposition item **B2** of design #574 (audit cycle 6 **H2** hardening). Replaces the spender's free choice of demurrage cluster factor with a deterministic, integer-only floor derived from public ring data. Rides the #323 coordinated reset.

### The hole (H2, second half)
The cluster factor that drives the demurrage charge was taken purely from the transaction's **spender-authored OUTPUT tags** (`effective_cluster_wealth_from_outputs`), gated only by the consensus-hostile f64 cosine plausibility test. A wealthy spender could tag outputs as background (factor 1x) and, by selecting fresh background-tagged decoys, drive demurrage to ~0.

### The fix
The effective cluster factor used for demurrage is now:

```
max(claimed_factor, ring_centroid_implied_factor)
```

The ring members' tags are **public chain state the spender cannot rewrite** — the real input is one of the ring members and carries its inherited (wealthy) cluster tags. The floor is a pure function of `(resolved ring members, chain per-cluster wealth)` with **no free or empirical parameter**. It can only ever *raise* the factor: a genuinely-background ring leaves a 1x claim unchanged.

## Changes

- **`cluster-tax/src/demurrage.rs`** — new `ring_centroid_implied_factor(members, curve)`: the wealth/factor analog of the existing `ring_elapsed_centroid` (value-weighted centroid of ring members' effective cluster wealth, mapped through the fee curve). Integer-only u128 staging, ordered-slice input.
- **`botho/src/ledger/store.rs`** — new `Ledger::ring_centroid_floored_factor(...)`: resolves per-cluster wealth from the ledger **fail-closed** (a DB error propagates rather than silently lowering the floor, matching the M7 fix) and applies `max(claimed, implied)`. This is the reusable helper the consensus enforcement (B4) will call.
- **`botho/src/mempool.rs`** — `validate_clsag_inputs` now also returns the resolved ring-member tags; the demurrage cluster factor is floored before `demurrage_charge`.

## Determinism contract (consensus-safe)
The floor is **integer-only** (no f64 — explicitly avoids the f64 cosine path for this purpose), **deterministic**, has **no HashMap/HashSet iteration-order dependence** (ordered slices, sums only), and uses **no node-local state**. It is a pure function of the resolved ring members and chain per-cluster wealth state — safe for the later consensus enforcement (B4) to reuse unchanged.

## Test Plan

`cargo build` clean; affected-crate tests green.

- **cluster-tax** (`demurrage.rs`): wealthy-ring implied factor is high; background-ring implies exactly 1x; value-weighting; empty ring; and an end-to-end check that a background-claimed factor pays **zero** demurrage while the ring-floored factor produces a **real** charge.
- **ledger** (`store.rs`): attack case (background claim + wealthy ring → factor floored up to the ring-implied value), legitimate background case (ring also background → unchanged), and floor-never-lowers a higher claim.
- Existing `mempool::` (41) and `ledger::store` (28) suites pass unchanged.

## Scope
Cluster-factor floor only. Does **not** change the demurrage age clock (B1/#577), does **not** add the `add_block` consensus fee-floor enforcement (B4/#578), and does **not** touch the tag-inheritance check (#580).

Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)