### PR TITLE
feat(wallet): build real CLSAG ring transactions in the CLI thin wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,8 @@ dependencies = [
  "bth-crypto-keys",
  "bth-crypto-pq",
  "bth-crypto-ring-signature",
+ "bth-transaction-clsag",
+ "bth-transaction-types",
  "chacha20poly1305",
  "chrono",
  "clap",

--- a/botho-wallet/Cargo.toml
+++ b/botho-wallet/Cargo.toml
@@ -22,6 +22,15 @@ bth-crypto-pq = { path = "../crypto/pq", optional = true }
 bth-crypto-ring-signature = { path = "../crypto/ring-signature" }
 bth-core = { path = "../core" }
 bth-cluster-tax = { path = "../cluster-tax", features = ["serde"] }
+# Real transaction format (CLSAG ring signatures + stealth-address outputs).
+# Provides RingMember, ClsagRingInput, Transaction::new_clsag, the correct
+# stealth-address TxOutput, and MIN_RING_SIZE/MIN_TX_FEE. This is the same
+# crate the node exposes as `botho::transaction`, so txs built here
+# bincode-round-trip through the node's `tx_submit` deserializer.
+bth-transaction-clsag = { path = "../transaction/clsag" }
+# Cluster-tag ancestry vector embedded in outputs (ClusterTagVector). Matches
+# the type the clsag TxOutput carries so inherited tags serialize identically.
+bth-transaction-types = { path = "../transaction/types" }
 botho = { path = "../botho", optional = true }
 
 # BIP39 mnemonic support

--- a/botho-wallet/src/commands/send.rs
+++ b/botho-wallet/src/commands/send.rs
@@ -10,8 +10,8 @@ use crate::{
     rpc_pool::RpcPool,
     storage::EncryptedWallet,
     transaction::{
-        apply_pending_change_tags, format_amount, parse_amount, sync_wallet, OwnedUtxo,
-        TransactionBuilder, DUST_THRESHOLD, PICOCREDITS_PER_CAD,
+        apply_pending_change_tags, format_amount, parse_amount, sync_wallet, to_tx_hex, OwnedUtxo,
+        TransactionBuilder, DUST_THRESHOLD, MIN_TX_FEE, PICOCREDITS_PER_CAD,
     },
 };
 
@@ -136,7 +136,10 @@ async fn run_classical(
     let output_count = 2; // Assume we'll have change for estimation
 
     let fee_estimate = fee_estimator.estimate_fee(&inputs_for_estimation, output_count);
-    let fee = fee_estimate.total_fee.max(1_000_000); // Enforce minimum fee
+    // Enforce the consensus fee floor. At zero cluster wealth the structural
+    // MIN_TX_FEE (100_000_000 picocredits) dominates the progressive estimate;
+    // the node rejects any transaction below it (bth_transaction_clsag).
+    let fee = fee_estimate.total_fee.max(MIN_TX_FEE);
 
     // Build transaction
     let builder = TransactionBuilder::new(keys.clone(), utxos, height);
@@ -212,14 +215,15 @@ async fn run_classical(
     println!();
     println!("Signing transaction...");
 
-    let transfer_result =
-        builder.build_transfer_with_metadata(&recipient, amount_picocredits, fee)?;
+    let transfer_result = builder
+        .build_transfer_with_metadata(&mut rpc, &recipient, amount_picocredits, fee)
+        .await?;
 
     // Submit transaction
     println!("Submitting transaction...");
 
     let tx_hash = rpc
-        .submit_transaction(&transfer_result.transaction.to_hex())
+        .submit_transaction(&to_tx_hex(&transfer_result.transaction)?)
         .await?;
 
     println!();

--- a/botho-wallet/src/decoy_selection.rs
+++ b/botho-wallet/src/decoy_selection.rs
@@ -1,52 +1,86 @@
 //! Decoy Selection for Ring Signatures
 //!
-//! Implements wallet-side decoy selection constraints to prevent fee inflation
-//! attacks and ensure good privacy properties for ring signatures.
+//! Wallet-side decoy-selection policy for CLSAG ring signatures. This module
+//! provides the age-band primitives shared with the live send path (see
+//! [`crate::ring_builder`]) plus a constraint-checking selector used for
+//! validating externally-supplied decoy sets.
 //!
-//! # Constraints
+//! # Age-similarity policy (matches the node)
 //!
-//! 1. **Age similarity**: Decoys should be within 2x age of real input
-//!    - `age > real_age / 2 && age < real_age * 2`
+//! Decoys are drawn from within **±10%** of the real input's age
+//! ([`AGE_SIMILARITY_SPREAD_BPS`]), floored at [`MIN_DECOY_AGE_BLOCKS`]
+//! confirmations. This mirrors the node's `GammaDecoySelector`
+//! (`botho/src/decoy_selection.rs`): a wider band (the old 2× ratio) let an
+//! age-heuristic adversary fingerprint CLI-wallet rings by their unusually
+//! broad ring-age spread. Keeping the same ±10% band collapses that distinction
+//! (issue #614 item 4; #314-safe under `ring_elapsed_quantile@max`).
 //!
-//! 2. **Cluster factor ceiling**: Decoys should not have significantly higher
-//!    factor
-//!    - `decoy_factor <= real_factor * 1.5`
+//! # Cluster-factor ceiling
 //!
-//! # Privacy Considerations
+//! Decoys must not have a significantly higher cluster factor than the real
+//! input (`decoy_factor <= real_factor * max_factor_ratio`). This prevents a
+//! malicious pool from inflating progressive fees via high-factor decoys.
 //!
-//! Overly strict constraints reduce the anonymity set. The design balances:
-//! - **Looser constraints** = larger anonymity set, less fee accuracy
-//! - **Stricter constraints** = smaller anonymity set, better fee accuracy
+//! # Ring size
 //!
-//! The recommended defaults (2x age, 1.5x factor) provide reasonable balance.
+//! The default ring size is [`DEFAULT_RING_SIZE`] = 20, matching the node's
+//! consensus floor `MIN_RING_SIZE`. Rings smaller than 20 are rejected by the
+//! node at signing and validation time, so the wallet must never build them.
 //!
-//! # Reference
+//! # Randomization
 //!
-//! See `docs/design/ring-signature-tag-propagation.md` for full design
-//! rationale.
+//! Eligible candidates are shuffled with a CSPRNG before the ring is drawn, so
+//! ring membership is never a deterministic first-N slice of a height-sorted
+//! pool (issue #614 item 5).
 
 use std::collections::HashMap;
 
-use bth_cluster_tax::{ClusterId, TagVector, TAG_WEIGHT_SCALE};
+use bth_cluster_tax::{ClusterId, TAG_WEIGHT_SCALE};
+use rand::{rngs::OsRng, seq::SliceRandom};
 
 use crate::fee_estimation::StoredTags;
+
+/// Minimum confirmations before an output may be used as a ring member (real or
+/// decoy). Mirrors the node's `MIN_DECOY_AGE_BLOCKS`.
+pub const MIN_DECOY_AGE_BLOCKS: u64 = 10;
+
+/// Half-width of the decoy age-similarity band, in basis points of the real
+/// input's age. `1_000` bps = ±10%. Mirrors the node's
+/// `AGE_SIMILARITY_SPREAD_BPS`.
+pub const AGE_SIMILARITY_SPREAD_BPS: u64 = 1_000;
+
+/// Default (and minimum) ring size, matching the node's consensus
+/// `MIN_RING_SIZE`. A ring of 20 provides a strong anonymity set with compact
+/// ~700-byte CLSAG signatures.
+pub const DEFAULT_RING_SIZE: usize = 20;
+
+/// Compute the inclusive `[min_age, max_age]` decoy-age band around a real
+/// input's age under the [`AGE_SIMILARITY_SPREAD_BPS`] policy.
+///
+/// The lower bound is floored at [`MIN_DECOY_AGE_BLOCKS`] so decoys are always
+/// confirmed. A degenerate real age (below the confirmation floor) can produce
+/// `min_age > max_age`, in which case no candidate is in-band; callers must
+/// guard against spending such young inputs before reaching this function.
+pub fn age_similarity_band(real_input_age: u64) -> (u64, u64) {
+    let delta = (real_input_age as u128 * AGE_SIMILARITY_SPREAD_BPS as u128 / 10_000) as u64;
+    let min_age = real_input_age
+        .saturating_sub(delta)
+        .max(MIN_DECOY_AGE_BLOCKS);
+    let max_age = real_input_age.saturating_add(delta);
+    (min_age, max_age)
+}
 
 /// Configuration for decoy selection constraints.
 #[derive(Clone, Debug)]
 pub struct DecoySelectionConfig {
-    /// Ring size (including real input).
-    /// Default: 11 (same as Monero)
+    /// Ring size (including the real input).
+    /// Default: [`DEFAULT_RING_SIZE`] (20) — the node's consensus floor.
     pub ring_size: usize,
-
-    /// Maximum age ratio between decoy and real input.
-    /// A value of 2.0 means decoys must be within 2x age of the real input.
-    /// Default: 2.0
-    pub max_age_ratio: f64,
 
     /// Maximum cluster factor ratio between decoy and real input.
     /// A value of 1.5 means decoy factor must be <= 1.5x real factor.
-    /// This prevents fee inflation attacks where malicious nodes select
-    /// high-factor decoys to inflate fees.
+    /// This prevents fee-inflation attacks where a malicious pool selects
+    /// high-factor decoys to inflate progressive fees.
     /// Default: 1.5
     pub max_factor_ratio: f64,
 }
@@ -54,8 +88,7 @@ pub struct DecoySelectionConfig {
 impl Default for DecoySelectionConfig {
     fn default() -> Self {
         Self {
-            ring_size: 11,
-            max_age_ratio: 2.0,
+            ring_size: DEFAULT_RING_SIZE,
             max_factor_ratio: 1.5,
         }
     }
@@ -63,10 +96,9 @@ impl Default for DecoySelectionConfig {
 
 impl DecoySelectionConfig {
     /// Create a new configuration with custom parameters.
-    pub fn new(ring_size: usize, max_age_ratio: f64, max_factor_ratio: f64) -> Self {
+    pub fn new(ring_size: usize, max_factor_ratio: f64) -> Self {
         Self {
             ring_size,
-            max_age_ratio,
             max_factor_ratio,
         }
     }
@@ -86,7 +118,8 @@ pub enum DecoySelectionError {
     /// No UTXOs available in the pool.
     EmptyUtxoPool,
 
-    /// The real UTXO has invalid parameters (e.g., zero age).
+    /// The real UTXO has invalid parameters (e.g., too young to spend
+    /// privately).
     InvalidRealUtxo(String),
 
     /// Ring size must be at least 2 (real input + 1 decoy).
@@ -196,7 +229,8 @@ impl UtxoCandidate {
     }
 }
 
-/// Select decoys for a ring signature that satisfy age and factor constraints.
+/// Select decoys for a ring signature that satisfy the age-similarity band and
+/// cluster-factor ceiling.
 ///
 /// # Arguments
 ///
@@ -207,30 +241,21 @@ impl UtxoCandidate {
 /// * `total_supply` - Total coin supply for factor normalization
 /// * `config` - Decoy selection configuration
 ///
-/// # Returns
-///
-/// A vector of selected decoy UTXOs, or an error if constraints cannot be
-/// satisfied.
-///
 /// # Constraints Applied
 ///
-/// 1. **Age similarity**: `decoy_age > real_age / max_age_ratio && decoy_age <
-///    real_age * max_age_ratio`
-/// 2. **Factor ceiling**: `decoy_factor <= real_factor * max_factor_ratio`
+/// 1. **Age similarity**: decoy age within [`age_similarity_band`] of the real
+///    input's age (±10%, floored at [`MIN_DECOY_AGE_BLOCKS`]).
+/// 2. **Factor ceiling**: `decoy_factor <= real_factor * max_factor_ratio`.
 ///
-/// # Example
+/// Eligible candidates are shuffled (CSPRNG) before the ring is drawn, so the
+/// result is not a deterministic first-N slice.
 ///
-/// ```ignore
-/// let config = DecoySelectionConfig::default();
-/// let decoys = select_decoys(
-///     &real_utxo,
-///     &utxo_pool,
-///     current_block,
-///     &cluster_wealth,
-///     total_supply,
-///     &config,
-/// )?;
-/// ```
+/// # Errors
+///
+/// Returns [`DecoySelectionError::InvalidRealUtxo`] if the real input is
+/// younger than [`MIN_DECOY_AGE_BLOCKS`] (spending it would produce a
+/// degenerate age band). Callers surfacing to users should translate this into
+/// a "wait for confirmations" message.
 pub fn select_decoys(
     real_utxo: &UtxoCandidate,
     utxo_pool: &[UtxoCandidate],
@@ -249,17 +274,21 @@ pub fn select_decoys(
     }
 
     let real_age = real_utxo.age(current_block);
-    if real_age == 0 {
-        return Err(DecoySelectionError::InvalidRealUtxo(
-            "UTXO has zero age".to_string(),
-        ));
+
+    // Young-input guard (mirrors node decoy_selection.rs; #611/#618). Below the
+    // confirmation floor the ±10% band is degenerate (min_age > max_age).
+    if real_age < MIN_DECOY_AGE_BLOCKS {
+        return Err(DecoySelectionError::InvalidRealUtxo(format!(
+            "UTXO is too new to spend privately — wait for at least {} confirmations \
+             (current age: {} block(s))",
+            MIN_DECOY_AGE_BLOCKS, real_age
+        )));
     }
 
     let real_factor = real_utxo.cluster_factor_global(cluster_wealth, total_supply);
 
-    // Calculate age bounds
-    let min_age = (real_age as f64 / config.max_age_ratio).ceil() as u64;
-    let max_age = (real_age as f64 * config.max_age_ratio).floor() as u64;
+    // Age band (±10%, floored at the confirmation minimum).
+    let (min_age, max_age) = age_similarity_band(real_age);
 
     // Calculate maximum allowed factor for decoys
     let max_allowed_factor = real_factor * config.max_factor_ratio;
@@ -267,7 +296,7 @@ pub fn select_decoys(
     let decoys_needed = config.decoys_needed();
 
     // Filter candidates that meet all constraints
-    let eligible: Vec<UtxoCandidate> = utxo_pool
+    let mut eligible: Vec<UtxoCandidate> = utxo_pool
         .iter()
         .filter(|candidate| {
             // Skip if same as real UTXO
@@ -277,7 +306,7 @@ pub fn select_decoys(
 
             let candidate_age = candidate.age(current_block);
 
-            // Age constraint: within max_age_ratio of real age
+            // Age constraint: within the ±10% band
             if candidate_age < min_age || candidate_age > max_age {
                 return false;
             }
@@ -301,27 +330,24 @@ pub fn select_decoys(
         });
     }
 
-    // Select decoys (for now, take first N; could add random selection)
-    Ok(eligible.into_iter().take(decoys_needed).collect())
+    // Shuffle before taking N so ring membership is randomized, not a
+    // deterministic first-N slice of a height-sorted pool.
+    let mut rng = OsRng;
+    eligible.shuffle(&mut rng);
+    eligible.truncate(decoys_needed);
+    Ok(eligible)
 }
 
-/// Select decoys with fallback to relaxed constraints.
+/// Select decoys with fallback to a relaxed cluster-factor ceiling.
 ///
-/// If strict constraints cannot be satisfied, progressively relaxes them
-/// while ensuring some level of privacy protection.
-///
-/// # Fallback Strategy
-///
-/// 1. Try with default constraints (2x age, 1.5x factor)
-/// 2. Relax age constraint to 3x
-/// 3. Relax factor constraint to 2.0x
-/// 4. Relax both to 4x age, 2.5x factor
-/// 5. If still insufficient, return error with best available count
+/// The age-similarity band is a **privacy invariant** and is never relaxed — a
+/// wider band would fingerprint the transaction. Only the factor ceiling is
+/// progressively relaxed if the strict ceiling yields too few decoys.
 ///
 /// # Warning
 ///
-/// Using relaxed constraints reduces privacy. The caller should consider
-/// warning the user or refusing the transaction if constraints are too relaxed.
+/// A relaxed factor ceiling admits higher-factor decoys, which can slightly
+/// raise the estimated fee. The caller should consider warning the user.
 pub fn select_decoys_with_fallback(
     real_utxo: &UtxoCandidate,
     utxo_pool: &[UtxoCandidate],
@@ -346,60 +372,37 @@ pub fn select_decoys_with_fallback(
         Err(e) => return Err(e),
     }
 
-    // Fallback 1: Relax age constraint
-    let relaxed_age = DecoySelectionConfig {
-        ring_size: config.ring_size,
-        max_age_ratio: 3.0,
-        max_factor_ratio: config.max_factor_ratio,
-    };
+    // Progressively relax ONLY the factor ceiling (never the age band).
+    for relaxed_factor in [2.0_f64, 3.0, 5.0] {
+        let relaxed = DecoySelectionConfig {
+            ring_size: config.ring_size,
+            max_factor_ratio: relaxed_factor,
+        };
 
-    if let Ok(decoys) = select_decoys(
+        match select_decoys(
+            real_utxo,
+            utxo_pool,
+            current_block,
+            cluster_wealth,
+            total_supply,
+            &relaxed,
+        ) {
+            Ok(decoys) => return Ok((decoys, true)),
+            Err(DecoySelectionError::InsufficientDecoys { .. }) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+
+    // Still insufficient after maximum relaxation — report the strict shortfall.
+    select_decoys(
         real_utxo,
         utxo_pool,
         current_block,
         cluster_wealth,
         total_supply,
-        &relaxed_age,
-    ) {
-        return Ok((decoys, true));
-    }
-
-    // Fallback 2: Relax factor constraint
-    let relaxed_factor = DecoySelectionConfig {
-        ring_size: config.ring_size,
-        max_age_ratio: config.max_age_ratio,
-        max_factor_ratio: 2.0,
-    };
-
-    if let Ok(decoys) = select_decoys(
-        real_utxo,
-        utxo_pool,
-        current_block,
-        cluster_wealth,
-        total_supply,
-        &relaxed_factor,
-    ) {
-        return Ok((decoys, true));
-    }
-
-    // Fallback 3: Relax both constraints significantly
-    let relaxed_both = DecoySelectionConfig {
-        ring_size: config.ring_size,
-        max_age_ratio: 4.0,
-        max_factor_ratio: 2.5,
-    };
-
-    match select_decoys(
-        real_utxo,
-        utxo_pool,
-        current_block,
-        cluster_wealth,
-        total_supply,
-        &relaxed_both,
-    ) {
-        Ok(decoys) => Ok((decoys, true)),
-        Err(e) => Err(e),
-    }
+        config,
+    )
+    .map(|decoys| (decoys, true))
 }
 
 /// Validate that a set of decoys meets the selection constraints.
@@ -419,8 +422,7 @@ pub fn validate_decoys(
     let real_age = real_utxo.age(current_block);
     let real_factor = real_utxo.cluster_factor_global(cluster_wealth, total_supply);
 
-    let min_age = (real_age as f64 / config.max_age_ratio).ceil() as u64;
-    let max_age = (real_age as f64 * config.max_age_ratio).floor() as u64;
+    let (min_age, max_age) = age_similarity_band(real_age);
     let max_allowed_factor = real_factor * config.max_factor_ratio;
 
     for (i, decoy) in decoys.iter().enumerate() {
@@ -482,13 +484,54 @@ mod tests {
     const TOTAL_SUPPLY: u64 = 10_000_000_000_000;
     const CURRENT_BLOCK: u64 = 10_000;
 
+    /// Build a pool of `n` decoy candidates whose ages fall inside the ±10%
+    /// band of a real input created at `real_created_at`, all with the given
+    /// tags. Ages are spread across the in-band window.
+    fn in_band_pool(n: usize, real_created_at: u64, tags: &[(u64, u32)]) -> Vec<UtxoCandidate> {
+        let real_age = CURRENT_BLOCK - real_created_at;
+        let (min_age, max_age) = age_similarity_band(real_age);
+        let mut pool = Vec::new();
+        for i in 0..n {
+            // Distribute ages evenly within [min_age, max_age].
+            let span = max_age - min_age;
+            let age = min_age + (i as u64 % (span + 1));
+            let created_at = CURRENT_BLOCK - age;
+            pool.push(create_utxo((i + 1) as u8, created_at, tags));
+        }
+        pool
+    }
+
     #[test]
     fn test_config_defaults() {
         let config = DecoySelectionConfig::default();
-        assert_eq!(config.ring_size, 11);
-        assert_eq!(config.max_age_ratio, 2.0);
+        assert_eq!(config.ring_size, 20);
         assert_eq!(config.max_factor_ratio, 1.5);
-        assert_eq!(config.decoys_needed(), 10);
+        assert_eq!(config.decoys_needed(), 19);
+        // Ring size must match the node's consensus floor.
+        assert_eq!(config.ring_size, DEFAULT_RING_SIZE);
+    }
+
+    #[test]
+    fn test_age_similarity_band() {
+        // ±10% around a healthy age.
+        assert_eq!(age_similarity_band(1000), (900, 1100));
+        assert_eq!(age_similarity_band(100), (90, 110));
+        // ±10% of 50 is ±5 -> [45, 55]; above the confirmation floor.
+        let (min_age, max_age) = age_similarity_band(50);
+        assert_eq!(min_age, 45);
+        assert_eq!(max_age, 55);
+        // A lower age hits the confirmation floor: ±10% of 80 is ±8 -> min 72.
+        let (min_floor, _) = age_similarity_band(80);
+        assert_eq!(min_floor, 72);
+    }
+
+    #[test]
+    fn test_age_similarity_band_floor() {
+        // A tiny age produces a degenerate band (min > max) after flooring.
+        let (min_age, max_age) = age_similarity_band(5);
+        assert_eq!(min_age, MIN_DECOY_AGE_BLOCKS);
+        assert_eq!(max_age, 5);
+        assert!(min_age > max_age, "degenerate band expected for young age");
     }
 
     #[test]
@@ -503,7 +546,6 @@ mod tests {
     fn test_cluster_factor_anonymous() {
         let utxo = create_utxo(1, 5_000, &[]);
         let factor = utxo.cluster_factor();
-        // Empty tags = 0% attribution = 1.0 factor
         assert!((factor - 1.0).abs() < 0.001);
     }
 
@@ -511,40 +553,17 @@ mod tests {
     fn test_cluster_factor_full_attribution() {
         let utxo = create_utxo(1, 5_000, &[(1, TAG_WEIGHT_SCALE)]);
         let factor = utxo.cluster_factor();
-        // 100% attribution = 6.0 factor
         assert!((factor - 6.0).abs() < 0.001);
     }
 
     #[test]
-    fn test_cluster_factor_partial_attribution() {
-        let utxo = create_utxo(1, 5_000, &[(1, TAG_WEIGHT_SCALE / 2)]);
-        let factor = utxo.cluster_factor();
-        // 50% attribution = 3.5 factor
-        assert!((factor - 3.5).abs() < 0.001);
-    }
-
-    #[test]
     fn test_select_decoys_basic() {
-        let real_utxo = create_utxo(0, 5_000, &[(1, TAG_WEIGHT_SCALE / 2)]);
+        // Real input created at 9_000 -> age 1000 -> band [900, 1100].
+        let real_utxo = create_utxo(0, 9_000, &[(1, TAG_WEIGHT_SCALE / 2)]);
         let cluster_wealth = create_cluster_wealth();
+        let pool = in_band_pool(25, 9_000, &[(1, TAG_WEIGHT_SCALE / 2)]);
 
-        // Create pool of eligible decoys
-        let mut pool = Vec::new();
-        for i in 1..=15 {
-            // Similar age (within 2x), similar factor
-            pool.push(create_utxo(
-                i,
-                4_000 + i as u64 * 100,
-                &[(1, TAG_WEIGHT_SCALE / 2)],
-            ));
-        }
-
-        let config = DecoySelectionConfig {
-            ring_size: 11,
-            max_age_ratio: 2.0,
-            max_factor_ratio: 1.5,
-        };
-
+        let config = DecoySelectionConfig::default(); // ring 20, needs 19
         let result = select_decoys(
             &real_utxo,
             &pool,
@@ -554,103 +573,84 @@ mod tests {
             &config,
         );
 
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "{:?}", result.err());
         let decoys = result.unwrap();
-        assert_eq!(decoys.len(), 10); // ring_size - 1
+        assert_eq!(decoys.len(), 19);
+        // All within the ±10% band.
+        for d in &decoys {
+            let age = d.age(CURRENT_BLOCK);
+            assert!((900..=1100).contains(&age), "age {} out of band", age);
+        }
     }
 
     #[test]
     fn test_select_decoys_age_filtering() {
-        let real_utxo = create_utxo(0, 9_000, &[]); // Age: 1000 blocks
+        // Real age 1000 -> band [900, 1100].
+        let real_utxo = create_utxo(0, 9_000, &[]);
         let cluster_wealth = create_cluster_wealth();
 
-        // Pool with various ages
-        let pool = vec![
-            create_utxo(1, 9_800, &[]), // Age: 200 - too young (< 500)
-            create_utxo(2, 9_500, &[]), // Age: 500 - at lower bound
-            create_utxo(3, 8_500, &[]), // Age: 1500 - good
-            create_utxo(4, 8_000, &[]), // Age: 2000 - at upper bound
-            create_utxo(5, 7_000, &[]), // Age: 3000 - too old (> 2000)
-            create_utxo(6, 8_700, &[]), // Age: 1300 - good
-            create_utxo(7, 8_200, &[]), // Age: 1800 - good
-        ];
+        let mut pool = in_band_pool(19, 9_000, &[]);
+        // Add clearly out-of-band candidates that must never be selected.
+        pool.push(create_utxo(200, 9_800, &[])); // age 200 - too young
+        pool.push(create_utxo(201, 8_000, &[])); // age 2000 - too old
 
-        let config = DecoySelectionConfig {
-            ring_size: 4, // Need 3 decoys
-            max_age_ratio: 2.0,
-            max_factor_ratio: 10.0, // Relax factor constraint for this test
-        };
-
-        let result = select_decoys(
+        let config = DecoySelectionConfig::default();
+        let decoys = select_decoys(
             &real_utxo,
             &pool,
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
             &config,
-        );
+        )
+        .expect("selection should succeed");
 
-        assert!(result.is_ok());
-        let decoys = result.unwrap();
-        assert_eq!(decoys.len(), 3);
-
-        // Verify all selected decoys meet age constraint
         for decoy in &decoys {
             let age = decoy.age(CURRENT_BLOCK);
-            assert!(age >= 500 && age <= 2000, "Age {} out of bounds", age);
+            assert!((900..=1100).contains(&age), "Age {} out of band", age);
+            assert_ne!(decoy.id, [200u8; 32]);
+            assert_ne!(decoy.id, [201u8; 32]);
         }
     }
 
     #[test]
     fn test_select_decoys_factor_filtering() {
-        let real_utxo = create_utxo(0, 5_000, &[(1, TAG_WEIGHT_SCALE / 4)]); // ~25% = factor ~2.25
-        let cluster_wealth = create_cluster_wealth();
+        // Real ~25% attribution to a wealthy cluster (50% of supply).
+        let real_utxo = create_utxo(0, 9_000, &[(1, TAG_WEIGHT_SCALE / 4)]);
+        let mut cluster_wealth = HashMap::new();
+        cluster_wealth.insert(ClusterId::new(1), 5_000_000_000_000); // 50% of supply
 
-        // Pool with various factors
-        let pool = vec![
-            create_utxo(1, 5_500, &[]),                          // 0% = 1.0 - good
-            create_utxo(2, 5_500, &[(1, TAG_WEIGHT_SCALE / 4)]), // 25% = ~2.25 - good
-            create_utxo(3, 5_500, &[(1, TAG_WEIGHT_SCALE / 2)]), /* 50% = 3.5 - at limit (1.5 *
-                                                                  * 2.25 = 3.375) */
-            create_utxo(4, 5_500, &[(1, TAG_WEIGHT_SCALE)]), // 100% = 6.0 - too high
-            create_utxo(5, 5_500, &[(1, TAG_WEIGHT_SCALE / 5)]), // 20% = ~2.0 - good
-        ];
+        // 19 acceptable low-factor (anonymous) decoys plus one 100%-attribution
+        // decoy whose factor exceeds real_factor * 1.5 and must be excluded.
+        let mut pool = in_band_pool(19, 9_000, &[]);
+        pool.push(create_utxo(250, 9_000, &[(1, TAG_WEIGHT_SCALE)]));
 
-        let config = DecoySelectionConfig {
-            ring_size: 4,
-            max_age_ratio: 10.0, // Relax age constraint for this test
-            max_factor_ratio: 1.5,
-        };
-
-        let result = select_decoys(
+        let config = DecoySelectionConfig::default();
+        let decoys = select_decoys(
             &real_utxo,
             &pool,
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
             &config,
-        );
+        )
+        .expect("selection should succeed");
 
-        assert!(result.is_ok());
-        let decoys = result.unwrap();
-        assert_eq!(decoys.len(), 3);
-
-        // Verify decoy 4 (100% attribution) was not selected
         for decoy in &decoys {
-            assert_ne!(decoy.id, [4u8; 32], "High-factor decoy should be excluded");
+            assert_ne!(
+                decoy.id, [250u8; 32],
+                "High-factor decoy should be excluded"
+            );
         }
     }
 
     #[test]
     fn test_select_decoys_insufficient() {
-        let real_utxo = create_utxo(0, 5_000, &[]);
+        let real_utxo = create_utxo(0, 9_000, &[]);
         let cluster_wealth = create_cluster_wealth();
+        let pool = in_band_pool(2, 9_000, &[]);
 
-        // Pool too small
-        let pool = vec![create_utxo(1, 5_500, &[]), create_utxo(2, 5_500, &[])];
-
-        let config = DecoySelectionConfig::default(); // Needs 10 decoys
-
+        let config = DecoySelectionConfig::default(); // needs 19
         let result = select_decoys(
             &real_utxo,
             &pool,
@@ -663,7 +663,7 @@ mod tests {
         assert!(matches!(
             result,
             Err(DecoySelectionError::InsufficientDecoys {
-                required: 10,
+                required: 19,
                 available: 2
             })
         ));
@@ -671,7 +671,7 @@ mod tests {
 
     #[test]
     fn test_select_decoys_empty_pool() {
-        let real_utxo = create_utxo(0, 5_000, &[]);
+        let real_utxo = create_utxo(0, 9_000, &[]);
         let cluster_wealth = create_cluster_wealth();
 
         let result = select_decoys(
@@ -688,13 +688,12 @@ mod tests {
 
     #[test]
     fn test_select_decoys_invalid_ring_size() {
-        let real_utxo = create_utxo(0, 5_000, &[]);
+        let real_utxo = create_utxo(0, 9_000, &[]);
         let cluster_wealth = create_cluster_wealth();
-        let pool = vec![create_utxo(1, 5_500, &[])];
+        let pool = in_band_pool(5, 9_000, &[]);
 
         let config = DecoySelectionConfig {
             ring_size: 1, // Invalid
-            max_age_ratio: 2.0,
             max_factor_ratio: 1.5,
         };
 
@@ -711,10 +710,36 @@ mod tests {
     }
 
     #[test]
-    fn test_select_decoys_zero_age() {
-        let real_utxo = create_utxo(0, CURRENT_BLOCK, &[]); // Created this block = 0 age
+    fn test_select_decoys_young_input_rejected() {
+        // Real input younger than the confirmation floor must be rejected
+        // cleanly (no panic, no degenerate band).
+        let real_utxo = create_utxo(0, CURRENT_BLOCK - 5, &[]); // age 5 < 10
         let cluster_wealth = create_cluster_wealth();
-        let pool = vec![create_utxo(1, 5_500, &[])];
+        let pool = in_band_pool(25, 9_000, &[]);
+
+        let result = select_decoys(
+            &real_utxo,
+            &pool,
+            CURRENT_BLOCK,
+            &cluster_wealth,
+            TOTAL_SUPPLY,
+            &DecoySelectionConfig::default(),
+        );
+
+        match result {
+            Err(DecoySelectionError::InvalidRealUtxo(msg)) => {
+                assert!(msg.contains("too new"), "unexpected message: {}", msg);
+            }
+            other => panic!("expected InvalidRealUtxo, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_select_decoys_zero_age_rejected() {
+        // Age 0 is a special case of the young-input guard.
+        let real_utxo = create_utxo(0, CURRENT_BLOCK, &[]);
+        let cluster_wealth = create_cluster_wealth();
+        let pool = in_band_pool(25, 9_000, &[]);
 
         let result = select_decoys(
             &real_utxo,
@@ -733,111 +758,113 @@ mod tests {
 
     #[test]
     fn test_select_decoys_excludes_self() {
-        let real_utxo = create_utxo(0, 5_000, &[]);
+        let real_utxo = create_utxo(0, 9_000, &[]);
         let cluster_wealth = create_cluster_wealth();
 
-        // Pool includes the real UTXO
-        let pool = vec![
-            create_utxo(0, 5_000, &[]), // Same as real
-            create_utxo(1, 5_500, &[]),
-            create_utxo(2, 5_500, &[]),
-            create_utxo(3, 5_500, &[]),
-        ];
+        // Pool includes the real UTXO (same id) plus enough in-band decoys.
+        let mut pool = in_band_pool(25, 9_000, &[]);
+        pool.push(create_utxo(0, 9_000, &[])); // same id as real
 
-        let config = DecoySelectionConfig {
-            ring_size: 3,
-            max_age_ratio: 2.0,
-            max_factor_ratio: 1.5,
-        };
-
-        let result = select_decoys(
+        let decoys = select_decoys(
             &real_utxo,
             &pool,
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
-            &config,
-        );
+            &DecoySelectionConfig::default(),
+        )
+        .expect("selection should succeed");
 
-        assert!(result.is_ok());
-        let decoys = result.unwrap();
-
-        // Verify real UTXO was not selected
         for decoy in &decoys {
             assert_ne!(decoy.id, real_utxo.id, "Real UTXO should not be in decoys");
         }
     }
 
     #[test]
-    fn test_select_decoys_with_fallback_success_first_try() {
-        let real_utxo = create_utxo(0, 5_000, &[]);
+    fn test_select_decoys_is_randomized() {
+        // With a pool much larger than needed, the selected set should not be
+        // the deterministic first-19 of the input order (astronomically
+        // unlikely under a fair shuffle).
+        let real_utxo = create_utxo(0, 9_000, &[]);
         let cluster_wealth = create_cluster_wealth();
+        let pool = in_band_pool(60, 9_000, &[]);
 
-        let mut pool = Vec::new();
-        for i in 1..=15 {
-            pool.push(create_utxo(i, 5_000 + i as u64 * 50, &[]));
-        }
+        let first_n_ids: Vec<[u8; 32]> = pool.iter().take(19).map(|c| c.id).collect();
 
-        let config = DecoySelectionConfig::default();
-
-        let result = select_decoys_with_fallback(
+        let decoys = select_decoys(
             &real_utxo,
             &pool,
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
-            &config,
-        );
+            &DecoySelectionConfig::default(),
+        )
+        .expect("selection should succeed");
+        let selected_ids: Vec<[u8; 32]> = decoys.iter().map(|c| c.id).collect();
 
-        assert!(result.is_ok());
-        let (decoys, relaxed) = result.unwrap();
-        assert_eq!(decoys.len(), 10);
+        assert_eq!(selected_ids.len(), 19);
+        assert_ne!(
+            selected_ids, first_n_ids,
+            "selection must be shuffled, not a deterministic first-N slice"
+        );
+    }
+
+    #[test]
+    fn test_select_decoys_with_fallback_success_first_try() {
+        let real_utxo = create_utxo(0, 9_000, &[]);
+        let cluster_wealth = create_cluster_wealth();
+        let pool = in_band_pool(25, 9_000, &[]);
+
+        let (decoys, relaxed) = select_decoys_with_fallback(
+            &real_utxo,
+            &pool,
+            CURRENT_BLOCK,
+            &cluster_wealth,
+            TOTAL_SUPPLY,
+            &DecoySelectionConfig::default(),
+        )
+        .expect("selection should succeed");
+
+        assert_eq!(decoys.len(), 19);
         assert!(!relaxed, "Should succeed without relaxation");
     }
 
     #[test]
-    fn test_select_decoys_with_fallback_relaxed() {
-        let real_utxo = create_utxo(0, 5_000, &[]); // Age: 5000
-        let cluster_wealth = create_cluster_wealth();
+    fn test_select_decoys_with_fallback_relaxes_factor() {
+        // Real input is anonymous (factor 1.0); strict ceiling 1.5x = 1.5.
+        let real_utxo = create_utxo(0, 9_000, &[]);
+        // Cluster 1 is wealthy so attributed decoys have a high factor.
+        let mut cluster_wealth = HashMap::new();
+        cluster_wealth.insert(ClusterId::new(1), 5_000_000_000_000); // 50%
 
-        // Pool with UTXOs outside strict age bounds but within relaxed bounds
-        let mut pool = Vec::new();
-        for i in 1..=15 {
-            // Ages around 1500-2000 (below min 2500 with 2x, but within 3x)
-            pool.push(create_utxo(i, 8_000 + i as u64 * 50, &[]));
-        }
+        // All in-band decoys are attributed to the wealthy cluster (high
+        // factor) — the strict ceiling excludes them, forcing relaxation.
+        let pool = in_band_pool(25, 9_000, &[(1, TAG_WEIGHT_SCALE)]);
 
-        let config = DecoySelectionConfig {
-            ring_size: 11,
-            max_age_ratio: 2.0, // Strict: age must be 2500-10000
-            max_factor_ratio: 1.5,
-        };
-
-        let result = select_decoys_with_fallback(
+        let (decoys, relaxed) = select_decoys_with_fallback(
             &real_utxo,
             &pool,
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
-            &config,
-        );
+            &DecoySelectionConfig::default(),
+        )
+        .expect("selection should succeed after relaxation");
 
-        assert!(result.is_ok());
-        let (_decoys, relaxed) = result.unwrap();
-        assert!(relaxed, "Should indicate constraints were relaxed");
+        assert_eq!(decoys.len(), 19);
+        assert!(relaxed, "Should indicate the factor ceiling was relaxed");
     }
 
     #[test]
     fn test_validate_decoys_all_valid() {
-        let real_utxo = create_utxo(0, 5_000, &[]); // Age: 5000
+        // Real age 1000 -> band [900, 1100].
+        let real_utxo = create_utxo(0, 9_000, &[]);
         let cluster_wealth = create_cluster_wealth();
 
         let decoys = vec![
-            create_utxo(1, 6_000, &[]), // Age: 4000 - within bounds
-            create_utxo(2, 7_000, &[]), // Age: 3000 - within bounds
+            create_utxo(1, 9_050, &[]), // age 950 - in band
+            create_utxo(2, 8_950, &[]), // age 1050 - in band
         ];
-
-        let config = DecoySelectionConfig::default();
 
         let violations = validate_decoys(
             &real_utxo,
@@ -845,24 +872,27 @@ mod tests {
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
-            &config,
+            &DecoySelectionConfig::default(),
         );
 
-        assert!(violations.is_empty(), "Expected no violations");
+        assert!(
+            violations.is_empty(),
+            "Expected no violations: {:?}",
+            violations
+        );
     }
 
     #[test]
     fn test_validate_decoys_age_violations() {
-        let real_utxo = create_utxo(0, 9_000, &[]); // Age: 1000
+        // Real age 1000 -> band [900, 1100].
+        let real_utxo = create_utxo(0, 9_000, &[]);
         let cluster_wealth = create_cluster_wealth();
 
         let decoys = vec![
-            create_utxo(1, 9_800, &[]), // Age: 200 - too young
-            create_utxo(2, 8_500, &[]), // Age: 1500 - valid
-            create_utxo(3, 5_000, &[]), // Age: 5000 - too old
+            create_utxo(1, 9_800, &[]), // age 200 - too young
+            create_utxo(2, 9_000, &[]), // age 1000 - valid
+            create_utxo(3, 5_000, &[]), // age 5000 - too old
         ];
-
-        let config = DecoySelectionConfig::default();
 
         let violations = validate_decoys(
             &real_utxo,
@@ -870,7 +900,7 @@ mod tests {
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
-            &config,
+            &DecoySelectionConfig::default(),
         );
 
         assert_eq!(violations.len(), 2);
@@ -882,30 +912,23 @@ mod tests {
 
     #[test]
     fn test_validate_decoys_factor_violation() {
-        // Real UTXO has low factor (anonymous = ~1.0)
-        let real_utxo = create_utxo(0, 5_000, &[]);
+        let real_utxo = create_utxo(0, 9_000, &[]);
 
-        // Create cluster wealth where cluster 1 is wealthy (50% of supply)
         let mut cluster_wealth = HashMap::new();
         cluster_wealth.insert(ClusterId::new(1), 5_000_000_000_000); // 50% of supply
 
-        // Decoy has 100% attribution to the wealthy cluster
-        // This gives a high factor that exceeds the 1.5x limit
-        let decoys = vec![create_utxo(1, 5_500, &[(1, TAG_WEIGHT_SCALE)])];
+        // Decoy age in band (age 1000), but 100% attribution -> high factor.
+        let decoys = vec![create_utxo(1, 9_000, &[(1, TAG_WEIGHT_SCALE)])];
 
         let config = DecoySelectionConfig::default();
 
         let real_factor = real_utxo.cluster_factor_global(&cluster_wealth, TOTAL_SUPPLY);
         let decoy_factor = decoys[0].cluster_factor_global(&cluster_wealth, TOTAL_SUPPLY);
-
-        // Verify our setup produces the expected violation condition
         assert!(
             decoy_factor > real_factor * config.max_factor_ratio,
-            "Decoy factor {} should exceed max allowed {} (real {} * {})",
+            "Decoy factor {} should exceed max allowed {}",
             decoy_factor,
-            real_factor * config.max_factor_ratio,
-            real_factor,
-            config.max_factor_ratio
+            real_factor * config.max_factor_ratio
         );
 
         let violations = validate_decoys(
@@ -920,7 +943,7 @@ mod tests {
         assert_eq!(
             violations.len(),
             1,
-            "Should detect 1 violation, found: {:?}",
+            "Should detect 1 violation: {:?}",
             violations
         );
         assert!(violations[0].1.contains("factor too high"));
@@ -929,10 +952,10 @@ mod tests {
     #[test]
     fn test_error_display() {
         let e1 = DecoySelectionError::InsufficientDecoys {
-            required: 10,
+            required: 19,
             available: 5,
         };
-        assert!(e1.to_string().contains("10"));
+        assert!(e1.to_string().contains("19"));
         assert!(e1.to_string().contains("5"));
 
         let e2 = DecoySelectionError::EmptyUtxoPool;

--- a/botho-wallet/src/lib.rs
+++ b/botho-wallet/src/lib.rs
@@ -14,10 +14,13 @@ pub mod decoy_selection;
 pub mod discovery;
 pub mod fee_estimation;
 pub mod keys;
+pub mod ring_builder;
 pub mod rpc_pool;
 pub mod secmem;
 pub mod storage;
 pub mod transaction;
+/// Legacy `botho-tx-v1` transaction types, quarantined (see module docs).
+pub mod transaction_legacy;
 
 pub mod commands;
 

--- a/botho-wallet/src/main.rs
+++ b/botho-wallet/src/main.rs
@@ -7,13 +7,16 @@ use clap::{Parser, Subcommand};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod commands;
+mod decoy_selection;
 mod discovery;
 mod fee_estimation;
 mod keys;
+mod ring_builder;
 mod rpc_pool;
 mod secmem;
 mod storage;
 mod transaction;
+mod transaction_legacy;
 
 #[derive(Parser)]
 #[command(name = "botho-wallet")]

--- a/botho-wallet/src/ring_builder.rs
+++ b/botho-wallet/src/ring_builder.rs
@@ -1,0 +1,214 @@
+//! CLSAG ring-member sourcing over RPC.
+//!
+//! The node builds ring signatures by pulling decoy outputs directly from its
+//! ledger (`Ledger::get_decoy_outputs_for_input`). The thin wallet has no
+//! ledger, so it reconstructs the same decoy pool via `chain_getOutputs` and
+//! applies the identical age policy the node uses:
+//!
+//! - **Age-similarity band** (`±10%`, [`AGE_SIMILARITY_SPREAD_BPS`]): decoys
+//!   are drawn from the height window whose ages fall within ±10% of the real
+//!   input's age. This keeps CLI-wallet rings indistinguishable from
+//!   node-wallet rings under a ring-age-spread adversary (issue #614 item 4).
+//! - **Confirmation floor** ([`MIN_DECOY_AGE_BLOCKS`]): decoys (and the real
+//!   input) must be at least 10 blocks deep. Inputs younger than this get a
+//!   clean user-facing error instead of a degenerate band / panic (mirrors the
+//!   #611 / #618 lesson).
+//! - **Shuffle**: the eligible pool is shuffled before taking N, so ring
+//!   membership is not a deterministic first-N slice of a height-sorted pool.
+
+use anyhow::{anyhow, Result};
+use bth_transaction_clsag::{RingMember, TxOutput};
+use bth_transaction_types::ClusterTagVector;
+use rand::{rngs::OsRng, seq::SliceRandom};
+
+use crate::{
+    decoy_selection::{age_similarity_band, MIN_DECOY_AGE_BLOCKS},
+    rpc_pool::{RpcPool, TxOutput as RpcTxOutput},
+};
+
+/// Parse a 32-byte key from a hex string, returning `None` on malformed input.
+fn parse_key32(hex_str: &str) -> Option<[u8; 32]> {
+    let bytes = hex::decode(hex_str).ok()?;
+    if bytes.len() < 32 {
+        return None;
+    }
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&bytes[..32]);
+    Some(key)
+}
+
+/// Parse a transparent amount from an `amount_commitment` hex string.
+///
+/// Botho uses transparent amounts (trivial zero-blinding Pedersen commitments),
+/// and the node emits the plaintext amount as little-endian bytes in this
+/// field (see `WalletScanner::parse_amount`). We need the amount to recompute
+/// the ring member's commitment identically to the node's
+/// `RingMember::from_output`.
+fn parse_amount(hex_str: &str) -> Option<u64> {
+    let bytes = hex::decode(hex_str).ok()?;
+    if bytes.len() < 8 {
+        return None;
+    }
+    Some(u64::from_le_bytes(bytes[..8].try_into().ok()?))
+}
+
+/// Convert an RPC output into a CLSAG [`RingMember`].
+///
+/// Reconstructs the same transparent commitment the node would compute for this
+/// output via `RingMember::from_output`, so the ring member the wallet submits
+/// matches the ledger's stored output at block acceptance.
+fn rpc_output_to_ring_member(out: &RpcTxOutput) -> Option<RingMember> {
+    let target_key = parse_key32(&out.target_key)?;
+    let public_key = parse_key32(&out.public_key)?;
+    let amount = parse_amount(&out.amount_commitment)?;
+
+    let tx_out = TxOutput {
+        amount,
+        target_key,
+        public_key,
+        e_memo: None,
+        cluster_tags: ClusterTagVector::empty(),
+    };
+    Some(RingMember::from_output(&tx_out))
+}
+
+/// Fetch `count` decoy ring members for a real input of age `real_input_age`.
+///
+/// # Arguments
+/// * `rpc` - connected RPC pool
+/// * `real_input_age` - `current_height - utxo.created_at`
+/// * `current_height` - current chain tip height
+/// * `exclude_keys` - target keys of the wallet's own inputs (never used as
+///   decoys)
+/// * `count` - number of decoys required (`MIN_RING_SIZE - 1`)
+///
+/// # Errors
+/// - The input is younger than [`MIN_DECOY_AGE_BLOCKS`] ("too young to spend
+///   privately") — returned *before* any RPC call, so a fresh UTXO never panics
+///   on a degenerate age band.
+/// - The chain does not yet hold enough age-similar confirmed outputs to fill
+///   the ring.
+pub async fn fetch_decoy_ring_members(
+    rpc: &mut RpcPool,
+    real_input_age: u64,
+    current_height: u64,
+    exclude_keys: &[[u8; 32]],
+    count: usize,
+) -> Result<Vec<RingMember>> {
+    // Young-input guard (mirrors node decoy_selection.rs guard; #611/#618).
+    // Under the ±10% band the lower bound is floored at MIN_DECOY_AGE_BLOCKS,
+    // so any input younger than that yields a degenerate band. Fail cleanly.
+    if real_input_age < MIN_DECOY_AGE_BLOCKS {
+        return Err(anyhow!(
+            "Input is too new to spend privately — wait for at least {} confirmations \
+             (current age: {} block(s)).",
+            MIN_DECOY_AGE_BLOCKS,
+            real_input_age
+        ));
+    }
+
+    // Compute the ±10% age band and translate it into an inclusive block-height
+    // window. Older age => lower height.
+    let (min_age, max_age) = age_similarity_band(real_input_age);
+    let start_height = current_height.saturating_sub(max_age);
+    // end_height is the youngest allowed decoy height; min_age >= MIN_DECOY_AGE
+    // guarantees it is at least MIN_DECOY_AGE_BLOCKS deep.
+    let end_height = current_height.saturating_sub(min_age);
+
+    // Fetch the candidate pool. `get_outputs` scans the [start, end] window.
+    // We add 1 to end to make the window inclusive of the youngest in-band
+    // height.
+    let blocks = rpc
+        .get_outputs(start_height, end_height.saturating_add(1))
+        .await?;
+
+    // Flatten to ring members, excluding our own inputs and malformed outputs.
+    let mut pool: Vec<RingMember> = Vec::new();
+    for block in &blocks {
+        for out in &block.outputs {
+            let member = match rpc_output_to_ring_member(out) {
+                Some(m) => m,
+                None => continue,
+            };
+            if exclude_keys.contains(&member.target_key) {
+                continue;
+            }
+            pool.push(member);
+        }
+    }
+
+    // De-duplicate by target key (an output can legitimately appear once; guard
+    // against any accidental repeats across overlapping ranges).
+    pool.sort_by(|a, b| a.target_key.cmp(&b.target_key));
+    pool.dedup_by(|a, b| a.target_key == b.target_key);
+
+    if pool.len() < count {
+        return Err(anyhow!(
+            "Not enough age-similar decoy outputs on-chain to build a ring. \
+             Need {}, found {} in the ±10% age band [{}, {}] blocks. \
+             The chain needs more confirmed outputs of similar age.",
+            count,
+            pool.len(),
+            min_age,
+            max_age
+        ));
+    }
+
+    // Shuffle before taking N so ring membership is not a deterministic slice.
+    let mut rng = OsRng;
+    pool.shuffle(&mut rng);
+    pool.truncate(count);
+    Ok(pool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keys::WalletKeys;
+
+    const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+
+    /// Build a valid RPC output by generating a real stealth output to a wallet
+    /// address, then serializing its fields the way `chain_getOutputs` does.
+    fn random_rpc_output(amount: u64) -> RpcTxOutput {
+        let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
+        let out = TxOutput::new(amount, &keys.public_address());
+        RpcTxOutput {
+            tx_hash: hex::encode([0u8; 32]),
+            output_index: 0,
+            target_key: hex::encode(out.target_key),
+            public_key: hex::encode(out.public_key),
+            amount_commitment: hex::encode(amount.to_le_bytes()),
+            cluster_tags: vec![],
+            pq_ciphertext: None,
+            is_pq_output: false,
+        }
+    }
+
+    #[test]
+    fn test_rpc_output_to_ring_member_roundtrips_fields() {
+        let out = random_rpc_output(12_345);
+        let member = rpc_output_to_ring_member(&out).expect("valid output");
+        assert_eq!(hex::encode(member.target_key), out.target_key);
+        assert_eq!(hex::encode(member.public_key), out.public_key);
+        // Commitment must equal the node's transparent commitment for 12_345.
+        let expected = TxOutput {
+            amount: 12_345,
+            target_key: member.target_key,
+            public_key: member.public_key,
+            e_memo: None,
+            cluster_tags: ClusterTagVector::empty(),
+        };
+        assert_eq!(
+            member.commitment,
+            RingMember::from_output(&expected).commitment
+        );
+    }
+
+    #[test]
+    fn test_rpc_output_to_ring_member_rejects_short_key() {
+        let mut out = random_rpc_output(1);
+        out.target_key = hex::encode([0u8; 4]); // too short
+        assert!(rpc_output_to_ring_member(&out).is_none());
+    }
+}

--- a/botho-wallet/src/transaction.rs
+++ b/botho-wallet/src/transaction.rs
@@ -11,26 +11,46 @@ use bth_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use bth_crypto_ring_signature::onetime_keys::{
     recover_onetime_private_key, recover_public_subaddress_spend_key,
 };
-use rand::{rngs::OsRng, RngCore};
+use bth_transaction_clsag::{ClsagRingInput, RingMember, Transaction, TxOutput, MIN_RING_SIZE};
+use bth_transaction_types::{ClusterId, ClusterTagEntry, ClusterTagVector};
+use rand::{rngs::OsRng, seq::SliceRandom};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use crate::{
     fee_estimation::StoredTags,
     keys::WalletKeys,
+    ring_builder::fetch_decoy_ring_members,
     rpc_pool::{BlockOutputs, RpcPool},
 };
+
+// The real transaction format lives in `bth-transaction-clsag` (the same crate
+// the node exposes as `botho::transaction`). Re-export the consensus fee floor
+// so callers (e.g. `commands::send`) can enforce it without importing the crate
+// directly.
+pub use bth_transaction_clsag::MIN_TX_FEE;
 
 #[cfg(feature = "pq")]
 use bth_crypto_pq::MlKem768Ciphertext;
 #[cfg(feature = "pq")]
 use bth_crypto_ring_signature::pq_onetime_keys::check_pq_output_ownership;
+#[cfg(feature = "pq")]
+use sha2::{Digest, Sha256};
 
 /// Picocredits per CAD
 pub const PICOCREDITS_PER_CAD: u64 = 1_000_000_000_000;
 
-/// Minimum transaction fee
+/// Minimum transaction fee (legacy display constant).
+///
+/// The consensus-enforced floor is [`MIN_TX_FEE`] (100_000_000 picocredits);
+/// transaction building must never submit a fee below it. This smaller value is
+/// retained only for backward-compatible display code.
 pub const MIN_FEE: u64 = 1_000_000; // 0.000001 CAD
+
+/// Cluster-tag decay rate for output inheritance.
+///
+/// Matches the node's `DEFAULT_CLUSTER_DECAY_RATE` so outputs built by the CLI
+/// wallet inherit ancestry identically to node-built transactions.
+pub const DEFAULT_CLUSTER_DECAY_RATE: u32 = 50_000;
 
 /// Dust threshold - minimum output amount in picocredits.
 /// Outputs below this value are rejected to prevent unspendable UTXOs.
@@ -177,131 +197,48 @@ impl PqOwnedUtxo {
     }
 }
 
-/// A transaction output
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TxOutput {
-    pub amount: u64,
-    pub recipient_view_key: [u8; 32],
-    pub recipient_spend_key: [u8; 32],
-    pub output_public_key: [u8; 32],
-}
+// NOTE: The wallet's own flat `botho-tx-v1` Transaction/TxInput/TxOutput types
+// (with cryptographically-broken stealth outputs) have been replaced by the
+// real CLSAG format from `bth-transaction-clsag`, imported at the top of this
+// module. The legacy types are quarantined in `transaction_legacy.rs` per
+// CLAUDE.md code-preservation. See issue #614.
 
-impl TxOutput {
-    /// Create a new output for a recipient
-    pub fn new(amount: u64, recipient: &PublicAddress) -> Self {
-        let view_key = recipient.view_public_key().to_bytes();
-        let spend_key = recipient.spend_public_key().to_bytes();
-
-        // Generate one-time output key using cryptographically secure RNG
-        let mut random_bytes = [0u8; 32];
-        OsRng.fill_bytes(&mut random_bytes);
-
-        let mut hasher = Sha256::new();
-        hasher.update(view_key);
-        hasher.update(spend_key);
-        hasher.update(amount.to_le_bytes());
-        hasher.update(random_bytes);
-        let output_key: [u8; 32] = hasher.finalize().into();
-
-        Self {
-            amount,
-            recipient_view_key: view_key,
-            recipient_spend_key: spend_key,
-            output_public_key: output_key,
-        }
+/// Convert wallet-local [`StoredTags`] into the on-chain [`ClusterTagVector`]
+/// carried by outputs. Cluster IDs and parts-per-million weights map 1:1.
+fn stored_tags_to_cluster_vector(tags: &StoredTags) -> ClusterTagVector {
+    let entries = tags
+        .tags
+        .iter()
+        .map(|&(id, weight)| ClusterTagEntry {
+            cluster_id: ClusterId(id),
+            weight,
+        })
+        .collect();
+    ClusterTagVector {
+        entries,
+        decay_state: None,
     }
 }
 
-/// A transaction input
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TxInput {
-    pub tx_hash: [u8; 32],
-    pub output_index: u32,
-    pub signature: Vec<u8>,
+/// Compute the merged, decayed cluster-tag vector inherited by all outputs of a
+/// transaction that spends `selected`. Mirrors the node's
+/// `Wallet::compute_inherited_tags` (amount-weighted merge at
+/// [`DEFAULT_CLUSTER_DECAY_RATE`]).
+fn inherited_cluster_tags(selected: &[OwnedUtxo]) -> ClusterTagVector {
+    let inputs: Vec<(ClusterTagVector, u64)> = selected
+        .iter()
+        .map(|u| (stored_tags_to_cluster_vector(&u.tags()), u.amount))
+        .collect();
+    ClusterTagVector::merge_weighted(&inputs, DEFAULT_CLUSTER_DECAY_RATE)
 }
 
-/// A complete transaction
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Transaction {
-    pub version: u32,
-    pub inputs: Vec<TxInput>,
-    pub outputs: Vec<TxOutput>,
-    pub fee: u64,
-    pub created_at_height: u64,
-}
-
-impl Transaction {
-    /// Create a new unsigned transaction
-    pub fn new(
-        inputs: Vec<TxInput>,
-        outputs: Vec<TxOutput>,
-        fee: u64,
-        created_at_height: u64,
-    ) -> Self {
-        Self {
-            version: 1,
-            inputs,
-            outputs,
-            fee,
-            created_at_height,
-        }
-    }
-
-    /// Compute the signing hash (message to be signed)
-    pub fn signing_hash(&self) -> [u8; 32] {
-        let mut hasher = Sha256::new();
-        hasher.update(b"botho-tx-v1");
-        hasher.update(self.version.to_le_bytes());
-
-        for input in &self.inputs {
-            hasher.update(input.tx_hash);
-            hasher.update(input.output_index.to_le_bytes());
-        }
-
-        for output in &self.outputs {
-            hasher.update(output.amount.to_le_bytes());
-            hasher.update(output.recipient_view_key);
-            hasher.update(output.recipient_spend_key);
-            hasher.update(output.output_public_key);
-        }
-
-        hasher.update(self.fee.to_le_bytes());
-        hasher.update(self.created_at_height.to_le_bytes());
-        hasher.finalize().into()
-    }
-
-    /// Compute the transaction hash
-    pub fn hash(&self) -> [u8; 32] {
-        let mut hasher = Sha256::new();
-        hasher.update(self.version.to_le_bytes());
-
-        for input in &self.inputs {
-            hasher.update(input.tx_hash);
-            hasher.update(input.output_index.to_le_bytes());
-        }
-
-        for output in &self.outputs {
-            hasher.update(output.amount.to_le_bytes());
-            hasher.update(output.recipient_view_key);
-            hasher.update(output.recipient_spend_key);
-            hasher.update(output.output_public_key);
-        }
-
-        hasher.update(self.fee.to_le_bytes());
-        hasher.update(self.created_at_height.to_le_bytes());
-        hasher.finalize().into()
-    }
-
-    /// Serialize to hex for submission
-    pub fn to_hex(&self) -> String {
-        let bytes = bincode::serialize(self).expect("Serialization should not fail");
-        hex::encode(bytes)
-    }
-
-    /// Total output amount
-    pub fn total_output(&self) -> u64 {
-        self.outputs.iter().map(|o| o.amount).sum()
-    }
+/// Serialize a signed transaction to hex for submission via `tx_submit`.
+///
+/// Uses the same bincode encoding the node's `tx_submit` handler deserializes
+/// into `botho::transaction::Transaction`.
+pub fn to_tx_hex(tx: &Transaction) -> Result<String> {
+    let bytes = bincode::serialize(tx).map_err(|e| anyhow!("Failed to serialize tx: {}", e))?;
+    Ok(hex::encode(bytes))
 }
 
 /// Result of building a transfer transaction.
@@ -343,35 +280,42 @@ impl TransactionBuilder {
         self.utxos.iter().map(|u| u.amount).sum()
     }
 
-    /// Build and sign a transaction
+    /// Build and sign a CLSAG transaction (fetches decoy ring members via RPC).
     ///
     /// If the change amount is below `DUST_THRESHOLD`, it is added to the fee
     /// instead of creating an unspendable output.
     ///
     /// Returns just the transaction for simple use cases. For cluster tag
     /// propagation, use `build_transfer_with_metadata` instead.
-    pub fn build_transfer(
+    pub async fn build_transfer(
         &self,
+        rpc: &mut RpcPool,
         recipient: &PublicAddress,
         amount: u64,
         fee: u64,
     ) -> Result<Transaction> {
-        let result = self.build_transfer_with_metadata(recipient, amount, fee)?;
+        let result = self
+            .build_transfer_with_metadata(rpc, recipient, amount, fee)
+            .await?;
         Ok(result.transaction)
     }
 
-    /// Build and sign a transaction with full metadata.
+    /// Build and sign a CLSAG transaction with full metadata.
     ///
-    /// If the change amount is below `DUST_THRESHOLD`, it is added to the fee
-    /// instead of creating an unspendable output.
+    /// This is the live send path. For each selected input it fetches an
+    /// age-similar decoy ring over RPC (`chain_getOutputs`), assembles a
+    /// ring-size-20 CLSAG ring with the real input at a randomized position,
+    /// and produces a transaction that bincode-round-trips through
+    /// `botho::transaction::Transaction`.
     ///
     /// Returns `TransferResult` containing:
     /// - The signed transaction
     /// - The actual fee (may be higher if dust was absorbed)
-    /// - The change output's public key (for cluster tag tracking)
+    /// - The change output's public key (for cluster tag tracking, issue #249)
     /// - The selected input UTXOs (for computing blended tags)
-    pub fn build_transfer_with_metadata(
+    pub async fn build_transfer_with_metadata(
         &self,
+        rpc: &mut RpcPool,
         recipient: &PublicAddress,
         amount: u64,
         fee: u64,
@@ -397,41 +341,160 @@ impl TransactionBuilder {
         // Select UTXOs
         let (selected, total_selected) = self.select_utxos(total_needed)?;
 
-        // Calculate change
+        // Exclude our own inputs from every ring's decoy pool.
+        let exclude_keys: Vec<[u8; 32]> = selected.iter().map(|u| u.target_key).collect();
+
+        // Fetch an age-similar decoy ring for each selected input. This is the
+        // only asynchronous step; the CLSAG assembly below is deterministic
+        // given the fetched rings, which keeps it unit-testable in isolation.
+        let decoys_needed = MIN_RING_SIZE - 1;
+        let mut decoy_rings: Vec<Vec<RingMember>> = Vec::with_capacity(selected.len());
+        for utxo in &selected {
+            let real_age = self.sync_height.saturating_sub(utxo.created_at);
+            let decoys = fetch_decoy_ring_members(
+                rpc,
+                real_age,
+                self.sync_height,
+                &exclude_keys,
+                decoys_needed,
+            )
+            .await?;
+            decoy_rings.push(decoys);
+        }
+
+        self.build_signed_transaction(
+            recipient,
+            amount,
+            fee,
+            selected,
+            total_selected,
+            decoy_rings,
+        )
+    }
+
+    /// Assemble and CLSAG-sign the transaction from pre-fetched decoy rings.
+    ///
+    /// Split out from the RPC decoy fetch so the full crypto assembly can be
+    /// exercised in tests with fixture UTXOs and ring members (the live path
+    /// sources `decoy_rings` from [`Self::build_transfer_with_metadata`]).
+    ///
+    /// `decoy_rings[i]` supplies the decoys for `selected[i]`; each must hold
+    /// at least `MIN_RING_SIZE - 1` members.
+    pub fn build_signed_transaction(
+        &self,
+        recipient: &PublicAddress,
+        amount: u64,
+        fee: u64,
+        selected: Vec<OwnedUtxo>,
+        total_selected: u64,
+        decoy_rings: Vec<Vec<RingMember>>,
+    ) -> Result<TransferResult> {
+        if decoy_rings.len() != selected.len() {
+            return Err(anyhow!(
+                "internal error: {} decoy rings for {} inputs",
+                decoy_rings.len(),
+                selected.len()
+            ));
+        }
+
+        let total_needed = amount
+            .checked_add(fee)
+            .ok_or_else(|| anyhow!("Amount overflow"))?;
         let change = total_selected
             .checked_sub(total_needed)
             .ok_or_else(|| anyhow!("Insufficient funds"))?;
 
-        // Create inputs (unsigned)
-        let inputs: Vec<TxInput> = selected
-            .iter()
-            .map(|utxo| TxInput {
-                tx_hash: utxo.tx_hash,
-                output_index: utxo.output_index,
-                signature: vec![], // Will be filled in after signing
-            })
-            .collect();
+        // All outputs inherit the same merged+decayed cluster-tag vector from
+        // the inputs (matches the node's create_private_transaction).
+        let inherited_tags = inherited_cluster_tags(&selected);
 
-        // Create outputs
-        let mut outputs = vec![TxOutput::new(amount, recipient)];
+        // Recipient output (real stealth address via Ristretto DH).
+        let mut outputs = vec![TxOutput::new_with_cluster_tags(
+            amount,
+            recipient,
+            None,
+            inherited_tags.clone(),
+        )];
 
-        // Handle change: if above dust threshold, create change output
-        // Otherwise, add dust to fee (prevents unspendable UTXOs)
+        // Change: if above dust, create a change output back to ourselves;
+        // otherwise absorb the dust into the fee to avoid an unspendable UTXO.
         let (actual_fee, change_output_public_key) = if change >= DUST_THRESHOLD {
-            let change_output = TxOutput::new(change, &self.keys.public_address());
-            let change_key = change_output.output_public_key;
+            let change_output = TxOutput::new_with_cluster_tags(
+                change,
+                &self.keys.public_address(),
+                None,
+                inherited_tags.clone(),
+            );
+            let change_key = change_output.public_key;
             outputs.push(change_output);
             (fee, Some(change_key))
         } else {
-            // Dust change is absorbed into fee
             (fee + change, None)
         };
 
-        // Create transaction
-        let mut tx = Transaction::new(inputs, outputs, actual_fee, self.sync_height);
+        // Preliminary tx (no inputs) yields the signing hash bound by all
+        // outputs, the fee, and the height — the CLSAG message.
+        let preliminary =
+            Transaction::new_clsag(Vec::new(), outputs.clone(), actual_fee, self.sync_height);
+        let signing_hash = preliminary.signing_hash();
 
-        // Sign all inputs
-        self.sign_transaction(&mut tx)?;
+        let account_key = self.keys.account_key();
+        let mut rng = OsRng;
+        let mut ring_inputs = Vec::with_capacity(selected.len());
+
+        for (utxo, decoys) in selected.iter().zip(decoy_rings.into_iter()) {
+            if decoys.len() < MIN_RING_SIZE - 1 {
+                return Err(anyhow!(
+                    "insufficient decoys for ring: need {}, have {}",
+                    MIN_RING_SIZE - 1,
+                    decoys.len()
+                ));
+            }
+
+            // Recover the one-time private key for this UTXO.
+            let onetime_private = utxo.recover_spend_key(account_key).ok_or_else(|| {
+                anyhow!(
+                    "Failed to recover spend key for UTXO {}",
+                    hex::encode(&utxo.tx_hash[0..8])
+                )
+            })?;
+
+            // Real ring member: transparent commitment over the spent amount.
+            let real_output = TxOutput {
+                amount: utxo.amount,
+                target_key: utxo.target_key,
+                public_key: utxo.public_key,
+                e_memo: None,
+                cluster_tags: ClusterTagVector::empty(),
+            };
+            let real_member = RingMember::from_output(&real_output);
+
+            // Assemble ring = real + decoys, then randomize the real input's
+            // position (CLSAG requires the signer index to be secret).
+            let mut ring: Vec<RingMember> = Vec::with_capacity(MIN_RING_SIZE);
+            ring.push(real_member);
+            ring.extend(decoys.into_iter().take(MIN_RING_SIZE - 1));
+            ring.shuffle(&mut rng);
+
+            let real_index = ring
+                .iter()
+                .position(|m| m.target_key == utxo.target_key)
+                .ok_or_else(|| anyhow!("internal error: real input missing from ring"))?;
+
+            let ring_input = ClsagRingInput::new(
+                ring,
+                real_index,
+                &onetime_private,
+                utxo.amount,
+                &signing_hash,
+                &mut rng,
+            )
+            .map_err(|e| anyhow!("Failed to create ring signature: {}", e))?;
+
+            ring_inputs.push(ring_input);
+        }
+
+        let tx = Transaction::new_clsag(ring_inputs, outputs, actual_fee, self.sync_height);
 
         Ok(TransferResult {
             transaction: tx,
@@ -439,6 +502,14 @@ impl TransactionBuilder {
             change_output_public_key,
             selected_inputs: selected,
         })
+    }
+
+    /// Select input UTXOs to cover `target` using a largest-first algorithm.
+    ///
+    /// Returns the selected UTXOs and their total value. Exposed for tests and
+    /// callers that want to preview which inputs a transfer would spend.
+    pub fn select_inputs(&self, target: u64) -> Result<(Vec<OwnedUtxo>, u64)> {
+        self.select_utxos(target)
     }
 
     /// Select UTXOs using largest-first algorithm
@@ -471,19 +542,6 @@ impl TransactionBuilder {
         }
 
         Ok((selected, total))
-    }
-
-    /// Sign all inputs of a transaction
-    fn sign_transaction(&self, tx: &mut Transaction) -> Result<()> {
-        let signing_hash = tx.signing_hash();
-
-        for input in &mut tx.inputs {
-            // Sign with our spend key
-            let signature = self.keys.sign(b"botho-tx-v1", &signing_hash);
-            input.signature = signature;
-        }
-
-        Ok(())
     }
 }
 
@@ -959,42 +1017,194 @@ mod tests {
         assert_eq!(builder.balance(), 1_500_000_000_000);
     }
 
+    // ------------------------------------------------------------------
+    // CLSAG transaction-building tests (issue #614).
+    //
+    // These drive the real crypto path: fixture UTXOs owned by a wallet plus
+    // fixture decoy ring members are assembled into a signed CLSAG tx via
+    // `build_signed_transaction` (the RPC decoy fetch is bypassed so the
+    // assembly is deterministic and CI-runnable). Live-testnet send is
+    // deferred to the operator.
+    // ------------------------------------------------------------------
+
+    const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+    // A distinct 24-word phrase for the recipient wallet.
+    const RECIPIENT_MNEMONIC: &str = "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title";
+
+    /// Create a UTXO that `keys` genuinely owns, by generating a real stealth
+    /// output to the wallet's default subaddress and capturing its keys.
+    fn owned_fixture_utxo(keys: &WalletKeys, amount: u64, created_at: u64) -> OwnedUtxo {
+        let out = TxOutput::new(amount, &keys.public_address());
+        let utxo = OwnedUtxo {
+            tx_hash: [9u8; 32],
+            output_index: 0,
+            amount,
+            created_at,
+            target_key: out.target_key,
+            public_key: out.public_key,
+            subaddress_index: 0,
+            cluster_tags: None,
+        };
+        // Sanity: the wallet must be able to recover the spend key.
+        assert!(
+            utxo.recover_spend_key(keys.account_key()).is_some(),
+            "fixture UTXO must be spendable by the wallet"
+        );
+        utxo
+    }
+
+    /// Build a ring of `n` random-but-valid decoy members.
+    fn fixture_decoys(n: usize) -> Vec<RingMember> {
+        let decoy_keys = WalletKeys::from_mnemonic(RECIPIENT_MNEMONIC).unwrap();
+        (0..n)
+            .map(|i| {
+                let out = TxOutput::new(1_000 + i as u64, &decoy_keys.public_address());
+                RingMember::from_output(&out)
+            })
+            .collect()
+    }
+
     #[test]
-    fn test_transaction_signing_hash() {
-        let tx1 = Transaction::new(
-            vec![TxInput {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                signature: vec![0u8; 64],
-            }],
-            vec![TxOutput {
-                amount: 1000,
-                recipient_view_key: [2u8; 32],
-                recipient_spend_key: [3u8; 32],
-                output_public_key: [4u8; 32],
-            }],
-            100,
-            1,
+    fn test_build_signed_transaction_roundtrips_and_verifies() {
+        use bth_transaction_clsag::Transaction as ClsagTx;
+
+        let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
+        let recipient_keys = WalletKeys::from_mnemonic(RECIPIENT_MNEMONIC).unwrap();
+        let recipient = recipient_keys.public_address();
+
+        let input_amount = 5_000_000_000_000u64; // 5 CAD
+        let send_amount = 1_000_000_000_000u64; // 1 CAD
+        let fee = MIN_TX_FEE;
+
+        let utxo = owned_fixture_utxo(&keys, input_amount, 50);
+        let builder = TransactionBuilder::new(keys.clone(), vec![utxo.clone()], 1_000);
+
+        let decoy_rings = vec![fixture_decoys(MIN_RING_SIZE - 1)];
+        let result = builder
+            .build_signed_transaction(
+                &recipient,
+                send_amount,
+                fee,
+                vec![utxo],
+                input_amount,
+                decoy_rings,
+            )
+            .expect("build should succeed");
+
+        let tx = &result.transaction;
+        // Ring size is exactly MIN_RING_SIZE (20).
+        assert_eq!(tx.inputs.len(), 1);
+        assert_eq!(tx.inputs.clsag()[0].ring.len(), MIN_RING_SIZE);
+
+        // Structure and balance/signature verification pass.
+        assert!(tx.is_valid_structure().is_ok(), "structure must be valid");
+        assert!(
+            tx.verify_ring_signatures().is_ok(),
+            "CLSAG ring signatures must verify"
         );
 
-        let tx2 = Transaction::new(
-            vec![TxInput {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                signature: vec![0xff; 64], // Different signature
-            }],
-            vec![TxOutput {
-                amount: 1000,
-                recipient_view_key: [2u8; 32],
-                recipient_spend_key: [3u8; 32],
-                output_public_key: [4u8; 32],
-            }],
-            100,
-            1,
+        // Bincode round-trip through the node's transaction type.
+        let hex = to_tx_hex(tx).expect("serialize");
+        let bytes = hex::decode(&hex).expect("hex decode");
+        let decoded: ClsagTx = bincode::deserialize(&bytes).expect("deserialize as node tx");
+        assert!(
+            decoded.verify_ring_signatures().is_ok(),
+            "round-tripped tx must still verify"
+        );
+        assert_eq!(decoded.fee, tx.fee);
+        assert_eq!(decoded.outputs.len(), tx.outputs.len());
+    }
+
+    #[test]
+    fn test_output_is_detectable_by_recipient() {
+        // The exact bug class the curator found: outputs must be detectable by
+        // the recipient's stealth-address scanner.
+        let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
+        let recipient_keys = WalletKeys::from_mnemonic(RECIPIENT_MNEMONIC).unwrap();
+        let recipient = recipient_keys.public_address();
+
+        let input_amount = 5_000_000_000_000u64;
+        let send_amount = 1_000_000_000_000u64;
+
+        let utxo = owned_fixture_utxo(&keys, input_amount, 50);
+        let builder = TransactionBuilder::new(keys.clone(), vec![utxo.clone()], 1_000);
+        let decoy_rings = vec![fixture_decoys(MIN_RING_SIZE - 1)];
+
+        let result = builder
+            .build_signed_transaction(
+                &recipient,
+                send_amount,
+                MIN_TX_FEE,
+                vec![utxo],
+                input_amount,
+                decoy_rings,
+            )
+            .expect("build should succeed");
+
+        // The first output is the recipient output. The recipient's scanner
+        // must detect ownership via the DH stealth protocol.
+        let recipient_scanner = WalletScanner::new(&recipient_keys);
+        let out = &result.transaction.outputs[0];
+        assert_eq!(out.amount, send_amount);
+        let owned = recipient_scanner.check_ownership(&out.target_key, &out.public_key);
+        assert_eq!(
+            owned,
+            Some(0),
+            "recipient must detect the output on their default subaddress"
         );
 
-        // Signing hash should be the same regardless of signature content
-        assert_eq!(tx1.signing_hash(), tx2.signing_hash());
+        // And the *sender* must NOT detect the recipient's output as their own.
+        let sender_scanner = WalletScanner::new(&keys);
+        assert_eq!(
+            sender_scanner.check_ownership(&out.target_key, &out.public_key),
+            None,
+            "sender must not own the recipient's output"
+        );
+
+        // The change output (if any) must be detectable by the sender.
+        if let Some(change_key) = result.change_output_public_key {
+            let change_out = result
+                .transaction
+                .outputs
+                .iter()
+                .find(|o| o.public_key == change_key)
+                .expect("change output present");
+            assert!(
+                sender_scanner
+                    .check_ownership(&change_out.target_key, &change_out.public_key)
+                    .is_some(),
+                "sender must detect their own change output"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_young_input_rejected_cleanly() {
+        // A UTXO younger than MIN_DECOY_AGE_BLOCKS must produce a clean,
+        // user-facing error (no panic) before any ring is built. We reach the
+        // young-input guard via the fetch path without needing a live node by
+        // constructing the decoy fetch directly.
+        use crate::ring_builder::fetch_decoy_ring_members;
+
+        // real_age = 5 (< 10) — guard must fire before any RPC call, so passing
+        // a placeholder RpcPool is never dereferenced. We assert the guard by
+        // calling the (RPC-independent) prefix through a helper that mirrors the
+        // build path: real_age computed from a fresh UTXO.
+        let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
+        let _utxo = owned_fixture_utxo(&keys, 5_000_000_000_000, 995); // height 1000 - 995 = age 5
+
+        // The guard lives at the top of fetch_decoy_ring_members and returns
+        // before touching `rpc`, but Rust still requires a &mut RpcPool. Build a
+        // disconnected pool; the guard returns first.
+        let mut rpc = RpcPool::new(crate::discovery::NodeDiscovery::new());
+        let err = fetch_decoy_ring_members(&mut rpc, 5, 1_000, &[], MIN_RING_SIZE - 1)
+            .await
+            .expect_err("young input must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("too new") && msg.contains("confirmations"),
+            "expected a clean young-input message, got: {msg}"
+        );
     }
 
     #[cfg(feature = "pq")]

--- a/botho-wallet/src/transaction_legacy.rs
+++ b/botho-wallet/src/transaction_legacy.rs
@@ -1,0 +1,169 @@
+//! Legacy `botho-tx-v1` transaction types (QUARANTINED — do not use).
+//!
+//! # Why this module exists
+//!
+//! Before issue #614, the CLI thin wallet built its own flat, non-private
+//! transaction format ("botho-tx-v1"): plaintext recipient view/spend keys, a
+//! per-input Schnorrkel signature, no ring signature, no key images, and a
+//! **cryptographically broken** stealth output.
+//!
+//! Specifically, [`TxOutput::new`] below derived `output_public_key` as
+//! `SHA256(view_key || spend_key || amount || random_bytes)`. That is NOT the
+//! Ristretto Diffie-Hellman stealth protocol the node uses
+//! (`create_tx_out_target_key` / `create_tx_out_public_key`). Outputs built
+//! this way could **never** be detected by a recipient's
+//! `WalletScanner::check_ownership`, and the flat transaction could never
+//! bincode-deserialize as `botho::transaction::Transaction` — the node rejected
+//! every CLI-built tx with `io error: unexpected end of file`.
+//!
+//! These types are preserved here (per CLAUDE.md code-preservation) rather than
+//! deleted outright, so the historical wire format and its signing-hash domain
+//! separator remain recoverable. **Nothing in the wallet builds or submits
+//! these anymore** — the live send path uses the real CLSAG format in
+//! [`crate::transaction`]. Do not reintroduce these into any submission path.
+
+#![allow(dead_code)]
+
+use bth_account_keys::PublicAddress;
+use rand::{rngs::OsRng, RngCore};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Legacy v1 transaction output (BROKEN stealth derivation — see module docs).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxOutput {
+    pub amount: u64,
+    pub recipient_view_key: [u8; 32],
+    pub recipient_spend_key: [u8; 32],
+    pub output_public_key: [u8; 32],
+}
+
+impl TxOutput {
+    /// Create a new output for a recipient (legacy, cryptographically broken).
+    ///
+    /// The `output_public_key` is a SHA256 hash, not a Ristretto DH key, so the
+    /// recipient can never detect it. Retained only for format archaeology.
+    pub fn new(amount: u64, recipient: &PublicAddress) -> Self {
+        let view_key = recipient.view_public_key().to_bytes();
+        let spend_key = recipient.spend_public_key().to_bytes();
+
+        let mut random_bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut random_bytes);
+
+        let mut hasher = Sha256::new();
+        hasher.update(view_key);
+        hasher.update(spend_key);
+        hasher.update(amount.to_le_bytes());
+        hasher.update(random_bytes);
+        let output_key: [u8; 32] = hasher.finalize().into();
+
+        Self {
+            amount,
+            recipient_view_key: view_key,
+            recipient_spend_key: spend_key,
+            output_public_key: output_key,
+        }
+    }
+}
+
+/// Legacy v1 transaction input (flat UTXO reference + Schnorrkel signature).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxInput {
+    pub tx_hash: [u8; 32],
+    pub output_index: u32,
+    pub signature: Vec<u8>,
+}
+
+/// Legacy v1 transaction (flat, non-private — see module docs).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Transaction {
+    pub version: u32,
+    pub inputs: Vec<TxInput>,
+    pub outputs: Vec<TxOutput>,
+    pub fee: u64,
+    pub created_at_height: u64,
+}
+
+impl Transaction {
+    /// Create a new unsigned legacy transaction.
+    pub fn new(
+        inputs: Vec<TxInput>,
+        outputs: Vec<TxOutput>,
+        fee: u64,
+        created_at_height: u64,
+    ) -> Self {
+        Self {
+            version: 1,
+            inputs,
+            outputs,
+            fee,
+            created_at_height,
+        }
+    }
+
+    /// Compute the legacy signing hash (message to be signed).
+    pub fn signing_hash(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(b"botho-tx-v1");
+        hasher.update(self.version.to_le_bytes());
+
+        for input in &self.inputs {
+            hasher.update(input.tx_hash);
+            hasher.update(input.output_index.to_le_bytes());
+        }
+
+        for output in &self.outputs {
+            hasher.update(output.amount.to_le_bytes());
+            hasher.update(output.recipient_view_key);
+            hasher.update(output.recipient_spend_key);
+            hasher.update(output.output_public_key);
+        }
+
+        hasher.update(self.fee.to_le_bytes());
+        hasher.update(self.created_at_height.to_le_bytes());
+        hasher.finalize().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_legacy_signing_hash_ignores_signature() {
+        let tx1 = Transaction::new(
+            vec![TxInput {
+                tx_hash: [1u8; 32],
+                output_index: 0,
+                signature: vec![0u8; 64],
+            }],
+            vec![TxOutput {
+                amount: 1000,
+                recipient_view_key: [2u8; 32],
+                recipient_spend_key: [3u8; 32],
+                output_public_key: [4u8; 32],
+            }],
+            100,
+            1,
+        );
+
+        let tx2 = Transaction::new(
+            vec![TxInput {
+                tx_hash: [1u8; 32],
+                output_index: 0,
+                signature: vec![0xff; 64], // Different signature
+            }],
+            vec![TxOutput {
+                amount: 1000,
+                recipient_view_key: [2u8; 32],
+                recipient_spend_key: [3u8; 32],
+                output_public_key: [4u8; 32],
+            }],
+            100,
+            1,
+        );
+
+        // Signing hash is independent of signature content.
+        assert_eq!(tx1.signing_hash(), tx2.signing_hash());
+    }
+}

--- a/botho-wallet/tests/integration_tests.rs
+++ b/botho-wallet/tests/integration_tests.rs
@@ -10,17 +10,61 @@
 use botho_wallet::{
     discovery::NodeDiscovery,
     keys::{validate_mnemonic, WalletKeys},
+    rpc_pool::RpcPool,
     storage::EncryptedWallet,
     transaction::{
-        format_amount, parse_amount, OwnedUtxo, Transaction, TransactionBuilder, TxInput, TxOutput,
-        MIN_FEE, PICOCREDITS_PER_CAD,
+        format_amount, parse_amount, to_tx_hex, OwnedUtxo, TransactionBuilder, MIN_TX_FEE,
+        PICOCREDITS_PER_CAD,
     },
+};
+
+// The real transaction format now comes from the shared clsag crate (the same
+// type the node accepts). The wallet's flat `botho-tx-v1` types were
+// quarantined in `transaction_legacy.rs` — see issue #614.
+use bth_transaction_clsag::{
+    RingMember, Transaction as ClsagTransaction, TxOutput as ClsagTxOutput, MIN_RING_SIZE,
 };
 use tempfile::TempDir;
 
 // Standard BIP39 test vector (24 words)
 const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+// A distinct valid 24-word phrase for recipient/decoy fixtures.
+const RECIPIENT_MNEMONIC: &str = "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title";
 const TEST_PASSWORD: &str = "secure-test-password-123!";
+
+/// Build a UTXO genuinely owned by `keys` (a real stealth output whose spend
+/// key the wallet can recover), suitable for CLSAG signing.
+fn owned_utxo(keys: &WalletKeys, amount: u64, created_at: u64, seed: u8) -> OwnedUtxo {
+    let out = ClsagTxOutput::new(amount, &keys.public_address());
+    OwnedUtxo {
+        tx_hash: [seed; 32],
+        output_index: 0,
+        amount,
+        created_at,
+        target_key: out.target_key,
+        public_key: out.public_key,
+        subaddress_index: 0,
+        cluster_tags: None,
+    }
+}
+
+/// A ring of `n` valid decoy members (real stealth outputs to a distinct
+/// wallet).
+fn fixture_decoys(n: usize) -> Vec<RingMember> {
+    let decoy_keys = WalletKeys::from_mnemonic(RECIPIENT_MNEMONIC).unwrap();
+    (0..n)
+        .map(|i| {
+            let out = ClsagTxOutput::new(1_000 + i as u64, &decoy_keys.public_address());
+            RingMember::from_output(&out)
+        })
+        .collect()
+}
+
+/// A disconnected RPC pool. Error-path builder tests reach their error before
+/// any RPC call, so the pool is never dialed.
+fn disconnected_rpc() -> RpcPool {
+    RpcPool::new(NodeDiscovery::new())
+}
 
 // ============================================================================
 // Wallet Lifecycle Tests
@@ -161,170 +205,135 @@ mod wallet_lifecycle {
 mod transaction_building {
     use super::*;
 
-    fn create_test_utxos() -> Vec<OwnedUtxo> {
-        vec![
-            OwnedUtxo {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                amount: 10 * PICOCREDITS_PER_CAD, // 10 CAD
-                created_at: 100,
-                target_key: [0u8; 32],
-                public_key: [0u8; 32],
-                subaddress_index: 0,
-                cluster_tags: None,
-            },
-            OwnedUtxo {
-                tx_hash: [2u8; 32],
-                output_index: 0,
-                amount: 5 * PICOCREDITS_PER_CAD, // 5 CAD
-                created_at: 101,
-                target_key: [0u8; 32],
-                public_key: [0u8; 32],
-                subaddress_index: 0,
-                cluster_tags: None,
-            },
-            OwnedUtxo {
-                tx_hash: [3u8; 32],
-                output_index: 1,
-                amount: 1 * PICOCREDITS_PER_CAD, // 1 CAD
-                created_at: 102,
-                target_key: [0u8; 32],
-                public_key: [0u8; 32],
-                subaddress_index: 0,
-                cluster_tags: None,
-            },
-        ]
-    }
+    // These drive the real CLSAG assembly via `build_signed_transaction` with
+    // fixture decoy rings (the RPC decoy fetch is bypassed so the tests are
+    // deterministic and node-free). Each fixture UTXO is a genuine stealth
+    // output the wallet can spend.
 
     #[test]
-    fn test_build_simple_transaction() {
+    fn test_build_clsag_transaction_verifies() {
         let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
-        let utxos = create_test_utxos();
-        let builder = TransactionBuilder::new(keys.clone(), utxos, 150);
+        let recipient = WalletKeys::from_mnemonic(RECIPIENT_MNEMONIC)
+            .unwrap()
+            .public_address();
 
-        // Build transaction: send 3 CAD
-        let recipient = keys.public_address(); // Send to self for testing
-        let amount = 3 * PICOCREDITS_PER_CAD;
-        let fee = MIN_FEE;
+        let input_amount = 10 * PICOCREDITS_PER_CAD;
+        let utxo = owned_utxo(&keys, input_amount, 50, 1);
+        let builder = TransactionBuilder::new(keys.clone(), vec![utxo.clone()], 150);
 
-        let tx = builder.build_transfer(&recipient, amount, fee).unwrap();
+        let tx = builder
+            .build_signed_transaction(
+                &recipient,
+                3 * PICOCREDITS_PER_CAD,
+                MIN_TX_FEE,
+                vec![utxo],
+                input_amount,
+                vec![fixture_decoys(MIN_RING_SIZE - 1)],
+            )
+            .unwrap()
+            .transaction;
 
-        // Verify transaction structure
-        assert_eq!(tx.version, 1);
-        assert!(!tx.inputs.is_empty());
-        assert!(!tx.outputs.is_empty());
-        assert_eq!(tx.fee, fee);
+        assert_eq!(tx.inputs.len(), 1);
+        assert_eq!(tx.inputs.clsag()[0].ring.len(), MIN_RING_SIZE);
+        assert_eq!(tx.fee, MIN_TX_FEE);
         assert_eq!(tx.created_at_height, 150);
-
-        // Verify all inputs are signed
-        for input in &tx.inputs {
-            assert!(!input.signature.is_empty());
-            assert_eq!(input.signature.len(), 64); // Schnorrkel signature
-        }
+        assert!(tx.is_valid_structure().is_ok());
+        assert!(tx.verify_ring_signatures().is_ok());
     }
 
     #[test]
     fn test_transaction_with_change() {
         let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
-        let utxos = vec![OwnedUtxo {
-            tx_hash: [1u8; 32],
-            output_index: 0,
-            amount: 10 * PICOCREDITS_PER_CAD,
-            created_at: 100,
-            target_key: [0u8; 32],
-            public_key: [0u8; 32],
-            subaddress_index: 0,
-            cluster_tags: None,
-        }];
+        let recipient = WalletKeys::from_mnemonic(RECIPIENT_MNEMONIC)
+            .unwrap()
+            .public_address();
 
-        let builder = TransactionBuilder::new(keys.clone(), utxos, 150);
+        let input_amount = 10 * PICOCREDITS_PER_CAD;
+        let utxo = owned_utxo(&keys, input_amount, 50, 1);
+        let builder = TransactionBuilder::new(keys.clone(), vec![utxo.clone()], 150);
 
-        // Send 3 CAD with 10 CAD UTXO - should have change
         let tx = builder
-            .build_transfer(&keys.public_address(), 3 * PICOCREDITS_PER_CAD, MIN_FEE)
-            .unwrap();
+            .build_signed_transaction(
+                &recipient,
+                3 * PICOCREDITS_PER_CAD,
+                MIN_TX_FEE,
+                vec![utxo],
+                input_amount,
+                vec![fixture_decoys(MIN_RING_SIZE - 1)],
+            )
+            .unwrap()
+            .transaction;
 
-        // Should have 2 outputs: recipient + change
+        // Recipient + change.
         assert_eq!(tx.outputs.len(), 2);
-
-        // Verify amounts
         let total_output: u64 = tx.outputs.iter().map(|o| o.amount).sum();
-        assert_eq!(total_output + tx.fee, 10 * PICOCREDITS_PER_CAD);
+        assert_eq!(total_output + tx.fee, input_amount);
+        assert!(tx.verify_ring_signatures().is_ok());
     }
 
     #[test]
     fn test_transaction_exact_amount_no_change() {
         let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
+        let recipient = WalletKeys::from_mnemonic(RECIPIENT_MNEMONIC)
+            .unwrap()
+            .public_address();
+
         let exact_amount = PICOCREDITS_PER_CAD; // 1 CAD
-        let fee = MIN_FEE;
-
-        let utxos = vec![OwnedUtxo {
-            tx_hash: [1u8; 32],
-            output_index: 0,
-            amount: exact_amount + fee,
-            created_at: 100,
-            target_key: [0u8; 32],
-            public_key: [0u8; 32],
-            subaddress_index: 0,
-            cluster_tags: None,
-        }];
-
-        let builder = TransactionBuilder::new(keys.clone(), utxos, 150);
+        let fee = MIN_TX_FEE;
+        let input_amount = exact_amount + fee;
+        let utxo = owned_utxo(&keys, input_amount, 50, 1);
+        let builder = TransactionBuilder::new(keys.clone(), vec![utxo.clone()], 150);
 
         let tx = builder
-            .build_transfer(&keys.public_address(), exact_amount, fee)
-            .unwrap();
+            .build_signed_transaction(
+                &recipient,
+                exact_amount,
+                fee,
+                vec![utxo],
+                input_amount,
+                vec![fixture_decoys(MIN_RING_SIZE - 1)],
+            )
+            .unwrap()
+            .transaction;
 
-        // Should have only 1 output (no change because it's dust)
+        // No change output (would be zero / dust).
         assert_eq!(tx.outputs.len(), 1);
         assert_eq!(tx.outputs[0].amount, exact_amount);
+        assert!(tx.verify_ring_signatures().is_ok());
     }
 
     #[test]
-    fn test_transaction_signing_deterministic() {
+    fn test_transaction_serialization_roundtrips_through_node_type() {
         let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
-        let utxos = create_test_utxos();
+        let recipient = WalletKeys::from_mnemonic(RECIPIENT_MNEMONIC)
+            .unwrap()
+            .public_address();
 
-        let builder1 = TransactionBuilder::new(keys.clone(), utxos.clone(), 150);
-        let builder2 = TransactionBuilder::new(keys.clone(), utxos, 150);
-
-        let tx1 = builder1
-            .build_transfer(&keys.public_address(), PICOCREDITS_PER_CAD, MIN_FEE)
-            .unwrap();
-        let tx2 = builder2
-            .build_transfer(&keys.public_address(), PICOCREDITS_PER_CAD, MIN_FEE)
-            .unwrap();
-
-        // Signing hash should be based on transaction content, not random
-        // Note: Outputs have random components, so hashes may differ
-        // But structure should be the same
-        assert_eq!(tx1.inputs.len(), tx2.inputs.len());
-        assert_eq!(tx1.fee, tx2.fee);
-    }
-
-    #[test]
-    fn test_transaction_serialization() {
-        let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
-        let utxos = create_test_utxos();
-        let builder = TransactionBuilder::new(keys.clone(), utxos, 150);
+        let input_amount = 5 * PICOCREDITS_PER_CAD;
+        let utxo = owned_utxo(&keys, input_amount, 50, 1);
+        let builder = TransactionBuilder::new(keys.clone(), vec![utxo.clone()], 150);
 
         let tx = builder
-            .build_transfer(&keys.public_address(), PICOCREDITS_PER_CAD, MIN_FEE)
-            .unwrap();
+            .build_signed_transaction(
+                &recipient,
+                PICOCREDITS_PER_CAD,
+                MIN_TX_FEE,
+                vec![utxo],
+                input_amount,
+                vec![fixture_decoys(MIN_RING_SIZE - 1)],
+            )
+            .unwrap()
+            .transaction;
 
-        // Serialize to hex
-        let hex = tx.to_hex();
-        assert!(!hex.is_empty());
-
-        // Should be valid hex
+        // Hex-encode the way `tx_submit` expects, then decode as the node's
+        // transaction type and re-verify.
+        let hex = to_tx_hex(&tx).unwrap();
         let bytes = hex::decode(&hex).unwrap();
-        assert!(!bytes.is_empty());
-
-        // Should be deserializable
-        let deserialized: Transaction = bincode::deserialize(&bytes).unwrap();
-        assert_eq!(deserialized.version, tx.version);
-        assert_eq!(deserialized.fee, tx.fee);
-        assert_eq!(deserialized.inputs.len(), tx.inputs.len());
+        let decoded: ClsagTransaction = bincode::deserialize(&bytes).unwrap();
+        assert_eq!(decoded.fee, tx.fee);
+        assert_eq!(decoded.inputs.len(), tx.inputs.len());
+        assert_eq!(decoded.outputs.len(), tx.outputs.len());
+        assert!(decoded.verify_ring_signatures().is_ok());
     }
 }
 
@@ -335,61 +344,64 @@ mod transaction_building {
 mod utxo_selection {
     use super::*;
 
-    #[test]
-    fn test_insufficient_funds() {
+    // Error-path builder tests: each returns before any RPC decoy fetch, so a
+    // disconnected pool is never dialed.
+
+    #[tokio::test]
+    async fn test_insufficient_funds() {
         let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
-        let utxos = vec![OwnedUtxo {
-            tx_hash: [1u8; 32],
-            output_index: 0,
-            amount: PICOCREDITS_PER_CAD, // Only 1 CAD
-            created_at: 100,
-            target_key: [0u8; 32],
-            public_key: [0u8; 32],
-            subaddress_index: 0,
-            cluster_tags: None,
-        }];
+        let utxos = vec![owned_utxo(&keys, PICOCREDITS_PER_CAD, 100, 1)]; // Only 1 CAD
 
         let builder = TransactionBuilder::new(keys.clone(), utxos, 150);
+        let mut rpc = disconnected_rpc();
 
-        // Try to send 10 CAD - should fail
-        let result =
-            builder.build_transfer(&keys.public_address(), 10 * PICOCREDITS_PER_CAD, MIN_FEE);
+        // Try to send 10 CAD - should fail during selection (pre-RPC).
+        let result = builder
+            .build_transfer(
+                &mut rpc,
+                &keys.public_address(),
+                10 * PICOCREDITS_PER_CAD,
+                MIN_TX_FEE,
+            )
+            .await;
 
         assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("Insufficient funds"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Insufficient funds"));
     }
 
-    #[test]
-    fn test_no_utxos_available() {
+    #[tokio::test]
+    async fn test_no_utxos_available() {
         let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
-        let utxos: Vec<OwnedUtxo> = vec![];
+        let builder = TransactionBuilder::new(keys.clone(), vec![], 150);
+        let mut rpc = disconnected_rpc();
 
-        let builder = TransactionBuilder::new(keys.clone(), utxos, 150);
-
-        let result = builder.build_transfer(&keys.public_address(), PICOCREDITS_PER_CAD, MIN_FEE);
+        let result = builder
+            .build_transfer(
+                &mut rpc,
+                &keys.public_address(),
+                PICOCREDITS_PER_CAD,
+                MIN_TX_FEE,
+            )
+            .await;
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("No UTXOs"));
     }
 
-    #[test]
-    fn test_zero_amount_rejected() {
+    #[tokio::test]
+    async fn test_zero_amount_rejected() {
         let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
-        let utxos = vec![OwnedUtxo {
-            tx_hash: [1u8; 32],
-            output_index: 0,
-            amount: PICOCREDITS_PER_CAD,
-            created_at: 100,
-            target_key: [0u8; 32],
-            public_key: [0u8; 32],
-            subaddress_index: 0,
-            cluster_tags: None,
-        }];
+        let utxos = vec![owned_utxo(&keys, PICOCREDITS_PER_CAD, 100, 1)];
 
         let builder = TransactionBuilder::new(keys.clone(), utxos, 150);
+        let mut rpc = disconnected_rpc();
 
-        let result = builder.build_transfer(&keys.public_address(), 0, MIN_FEE);
+        let result = builder
+            .build_transfer(&mut rpc, &keys.public_address(), 0, MIN_TX_FEE)
+            .await;
 
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("greater than 0"));
@@ -399,50 +411,20 @@ mod utxo_selection {
     fn test_largest_first_selection() {
         let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
 
-        // Create UTXOs of varying sizes
+        // UTXOs of varying sizes (distinct tx_hash seeds).
         let utxos = vec![
-            OwnedUtxo {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                amount: 1 * PICOCREDITS_PER_CAD, // 1 CAD - smallest
-                created_at: 100,
-                target_key: [0u8; 32],
-                public_key: [0u8; 32],
-                subaddress_index: 0,
-                cluster_tags: None,
-            },
-            OwnedUtxo {
-                tx_hash: [2u8; 32],
-                output_index: 0,
-                amount: 5 * PICOCREDITS_PER_CAD, // 5 CAD - largest
-                created_at: 101,
-                target_key: [0u8; 32],
-                public_key: [0u8; 32],
-                subaddress_index: 0,
-                cluster_tags: None,
-            },
-            OwnedUtxo {
-                tx_hash: [3u8; 32],
-                output_index: 0,
-                amount: 2 * PICOCREDITS_PER_CAD, // 2 CAD - medium
-                created_at: 102,
-                target_key: [0u8; 32],
-                public_key: [0u8; 32],
-                subaddress_index: 0,
-                cluster_tags: None,
-            },
+            owned_utxo(&keys, PICOCREDITS_PER_CAD, 100, 1), // 1 CAD - smallest
+            owned_utxo(&keys, 5 * PICOCREDITS_PER_CAD, 101, 2), // 5 CAD - largest
+            owned_utxo(&keys, 2 * PICOCREDITS_PER_CAD, 102, 3), // 2 CAD - medium
         ];
 
         let builder = TransactionBuilder::new(keys.clone(), utxos, 150);
 
-        // Request 4 CAD - should select the 5 CAD UTXO
-        let tx = builder
-            .build_transfer(&keys.public_address(), 4 * PICOCREDITS_PER_CAD, MIN_FEE)
-            .unwrap();
-
-        // Should only need 1 input (the 5 CAD UTXO)
-        assert_eq!(tx.inputs.len(), 1);
-        assert_eq!(tx.inputs[0].tx_hash, [2u8; 32]); // The 5 CAD UTXO
+        // Request 4 CAD - largest-first should select only the 5 CAD UTXO.
+        let (selected, total) = builder.select_inputs(4 * PICOCREDITS_PER_CAD).unwrap();
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].tx_hash, [2u8; 32]); // The 5 CAD UTXO
+        assert_eq!(total, 5 * PICOCREDITS_PER_CAD);
     }
 
     #[test]
@@ -474,13 +456,10 @@ mod utxo_selection {
 
         let builder = TransactionBuilder::new(keys.clone(), utxos, 150);
 
-        // Request 4 CAD - needs both UTXOs
-        let tx = builder
-            .build_transfer(&keys.public_address(), 4 * PICOCREDITS_PER_CAD, MIN_FEE)
-            .unwrap();
-
-        // Should need 2 inputs
-        assert_eq!(tx.inputs.len(), 2);
+        // Request 4 CAD - needs both UTXOs.
+        let (selected, total) = builder.select_inputs(4 * PICOCREDITS_PER_CAD).unwrap();
+        assert_eq!(selected.len(), 2);
+        assert_eq!(total, 5 * PICOCREDITS_PER_CAD);
     }
 
     #[test]
@@ -783,53 +762,40 @@ mod signing {
     }
 
     #[test]
-    fn test_transaction_inputs_all_signed() {
+    fn test_transaction_inputs_all_have_ring_signatures() {
         let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
+        let recipient = WalletKeys::from_mnemonic(RECIPIENT_MNEMONIC)
+            .unwrap()
+            .public_address();
 
-        let utxos = vec![
-            OwnedUtxo {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                amount: PICOCREDITS_PER_CAD,
-                created_at: 100,
-                target_key: [0u8; 32],
-                public_key: [0u8; 32],
-                subaddress_index: 0,
-                cluster_tags: None,
-            },
-            OwnedUtxo {
-                tx_hash: [2u8; 32],
-                output_index: 0,
-                amount: PICOCREDITS_PER_CAD,
-                created_at: 101,
-                target_key: [0u8; 32],
-                public_key: [0u8; 32],
-                subaddress_index: 0,
-                cluster_tags: None,
-            },
-            OwnedUtxo {
-                tx_hash: [3u8; 32],
-                output_index: 0,
-                amount: PICOCREDITS_PER_CAD,
-                created_at: 102,
-                target_key: [0u8; 32],
-                public_key: [0u8; 32],
-                subaddress_index: 0,
-                cluster_tags: None,
-            },
-        ];
-
-        let builder = TransactionBuilder::new(keys.clone(), utxos, 150);
+        // Two owned inputs of 1 CAD each; spend ~1 CAD + fee across both.
+        let u1 = owned_utxo(&keys, PICOCREDITS_PER_CAD, 100, 1);
+        let u2 = owned_utxo(&keys, PICOCREDITS_PER_CAD, 101, 2);
+        let total_selected = 2 * PICOCREDITS_PER_CAD;
+        let builder = TransactionBuilder::new(keys.clone(), vec![u1.clone(), u2.clone()], 150);
 
         let tx = builder
-            .build_transfer(&keys.public_address(), 2 * PICOCREDITS_PER_CAD, MIN_FEE)
-            .unwrap();
+            .build_signed_transaction(
+                &recipient,
+                PICOCREDITS_PER_CAD,
+                MIN_TX_FEE,
+                vec![u1, u2],
+                total_selected,
+                vec![
+                    fixture_decoys(MIN_RING_SIZE - 1),
+                    fixture_decoys(MIN_RING_SIZE - 1),
+                ],
+            )
+            .unwrap()
+            .transaction;
 
-        // Every input should have a valid signature
-        for input in &tx.inputs {
-            assert!(!input.signature.is_empty());
-            assert_eq!(input.signature.len(), 64);
+        // Every input carries a full CLSAG ring signature.
+        assert_eq!(tx.inputs.len(), 2);
+        for input in tx.inputs.clsag() {
+            assert_eq!(input.ring.len(), MIN_RING_SIZE);
+            assert!(!input.clsag_signature.is_empty());
         }
+        assert!(tx.verify_ring_signatures().is_ok());
     }
 }
 
@@ -840,140 +806,63 @@ mod signing {
 mod transaction_hash {
     use super::*;
 
+    // The CLSAG signing hash is computed over outputs + fee + height (never over
+    // signatures, which don't exist yet at signing time). Build outputs directly
+    // from the clsag TxOutput type.
+    fn clsag_output(amount: u64, target: [u8; 32], public: [u8; 32]) -> ClsagTxOutput {
+        ClsagTxOutput {
+            amount,
+            target_key: target,
+            public_key: public,
+            e_memo: None,
+            cluster_tags: Default::default(),
+        }
+    }
+
     #[test]
-    fn test_signing_hash_excludes_signatures() {
-        let tx1 = Transaction::new(
-            vec![TxInput {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                signature: vec![0u8; 64],
-            }],
-            vec![TxOutput {
-                amount: 1000,
-                recipient_view_key: [2u8; 32],
-                recipient_spend_key: [3u8; 32],
-                output_public_key: [4u8; 32],
-            }],
-            100,
-            1,
-        );
-
-        let tx2 = Transaction::new(
-            vec![TxInput {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                signature: vec![0xff; 64], // Different signature
-            }],
-            vec![TxOutput {
-                amount: 1000,
-                recipient_view_key: [2u8; 32],
-                recipient_spend_key: [3u8; 32],
-                output_public_key: [4u8; 32],
-            }],
-            100,
-            1,
-        );
-
-        // Signing hash should be the same
+    fn test_signing_hash_deterministic_over_content() {
+        let outputs = vec![clsag_output(1000, [2u8; 32], [3u8; 32])];
+        let tx1 = ClsagTransaction::new_clsag(Vec::new(), outputs.clone(), 100, 1);
+        let tx2 = ClsagTransaction::new_clsag(Vec::new(), outputs, 100, 1);
+        // Same content -> same signing hash (and it does not depend on any
+        // input signatures, which are absent here by construction).
         assert_eq!(tx1.signing_hash(), tx2.signing_hash());
     }
 
     #[test]
     fn test_signing_hash_changes_with_amount() {
-        let tx1 = Transaction::new(
-            vec![TxInput {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                signature: vec![],
-            }],
-            vec![TxOutput {
-                amount: 1000,
-                recipient_view_key: [2u8; 32],
-                recipient_spend_key: [3u8; 32],
-                output_public_key: [4u8; 32],
-            }],
+        let tx1 = ClsagTransaction::new_clsag(
+            Vec::new(),
+            vec![clsag_output(1000, [2u8; 32], [3u8; 32])],
             100,
             1,
         );
-
-        let tx2 = Transaction::new(
-            vec![TxInput {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                signature: vec![],
-            }],
-            vec![TxOutput {
-                amount: 2000, // Different amount
-                recipient_view_key: [2u8; 32],
-                recipient_spend_key: [3u8; 32],
-                output_public_key: [4u8; 32],
-            }],
+        let tx2 = ClsagTransaction::new_clsag(
+            Vec::new(),
+            vec![clsag_output(2000, [2u8; 32], [3u8; 32])],
             100,
             1,
         );
-
         assert_ne!(tx1.signing_hash(), tx2.signing_hash());
     }
 
     #[test]
     fn test_signing_hash_changes_with_fee() {
-        let tx1 = Transaction::new(
-            vec![TxInput {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                signature: vec![],
-            }],
-            vec![TxOutput {
-                amount: 1000,
-                recipient_view_key: [2u8; 32],
-                recipient_spend_key: [3u8; 32],
-                output_public_key: [4u8; 32],
-            }],
-            100,
-            1,
-        );
-
-        let tx2 = Transaction::new(
-            vec![TxInput {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                signature: vec![],
-            }],
-            vec![TxOutput {
-                amount: 1000,
-                recipient_view_key: [2u8; 32],
-                recipient_spend_key: [3u8; 32],
-                output_public_key: [4u8; 32],
-            }],
-            200, // Different fee
-            1,
-        );
-
+        let outputs = vec![clsag_output(1000, [2u8; 32], [3u8; 32])];
+        let tx1 = ClsagTransaction::new_clsag(Vec::new(), outputs.clone(), 100, 1);
+        let tx2 = ClsagTransaction::new_clsag(Vec::new(), outputs, 200, 1);
         assert_ne!(tx1.signing_hash(), tx2.signing_hash());
     }
 
     #[test]
     fn test_hash_is_deterministic() {
-        let tx = Transaction::new(
-            vec![TxInput {
-                tx_hash: [1u8; 32],
-                output_index: 0,
-                signature: vec![0u8; 64],
-            }],
-            vec![TxOutput {
-                amount: 1000,
-                recipient_view_key: [2u8; 32],
-                recipient_spend_key: [3u8; 32],
-                output_public_key: [4u8; 32],
-            }],
+        let tx = ClsagTransaction::new_clsag(
+            Vec::new(),
+            vec![clsag_output(1000, [2u8; 32], [3u8; 32])],
             100,
             1,
         );
-
-        let hash1 = tx.signing_hash();
-        let hash2 = tx.signing_hash();
-
-        assert_eq!(hash1, hash2);
+        assert_eq!(tx.signing_hash(), tx.signing_hash());
     }
 }
 
@@ -1164,36 +1053,39 @@ mod decoy_selection {
         wealth
     }
 
+    /// Build `n` in-band decoy candidates for a real input of the given age.
+    /// Ages are spread evenly across the ±10% band [900, 1100] (real age 1000).
+    fn in_band_pool(n: usize, attribution_pct: u32) -> Vec<UtxoCandidate> {
+        // Real age 1000 -> band [900, 1100].
+        let (min_age, max_age) = (900u64, 1100u64);
+        (0..n)
+            .map(|i| {
+                let age = min_age + (i as u64 % (max_age - min_age + 1));
+                create_utxo((i + 1) as u8, CURRENT_BLOCK - age, attribution_pct)
+            })
+            .collect()
+    }
+
     #[test]
     fn test_decoy_selection_integration() {
-        // Create a realistic UTXO pool with varying ages and attributions
-        let real_utxo = create_utxo(0, 5_000, 25); // Age: 5000 blocks, 25% attribution
-
-        let mut pool = Vec::new();
-        // Add UTXOs with similar characteristics (good decoys)
-        for i in 1..=20 {
-            let created_at = 4_500 + (i as u64 * 100); // Ages: 5500 to 3500
-            let attribution = 20 + (i % 10); // 20-29% attribution
-            pool.push(create_utxo(i, created_at, attribution as u32));
-        }
+        // Real input age 1000 -> ±10% band [900, 1100].
+        let real_utxo = create_utxo(0, 9_000, 25);
+        let pool = in_band_pool(25, 25);
 
         let cluster_wealth = create_cluster_wealth();
-        let config = DecoySelectionConfig::default(); // Ring size 11
+        let config = DecoySelectionConfig::default(); // Ring size 20
 
-        let result = select_decoys(
+        let decoys = select_decoys(
             &real_utxo,
             &pool,
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
             &config,
-        );
+        )
+        .expect("selection should succeed");
+        assert_eq!(decoys.len(), 19, "Should select 19 decoys for ring size 20");
 
-        assert!(result.is_ok(), "Should succeed: {:?}", result);
-        let decoys = result.unwrap();
-        assert_eq!(decoys.len(), 10, "Should select 10 decoys for ring size 11");
-
-        // Validate all selected decoys meet constraints
         let violations = validate_decoys(
             &real_utxo,
             &decoys,
@@ -1211,47 +1103,31 @@ mod decoy_selection {
 
     #[test]
     fn test_decoy_selection_prevents_fee_inflation_attack() {
-        // Scenario: Malicious node tries to select high-factor decoys
-        // to inflate the user's fees
-
-        let real_utxo = create_utxo(0, 5_000, 10); // Low attribution (10%)
+        // A malicious pool offers high-factor decoys to inflate the user's fee;
+        // the factor ceiling must exclude them.
+        let real_utxo = create_utxo(0, 9_000, 10); // Low attribution (10%)
         let cluster_wealth = create_cluster_wealth();
 
-        // Pool contains both low-factor and high-factor UTXOs
-        let mut pool = Vec::new();
-
-        // Some legitimate low-factor decoys
-        for i in 1..=5 {
-            pool.push(create_utxo(i, 5_000 + i as u64 * 50, 15)); // ~15%
+        // 19 legitimate low-factor in-band decoys + several high-factor ones.
+        let mut pool = in_band_pool(19, 15);
+        for i in 20..=28 {
+            pool.push(create_utxo(i, CURRENT_BLOCK - 1000, 100)); // 100% attribution
         }
 
-        // High-factor "attack" decoys
-        for i in 6..=15 {
-            pool.push(create_utxo(i, 5_000 + i as u64 * 50, 100)); // 100%
-        }
-
-        let config = DecoySelectionConfig {
-            ring_size: 6, // Need 5 decoys
-            max_age_ratio: 2.0,
-            max_factor_ratio: 1.5, // Key constraint!
-        };
-
-        let result = select_decoys(
+        let config = DecoySelectionConfig::default(); // ring 20, factor ceiling 1.5
+        let decoys = select_decoys(
             &real_utxo,
             &pool,
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
             &config,
-        );
+        )
+        .expect("selection should succeed");
 
-        assert!(result.is_ok());
-        let decoys = result.unwrap();
-
-        // Verify NO high-factor decoys were selected
+        let real_factor = real_utxo.cluster_factor_global(&cluster_wealth, TOTAL_SUPPLY);
         for decoy in &decoys {
             let factor = decoy.cluster_factor_global(&cluster_wealth, TOTAL_SUPPLY);
-            let real_factor = real_utxo.cluster_factor_global(&cluster_wealth, TOTAL_SUPPLY);
             assert!(
                 factor <= real_factor * config.max_factor_ratio,
                 "High-factor decoy should be excluded: factor {} > max {}",
@@ -1263,28 +1139,42 @@ mod decoy_selection {
 
     #[test]
     fn test_decoy_selection_enforces_age_similarity() {
-        let real_utxo = create_utxo(0, 9_000, 0); // Age: 1000 blocks
+        // Real age 1000 -> band [900, 1100].
+        let real_utxo = create_utxo(0, 9_000, 0);
         let cluster_wealth = create_cluster_wealth();
 
-        // Pool with various ages
-        let pool = vec![
-            create_utxo(1, 9_800, 0),  // Age: 200 - too young
-            create_utxo(2, 9_600, 0),  // Age: 400 - too young
-            create_utxo(3, 8_500, 0),  // Age: 1500 - valid
-            create_utxo(4, 8_000, 0),  // Age: 2000 - at limit
-            create_utxo(5, 7_000, 0),  // Age: 3000 - too old
-            create_utxo(6, 6_000, 0),  // Age: 4000 - too old
-            create_utxo(7, 8_800, 0),  // Age: 1200 - valid
-            create_utxo(8, 8_600, 0),  // Age: 1400 - valid
-            create_utxo(9, 8_300, 0),  // Age: 1700 - valid
-            create_utxo(10, 9_400, 0), // Age: 600 - valid (min age ~500)
-        ];
+        let mut pool = in_band_pool(19, 0);
+        // Out-of-band candidates that must never be selected.
+        pool.push(create_utxo(200, 9_800, 0)); // age 200 - too young
+        pool.push(create_utxo(201, 7_000, 0)); // age 3000 - too old
 
-        let config = DecoySelectionConfig {
-            ring_size: 5, // Need 4 decoys
-            max_age_ratio: 2.0,
-            max_factor_ratio: 10.0, // Relaxed for this test
-        };
+        let config = DecoySelectionConfig::default();
+        let decoys = select_decoys(
+            &real_utxo,
+            &pool,
+            CURRENT_BLOCK,
+            &cluster_wealth,
+            TOTAL_SUPPLY,
+            &config,
+        )
+        .expect("selection should succeed");
+
+        for decoy in &decoys {
+            let age = decoy.age(CURRENT_BLOCK);
+            assert!(
+                (900..=1100).contains(&age),
+                "Decoy age {} outside ±10% band",
+                age
+            );
+        }
+    }
+
+    #[test]
+    fn test_decoy_selection_rejects_young_input() {
+        // A real input younger than the confirmation floor must fail cleanly.
+        let real_utxo = create_utxo(0, CURRENT_BLOCK - 5, 0); // age 5 < 10
+        let cluster_wealth = create_cluster_wealth();
+        let pool = in_band_pool(25, 0);
 
         let result = select_decoys(
             &real_utxo,
@@ -1292,49 +1182,26 @@ mod decoy_selection {
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
-            &config,
+            &DecoySelectionConfig::default(),
         );
-
-        assert!(result.is_ok());
-        let decoys = result.unwrap();
-
-        // Verify all decoys are within age bounds
-        let real_age = 1000u64;
-        let min_age = (real_age as f64 / 2.0).ceil() as u64;
-        let max_age = (real_age as f64 * 2.0).floor() as u64;
-
-        for decoy in &decoys {
-            let age = decoy.age(CURRENT_BLOCK);
-            assert!(
-                age >= min_age && age <= max_age,
-                "Decoy age {} outside bounds [{}, {}]",
-                age,
-                min_age,
-                max_age
-            );
-        }
+        assert!(matches!(
+            result,
+            Err(DecoySelectionError::InvalidRealUtxo(_))
+        ));
     }
 
     #[test]
-    fn test_decoy_selection_fallback_relaxes_constraints() {
-        let real_utxo = create_utxo(0, 9_000, 0); // Age: 1000 blocks
-        let cluster_wealth = create_cluster_wealth();
+    fn test_decoy_selection_fallback_relaxes_factor() {
+        // Only high-factor in-band decoys exist; the strict factor ceiling
+        // fails, but the fallback relaxes the ceiling (never the age band).
+        let real_utxo = create_utxo(0, 9_000, 0); // anonymous, factor ~1.0
+        let mut cluster_wealth = HashMap::new();
+        cluster_wealth.insert(ClusterId::new(1), 5_000_000_000_000); // 50% of supply
 
-        // Pool with UTXOs outside strict bounds but within fallback bounds
-        let mut pool = Vec::new();
-        for i in 1..=15 {
-            // Ages around 300-400 (below strict min of 500, but within relaxed 333)
-            pool.push(create_utxo(i, 9_650 + i as u64 * 5, 0));
-        }
+        let pool = in_band_pool(25, 100); // all 100%-attribution (high factor)
 
-        let config = DecoySelectionConfig {
-            ring_size: 5,
-            max_age_ratio: 2.0, // Strict bounds
-            max_factor_ratio: 1.5,
-        };
-
-        // Strict selection should fail
-        let strict_result = select_decoys(
+        let config = DecoySelectionConfig::default();
+        let strict = select_decoys(
             &real_utxo,
             &pool,
             CURRENT_BLOCK,
@@ -1343,52 +1210,42 @@ mod decoy_selection {
             &config,
         );
         assert!(
-            matches!(
-                strict_result,
-                Err(DecoySelectionError::InsufficientDecoys { .. })
-            ),
-            "Strict selection should fail"
+            matches!(strict, Err(DecoySelectionError::InsufficientDecoys { .. })),
+            "Strict factor ceiling should exclude all high-factor decoys"
         );
 
-        // Fallback should succeed with relaxed constraints
-        let fallback_result = select_decoys_with_fallback(
+        let (decoys, was_relaxed) = select_decoys_with_fallback(
             &real_utxo,
             &pool,
             CURRENT_BLOCK,
             &cluster_wealth,
             TOTAL_SUPPLY,
             &config,
+        )
+        .expect("fallback should succeed");
+        assert!(
+            was_relaxed,
+            "Should indicate the factor ceiling was relaxed"
         );
-
-        assert!(fallback_result.is_ok(), "Fallback should succeed");
-        let (decoys, was_relaxed) = fallback_result.unwrap();
-        assert!(was_relaxed, "Should indicate constraints were relaxed");
-        assert_eq!(decoys.len(), 4, "Should still select required decoys");
+        assert_eq!(decoys.len(), 19, "Should still select required decoys");
     }
 
     #[test]
     fn test_validate_decoys_detects_violations() {
-        let real_utxo = create_utxo(0, 9_000, 10); // Age: 1000, 10% attribution
+        // Real age 1000 -> band [900, 1100].
+        let real_utxo = create_utxo(0, 9_000, 10);
 
-        // Use cluster wealth where cluster 1 is wealthy (50% of supply)
-        // This makes 100% attribution to cluster 1 produce a high factor
         let mut cluster_wealth = HashMap::new();
         cluster_wealth.insert(ClusterId::new(1), 5_000_000_000_000); // 50% of supply
 
-        // Create decoys with violations
         let decoys = vec![
             create_utxo(1, 9_900, 10),  // Age: 100 - TOO YOUNG
-            create_utxo(2, 8_500, 10),  // Age: 1500 - valid
+            create_utxo(2, 9_000, 10),  // Age: 1000 - valid
             create_utxo(3, 5_000, 10),  // Age: 5000 - TOO OLD
-            create_utxo(4, 8_700, 100), // Age: 1300, 100% attribution - FACTOR TOO HIGH
+            create_utxo(4, 9_000, 100), // Age: 1000, 100% attribution - FACTOR TOO HIGH
         ];
 
-        let config = DecoySelectionConfig {
-            ring_size: 5,
-            max_age_ratio: 2.0,
-            max_factor_ratio: 1.5,
-        };
-
+        let config = DecoySelectionConfig::default();
         let violations = validate_decoys(
             &real_utxo,
             &decoys,
@@ -1398,15 +1255,12 @@ mod decoy_selection {
             &config,
         );
 
-        // Should detect 3 violations (too young, too old, high factor)
         assert_eq!(
             violations.len(),
             3,
             "Should detect 3 violations: {:?}",
             violations
         );
-
-        // Verify specific violations
         assert!(
             violations
                 .iter()
@@ -1424,69 +1278,6 @@ mod decoy_selection {
                 .iter()
                 .any(|(idx, msg)| *idx == 3 && msg.contains("factor")),
             "Should detect factor violation"
-        );
-    }
-
-    #[test]
-    fn test_decoy_selection_realistic_scenario() {
-        // Simulate a realistic decoy selection for a user transaction
-
-        // User has a UTXO from commerce (30% attribution, 2000 blocks old)
-        let real_utxo = create_utxo(0, 8_000, 30);
-        let cluster_wealth = create_cluster_wealth();
-
-        // Create a realistic UTXO pool with diverse characteristics
-        let mut pool = Vec::new();
-
-        // Old anonymous UTXOs (too different in age)
-        for i in 1..=5 {
-            pool.push(create_utxo(i, 1_000 + i as u64 * 100, 0));
-        }
-
-        // Recent low-value UTXOs (within age range)
-        for i in 6..=15 {
-            pool.push(create_utxo(i, 7_000 + i as u64 * 100, 20));
-        }
-
-        // Commerce UTXOs similar to real input (best candidates)
-        for i in 16..=25 {
-            pool.push(create_utxo(i, 7_500 + i as u64 * 50, 25));
-        }
-
-        // High-value whale UTXOs (factor too high)
-        for i in 26..=30 {
-            pool.push(create_utxo(i, 7_800 + i as u64 * 30, 90));
-        }
-
-        let config = DecoySelectionConfig::default();
-
-        let result = select_decoys(
-            &real_utxo,
-            &pool,
-            CURRENT_BLOCK,
-            &cluster_wealth,
-            TOTAL_SUPPLY,
-            &config,
-        );
-
-        assert!(result.is_ok());
-        let decoys = result.unwrap();
-        assert_eq!(decoys.len(), 10);
-
-        // Validate the selection meets all constraints
-        let violations = validate_decoys(
-            &real_utxo,
-            &decoys,
-            CURRENT_BLOCK,
-            &cluster_wealth,
-            TOTAL_SUPPLY,
-            &config,
-        );
-
-        assert!(
-            violations.is_empty(),
-            "Realistic scenario should produce valid selection: {:?}",
-            violations
         );
     }
 }

--- a/web/packages/desktop/src-tauri/src/wallet.rs
+++ b/web/packages/desktop/src-tauri/src/wallet.rs
@@ -33,7 +33,8 @@ use botho_wallet::{
     rpc_pool::RpcPool,
     storage::EncryptedWallet,
     transaction::{
-        sync_wallet as do_sync_wallet, OwnedUtxo, TransactionBuilder, PICOCREDITS_PER_CAD,
+        sync_wallet as do_sync_wallet, to_tx_hex, OwnedUtxo, TransactionBuilder,
+        PICOCREDITS_PER_CAD,
     },
 };
 
@@ -527,21 +528,25 @@ async fn send_transaction_internal(
     // Build transaction based on privacy level
     let tx = match params.privacy_level {
         PrivacyLevel::Standard => builder
-            .build_transfer(&recipient, amount, fee)
+            .build_transfer(&mut rpc, &recipient, amount, fee)
+            .await
             .map_err(|e| anyhow!("Failed to build transaction: {}", e))?,
         PrivacyLevel::Private => {
             // For private transactions, we would use ring signatures
             // For now, fall back to standard (private tx requires more infrastructure)
             log::warn!("Private transactions not yet fully implemented, using standard");
             builder
-                .build_transfer(&recipient, amount, fee)
+                .build_transfer(&mut rpc, &recipient, amount, fee)
+                .await
                 .map_err(|e| anyhow!("Failed to build transaction: {}", e))?
         }
     };
 
     // 8. Submit transaction
     let tx_hash = rpc
-        .submit_transaction(&tx.to_hex())
+        .submit_transaction(
+            &to_tx_hex(&tx).map_err(|e| anyhow!("Failed to serialize transaction: {}", e))?,
+        )
         .await
         .map_err(|e| anyhow!("Failed to submit transaction: {}", e))?;
 


### PR DESCRIPTION
## Summary

The CLI thin wallet (`botho-wallet`) still built the legacy flat `botho-tx-v1`
transaction (plaintext recipient keys, no ring signature, a
cryptographically-broken SHA256 stealth output). The node's `tx_submit`
bincode-deserializes `botho::transaction::Transaction` (CLSAG) and rejected
every CLI tx with `unexpected end of file` — nobody could transact from the CLI
wallet. This ports the builder to the real CLSAG ring format so the node
accepts and confirms wallet-built transactions. Closes #614 (mainnet blocker 4).

## Changes

- **Deps**: add `bth-transaction-clsag` and `bth-transaction-types` to
  `botho-wallet/Cargo.toml`. `transaction.rs` now imports the real
  `Transaction`, `TxOutput`, `ClsagRingInput`, `RingMember`, `MIN_RING_SIZE`,
  `MIN_TX_FEE` — the same crate the node exposes as `botho::transaction`.
- **Legacy quarantine**: the flat `Transaction`/`TxInput`/`TxOutput` (whose
  `TxOutput::new` used `SHA256(view||spend||amount||random)` instead of the
  Ristretto DH stealth protocol, so recipients could never detect the output)
  are preserved in `botho-wallet/src/transaction_legacy.rs` with a rationale
  doc comment — not silently deleted (CLAUDE.md code-preservation).
- **Ring sourcing over RPC** (`ring_builder.rs`): `fetch_decoy_ring_members`
  computes the ±10% age band (`AGE_SIMILARITY_SPREAD_BPS = 1_000`) from the real
  input's age, fetches candidates via `chain_getOutputs`, excludes own inputs,
  parses hex fields into `RingMember` (recomputing the transparent commitment
  identically to the node's `RingMember::from_output`), **shuffles**, and takes
  `MIN_RING_SIZE - 1`. Inputs younger than `MIN_DECOY_AGE_BLOCKS = 10` get a
  clean user-facing error, never a degenerate-band panic (mirrors #611/#618).
- **Builder**: `build_transfer_with_metadata` is now async, fetches an
  age-similar decoy ring per input, and assembles a ring-size-20 CLSAG ring with
  the real input at a randomized position. Outputs inherit merged+decayed
  cluster tags from the inputs (`merge_weighted` @
  `DEFAULT_CLUSTER_DECAY_RATE = 50_000`), matching the node. The #249
  pending-change-tags machinery is preserved (change output's `public_key`).
- **send.rs**: enforces the consensus fee floor via `max(estimate, MIN_TX_FEE)`
  (structural `MIN_TX_FEE = 100_000_000` dominates at zero cluster wealth) and
  serializes via bincode hex through `to_tx_hex`.
- **decoy_selection.rs**: `DecoySelectionConfig` default ring size 11 -> 20;
  age policy switched from the fingerprintable 2× ratio to the node's ±10% band
  (`age_similarity_band`); eligible pool shuffled before take-N; young-input
  guard. Tests updated; integration suite ported to the CLSAG model.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `botho-wallet send` produces a tx the node accepts | ⏳ deferred | Cannot run live send from CI; covered by the round-trip + full build/sign/verify unit tests below. Deferred to operator on the 3.0.0 testnet. |
| Fee handling respects the consensus fee floor | ✅ | `send.rs` uses `.max(MIN_TX_FEE)`; builds reject nothing below it. |
| Integration test: build + bincode-round-trip through node `Transaction` | ✅ | `test_build_signed_transaction_roundtrips_and_verifies` + `test_transaction_serialization_roundtrips_through_node_type` decode as `bth_transaction_clsag::Transaction` and pass `verify_ring_signatures()`; ring size asserted == 20. |
| Legacy code removed or clearly quarantined | ✅ | `transaction_legacy.rs` with doc comment; wired in `lib.rs`/`main.rs`. |
| Ring size = 20 (MIN_RING_SIZE) | ✅ | `fetch_decoy_ring_members` takes `MIN_RING_SIZE-1`; assertions in tests. |
| ±10% age band, not fingerprintable | ✅ | `age_similarity_band` (`AGE_SIMILARITY_SPREAD_BPS`); `test_decoy_selection_enforces_age_similarity`. |
| Shuffled decoys | ✅ | `pool.shuffle` in ring_builder + `select_decoys`; `test_select_decoys_is_randomized`. |
| Young-input clean error (no panic) | ✅ | `test_young_input_rejected_cleanly`, `test_select_decoys_young_input_rejected`. |
| Output detectability (the curator's bug class) | ✅ | `test_output_is_detectable_by_recipient`: recipient's `WalletScanner::check_ownership` detects the produced `TxOutput` (Some(0)); sender does not; sender detects change. |

## Test Plan

- `cargo test -p botho-wallet` — 182 tests pass (112 lib, 56 integration, 2 doc, plus bin).
- `cargo build -p botho-wallet` and `--no-default-features` both clean.
- `cargo fmt -p botho-wallet -- --check` clean; `cargo clippy -p botho-wallet` introduces no new warnings in the touched files.
- **Deferred to operator**: live `botho-wallet send <addr> 0.001` on the 3.0.0 testnet to confirm on-chain acceptance (cannot run from CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)