### PR TITLE
feat(web-wallet): harden /pay confirm against malicious request links

### DIFF
--- a/web/packages/web-wallet/src/pages/pay.test.tsx
+++ b/web/packages/web-wallet/src/pages/pay.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Hardening of the /pay confirm screen against malicious payment-request links
+ * (#588): a link's `to`/`amount`/`memo` are all attacker-controllable, so the
+ * confirm screen must (a) flag a first-time recipient, (b) frame the memo as
+ * coming from the requester (not Botho), and (c) never treat a large
+ * link-supplied amount as pre-approved.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import {
+  createMnemonic12,
+  deriveAddressFromMnemonic,
+  BTH_MULTIPLIER,
+  type Contact,
+} from '@botho/core'
+import { buildPaymentRequestFragment, type PaymentRequest } from '../lib/payment-request'
+import { PayPage } from './pay'
+
+// Mock the wallet + network contexts so the page is self-contained.
+const useWalletMock = vi.fn()
+vi.mock('../contexts/wallet', () => ({
+  useWallet: () => useWalletMock(),
+}))
+vi.mock('../contexts/network', () => ({
+  useNetwork: () => ({ network: { explorerUrl: 'https://explorer.test' } }),
+}))
+
+const ASYNC_NOOP = async () => {}
+
+// Two distinct, structurally valid testnet addresses.
+const RECIPIENT = deriveAddressFromMnemonic(createMnemonic12(), 'testnet')
+const OWN = deriveAddressFromMnemonic(createMnemonic12(), 'testnet')
+
+function makeContact(address: string, name: string): Contact {
+  return {
+    id: 'c1',
+    name,
+    address,
+    createdAt: 0 as Contact['createdAt'],
+    updatedAt: 0 as Contact['updatedAt'],
+    txCount: 1,
+  }
+}
+
+function baseWallet(overrides: Record<string, unknown> = {}) {
+  return {
+    hasWallet: true,
+    isLocked: false,
+    address: OWN,
+    contacts: [] as Contact[],
+    addContact: vi.fn(ASYNC_NOOP),
+    send: vi.fn(async () => 'deadbeef'),
+    refreshBalance: vi.fn(ASYNC_NOOP),
+    refreshTransactions: vi.fn(ASYNC_NOOP),
+    createWallet: vi.fn(ASYNC_NOOP),
+    importWallet: vi.fn(ASYNC_NOOP),
+    unlockWallet: vi.fn(ASYNC_NOOP),
+    balance: null,
+    ...overrides,
+  }
+}
+
+function renderPay(req: PaymentRequest) {
+  window.location.hash = '#' + buildPaymentRequestFragment(req)
+  return render(
+    <MemoryRouter>
+      <PayPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('PayPage recipient + memo + amount hardening (#588)', () => {
+  beforeEach(() => {
+    cleanup()
+    useWalletMock.mockReset()
+    window.location.hash = ''
+  })
+
+  it('shows the unknown-recipient badge when the address is not a contact', () => {
+    useWalletMock.mockReturnValue(baseWallet({ contacts: [] }))
+    renderPay({ to: RECIPIENT })
+
+    expect(screen.getByText(/You have not paid this address before/i)).toBeDefined()
+    // The reassuring "in your contacts" line must NOT appear for a stranger.
+    expect(screen.queryByText(/in your contacts/i)).toBeNull()
+  })
+
+  it('does NOT show the unknown-recipient badge for a saved contact', () => {
+    useWalletMock.mockReturnValue(
+      baseWallet({ contacts: [makeContact(RECIPIENT, 'Alice')] }),
+    )
+    renderPay({ to: RECIPIENT })
+
+    expect(screen.queryByText(/You have not paid this address before/i)).toBeNull()
+    expect(screen.getByText(/in your contacts/i)).toBeDefined()
+  })
+
+  it('matches contacts case-insensitively (no false stranger warning)', () => {
+    useWalletMock.mockReturnValue(
+      baseWallet({ contacts: [makeContact(RECIPIENT.toUpperCase(), 'Bob')] }),
+    )
+    renderPay({ to: RECIPIENT })
+
+    expect(screen.queryByText(/You have not paid this address before/i)).toBeNull()
+  })
+
+  it('frames the memo as coming from the requester, not Botho', () => {
+    useWalletMock.mockReturnValue(baseWallet())
+    renderPay({ to: RECIPIENT, memo: 'Verified by Botho — safe to send' })
+
+    // The provenance label distances the app from attacker-supplied text.
+    expect(screen.getByText(/Note from the requester/i)).toBeDefined()
+    expect(screen.getByText(/not from Botho/i)).toBeDefined()
+    // The attacker text itself still renders (as untrusted content).
+    expect(screen.getByText(/Verified by Botho — safe to send/i)).toBeDefined()
+  })
+
+  it('requires an explicit acknowledgement for a large link-supplied amount', () => {
+    useWalletMock.mockReturnValue(baseWallet())
+    renderPay({ to: RECIPIENT, amount: 250n * BTH_MULTIPLIER })
+
+    // A large prefilled amount surfaces an acknowledgement, and Pay stays
+    // disabled until it is ticked (link amount is never pre-approved).
+    expect(screen.getByText(/This link is requesting a large amount/i)).toBeDefined()
+    const payButton = screen.getByRole('button', { name: /Pay/i }) as HTMLButtonElement
+    expect(payButton.disabled).toBe(true)
+  })
+
+  it('does not gate a small link-supplied amount behind acknowledgement', () => {
+    useWalletMock.mockReturnValue(baseWallet())
+    renderPay({ to: RECIPIENT, amount: 1n * BTH_MULTIPLIER })
+
+    expect(screen.queryByText(/This link is requesting a large amount/i)).toBeNull()
+  })
+})

--- a/web/packages/web-wallet/src/pages/pay.tsx
+++ b/web/packages/web-wallet/src/pages/pay.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Button, Card, Input, Logo } from '@botho/ui'
-import { formatBTH, parseBTH, isValidAddress, createMnemonic12 } from '@botho/core'
+import {
+  formatBTH,
+  parseBTH,
+  isValidAddress,
+  createMnemonic12,
+  BTH_MULTIPLIER,
+  type Contact,
+} from '@botho/core'
 import {
   Send,
   AlertCircle,
@@ -12,10 +19,21 @@ import {
   Eye,
   ExternalLink,
   ShieldAlert,
+  ShieldQuestion,
+  UserCheck,
+  UserPlus,
 } from 'lucide-react'
 import { useWallet } from '../contexts/wallet'
 import { useNetwork } from '../contexts/network'
 import { parsePaymentRequestFragment, type PaymentRequest } from '../lib/payment-request'
+
+/**
+ * A payment-request link is fully attacker-controllable. When such a link
+ * PRE-FILLS an amount at or above this threshold (in picocredits), the payer
+ * must actively acknowledge it (or re-enter the amount themselves) before the
+ * Pay button enables — a link-supplied amount is never treated as pre-approved.
+ */
+const LARGE_PREFILL_THRESHOLD = 100n * BTH_MULTIPLIER // 100 BTH
 
 /**
  * Pay page for payment-request links (#470) — the *pull* complement to the
@@ -40,7 +58,8 @@ export function PayPage() {
     hasWallet,
     isLocked,
     address,
-    getContactName,
+    contacts,
+    addContact,
     send,
     refreshBalance,
     refreshTransactions,
@@ -133,7 +152,8 @@ export function PayPage() {
                     request={request}
                     ownAddress={address}
                     balance={balance}
-                    getContactName={getContactName}
+                    contacts={contacts}
+                    addContact={addContact}
                     send={send}
                     refreshBalance={refreshBalance}
                     refreshTransactions={refreshTransactions}
@@ -158,7 +178,8 @@ function PayConfirm({
   request,
   ownAddress,
   balance,
-  getContactName,
+  contacts,
+  addContact,
   send,
   refreshBalance,
   refreshTransactions,
@@ -167,7 +188,8 @@ function PayConfirm({
   request: PaymentRequest
   ownAddress: string | null
   balance: import('@botho/core').Balance | null
-  getContactName: (address: string) => string
+  contacts: Contact[]
+  addContact: (name: string, address: string, notes?: string) => Promise<Contact>
   send: (to: string, amount: bigint, memo?: string) => Promise<string>
   refreshBalance: () => Promise<void>
   refreshTransactions: () => Promise<void>
@@ -176,16 +198,30 @@ function PayConfirm({
   const [amountStr, setAmountStr] = useState(
     request.amount !== undefined ? formatBTH(request.amount, { separators: false }) : '',
   )
+  // Whether the payer has touched the amount field. Editing the amount counts as
+  // actively (re-)entering it, which clears the large-prefill acknowledgement.
+  const [amountEdited, setAmountEdited] = useState(false)
+  // Explicit acknowledgement of a large amount that the LINK pre-filled.
+  const [largeAmountAck, setLargeAmountAck] = useState(false)
   const [isSending, setIsSending] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [txHash, setTxHash] = useState<string | null>(null)
+  // Post-pay "save as contact" affordance (only offered for unknown recipients).
+  const [saveName, setSaveName] = useState('')
+  const [savingContact, setSavingContact] = useState(false)
+  const [savedContact, setSavedContact] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
-  const contactName = useMemo(() => {
-    const name = getContactName(request.to)
-    // getContactName falls back to a shortened address when unknown; only show a
-    // "name" when it differs from the raw address (i.e. an actual contact).
-    return name && name !== request.to ? name : null
-  }, [getContactName, request.to])
+  // Resolve the recipient against the address book directly (case-insensitive).
+  // An entry here means the payer has saved or previously paid this address; its
+  // absence is the signal for the unknown-recipient warning below.
+  const existingContact = useMemo(
+    () => contacts.find((c) => c.address.toLowerCase() === request.to.toLowerCase()),
+    [contacts, request.to],
+  )
+  const isKnownRecipient = existingContact !== undefined
+  const contactName =
+    existingContact && existingContact.name.trim() ? existingContact.name.trim() : null
 
   const addressValid = isValidAddress(request.to)
   const isSelfPay = ownAddress != null && ownAddress === request.to
@@ -201,7 +237,14 @@ function PayConfirm({
     }
   }
 
-  const canPay = addressValid && amount > 0n && !amountError && !isSending
+  // A large, link-supplied (still-untouched) amount must be acknowledged before
+  // paying. Re-entering the amount yourself satisfies the same requirement.
+  const prefilledAmount = request.amount
+  const isLargePrefill =
+    prefilledAmount !== undefined && prefilledAmount >= LARGE_PREFILL_THRESHOLD
+  const needsLargeAck = isLargePrefill && !amountEdited && !largeAmountAck
+
+  const canPay = addressValid && amount > 0n && !amountError && !isSending && !needsLargeAck
 
   const handlePay = async () => {
     if (!canPay) return
@@ -218,8 +261,24 @@ function PayConfirm({
     }
   }
 
+  const handleSaveContact = async () => {
+    setSavingContact(true)
+    setSaveError(null)
+    try {
+      await addContact(saveName.trim(), request.to)
+      setSavedContact(true)
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Could not save contact.')
+    } finally {
+      setSavingContact(false)
+    }
+  }
+
   if (txHash) {
     const explorerTxUrl = explorerBase ? `${explorerBase}/tx/${txHash}` : null
+    // Offer to remember a first-time recipient so the next payment shows them as
+    // a known contact rather than an anonymous address.
+    const offerSaveContact = !isKnownRecipient && !isSelfPay
     return (
       <div className="space-y-4">
         <div className="flex flex-col items-center gap-2 text-center">
@@ -241,6 +300,41 @@ function PayConfirm({
             </a>
           )}
         </div>
+
+        {offerSaveContact &&
+          (savedContact ? (
+            <div className="flex items-center gap-2 p-3 rounded-lg bg-success/10 border border-success/20 text-success text-xs">
+              <UserCheck size={15} className="shrink-0" />
+              <span>Saved to your contacts.</span>
+            </div>
+          ) : (
+            <div className="space-y-2 p-3 rounded-lg bg-abyss border border-steel">
+              <p className="text-xs text-ghost flex items-center gap-1.5">
+                <UserPlus size={14} className="text-pulse" />
+                Save this address as a contact?
+              </p>
+              <Input
+                type="text"
+                placeholder="Name (optional)"
+                value={saveName}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  setSaveName(e.target.value)
+                  setSaveError(null)
+                }}
+              />
+              {saveError && <p className="text-xs text-danger">{saveError}</p>}
+              <Button
+                onClick={handleSaveContact}
+                disabled={savingContact}
+                variant="secondary"
+                className="w-full justify-center"
+              >
+                {savingContact ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}
+                Save as contact
+              </Button>
+            </div>
+          ))}
+
         <Link to="/wallet">
           <Button className="w-full justify-center">Go to my wallet</Button>
         </Link>
@@ -274,9 +368,40 @@ function PayConfirm({
         </div>
       )}
 
+      {/*
+        Recipient trust framing. A phone user cannot eyeball-verify a base58
+        address, and a payment-request link can point anywhere, so a first-time
+        recipient gets a distinct warning while a saved contact is reassured.
+      */}
+      {!isSelfPay &&
+        (isKnownRecipient ? (
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-success/10 border border-success/20 text-success text-xs">
+            <UserCheck size={15} className="shrink-0 mt-0.5" />
+            <span>
+              {contactName
+                ? `You've paid ${contactName} before — they're in your contacts.`
+                : "You've paid this address before — it's in your contacts."}
+            </span>
+          </div>
+        ) : (
+          <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 text-amber-200/90 text-xs">
+            <ShieldQuestion size={15} className="text-amber-400 shrink-0 mt-0.5" />
+            <span>
+              <strong className="font-semibold text-amber-100">
+                You have not paid this address before.
+              </strong>{' '}
+              Double-check the full address above — payment-request links are
+              attacker-controllable and payments can&apos;t be reversed.
+            </span>
+          </div>
+        ))}
+
       {request.memo && (
         <div>
-          <label className="block text-sm text-ghost mb-1.5">Memo</label>
+          <label className="block text-sm text-ghost mb-1.5">
+            Note from the requester{' '}
+            <span className="text-ghost/60">(not from Botho)</span>
+          </label>
           <div className="px-3 py-2 rounded-lg bg-abyss border border-steel text-sm text-light break-words">
             {request.memo}
           </div>
@@ -303,6 +428,7 @@ function PayConfirm({
           value={amountStr}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             setAmountStr(e.target.value)
+            setAmountEdited(true)
             setError(null)
           }}
           autoFocus={request.amount === undefined}
@@ -311,6 +437,28 @@ function PayConfirm({
           <p className="text-xs text-ghost mt-1">
             The requester didn&apos;t specify an amount — enter how much to send.
           </p>
+        )}
+
+        {/*
+          A large amount pre-filled by the LINK is never pre-approved: require an
+          explicit tick (or a manual re-entry, which clears this) before paying.
+        */}
+        {isLargePrefill && !amountEdited && (
+          <label className="mt-3 flex items-start gap-2 cursor-pointer p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
+            <input
+              type="checkbox"
+              checked={largeAmountAck}
+              onChange={(e) => setLargeAmountAck(e.target.checked)}
+              className="mt-0.5 w-4 h-4 accent-pulse shrink-0"
+            />
+            <span className="text-xs text-amber-200/90">
+              This link is requesting a large amount (
+              <strong className="font-semibold text-amber-100">
+                {formatBTH(prefilledAmount!)} BTH
+              </strong>
+              ). I&apos;ve verified the amount and recipient and want to send it.
+            </span>
+          </label>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
Payment-request links (`/pay#<base64url({to,amount?,memo?})>`) are fully attacker-controllable, and the `/pay` confirm screen is the sole defense before an outbound send. This adds three guardrails so a hostile link can't quietly steer a payment, socially-engineer the payer, or smuggle a large pre-approved amount.

## Changes
- **Unknown-recipient badge** (`pay.tsx`): the recipient is resolved against the address book directly (case-insensitive), replacing the old `getContactName` truncation heuristic. A first-time payee gets a distinct amber "You have not paid this address before" warning; a saved contact gets a reassuring green "in your contacts" badge. After a successful pay to a stranger, an inline "Save as contact" affordance is offered.
- **Memo provenance framing**: the memo label is now "Note from the requester (not from Botho)" so attacker-supplied text can't impersonate the app/system. The memo still renders as untrusted (React-escaped) content.
- **Amount sanity**: a large amount (>= 100 BTH) pre-filled by the link now requires an explicit acknowledgement checkbox (or a manual re-entry of the amount, which clears it) before the Pay button enables. A link-supplied amount is never treated as pre-approved.
- **Tests** (`pay.test.tsx`): unknown recipient renders the badge; a saved contact does not (and matches case-insensitively); memo renders under the "Note from the requester / not from Botho" framing; a large prefilled amount gates Pay behind acknowledgement while a small one does not.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Unknown-recipient badge, visually distinct from a known contact | done | Amber ShieldQuestion warning vs. green UserCheck badge; covered by tests |
| Offer "save as contact" after a successful pay | done | Inline save form on the success screen for non-contact, non-self recipients |
| Memo framed as "from requester (not from Botho)", rendered as untrusted text | done | Relabeled; React-escaped; test asserts framing + raw attacker text both render |
| Large prefilled amount requires active confirm/re-enter; link amount never pre-approved | done | Acknowledgement checkbox gates canPay; editing the field clears it; tests cover large vs. small |
| Tests: unknown badge / contact no-badge / memo framing | done | pay.test.tsx, 6 tests passing |

## Test Plan
- `pnpm vitest run packages/web-wallet/src/pages/pay.test.tsx` — 6 passed
- `pnpm test:run` — 471 passed, 10 skipped (no regressions)
- `pnpm -r typecheck` — all packages clean
- `pnpm --filter @botho/web-wallet build` — succeeds

## Out of scope
Address-book trust scoring / on-chain reputation (tracked separately).

Closes #588