### PR TITLE
fix(consensus): reject/saturate block fee-sum overflow instead of wrapping

### DIFF
--- a/botho/src/block.rs
+++ b/botho/src/block.rs
@@ -592,9 +592,24 @@ impl Block {
         hasher.finalize().into()
     }
 
-    /// Get total fees from all transactions
+    /// Get total fees from all transactions.
+    ///
+    /// Per-transaction fees are attacker-influenced, so this accumulates with
+    /// `saturating_add`: a crafted block whose fees sum past `u64::MAX` clamps
+    /// to `u64::MAX` rather than wrapping silently (release, `overflow-checks =
+    /// false`) or panicking (debug). See issue #599.
+    ///
+    /// Caller contract: this is *not* an authoritative fee total for consensus
+    /// arithmetic. A saturated value only ever fails validation — it cannot
+    /// match a block's declared lottery split — and any block with an
+    /// overflowing fee total is rejected outright by the ledger via a checked
+    /// accumulation in `add_block_inner` (`LedgerError::FeeOverflow`). Callers
+    /// use it only for the "are there any fees at all?" gate and for lottery
+    /// accounting that is separately re-checked against the block's summary.
     pub fn total_fees(&self) -> u64 {
-        self.transactions.iter().map(|tx| tx.fee).sum()
+        self.transactions
+            .iter()
+            .fold(0u64, |acc, tx| acc.saturating_add(tx.fee))
     }
 }
 
@@ -1836,6 +1851,45 @@ mod tests {
         let hash1 = genesis.hash();
         let hash2 = genesis.hash();
         assert_eq!(hash1, hash2);
+    }
+
+    // --- #599: fee-sum overflow is handled deterministically ---
+
+    /// `total_fees()` must saturate rather than wrap silently (release) or
+    /// panic (debug) when attacker-influenced per-tx fees sum past `u64::MAX`.
+    /// This test is meaningful in BOTH build modes: in debug the old `.sum()`
+    /// panicked here; in release it wrapped to a small value.
+    #[test]
+    fn test_total_fees_saturates_on_overflow() {
+        let mut genesis = Block::genesis();
+        // Two fees whose sum exceeds u64::MAX. A wrapping accumulator would
+        // yield u64::MAX.wrapping_add(2) == 1; a saturating one yields u64::MAX.
+        genesis.transactions = vec![
+            Transaction::new_stub_with_fee(u64::MAX),
+            Transaction::new_stub_with_fee(3),
+        ];
+
+        let total = genesis.total_fees();
+        assert_eq!(
+            total,
+            u64::MAX,
+            "fee total must clamp to u64::MAX, not wrap"
+        );
+        // The "any fees at all?" gate still fires on the saturated total.
+        assert!(total > 0);
+    }
+
+    /// A non-overflowing fee total is still summed correctly after the switch
+    /// to saturating accumulation.
+    #[test]
+    fn test_total_fees_normal_sum() {
+        let mut genesis = Block::genesis();
+        genesis.transactions = vec![
+            Transaction::new_stub_with_fee(100),
+            Transaction::new_stub_with_fee(250),
+            Transaction::new_stub_with_fee(650),
+        ];
+        assert_eq!(genesis.total_fees(), 1000);
     }
 
     // Note: Block reward calculation uses calculate_block_reward() which is

--- a/botho/src/ledger/mod.rs
+++ b/botho/src/ledger/mod.rs
@@ -53,6 +53,14 @@ pub enum LedgerError {
 
     #[error("Lottery winner not found in candidates: {0}")]
     LotteryWinnerNotEligible(String),
+
+    /// The sum of per-transaction fees in the block overflows `u64`. Fees are
+    /// attacker-influenced, so a crafted block whose fees sum past `u64::MAX`
+    /// would wrap silently under `overflow-checks=false` (release) or panic in
+    /// debug. We reject such blocks deterministically instead. Mirrors the
+    /// per-tx balance overflow guard from issue #340.
+    #[error("Block fee total overflows u64")]
+    FeeOverflow,
 }
 
 /// Information about the current chain state

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -209,6 +209,21 @@ const META_CURRENT_REWARD: &[u8] = b"current_reward";
 // Redistribution lottery carryover pool (consensus state)
 const META_LOTTERY_POOL: &[u8] = b"lottery_pool";
 
+/// Sum a block's per-transaction fees, rejecting on `u64` overflow.
+///
+/// Per-tx fees are attacker-influenced, so a naive `.sum::<u64>()` would wrap
+/// silently under `overflow-checks = false` (release) or panic (debug) for a
+/// crafted block whose fees total past `u64::MAX`. We accumulate with
+/// `checked_add` and return `LedgerError::FeeOverflow` instead, matching the
+/// per-tx balance overflow guard from issue #340. See issue #599.
+fn checked_block_fees(block: &Block) -> Result<u64, LedgerError> {
+    block
+        .transactions
+        .iter()
+        .try_fold(0u64, |acc, tx| acc.checked_add(tx.fee))
+        .ok_or(LedgerError::FeeOverflow)
+}
+
 impl Ledger {
     /// Open or create a ledger at the given path (defaults to Testnet for
     /// backward compatibility)
@@ -861,7 +876,11 @@ impl Ledger {
         // fee would overstate destroyed supply 5x and break conservation
         // (audit cycle 6, M4). The lottery summary's burn amount was verified
         // against the pool accounting by `validate_block_lottery` above.
-        let block_fees: u64 = block.transactions.iter().map(|tx| tx.fee).sum();
+        //
+        // Fees are attacker-influenced, so accumulate with `checked_add` and
+        // reject on overflow rather than wrapping silently (release) or
+        // panicking (debug). See issue #599 (mirrors the #340 balance guard).
+        let block_fees: u64 = checked_block_fees(block)?;
         let actually_burned = block.lottery_summary.amount_burned;
         let new_total_fees_burned = state.total_fees_burned + actually_burned as u128;
 
@@ -3369,6 +3388,49 @@ mod tests {
     // leaving the conserved state unchanged — the exact pre/post check the
     // fuzz target performs.
     // ------------------------------------------------------------------
+    // #599: the block-fee accumulation in `add_block_inner` must reject a
+    // fee-sum overflow with a typed error rather than wrapping silently
+    // (release) or panicking (debug). `checked_block_fees` is the exact
+    // reduction `add_block_inner` invokes; we test it directly because driving
+    // an overflowing-fee block all the way to the fee-accounting line would
+    // require it to first pass every prior consensus gate (PoW, ring
+    // signatures, lottery validation), which an attacker cannot do for a
+    // u64::MAX fee total. This test is meaningful in BOTH build modes: the old
+    // `.sum()` panicked here in debug and wrapped to 1 in release.
+    #[test]
+    fn test_checked_block_fees_rejects_overflow() {
+        use crate::transaction::Transaction;
+
+        let mut block = Block::genesis_for_network(Network::Testnet);
+        // Two fees whose sum exceeds u64::MAX.
+        block.transactions = vec![
+            Transaction::new_stub_with_fee(u64::MAX),
+            Transaction::new_stub_with_fee(3),
+        ];
+
+        let result = checked_block_fees(&block);
+        assert!(
+            matches!(result, Err(LedgerError::FeeOverflow)),
+            "fee-sum overflow must be rejected with LedgerError::FeeOverflow, got {:?}",
+            result
+        );
+    }
+
+    // #599: a non-overflowing fee total is still summed correctly.
+    #[test]
+    fn test_checked_block_fees_normal_sum() {
+        use crate::transaction::Transaction;
+
+        let mut block = Block::genesis_for_network(Network::Testnet);
+        block.transactions = vec![
+            Transaction::new_stub_with_fee(100),
+            Transaction::new_stub_with_fee(250),
+            Transaction::new_stub_with_fee(650),
+        ];
+
+        assert_eq!(checked_block_fees(&block).unwrap(), 1000);
+    }
+
     #[test]
     fn fuzz_wiring_add_block_rejects_malformed_and_conserves_supply() {
         let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary
Two unchecked `.sum::<u64>()` reductions over attacker-influenced per-transaction fees could wrap silently under `overflow-checks = false` (release) or panic in debug when a crafted block's fees sum past `u64::MAX`. This hardens both sites so an overflowing fee total is handled deterministically instead. Severity is Low (neither value feeds a mint/balance decision), but this closes a latent debug-panic DoS surface on gossiped blocks and a wrapped-total gate flip.

## Changes
- **`botho/src/ledger/mod.rs`**: add typed `LedgerError::FeeOverflow` variant.
- **`botho/src/ledger/store.rs`**: replace the raw `.sum()` at the fee-accounting line with a new `checked_block_fees` helper (`try_fold` + `checked_add`) that returns `LedgerError::FeeOverflow`. `add_block_inner` now rejects the block on overflow, mirroring the #340 per-tx balance guard.
- **`botho/src/block.rs`**: `Block::total_fees()` now uses `saturating_add` with a documented caller contract — a saturated total only ever fails validation and is separately rejected by the ledger, so the `total_fees() > 0` gate and lottery accounting can no longer panic or wrap.
- Regression tests for both sites (a fee sum past `u64::MAX`), verified in **both** debug and release.

Out of scope (per issue Notes): the adjacent max-tx-count / max-serialized-size bound in `add_block_inner`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Both sites reject (or saturate w/ documented rationale) instead of wrapping/panicking | done | `store.rs` rejects via `LedgerError::FeeOverflow`; `block.rs` `total_fees()` saturates with a documented caller contract |
| Test: block whose `tx.fee` sum past `u64::MAX` handled deterministically in debug AND release | done | `test_total_fees_saturates_on_overflow`, `test_checked_block_fees_rejects_overflow` pass under `cargo test -p botho --lib` and `--release` |

## Test Plan
- `cargo build -p botho` — clean (pre-existing dead-code warnings only).
- `cargo test -p botho --lib -- total_fees checked_block_fees` — 5 passed (debug).
- `cargo test -p botho --lib --release -- total_fees checked_block_fees` — 5 passed (release).
- `cargo test -p botho --lib -- block:: consensus::lottery:: ledger::store::` — 86 passed, 0 failed.
- `cargo clippy -p botho --lib` — 0 errors.

Closes #599