### PR TITLE
docs: refresh PLAN.md mainnet-blocker list to post-#606 reality

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -4,15 +4,16 @@
 
 Core functionality complete. Internal security audits completed 5 cycles. See `audits/` for full reports.
 
-**Current (2026-06-11):** Cycle 5 audit (2026-01-03) shows **0 Critical, 0 High** (6 Medium, 5 Low). The economic redistribution mechanism (cluster-tilted lottery + emission routing + spend-time demurrage) is implemented and empirically validated against adversarial simulation — passes the Δgini > 0.05 criterion in the gamed equilibrium (see `docs/design/cluster-tilted-redistribution.md`, `experiments/ANALYSIS.md`). These changes are consensus-breaking: **a coordinated testnet reset is required before next deploy.**
+**Current (2026-07-02):** Live 3-node testnet on protocol **3.0.0** (coordinated reset #606, fresh genesis 2026-07-02) running `main` with the full cycle-6 consensus hardening enforced: H1 deterministic consensus fee floor (#602), fee-sum overflow rejection (#601), fail-closed double-spend checks (#600), H2 cluster-tag inheritance + demurrage quantile (#580/#602), M3 rebuild/incremental parity (#607). Fee floor verified live: under-floor tx rejected, at-floor tx confirmed, all nodes converged. Gini mechanism re-validated with spend-time accrual (#314, closed). Web-wallet at-rest security issues closed (#474/#475/#476). Internal audit cycle 6 complete (`audits/2026-06-11-cycle6.md`) — all Criticals and Highs closed and deployed.
 
 **Remaining mainnet blockers:**
-1. **Seed node SPOF** — single hardcoded seed (one EC2 box); needs ≥3 regional seeds + DNS failover
-2. **External security audit** — internal cycles clean; external audit gates v1.0
-3. **Protocol-version mismatch only warns** — peers with incompatible versions are not disconnected, undermining coordinated-upgrade enforcement (fork-risk hygiene)
-4. **Internal audit cycle 6** — today's consensus changes (lottery, emission, demurrage, fixed-point math) are unaudited
+1. **Seed node SPOF** — all three testnet nodes in one region; needs ≥3 regional seeds + DNS failover (scaffolding exists behind `BOTHO_REGIONAL_SEEDS=1`; DNS TXT path preferred — see `infra/seed/TESTNET_RESET.md` §4)
+2. **External security audit** — internal cycles clean; external audit gates v1.0 (operator engagement)
+3. **M2 economic decision (#605)** — cluster-wealth decay schedule vs accept-and-document; consensus-breaking if decay chosen, so it must be decided BEFORE mainnet genesis (no-hard-forks policy)
+4. **CLI wallet tx-format port (#610 follow-up)** — CLI thin wallet still builds legacy pre-CLSAG transactions; users cannot transact from the CLI until ported (web/mobile paths unaffected)
+5. **Release engineering** — cut a reproducible tagged release (current deploys are build-on-host); `release.yml` dry-run path verified, needs a real `v0.3.x` tag + published artifacts
 
-**Testnet watch items:** "everyone parks" demurrage drift (countermeasure designed: eligibility decay on tilted payout); lottery payout privacy (winners visible on-chain).
+**Testnet watch items:** "everyone parks" demurrage drift (countermeasure designed: eligibility decay on tilted payout); lottery payout privacy (winners visible on-chain); decoy-sourced tag inflation bound (#581, phase-2 Pedersen tags).
 
 ---
 


### PR DESCRIPTION
Doc-only update. The mainnet-blocker list was written 2026-06-11 and two of its four items are now complete and deployed:

- ~~Protocol-version mismatch only warns~~ → major-version peer disconnect enforced; verified end-to-end in PR #608 and live on the 3.0.0 testnet
- ~~Internal audit cycle 6~~ → complete (`audits/2026-06-11-cycle6.md`); all Criticals/Highs closed and deployed via the #606 reset

Replaced with the real remaining gaps (M2 decision #605, CLI wallet CLSAG port, reproducible release tagging) and updated the status paragraph to describe the live 3.0.0 testnet. Also moved #581 into the watch-items line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)