### PR TITLE
feat(faucet): return structured warming-up result on decoy cold start

### DIFF
--- a/botho/src/ledger/mod.rs
+++ b/botho/src/ledger/mod.rs
@@ -21,6 +21,15 @@ pub enum LedgerError {
     #[error("Invalid block: {0}")]
     InvalidBlock(String),
 
+    /// Not enough age-eligible decoy outputs exist yet to form a ring
+    /// signature. This is a cold-start condition on a fresh chain (the decoy
+    /// anonymity set has not warmed up), not a bug — it self-heals as outputs
+    /// mature. Kept as a distinct typed variant so callers (e.g. the faucet
+    /// RPC) can match it precisely and surface a graceful "warming up" response
+    /// instead of a scary raw error string.
+    #[error("Insufficient decoy candidates: need {required}, have {available}. The ledger needs more confirmed outputs for private transactions.")]
+    InsufficientDecoys { required: usize, available: usize },
+
     #[error("Block already exists at height {0}")]
     BlockExists(u64),
 

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -1705,11 +1705,10 @@ impl Ledger {
                 DecoySelectionError::InsufficientCandidates {
                     required,
                     available,
-                } => LedgerError::InvalidBlock(format!(
-                    "Insufficient decoy candidates: need {}, have {}. \
-                         The ledger needs more confirmed outputs for private transactions.",
-                    required, available
-                )),
+                } => LedgerError::InsufficientDecoys {
+                    required,
+                    available,
+                },
                 DecoySelectionError::InvalidDistribution => {
                     LedgerError::InvalidBlock("Invalid gamma distribution parameters".to_string())
                 }
@@ -1778,10 +1777,10 @@ impl Ledger {
                 DecoySelectionError::InsufficientCandidates {
                     required,
                     available,
-                } => LedgerError::InvalidBlock(format!(
-                    "Insufficient decoy candidates: need {}, have {}",
-                    required, available
-                )),
+                } => LedgerError::InsufficientDecoys {
+                    required,
+                    available,
+                },
                 DecoySelectionError::InvalidDistribution => {
                     LedgerError::InvalidBlock("Invalid gamma distribution parameters".to_string())
                 }
@@ -2765,6 +2764,42 @@ mod tests {
             bth_transaction_types::ClusterId(cluster_id),
             TAG_WEIGHT_SCALE,
         )])
+    }
+
+    /// Cold-start (issue #583): a fresh-genesis chain has no age-eligible
+    /// outputs, so decoy gather must fail with the *typed*
+    /// `LedgerError::InsufficientDecoys` variant (carrying the structured
+    /// required/available counts) rather than a stringly-typed `InvalidBlock`.
+    /// This is what lets the faucet RPC match the cold-start condition
+    /// precisely and return a graceful "warming up" response.
+    #[test]
+    fn test_cold_start_decoy_gather_returns_typed_insufficient_decoys() {
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        let mut rng = rand::thread_rng();
+        let decoys_needed = 19;
+
+        // get_decoy_outputs_for_input (used by create_private_transaction).
+        let result = ledger.get_decoy_outputs_for_input(decoys_needed, &[], 10, 0, None, &mut rng);
+        match result {
+            Err(LedgerError::InsufficientDecoys {
+                required,
+                available,
+            }) => {
+                assert_eq!(required, decoys_needed);
+                assert_eq!(available, 0, "fresh chain has no eligible decoys");
+            }
+            other => panic!("expected typed InsufficientDecoys, got {:?}", other),
+        }
+
+        // The sibling OSPEAD gather must map to the same typed variant.
+        let result = ledger.get_decoy_outputs_ospead(decoys_needed, &[], 10, None, &mut rng);
+        assert!(
+            matches!(result, Err(LedgerError::InsufficientDecoys { .. })),
+            "ospead gather should also surface the typed variant, got {:?}",
+            result
+        );
     }
 
     /// Attack case: the spender claims a background (1x) factor from output

--- a/botho/src/rpc/faucet.rs
+++ b/botho/src/rpc/faucet.rs
@@ -449,6 +449,20 @@ pub struct FaucetResponse {
     pub amount: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount_formatted: Option<String>,
+    /// Set to `true` when the request failed only because the chain's decoy
+    /// anonymity set has not warmed up yet (cold-start after a fresh genesis).
+    /// This is a transient, self-healing condition — not an error — so callers
+    /// (e.g. the web-wallet) can render a friendly "chain warming up, try again
+    /// shortly" state instead of a scary raw error. See issue #583.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warming_up: Option<bool>,
+    /// Number of age-eligible decoy outputs currently available (warming-up
+    /// only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub have_decoys: Option<usize>,
+    /// Number of decoy outputs needed to form a ring (warming-up only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub need_decoys: Option<usize>,
 }
 
 impl FaucetResponse {
@@ -459,7 +473,45 @@ impl FaucetResponse {
             tx_hash: Some(tx_hash),
             amount: Some(amount.to_string()),
             amount_formatted: Some(format!("{:.6} BTH", bth)),
+            warming_up: None,
+            have_decoys: None,
+            need_decoys: None,
         }
+    }
+
+    /// Build a graceful "chain warming up" response for the cold-start
+    /// insufficient-decoys condition. Returned as a normal JSON-RPC result
+    /// (HTTP 200), not an error, with `success: false` and `warmingUp: true`.
+    pub fn warming_up(have_decoys: usize, need_decoys: usize) -> Self {
+        Self {
+            success: false,
+            tx_hash: None,
+            amount: None,
+            amount_formatted: None,
+            warming_up: Some(true),
+            have_decoys: Some(have_decoys),
+            need_decoys: Some(need_decoys),
+        }
+    }
+
+    /// Inspect an error returned from transaction creation and, *only* if it is
+    /// the cold-start insufficient-decoys condition
+    /// (`LedgerError::InsufficientDecoys`, threaded through the anyhow source
+    /// chain), return the corresponding warming-up response.
+    ///
+    /// Returns `None` for every other error so that genuine tx-creation
+    /// failures still surface as real errors — this is the guard against
+    /// over-suppression (issue #583).
+    pub fn warming_up_for_tx_error(err: &anyhow::Error) -> Option<Self> {
+        err.chain()
+            .find_map(|cause| cause.downcast_ref::<crate::ledger::LedgerError>())
+            .and_then(|ledger_err| match ledger_err {
+                crate::ledger::LedgerError::InsufficientDecoys {
+                    required,
+                    available,
+                } => Some(Self::warming_up(*available, *required)),
+                _ => None,
+            })
     }
 }
 
@@ -484,6 +536,76 @@ mod tests {
         let ip: IpAddr = "192.168.1.1".parse().unwrap();
 
         assert!(state.check_rate_limit(ip, "view:abc\nspend:def").is_ok());
+    }
+
+    // --- Cold-start "warming up" response (issue #583) ---
+
+    #[test]
+    fn test_warming_up_response_serde_shape() {
+        // The structured warming-up result must serialize to the camelCase
+        // shape the web-wallet expects: success:false, warmingUp:true with
+        // haveDecoys/needDecoys, and NO txHash/amount fields.
+        let response = FaucetResponse::warming_up(4, 19);
+        let value = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(value["success"], serde_json::json!(false));
+        assert_eq!(value["warmingUp"], serde_json::json!(true));
+        assert_eq!(value["haveDecoys"], serde_json::json!(4));
+        assert_eq!(value["needDecoys"], serde_json::json!(19));
+        assert!(value.get("txHash").is_none());
+        assert!(value.get("amount").is_none());
+    }
+
+    #[test]
+    fn test_success_response_has_no_warming_up_flag() {
+        // A normal successful dispense must not carry warming-up fields.
+        let response = FaucetResponse::success("deadbeef".to_string(), 10_000_000_000_000);
+        let value = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(value["success"], serde_json::json!(true));
+        assert!(value.get("warmingUp").is_none());
+        assert!(value.get("haveDecoys").is_none());
+        assert!(value.get("needDecoys").is_none());
+        assert_eq!(value["txHash"], serde_json::json!("deadbeef"));
+    }
+
+    #[test]
+    fn test_cold_start_insufficient_decoys_maps_to_warming_up() {
+        // Simulate the error the wallet surfaces on a fresh-genesis chain:
+        // a typed LedgerError::InsufficientDecoys threaded through the anyhow
+        // source chain (mirrors wallet::create_private_transaction wrapping).
+        let err = anyhow::Error::new(crate::ledger::LedgerError::InsufficientDecoys {
+            required: 19,
+            available: 4,
+        })
+        .context("Failed to get decoy outputs");
+        let err = err.context("Failed to create transaction");
+
+        let response = FaucetResponse::warming_up_for_tx_error(&err)
+            .expect("insufficient-decoys error should map to a warming-up response");
+
+        assert_eq!(response.success, false);
+        assert_eq!(response.warming_up, Some(true));
+        assert_eq!(response.have_decoys, Some(4));
+        assert_eq!(response.need_decoys, Some(19));
+    }
+
+    #[test]
+    fn test_genuine_tx_error_is_not_suppressed() {
+        // Guard against over-suppression: any error that is NOT the cold-start
+        // insufficient-decoys case must return None so it surfaces as a real
+        // error to the caller.
+
+        // A plain anyhow error (e.g. "No UTXOs to spend").
+        let plain = anyhow::anyhow!("No UTXOs to spend");
+        assert!(FaucetResponse::warming_up_for_tx_error(&plain).is_none());
+
+        // A *different* typed LedgerError must also surface normally.
+        let other = anyhow::Error::new(crate::ledger::LedgerError::InvalidBlock(
+            "key image already spent".to_string(),
+        ))
+        .context("Failed to get decoy outputs");
+        assert!(FaucetResponse::warming_up_for_tx_error(&other).is_none());
     }
 
     #[test]

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -2977,6 +2977,28 @@ async fn handle_faucet_request(
     ) {
         Ok(t) => t,
         Err(e) => {
+            // Cold-start guard (issue #583): on a fresh-genesis chain the decoy
+            // anonymity set has not warmed up yet, so ring formation fails with
+            // a typed `LedgerError::InsufficientDecoys`. This self-heals in
+            // ~30 blocks. Catch ONLY that specific case and return a graceful,
+            // structured "warming up" result (HTTP 200, not an error) so the
+            // web-wallet can render a friendly message. All other tx-creation
+            // failures still surface as real errors below.
+            if let Some(response) = faucet::FaucetResponse::warming_up_for_tx_error(&e) {
+                warn!(
+                    "Faucet: chain warming up — insufficient decoys (have {:?}, need {:?})",
+                    response.have_decoys, response.need_decoys
+                );
+                return match serde_json::to_value(&response) {
+                    Ok(value) => JsonRpcResponse::success(id, value),
+                    Err(e) => JsonRpcResponse::error(
+                        id,
+                        -32000,
+                        &format!("Failed to serialize response: {}", e),
+                    ),
+                };
+            }
+
             error!("Faucet: failed to create transaction: {}", e);
             return JsonRpcResponse::error(
                 id,

--- a/botho/src/wallet.rs
+++ b/botho/src/wallet.rs
@@ -514,7 +514,12 @@ impl Wallet {
                     Some(&selector),
                     &mut rng,
                 )
-                .map_err(|e| anyhow::anyhow!("Failed to get decoy outputs: {}", e))?;
+                // Preserve the typed `LedgerError` as the anyhow source (via
+                // `.context`, not `anyhow!("{}", e)`) so callers such as the
+                // faucet RPC can downcast to `LedgerError::InsufficientDecoys`
+                // and surface a graceful cold-start "warming up" response
+                // instead of string-matching a raw error.
+                .map_err(|e| anyhow::Error::new(e).context("Failed to get decoy outputs"))?;
 
             if decoys.len() < decoys_needed {
                 return Err(anyhow::anyhow!(

--- a/web/packages/web-wallet/src/components/FaucetButton.test.tsx
+++ b/web/packages/web-wallet/src/components/FaucetButton.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the faucet button's cold-start handling (issue #583):
+ *   - a structured `warmingUp` result renders a friendly "warming up" state
+ *     (NOT a scary error), with the have/need decoy counts.
+ *   - a genuine JSON-RPC error still renders as an error (no over-suppression).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { FaucetButton } from './FaucetButton'
+
+// --- Mock the two contexts the button reads --------------------------------
+const useNetworkMock = vi.fn()
+const useWalletMock = vi.fn()
+vi.mock('../contexts/network', () => ({ useNetwork: () => useNetworkMock() }))
+vi.mock('../contexts/wallet', () => ({ useWallet: () => useWalletMock() }))
+
+function setupContexts() {
+  useNetworkMock.mockReturnValue({
+    network: {
+      faucetEndpoint: 'https://faucet.example/rpc',
+      explorerUrl: 'https://explorer.example',
+    },
+    hasFaucet: true,
+  })
+  useWalletMock.mockReturnValue({ address: 'view:abc\nspend:def' })
+}
+
+function mockFetchJson(json: unknown) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    json: async () => json,
+  }) as unknown as typeof fetch
+}
+
+describe('FaucetButton cold-start warming-up handling', () => {
+  beforeEach(() => {
+    cleanup()
+    useNetworkMock.mockReset()
+    useWalletMock.mockReset()
+    setupContexts()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders a friendly "warming up" state for a structured warmingUp result', async () => {
+    mockFetchJson({ result: { warmingUp: true, haveDecoys: 4, needDecoys: 19 } })
+
+    render(<FaucetButton />)
+    fireEvent.click(screen.getByRole('button', { name: /request bth/i }))
+
+    expect(await screen.findByText(/warming up/i)).toBeTruthy()
+    // Shows progress toward the needed anonymity set.
+    expect(screen.getByText(/4\/19 ready/)).toBeTruthy()
+    // It must NOT be presented as a raw decoy error.
+    expect(screen.queryByText(/insufficient decoy/i)).toBeNull()
+  })
+
+  it('still surfaces a genuine faucet error (no over-suppression)', async () => {
+    mockFetchJson({ error: { code: -32000, message: 'Faucet has insufficient balance' } })
+
+    render(<FaucetButton />)
+    fireEvent.click(screen.getByRole('button', { name: /request bth/i }))
+
+    expect(await screen.findByText(/insufficient balance/i)).toBeTruthy()
+    expect(screen.queryByText(/warming up/i)).toBeNull()
+  })
+})

--- a/web/packages/web-wallet/src/components/FaucetButton.tsx
+++ b/web/packages/web-wallet/src/components/FaucetButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Button, Card } from '@botho/ui'
-import { Droplets, Loader2, Check, AlertCircle, ExternalLink } from 'lucide-react'
+import { Droplets, Loader2, Check, AlertCircle, ExternalLink, Hourglass } from 'lucide-react'
 import { useNetwork } from '../contexts/network'
 import { useWallet } from '../contexts/wallet'
 
@@ -10,6 +10,12 @@ interface FaucetResponse {
   amount?: number
   error?: string
   retryAfter?: number
+  // Cold-start "chain warming up" state (issue #583): the node returns a
+  // structured result (not an error) when the decoy anonymity set is still
+  // too small to build a private transaction on a freshly-reset chain.
+  warmingUp?: boolean
+  haveDecoys?: number
+  needDecoys?: number
 }
 
 export function FaucetButton() {
@@ -71,6 +77,16 @@ export function FaucetButton() {
             error: json.error.message || 'Faucet request failed',
           })
         }
+      } else if (json.result?.warmingUp) {
+        // Cold-start: the chain hasn't accumulated enough age-eligible decoy
+        // outputs yet. This self-heals within ~30 blocks of a reset, so show a
+        // friendly "warming up" state rather than a scary error.
+        setResult({
+          success: false,
+          warmingUp: true,
+          haveDecoys: json.result.haveDecoys,
+          needDecoys: json.result.needDecoys,
+        })
       } else if (json.result) {
         setResult({
           success: true,
@@ -120,11 +136,15 @@ export function FaucetButton() {
             <div className={`mb-4 p-3 rounded-lg ${
               result.success
                 ? 'bg-success/10 border border-success/20'
-                : 'bg-danger/10 border border-danger/20'
+                : result.warmingUp
+                  ? 'bg-pulse/10 border border-pulse/20'
+                  : 'bg-danger/10 border border-danger/20'
             }`}>
               <div className="flex items-start gap-2">
                 {result.success ? (
                   <Check size={16} className="text-success mt-0.5 shrink-0" />
+                ) : result.warmingUp ? (
+                  <Hourglass size={16} className="text-pulse mt-0.5 shrink-0" />
                 ) : (
                   <AlertCircle size={16} className="text-danger mt-0.5 shrink-0" />
                 )}
@@ -145,6 +165,20 @@ export function FaucetButton() {
                           <ExternalLink size={12} />
                         </a>
                       )}
+                    </>
+                  ) : result.warmingUp ? (
+                    <>
+                      <p className="text-sm text-pulse">
+                        Chain is warming up — try again shortly.
+                      </p>
+                      <p className="text-xs text-ghost mt-1">
+                        A freshly reset testnet needs a few blocks to build up enough
+                        outputs for private transactions
+                        {result.haveDecoys != null && result.needDecoys != null
+                          ? ` (${result.haveDecoys}/${result.needDecoys} ready)`
+                          : ''}
+                        . This usually clears within ~10 minutes.
+                      </p>
                     </>
                   ) : (
                     <>


### PR DESCRIPTION
## Summary

On a freshly-reset (fresh-genesis) testnet the decoy anonymity set is empty until ~30 coinbase outputs mature, so `faucet_request` (and any private spend) fails for the first ~10 minutes with a raw, scary error string:

```
Failed to create transaction: Failed to get decoy outputs:
Invalid block: Insufficient decoy candidates: need 19, have 0
```

This is a self-healing cold-start property, not a bug (see the cold-start finding from #323). Per the operator decision on #583 (option A only — no genesis pre-funding), this PR catches **only** that specific cold-start condition at the faucet boundary and returns a graceful, structured "warming up" result instead of a raw error. All other tx-creation failures still surface as real errors.

## Changes

- **Typed error variant**: add `LedgerError::InsufficientDecoys { required, available }` and map both decoy-gather sites (`get_decoy_outputs_ospead`, `get_decoy_outputs_for_input`) to it instead of a formatted `InvalidBlock` string. Callers can now match the cold-start case precisely rather than string-matching.
- **Preserve the type through anyhow**: `wallet::create_private_transaction` now wraps the decoy error with `anyhow::Error::new(e).context(...)` (instead of `anyhow!("{}", e)`) so the typed `LedgerError` survives in the source chain and is downcastable.
- **Faucet boundary**: `faucet_request` uses a new `FaucetResponse::warming_up_for_tx_error` helper that returns a warming-up response **only** for `InsufficientDecoys` (via the anyhow source chain), and `None` for everything else. On match it returns a normal JSON-RPC result (HTTP 200): `{"success":false,"warmingUp":true,"haveDecoys":N,"needDecoys":19}` (camelCase, matching the existing `FaucetResponse` serde shape).
- **Web-wallet**: `FaucetButton` renders a friendly "Chain is warming up — try again shortly" state (with `haveDecoys/needDecoys` progress) when `warmingUp` is true, distinct from the error state.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `faucet_request` returns structured `warmingUp` response for the `InsufficientCandidates` case (no raw error string) | ✅ | `test_cold_start_insufficient_decoys_maps_to_warming_up`, `test_warming_up_response_serde_shape` |
| All other failures still return real errors (no over-suppression) | ✅ | `test_genuine_tx_error_is_not_suppressed` (plain anyhow + a different typed `LedgerError` both return `None`); web `still surfaces a genuine faucet error` |
| Web-wallet shows a friendly warmup message | ✅ | `FaucetButton.test.tsx` `renders a friendly "warming up" state` |
| Cold-start produces the typed error | ✅ | `test_cold_start_decoy_gather_returns_typed_insufficient_decoys` (both gather sites) |

## Test Plan

- `cargo build -p botho` — clean (pre-existing warnings only).
- `cargo test -p botho --lib ledger::store::tests` — 29 passed; `rpc::faucet::tests` — 13 passed; `wallet::` — 17 passed.
- `pnpm --filter @botho/web-wallet typecheck` — clean.
- `pnpm test:run packages/web-wallet/src/components/FaucetButton.test.tsx` — 2 passed.

Scope: only the cold-start decoy warmup handling (faucet RPC + web-wallet message). No changes to decoy selection logic, `RING_SIZE`, `MIN_DECOY_AGE_BLOCKS`, or genesis.

References the cold-start finding from #323.

Closes #583