### PR TITLE
docs(infra): remove stale --relay flag references (#613)

### DIFF
--- a/infra/seed/README.md
+++ b/infra/seed/README.md
@@ -42,8 +42,9 @@ see **[`TESTNET_RESET.md`](./TESTNET_RESET.md)**.
 A lone seed cannot form the default `recommended` quorum (needs >= 2 nodes), so
 minting stalls. For single-seed bring-up, run with `--mint --mint-threads 1`
 and set `[network.quorum]` to `mode = "explicit"`, `threshold = 1`,
-`members = []`. Switch back to `--relay` + `recommended` once a second node
-joins. The exact `ExecStart` variants are documented in `botho-seed.service`.
+`members = []`. Switch back to relay mode (plain `run`, minting disabled) +
+`recommended` once a second node joins. The exact `ExecStart` variants are
+documented in `botho-seed.service`.
 
 ## Node Setup
 

--- a/infra/seed/TESTNET_RESET.md
+++ b/infra/seed/TESTNET_RESET.md
@@ -77,7 +77,9 @@ so minting stalls at *"have 1, need 2"*.
   ```
 
 - **Multi-seed (>= 2 nodes):** use the committed `botho-seed.service` as-is
-  (`run --relay`, no minting on seeds) and quorum `mode = "recommended"`.
+  (plain `run` with `[minting] enabled = false` — there is no `--relay` CLI
+  flag; relay behavior is simply running without minting) and quorum
+  `mode = "recommended"`.
   Run minting on a dedicated validator/faucet node.
 
 See the header comments in `botho-seed.service` for the exact `ExecStart`

--- a/infra/seed/botho-seed.service
+++ b/infra/seed/botho-seed.service
@@ -30,9 +30,14 @@ WorkingDirectory=/home/ubuntu
 #   threshold = 1
 #   members = []
 #
-# Switch BACK to --relay (and quorum mode "recommended") once a second seed /
-# validator joins. See infra/seed/README.md "Single-seed vs multi-seed".
-ExecStart=/usr/local/bin/botho --testnet run --relay
+# Switch BACK to relay mode (no --mint flags, [minting] enabled = false in
+# config.toml, quorum mode "recommended") once a second seed / validator
+# joins. See infra/seed/README.md "Single-seed vs multi-seed".
+#
+# NOTE: there is no --relay CLI flag (verified against the 3.0.0 binary,
+# 2026-07-04 — passing it fails with "unexpected argument"). Relay behavior
+# is simply running without minting.
+ExecStart=/usr/local/bin/botho --testnet run
 
 # Restart on failure
 Restart=on-failure


### PR DESCRIPTION
Found live while provisioning the regional seeds for #613: the committed `botho-seed.service` ExecStart uses `run --relay`, but the flag no longer exists — the 3.0.0 binary exits with `error: unexpected argument '--relay' found`, leaving the unit in an activating/crash loop. Relay behavior today is simply running without minting (`[minting] enabled = false`).

Fixes the unit file and the two doc references, with a note in the unit header so the next provisioning doesn't trip on it.

Updates #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)