### PR TITLE
build(M1-B5): assert mempool relay fee only tightens above consensus floor

### DIFF
--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -1648,6 +1648,19 @@ impl Ledger {
         Ok(())
     }
 
+    /// Test-only entry point to the private block-validity gate
+    /// [`Ledger::verify_consensus_fee_floor`], so tests in sibling modules
+    /// (e.g. the mempool relay-only-tightening invariant, issue #579) can
+    /// exercise the real consensus acceptance path rather than re-deriving it.
+    #[cfg(test)]
+    pub fn verify_consensus_fee_floor_for_test(
+        &self,
+        tx: &BothoTransaction,
+        block_height: u64,
+    ) -> Result<(), LedgerError> {
+        self.verify_consensus_fee_floor(tx, block_height)
+    }
+
     /// Compute the deterministic consensus fee floor for a transfer tx.
     ///
     /// Split out from [`Ledger::verify_consensus_fee_floor`] so tests (and any

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -678,7 +678,18 @@ impl Mempool {
         // Count outputs with encrypted memos for fee calculation
         let num_memos = tx.outputs.iter().filter(|o| o.has_memo()).count();
 
-        // Get the current dynamic fee base (adjusts based on congestion)
+        // Get the current dynamic fee base (adjusts based on congestion).
+        //
+        // RELAY-ONLY policy: `DynamicFeeBase` carries a node-local f64 EMA (reset
+        // on restart) and a wall-clock `at_min_block_time` flag, so its output is
+        // NOT deterministic across nodes. It must NEVER enter consensus — see the
+        // type docs on `bth_cluster_tax::DynamicFeeBase` and the consensus floor
+        // `Ledger::consensus_fee_floor` (which deliberately pins the base to the
+        // neutral `CONSENSUS_FEE_BASE`, omitting congestion). Because
+        // `compute_base` is clamped to `>= base_min == CONSENSUS_FEE_BASE`, this
+        // term can only ever RAISE the local relay threshold above the consensus
+        // floor (never below it) — the relay-only-tightening invariant asserted
+        // just below where `minimum_fee` is computed.
         let dynamic_base = self.dynamic_fee.compute_base(self.at_min_block_time);
 
         // Use dynamic fee calculation for minimum (with actual output count)
@@ -707,9 +718,13 @@ impl Mempool {
         let demurrage_factor =
             self.ring_centroid_floored_factor(&ring_tags, claimed_factor, ledger)?;
 
+        // Current chain tip height. Used both for the demurrage clock below and
+        // for the relay-only-tightening invariant check (M1-B5), so the mempool
+        // and the consensus floor evaluate the demurrage at the identical height.
+        let chain_height = ledger.get_chain_state().map(|s| s.height).unwrap_or(0);
+
         let demurrage = {
             let policy = crate::monetary::mainnet_policy();
-            let chain_height = ledger.get_chain_state().map(|s| s.height).unwrap_or(0);
             // H2/B1 (issue #578, design #574): use the max-quantile order
             // statistic of ring-member ages, NOT the value-weighted mean. The
             // mean lets a spender pad the ring with fresh high-value decoys to
@@ -732,6 +747,46 @@ impl Mempool {
             )
         };
         let minimum_fee = base_minimum_fee.saturating_add(demurrage);
+
+        // M1-B5 (issue #579, design #574 Q1/Q2): relay-only-tightening invariant.
+        //
+        // The mempool admission threshold `minimum_fee` must NEVER fall below the
+        // deterministic consensus fee floor (`Ledger::consensus_fee_floor`, added
+        // in H1-B4 / #578). Relay policy may only ever TIGHTEN above the consensus
+        // floor — it can never admit a transaction that consensus would reject at
+        // block validation (Bitcoin's min-relay-fee vs. consensus-validity split).
+        //
+        // Both sides compute the SAME base curve and the SAME demurrage kernel
+        // (`ring_elapsed_quantile@max` + `ring_centroid_floored_factor`) at the
+        // SAME `chain_height`; the ONLY structural difference is the congestion
+        // term: the mempool multiplies in `dynamic_base = compute_base(..)` while
+        // the consensus floor pins the base to the neutral `CONSENSUS_FEE_BASE`
+        // (== `DynamicFeeBase::default().base_min`). Because `dynamic_base >=
+        // base_min` always (`compute_base` is clamped to `[base_min, base_max]`),
+        // `minimum_fee >= consensus_floor` holds structurally.
+        //
+        // This is a SAFETY NET, not a gate: it does not change the admission
+        // decision below (that still compares `tx.fee` against `minimum_fee`).
+        // We use `debug_assert!` so the invariant is enforced in tests/CI and
+        // during development without adding a hot-path ledger read (an extra
+        // `consensus_fee_floor` call, which resolves ring UTXOs) to release
+        // builds. If it ever fires, a relay-policy change has broken the
+        // never-fall-below-consensus contract and must be fixed before ship.
+        debug_assert!(
+            {
+                match ledger.consensus_fee_floor(&tx, chain_height) {
+                    Ok(consensus_floor) => minimum_fee >= consensus_floor,
+                    // A DB error recomputing the floor is not an invariant
+                    // violation; skip the assertion rather than panic on
+                    // transient ledger pressure.
+                    Err(_) => true,
+                }
+            },
+            "mempool relay minimum_fee {} fell below the consensus fee floor \
+             (relay must only tighten, never fall below consensus; height {})",
+            minimum_fee,
+            chain_height,
+        );
 
         if tx.fee < minimum_fee {
             let shortfall = minimum_fee.saturating_sub(tx.fee);
@@ -2123,5 +2178,262 @@ mod tests {
         let dynamic_fee = DynamicFeeBase::default();
         let mempool = Mempool::with_dynamic_fee(config, dynamic_fee);
         assert!(mempool.is_fee_enforcement_enabled());
+    }
+
+    // ---------------------------------------------------------------------
+    // M1-B5 (issue #579, design #574): relay-only-tightening invariant.
+    //
+    // The mempool admission threshold must always be >= the deterministic
+    // consensus fee floor: relay policy can only ever TIGHTEN above consensus,
+    // never fall below it. Congestion (the node-local `DynamicFeeBase`) stays a
+    // relay-only multiplier; block validity uses the congestion-free
+    // `Ledger::consensus_fee_floor`. A node with a HOT congestion EMA and a node
+    // with a COLD EMA therefore both admit/reject against a threshold that is
+    // always >= the (shared) consensus floor, and both accept the identical set
+    // of BLOCKS.
+    // ---------------------------------------------------------------------
+
+    /// Seed the ledger, via a snapshot, with a set of ring UTXOs and cluster
+    /// wealth, returning the ring members that reference them. Mirrors the
+    /// store.rs `seed_ring_utxos` helper but through the public snapshot path
+    /// (the low-level UTXO db is private to the ledger module).
+    #[cfg(test)]
+    fn seed_ring_via_snapshot(
+        ledger: &Ledger,
+        // (amount, created_at, cluster_id (0 == background), seed byte)
+        specs: &[(u64, u64, u64, u8)],
+        tip_height: u64,
+        cluster_wealth: &[(u64, u64)],
+    ) -> Vec<RingMember> {
+        use crate::ledger::{ChainState, UtxoSnapshot};
+        use crate::transaction::{Utxo, UtxoId};
+        use bth_transaction_types::{ClusterId, TAG_WEIGHT_SCALE};
+
+        let mut utxos = Vec::new();
+        let mut ring = Vec::new();
+        for &(amount, created_at, cluster, seed) in specs {
+            let tags = if cluster == 0 {
+                ClusterTagVector::empty()
+            } else {
+                ClusterTagVector::from_pairs(&[(ClusterId(cluster), TAG_WEIGHT_SCALE)])
+            };
+            let output = TxOutput {
+                amount,
+                target_key: [seed; 32],
+                public_key: [seed.wrapping_add(1); 32],
+                e_memo: None,
+                cluster_tags: tags,
+            };
+            utxos.push(Utxo {
+                id: UtxoId::new([seed; 32], 0),
+                output: output.clone(),
+                created_at,
+            });
+            ring.push(RingMember::from_output(&output));
+        }
+
+        let mut chain_state = ChainState::default();
+        chain_state.height = tip_height;
+        let snapshot = UtxoSnapshot::new(
+            tip_height,
+            [0u8; 32],
+            chain_state,
+            utxos,
+            vec![],
+            cluster_wealth.to_vec(),
+        )
+        .unwrap();
+        ledger.load_from_snapshot(&snapshot, None).unwrap();
+        ring
+    }
+
+    /// Compute the mempool relay-admission `minimum_fee` for `tx` under a given
+    /// `DynamicFeeBase` congestion state. This reproduces the exact formula used
+    /// in `Mempool::add_tx` (base curve × cluster factor × congestion base, plus
+    /// the `ring_elapsed_quantile@max` + factor-floored demurrage) so the test
+    /// asserts against the true relay threshold, differing from the consensus
+    /// floor ONLY by the congestion multiplier.
+    #[cfg(test)]
+    fn relay_minimum_fee(
+        tx: &Transaction,
+        ledger: &Ledger,
+        fee_config: &FeeConfig,
+        dynamic_fee: &DynamicFeeBase,
+        at_min_block_time: bool,
+    ) -> u64 {
+        let tx_size_bytes = tx.estimate_size();
+        let num_outputs = tx.outputs.len();
+        let num_memos = tx.outputs.iter().filter(|o| o.has_memo()).count();
+        let cluster_wealth = effective_cluster_wealth_from_outputs(&tx.outputs, ledger).unwrap();
+        let dynamic_base = dynamic_fee.compute_base(at_min_block_time);
+
+        let base_minimum_fee = fee_config.minimum_fee_dynamic_with_outputs(
+            FeeTransactionType::Hidden,
+            tx_size_bytes,
+            cluster_wealth,
+            num_outputs,
+            num_memos,
+            dynamic_base,
+        );
+
+        let output_sum: u64 = tx
+            .outputs
+            .iter()
+            .fold(0u64, |acc, o| acc.saturating_add(o.amount));
+
+        // Ring members: (value, created_at) for the age quantile, plus tags for
+        // the factor floor — resolved from the committed UTXO set, exactly as
+        // the mempool does inside validate_clsag_inputs.
+        let mut ring_members: Vec<(u64, u64)> = Vec::new();
+        let mut ring_tags: Vec<(ClusterTagVector, u64)> = Vec::new();
+        for input in tx.inputs.clsag() {
+            for member in &input.ring {
+                if let Ok(Some(utxo)) = ledger.get_utxo_by_target_key(&member.target_key) {
+                    ring_members.push((utxo.output.amount, utxo.created_at));
+                    ring_tags.push((utxo.output.cluster_tags.clone(), utxo.output.amount));
+                }
+            }
+        }
+
+        let claimed_factor = fee_config.cluster_factor(cluster_wealth);
+        let ring_refs: Vec<(u64, &ClusterTagVector)> =
+            ring_tags.iter().map(|(tags, value)| (*value, tags)).collect();
+        let demurrage_factor = ledger
+            .ring_centroid_floored_factor(claimed_factor, &ring_refs, &fee_config.cluster_curve)
+            .unwrap();
+
+        let policy = crate::monetary::mainnet_policy();
+        let chain_height = ledger.get_chain_state().map(|s| s.height).unwrap_or(0);
+        let elapsed = bth_cluster_tax::ring_elapsed_quantile(&ring_members, chain_height, 10_000);
+        let blocks_per_year = (365 * 24 * 60 * 60) / policy.target_block_time_secs.max(1);
+        let demurrage = bth_cluster_tax::demurrage_charge(
+            output_sum,
+            demurrage_factor,
+            elapsed,
+            policy.demurrage_rate_bps(chain_height),
+            blocks_per_year,
+        );
+
+        base_minimum_fee.saturating_add(demurrage)
+    }
+
+    /// A HOT node (congested, elevated `DynamicFeeBase`) and a COLD node
+    /// (uncongested) both compute a relay `minimum_fee` that is >= the
+    /// consensus fee floor. The hot node is strictly stricter (relay only
+    /// tightens); the consensus floor is identical for both (block validity is
+    /// congestion-independent), so both nodes accept the same BLOCKS.
+    #[test]
+    fn relay_minimum_never_below_consensus_floor_hot_and_cold() {
+        use crate::transaction::{ClsagRingInput, TxInputs};
+        use bth_transaction_types::{ClusterId, TAG_WEIGHT_SCALE};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        // Wealthy, old cluster so demurrage is non-trivial. Height must be past
+        // the halving interval for demurrage to be active (see store.rs tests).
+        let tip_height = 8_000_000u64;
+        let wealthy_cluster = 9u64;
+        let ring = seed_ring_via_snapshot(
+            &ledger,
+            &[
+                (100_000_000, 0, wealthy_cluster, 80),
+                (100_000_000, 10, wealthy_cluster, 81),
+            ],
+            tip_height,
+            &[(wealthy_cluster, 10_000_000_000)],
+        );
+
+        let outputs = vec![TxOutput {
+            amount: 90_000_000,
+            target_key: [130; 32],
+            public_key: [131; 32],
+            e_memo: None,
+            cluster_tags: ClusterTagVector::from_pairs(&[(ClusterId(wealthy_cluster), TAG_WEIGHT_SCALE)]),
+        }];
+        let tx = Transaction {
+            inputs: TxInputs::new(vec![ClsagRingInput {
+                ring,
+                key_image: [0u8; 32],
+                commitment_key_image: [0u8; 32],
+                clsag_signature: Vec::new(),
+                pseudo_output_amount: 0,
+            }]),
+            outputs,
+            fee: 0,
+            created_at_height: 0,
+        };
+
+        let fee_config = FeeConfig::default();
+
+        // Consensus floor: congestion-free, evaluated at the same height the
+        // mempool uses for its demurrage clock.
+        let consensus_floor = ledger.consensus_fee_floor(&tx, tip_height).unwrap();
+        assert!(consensus_floor > 0, "expected a positive floor for a wealthy old ring");
+
+        // COLD node: fresh EMA, not at min block time -> dynamic base pinned to
+        // base_min == CONSENSUS_FEE_BASE.
+        let cold = DynamicFeeBase::default();
+        let relay_cold = relay_minimum_fee(&tx, &ledger, &fee_config, &cold, false);
+
+        // HOT node: sustained 100% fullness at min block time -> elevated base.
+        let mut hot = DynamicFeeBase::default();
+        for _ in 0..50 {
+            hot.update(100, 100, true);
+        }
+        assert!(
+            hot.compute_base(true) > cold.compute_base(false),
+            "hot node's congestion base must exceed the cold node's"
+        );
+        let relay_hot = relay_minimum_fee(&tx, &ledger, &fee_config, &hot, true);
+
+        // Relay only tightens: both nodes are >= the consensus floor, and the
+        // hot node is strictly stricter than the cold node.
+        assert!(
+            relay_cold >= consensus_floor,
+            "cold relay minimum {relay_cold} fell below consensus floor {consensus_floor}"
+        );
+        assert!(
+            relay_hot >= consensus_floor,
+            "hot relay minimum {relay_hot} fell below consensus floor {consensus_floor}"
+        );
+        assert!(
+            relay_hot > relay_cold,
+            "hot node must charge more than cold node (hot={relay_hot}, cold={relay_cold})"
+        );
+
+        // The cold, uncongested relay minimum equals the consensus floor exactly:
+        // the only difference between them is the congestion multiplier, which is
+        // 1x when uncongested.
+        assert_eq!(
+            relay_cold, consensus_floor,
+            "uncongested relay minimum must equal the consensus floor (same kernel, 1x congestion)"
+        );
+
+        // Block validity is congestion-independent: `verify_consensus_fee_floor`
+        // never reads any node-local congestion state, so the block-acceptance
+        // decision is identical for the hot and cold nodes above. A tx paying
+        // exactly `consensus_floor` is block-valid; one paying `consensus_floor -
+        // 1` is not — on every node, regardless of EMA.
+        let at_floor_tx = Transaction {
+            fee: consensus_floor,
+            ..tx.clone()
+        };
+        assert!(
+            ledger
+                .verify_consensus_fee_floor_for_test(&at_floor_tx, tip_height)
+                .is_ok(),
+            "a tx at exactly the consensus floor must pass block validation"
+        );
+        let under_tx = Transaction {
+            fee: consensus_floor - 1,
+            ..tx.clone()
+        };
+        assert!(
+            ledger
+                .verify_consensus_fee_floor_for_test(&under_tx, tip_height)
+                .is_err(),
+            "a tx below the consensus floor must be rejected at block validation"
+        );
     }
 }

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -2205,8 +2205,10 @@ mod tests {
         tip_height: u64,
         cluster_wealth: &[(u64, u64)],
     ) -> Vec<RingMember> {
-        use crate::ledger::{ChainState, UtxoSnapshot};
-        use crate::transaction::{Utxo, UtxoId};
+        use crate::{
+            ledger::{ChainState, UtxoSnapshot},
+            transaction::{Utxo, UtxoId},
+        };
         use bth_transaction_types::{ClusterId, TAG_WEIGHT_SCALE};
 
         let mut utxos = Vec::new();
@@ -2248,11 +2250,12 @@ mod tests {
     }
 
     /// Compute the mempool relay-admission `minimum_fee` for `tx` under a given
-    /// `DynamicFeeBase` congestion state. This reproduces the exact formula used
-    /// in `Mempool::add_tx` (base curve × cluster factor × congestion base, plus
-    /// the `ring_elapsed_quantile@max` + factor-floored demurrage) so the test
-    /// asserts against the true relay threshold, differing from the consensus
-    /// floor ONLY by the congestion multiplier.
+    /// `DynamicFeeBase` congestion state. This reproduces the exact formula
+    /// used in `Mempool::add_tx` (base curve × cluster factor × congestion
+    /// base, plus the `ring_elapsed_quantile@max` + factor-floored
+    /// demurrage) so the test asserts against the true relay threshold,
+    /// differing from the consensus floor ONLY by the congestion
+    /// multiplier.
     #[cfg(test)]
     fn relay_minimum_fee(
         tx: &Transaction,
@@ -2296,8 +2299,10 @@ mod tests {
         }
 
         let claimed_factor = fee_config.cluster_factor(cluster_wealth);
-        let ring_refs: Vec<(u64, &ClusterTagVector)> =
-            ring_tags.iter().map(|(tags, value)| (*value, tags)).collect();
+        let ring_refs: Vec<(u64, &ClusterTagVector)> = ring_tags
+            .iter()
+            .map(|(tags, value)| (*value, tags))
+            .collect();
         let demurrage_factor = ledger
             .ring_centroid_floored_factor(claimed_factor, &ring_refs, &fee_config.cluster_curve)
             .unwrap();
@@ -2349,7 +2354,10 @@ mod tests {
             target_key: [130; 32],
             public_key: [131; 32],
             e_memo: None,
-            cluster_tags: ClusterTagVector::from_pairs(&[(ClusterId(wealthy_cluster), TAG_WEIGHT_SCALE)]),
+            cluster_tags: ClusterTagVector::from_pairs(&[(
+                ClusterId(wealthy_cluster),
+                TAG_WEIGHT_SCALE,
+            )]),
         }];
         let tx = Transaction {
             inputs: TxInputs::new(vec![ClsagRingInput {
@@ -2369,7 +2377,10 @@ mod tests {
         // Consensus floor: congestion-free, evaluated at the same height the
         // mempool uses for its demurrage clock.
         let consensus_floor = ledger.consensus_fee_floor(&tx, tip_height).unwrap();
-        assert!(consensus_floor > 0, "expected a positive floor for a wealthy old ring");
+        assert!(
+            consensus_floor > 0,
+            "expected a positive floor for a wealthy old ring"
+        );
 
         // COLD node: fresh EMA, not at min block time -> dynamic base pinned to
         // base_min == CONSENSUS_FEE_BASE.

--- a/cluster-tax/src/dynamic_fee.rs
+++ b/cluster-tax/src/dynamic_fee.rs
@@ -1,5 +1,29 @@
 //! Dynamic fee base that responds to network congestion.
 //!
+//! # RELAY-ONLY policy — MUST NOT enter consensus
+//!
+//! Every value produced by [`DynamicFeeBase`] is **node-local and
+//! non-deterministic across the network**, so it must be confined to
+//! mempool/relay admission policy and must NEVER feed a consensus (block
+//! validation) decision:
+//!
+//! - `ema_fullness` is an `f64` (non-associative floating-point arithmetic can
+//!   differ across compilers/architectures) that is **reset on node restart**
+//!   (see the field docs), so two honest nodes routinely disagree on it.
+//! - `compute_base`/`update` take an `at_min_block_time` flag derived from
+//!   wall-clock block timing, which is also node-local.
+//!
+//! A node with a HOT congestion EMA and a node with a COLD EMA therefore compute
+//! different fee bases for the same transaction. If that value gated block
+//! validity, the two nodes would accept different sets of blocks and the chain
+//! would fork (audit cycle 6 finding **M1**). Consensus instead uses a fixed,
+//! congestion-free floor (`botho::ledger::Ledger::consensus_fee_floor`, pinned to
+//! `DynamicFeeBase::default().base_min` with NO congestion term). Relay policy
+//! layers this dynamic base on top: because `compute_base` is always clamped to
+//! `>= base_min`, the relay threshold can only ever TIGHTEN above the consensus
+//! floor, never fall below it (Bitcoin's min-relay-fee vs. consensus-validity
+//! split; design #574 Q1/Q2, invariant enforced in `botho::mempool`).
+//!
 //! # Design Philosophy
 //!
 //! Botho uses a cascaded congestion control system:
@@ -48,6 +72,11 @@ use std::collections::VecDeque;
 ///
 /// Only activates when block timing is at minimum (maximum capacity).
 /// Uses exponential response to strongly discourage excess demand.
+///
+/// **RELAY-ONLY**: its `f64` `ema_fullness` (reset on restart) and wall-clock
+/// `at_min_block_time` input are node-local, so this value must never enter
+/// consensus. See the module-level docs for why congestion pricing stays out of
+/// the consensus fee floor.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DynamicFeeBase {

--- a/cluster-tax/src/dynamic_fee.rs
+++ b/cluster-tax/src/dynamic_fee.rs
@@ -13,16 +13,17 @@
 //! - `compute_base`/`update` take an `at_min_block_time` flag derived from
 //!   wall-clock block timing, which is also node-local.
 //!
-//! A node with a HOT congestion EMA and a node with a COLD EMA therefore compute
-//! different fee bases for the same transaction. If that value gated block
-//! validity, the two nodes would accept different sets of blocks and the chain
-//! would fork (audit cycle 6 finding **M1**). Consensus instead uses a fixed,
-//! congestion-free floor (`botho::ledger::Ledger::consensus_fee_floor`, pinned to
-//! `DynamicFeeBase::default().base_min` with NO congestion term). Relay policy
-//! layers this dynamic base on top: because `compute_base` is always clamped to
-//! `>= base_min`, the relay threshold can only ever TIGHTEN above the consensus
-//! floor, never fall below it (Bitcoin's min-relay-fee vs. consensus-validity
-//! split; design #574 Q1/Q2, invariant enforced in `botho::mempool`).
+//! A node with a HOT congestion EMA and a node with a COLD EMA therefore
+//! compute different fee bases for the same transaction. If that value gated
+//! block validity, the two nodes would accept different sets of blocks and the
+//! chain would fork (audit cycle 6 finding **M1**). Consensus instead uses a
+//! fixed, congestion-free floor (`botho::ledger::Ledger::consensus_fee_floor`,
+//! pinned to `DynamicFeeBase::default().base_min` with NO congestion term).
+//! Relay policy layers this dynamic base on top: because `compute_base` is
+//! always clamped to `>= base_min`, the relay threshold can only ever TIGHTEN
+//! above the consensus floor, never fall below it (Bitcoin's min-relay-fee vs.
+//! consensus-validity split; design #574 Q1/Q2, invariant enforced in
+//! `botho::mempool`).
 //!
 //! # Design Philosophy
 //!


### PR DESCRIPTION
## Summary

Item **B5** of design #574 (M1 handling). Adds a guard + docs that enforce the relay-only-tightening invariant: the mempool admission fee threshold is always `>=` the deterministic consensus fee floor. Congestion pricing stays a relay-only policy and never enters consensus. Dependency B4 (#578) is merged (PR #602), so this is unblocked.

**No consensus change; no mempool admission-behavior change** beyond the added assertion.

## What changed

1. **Guard** (`botho/src/mempool.rs`, `Mempool::add_tx`): a `debug_assert!` at the admission fee-check site verifies `minimum_fee >= ledger.consensus_fee_floor(&tx, chain_height)`. Both sides compute the SAME base curve and the SAME demurrage kernel (`ring_elapsed_quantile@max` + `ring_centroid_floored_factor`) at the SAME `chain_height`; the only structural difference is the relay congestion multiplier `dynamic_base`, which `compute_base` clamps to `>= base_min == CONSENSUS_FEE_BASE`. So the invariant holds structurally.
   - `chain_height` is hoisted out of the demurrage block so both the demurrage clock and the assertion use the identical height (avoids a false-fire from an off-by-one-block demurrage age).
   - On a DB error recomputing the floor, the assertion is skipped (not an invariant violation).

   **Chosen mechanism: `debug_assert!` (not a runtime check).** It enforces the contract in tests/CI and during development without adding an extra hot-path ledger read (ring-UTXO resolution) to release builds. If it ever fires, a relay-policy change has broken the never-fall-below-consensus contract and must be fixed before ship. Admission still decides on `tx.fee < minimum_fee` exactly as before.

2. **Docs**:
   - `cluster-tax/src/dynamic_fee.rs`: module-level + `DynamicFeeBase` type doc-comments marking it **RELAY-ONLY** — its `f64 ema_fullness` (reset on restart) and wall-clock `at_min_block_time` inputs are node-local and must never enter consensus; captures why congestion stays out of the consensus floor and how the clamp guarantees relay only tightens.
   - `botho/src/mempool.rs`: a note at the `dynamic_base` site cross-referencing the consensus floor and the invariant.

3. **Test** (`relay_minimum_never_below_consensus_floor_hot_and_cold`): a HOT congestion EMA and a COLD EMA both produce a relay minimum `>=` the consensus floor (hot strictly stricter); the uncongested/cold minimum equals the floor exactly (only difference is the 1x congestion multiplier); and both nodes accept the same BLOCKS (block validation via `verify_consensus_fee_floor` is congestion-independent — a tx at the floor is valid, one below is rejected, regardless of EMA). Reuses the store.rs seeding pattern via the public snapshot path.

4. Added a `#[cfg(test)] verify_consensus_fee_floor_for_test` wrapper on `Ledger` so the sibling mempool test can exercise the real consensus block-validity gate rather than re-deriving it.

## Scope discipline

- Did NOT modify `add_block` / `consensus_fee_floor` (B4 is merged).
- Did NOT touch #581's tag-bound tightening.

## Testing

- `cargo build -p botho` — clean (pre-existing warnings only)
- `cargo test -p botho --lib mempool` — 48 passed (incl. the new test)
- `cargo test -p botho --lib consensus_fee_floor` — 6 passed
- `cargo test -p bth-cluster-tax dynamic_fee` — 16 passed

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)