### PR TITLE
fix(infra): add cmake to deploy build prereqs (randomx-rs); document low-RAM build path

### DIFF
--- a/infra/faucet/README.md
+++ b/infra/faucet/README.md
@@ -59,6 +59,38 @@ cd botho/infra/faucet
 sudo ./deploy-faucet.sh
 ```
 
+> **Build prerequisites.** A from-source build needs
+> `build-essential cmake pkg-config libssl-dev` plus a Rust toolchain. `cmake`
+> is mandatory: `randomx-rs` compiles RandomX's C++ via a cmake build script and
+> the build aborts without it. The deploy scripts (`deploy-faucet.sh`,
+> `deploy-botho.sh`) install these automatically.
+
+### Building for low-RAM seed boxes (build-once-and-distribute)
+
+The seed boxes are **t4g.small (1.8 GiB RAM, 0 swap)** and a `--release` build of
+this workspace OOMs there. Do **not** build on the seeds. The verified path (used
+in the #323 redeploy) is to build once on the faucet and copy the binary to the
+seeds:
+
+```bash
+# On the faucet (t4g.medium, 3.7 GiB RAM) — add a temporary swapfile first so
+# the RandomX-linked release build doesn't OOM:
+sudo fallocate -l 4G /swapfile && sudo chmod 600 /swapfile
+sudo mkswap /swapfile && sudo swapon /swapfile
+
+cd ~/botho && git fetch origin && git reset --hard origin/main
+cargo build --release -p botho
+
+# Distribute the identical aarch64 binary to each seed (all boxes are
+# Ubuntu 24.04.3 / glibc 2.39, so the binary is portable):
+scp target/release/botho ubuntu@seed.botho.io:/tmp/botho
+scp target/release/botho ubuntu@seed2.botho.io:/tmp/botho
+# then on each seed: sudo install -m755 /tmp/botho /usr/local/bin/botho && restart the service
+
+# Optional: remove the swapfile when done.
+sudo swapoff /swapfile && sudo rm /swapfile
+```
+
 ### Option 2: Manual Deployment
 
 See [Manual Deployment Steps](#manual-deployment-steps) below.
@@ -318,12 +350,18 @@ The faucet includes built-in rate limiting to prevent abuse:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y build-essential curl git pkg-config libssl-dev
+sudo apt-get install -y build-essential cmake curl git pkg-config libssl-dev
 
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source ~/.cargo/env
 ```
+
+> **`cmake` is required.** `randomx-rs` compiles the RandomX C++ library via a
+> cmake build script; without it a from-source build fails with
+> ``error: failed to run custom build command for `randomx-rs` ... is `cmake`
+> not installed?``. The full build prerequisite set is
+> `build-essential cmake pkg-config libssl-dev` plus a Rust toolchain.
 
 ### 3. Build Botho
 

--- a/infra/faucet/deploy-botho.sh
+++ b/infra/faucet/deploy-botho.sh
@@ -54,7 +54,7 @@ fi
 
 # Step 2: Ensure build dependencies
 log_step "Checking build dependencies..."
-ssh $SSH_OPTS "$HOST" "sudo apt-get update -qq && sudo apt-get install -y -qq build-essential pkg-config libssl-dev" >/dev/null
+ssh $SSH_OPTS "$HOST" "sudo apt-get update -qq && sudo apt-get install -y -qq build-essential cmake pkg-config libssl-dev" >/dev/null
 
 # Step 3: Clone or update repository
 log_step "Updating source code on server..."

--- a/infra/faucet/deploy-faucet.sh
+++ b/infra/faucet/deploy-faucet.sh
@@ -86,6 +86,7 @@ log_step "Installing system dependencies..."
 apt-get update
 apt-get install -y \
     build-essential \
+    cmake \
     curl \
     git \
     pkg-config \

--- a/infra/seed/TESTNET_RESET.md
+++ b/infra/seed/TESTNET_RESET.md
@@ -135,8 +135,17 @@ run `workflow_dispatch` with `dry_run=true`, or locally:
 
 1. **Build/publish a current release binary** — either push a fresh `v0.2.x`
    tag (triggers `release.yml`) or build `linux-aarch64` and copy to the host.
+   Build prerequisites are `build-essential cmake pkg-config libssl-dev` plus a
+   Rust toolchain — **`cmake` is mandatory** (`randomx-rs` compiles RandomX's C++
+   via a cmake build script and the build aborts without it).
+   **Do not build on the seed boxes:** they are t4g.small (1.8 GiB RAM, 0 swap)
+   and a release build OOMs. Build once on the faucet (3.7 GiB + a temporary 4 GiB
+   swapfile) and `scp` the identical aarch64 binary to the seeds — all boxes are
+   Ubuntu 24.04.3 / glibc 2.39, so the binary is portable. See the
+   "Building for low-RAM seed boxes" note in `infra/faucet/README.md`.
 2. **Deploy the binary** to `seed.botho.io` (`infra/seed/deploy-botho.sh`,
-   needs SSH key).
+   needs SSH key). Note `deploy-botho.sh` builds **on the host**, which OOMs on
+   t4g.small seeds — use the build-once-and-distribute path above for seeds.
 3. **Reset the chain** to fresh genesis on protocol 2.0.0
    (`reset-chain.sh` / `reset-to-testnet.sh` against the live host).
 4. **Bring up >= 1 additional regional seed** to retire `peerCount: 0`, switch

--- a/infra/seed/deploy-botho.sh
+++ b/infra/seed/deploy-botho.sh
@@ -54,7 +54,7 @@ fi
 
 # Step 2: Ensure build dependencies
 log_step "Checking build dependencies..."
-ssh $SSH_OPTS "$HOST" "sudo apt-get update -qq && sudo apt-get install -y -qq build-essential pkg-config libssl-dev" >/dev/null
+ssh $SSH_OPTS "$HOST" "sudo apt-get update -qq && sudo apt-get install -y -qq build-essential cmake pkg-config libssl-dev" >/dev/null
 
 # Step 3: Clone or update repository
 log_step "Updating source code on server..."


### PR DESCRIPTION
## Summary
The from-source deploy scripts installed `build-essential pkg-config libssl-dev` but not `cmake`. `randomx-rs v1.4.1` compiles RandomX's C++ via a cmake build script, so a fresh-host build aborts with `error: failed to run custom build command for randomx-rs ... is cmake not installed?`. This actually broke the #323 testnet redeploy until `cmake` was installed manually. This PR adds `cmake` to every from-source build path and documents the prereqs plus the low-RAM build-once-and-distribute workflow.

## Changes
- `infra/faucet/deploy-botho.sh` — add `cmake` to the apt prereq install (now `build-essential cmake pkg-config libssl-dev`).
- `infra/seed/deploy-botho.sh` — same fix (sibling build-from-source script).
- `infra/faucet/deploy-faucet.sh` — add `cmake` to the apt install list (also builds from source via `cargo build --release`).
- `infra/faucet/README.md` — document the full build prereq set, why `cmake` is mandatory, and a "Building for low-RAM seed boxes" note (build once on the faucet behind a temp 4 GiB swapfile, `scp` the portable aarch64 binary to the seeds).
- `infra/seed/TESTNET_RESET.md` — note the cmake prereq and the build-once-and-distribute path in the operator runbook steps.

## Audit of build-from-source paths
`rg -n "apt-get install|build-essential|cargo build" infra` surfaced four build paths:
- `infra/faucet/deploy-botho.sh`, `infra/seed/deploy-botho.sh`, `infra/faucet/deploy-faucet.sh` — all `cargo build` from source; all fixed.
- `infra/baas/rig-bootstrap.sh` — **not** affected: it fetches a prebuilt binary (`BOTHO_BINARY_URL`) and never runs `cargo build`, so no cmake is needed.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cmake` added to deploy-botho.sh apt install | done | Line now installs `build-essential cmake pkg-config libssl-dev` |
| Sibling build-from-source scripts audited and fixed | done | seed/deploy-botho.sh + faucet/deploy-faucet.sh fixed; rig-bootstrap.sh confirmed binary-fetch (no fix needed) |
| Prereq set documented | done | faucet/README.md + seed/TESTNET_RESET.md list `build-essential cmake pkg-config libssl-dev` + rust toolchain |
| Low-RAM build path documented | done | faucet/README.md "Building for low-RAM seed boxes" section; cross-referenced in TESTNET_RESET.md |
| No deploy-logic / service-unit / Rust changes | done | Diff is shell prereq lines + docs only |

## Test Plan
- `bash -n` on all three edited scripts — syntax OK.
- No Rust build triggered (shell + docs only; no cargo tests apply).

Closes #584

Discovered during the #323 testnet redeploy.