### PR TITLE
build(#606): bump PROTOCOL_VERSION to 3.0.0 for H1 consensus fee-floor reset

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 604
-# Branch: feature/issue-604
+# Issue: 606
+# Branch: feature/issue-606
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/botho/src/network/discovery.rs
+++ b/botho/src/network/discovery.rs
@@ -66,26 +66,33 @@ use crate::{
 /// old (1.x) format are consensus-incompatible and are disconnected by the
 /// major-version check. Coordinate with the planned testnet reset.
 ///
-/// Bumped to 2.1.0 for the cycle-6 H1 consensus work (issue #606, successor to
+/// Bumped to 3.0.0 for the cycle-6 H1 consensus work (issue #606, successor to
 /// #323). Current `main` now enforces block-acceptance rules that the running
 /// 2.0.0 chain does not: the deterministic consensus fee floor in `add_block`
 /// (H1, PR #602), block fee-sum overflow rejection (#601), and fail-closed
 /// key-image double-spend checks in the store and mempool (#600/#564/#598).
 /// These are consensus-incompatible with the 2.0.0 chain's already-produced
 /// history, so a rolling upgrade is impossible — a coordinated testnet reset
-/// with a fresh genesis is required. `MIN_SUPPORTED_PROTOCOL_VERSION` is raised
-/// in lockstep so 2.0.0 peers are disconnected via the protocol-version
-/// peer-disconnect mechanism rather than silently forking against the new
-/// block-acceptance rules.
-pub const PROTOCOL_VERSION: &str = "2.1.0";
+/// with a fresh genesis is required.
+///
+/// A MAJOR bump (not 2.1.0) is required because the peer-disconnect mechanism
+/// (`is_consensus_compatible` / `consensus_incompatibility`) compares major
+/// versions only: minor/patch differences within the same major merely warn
+/// (graceful soft-fork behavior). Only a major bump actually disconnects
+/// 2.0.0 peers instead of letting them silently fork against the new
+/// block-acceptance rules. `MIN_SUPPORTED_PROTOCOL_VERSION` is raised in
+/// lockstep.
+pub const PROTOCOL_VERSION: &str = "3.0.0";
 
 /// Minimum supported protocol version.
 /// Peers below this version are consensus-incompatible and are disconnected.
-/// Raised to 2.1.0 alongside `PROTOCOL_VERSION` for the H1 consensus fee-floor
+/// Raised to 3.0.0 alongside `PROTOCOL_VERSION` for the H1 consensus fee-floor
 /// deploy (issue #606): 2.0.0 peers produce/accept blocks that violate the new
 /// deterministic fee floor (#602) and related fail-closed rules, so they must
-/// be dropped rather than allowed to fork the reset chain.
-pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "2.1.0";
+/// be dropped rather than allowed to fork the reset chain. The bump is a MAJOR
+/// bump because the disconnect check (`is_consensus_compatible`) is major-only;
+/// a minor bump would only warn.
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "3.0.0";
 
 /// Topic for block announcements
 const BLOCKS_TOPIC: &str = "botho/blocks/1.0.0";
@@ -2148,24 +2155,41 @@ mod tests {
 
     #[test]
     fn test_protocol_version_constant() {
-        // Bumped to 2.1.0 for the cycle-6 H1 consensus fee-floor deploy
+        // Bumped to 3.0.0 for the cycle-6 H1 consensus fee-floor deploy
         // (issue #606): current `main` enforces the deterministic consensus
         // fee floor (#602) plus fee-sum overflow (#601) and fail-closed
         // double-spend (#600/#564/#598), all incompatible with the running
         // 2.0.0 chain, requiring a coordinated reset with fresh genesis.
-        assert_eq!(PROTOCOL_VERSION, "2.1.0");
+        // A MAJOR bump is required because `is_consensus_compatible` (the
+        // peer-disconnect gate) compares majors only — a minor bump would
+        // merely warn, leaving 2.0.0 peers connected and silently forking.
+        assert_eq!(PROTOCOL_VERSION, "3.0.0");
         let parsed = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
-        assert_eq!(parsed.major, 2);
-        assert_eq!(parsed.minor, 1);
+        assert_eq!(parsed.major, 3);
+        assert_eq!(parsed.minor, 0);
         assert_eq!(parsed.patch, 0);
     }
 
     #[test]
     fn test_min_supported_protocol_version_constant() {
-        assert_eq!(MIN_SUPPORTED_PROTOCOL_VERSION, "2.1.0");
+        assert_eq!(MIN_SUPPORTED_PROTOCOL_VERSION, "3.0.0");
         let parsed = ProtocolVersion::parse(MIN_SUPPORTED_PROTOCOL_VERSION).unwrap();
-        assert_eq!(parsed.major, 2);
-        assert_eq!(parsed.minor, 1);
+        assert_eq!(parsed.major, 3);
+        assert_eq!(parsed.minor, 0);
+    }
+
+    /// Regression guard for #606: the 3.0.0 deploy must actually DISCONNECT
+    /// 2.0.0 peers (not just warn). This pins the major-only disconnect
+    /// semantics against the live constants.
+    #[test]
+    fn test_v2_peers_are_consensus_incompatible_with_current() {
+        let local = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
+        let old_peer = ProtocolVersion::parse("2.0.0").unwrap();
+        assert!(!old_peer.is_consensus_compatible(&local));
+        assert_eq!(
+            ProtocolVersion::consensus_incompatibility(&Some(old_peer.clone()), &local),
+            Some(old_peer)
+        );
     }
 
     #[test]

--- a/botho/src/network/discovery.rs
+++ b/botho/src/network/discovery.rs
@@ -65,13 +65,27 @@ use crate::{
 /// consensus-breaking change to the transaction wire format. Nodes running the
 /// old (1.x) format are consensus-incompatible and are disconnected by the
 /// major-version check. Coordinate with the planned testnet reset.
-pub const PROTOCOL_VERSION: &str = "2.0.0";
+///
+/// Bumped to 2.1.0 for the cycle-6 H1 consensus work (issue #606, successor to
+/// #323). Current `main` now enforces block-acceptance rules that the running
+/// 2.0.0 chain does not: the deterministic consensus fee floor in `add_block`
+/// (H1, PR #602), block fee-sum overflow rejection (#601), and fail-closed
+/// key-image double-spend checks in the store and mempool (#600/#564/#598).
+/// These are consensus-incompatible with the 2.0.0 chain's already-produced
+/// history, so a rolling upgrade is impossible — a coordinated testnet reset
+/// with a fresh genesis is required. `MIN_SUPPORTED_PROTOCOL_VERSION` is raised
+/// in lockstep so 2.0.0 peers are disconnected via the protocol-version
+/// peer-disconnect mechanism rather than silently forking against the new
+/// block-acceptance rules.
+pub const PROTOCOL_VERSION: &str = "2.1.0";
 
 /// Minimum supported protocol version.
-/// Peers below this major version are consensus-incompatible (their
-/// transaction wire format predates the I4 multi-input balance fix) and are
-/// disconnected.
-pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "2.0.0";
+/// Peers below this version are consensus-incompatible and are disconnected.
+/// Raised to 2.1.0 alongside `PROTOCOL_VERSION` for the H1 consensus fee-floor
+/// deploy (issue #606): 2.0.0 peers produce/accept blocks that violate the new
+/// deterministic fee floor (#602) and related fail-closed rules, so they must
+/// be dropped rather than allowed to fork the reset chain.
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "2.1.0";
 
 /// Topic for block announcements
 const BLOCKS_TOPIC: &str = "botho/blocks/1.0.0";
@@ -2134,20 +2148,24 @@ mod tests {
 
     #[test]
     fn test_protocol_version_constant() {
-        // Bumped to 2.0.0 for the consensus-breaking I4 multi-input CLSAG
-        // balance fix (new `pseudo_output_amount` tx wire field).
-        assert_eq!(PROTOCOL_VERSION, "2.0.0");
+        // Bumped to 2.1.0 for the cycle-6 H1 consensus fee-floor deploy
+        // (issue #606): current `main` enforces the deterministic consensus
+        // fee floor (#602) plus fee-sum overflow (#601) and fail-closed
+        // double-spend (#600/#564/#598), all incompatible with the running
+        // 2.0.0 chain, requiring a coordinated reset with fresh genesis.
+        assert_eq!(PROTOCOL_VERSION, "2.1.0");
         let parsed = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
         assert_eq!(parsed.major, 2);
-        assert_eq!(parsed.minor, 0);
+        assert_eq!(parsed.minor, 1);
         assert_eq!(parsed.patch, 0);
     }
 
     #[test]
     fn test_min_supported_protocol_version_constant() {
-        assert_eq!(MIN_SUPPORTED_PROTOCOL_VERSION, "2.0.0");
+        assert_eq!(MIN_SUPPORTED_PROTOCOL_VERSION, "2.1.0");
         let parsed = ProtocolVersion::parse(MIN_SUPPORTED_PROTOCOL_VERSION).unwrap();
         assert_eq!(parsed.major, 2);
+        assert_eq!(parsed.minor, 1);
     }
 
     #[test]

--- a/mobile/app/src/config/network.test.ts
+++ b/mobile/app/src/config/network.test.ts
@@ -31,32 +31,35 @@ describe("compareNetwork", () => {
 
 describe("isProtocolCompatible", () => {
   it("accepts a node whose major version matches the client", () => {
-    // CLIENT_PROTOCOL_VERSION is 2.x; node speaks 2.x and accepts down to 2.x.
-    expect(isProtocolCompatible("2.0.0", "2.0.0")).toBe(true);
-    expect(isProtocolCompatible("2.3.1", "2.0.0")).toBe(true);
+    // CLIENT_PROTOCOL_VERSION is 3.x (issue #606 H1 fee-floor reset); node
+    // speaks 3.x and accepts down to 3.x.
+    expect(isProtocolCompatible("3.0.0", "3.0.0")).toBe(true);
+    expect(isProtocolCompatible("3.3.1", "3.0.0")).toBe(true);
   });
 
   it("accepts when the client falls inside the node's accepted window", () => {
-    // Node speaks 3.x but accepts down to 2.x -> client 2.x is fine.
-    expect(isProtocolCompatible("3.0.0", "2.0.0")).toBe(true);
+    // Node speaks 4.x but accepts down to 3.x -> client 3.x is fine.
+    expect(isProtocolCompatible("4.0.0", "3.0.0")).toBe(true);
   });
 
   it("rejects when the node requires a newer protocol than the client", () => {
-    expect(isProtocolCompatible("3.0.0", "3.0.0")).toBe(false);
+    expect(isProtocolCompatible("4.0.0", "4.0.0")).toBe(false);
   });
 
   it("rejects when the node is older than the client", () => {
+    // A pre-reset 2.x node no longer shares consensus rules with this client.
+    expect(isProtocolCompatible("2.0.0", "2.0.0")).toBe(false);
     expect(isProtocolCompatible("1.0.0", "1.0.0")).toBe(false);
   });
 
   it("rejects when the node's protocol version is missing/unparsable", () => {
     expect(isProtocolCompatible(undefined, undefined)).toBe(false);
     expect(isProtocolCompatible("", "")).toBe(false);
-    expect(isProtocolCompatible("abc", "2.0.0")).toBe(false);
+    expect(isProtocolCompatible("abc", "3.0.0")).toBe(false);
   });
 
   it("defaults the min to the node's own major when min is absent", () => {
-    expect(isProtocolCompatible("2.0.0", undefined)).toBe(true);
-    expect(isProtocolCompatible("3.0.0", undefined)).toBe(false);
+    expect(isProtocolCompatible("3.0.0", undefined)).toBe(true);
+    expect(isProtocolCompatible("4.0.0", undefined)).toBe(false);
   });
 });

--- a/mobile/app/src/config/network.ts
+++ b/mobile/app/src/config/network.ts
@@ -27,7 +27,7 @@ export const EXPECTED_NETWORK = "botho-testnet";
  * we treat a node as compatible when our version is within that node's
  * accepted window (major version match, see `isProtocolCompatible`).
  */
-export const CLIENT_PROTOCOL_VERSION = "2.0.0";
+export const CLIENT_PROTOCOL_VERSION = "2.1.0";
 
 /** Outcome of comparing a node's reported network against this build. */
 export type NetworkMatch = "match" | "mismatch" | "unknown";

--- a/mobile/app/src/config/network.ts
+++ b/mobile/app/src/config/network.ts
@@ -27,7 +27,7 @@ export const EXPECTED_NETWORK = "botho-testnet";
  * we treat a node as compatible when our version is within that node's
  * accepted window (major version match, see `isProtocolCompatible`).
  */
-export const CLIENT_PROTOCOL_VERSION = "2.1.0";
+export const CLIENT_PROTOCOL_VERSION = "3.0.0";
 
 /** Outcome of comparing a node's reported network against this build. */
 export type NetworkMatch = "match" | "mismatch" | "unknown";


### PR DESCRIPTION
## Summary

Code-only slice of #606 (coordinated testnet reset for the H1 consensus fee floor; successor to #323). This bumps the wire protocol version so 2.0.0 peers are disconnected from the reset chain.

`main` now enforces block-acceptance rules the running 2.0.0 chain does not — the deterministic consensus fee floor in `add_block` (H1, PR #602), block fee-sum overflow rejection (#601), and fail-closed key-image double-spend checks in the store and mempool (#600/#564/#598). These are consensus-incompatible with the 2.0.0 chain's existing history, so a rolling upgrade is impossible; a coordinated reset with a fresh genesis is required.

## Why 3.0.0 (major) and not 2.1.0 (minor)

The issue lists "2.1.0 (or 3.0.0)". The first revision of this PR used 2.1.0, but the peer-disconnect mechanism (`ProtocolVersion::consensus_incompatibility` -> `is_consensus_compatible` in `botho/src/network/discovery.rs`) compares **major versions only** — minor/patch differences within the same major merely log a warning (graceful soft-fork behavior) and do NOT disconnect. Since the H1 fee floor is consensus-breaking and #606 explicitly requires 2.0.0 peers to be **disconnected** (not warned), the bump must be major. This also matches the constant's own doc contract ("Major: Breaking changes requiring hard fork") and the precedent of the 1.x -> 2.0.0 I4 bump.

A new regression test (`test_v2_peers_are_consensus_incompatible_with_current`) pins this: it asserts a 2.0.0 peer is consensus-incompatible with the live `PROTOCOL_VERSION` constant, so a future accidental minor-only bump of a consensus-breaking change would fail the suite.

## Changes

- `botho/src/network/discovery.rs`
  - `PROTOCOL_VERSION`: `2.0.0` -> `3.0.0`
  - `MIN_SUPPORTED_PROTOCOL_VERSION`: `2.0.0` -> `3.0.0`
  - Rationale comments in the existing 2.0.0 comment style, including why the bump is major.
  - Updated `test_protocol_version_constant` / `test_min_supported_protocol_version_constant` assertions to 3.0.0.
  - New `test_v2_peers_are_consensus_incompatible_with_current` regression guard (see above).
- `mobile/app/src/config/network.ts`
  - `CLIENT_PROTOCOL_VERSION`: `2.0.0` -> `3.0.0` (thin-client wire version advertised to nodes; version-coupled).
  - The compatibility logic (`isProtocolCompatible`) derives the client major dynamically — no hardcoded major==2 existed in the logic itself.
- `mobile/app/src/config/network.test.ts`
  - Test literals assumed a major-2 client; rewritten for the major-3 window (same-major accept, node-window accept, newer-node reject, missing-min default), including an explicit new assertion that a pre-reset 2.x node is rejected.

## Version references checked

Updated (version-coupled):
- `botho/src/network/discovery.rs` PROTOCOL_VERSION / MIN_SUPPORTED_PROTOCOL_VERSION + constant tests (+ new regression test)
- `mobile/app/src/config/network.ts` CLIENT_PROTOCOL_VERSION
- `mobile/app/src/config/network.test.ts` (client-major-dependent literals)

Checked and intentionally left unchanged:
- `botho/src/rpc/mod.rs` (`3638`, `3639`, `3661`, `3662`, `4157`, `4179`): test-local `NodeIdentity`/peer fixtures with hardcoded "2.0.0"; they assert payload shape, not the real constant, and pass unchanged.
- `botho/src/network/discovery.rs` (generic version-comparison unit tests): use "2.0.0"/"3.0.0" as arbitrary example versions, not the live constant.
- `gossip/src/service.rs:828`: test-local literal, unrelated to node protocol version.
- `infra/seed/TESTNET_RESET.md`, `infra/seed/README.md`: operator runbook docs; part of the deployment task and out of scope for this code change (left for the operator — note they will need updating to say protocol 3.0.0 during the reset).
- `web/packages/core/package-lock.json`, `web/packages/desktop/package.json`: `@scure/base` / `@tauri-apps/cli` dependency versions — unrelated.
- `CHANGELOG.md`, `.claude/commands/loom/{bump,release}.md`: semver spec URL `semver.org/spec/v2.0.0.html` — unrelated.
- `mobile/app/src/types/wallet.ts:103`, `botho/src/rpc/mod.rs:103/132`: doc-comment examples ("e.g. \"2.0.0\""), not live values.

## Testing

- `cargo build`: success (pre-existing warnings only).
- `cargo test -p botho --lib network::discovery`: 47 passed, 0 failed (includes the new regression guard).
- `cargo test -p botho --lib node_identity`: 2 passed.
- `cargo test -p botho --lib commands::run`: 10 passed.
- Mobile jest tests not runnable in this environment (node_modules absent); test expectations were updated in lockstep with the client major and verified by inspection against the pure `isProtocolCompatible` logic.

## Scope / out of scope

`Updates #606` (does NOT close it). The deployment tasks in #606 remain open for the operator: wipe + re-genesis of seed / seed2 / faucet, redeploy per the #323 runbook (updating the runbook's protocol references to 3.0.0), re-fund faucet, smoke-test a fee-floor transfer and an under-floor rejection, verify multi-node SCP externalization. No infra actions (deploys, node restarts, faucet ops) were taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)