### PR TITLE
fix(release): portable sha256 for macOS runners (#615)

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -132,6 +132,15 @@ DIST_DIR="$PROJECT_ROOT/dist"
 rm -rf "$DIST_DIR"
 mkdir -p "$DIST_DIR"
 
+# Portable SHA-256: coreutils sha256sum on Linux, shasum on macOS runners
+sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$@"
+    else
+        shasum -a 256 "$@"
+    fi
+}
+
 # List of binaries to package
 BINARIES=(
     "botho"
@@ -147,7 +156,7 @@ for bin in "${BINARIES[@]}"; do
         cp "$BINARY_PATH" "$DIST_DIR/"
 
         # Generate individual checksum
-        (cd "$DIST_DIR" && sha256sum "$bin" > "$bin.sha256")
+        (cd "$DIST_DIR" && sha256 "$bin" > "$bin.sha256")
 
         echo "  $bin: $(cat "$DIST_DIR/$bin.sha256" | cut -d' ' -f1)"
     else
@@ -156,7 +165,7 @@ for bin in "${BINARIES[@]}"; do
 done
 
 # Generate combined checksums file
-(cd "$DIST_DIR" && sha256sum * 2>/dev/null | grep -v '\.sha256$' | grep -v '\.sig$' | grep -v 'checksums.txt' > checksums.txt) || true
+(cd "$DIST_DIR" && sha256 * 2>/dev/null | grep -v '\.sha256$' | grep -v '\.sig$' | grep -v 'checksums.txt' > checksums.txt) || true
 
 echo ""
 echo "=== Build Metadata ==="


### PR DESCRIPTION
First bit-rot fix from the #615 release dry-run (run 28637376638 on main @ 8503ade):

- linux x86_64 + **aarch64 (our deploy target)**: built successfully ✅
- aarch64-apple-darwin: build succeeded but died at checksum collection — `sha256sum: command not found` (macOS ships `shasum`, not coreutils)

This adds a portable `sha256()` wrapper (prefer `sha256sum`, fall back to `shasum -a 256`) and uses it at both call sites. `bash -n` clean. Will re-dispatch the dry-run after merge to validate the full matrix.

Updates #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)