### PR TITLE
docs(security): refresh threat model for cycle-6 + economic mechanism (audit prep, #616)

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -4,13 +4,67 @@ This document describes Botho's threat model for external security auditors. It 
 
 ## Table of Contents
 
+- [Changes Since Last Revision](#changes-since-last-revision)
 - [Assets](#assets)
 - [Adversaries](#adversaries)
 - [Trust Assumptions](#trust-assumptions)
 - [Attack Surface](#attack-surface)
 - [Security Properties](#security-properties)
+- [Economic Mechanism Threats](#economic-mechanism-threats)
 - [Mitigations](#mitigations)
 - [Threat Matrix](#threat-matrix)
+
+---
+
+## Changes Since Last Revision
+
+**Revision date: 2026-07-04.** This refresh brings the threat model up to
+post-cycle-6 reality. The prior revision predated (a) the cluster-tilted
+economic redistribution mechanism (tilted lottery + emission routing +
+spend-time demurrage) and (b) the cycle-6 consensus block-acceptance
+hardening. Every claim about current behavior below has been verified against
+the merged code or the referenced PR; open residuals are called out explicitly
+with their tracking issue.
+
+**New / expanded threat coverage:**
+
+- **Consensus block-acceptance path** — a new attack-surface section. Cycle 6
+  ([audit](../../audits/2026-06-11-cycle6.md)) found that blocks arriving via
+  gossip/sync bypassed most economic consensus rules (five Criticals: C1–C5).
+  The `Ledger::add_block` path now enforces expected difficulty (C1),
+  recomputed emission reward + timestamp bounds (C2), ring-member UTXO
+  resolution (C3), `tx_root` recomputation (C4), a single integer difficulty
+  controller (C5, #553), a cluster-tag inflation guard (C6, #576/#580), and a
+  deterministic consensus fee floor with spend-time demurrage (C7,
+  #578/#602). Fee-sum overflow now rejects (#601); consensus double-spend and
+  wealth reads fail closed on DB error (#600/#564); block + emission state
+  commit in one LMDB txn (#560); rebuild vs incremental cluster-wealth
+  arithmetic is now parity-matched (M3, #604/#607).
+- **Economic mechanism threats** — a new section: gaming the tilted lottery,
+  demurrage parking, cluster-tag inflation via spender-chosen decoys, and
+  fee-market manipulation.
+- **Bootstrap / seed-discovery attack surface** — DNS TXT seed discovery and
+  the multi-region testnet seed topology (#613).
+- **Wallet ring-age fingerprinting** — the OSPEAD age-similar decoy policy
+  (#596) and the degenerate-band DoS it introduced and then fixed
+  (#611 → #618); the CLI thin wallet now builds real CLSAG rings (#620).
+
+**Documented open residuals (NOT mitigated — tracked):**
+
+- **#581** — cluster-tag inflation via decoy-sourced input mass. The C6 guard
+  bounds output tag-mass by the mass of the *resolved ring members*, which
+  include spender-chosen decoys, so a spender who selects high-cluster-mass
+  decoys can inflate the permitted output mass above what the real inputs
+  supply. Accepted residual (never false-rejects a valid block; tightening
+  needs a decoy-independent input set).
+- **Lottery / demurrage payout privacy** — lottery winners are visible
+  on-chain and cluster-tilted selection statistically leaks winner factor
+  distribution (design doc Open Question 4). Open, unquantified.
+- **"Everyone parks" drift** — spend-time demurrage charges accrual at spend,
+  so a permanently parked coin pays nothing until it moves (nominal share
+  drifts ~+0.5pp/5yr, offset by unbooked accrued liability). The designed
+  countermeasure (eligibility decay on the payout weight) is not implemented;
+  see #314 / design Open Question 0.
 
 ---
 
@@ -65,6 +119,27 @@ The following assets require protection in the Botho system:
 | Transaction propagation | Censorship | Gossipsub flooding |
 | Peer connections | Sybil attacks | Connection limiting |
 | RPC endpoints | DoS attacks | Rate limiting |
+
+### 5. Economic Redistribution Integrity
+
+The cluster-tilted redistribution mechanism introduces consensus-critical
+economic state whose integrity is now an asset in its own right. See the
+[design doc](../design/cluster-tilted-redistribution.md) and
+[cycle-6 audit](../../audits/2026-06-11-cycle6.md).
+
+| Component | Threat | Protection |
+|-----------|--------|------------|
+| Emission reward / total supply | Inflation via forged reward | `add_block` recomputes `calculate_block_reward` and rejects mismatch (C2) |
+| Lottery pool + carryover | Payout suppression / seed-grinding | Validator re-derives the deterministic draw; per-block payout cap ≤ 1 reward with carryover; seed-rotated candidate window (#573) |
+| Per-cluster wealth state (`cluster_wealth_db`) | Fee-rate evasion by splitting | Fees key off *global* cluster wealth (split-invariant); rebuild/incremental parity via `saturating_add` (M3, #607) |
+| Demurrage accrual | Evasion of the stock-level levy | Consensus fee floor recomputes `base_minimum_fee + demurrage_charge` at block validation (C7, #602) |
+| Cluster-tag mass | Tag inflation to lower factor | Conservation-of-mass guard at block validation (C6, #580); residual #581 |
+
+**File references:**
+- Block-acceptance gates: `botho/src/ledger/store.rs` (`add_block_inner`, C1–C7)
+- Consensus fee floor + demurrage: `botho/src/ledger/store.rs` (`consensus_fee_floor`, `verify_consensus_fee_floor`)
+- Lottery draw: `botho/src/consensus/lottery.rs`, `cluster-tax/src/lottery.rs`
+- Demurrage math: `cluster-tax/src/demurrage.rs`, `bth_cluster_tax::ring_elapsed_quantile`
 
 ---
 
@@ -170,6 +245,35 @@ The following assets require protection in the Botho system:
 **Note:** CLSAG ring signatures are classical and vulnerable to quantum attacks. However, sender privacy is ephemeral—its value degrades over time as economic context becomes historical. See [ADR-0001](../decisions/0001-deprecate-lion-ring-signatures.md) for the rationale.
 
 **Mitigation level:** High (PQ cryptography for critical paths)
+
+### 7. Economic / Strategic Adversary
+
+**Capability:** A well-capitalized holder (a "whale") who transacts within the
+protocol's rules to defeat the redistribution mechanism. Does not need to break
+cryptography or control consensus — only to shape its own transactions and
+holdings.
+
+**Goals:**
+- Capture the cluster-tilted lottery payout stream
+- Avoid the progressive cluster-factor fee (evade attribution)
+- Avoid spend-time demurrage (park wealth, or dilute the ring age clock)
+- Inflate output cluster-tag mass beyond what real inputs supply
+
+**Cannot:**
+- Gain lottery weight by splitting UTXOs (weight is value-weighted, Sybil/split-invariant by construction)
+- Lower its fee rate by splitting funds across accounts (fees key off *global* cluster wealth)
+- Dilute the consensus demurrage clock with fresh decoys (the floor uses `ring_elapsed_quantile@max`, an unweighted order statistic — B1)
+- Escape a wealthy ring's demurrage with background-tagged outputs (factor floored at the ring-centroid-implied value — B2)
+
+**Residual levers (open):**
+- Shedding cluster attribution via wash trading (rate-bounded by tag decay, but the single remaining designed lever)
+- Decoy-sourced tag-mass inflation against the C6 guard (**#581**, accepted residual)
+- Permanent parking to defer demurrage (**#314** / "everyone parks" watch item)
+- Payout-privacy leakage from on-chain lottery winners (design Open Question 4)
+
+**Mitigation level:** Medium — the core split/Sybil vectors are closed by
+construction and validated by simulation ([design doc](../design/cluster-tilted-redistribution.md));
+the residuals above are explicitly tracked, not mitigated.
 
 | Component | Algorithm | Quantum Safety |
 |-----------|-----------|----------------|
@@ -311,6 +415,71 @@ The following assets require protection in the Botho system:
 | IPC injection | Command validation | Mitigated |
 | Update MITM | Signed updates | Planned |
 
+### 5. Consensus Block-Acceptance Path
+
+**Path:** `Ledger::add_block` / `add_block_inner` — the code every node runs on
+a block received via gossip or sync. Cycle 6 found this path enforced only
+height, prev-hash, self-declared PoW, lottery accounting, key images, and ring
+signatures; the following economic gates were subsequently added (all verified
+in `botho/src/ledger/store.rs`).
+
+| Gate | Rule enforced at block acceptance | Reference | Status |
+|------|-----------------------------------|-----------|--------|
+| C1: Difficulty | `header.difficulty == chain-expected difficulty`, then `is_valid_pow` | `store.rs` C1 (`#553` controller) | Mitigated |
+| C2: Reward | `minting_tx.reward == calculate_block_reward(...)`; reject mismatch | `store.rs` (expected_reward) | Mitigated |
+| C2: Timestamp | minting/header timestamps agree; `>= parent`; `<= now + MAX_FUTURE_TIMESTAMP_SECS` | `store.rs` | Mitigated |
+| C3: Ring members | Every ring member resolved against the UTXO set (`verify_ring_members`) | `store.rs` | Mitigated |
+| C4: tx_root | `header.tx_root == Block::compute_tx_root(&transactions)` | `store.rs` | Mitigated |
+| C5: Difficulty controller | Single integer (u128 bps) controller; f64 eliminated from live path | `#553` | Mitigated |
+| C6: Tag inheritance | Output cluster-tag mass ≤ resolved-ring-member input mass (conservation) | `check_cluster_tag_inheritance` (#576/#580) | Mitigated (residual #581) |
+| C7: Fee floor | `tx.fee >= base_minimum_fee + demurrage_charge` (congestion-free, integer) | `consensus_fee_floor` (#578/#602) | Mitigated |
+| Fee-sum overflow | `checked_block_fees` → `LedgerError::FeeOverflow` instead of wrapping | `#601` | Mitigated |
+| Emission-state atomicity | Block + difficulty/reward/epoch state commit in one LMDB txn | `#560` | Mitigated |
+| DB-error handling | `is_key_image_spent` / `get_cluster_wealth` fail **closed** on error | `#600` / `#564` | Mitigated |
+
+**Consensus determinism discipline (why these are fork-safe):** the fee floor
+uses a fixed `CONSENSUS_FEE_BASE` (not the mempool's f64 congestion EMA), the
+demurrage clock uses an unweighted order statistic (`ring_elapsed_quantile@max`)
+over public ring-member `(value, created_at)`, cluster wealth is read from
+committed pre-block state, and all accumulation is integer + `BTreeMap`. The
+mempool's dynamic congestion base can only raise a node's local admission
+threshold *above* this floor, never below (Bitcoin min-relay vs.
+consensus-validity split).
+
+**Open items from cycle 6 (not consensus-exploitable today, tracked):**
+- Cumulative cluster wealth never decrements (M2) — an economics/design
+  question, deterministic.
+- Fee accounting books 100% of fees as burned while 80% is redistributed (M4)
+  — no consensus effect today (difficulty ignores burns).
+- No explicit fork-choice/reorg handling in `add_block` beyond exact
+  next-height; interaction with SCP finalization needs documented verification
+  (I6).
+
+### 6. Bootstrap / Seed-Discovery Attack Surface
+
+**Components:** DNS TXT seed discovery (`botho/src/network/dns_seeds.rs`),
+hardcoded fallback seed list (`botho/src/network/seeds.rs`), protocol-version
+peer gating (`botho/src/network/discovery.rs`).
+
+**Bootstrap order:** (1) explicit `bootstrap_peers` in `config.toml`, (2) DNS
+TXT discovery (`seeds.botho.io` / `seeds.testnet.botho.io`), (3) hardcoded
+fallback list. The testnet fallback list ships the live regional seeds by
+default (#613): a primary (`seed.botho.io`) plus regional hosts
+`us`/`eu`/`ap.seed.botho.io`. Mainnet regional hostnames are scaffolding, gated
+behind `BOTHO_REGIONAL_SEEDS`.
+
+| Attack | Mitigation | Status |
+|--------|------------|--------|
+| DNS poisoning / spoofed TXT seeds | Falls back to hardcoded seeds on DNS failure; block validation rejects any peer's invalid chain regardless of how it was discovered | Partial — DNS records are **not** cryptographically pinned (no DNSSEC dependency); a poisoned resolver can bias peer selection / attempt eclipse |
+| Eclipse via seed-list control | Multi-region seed diversity (#613); per-IP connection caps | Partial |
+| Malicious primary seed | Mainnet primary seed multiaddr pins a peer ID; testnet primary resolves peer ID dynamically (host re-key without client release) | Partial (testnet unpinned by design) |
+| Protocol downgrade / incompatible peers | Major-version mismatch disconnects (`PROTOCOL_VERSION` 3.0.0, `consensus_incompatibility`, #608); minor/patch differences warn only | Mitigated (upgrade hygiene, not a security boundary — see I1) |
+| Redial storm after version disconnect | Per-IP caps bound cost; no ban/backoff window yet (L1) | Partial |
+
+**Note:** protocol versions are self-reported via libp2p identify. The
+disconnect is upgrade hygiene, not a trust boundary — a lying peer is still
+excluded only by block validation (cycle-6 I1).
+
 ---
 
 ## Security Properties
@@ -330,11 +499,25 @@ Pr[adversary correctly determines R1 = R2 | blockchain] ≤ negl(λ)
 - Stealth addresses (one-time destination keys)
 - Ring signatures (CLSAG ring=20)
 - Cluster-aware decoy selection (≥70% cosine similarity)
+- Age-similar decoy selection: decoys drawn from ±10% of the real input's age
+  (`AGE_SIMILARITY_SPREAD_BPS`), floored at `MIN_DECOY_AGE_BLOCKS`
+  confirmations, CSPRNG-shuffled (not a deterministic first-N height slice).
+  The node and the CLI thin wallet share this policy
+  (`botho/src/decoy_selection.rs`, `botho-wallet/src/decoy_selection.rs`).
 
 **Limitations:**
 - Network-level correlation possible without Tor
 - Cluster tag fingerprinting reduces effective ring size
 - Exchange KYC can link identities
+- **Ring-age fingerprinting (mitigated, residual):** an earlier wallet decoy
+  policy used a wide (~2×) age band; a chain-analysis adversary could
+  fingerprint wallet-built rings by their unusually broad ring-age spread. The
+  ±10% age-similarity band (#596) collapses that distinction and is `#314`-safe
+  under `ring_elapsed_quantile@max`. The band is degenerate for very young
+  inputs (below the confirmation floor `min_age > max_age`); spending such
+  inputs is guarded with a clean error rather than a panic (fixed #611 → #618).
+  Age-similarity is a heuristic-resistance measure, not a proof of
+  indistinguishability.
 
 ### 2. Amount Confidentiality
 
@@ -411,6 +594,116 @@ where Δ depends on network conditions and fee priority
 - Fee-priority mempool ordering
 - Dynamic block timing (5-40s based on load)
 
+### 6. Economic Redistribution Integrity
+
+**Property:** The supply schedule, lottery payout, and progressive
+fee/demurrage terms are computed identically by the block proposer and every
+validator, from committed chain state — so they cannot be forged, evaded by
+UTXO structure, or made to fork the chain.
+
+**Informal statement:**
+```
+For a block B applied at height H by any honest node:
+- reward(B) == calculate_block_reward(H, total_mined)   (no inflation)
+- for every transfer tx T in B: fee(T) >= base_minimum_fee(T)
+                                          + demurrage_charge(T, H)   (no evasion)
+- lottery winners == deterministic draw over the seed-rotated candidate window
+- output cluster-tag mass <= resolved-ring-member input mass          (C6)
+```
+
+**Achieved via:**
+- Emission reward recomputation and timestamp bounds at acceptance (C2)
+- Deterministic integer consensus fee floor with `ring_elapsed_quantile@max`
+  demurrage clock and ring-centroid-floored factor (C7, #602)
+- Value-weighted, split-invariant lottery weight; per-block payout cap with
+  carryover; validator re-derivation of the draw
+- Global (not per-UTXO) cluster wealth as the fee-rate signal
+
+**Limitations (open residuals):**
+- Decoy-sourced tag-mass inflation vs. the C6 guard (**#581**)
+- Spend-time (not continuous) demurrage → "everyone parks" drift (**#314**)
+- Lottery payout privacy: winners visible on-chain, factor distribution leaks
+- Cluster wealth is cumulative and never decrements (M2)
+
+---
+
+## Economic Mechanism Threats
+
+The cluster-tilted redistribution mechanism is designed so that the primary
+gaming vectors are closed *by construction* (value-weighting, global cluster
+wealth) rather than by policy — see the
+[design doc](../design/cluster-tilted-redistribution.md), empirically validated
+by 5-year honest-and-gamed simulation. This section enumerates the specific
+threats and their current status against merged code.
+
+### 1. Gaming the tilted lottery (payout capture)
+
+**Threat:** A whale splits/churns UTXOs to capture the redistribution stream
+(the failure mode of uniform/Hybrid-α payouts, which *inverted* Gini under
+gaming — whale 5%→24% in simulation).
+
+**Status:** Mitigated by construction. Lottery weight is
+`value × (max_factor − cluster_factor + 1) / max_factor` — value-weighted, so
+splitting a position never increases total weight. The consensus lottery
+defaults to `ClusterWeighted` (not the grindable `Hybrid { alpha }`). Because
+churn/split fees feed the pool, attacking the mechanism *funds* it (gamed
+simulation redistributes marginally more than honest). Payout cap ≤ 1 reward
+with carryover, plus a seed-rotated candidate window (#573), bounds
+seed-grinding gain below the PoW cost of a regrind.
+
+**Residual:** payout privacy — on-chain winners statistically reveal the winner
+factor distribution (design Open Question 4). Open.
+
+### 2. Demurrage evasion
+
+**Threat:** Avoid the spend-time demurrage levy, the load-bearing stock-level
+term of the validated Gini mechanism, by (a) selecting fresh high-value decoys
+to dilute the ring age clock, (b) tagging outputs as background to zero the
+factor, or (c) never spending.
+
+**Status:**
+- (a) **Mitigated:** the consensus floor's demurrage clock is
+  `ring_elapsed_quantile@max` — an *unweighted* order statistic over ring-member
+  ages, value-independent, so fresh high-value decoys cannot pull it to zero
+  (H2/B1).
+- (b) **Mitigated:** the factor is floored at the ring-centroid-implied factor
+  (`ring_centroid_floored_factor`, B2), so background-tagged outputs cannot
+  escape a wealthy ring's demurrage.
+- (c) **Open residual (#314):** demurrage accrues at *spend*, not continuously,
+  so a permanently parked coin pays nothing until it moves. Simulation bounds
+  the "everyone parks" drift to ~+0.5pp/5yr (offset by unbooked accrued
+  liability); the designed countermeasure (eligibility decay on payout weight)
+  is not yet implemented.
+
+### 3. Cluster-tag inflation via decoys (#581)
+
+**Threat:** Inflate output cluster-tag mass beyond what the real inputs supply,
+lowering effective factors / diluting the wealth signal.
+
+**Status:** Partially mitigated. The C6 conservation-of-mass guard (#576/#580)
+rejects blocks where output tag-mass exceeds input tag-mass per cluster. But
+the "input" mass is summed over the *resolved ring members*, which include
+spender-chosen decoys — so a spender who picks high-cluster-mass decoys can
+raise the permitted output mass above what the real inputs actually supply.
+This is an **accepted residual tracked in #581**: the current bound never
+false-rejects a valid block (ring mass is an upper bound on true input mass),
+and tightening it requires a decoy-independent input set. The wallet-side
+cluster-factor ceiling on decoys (`decoy_factor <= real_factor × ratio`)
+limits, but does not eliminate, the lever for honest wallets.
+
+### 4. Fee-market manipulation
+
+**Threat:** A miner includes their own transactions fee-free, or a wealthy
+cluster self-mines / pays miners out-of-band, to evade the progressive fee and
+demurrage (cycle-6 H1: these were mempool-only policy).
+
+**Status:** Mitigated. The consensus fee floor (C7, #602) recomputes
+`base_minimum_fee + demurrage_charge` per transfer tx at block validation from
+committed chain state, so under-fee transactions are rejected by every
+validator regardless of who mined them. The floor is congestion-free
+(deterministic), so it cannot be gamed via node-local congestion state, and the
+mempool's dynamic base can only make a node *stricter*.
+
 ---
 
 ## Mitigations
@@ -462,6 +755,22 @@ where Δ depends on network conditions and fee priority
 | HMAC forgery | Constant-time comparison | `auth.rs:273-283` |
 | Wallet password brute-force | Exponential backoff + lockout | `storage.rs:104-112` |
 
+#### 6. Consensus / Economic Integrity (cycle 6)
+
+| Threat | Mitigation | Implementation |
+|--------|------------|----------------|
+| Self-declared low difficulty | Expected-difficulty gate (C1) | `store.rs` add_block |
+| Reward inflation | Recompute `calculate_block_reward` (C2) | `store.rs` add_block |
+| Ring counterfeit inputs | UTXO-set ring resolution (C3) | `verify_ring_members` |
+| tx-list substitution | `tx_root` recomputation (C4) | `store.rs` add_block |
+| Platform-divergent difficulty | Single integer controller (C5) | `#553` |
+| Cluster-tag inflation | Conservation-of-mass guard (C6) | `check_cluster_tag_inheritance` (#580) |
+| Fee/demurrage evasion | Deterministic consensus fee floor (C7) | `consensus_fee_floor` (#602) |
+| Fee-sum overflow | `checked_block_fees` → typed error | `#601` |
+| Consensus DB-error fail-open | Fail closed on read error | `#600` / `#564` |
+| Non-atomic emission state | Single-txn commit | `#560` |
+| Rebuild/incremental drift | `saturating_add` parity | `#607` |
+
 ---
 
 ## Threat Matrix
@@ -476,6 +785,12 @@ where Δ depends on network conditions and fee priority
 | Privacy breach | Information Disclosure | Transaction data | Ring sigs, commitments | ✓ |
 | Node DoS | Denial of Service | Network | Rate limiting | ✓ |
 | Privilege escalation | Elevation of Privilege | RPC | API key tiers | ✓ |
+| Inflation via forged reward | Tampering | Supply | `add_block` reward recomputation (C2) | ✓ |
+| Block-list substitution | Tampering | Blockchain | `tx_root` recomputation (C4) | ✓ |
+| Zero-PoW chain injection | Spoofing | Consensus | Expected-difficulty gate (C1) | ✓ |
+| Fee/demurrage evasion | Repudiation | Economics | Consensus fee floor (C7) | ✓ |
+| Tag-mass inflation | Tampering | Economics | C6 guard; residual #581 | ◐ |
+| DNS seed poisoning | Spoofing | Bootstrap | Hardcoded fallback; block validation | ◐ |
 
 ### Risk Matrix
 
@@ -487,6 +802,15 @@ where Δ depends on network conditions and fee priority
 | RPC DoS | High | Low | Medium | Rate limited |
 | Eclipse attack | Low | High | Medium | Partial mitigation |
 | Cluster fingerprinting | Medium | Medium | Medium | OSPEAD mitigated |
+| Inflation via forged block reward | Low | Critical | High | Mitigated (C2, #602) |
+| Block-acceptance economic bypass (C1–C7) | Low | Critical | High | Mitigated (cycle 6) |
+| Lottery payout capture (split/churn) | Medium | Medium | Medium | Mitigated by construction |
+| Demurrage parking ("everyone parks") | Low | Medium | Low-Medium | Open residual (#314) |
+| Tag-mass inflation via decoys | Medium | Medium | Medium | Partial (residual #581) |
+| Fee-market manipulation (self-mining) | Medium | Medium | Medium | Mitigated (C7) |
+| DNS seed poisoning / eclipse | Low | High | Medium | Partial (no seed pinning) |
+| Ring-age fingerprinting | Medium | Medium | Medium | Mitigated (#596) |
+| Lottery/demurrage payout privacy | Medium | Low | Low-Medium | Open (unquantified) |
 
 ---
 
@@ -497,6 +821,8 @@ where Δ depends on network conditions and fee priority
 - [Security Guide](../concepts/security.md) - Operational security practices
 - [Privacy Features](../concepts/privacy.md) - Cryptographic privacy mechanisms
 - [Transactions](../concepts/transactions.md) - Transaction types and structure
+- [Cluster-Tilted Redistribution](../design/cluster-tilted-redistribution.md) - Economic mechanism design (validated)
+- [Cycle-6 Internal Audit](../../audits/2026-06-11-cycle6.md) - Consensus-economics findings (C1–C7, H/M/L)
 
 ### External Standards
 - [NIST FIPS 203](https://csrc.nist.gov/pubs/fips/203/final) - ML-KEM specification

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -463,15 +463,20 @@ peer gating (`botho/src/network/discovery.rs`).
 
 **Bootstrap order:** (1) explicit `bootstrap_peers` in `config.toml`, (2) DNS
 TXT discovery (`seeds.botho.io` / `seeds.testnet.botho.io`), (3) hardcoded
-fallback list. The testnet fallback list ships the live regional seeds by
-default (#613): a primary (`seed.botho.io`) plus regional hosts
-`us`/`eu`/`ap.seed.botho.io`. Mainnet regional hostnames are scaffolding, gated
-behind `BOTHO_REGIONAL_SEEDS`.
+fallback list. The testnet fallback list ships the regional seeds live and
+on by default as of 2026-07-04 (#613; verifiable in `seeds.rs`, where
+`fallback_seeds(Network::Testnet)` unconditionally returns the primary plus
+regionals): a primary (`seed.botho.io`) plus regional hosts
+`us`/`eu`/`ap.seed.botho.io`. Multi-region seed diversity is therefore an
+active default, but #613 remains open for the residual hardening it tracks —
+health-checked DNS failover and seed-availability alerting are not yet
+shipped. Mainnet regional hostnames are still scaffolding, gated behind
+`BOTHO_REGIONAL_SEEDS`.
 
 | Attack | Mitigation | Status |
 |--------|------------|--------|
 | DNS poisoning / spoofed TXT seeds | Falls back to hardcoded seeds on DNS failure; block validation rejects any peer's invalid chain regardless of how it was discovered | Partial — DNS records are **not** cryptographically pinned (no DNSSEC dependency); a poisoned resolver can bias peer selection / attempt eclipse |
-| Eclipse via seed-list control | Multi-region seed diversity (#613); per-IP connection caps | Partial |
+| Eclipse via seed-list control | Multi-region seed diversity (testnet regionals live & default-on 2026-07-04, #613; DNS failover and seed-availability alerting still tracked there); per-IP connection caps | Partial |
 | Malicious primary seed | Mainnet primary seed multiaddr pins a peer ID; testnet primary resolves peer ID dynamically (host re-key without client release) | Partial (testnet unpinned by design) |
 | Protocol downgrade / incompatible peers | Major-version mismatch disconnects (`PROTOCOL_VERSION` 3.0.0, `consensus_incompatibility`, #608); minor/patch differences warn only | Mitigated (upgrade hygiene, not a security boundary — see I1) |
 | Redial storm after version disconnect | Per-IP caps bound cost; no ban/backoff window yet (L1) | Partial |


### PR DESCRIPTION
## Summary

Refreshes `docs/security/threat-model.md` for post-cycle-6 reality as automatable prep for the external security audit engagement (**Updates #616**, mainnet blocker 2). The prior revision predated (a) the cluster-tilted economic redistribution mechanism and (b) the cycle-6 consensus block-acceptance hardening. An auditor will read this document as ground truth, so **every current-behavior claim was verified against merged code or the referenced PR**; open residuals are flagged explicitly rather than asserted as mitigated.

## Sections added / updated

- **Changes Since Last Revision** (new, dated 2026-07-04) — summary of new coverage and documented open residuals.
- **Attack Surface -> Consensus Block-Acceptance Path** (new) — the C1-C7 `add_block` gates with PR refs: expected difficulty (C1), recomputed reward + timestamp bounds (C2), ring-member UTXO resolution (C3), `tx_root` recomputation (C4), single integer difficulty controller (C5, #553), cluster-tag inflation guard (C6, #576/#580), deterministic consensus fee floor + spend-time demurrage (C7, #578/#602), fee-sum overflow rejection (#601), fail-closed DB reads (#600/#564), atomic emission state (#560), rebuild/incremental parity (M3, #607).
- **Attack Surface -> Bootstrap / Seed-Discovery** (new) — DNS TXT discovery, multi-region testnet seed topology, protocol-version peer gating (#613, #608).
- **Economic Mechanism Threats** (new section) — tilted-lottery gaming, demurrage evasion (B1/B2 + parking residual), cluster-tag inflation via decoys, fee-market manipulation.
- **Assets** — new "Economic Redistribution Integrity" asset.
- **Adversaries** — new "Economic / Strategic Adversary".
- **Security Properties** — new "Economic Redistribution Integrity"; Transaction Unlinkability updated for age-similar decoys and ring-age fingerprinting (#596, #611 -> #618, CLI CLSAG #620).
- **Mitigations** — new "Consensus / Economic Integrity (cycle 6)" table.
- **Threat Matrix** — new STRIDE + risk rows.
- **References** — added design doc and cycle-6 audit.

## Open residuals documented (NOT marked mitigated)

- **#581** — cluster-tag inflation via decoy-sourced input mass (C6 bounds output mass by resolved-ring-member mass, which includes spender-chosen decoys). Accepted residual.
- **Lottery / demurrage payout privacy** — on-chain winners leak factor distribution (design Open Question 4). Open, unquantified.
- **"Everyone parks" drift (#314)** — spend-time (not continuous) demurrage; designed eligibility-decay countermeasure not implemented.
- Carried cycle-6 items noted as tracked, not consensus-exploitable today: cumulative cluster wealth (M2), fee-burn accounting overstatement (M4), fork-choice/reorg documentation gap (I6), no ban/backoff after version disconnect (L1).

## Verification note

One claim I could not corroborate as written and therefore did **not** assert: the task described a "5-node multi-region seed topology." The code (`botho/src/network/seeds.rs`) defines a primary seed (`seed.botho.io`) plus **three** regional hosts (`us`/`eu`/`ap.seed.botho.io`) = 4 fallback entries; the doc describes it that way. All other claims verified in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)