### PR TITLE
feat(web-wallet): gate ?rpc= deep links behind an explicit trust confirmation

### DIFF
--- a/web/packages/web-wallet/src/components/CustomRpcTrustGate.test.tsx
+++ b/web/packages/web-wallet/src/components/CustomRpcTrustGate.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Component-level tests for the custom-RPC trust gate + banner (#587).
+ *
+ * These render the gate/banner in isolation with a mocked network context to
+ * assert the user-facing copy and the wiring of the accept / decline / revert
+ * actions. The end-to-end "a `?rpc=` link never silently switches the active
+ * node" guarantee is covered against the REAL provider in
+ * `../contexts/network-deep-link.test.tsx`.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, act } from '@testing-library/react'
+
+const useNetworkMock = vi.fn()
+vi.mock('../contexts/network', () => ({ useNetwork: () => useNetworkMock() }))
+
+import { CustomRpcTrustGate, CustomNodeBanner } from './CustomRpcTrustGate'
+
+describe('CustomRpcTrustGate component (#587)', () => {
+  beforeEach(() => {
+    cleanup()
+    useNetworkMock.mockReset()
+  })
+
+  it('renders nothing when there is no pending link', () => {
+    useNetworkMock.mockReturnValue({ pendingRpcLink: null })
+    render(<CustomRpcTrustGate />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('shows the explicit trust message naming the host, with a decline default', () => {
+    const decline = vi.fn()
+    useNetworkMock.mockReturnValue({
+      pendingRpcLink: { rpcUrl: 'https://evil.example/rpc', host: 'evil.example', trust: 'unknown' },
+      acceptPendingRpcLink: vi.fn(),
+      declinePendingRpcLink: decline,
+    })
+    render(<CustomRpcTrustGate />)
+
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByText(/point your wallet at/i)).toBeTruthy()
+    expect(screen.getByText('evil.example')).toBeTruthy()
+    expect(screen.getByText(/balances, confirmations, and transaction relay/i)).toBeTruthy()
+    // Unknown host => stronger warning.
+    expect(screen.getByText(/Unknown host/i)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /decline \(keep current node\)/i }))
+    expect(decline).toHaveBeenCalled()
+  })
+
+  it('shows a softer hint for a known Botho-operated host', () => {
+    useNetworkMock.mockReturnValue({
+      pendingRpcLink: {
+        rpcUrl: 'https://rig.testnet.botho.io/rpc',
+        host: 'rig.testnet.botho.io',
+        trust: 'known',
+      },
+      acceptPendingRpcLink: vi.fn(),
+      declinePendingRpcLink: vi.fn(),
+    })
+    render(<CustomRpcTrustGate />)
+    expect(screen.getByText(/Botho-operated host/i)).toBeTruthy()
+    expect(screen.queryByText(/Unknown host/i)).toBeNull()
+  })
+
+  it('calls acceptPendingRpcLink when the user trusts & connects', async () => {
+    const accept = vi.fn().mockResolvedValue(true)
+    useNetworkMock.mockReturnValue({
+      pendingRpcLink: {
+        rpcUrl: 'https://rig.testnet.botho.io/rpc',
+        host: 'rig.testnet.botho.io',
+        trust: 'known',
+      },
+      acceptPendingRpcLink: accept,
+      declinePendingRpcLink: vi.fn(),
+    })
+    render(<CustomRpcTrustGate />)
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /trust & connect/i }))
+    })
+    expect(accept).toHaveBeenCalled()
+  })
+})
+
+describe('CustomNodeBanner component (#587)', () => {
+  beforeEach(() => {
+    cleanup()
+    useNetworkMock.mockReset()
+  })
+
+  it('is hidden when not on a link-supplied node', () => {
+    useNetworkMock.mockReturnValue({ customNodeFromLink: null })
+    render(<CustomNodeBanner />)
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+
+  it('names the custom host and offers a one-tap revert', () => {
+    const revert = vi.fn()
+    useNetworkMock.mockReturnValue({
+      customNodeFromLink: 'rig-x.testnet.botho.io',
+      revertCustomNode: revert,
+    })
+    render(<CustomNodeBanner />)
+    expect(screen.getByRole('status')).toBeTruthy()
+    expect(screen.getByText(/from a link/i)).toBeTruthy()
+    expect(screen.getByText('rig-x.testnet.botho.io')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: /switch back/i }))
+    expect(revert).toHaveBeenCalled()
+  })
+})

--- a/web/packages/web-wallet/src/components/CustomRpcTrustGate.tsx
+++ b/web/packages/web-wallet/src/components/CustomRpcTrustGate.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react'
+import { Card } from '@botho/ui'
+import { ShieldAlert, ShieldCheck, X, Link2 } from 'lucide-react'
+import { useNetwork } from '../contexts/network'
+
+/**
+ * Trust gate for custom-RPC deep links (#587).
+ *
+ * When the wallet is opened with a `?rpc=<https endpoint>` link, the network
+ * context does NOT switch nodes — it surfaces the parsed link as
+ * `pendingRpcLink`. This modal is the explicit, unmistakable confirmation the
+ * user must clear before that node is ever used:
+ *
+ *   "This link wants to point your wallet at <host>. You will be trusting it for
+ *    balances, confirmations, and transaction relay. Only continue if you trust
+ *    whoever sent this link."
+ *
+ * Decline is the default (keep current node); Accept is the deliberate,
+ * secondary action. An UNKNOWN host (not a Botho-operated domain) gets a
+ * stronger warning than a `known` host. HTTPS validation already happened in
+ * `parseRpcDeepLink`; this gate is the second, necessary half of the defence.
+ */
+export function CustomRpcTrustGate() {
+  const { pendingRpcLink, acceptPendingRpcLink, declinePendingRpcLink } = useNetwork()
+  const [busy, setBusy] = useState(false)
+
+  if (!pendingRpcLink) return null
+
+  const { host, trust } = pendingRpcLink
+  const known = trust === 'known'
+
+  const handleAccept = async () => {
+    setBusy(true)
+    try {
+      await acceptPendingRpcLink()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-void/80 backdrop-blur-sm flex items-end sm:items-center justify-center p-0 sm:p-4 z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="rpc-trust-title"
+    >
+      <Card className="w-full sm:max-w-md p-5 sm:p-6 rounded-t-2xl sm:rounded-2xl max-h-[92vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            {known ? (
+              <ShieldCheck className="text-pulse" size={20} />
+            ) : (
+              <ShieldAlert className="text-danger" size={20} />
+            )}
+            <h3 id="rpc-trust-title" className="font-display text-lg font-semibold">
+              Trust this node?
+            </h3>
+          </div>
+          <button
+            onClick={declinePendingRpcLink}
+            className="text-ghost hover:text-light"
+            aria-label="Decline"
+            disabled={busy}
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <p className="text-sm text-light">
+          This link wants to point your wallet at{' '}
+          <span className="font-semibold break-all text-pulse">{host}</span>. You will be trusting
+          it for balances, confirmations, and transaction relay. Only continue if you trust whoever
+          sent this link.
+        </p>
+
+        {known ? (
+          <div className="mt-3 flex items-start gap-2 rounded-lg border border-pulse/30 bg-pulse/10 p-3">
+            <ShieldCheck size={16} className="text-pulse mt-0.5 shrink-0" />
+            <p className="text-xs text-ghost">
+              This looks like a Botho-operated host. That is a hint only — a link can still be
+              forged, so only continue if you expected it.
+            </p>
+          </div>
+        ) : (
+          <div className="mt-3 flex items-start gap-2 rounded-lg border border-danger/30 bg-danger/10 p-3">
+            <ShieldAlert size={16} className="text-danger mt-0.5 shrink-0" />
+            <p className="text-xs text-ghost">
+              <span className="font-semibold text-light">Unknown host.</span> This is not a
+              recognised Botho node. A hostile node can lie about your balance and confirmations
+              (fake &quot;payment received&quot;), withhold your transactions, and harvest your
+              addresses and IP. Decline unless you personally trust this operator.
+            </p>
+          </div>
+        )}
+
+        <div className="mt-5 flex flex-col-reverse sm:flex-row gap-2 sm:justify-end">
+          {/* Decline is the default / primary action: keep the current node. */}
+          <button
+            type="button"
+            onClick={declinePendingRpcLink}
+            disabled={busy}
+            className="rounded-lg bg-steel px-4 py-2.5 text-sm font-medium text-light hover:bg-steel/80 transition-colors disabled:opacity-50"
+          >
+            Decline (keep current node)
+          </button>
+          <button
+            type="button"
+            onClick={handleAccept}
+            disabled={busy}
+            className={`rounded-lg px-4 py-2.5 text-sm font-medium transition-colors disabled:opacity-50 ${
+              known
+                ? 'bg-pulse/20 text-pulse hover:bg-pulse/30'
+                : 'bg-danger/20 text-danger hover:bg-danger/30'
+            }`}
+          >
+            {busy ? 'Connecting…' : 'Trust & connect'}
+          </button>
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+/**
+ * Persistent banner shown while the wallet is connected to a custom node that
+ * was accepted from a deep link (#587). Keeps the user aware they are off the
+ * default seeds and offers a one-tap revert back to the default ingress.
+ */
+export function CustomNodeBanner() {
+  const { customNodeFromLink, revertCustomNode } = useNetwork()
+
+  if (!customNodeFromLink) return null
+
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-3 rounded-lg border border-pulse/30 bg-pulse/10 p-3 sm:p-4"
+    >
+      <Link2 size={18} className="text-pulse mt-0.5 shrink-0" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-light">
+          Connected to custom node{' '}
+          <span className="break-all text-pulse">{customNodeFromLink}</span>{' '}
+          <span className="text-ghost font-normal">(from a link)</span>
+        </p>
+        <p className="text-xs text-ghost mt-1">
+          You are off the default Botho nodes. This node serves all your balances, confirmations,
+          and transaction relay. Switch back if you did not mean to connect here.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={revertCustomNode}
+        className="rounded-md bg-pulse/20 px-3 py-1.5 text-xs font-medium text-light hover:bg-pulse/30 transition-colors whitespace-nowrap shrink-0"
+      >
+        Switch back
+      </button>
+    </div>
+  )
+}

--- a/web/packages/web-wallet/src/config/networks.ts
+++ b/web/packages/web-wallet/src/config/networks.ts
@@ -225,6 +225,13 @@ export async function validateRpcEndpoint(endpoint: string): Promise<boolean> {
 const INGRESS_STORAGE_KEY = 'botho_selected_ingress'
 const NETWORK_STORAGE_KEY = 'botho_selected_network'
 const CUSTOM_ENDPOINT_KEY = 'botho_custom_endpoint'
+/**
+ * Records the host of a custom node the user accepted *from a deep link* (#587).
+ * Persisted so the "connected to custom node <host> (from a link)" banner
+ * survives a reload, reminding the user they are off the default seeds. Cleared
+ * whenever the user reverts or picks a built-in ingress.
+ */
+const CUSTOM_NODE_FROM_LINK_KEY = 'botho_custom_node_from_link'
 
 /**
  * Save selected ingress node to localStorage.
@@ -235,6 +242,41 @@ export function saveSelectedIngress(ingressId: string): void {
     // Keep the legacy network key consistent so older reads stay valid.
     localStorage.setItem(NETWORK_STORAGE_KEY, DEFAULT_NETWORK_ID)
     localStorage.removeItem(CUSTOM_ENDPOINT_KEY)
+    // Choosing a built-in ingress means we are no longer on a link-supplied node.
+    localStorage.removeItem(CUSTOM_NODE_FROM_LINK_KEY)
+  } catch {
+    // localStorage may not be available
+  }
+}
+
+/**
+ * Persist that the active custom node was accepted from a deep link (#587),
+ * keyed by host. Drives the "from a link" banner.
+ */
+export function saveCustomNodeFromLink(host: string): void {
+  try {
+    localStorage.setItem(CUSTOM_NODE_FROM_LINK_KEY, host)
+  } catch {
+    // localStorage may not be available
+  }
+}
+
+/**
+ * Load the host of the link-supplied custom node, or `null` when the active node
+ * was not accepted from a link (or storage is unavailable).
+ */
+export function loadCustomNodeFromLink(): string | null {
+  try {
+    return localStorage.getItem(CUSTOM_NODE_FROM_LINK_KEY)
+  } catch {
+    return null
+  }
+}
+
+/** Forget the link-supplied custom node marker (on revert / manual switch). */
+export function clearCustomNodeFromLink(): void {
+  try {
+    localStorage.removeItem(CUSTOM_NODE_FROM_LINK_KEY)
   } catch {
     // localStorage may not be available
   }

--- a/web/packages/web-wallet/src/contexts/network-deep-link.test.tsx
+++ b/web/packages/web-wallet/src/contexts/network-deep-link.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Security regression for custom-RPC deep links, against the REAL NetworkProvider (#587).
+ *
+ * The guarantee under test: opening the wallet with a `?rpc=<https>` deep link
+ * must NEVER silently switch the active node. The link is surfaced as a
+ * *pending* trust prompt; only an explicit accept applies it, and a decline
+ * leaves the prior node intact.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor, act } from '@testing-library/react'
+import { NetworkProvider, useNetwork } from './network'
+import { buildWalletRpcLink } from '../lib/custom-rpc-link'
+
+// jsdom serves an opaque origin by default, so `localStorage` is unavailable.
+// Provide a simple in-memory shim (matching the other context tests) so the
+// network context's persistence helpers work under test.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+// jsdom serves an opaque origin by default, so `window.location.search` does not
+// update via history and `localStorage` is unavailable. Install a deterministic
+// location + history shim so the provider's deep-link effect (which reads
+// `location.search`/`location.href` and strips the param via
+// `history.replaceState`) behaves like a real same-origin navigation.
+let currentUrl = new URL('https://wallet.botho.io/wallet')
+Object.defineProperty(window, 'location', {
+  configurable: true,
+  get: () => currentUrl,
+})
+Object.defineProperty(window, 'history', {
+  configurable: true,
+  value: {
+    replaceState: (_state: unknown, _title: string, url: string) => {
+      currentUrl = new URL(url, currentUrl)
+    },
+  },
+})
+
+/** Probe that renders the network context's trust-gate surface into the DOM. */
+function Probe() {
+  const {
+    ingressId,
+    pendingRpcLink,
+    customNodeFromLink,
+    acceptPendingRpcLink,
+    declinePendingRpcLink,
+    revertCustomNode,
+  } = useNetwork()
+  return (
+    <div>
+      <span data-testid="ingress">{ingressId}</span>
+      <span data-testid="pending-host">{pendingRpcLink ? pendingRpcLink.host : 'none'}</span>
+      <span data-testid="pending-trust">{pendingRpcLink ? pendingRpcLink.trust : 'none'}</span>
+      <span data-testid="from-link">{customNodeFromLink ?? 'none'}</span>
+      <button onClick={() => void acceptPendingRpcLink()}>accept</button>
+      <button onClick={declinePendingRpcLink}>decline</button>
+      <button onClick={revertCustomNode}>revert</button>
+    </div>
+  )
+}
+
+/** Set window.location.search by replacing the wallet path. */
+function setSearch(query: string) {
+  currentUrl = new URL(`https://wallet.botho.io/wallet${query}`)
+}
+
+/** `?rpc=<encoded url>` query string for a given endpoint. */
+function rpcQuery(rpcUrl: string): string {
+  const link = buildWalletRpcLink('/wallet', rpcUrl)
+  return link.slice(link.indexOf('?'))
+}
+
+describe('custom-RPC deep link is gated by the NetworkProvider (#587)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setSearch('')
+    // fetch is only exercised on accept (reachability check); default to online.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ jsonrpc: '2.0', id: 1, result: { chainHeight: 1, synced: true } }),
+      })),
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+    localStorage.clear()
+    setSearch('')
+  })
+
+  it('does NOT switch the active node on load — it raises a pending prompt instead', async () => {
+    setSearch(rpcQuery('https://evil.example/rpc'))
+    render(
+      <NetworkProvider>
+        <Probe />
+      </NetworkProvider>,
+    )
+
+    // The active node is still the default seed — the link did not touch it.
+    expect(screen.getByTestId('ingress').textContent).toBe('seed')
+    // But the link is surfaced as a pending prompt for the unknown host.
+    await waitFor(() => expect(screen.getByTestId('pending-host').textContent).toBe('evil.example'))
+    expect(screen.getByTestId('pending-trust').textContent).toBe('unknown')
+    expect(screen.getByTestId('from-link').textContent).toBe('none')
+    // The param is stripped from the URL so a refresh does not re-arm it.
+    expect(window.location.search).toBe('')
+  })
+
+  it('decline leaves the prior node intact', async () => {
+    setSearch(rpcQuery('https://evil.example/rpc'))
+    render(
+      <NetworkProvider>
+        <Probe />
+      </NetworkProvider>,
+    )
+    await waitFor(() => expect(screen.getByTestId('pending-host').textContent).toBe('evil.example'))
+
+    fireEvent.click(screen.getByText('decline'))
+
+    expect(screen.getByTestId('pending-host').textContent).toBe('none')
+    expect(screen.getByTestId('ingress').textContent).toBe('seed')
+    expect(screen.getByTestId('from-link').textContent).toBe('none')
+    expect(localStorage.getItem('botho_custom_node_from_link')).toBeNull()
+  })
+
+  it('accept switches to the custom node and records the "from a link" marker', async () => {
+    setSearch(rpcQuery('https://rig-x.testnet.botho.io/rpc'))
+    render(
+      <NetworkProvider>
+        <Probe />
+      </NetworkProvider>,
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('pending-host').textContent).toBe('rig-x.testnet.botho.io'),
+    )
+    expect(screen.getByTestId('pending-trust').textContent).toBe('known')
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('accept'))
+    })
+
+    await waitFor(() => expect(screen.getByTestId('ingress').textContent).toBe('custom'))
+    expect(screen.getByTestId('from-link').textContent).toBe('rig-x.testnet.botho.io')
+    expect(screen.getByTestId('pending-host').textContent).toBe('none')
+    expect(localStorage.getItem('botho_custom_node_from_link')).toBe('rig-x.testnet.botho.io')
+  })
+
+  it('revert returns to the default node and clears the marker', async () => {
+    setSearch(rpcQuery('https://rig-x.testnet.botho.io/rpc'))
+    render(
+      <NetworkProvider>
+        <Probe />
+      </NetworkProvider>,
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('pending-host').textContent).toBe('rig-x.testnet.botho.io'),
+    )
+    await act(async () => {
+      fireEvent.click(screen.getByText('accept'))
+    })
+    await waitFor(() => expect(screen.getByTestId('ingress').textContent).toBe('custom'))
+
+    fireEvent.click(screen.getByText('revert'))
+
+    expect(screen.getByTestId('ingress').textContent).toBe('seed')
+    expect(screen.getByTestId('from-link').textContent).toBe('none')
+    expect(localStorage.getItem('botho_custom_node_from_link')).toBeNull()
+  })
+})

--- a/web/packages/web-wallet/src/contexts/network.tsx
+++ b/web/packages/web-wallet/src/contexts/network.tsx
@@ -24,8 +24,31 @@ import {
   loadSelectedNetwork,
   validateRpcEndpoint,
   fetchNodeHealth,
+  saveCustomNodeFromLink,
+  loadCustomNodeFromLink,
+  clearCustomNodeFromLink,
 } from '../config/networks'
-import { parseRpcDeepLink } from '../lib/custom-rpc-link'
+import {
+  parseRpcDeepLink,
+  rpcLinkHost,
+  classifyRpcHost,
+  type RpcHostTrust,
+} from '../lib/custom-rpc-link'
+
+/**
+ * A `?rpc=` deep link that has been parsed and validated but NOT yet applied —
+ * it is awaiting an explicit user trust decision (#587). Surfacing it as
+ * "pending" instead of applying it is the whole point of the guardrail: a link
+ * must never silently switch the active node.
+ */
+export interface PendingRpcLink {
+  /** The validated https RPC endpoint the link wants to use. */
+  rpcUrl: string
+  /** Bare host shown to the user ("point your wallet at <host>"). */
+  host: string
+  /** Whether the host is a known Botho-operated host or an unknown third party. */
+  trust: RpcHostTrust
+}
 
 interface NetworkState {
   /** Currently selected network (derived from the selected ingress node). */
@@ -40,6 +63,17 @@ interface NetworkState {
   hasFaucet: boolean
   /** Per-ingress-node health snapshots, keyed by ingress id. */
   nodeHealth: Record<string, NodeHealth>
+  /**
+   * A parsed-but-not-yet-applied `?rpc=` deep link awaiting the user's trust
+   * decision, or `null` when there is none (#587).
+   */
+  pendingRpcLink: PendingRpcLink | null
+  /**
+   * Host of the custom node the user is currently connected to *because they
+   * accepted a deep link*, or `null` when on a built-in / manually-set node.
+   * Drives the persistent "from a link" banner.
+   */
+  customNodeFromLink: string | null
 }
 
 interface NetworkContextValue extends NetworkState {
@@ -61,6 +95,17 @@ interface NetworkContextValue extends NetworkState {
    * (the NetworkSelector) so the landing page makes no node calls.
    */
   startHealthPolling: () => () => void
+  /**
+   * Apply the pending `?rpc=` deep link as the custom ingress (#587). Validates
+   * reachability first; on success persists the "from a link" marker so the
+   * banner appears. No-op when there is no pending link. Resolves to whether the
+   * node was applied.
+   */
+  acceptPendingRpcLink: () => Promise<boolean>
+  /** Dismiss the pending deep link WITHOUT switching nodes — the prior node is left intact (#587). */
+  declinePendingRpcLink: () => void
+  /** Revert a link-supplied custom node back to the default ingress with one tap (#587). */
+  revertCustomNode: () => void
 }
 
 const NetworkContext = createContext<NetworkContextValue | null>(null)
@@ -92,6 +137,9 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
     const { network, ingressId } = getInitialNetwork()
     const nodeHealth: Record<string, NodeHealth> = {}
     for (const n of INGRESS_NODES) nodeHealth[n.id] = { status: 'checking' }
+    // Only honour a persisted "from a link" marker if we are actually still on a
+    // custom node; otherwise a stale marker would mislabel a built-in ingress.
+    const customNodeFromLink = ingressId === 'custom' ? loadCustomNodeFromLink() : null
     return {
       network,
       ingressId,
@@ -99,6 +147,8 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
       validationError: null,
       hasFaucet: !!network.faucetEndpoint,
       nodeHealth,
+      pendingRpcLink: null,
+      customNodeFromLink,
     }
   })
 
@@ -109,6 +159,13 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
       detail: { network: state.network }
     }))
   }, [state.network])
+
+  // Mirror the pending deep link into a ref so `acceptPendingRpcLink` always sees
+  // the latest value without re-creating the (stable) setCustomEndpoint closure.
+  const pendingRpcLinkRef = useRef<PendingRpcLink | null>(null)
+  useEffect(() => {
+    pendingRpcLinkRef.current = state.pendingRpcLink
+  }, [state.pendingRpcLink])
 
   // Poll each ingress node's health via node_getStatus.
   //
@@ -161,6 +218,8 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
       isValidating: false,
       validationError: null,
       hasFaucet: !!network.faucetEndpoint,
+      // Switching to a built-in node clears any "from a link" status.
+      customNodeFromLink: null,
     }))
   }, [])
 
@@ -192,6 +251,10 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
 
       const network = createCustomNetwork(endpoint)
       saveSelectedNetwork('custom', endpoint)
+      // A directly-set custom endpoint is NOT a link-supplied node; drop any
+      // stale "from a link" marker. acceptPendingRpcLink re-sets it afterward
+      // for the deep-link path.
+      clearCustomNodeFromLink()
 
       setState(s => ({
         ...s,
@@ -200,6 +263,7 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
         isValidating: false,
         validationError: null,
         hasFaucet: !!network.faucetEndpoint,
+        customNodeFromLink: null,
       }))
 
       return true
@@ -213,19 +277,23 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
     }
   }, [])
 
-  // Custom-RPC deep link (P6.3, #458 §3 step 5): when the wallet is opened with
-  // a `?rpc=<https endpoint>` param (e.g. from the rig status page's "Open in
-  // wallet" link), pre-select it as the custom ingress. `setCustomEndpoint`
-  // validates reachability via node_getStatus before committing, and strips the
-  // param from the URL so a refresh/back doesn't reapply a stale link.
-  const deepLinkApplied = useRef(false)
+  // Custom-RPC deep link (P6.3, #458 §3 step 5) behind a trust gate (#587).
+  //
+  // SECURITY: a `?rpc=` link is attacker-controllable and must NEVER silently
+  // switch the active node. So instead of applying it, we surface the parsed
+  // link as a PENDING trust prompt (`pendingRpcLink`); the user must explicitly
+  // accept it (`acceptPendingRpcLink`) before it touches the active node, and a
+  // decline leaves the prior node intact. The param is stripped from the URL
+  // immediately so a refresh/back/share doesn't silently re-arm the prompt with
+  // a stale link.
+  const deepLinkSeen = useRef(false)
   useEffect(() => {
-    if (deepLinkApplied.current) return
+    if (deepLinkSeen.current) return
     if (typeof window === 'undefined') return
     const parsed = parseRpcDeepLink(window.location.search)
     if (parsed.ok !== true) return
-    deepLinkApplied.current = true
-    void setCustomEndpoint(parsed.rpcUrl)
+    deepLinkSeen.current = true
+    const host = rpcLinkHost(parsed.rpcUrl)
     try {
       const url = new URL(window.location.href)
       url.searchParams.delete('rpc')
@@ -233,7 +301,39 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
     } catch {
       // history API unavailable (non-browser test env) — ignore.
     }
+    if (!host) return
+    // Stash the parsed link for the trust gate; do NOT apply it here.
+    setState((s) => ({
+      ...s,
+      pendingRpcLink: { rpcUrl: parsed.rpcUrl, host, trust: classifyRpcHost(parsed.rpcUrl) },
+    }))
+  }, [])
+
+  const acceptPendingRpcLink = useCallback(async (): Promise<boolean> => {
+    const pending = pendingRpcLinkRef.current
+    if (!pending) return false
+    const ok = await setCustomEndpoint(pending.rpcUrl)
+    if (ok) {
+      // Only mark "from a link" once the node actually validated and committed.
+      saveCustomNodeFromLink(pending.host)
+      setState((s) => ({ ...s, pendingRpcLink: null, customNodeFromLink: pending.host }))
+    } else {
+      // Validation failed (unreachable node): clear the prompt but stay on the
+      // prior node. The validationError set by setCustomEndpoint is surfaced.
+      setState((s) => ({ ...s, pendingRpcLink: null }))
+    }
+    return ok
   }, [setCustomEndpoint])
+
+  const declinePendingRpcLink = useCallback(() => {
+    // Decline = keep the current node. We touch nothing but the prompt itself.
+    setState((s) => ({ ...s, pendingRpcLink: null }))
+  }, [])
+
+  const revertCustomNode = useCallback(() => {
+    clearCustomNodeFromLink()
+    selectIngress(DEFAULT_INGRESS_ID)
+  }, [selectIngress])
 
   return (
     <NetworkContext.Provider
@@ -246,6 +346,9 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
         ingressNodes: INGRESS_NODES,
         refreshHealth: runHealthChecks,
         startHealthPolling,
+        acceptPendingRpcLink,
+        declinePendingRpcLink,
+        revertCustomNode,
       }}
     >
       {children}

--- a/web/packages/web-wallet/src/lib/custom-rpc-link.test.ts
+++ b/web/packages/web-wallet/src/lib/custom-rpc-link.test.ts
@@ -4,6 +4,8 @@ import {
   buildWalletRpcLink,
   isValidRpcUrl,
   parseRpcDeepLink,
+  rpcLinkHost,
+  classifyRpcHost,
 } from './custom-rpc-link'
 
 describe('isValidRpcUrl', () => {
@@ -75,5 +77,41 @@ describe('buildWalletRpcLink', () => {
     const parsed = parseRpcDeepLink(search)
     expect(parsed.ok).toBe(true)
     if (parsed.ok === true) expect(parsed.rpcUrl).toBe(rpc)
+  })
+})
+
+describe('rpcLinkHost', () => {
+  it('extracts the bare host without the port', () => {
+    expect(rpcLinkHost('https://rig-abc.testnet.botho.io:8443/rpc')).toBe(
+      'rig-abc.testnet.botho.io',
+    )
+  })
+
+  it('returns null for an unparseable url', () => {
+    expect(rpcLinkHost('not a url')).toBeNull()
+  })
+})
+
+describe('classifyRpcHost (#587 trust hint — never an authorization decision)', () => {
+  it('treats Botho-operated hosts as known', () => {
+    expect(classifyRpcHost('https://seed.botho.io/rpc')).toBe('known')
+    expect(classifyRpcHost('https://rig-abc.testnet.botho.io/rpc')).toBe('known')
+    expect(classifyRpcHost('https://botho.io/rpc')).toBe('known')
+  })
+
+  it('treats loopback (dev) as known', () => {
+    expect(classifyRpcHost('http://localhost:8787/rpc')).toBe('known')
+    expect(classifyRpcHost('http://127.0.0.1/rpc')).toBe('known')
+  })
+
+  it('flags arbitrary third-party hosts as unknown', () => {
+    expect(classifyRpcHost('https://evil.example/rpc')).toBe('unknown')
+    // A look-alike that merely CONTAINS the brand is still unknown.
+    expect(classifyRpcHost('https://botho.io.evil.example/rpc')).toBe('unknown')
+    expect(classifyRpcHost('https://notbotho.io/rpc')).toBe('unknown')
+  })
+
+  it('treats an unparseable url as unknown (most conservative)', () => {
+    expect(classifyRpcHost('not a url')).toBe('unknown')
   })
 })

--- a/web/packages/web-wallet/src/lib/custom-rpc-link.ts
+++ b/web/packages/web-wallet/src/lib/custom-rpc-link.ts
@@ -16,6 +16,18 @@
  *   - must be HTTPS (or http://localhost for local dev),
  *   - we do NOT fetch it here — reachability is checked by the network context's
  *     `setCustomEndpoint` (`node_getStatus`) before it is committed.
+ *
+ * SECURITY GUARDRAIL (#587): HTTPS validation is necessary but NOT sufficient.
+ * A `?rpc=` link is attacker-controllable (Signal/QR/paste all carry it), and an
+ * attacker's node is perfectly valid HTTPS — it can lie about balances and
+ * confirmations, censor/withhold the user's transactions, and harvest addresses
+ * + IP. Therefore a parsed link MUST NEVER silently switch the active node. The
+ * network context surfaces a parsed link as a *pending* trust prompt
+ * (`pendingRpcLink`) and only applies it after an explicit user accept; a
+ * decline leaves the prior node intact. Anyone wiring a new consumer of
+ * `parseRpcDeepLink` must route it through that trust gate — do NOT call
+ * `setCustomEndpoint` directly from a deep link. See `classifyRpcHost` below and
+ * the `CustomRpcTrustGate` component.
  */
 
 /** The query-string key carrying a custom RPC endpoint in a deep link. */
@@ -81,4 +93,54 @@ export function parseRpcDeepLink(search: string): ParsedRpcLink {
 export function buildWalletRpcLink(walletPath: string, rpcUrl: string): string {
   const sep = walletPath.includes('?') ? '&' : '?'
   return `${walletPath}${sep}${RPC_PARAM}=${encodeURIComponent(rpcUrl)}`
+}
+
+/**
+ * Extract the bare host (no port) from a candidate RPC URL, or `null` when the
+ * URL cannot be parsed. Used by the trust gate to name the node the link wants
+ * to point the wallet at ("This link wants to point your wallet at <host>").
+ */
+export function rpcLinkHost(candidate: string): string | null {
+  try {
+    return new URL(candidate).hostname
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Host suffixes operated by the Botho project. A link whose host falls under one
+ * of these is shown as a "known operator" hint (e.g. a BaaS-provisioned rig at
+ * `rig-abc.testnet.botho.io`); anything else is an UNKNOWN host shown with a
+ * stronger warning. This is a hint only — it never bypasses the trust gate, it
+ * just tunes the wording so a fully-arbitrary `evil.example` cannot masquerade
+ * as a first-party node.
+ */
+export const KNOWN_RPC_HOST_SUFFIXES = ['.botho.io'] as const
+
+/** Hosts that are exactly the operator apex (not just a subdomain). */
+const KNOWN_RPC_HOST_EXACT = ['botho.io'] as const
+
+export type RpcHostTrust = 'known' | 'unknown'
+
+/**
+ * Classify a candidate RPC URL's host as a `known` Botho-operated host or an
+ * `unknown` third-party host. Loopback (localhost / 127.0.0.1) counts as
+ * `known` so local-dev links don't trip the stronger-warning path. An
+ * unparseable URL is treated as `unknown` (most conservative).
+ *
+ * IMPORTANT: this is a UI hint, not an authorization decision. Both `known` and
+ * `unknown` hosts still require explicit user acceptance via the trust gate
+ * (#587) — see the security note at the top of this file.
+ */
+export function classifyRpcHost(candidate: string): RpcHostTrust {
+  const host = rpcLinkHost(candidate)
+  if (host === null) return 'unknown'
+  const lower = host.toLowerCase()
+  if (lower === 'localhost' || lower === '127.0.0.1') return 'known'
+  if (KNOWN_RPC_HOST_EXACT.includes(lower as (typeof KNOWN_RPC_HOST_EXACT)[number])) {
+    return 'known'
+  }
+  if (KNOWN_RPC_HOST_SUFFIXES.some((suffix) => lower.endsWith(suffix))) return 'known'
+  return 'unknown'
 }

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -12,6 +12,7 @@ import { RequestModal } from '../components/RequestModal'
 import { ReceiveModal } from '../components/ReceiveModal'
 import { OutstandingLinks } from '../components/OutstandingLinks'
 import { OfflineBanner } from '../components/OfflineBanner'
+import { CustomRpcTrustGate, CustomNodeBanner } from '../components/CustomRpcTrustGate'
 import { PasswordFields, PasswordSettingsModal, isPasswordValid } from '../components/PasswordSettingsModal'
 import { Send, Link2, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2, Users, QrCode, Clock } from 'lucide-react'
 
@@ -399,6 +400,10 @@ function WalletDashboard() {
           node goes unreachable mid-use, with a one-click switch action. */}
       <OfflineBanner />
 
+      {/* Custom-node-from-a-link banner (#587): reminds the user they accepted a
+          `?rpc=` deep link and are off the default seeds, with a one-tap revert. */}
+      <CustomNodeBanner />
+
       <BalanceCard
         balance={balance}
         address={address}
@@ -678,6 +683,10 @@ export function WalletPage() {
 
   return (
     <div className="min-h-screen">
+      {/* Custom-RPC deep-link trust gate (#587): a `?rpc=` link is surfaced as a
+          pending prompt and must be explicitly accepted before it can switch the
+          active node. Rendered at the page root so it overlays any wallet view. */}
+      <CustomRpcTrustGate />
       <header className="border-b border-steel bg-abyss/50 backdrop-blur-md sticky top-0 z-40">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between">
           <Link to={homeHref} className="flex items-center gap-2 sm:gap-3">


### PR DESCRIPTION
## Summary

A custom-RPC deep link (`/wallet?rpc=<https-url>`) was being applied **silently on load**: `NetworkProvider`'s deep-link effect called `setCustomEndpoint()` directly, repointing all read/write RPC at the link-supplied node with no user consent. A `?rpc=` link is attacker-controllable (Signal/WhatsApp/QR/paste all carry it), and HTTPS validation does **not** help — an attacker's node is valid HTTPS and can fake balances/confirmations ("payment received"), censor/withhold the user's transactions, and harvest addresses + IP.

This PR makes the deep link require an **explicit trust confirmation** before it can ever switch the active node, satisfying issue #587. (Note: the issue described the link as "unwired", but it had since been wired unsafely in `network.tsx` — this PR removes the silent-switch and gates it.)

## Changes

- **`contexts/network.tsx`**: the deep-link effect no longer calls `setCustomEndpoint()`. It parses + validates the link, strips the `rpc` param from the URL, and surfaces it as a `pendingRpcLink` (host + known/unknown trust). New context actions: `acceptPendingRpcLink()` (validates reachability, then commits + records the "from a link" marker), `declinePendingRpcLink()` (keeps the current node, touches nothing else), and `revertCustomNode()` (one-tap back to the default ingress).
- **`components/CustomRpcTrustGate.tsx`**: `CustomRpcTrustGate` modal with the unmistakable confirmation copy ("This link wants to point your wallet at **<host>**. You will be trusting it for balances, confirmations, and transaction relay. Only continue if you trust whoever sent this link."), **Decline as the default**, and a stronger warning for unknown (non-`botho.io`) hosts. `CustomNodeBanner` persistent banner ("connected to custom node <host> (from a link)") with one-tap revert.
- **`lib/custom-rpc-link.ts`**: `rpcLinkHost()` + `classifyRpcHost()` (allow-list hint for `*.botho.io` / loopback vs. unknown) and a security guardrail comment so no future consumer re-wires the link without the gate.
- **`config/networks.ts`**: `saveCustomNodeFromLink()` / `loadCustomNodeFromLink()` / `clearCustomNodeFromLink()` persistence (cleared on revert or when a built-in / manual node is selected).
- **`pages/wallet.tsx`**: mounts the trust gate (page root) and the from-link banner (top of the dashboard).

## Acceptance Criteria Verification

| Criterion (issue #587) | Status | Verification |
|---|---|---|
| `?rpc=` link must never silently switch the active node | ✅ | `network-deep-link.test.tsx`: after load with a `?rpc=` link the active ingress is still `seed`; only a pending prompt is raised |
| Explicit, unmistakable confirmation naming the host, with Decline default | ✅ | `CustomRpcTrustGate` renders the exact copy; Decline is the default action; component test asserts the message + decline wiring |
| Persisted "connected to custom node <host> (from a link)" banner with one-tap revert | ✅ | `CustomNodeBanner` + `botho_custom_node_from_link` localStorage marker; revert returns to default and clears the marker (tested) |
| HTTPS-only validation stays AND is paired with the trust gate | ✅ | `isValidRpcUrl`/`parseRpcDeepLink` unchanged; acceptance still runs `setCustomEndpoint` reachability check; gate is the second half |
| Allow-list / known-operator hint vs. unknown host stronger warning | ✅ | `classifyRpcHost` (`*.botho.io`/loopback = known) drives softer vs. stronger warning copy; tested incl. look-alike `botho.io.evil.example` → unknown |
| Test: link does not mutate active node without explicit accept; decline leaves prior node intact | ✅ | `network-deep-link.test.tsx` (real `NetworkProvider`): load = no mutation; decline keeps `seed`; accept switches to `custom`; revert restores |

## Test Plan

- `pnpm --filter @botho/web-wallet typecheck` and `pnpm -r typecheck` — pass.
- `vitest run packages/web-wallet` — 120 pass (incl. 4 real-provider regression, 6 gate/banner component, 17 link-lib tests).
- `pnpm test:run` (full monorepo) — 481 pass / 10 skipped, no regressions.

Closes #587