### PR TITLE
feat(sim): empirical-gate harness for #577 — decoy-quantile demurrage sweep + ring_elapsed_quantile kernel

### DIFF
--- a/cluster-tax/src/bin/sim.rs
+++ b/cluster-tax/src/bin/sim.rs
@@ -519,6 +519,46 @@ mod cli {
             #[arg(long)]
             quick: bool,
         },
+
+        /// Decoy-quantile demurrage sweep (empirical gate for #577 / H2-B1):
+        /// compare the value-weighted-mean age kernel (centroid) against
+        /// value-independent order statistics (quantile@p75/p90/max) under an
+        /// ADVERSARIAL decoy population. Reports final Gini, Δgini, the
+        /// adversary dilution ratio and the honest over-charge ratio per
+        /// kernel. Does NOT wire anything into consensus.
+        DecoyQuantileSweep {
+            /// Number of factor-1 background holders
+            #[arg(long, default_value = "100")]
+            poor: usize,
+
+            /// Number of honest factor-6 whales (age-similar decoys)
+            #[arg(long, default_value = "10")]
+            honest_whales: usize,
+
+            /// Number of adversarial factor-6 whales (fresh high-value decoys)
+            #[arg(long, default_value = "10")]
+            adversary_whales: usize,
+
+            /// Ring size (1 real input + ring_size-1 decoys)
+            #[arg(long, default_value = "11")]
+            ring_size: usize,
+
+            /// Simulated rounds (each round ~= one year of holding)
+            #[arg(long, default_value = "25")]
+            rounds: u64,
+
+            /// Annual demurrage rate in basis points at max cluster factor
+            #[arg(long, default_value = "200")]
+            rate_bps: u32,
+
+            /// Honest decoy age jitter half-width in basis points (500 = ±5%)
+            #[arg(long, default_value = "500")]
+            honest_jitter_bps: u32,
+
+            /// Base RNG seed for reproducibility
+            #[arg(long, default_value = "2953379877")]
+            seed: u64,
+        },
     }
 
     pub fn run(cli: Cli) {
@@ -717,6 +757,25 @@ mod cli {
                 whales,
                 &output,
                 quick,
+            ),
+            Command::DecoyQuantileSweep {
+                poor,
+                honest_whales,
+                adversary_whales,
+                ring_size,
+                rounds,
+                rate_bps,
+                honest_jitter_bps,
+                seed,
+            } => run_decoy_quantile_sweep(
+                poor,
+                honest_whales,
+                adversary_whales,
+                ring_size,
+                rounds,
+                rate_bps,
+                honest_jitter_bps,
+                seed,
             ),
         }
     }
@@ -4021,6 +4080,44 @@ mod cli {
             Ok(()) => println!("Wrote CSV:     {}", csv_path.display()),
             Err(e) => eprintln!("Failed to write {}: {e}", csv_path.display()),
         }
+    }
+
+    /// Decoy-quantile demurrage sweep (empirical gate for issue #577 / H2-B1).
+    ///
+    /// Compares the shipped value-weighted-mean age kernel against
+    /// value-independent order statistics under an adversarial decoy
+    /// population, and prints the gate table. Does NOT wire anything into
+    /// consensus — #577's consensus wiring stays blocked under #323.
+    #[allow(clippy::too_many_arguments)]
+    fn run_decoy_quantile_sweep(
+        poor: usize,
+        honest_whales: usize,
+        adversary_whales: usize,
+        ring_size: usize,
+        rounds: u64,
+        rate_bps: u32,
+        honest_jitter_bps: u32,
+        seed: u64,
+    ) {
+        use bth_cluster_tax::simulation::decoy_quantile_sweep::{
+            run_decoy_sweep, to_table, DecoySweepParams,
+        };
+
+        let defaults = DecoySweepParams::default();
+        let params = DecoySweepParams {
+            poor,
+            honest_whales,
+            adversary_whales,
+            ring_size,
+            rounds,
+            rate_bps,
+            honest_jitter_bps,
+            seed,
+            ..defaults
+        };
+
+        let report = run_decoy_sweep(&params);
+        println!("{}", to_table(&report));
     }
 }
 

--- a/cluster-tax/src/demurrage.rs
+++ b/cluster-tax/src/demurrage.rs
@@ -122,6 +122,87 @@ pub fn ring_elapsed_centroid(members: &[(u64, u64)], current_height: u64) -> u64
     (weighted / total_value) as u64
 }
 
+/// Compute a value-independent quantile (order statistic) of the elapsed ages
+/// of a ring's members.
+///
+/// Where [`ring_elapsed_centroid`] takes the **value-weighted mean** of the
+/// ring members' ages, this takes an **unweighted order statistic** (a
+/// percentile) over the ages. `quantile_bps` selects the percentile in basis
+/// points of the sorted ages: `10000` = the maximum age, `9000` = p90, `7500` =
+/// p75, `5000` = the median, `0` = the minimum.
+///
+/// # Why value-independent (audit cycle 6 H2, design #574 item B1, issue #577)
+///
+/// The value-weighted mean is exactly the H2 *age*-dilution vector. A spender
+/// who holds an old, wealthy real input can drag the centroid age toward zero
+/// by padding the ring with **fresh, high-value** background-tagged decoys:
+/// every such decoy contributes `value × 0` to the weighted numerator while
+/// inflating the denominator, so the mean collapses toward the decoys' (zero)
+/// age even though the real input is old. The factor-side floor (item B2,
+/// [`ring_centroid_implied_factor`]) closes the wealth/factor leg of this
+/// attack, but the age leg remains open against the mean kernel.
+///
+/// An order statistic over ages defeats this because **value is not in the
+/// computation at all**: a fresh decoy is just one more `0` in the sorted age
+/// list, and no amount of value attached to it moves a percentile. The real
+/// input is a single old member; the maximum (`quantile_bps = 10000`) is the
+/// one statistic guaranteed to surface a lone old member regardless of how many
+/// fresh decoys surround it. Lower percentiles (p75/p90) only surface the real
+/// input when the old members make up more than `(1 − quantile)` of the ring —
+/// for a single real input in a ring of size `n`, that requires
+/// `quantile_bps > (n − 1)/n × 10000`. This tradeoff is the subject of the
+/// empirical decoy-quantile sweep (`simulation::decoy_quantile_sweep`).
+///
+/// # Arguments
+/// * `members` - `(value, creation_height)` for each ring member (public data).
+///   The `value` field is **accepted but deliberately ignored** so this
+///   function is drop-in comparable with [`ring_elapsed_centroid`]; only the
+///   per-member elapsed age `current_height − creation_height` is used.
+/// * `current_height` - The validating block height.
+/// * `quantile_bps` - The percentile to return, in basis points (`0..=10000`).
+///   Values above `10000` are clamped to `10000`.
+///
+/// # Returns
+/// The `quantile_bps`-th percentile of the members' elapsed ages, by the
+/// nearest-rank method (`rank = ceil(quantile_bps/10000 × n)`, `index =
+/// rank − 1` clamped into `0..n`). Empty set → 0. A single member → that
+/// member's elapsed age for every quantile.
+///
+/// # Determinism
+/// CONSENSUS-CRITICAL: pure integer arithmetic, operates on a sorted *copy* of
+/// the elapsed ages (no in-place mutation of caller data, no float, no
+/// HashMap/HashSet iteration order). The sort is total over `u64`, so the
+/// output is a pure function of the multiset of ages and `quantile_bps`. Safe
+/// for the consensus age-floor enforcement (#577) to reuse unchanged once
+/// wired.
+pub fn ring_elapsed_quantile(
+    members: &[(u64, u64)],
+    current_height: u64,
+    quantile_bps: u32,
+) -> u64 {
+    if members.is_empty() {
+        return 0;
+    }
+
+    // Order statistic over AGES ONLY — value is intentionally not read. A
+    // high-value fresh decoy is just another `0` here and cannot move the result.
+    let mut ages: Vec<u64> = members
+        .iter()
+        .map(|&(_value, creation_height)| current_height.saturating_sub(creation_height))
+        .collect();
+    ages.sort_unstable();
+
+    let n = ages.len() as u64;
+    let q = quantile_bps.min(10_000) as u64;
+
+    // Nearest-rank: rank = ceil(q/10000 × n), index = rank - 1, clamped to
+    // [0, n-1]. Pure integer ceil via (a + b - 1) / b. q = 0 → index 0 (min);
+    // q = 10000 → index n-1 (max).
+    let rank = (q * n).div_ceil(10_000);
+    let index = rank.saturating_sub(1).min(n - 1) as usize;
+    ages[index]
+}
+
 /// Compute the cluster factor implied by the value-weighted centroid of a
 /// ring's own cluster wealth.
 ///
@@ -299,6 +380,118 @@ mod tests {
     fn test_ring_centroid_empty_and_zero_value() {
         assert_eq!(ring_elapsed_centroid(&[], 1000), 0);
         assert_eq!(ring_elapsed_centroid(&[(0, 0)], 1000), 0);
+    }
+
+    #[test]
+    fn test_ring_quantile_known_set() {
+        // current = 100, creation heights chosen so elapsed = {10,20,30,40,50}.
+        // Values are varied (and large on fresh members) to prove the result is
+        // value-INDEPENDENT.
+        let current = 100u64;
+        let members = [
+            (1u64, current - 10),        // elapsed 10
+            (999_999_999, current - 20), // elapsed 20 (huge value: must not matter)
+            (7, current - 30),           // elapsed 30
+            (3, current - 40),           // elapsed 40
+            (1, current - 50),           // elapsed 50
+        ];
+        // n = 5, nearest-rank.
+        assert_eq!(ring_elapsed_quantile(&members, current, 10_000), 50); // max
+        assert_eq!(ring_elapsed_quantile(&members, current, 9_000), 50); // p90: rank=ceil(4.5)=5
+        assert_eq!(ring_elapsed_quantile(&members, current, 7_500), 40); // p75: rank=ceil(3.75)=4
+        assert_eq!(ring_elapsed_quantile(&members, current, 5_000), 30); // p50: rank=ceil(2.5)=3
+        assert_eq!(ring_elapsed_quantile(&members, current, 2_500), 20); // p25: rank=ceil(1.25)=2
+        assert_eq!(ring_elapsed_quantile(&members, current, 0), 10); // p0 = min
+    }
+
+    #[test]
+    fn test_ring_quantile_value_independent() {
+        // Same ages, wildly different values -> identical quantiles. This is the
+        // structural property the H2 age-dilution attack cannot bypass.
+        let current = 1_000u64;
+        let cheap = [(1u64, 900), (1, 800), (1, 700)]; // elapsed 100,200,300
+        let pricey = [(u64::MAX, 900), (u64::MAX, 800), (u64::MAX, 700)];
+        for q in [0u32, 2_500, 5_000, 7_500, 9_000, 10_000] {
+            assert_eq!(
+                ring_elapsed_quantile(&cheap, current, q),
+                ring_elapsed_quantile(&pricey, current, q),
+                "quantile {q} must not depend on value"
+            );
+        }
+    }
+
+    #[test]
+    fn test_ring_quantile_resists_h2_dilution_that_mean_succumbs_to() {
+        // The #577 / H2 age-dilution attack: an OLD, wealthy real input padded
+        // with FRESH, EQUAL-VALUE decoys. The value-weighted mean collapses
+        // toward the decoys' zero age; the max-quantile recovers the real age.
+        let current = 1_000_000u64;
+        let real_age = current; // real input created at height 0
+        let mut members = vec![(100_000_000u64, 0u64)]; // real: 100M, age 1_000_000
+        for _ in 0..10 {
+            members.push((100_000_000, current)); // fresh decoy, equal value,
+                                                  // age 0
+        }
+
+        // Mean kernel SUCCUMBS: 100M×T / (11×100M) = T/11 — dragged ~91% down.
+        let mean = ring_elapsed_centroid(&members, current);
+        assert!(
+            mean < real_age / 8,
+            "mean should be diluted far below the real age: mean={mean}, real={real_age}"
+        );
+
+        // Max-quantile RESISTS: the lone old member is the maximum age, fully
+        // recovered regardless of how many fresh decoys surround it.
+        let qmax = ring_elapsed_quantile(&members, current, 10_000);
+        assert_eq!(
+            qmax, real_age,
+            "max-quantile must recover the real age exactly"
+        );
+
+        // The charge a factor-6 spender owes is restored by the quantile kernel.
+        let charge_mean = demurrage_charge(100_000_000, 6_000, mean, 200, BLOCKS_PER_YEAR);
+        let charge_qmax = demurrage_charge(100_000_000, 6_000, qmax, 200, BLOCKS_PER_YEAR);
+        assert!(
+            charge_qmax > charge_mean * 8,
+            "quantile charge {charge_qmax} must dwarf the diluted mean charge {charge_mean}"
+        );
+    }
+
+    #[test]
+    fn test_ring_quantile_lone_real_input_needs_max() {
+        // With a single old real input in a ring of 11 fresh decoys, only the
+        // maximum surfaces it; p90 and p75 still return a fresh (zero) age.
+        // This is the order-statistic tradeoff the sweep quantifies.
+        let current = 500_000u64;
+        let mut members = vec![(1u64, 0u64)]; // real input, age 500_000
+        for _ in 0..10 {
+            members.push((1, current)); // fresh decoys, age 0
+        }
+        assert_eq!(ring_elapsed_quantile(&members, current, 10_000), 500_000); // max recovers
+        assert_eq!(ring_elapsed_quantile(&members, current, 9_000), 0); // p90 misses
+        assert_eq!(ring_elapsed_quantile(&members, current, 7_500), 0); // p75 misses
+    }
+
+    #[test]
+    fn test_ring_quantile_empty_and_single() {
+        // Empty -> 0 for every quantile.
+        for q in [0u32, 5_000, 10_000] {
+            assert_eq!(ring_elapsed_quantile(&[], 1000, q), 0);
+        }
+        // Single member -> its elapsed age for every quantile.
+        for q in [0u32, 2_500, 5_000, 7_500, 10_000] {
+            assert_eq!(ring_elapsed_quantile(&[(42, 300)], 1000, q), 700);
+        }
+    }
+
+    #[test]
+    fn test_ring_quantile_clamps_out_of_range_bps() {
+        // quantile_bps above 10_000 clamps to the max.
+        let members = [(1u64, 90), (1, 80), (1, 70)]; // current 100 -> 10,20,30
+        assert_eq!(
+            ring_elapsed_quantile(&members, 100, 50_000),
+            ring_elapsed_quantile(&members, 100, 10_000)
+        );
     }
 
     #[test]

--- a/cluster-tax/src/lib.rs
+++ b/cluster-tax/src/lib.rs
@@ -95,7 +95,9 @@ pub use crypto::{
     ENTROPY_SCALE,
     MIN_ENTROPY_THRESHOLD_SCALED,
 };
-pub use demurrage::{demurrage_charge, ring_centroid_implied_factor, ring_elapsed_centroid};
+pub use demurrage::{
+    demurrage_charge, ring_centroid_implied_factor, ring_elapsed_centroid, ring_elapsed_quantile,
+};
 pub use dynamic_fee::{DynamicFeeBase, DynamicFeeState, FeeSuggestion};
 pub use entropy_decay::{
     apply_entropy_decay, calculate_entropy_decay, compare_decay_modes, conservative_entropy_delta,

--- a/cluster-tax/src/simulation/decoy_quantile_sweep.rs
+++ b/cluster-tax/src/simulation/decoy_quantile_sweep.rs
@@ -1,0 +1,651 @@
+//! Decoy-quantile demurrage sweep — empirical gate for issue #577 (H2-B1).
+//!
+//! # What this gate answers
+//!
+//! Demurrage charges a holding fee on wealthy-cluster coins at spend time.
+//! Under ring signatures the real input is hidden, so the *elapsed age* fed
+//! into the charge is estimated from the public creation heights of the whole
+//! ring. The shipped estimator, [`crate::ring_elapsed_centroid`], is the
+//! **value-weighted mean** of the members' ages. That mean is an attack surface
+//! (audit cycle 6 H2): a whale holding an old, wealthy coin can pad the ring
+//! with **fresh, high-value** decoys, dragging the value-weighted age toward
+//! zero and escaping most of the charge. The factor-side floor (#574 B2) closes
+//! the wealth leg; this sweep evaluates the proposed age-side fix — replacing
+//! the mean with a value-independent order statistic,
+//! [`crate::ring_elapsed_quantile`].
+//!
+//! The module docs of `demurrage.rs` record the design property the whole
+//! mechanism rests on: the emission-fraction sweep passes its Δgini > 0.05
+//! criterion at miner-viable emission **only with demurrage active**. This
+//! sweep re-confirms that property holds under the NEW kernel against an
+//! **adversarial** decoy population, and measures three numbers per candidate
+//! kernel:
+//!
+//! 1. **Δgini vs the no-demurrage baseline** — must stay above 0.05 (the design
+//!    criterion the centroid kernel was validated against).
+//! 2. **Adversary dilution ratio** = realized charge / charge on TRUE holding
+//!    age, summed over the adversaries' spends. `1.0` = no escape; `→0` = full
+//!    escape. The H2 vector drives this toward 0 against the mean kernel.
+//! 3. **Honest over-charge ratio** = realized charge / true accrual for honest
+//!    spenders. Must stay `≈1.0` — the #314 re-check that honest spenders are
+//!    not over-charged by the new estimator.
+//!
+//! A kernel **passes the gate** iff Δgini > 0.05 AND dilution ≈ 1.0 AND
+//! over-charge ≈ 1.0.
+//!
+//! # Why a focused Monte-Carlo (not the agent framework)
+//!
+//! The agent framework ([`crate::simulation::run_simulation`]) models balances
+//! and transactions but does not express ring composition or decoy selection —
+//! the exact lever this attack pulls. So this is a focused Monte-Carlo over
+//! ring compositions: each spend builds an explicit ring (real input + decoys),
+//! feeds it through the candidate kernel into [`crate::demurrage_charge`],
+//! accumulates per-agent wealth, redistributes the proceeds per-capita (the
+//! lottery's egalitarian payout), and computes Gini with the shared
+//! [`super::metrics::calculate_gini`] — no second Gini implementation.
+//!
+//! Spend-time anchoring matches the node and issue #314: a coin's age anchor
+//! resets on spend, and the accrued charge is paid at that spend.
+//!
+//! # Determinism
+//!
+//! Reproducible: every ring is built from a `ChaCha8Rng` seeded
+//! deterministically from `(base_seed, agent_index, round)`, so the run does
+//! not depend on iteration order and is byte-for-byte stable across runs. The
+//! kernel itself is consensus-grade pure-integer; the surrounding sim uses
+//! `f64` only for ratios and reporting.
+
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+
+use crate::{demurrage_charge, ring_elapsed_centroid, ring_elapsed_quantile};
+
+/// Basis-point scale (10000 = 100%).
+const BPS: u64 = 10_000;
+
+/// A candidate age estimator under test.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Kernel {
+    /// The shipped value-weighted mean ([`ring_elapsed_centroid`]) — the
+    /// baseline the new kernel must beat on dilution resistance.
+    Centroid,
+    /// A value-independent order statistic ([`ring_elapsed_quantile`]) at the
+    /// given percentile in basis points (7500 = p75, 9000 = p90, 10000 = max).
+    Quantile(u32),
+}
+
+impl Kernel {
+    /// Short label for the report table.
+    pub fn label(&self) -> String {
+        match self {
+            Kernel::Centroid => "centroid (mean)".to_string(),
+            Kernel::Quantile(10_000) => "quantile@max".to_string(),
+            Kernel::Quantile(bps) => format!("quantile@p{}", bps / 100),
+        }
+    }
+
+    /// Estimate elapsed age for a ring under this kernel.
+    fn estimate(&self, members: &[(u64, u64)], current_height: u64) -> u64 {
+        match self {
+            Kernel::Centroid => ring_elapsed_centroid(members, current_height),
+            Kernel::Quantile(bps) => ring_elapsed_quantile(members, current_height, *bps),
+        }
+    }
+}
+
+/// Which behavioural class an agent belongs to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Kind {
+    /// Factor-1 background holders: pay zero demurrage, receive redistribution.
+    Poor,
+    /// Wealthy factor-6 holders who select **age-similar** decoys (the Botho
+    /// wallet default). No adversarial intent.
+    HonestWhale,
+    /// Wealthy factor-6 holders who hold old coins but deliberately select
+    /// **fresh, high-value** decoys to dilute the age estimate — the #577 / H2
+    /// vector.
+    AdversaryWhale,
+}
+
+/// One agent in the Monte-Carlo.
+#[derive(Clone, Debug)]
+struct Agent {
+    kind: Kind,
+    /// Current wealth (moves under demurrage + redistribution).
+    wealth: u64,
+    /// Cluster factor in FACTOR_SCALE units (1000 = 1x, 6000 = 6x).
+    factor_scaled: u64,
+    /// Height at which this agent's coins were last anchored (reset on spend).
+    anchor: u64,
+}
+
+/// Tunable parameters for the sweep.
+#[derive(Clone, Debug)]
+pub struct DecoySweepParams {
+    /// Number of factor-1 background holders.
+    pub poor: usize,
+    /// Number of honest factor-6 whales (age-similar decoys).
+    pub honest_whales: usize,
+    /// Number of adversarial factor-6 whales (fresh high-value decoys).
+    pub adversary_whales: usize,
+    /// Starting wealth of each poor holder.
+    pub poor_wealth: u64,
+    /// Starting wealth of each whale (honest and adversary alike).
+    pub whale_wealth: u64,
+    /// Ring size (1 real input + `ring_size - 1` decoys).
+    pub ring_size: usize,
+    /// Number of simulated rounds; each round = one spend per agent and one
+    /// per-capita redistribution. With `blocks_per_round == blocks_per_year`,
+    /// one round represents one year of holding.
+    pub rounds: u64,
+    /// Blocks advanced per round.
+    pub blocks_per_round: u64,
+    /// Annual demurrage rate at max factor, in basis points (200 = 2%/yr).
+    pub rate_bps: u32,
+    /// Blocks per year for the charge formula.
+    pub blocks_per_year: u64,
+    /// Half-width of honest decoy age jitter, in basis points of the real age
+    /// (500 = ±5%). Adversary decoys ignore this (always fresh).
+    pub honest_jitter_bps: u32,
+    /// Base RNG seed (combined with agent index and round).
+    pub seed: u64,
+}
+
+impl Default for DecoySweepParams {
+    fn default() -> Self {
+        // Each round = one year (blocks_per_round == blocks_per_year), so a
+        // 25-round run is ~25 years of holding — long enough that 2%/yr
+        // demurrage drives a visible Gini compression under full payment.
+        let blocks_per_year = 6_307_200; // 5s blocks, matches the node
+        Self {
+            poor: 100,
+            honest_whales: 10,
+            adversary_whales: 10,
+            poor_wealth: 1_000,
+            whale_wealth: 1_000_000,
+            ring_size: 11,
+            rounds: 25,
+            blocks_per_round: blocks_per_year,
+            rate_bps: 200,
+            blocks_per_year,
+            honest_jitter_bps: 500,
+            seed: 0xB07A_2025,
+        }
+    }
+}
+
+impl DecoySweepParams {
+    fn num_agents(&self) -> usize {
+        self.poor + self.honest_whales + self.adversary_whales
+    }
+
+    fn build_population(&self) -> Vec<Agent> {
+        let mut agents = Vec::with_capacity(self.num_agents());
+        for _ in 0..self.poor {
+            agents.push(Agent {
+                kind: Kind::Poor,
+                wealth: self.poor_wealth,
+                factor_scaled: 1_000, // 1x
+                anchor: 0,
+            });
+        }
+        for _ in 0..self.honest_whales {
+            agents.push(Agent {
+                kind: Kind::HonestWhale,
+                wealth: self.whale_wealth,
+                factor_scaled: 6_000, // 6x
+                anchor: 0,
+            });
+        }
+        for _ in 0..self.adversary_whales {
+            agents.push(Agent {
+                kind: Kind::AdversaryWhale,
+                wealth: self.whale_wealth,
+                factor_scaled: 6_000, // 6x
+                anchor: 0,
+            });
+        }
+        agents
+    }
+}
+
+/// Build the ring a given agent presents at a spend.
+///
+/// Returns `(value, creation_height)` members including the real input. Honest
+/// and poor agents pick **age-similar** decoys (jittered around the real age);
+/// adversaries pick **fresh, equal-value** decoys (creation_height ==
+/// current_height → age 0) — the maximal mean-dilution choice.
+fn build_ring(
+    rng: &mut ChaCha8Rng,
+    kind: Kind,
+    real_value: u64,
+    real_age: u64,
+    current_height: u64,
+    ring_size: usize,
+    honest_jitter_bps: u32,
+) -> Vec<(u64, u64)> {
+    let mut members = Vec::with_capacity(ring_size);
+    let real_creation = current_height.saturating_sub(real_age);
+    members.push((real_value, real_creation));
+
+    for _ in 1..ring_size {
+        match kind {
+            Kind::AdversaryWhale => {
+                // Fresh decoy, equal value: contributes `value × 0` to the
+                // value-weighted mean numerator while inflating its denominator.
+                members.push((real_value, current_height));
+            }
+            Kind::HonestWhale | Kind::Poor => {
+                // Age-similar decoy: age within ±jitter of the real age, value
+                // comparable to the real input (so the mean is well-behaved).
+                let span = (real_age.saturating_mul(honest_jitter_bps as u64)) / BPS;
+                let age = if span == 0 {
+                    real_age
+                } else {
+                    let delta = rng.gen_range(0..=2 * span) as i64 - span as i64;
+                    (real_age as i64 + delta).max(0) as u64
+                };
+                let creation = current_height.saturating_sub(age);
+                // Value jitter ±10% so the value-weighted mean is realistic.
+                let vspan = real_value / 10;
+                let value = if vspan == 0 {
+                    real_value
+                } else {
+                    let dv = rng.gen_range(0..=2 * vspan) as i64 - vspan as i64;
+                    (real_value as i64 + dv).max(1) as u64
+                };
+                members.push((value, creation));
+            }
+        }
+    }
+    members
+}
+
+/// Per-kernel outcome of one Monte-Carlo run.
+#[derive(Clone, Debug)]
+struct RunOutcome {
+    final_gini: f64,
+    /// Σ realized demurrage charged to adversaries (under the kernel estimate).
+    adv_realized: u128,
+    /// Σ demurrage adversaries would owe on their TRUE holding age.
+    adv_true: u128,
+    /// Σ realized demurrage charged to honest whales.
+    honest_realized: u128,
+    /// Σ demurrage honest whales would owe on their TRUE holding age.
+    honest_true: u128,
+}
+
+/// Run one Monte-Carlo pass. `kernel == None` is the no-demurrage baseline
+/// (charges forced to zero, no redistribution) used to anchor Δgini.
+fn run_one(params: &DecoySweepParams, kernel: Option<Kernel>) -> RunOutcome {
+    let mut agents = params.build_population();
+    let n = agents.len();
+
+    let mut adv_realized: u128 = 0;
+    let mut adv_true: u128 = 0;
+    let mut honest_realized: u128 = 0;
+    let mut honest_true: u128 = 0;
+
+    // Integer redistribution carry so per-capita division loses nothing.
+    let mut pool_carry: u64 = 0;
+
+    for round in 1..=params.rounds {
+        let current_height = round * params.blocks_per_round;
+        let mut pool: u64 = pool_carry;
+
+        for (idx, agent) in agents.iter_mut().enumerate() {
+            let true_age = current_height.saturating_sub(agent.anchor);
+            // Spend moves the agent's whole stack; the charge binds to that.
+            let value = agent.wealth;
+
+            if let Some(kernel) = kernel {
+                // Deterministic per-(agent, round) RNG: independent of iteration
+                // order, byte-for-byte reproducible.
+                let mut rng = ChaCha8Rng::seed_from_u64(
+                    params
+                        .seed
+                        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                        .wrapping_add((idx as u64).wrapping_mul(0x1000_0001))
+                        .wrapping_add(round.wrapping_mul(0x0100_0193)),
+                );
+                let ring = build_ring(
+                    &mut rng,
+                    agent.kind,
+                    value,
+                    true_age,
+                    current_height,
+                    params.ring_size,
+                    params.honest_jitter_bps,
+                );
+                let est_age = kernel.estimate(&ring, current_height);
+
+                let realized = demurrage_charge(
+                    value,
+                    agent.factor_scaled,
+                    est_age,
+                    params.rate_bps,
+                    params.blocks_per_year,
+                )
+                .min(agent.wealth);
+                let truth = demurrage_charge(
+                    value,
+                    agent.factor_scaled,
+                    true_age,
+                    params.rate_bps,
+                    params.blocks_per_year,
+                );
+
+                match agent.kind {
+                    Kind::AdversaryWhale => {
+                        adv_realized += realized as u128;
+                        adv_true += truth as u128;
+                    }
+                    Kind::HonestWhale => {
+                        honest_realized += realized as u128;
+                        honest_true += truth as u128;
+                    }
+                    Kind::Poor => {}
+                }
+
+                agent.wealth -= realized;
+                pool += realized;
+            }
+
+            // Spend-time anchoring (#314): the anchor resets at every spend.
+            agent.anchor = current_height;
+        }
+
+        // Per-capita redistribution (egalitarian lottery payout).
+        if n > 0 && pool > 0 {
+            let share = pool / n as u64;
+            pool_carry = pool % n as u64;
+            if share > 0 {
+                for agent in agents.iter_mut() {
+                    agent.wealth += share;
+                }
+            }
+        } else {
+            pool_carry = pool;
+        }
+    }
+
+    let wealths: Vec<u64> = agents.iter().map(|a| a.wealth).collect();
+    let final_gini = super::metrics::calculate_gini(&wealths);
+
+    RunOutcome {
+        final_gini,
+        adv_realized,
+        adv_true,
+        honest_realized,
+        honest_true,
+    }
+}
+
+/// Result row for one candidate kernel.
+#[derive(Clone, Debug)]
+pub struct KernelResult {
+    pub kernel: Kernel,
+    pub final_gini: f64,
+    /// Δgini vs the no-demurrage baseline (baseline_gini − kernel_gini);
+    /// positive = inequality reduced.
+    pub delta_gini: f64,
+    /// Adversary realized charge / true-age charge. 1.0 = no escape, →0 = full
+    /// escape.
+    pub adversary_dilution_ratio: f64,
+    /// Honest realized charge / true accrual. Must stay ≈1.0.
+    pub honest_overcharge_ratio: f64,
+}
+
+impl KernelResult {
+    /// The gate: Δgini > 0.05 AND dilution ≈ 1.0 AND over-charge ≈ 1.0.
+    pub fn passes(&self) -> bool {
+        self.delta_gini > 0.05
+            && (self.adversary_dilution_ratio - 1.0).abs() <= 0.10
+            && (self.honest_overcharge_ratio - 1.0).abs() <= 0.15
+    }
+}
+
+/// Full sweep across the baseline (no demurrage) and every candidate kernel.
+#[derive(Clone, Debug)]
+pub struct DecoySweepReport {
+    /// Final Gini with demurrage disabled (the Δgini anchor).
+    pub baseline_gini: f64,
+    /// Initial Gini of the population (sanity reference).
+    pub initial_gini: f64,
+    pub results: Vec<KernelResult>,
+    pub params: DecoySweepParams,
+}
+
+/// The candidate kernels evaluated by the sweep, in report order.
+pub fn candidate_kernels() -> Vec<Kernel> {
+    vec![
+        Kernel::Centroid,
+        Kernel::Quantile(7_500),  // p75
+        Kernel::Quantile(9_000),  // p90
+        Kernel::Quantile(10_000), // max
+    ]
+}
+
+/// Run the full decoy-quantile sweep.
+pub fn run_decoy_sweep(params: &DecoySweepParams) -> DecoySweepReport {
+    let initial = params.build_population();
+    let initial_wealths: Vec<u64> = initial.iter().map(|a| a.wealth).collect();
+    let initial_gini = super::metrics::calculate_gini(&initial_wealths);
+
+    let baseline = run_one(params, None);
+    let baseline_gini = baseline.final_gini;
+
+    let results = candidate_kernels()
+        .into_iter()
+        .map(|kernel| {
+            let out = run_one(params, Some(kernel));
+            let adversary_dilution_ratio = if out.adv_true > 0 {
+                out.adv_realized as f64 / out.adv_true as f64
+            } else {
+                // No true charge to dilute -> treat as no escape.
+                1.0
+            };
+            let honest_overcharge_ratio = if out.honest_true > 0 {
+                out.honest_realized as f64 / out.honest_true as f64
+            } else {
+                1.0
+            };
+            KernelResult {
+                kernel,
+                final_gini: out.final_gini,
+                delta_gini: baseline_gini - out.final_gini,
+                adversary_dilution_ratio,
+                honest_overcharge_ratio,
+            }
+        })
+        .collect();
+
+    DecoySweepReport {
+        baseline_gini,
+        initial_gini,
+        results,
+        params: params.clone(),
+    }
+}
+
+/// Render the report as a plain-text comparison table for the CLI.
+pub fn to_table(report: &DecoySweepReport) -> String {
+    let p = &report.params;
+    let mut s = String::new();
+    s.push_str("Decoy-Quantile Demurrage Sweep (empirical gate for #577 / H2-B1)\n");
+    s.push_str("================================================================\n");
+    s.push_str(&format!(
+        "Population: {} poor (1x) / {} honest whales (6x, age-similar decoys) / {} adversary whales (6x, FRESH high-value decoys)\n",
+        p.poor, p.honest_whales, p.adversary_whales,
+    ));
+    s.push_str(&format!(
+        "Ring size {} (1 real input + {} decoys) | {} rounds × {} blocks (~{} yr) | rate {}bps/yr at factor 6 | honest jitter ±{}%\n",
+        p.ring_size,
+        p.ring_size - 1,
+        p.rounds,
+        p.blocks_per_round,
+        p.rounds * p.blocks_per_round / p.blocks_per_year,
+        p.rate_bps,
+        p.honest_jitter_bps / 100,
+    ));
+    s.push_str(&format!(
+        "Initial Gini {:.4} | no-demurrage baseline Gini {:.4} (Δgini anchor)\n\n",
+        report.initial_gini, report.baseline_gini,
+    ));
+
+    s.push_str(
+        "| kernel          | final_gini | Δgini   | adv_dilution | honest_overcharge | passes |\n",
+    );
+    s.push_str(
+        "|-----------------|------------|---------|--------------|-------------------|--------|\n",
+    );
+    for r in &report.results {
+        s.push_str(&format!(
+            "| {:<15} | {:>10.4} | {:>+7.4} | {:>12.4} | {:>17.4} | {:^6} |\n",
+            r.kernel.label(),
+            r.final_gini,
+            r.delta_gini,
+            r.adversary_dilution_ratio,
+            r.honest_overcharge_ratio,
+            if r.passes() { "YES" } else { "no" },
+        ));
+    }
+    s.push('\n');
+
+    // Interpretation footer (factual; mirrors the K/J/M scenario style).
+    s.push_str("Reading the table:\n");
+    s.push_str("- Δgini is vs the no-demurrage baseline; the design criterion is Δgini > 0.05.\n");
+    s.push_str(
+        "- adv_dilution = adversary realized charge / charge on their TRUE holding age.\n  1.0 = no escape; →0 = the fresh-high-value-decoy attack succeeds.\n",
+    );
+    s.push_str(
+        "- honest_overcharge = honest realized charge / true accrual (#314 re-check). Must stay ≈1.0.\n",
+    );
+    s.push_str(
+        "- passes = Δgini > 0.05 AND |adv_dilution−1| ≤ 0.10 AND |honest_overcharge−1| ≤ 0.15.\n",
+    );
+    s.push_str(&format!(
+        "- The mean kernel succumbs to the age-dilution vector: with a single old real input\n  among {} fresh decoys, only the MAXIMUM order statistic surfaces it. A percentile p\n  recovers a lone real input only when p > (ring_size−1)/ring_size × 100% = {:.1}%, so\n  p75/p90 still return a fresh decoy age here. This ring-size dependence is the core\n  tradeoff: max resists the attack fully but relies on age-similar honest decoy selection\n  to avoid over-charging honest spenders.\n",
+        p.ring_size - 1,
+        (p.ring_size as f64 - 1.0) / p.ring_size as f64 * 100.0,
+    ));
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn quick_params() -> DecoySweepParams {
+        DecoySweepParams {
+            poor: 30,
+            honest_whales: 4,
+            adversary_whales: 4,
+            rounds: 10,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn sweep_runs_and_reports_all_kernels() {
+        let report = run_decoy_sweep(&quick_params());
+        assert_eq!(report.results.len(), 4);
+        let table = to_table(&report);
+        assert!(table.contains("centroid (mean)"));
+        assert!(table.contains("quantile@max"));
+        assert!(table.contains("passes"));
+    }
+
+    #[test]
+    fn sweep_is_reproducible() {
+        let p = quick_params();
+        let a = to_table(&run_decoy_sweep(&p));
+        let b = to_table(&run_decoy_sweep(&p));
+        assert_eq!(a, b, "sweep output must be deterministic");
+    }
+
+    #[test]
+    fn max_kernel_resists_dilution_centroid_does_not() {
+        let report = run_decoy_sweep(&DecoySweepParams::default());
+        let centroid = report
+            .results
+            .iter()
+            .find(|r| r.kernel == Kernel::Centroid)
+            .unwrap();
+        let qmax = report
+            .results
+            .iter()
+            .find(|r| r.kernel == Kernel::Quantile(10_000))
+            .unwrap();
+
+        // The mean kernel lets the adversary escape most of the charge.
+        assert!(
+            centroid.adversary_dilution_ratio < 0.5,
+            "centroid dilution {} should show heavy escape",
+            centroid.adversary_dilution_ratio
+        );
+        // The max-quantile recovers the true age: ~no escape.
+        assert!(
+            (qmax.adversary_dilution_ratio - 1.0).abs() < 0.01,
+            "max dilution {} should be ~1.0",
+            qmax.adversary_dilution_ratio
+        );
+    }
+
+    #[test]
+    fn honest_spenders_not_overcharged_under_any_kernel() {
+        let report = run_decoy_sweep(&DecoySweepParams::default());
+        for r in &report.results {
+            assert!(
+                (r.honest_overcharge_ratio - 1.0).abs() <= 0.15,
+                "{} over-charges honest spenders: ratio {}",
+                r.kernel.label(),
+                r.honest_overcharge_ratio
+            );
+        }
+    }
+
+    #[test]
+    fn lone_real_input_only_max_passes_dilution() {
+        // With ring_size 11 and a single old real input, only the max statistic
+        // surfaces it; p75/p90 return a fresh decoy age (heavy dilution).
+        let report = run_decoy_sweep(&DecoySweepParams::default());
+        let p75 = report
+            .results
+            .iter()
+            .find(|r| r.kernel == Kernel::Quantile(7_500))
+            .unwrap();
+        let p90 = report
+            .results
+            .iter()
+            .find(|r| r.kernel == Kernel::Quantile(9_000))
+            .unwrap();
+        assert!(
+            p75.adversary_dilution_ratio < 0.5,
+            "p75 dilution {} should show escape for a lone real input",
+            p75.adversary_dilution_ratio
+        );
+        assert!(
+            p90.adversary_dilution_ratio < 0.5,
+            "p90 dilution {} should show escape for a lone real input",
+            p90.adversary_dilution_ratio
+        );
+    }
+
+    #[test]
+    fn demurrage_reduces_gini_under_max_kernel() {
+        // The design property: with demurrage active (and not escaped), Δgini
+        // exceeds the 0.05 criterion.
+        let report = run_decoy_sweep(&DecoySweepParams::default());
+        let qmax = report
+            .results
+            .iter()
+            .find(|r| r.kernel == Kernel::Quantile(10_000))
+            .unwrap();
+        assert!(
+            qmax.delta_gini > 0.05,
+            "max kernel Δgini {} should exceed 0.05",
+            qmax.delta_gini
+        );
+    }
+}

--- a/cluster-tax/src/simulation/mod.rs
+++ b/cluster-tax/src/simulation/mod.rs
@@ -26,6 +26,8 @@ pub mod agents;
 #[cfg(any(feature = "cli", test))]
 pub mod constrained_analysis;
 #[cfg(any(feature = "cli", test))]
+pub mod decoy_quantile_sweep;
+#[cfg(any(feature = "cli", test))]
 pub mod emission_sweep;
 pub mod lottery;
 mod metrics;


### PR DESCRIPTION
## Empirical gate for #577 (H2-B1) — does NOT close #577

#577's consensus wiring stays **blocked under #323**. This PR delivers the *empirical-gate artifact* the issue requires ("needs sim results + human sign-off; do NOT auto-build") plus the new kernel as a **pure, unwired** function — value-preserving and dead until B1 wires it post-reset, the same pattern as #570's f64 prereq.

### What's here
- `cluster-tax/src/demurrage.rs` — `ring_elapsed_quantile(members, current_height, quantile_bps)`: an integer nearest-rank order-statistic over ring-member **ages only** (value deliberately unread — value-weighting is exactly the H2 dilution vector). `q=10000`→max, `7500`→p75. Pure, deterministic, consensus-safe. Unit-tested (incl. the H2 attack case the mean kernel fails).
- `cluster-tax/src/simulation/decoy_quantile_sweep.rs` + `cluster-tax-sim decoy-quantile-sweep` subcommand — adversarial decoy sweep measuring, per candidate kernel: final Gini, Δgini vs no-demurrage baseline, adversary age-dilution ratio, and honest #314 over-charge ratio.

### Sweep result (default population: 100 poor / 10 honest whales / 10 adversary whales, ring 11, ~25yr, 200bps)
```
| kernel          | final_gini | Δgini   | adv_dilution | honest_overcharge | passes |
|-----------------|------------|---------|--------------|-------------------|--------|
| centroid (mean) |     0.6568 | +0.1716 |       0.0909 |            0.9988 |   no   |
| quantile@p75    |     0.6748 | +0.1535 |       0.0000 |            1.0232 |   no   |
| quantile@p90    |     0.6740 | +0.1544 |       0.0000 |            1.0303 |   no   |
| quantile@max    |     0.4822 | +0.3462 |       1.0000 |            1.0386 |  YES   |
```
- `adv_dilution` = adversary realized charge / charge on TRUE holding age. 1.0 = attack fully blocked; →0 = fresh-decoy attack succeeds.
- `honest_overcharge` = honest realized charge / true accrual (#314 re-check). Must stay ≈1.0.
- The current **mean** kernel lets the adversary escape ~91% of demurrage (0.0909). **p75/p90 fail outright** — a lone real input in an 11-ring needs p > 90.9% to surface, so sub-max percentiles return a fresh decoy (adv_dilution 0.0). **Only `max` passes.**

### Honest over-charge sensitivity (`max` kernel) — the sign-off condition
| honest decoy age-spread | honest_overcharge | within #314 tol (≤15%) |
|---|---|---|
| ±5% | 1.039 | ✅ |
| ±10% | 1.077 | ✅ |
| ±20% | 1.158 | ❌ |
| ±35% | 1.277 | ❌ |
| ±50% | 1.388 | ❌ |

Seed-stable (0.4821–0.4822 final Gini across seeds 11111/22222/33333).

### Recommendation / sign-off
**Adopt `quantile@max` (10000) for B1**, with a **coupled requirement**: honest wallets must select **age-similar decoys** (≤~±10% spread) or honest spenders breach the #314 over-charge bound. Filed as a companion wallet-decoy-policy dependency (see linked issue). Gate status: **PASSED-with-condition**.

### Verification
- `cargo test -p bth-cluster-tax --lib` → **419 passed, 0 failed** (incl. 6 new quantile-kernel tests).
- `cargo fmt` clean. Sweep output above captured from `cluster-tax-sim decoy-quantile-sweep`.

Refs #577.
