### PR TITLE
feat: claim-link hygiene — amount cap, unfurl-safe no-auto-fetch, stale nudges

### DIFF
--- a/web/packages/core/src/storage/claim-links.test.ts
+++ b/web/packages/core/src/storage/claim-links.test.ts
@@ -234,4 +234,32 @@ describe('EncryptedClaimLinks', () => {
     // Still encrypted at rest after the status update.
     expect(isVaultBlob(localStorage.getItem(STORAGE_KEY)!)).toBe(true)
   })
+
+  // Confirm the #474 at-rest guarantee STILL holds for the sender's
+  // outstanding-link records across the full lifecycle (#589): the bearer
+  // secret must never appear in cleartext in localStorage — not after add, not
+  // after a status transition. This is the persistence side of "treat a claim
+  // link like cash": if the device's storage is read, no live secret leaks.
+  it('never leaves a bearer secret in plaintext across the record lifecycle (#589)', async () => {
+    const key = await VaultKey.fromPassword('hygiene-589-pw')
+    const store = new ClaimLinkStore(new EncryptedClaimLinks(() => key))
+    await store.load()
+    const rec = await store.add(SAMPLE)
+
+    const assertNoCleartext = () => {
+      const raw = localStorage.getItem(STORAGE_KEY)!
+      expect(isVaultBlob(raw)).toBe(true)
+      for (const word of SAMPLE.ephMnemonic.split(' ')) {
+        expect(raw).not.toContain(word)
+      }
+      expect(raw).not.toContain(SAMPLE.ephMnemonic)
+      expect(raw).not.toContain(SAMPLE.ephAddress)
+    }
+
+    assertNoCleartext() // after add
+    await store.setStatus(rec.id, 'claimed')
+    assertNoCleartext() // after marking claimed
+    await store.setStatus(rec.id, 'refunded')
+    assertNoCleartext() // after marking refunded
+  })
 })

--- a/web/packages/core/src/wallet/claim-link.test.ts
+++ b/web/packages/core/src/wallet/claim-link.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect } from 'vitest'
 import {
   CLAIM_LINK_VERSION,
   CLAIM_LINK_ENTROPY_BYTES,
+  CLAIM_LINK_MAX_AMOUNT_PICOCREDITS,
   createClaimLinkMnemonic,
   encodeClaimLinkFragment,
   buildClaimLink,
   parseClaimLinkFragment,
+  isWithinClaimLinkCap,
+  assertClaimLinkAmountWithinCap,
 } from './claim-link'
 import { isValidMnemonic, deriveAddress, createMnemonic } from './index'
 
@@ -128,6 +131,96 @@ describe('claim-link helpers', () => {
 
     it('exposes the expected entropy size constant', () => {
       expect(CLAIM_LINK_ENTROPY_BYTES).toBe(16)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Unfurl-safety invariant (#589)
+  //
+  // The property that makes sharing a claim link over an E2E messenger safe:
+  // the bearer secret lives ONLY in the URL FRAGMENT. Browsers never transmit
+  // the fragment to a server, so a messenger link-preview / unfurl fetch (a
+  // server-side GET of the URL) can never see — let alone act on — the secret.
+  // These tests codify that the secret never leaks into the path or query.
+  // -------------------------------------------------------------------------
+  describe('unfurl-safety invariant: secret is fragment-only', () => {
+    function secretOf(fragment: string): string {
+      const s = fragment.replace(/^#/, '').split('.')[1]
+      expect(s).toBeTruthy()
+      return s
+    }
+
+    it('puts the bearer secret ONLY in the fragment (never path or query)', () => {
+      const m = createClaimLinkMnemonic()
+      const url = buildClaimLink('https://wallet.botho.io', m)
+      const u = new URL(url)
+      const secret = secretOf(u.hash)
+
+      // The fragment carries the secret...
+      expect(u.hash.slice(1)).toContain(secret)
+      // ...and the path / query carry none of it.
+      expect(u.pathname).toBe('/claim')
+      expect(u.search).toBe('')
+      expect(u.pathname).not.toContain(secret)
+      expect(u.search).not.toContain(secret)
+    })
+
+    it('keeps the secret out of the part of the URL a server would receive', () => {
+      // A messenger preview bot / web server only ever sees everything BEFORE
+      // the `#` (browsers strip the fragment before sending the request).
+      const m = createClaimLinkMnemonic()
+      const amountHint = 5_000_000_000_000n
+      const url = buildClaimLink('https://wallet.botho.io', m, amountHint)
+      const hashIdx = url.indexOf('#')
+      const serverVisible = url.slice(0, hashIdx)
+      const secret = secretOf(url.slice(hashIdx))
+
+      expect(serverVisible).toBe('https://wallet.botho.io/claim')
+      expect(serverVisible).not.toContain(secret)
+      // The amount hint is also fragment-only — nothing about the link reaches
+      // the server beyond the static `/claim` path.
+      expect(serverVisible).not.toContain(amountHint.toString())
+      expect(serverVisible).not.toContain('?')
+    })
+
+    it('never emits a query string, even with an amount hint', () => {
+      const m = createClaimLinkMnemonic()
+      const url = buildClaimLink('https://wallet.botho.io', m, 1n)
+      const u = new URL(url)
+      expect(u.search).toBe('')
+      // Everything secret-bearing is after the `#`.
+      expect(url.indexOf('?')).toBe(-1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Per-link amount cap (#589): treat a claim link like cash.
+  // -------------------------------------------------------------------------
+  describe('per-link amount cap', () => {
+    it('caps the maximum at 1,000 BTH (in picocredits)', () => {
+      expect(CLAIM_LINK_MAX_AMOUNT_PICOCREDITS).toBe(1_000n * 1_000_000_000_000n)
+    })
+
+    it('isWithinClaimLinkCap accepts positive amounts up to the cap', () => {
+      expect(isWithinClaimLinkCap(1n)).toBe(true)
+      expect(isWithinClaimLinkCap(CLAIM_LINK_MAX_AMOUNT_PICOCREDITS)).toBe(true)
+    })
+
+    it('isWithinClaimLinkCap rejects non-positive and over-cap amounts', () => {
+      expect(isWithinClaimLinkCap(0n)).toBe(false)
+      expect(isWithinClaimLinkCap(-1n)).toBe(false)
+      expect(isWithinClaimLinkCap(CLAIM_LINK_MAX_AMOUNT_PICOCREDITS + 1n)).toBe(false)
+    })
+
+    it('assertClaimLinkAmountWithinCap throws above the cap with a request-link nudge', () => {
+      expect(() =>
+        assertClaimLinkAmountWithinCap(CLAIM_LINK_MAX_AMOUNT_PICOCREDITS + 1n),
+      ).toThrow(/request link/i)
+    })
+
+    it('assertClaimLinkAmountWithinCap permits amounts at or below the cap', () => {
+      expect(() => assertClaimLinkAmountWithinCap(CLAIM_LINK_MAX_AMOUNT_PICOCREDITS)).not.toThrow()
+      expect(() => assertClaimLinkAmountWithinCap(1n)).not.toThrow()
     })
   })
 })

--- a/web/packages/core/src/wallet/claim-link.ts
+++ b/web/packages/core/src/wallet/claim-link.ts
@@ -41,6 +41,51 @@ export const CLAIM_LINK_VERSION = 'v1'
 /** Length, in bytes, of the entropy backing a 12-word (128-bit) mnemonic. */
 export const CLAIM_LINK_ENTROPY_BYTES = 16
 
+/** Picocredits per 1 BTH (12 decimals, mirrors `format.ts`). */
+const PICOCREDITS_PER_BTH = 1_000_000_000_000n
+
+/**
+ * Hard cap, in picocredits, on the amount a single bearer claim link may carry
+ * (issue #589).
+ *
+ * RATIONALE — "treat a claim link like cash": a claim link is a *bearer
+ * instrument*. The bearer secret persists in BOTH parties' chat history, cloud
+ * chat backups, and screenshots even over an E2E-encrypted messenger; anyone
+ * who later reads that history can drain any still-unclaimed link. Capping the
+ * amount bounds the loss if that history is compromised — you would not text
+ * someone a large stack of cash. Larger transfers should use a **request link**
+ * (a pull: the payer keeps custody until they approve), which never parks a
+ * spendable secret in a chat log.
+ *
+ * 1,000 BTH is a deliberately conservative default for a person-to-person
+ * "cash-like" transfer; it is a product call and may be revisited as BTH's
+ * real-world value settles. It is enforced at link-creation time (UI + the
+ * funding path) so funds can never be parked above the cap.
+ */
+export const CLAIM_LINK_MAX_AMOUNT_PICOCREDITS = 1_000n * PICOCREDITS_PER_BTH
+
+/** True if `amount` (picocredits) is within the per-link cap (and positive). */
+export function isWithinClaimLinkCap(amount: bigint): boolean {
+  return amount > 0n && amount <= CLAIM_LINK_MAX_AMOUNT_PICOCREDITS
+}
+
+/**
+ * Throw a descriptive error if `amount` (picocredits) exceeds the per-link cap.
+ *
+ * Used by the funding path so a too-large amount is rejected BEFORE any
+ * on-chain spend. The message nudges toward a request link for large transfers.
+ */
+export function assertClaimLinkAmountWithinCap(amount: bigint): void {
+  if (amount > CLAIM_LINK_MAX_AMOUNT_PICOCREDITS) {
+    const capBth = (CLAIM_LINK_MAX_AMOUNT_PICOCREDITS / PICOCREDITS_PER_BTH).toString()
+    throw new Error(
+      `Claim links are capped at ${capBth} BTH — treat them like cash. ` +
+        'For a larger transfer, use a request link instead so the funds stay in your ' +
+        'custody until the recipient pulls them.',
+    )
+  }
+}
+
 /**
  * A parsed claim-link secret: the reconstructed ephemeral mnemonic plus the
  * optional, non-authoritative amount hint (picocredits) carried in the link.

--- a/web/packages/core/src/wallet/index.ts
+++ b/web/packages/core/src/wallet/index.ts
@@ -15,10 +15,13 @@ import {
 export {
   CLAIM_LINK_VERSION,
   CLAIM_LINK_ENTROPY_BYTES,
+  CLAIM_LINK_MAX_AMOUNT_PICOCREDITS,
   createClaimLinkMnemonic,
   encodeClaimLinkFragment,
   buildClaimLink,
   parseClaimLinkFragment,
+  isWithinClaimLinkCap,
+  assertClaimLinkAmountWithinCap,
   type ClaimLinkSecret,
 } from './claim-link'
 

--- a/web/packages/web-wallet/src/components/OutstandingLinks.tsx
+++ b/web/packages/web-wallet/src/components/OutstandingLinks.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from 'react'
 import { Button, Card } from '@botho/ui'
-import { formatBTH, shortenAddress, buildClaimLink } from '@botho/core'
-import { Link2, Copy, Check, RotateCcw, Trash2, RefreshCw } from 'lucide-react'
+import {
+  formatBTH,
+  shortenAddress,
+  buildClaimLink,
+  CLAIM_LINK_EXPIRY_WINDOW_SECONDS,
+} from '@botho/core'
+import { Link2, Copy, Check, RotateCcw, Trash2, RefreshCw, AlertTriangle } from 'lucide-react'
 import { useWallet } from '../contexts/wallet'
 
 /**
@@ -11,7 +16,18 @@ import { useWallet } from '../contexts/wallet'
  * link again, reclaim (refund) an unclaimed link's funds, or forget a record.
  * Status is refreshed by re-scanning each ephemeral wallet (chain is the source
  * of truth: a swept output reads back as "claimed").
+ *
+ * STALE-LINK NUDGE (#589): an unclaimed bearer secret that lingers in a chat
+ * log is drainable by anyone who later reads that history. Links left
+ * outstanding past the expiry window are surfaced prominently with a one-tap
+ * reclaim so funds don't sit claimable in chat history indefinitely.
  */
+
+/** True if an outstanding link has aged past the expiry-nudge window. */
+function isStale(link: { status: string; createdAt: number }, nowSeconds: number): boolean {
+  return link.status === 'outstanding' && nowSeconds - link.createdAt >= CLAIM_LINK_EXPIRY_WINDOW_SECONDS
+}
+
 export function OutstandingLinks() {
   const { claimLinks, refreshClaimLinks, refundClaimLink, forgetClaimLink } = useWallet()
   const [busyId, setBusyId] = useState<string | null>(null)
@@ -27,6 +43,9 @@ export function OutstandingLinks() {
   }, [])
 
   if (claimLinks.length === 0) return null
+
+  const nowSeconds = Math.floor(Date.now() / 1000)
+  const staleCount = claimLinks.filter((l) => isStale(l, nowSeconds)).length
 
   const handleRefresh = async () => {
     setRefreshing(true)
@@ -94,16 +113,38 @@ export function OutstandingLinks() {
         </div>
       )}
 
+      {staleCount > 0 && (
+        <div className="mb-3 flex items-start gap-2 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-200/90 text-xs">
+          <AlertTriangle size={14} className="shrink-0 mt-0.5 text-amber-400" />
+          <span>
+            {staleCount === 1
+              ? 'You have 1 link that has been unclaimed for over a week.'
+              : `You have ${staleCount} links that have been unclaimed for over a week.`}{' '}
+            Reclaim {staleCount === 1 ? 'it' : 'them'} so the funds don&apos;t sit claimable in
+            the recipient&apos;s chat history.
+          </span>
+        </div>
+      )}
+
       <div className="space-y-2">
-        {claimLinks.map((link) => (
+        {claimLinks.map((link) => {
+          const stale = isStale(link, nowSeconds)
+          return (
           <div
             key={link.id}
-            className="flex items-center justify-between gap-3 p-3 rounded-lg bg-abyss border border-steel"
+            className={`flex items-center justify-between gap-3 p-3 rounded-lg bg-abyss border ${
+              stale ? 'border-amber-500/40' : 'border-steel'
+            }`}
           >
             <div className="min-w-0">
               <div className="flex items-center gap-2">
                 <span className="text-sm text-light font-medium">{formatBTH(link.amount)} BTH</span>
                 {statusLabel(link.status)}
+                {stale && (
+                  <span className="inline-flex items-center gap-1 text-xs text-amber-400">
+                    <AlertTriangle size={11} /> Stale
+                  </span>
+                )}
               </div>
               <p className="text-xs text-ghost font-mono truncate">{shortenAddress(link.ephAddress)}</p>
             </div>
@@ -141,7 +182,8 @@ export function OutstandingLinks() {
               </Button>
             </div>
           </div>
-        ))}
+          )
+        })}
       </div>
     </Card>
   )

--- a/web/packages/web-wallet/src/components/SendLinkModal.tsx
+++ b/web/packages/web-wallet/src/components/SendLinkModal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Button, Card, Input } from '@botho/ui'
-import { formatBTH, parseBTH } from '@botho/core'
+import { formatBTH, parseBTH, CLAIM_LINK_MAX_AMOUNT_PICOCREDITS } from '@botho/core'
 import { Link2, Copy, Check, AlertCircle, Loader2, X, ShieldAlert } from 'lucide-react'
 import { useWallet, type CreatedClaimLink } from '../contexts/wallet'
 
@@ -42,7 +42,10 @@ export function SendLinkModal({ isOpen, onClose }: { isOpen: boolean; onClose: (
     amount = 0n
   }
   const available = balance?.available ?? 0n
-  const canCreate = amount > 0n && !isCreating
+  // Per-link amount cap (#589): bound how much can sit claimable in chat
+  // history. Over the cap, block creation and nudge toward a request link.
+  const overCap = amount > CLAIM_LINK_MAX_AMOUNT_PICOCREDITS
+  const canCreate = amount > 0n && !overCap && !isCreating
 
   const handleCreate = async () => {
     setError(null)
@@ -105,6 +108,19 @@ export function SendLinkModal({ isOpen, onClose }: { isOpen: boolean; onClose: (
                 Available: {formatBTH(available)} BTH. A small network fee is added to
                 cover the recipient&apos;s claim.
               </p>
+              <p className="text-xs text-ghost mt-1">
+                Max per link: {formatBTH(CLAIM_LINK_MAX_AMOUNT_PICOCREDITS)} BTH.
+              </p>
+              {overCap && (
+                <div className="mt-2 flex items-start gap-2 p-2.5 rounded-lg bg-danger/10 border border-danger/20 text-danger text-xs">
+                  <AlertCircle size={14} className="shrink-0 mt-0.5" />
+                  <span>
+                    Claim links are capped at {formatBTH(CLAIM_LINK_MAX_AMOUNT_PICOCREDITS)} BTH —
+                    treat them like cash. For a larger transfer, use a <strong>request link</strong>{' '}
+                    instead so the funds stay in your custody until the recipient pulls them.
+                  </span>
+                </div>
+              )}
             </div>
 
             <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from 'react'
 import { RemoteNodeAdapter, type WsConnectionStatus } from '@botho/adapters'
-import { AddressBook, EncryptedAddressBook, ClaimLinkStore, EncryptedClaimLinks, saveWallet, loadWallet, loadWalletWithKey, getWalletInfo, deriveAddress, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet, createClaimLinkMnemonic, buildClaimLink, VaultKey, MIN_PASSWORD_LENGTH } from '@botho/core'
+import { AddressBook, EncryptedAddressBook, ClaimLinkStore, EncryptedClaimLinks, saveWallet, loadWallet, loadWalletWithKey, getWalletInfo, deriveAddress, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet, createClaimLinkMnemonic, buildClaimLink, assertClaimLinkAmountWithinCap, VaultKey, MIN_PASSWORD_LENGTH } from '@botho/core'
 import type { Balance, Contact, NodeInfo, Transaction, ClaimLinkRecord, Timestamp } from '@botho/core'
 import { buildSendTransaction, spendableBalance, buildOwnedHistory } from '@botho/wasm-signer'
 import { buildAndSubmitSend, scanEphemeral, sweepEphemeral, SWEEP_FEE_RESERVE } from '../lib/claim-link-ops'
@@ -1071,6 +1071,12 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const mnemonic = mnemonicRef.current
     if (!mnemonic) throw new Error('Wallet is locked. Unlock it before sending.')
     if (amount <= 0n) throw new Error('Amount must be greater than 0')
+
+    // Per-link amount cap (#589): a claim link is a bearer instrument whose
+    // secret lingers in chat history — bound the loss by treating it like cash.
+    // Reject an over-cap amount BEFORE any on-chain spend; large transfers
+    // should use a request link instead.
+    assertClaimLinkAmountWithinCap(amount)
 
     // CRITICAL: the claim-link bearer secret can only be persisted under a vault
     // key (encrypted at rest). A plaintext / no-password wallet has no session

--- a/web/packages/web-wallet/src/pages/claim.test.tsx
+++ b/web/packages/web-wallet/src/pages/claim.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { buildClaimLink, createClaimLinkMnemonic } from '@botho/core'
+
+/**
+ * Unfurl-safety regression test (#589).
+ *
+ * The security-load-bearing invariant that makes sharing a claim link over an
+ * E2E messenger safe: the `/claim` page performs NO network fetch keyed on the
+ * bearer secret until the recipient EXPLICITLY acts. So a messenger
+ * link-preview / unfurl fetch — or any incidental load of the page — can never
+ * trigger an on-chain scan or claim, nor leak the secret.
+ *
+ * We mock the transaction ops (`scanEphemeral` / `sweepEphemeral`) — the ONLY
+ * functions that touch the node with the secret — and assert they are not
+ * invoked on mount, only after the explicit "Reveal" action.
+ */
+
+const scanEphemeralMock = vi.fn()
+const sweepEphemeralMock = vi.fn()
+vi.mock('../lib/claim-link-ops', () => ({
+  scanEphemeral: (...args: unknown[]) => scanEphemeralMock(...args),
+  sweepEphemeral: (...args: unknown[]) => sweepEphemeralMock(...args),
+}))
+
+// Fake adapter: every method is a spy so we can assert the page makes NO
+// network call before explicit user action.
+const adapterSpies = {
+  isConnected: vi.fn(() => true),
+  getBlockHeight: vi.fn(async () => 100),
+  estimateFee: vi.fn(async () => 0n),
+  getRawOutputs: vi.fn(async () => []),
+  areKeyImagesSpent: vi.fn(async () => []),
+  submitTransaction: vi.fn(async () => ({ success: true, txHash: 'tx' })),
+  onNewBlock: vi.fn(() => () => {}),
+}
+vi.mock('../contexts/wallet', () => ({
+  useAdapter: () => adapterSpies,
+}))
+vi.mock('../contexts/network', () => ({
+  useNetwork: () => ({ network: { explorerUrl: null } }),
+}))
+
+// Imported AFTER the mocks are registered.
+import { ClaimPage } from './claim'
+
+function setClaimHash(): string {
+  const mnemonic = createClaimLinkMnemonic()
+  const url = buildClaimLink('https://wallet.botho.io', mnemonic)
+  const fragment = url.slice(url.indexOf('#'))
+  window.location.hash = fragment
+  return fragment
+}
+
+function renderClaim() {
+  return render(
+    <MemoryRouter>
+      <ClaimPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('ClaimPage unfurl-safety (#589): no network fetch before user action', () => {
+  beforeEach(() => {
+    cleanup()
+    scanEphemeralMock.mockReset()
+    scanEphemeralMock.mockResolvedValue({ gross: 5_000_000_000_000n, fee: 100_000_000n, net: 4_900_000_000_000n })
+    sweepEphemeralMock.mockReset()
+    for (const spy of Object.values(adapterSpies)) spy.mockClear()
+    window.history.replaceState(null, '', '/claim')
+  })
+
+  afterEach(() => {
+    window.location.hash = ''
+  })
+
+  it('does NOT scan/claim or hit the node on mount with a valid link in the fragment', async () => {
+    setClaimHash()
+    renderClaim()
+
+    // The page parsed the fragment locally and is waiting for explicit action.
+    await screen.findByRole('button', { name: /reveal/i })
+
+    // The security invariant: nothing reached the node, and no scan/claim ran.
+    expect(scanEphemeralMock).not.toHaveBeenCalled()
+    expect(sweepEphemeralMock).not.toHaveBeenCalled()
+    expect(adapterSpies.getRawOutputs).not.toHaveBeenCalled()
+    expect(adapterSpies.areKeyImagesSpent).not.toHaveBeenCalled()
+    expect(adapterSpies.submitTransaction).not.toHaveBeenCalled()
+  })
+
+  it('strips the secret from the URL on mount (fragment never lingers)', async () => {
+    setClaimHash()
+    renderClaim()
+    await screen.findByRole('button', { name: /reveal/i })
+    // The fragment has been cleared from the address bar by replaceState.
+    expect(window.location.hash).toBe('')
+  })
+
+  it('only scans AFTER the explicit Reveal action', async () => {
+    setClaimHash()
+    renderClaim()
+
+    const revealBtn = await screen.findByRole('button', { name: /reveal/i })
+    expect(scanEphemeralMock).not.toHaveBeenCalled()
+
+    fireEvent.click(revealBtn)
+
+    // The first network-touching call happens only now, keyed on the secret.
+    await waitFor(() => expect(scanEphemeralMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('shows an invalid state (no scan) when there is no fragment at all', async () => {
+    window.location.hash = ''
+    renderClaim()
+    await screen.findByText(/no claim link found/i)
+    expect(scanEphemeralMock).not.toHaveBeenCalled()
+  })
+})

--- a/web/packages/web-wallet/src/pages/claim.tsx
+++ b/web/packages/web-wallet/src/pages/claim.tsx
@@ -35,10 +35,20 @@ import { scanEphemeral, sweepEphemeral, type EphemeralScan } from '../lib/claim-
  *
  * Chain is the source of truth: a swept (already-claimed) or not-yet-confirmed
  * link both scan to an empty spendable set; we distinguish via state.
+ *
+ * UNFURL-SAFETY INVARIANT (#589): parsing the fragment is a pure, local,
+ * non-network operation. The page performs NO network fetch keyed on the bearer
+ * secret until the recipient EXPLICITLY acts (clicks "Reveal"). So even if a
+ * link-preview / unfurl bot were to load this page WITH the fragment (it
+ * normally can't — browsers never send the fragment to a server), it would
+ * never trigger an on-chain scan or claim, nor leak the secret. The `claim-page
+ * performs no fetch before user action` regression test in `claim.test.tsx`
+ * locks this in.
  */
 
 type ClaimState =
   | 'parsing'
+  | 'ready' // secret parsed & held locally; awaiting explicit user action (no network yet)
   | 'invalid'
   | 'scanning'
   | 'waiting' // funding not yet confirmed
@@ -66,6 +76,11 @@ export function ClaimPage() {
 
   // 1. Parse the fragment ONCE on mount, then strip it from the URL so the
   //    bearer secret does not linger in the address bar / history.
+  //
+  //    NOTE (#589): parsing is purely local — NO network call happens here. We
+  //    land in the 'ready' state and wait for the recipient to explicitly act
+  //    before touching the node (see `handleReveal`). This is the unfurl-safety
+  //    invariant: a preview/unfurl load can never trigger a scan or claim.
   useEffect(() => {
     const hash = window.location.hash
     if (!hash || hash === '#') {
@@ -82,11 +97,19 @@ export function ClaimPage() {
       } catch {
         // replaceState may be unavailable in some embeds; non-fatal.
       }
-      setState('scanning')
+      // Do NOT scan yet — wait for an explicit user action (unfurl-safety).
+      setState('ready')
     } catch (err) {
       setState('invalid')
       setError(err instanceof Error ? err.message : 'This claim link is not valid.')
     }
+  }, [])
+
+  // Explicit user action that begins the first network call (the scan). Keeping
+  // the scan behind this gate is what makes a preview/unfurl fetch a no-op.
+  const handleReveal = useCallback(() => {
+    setError(null)
+    setState('scanning')
   }, [])
 
   const runScan = useCallback(async () => {
@@ -193,7 +216,30 @@ export function ClaimPage() {
             {(state === 'parsing' || state === 'scanning') && (
               <div className="flex flex-col items-center gap-3 py-6 text-ghost">
                 <Loader2 size={28} className="animate-spin text-pulse" />
-                <p className="text-sm">Reading your claim link…</p>
+                <p className="text-sm">
+                  {state === 'scanning' ? 'Checking your claim link…' : 'Reading your claim link…'}
+                </p>
+              </div>
+            )}
+
+            {state === 'ready' && (
+              <div className="space-y-4">
+                <div className="text-center">
+                  <p className="text-sm text-ghost">Someone sent you a claim link.</p>
+                  {secret?.amountHint !== undefined && (
+                    <p className="font-display text-2xl font-bold text-pulse mt-1">
+                      ~{formatBTH(secret.amountHint)} BTH
+                    </p>
+                  )}
+                </div>
+                <Button onClick={handleReveal} className="w-full justify-center">
+                  <Gift size={16} className="mr-2" />
+                  Reveal &amp; check this link
+                </Button>
+                <p className="text-xs text-ghost text-center">
+                  We only contact the network once you tap above — your link stays private until
+                  then.
+                </p>
               </div>
             )}
 
@@ -320,6 +366,19 @@ export function ClaimPage() {
                     </a>
                   )}
                 </div>
+
+                {/* Post-claim hygiene (#589): the link is now spent, but its
+                    bearer secret still lingers in the chat. Nudge the recipient
+                    to delete the message to cut its dwell time in history. */}
+                <div className="flex items-start gap-2 p-3 rounded-lg bg-steel/40 border border-steel text-xs text-ghost">
+                  <ShieldAlert size={14} className="shrink-0 mt-0.5 text-amber-400" />
+                  <span>
+                    For your privacy, delete the message that contained this link from your chat.
+                    It&apos;s already claimed and can&apos;t be used again, but removing it keeps the
+                    secret out of your message history and backups.
+                  </span>
+                </div>
+
                 <Link to="/wallet">
                   <Button className="w-full justify-center">Go to my wallet</Button>
                 </Link>


### PR DESCRIPTION
## Summary

Hardens claim-link bearer-secret hygiene for the E2E-messenger sharing model
(#589). The transit risk is already handled (E2E + fragment design); this PR
bounds how long/large a live bearer secret can linger in chat history and
**codifies the unfurl-safety invariant with a regression test**.

## Changes

- **Unfurl-safety / no-auto-fetch (security-load-bearing):** the `/claim` page
  no longer scans on mount. After parsing the fragment locally it lands in a new
  `ready` state and waits for an explicit "Reveal & check this link" tap before
  any network call. A messenger preview/unfurl load can no longer trigger a
  scan/claim or leak the secret. New regression test `claim.test.tsx` asserts no
  `scanEphemeral`/`sweepEphemeral`/node call happens on mount, only after the
  explicit action — plus a unit test in `claim-link.test.ts` proving the bearer
  secret lives ONLY in the URL fragment (never path/query, nothing secret in the
  server-visible part of the URL).
- **Per-link amount cap:** new `CLAIM_LINK_MAX_AMOUNT_PICOCREDITS` (1,000 BTH)
  with `isWithinClaimLinkCap` / `assertClaimLinkAmountWithinCap` helpers and a
  documented "treat like cash" rationale. Enforced in `sendViaLink` BEFORE any
  on-chain spend and in `SendLinkModal` (blocks creation + nudges toward a
  request link for larger transfers).
- **Aggressive expiry + refund nudge:** `OutstandingLinks` surfaces stale
  (past the expiry window) outstanding links prominently with a banner + per-row
  "Stale" badge, pushing the sender to one-tap reclaim so funds don't sit
  claimable in chat history.
- **Post-claim hygiene UX:** after a successful claim the page suggests deleting
  the chat message containing the link. Refund already marks the link dead
  (`refunded`).
- **At-rest (#474) confirmation:** added a lifecycle test asserting the sender's
  outstanding-link bearer secret is never written to localStorage in cleartext
  across add → claimed → refunded.

## Cap value rationale

1,000 BTH is a deliberately conservative person-to-person "cash-like" default,
documented as a product call that may be revisited as BTH's value settles. The
goal is to bound loss if chat history is compromised; large transfers should use
a request (pull) link that never parks a spendable secret in a chat log.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Per-link amount cap | ✅ | `CLAIM_LINK_MAX_AMOUNT_PICOCREDITS` + helpers; enforced in `sendViaLink` and `SendLinkModal`; unit tests in `claim-link.test.ts` |
| Aggressive expiry + refund nudge | ✅ | `OutstandingLinks` stale banner + badge using `CLAIM_LINK_EXPIRY_WINDOW_SECONDS`; one-tap reclaim retained |
| Post-claim hygiene UX | ✅ | "delete the message" hint on the claimed screen; refund marks link `refunded` |
| Unfurl-safety + no-auto-fetch regression test | ✅ | `claim.tsx` gates scan behind explicit Reveal; `claim.test.tsx` asserts no network call on mount, only after action; fragment-only secret test in `claim-link.test.ts` |
| Confirm #474 at-rest encryption holds | ✅ | New lifecycle no-cleartext test in `claim-links.test.ts` |

## Test Plan

- `vitest run` — 478 passed, 7 skipped (no regressions; act warnings are
  pre-existing in unrelated send-modal tests).
- `pnpm -r typecheck` — clean across all 8 packages.
- Targeted: `claim-link.test.ts` (26), `claim-links.test.ts` (13),
  `claim.test.tsx` (4), `claim-link-ops.test.ts` (7) all green.

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)