### PR TITLE
build(#605): bump PROTOCOL_VERSION to 4.0.0 for #626 + #605 testnet reset

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 606
-# Branch: feature/issue-606
+# Issue: 605
+# Branch: feature/issue-605
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/botho/src/network/discovery.rs
+++ b/botho/src/network/discovery.rs
@@ -82,17 +82,30 @@ use crate::{
 /// 2.0.0 peers instead of letting them silently fork against the new
 /// block-acceptance rules. `MIN_SUPPORTED_PROTOCOL_VERSION` is raised in
 /// lockstep.
-pub const PROTOCOL_VERSION: &str = "3.0.0";
+///
+/// Bumped to 4.0.0 for the coordinated testnet reset deploying the #626
+/// consensus changes and the ratified #605 semantics. #626 replaces the C7
+/// consensus fee floor with a log-domain fee curve and widens cluster-wealth
+/// accounting to u128 (#627/#628/#629), and #605 ratifies the cluster-wealth
+/// decay semantics that ride the same reset. Because #626 changes the C7 fee
+/// floor a block must satisfy to be accepted, 3.0.0 peers are
+/// consensus-incompatible with the reset chain's block-acceptance rules — they
+/// would compute a different floor and fork. As with the 2.x -> 3.0.0 bump this
+/// must be MAJOR: `is_consensus_compatible` / `consensus_incompatibility`
+/// compare major versions only, so only a major bump disconnects 3.0.0 peers
+/// rather than letting them silently fork. `MIN_SUPPORTED_PROTOCOL_VERSION` is
+/// raised in lockstep.
+pub const PROTOCOL_VERSION: &str = "4.0.0";
 
 /// Minimum supported protocol version.
 /// Peers below this version are consensus-incompatible and are disconnected.
-/// Raised to 3.0.0 alongside `PROTOCOL_VERSION` for the H1 consensus fee-floor
-/// deploy (issue #606): 2.0.0 peers produce/accept blocks that violate the new
-/// deterministic fee floor (#602) and related fail-closed rules, so they must
-/// be dropped rather than allowed to fork the reset chain. The bump is a MAJOR
-/// bump because the disconnect check (`is_consensus_compatible`) is major-only;
-/// a minor bump would only warn.
-pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "3.0.0";
+/// Raised to 4.0.0 alongside `PROTOCOL_VERSION` for the reset deploying the
+/// #626 log-domain fee curve (u128 cluster wealth, #627/#628/#629) and the
+/// ratified #605 semantics: 3.0.0 peers apply the old C7 fee floor and would
+/// accept/produce blocks the reset chain rejects, so they must be dropped
+/// rather than allowed to fork. The bump is MAJOR because the disconnect check
+/// (`is_consensus_compatible`) is major-only; a minor bump would only warn.
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "4.0.0";
 
 /// Topic for block announcements
 const BLOCKS_TOPIC: &str = "botho/blocks/1.0.0";
@@ -2155,36 +2168,55 @@ mod tests {
 
     #[test]
     fn test_protocol_version_constant() {
-        // Bumped to 3.0.0 for the cycle-6 H1 consensus fee-floor deploy
-        // (issue #606): current `main` enforces the deterministic consensus
-        // fee floor (#602) plus fee-sum overflow (#601) and fail-closed
-        // double-spend (#600/#564/#598), all incompatible with the running
-        // 2.0.0 chain, requiring a coordinated reset with fresh genesis.
+        // Bumped to 4.0.0 for the coordinated reset deploying the #626
+        // consensus changes (log-domain fee curve replacing the C7 fee
+        // floor; u128 cluster wealth, #627/#628/#629) and the ratified #605
+        // cluster-wealth decay semantics. #626 changes the fee floor a block
+        // must satisfy to be accepted, so 3.0.0 peers are consensus-
+        // incompatible with the reset chain and a fresh genesis is required.
         // A MAJOR bump is required because `is_consensus_compatible` (the
         // peer-disconnect gate) compares majors only — a minor bump would
-        // merely warn, leaving 2.0.0 peers connected and silently forking.
-        assert_eq!(PROTOCOL_VERSION, "3.0.0");
+        // merely warn, leaving 3.0.0 peers connected and silently forking.
+        assert_eq!(PROTOCOL_VERSION, "4.0.0");
         let parsed = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
-        assert_eq!(parsed.major, 3);
+        assert_eq!(parsed.major, 4);
         assert_eq!(parsed.minor, 0);
         assert_eq!(parsed.patch, 0);
     }
 
     #[test]
     fn test_min_supported_protocol_version_constant() {
-        assert_eq!(MIN_SUPPORTED_PROTOCOL_VERSION, "3.0.0");
+        assert_eq!(MIN_SUPPORTED_PROTOCOL_VERSION, "4.0.0");
         let parsed = ProtocolVersion::parse(MIN_SUPPORTED_PROTOCOL_VERSION).unwrap();
-        assert_eq!(parsed.major, 3);
+        assert_eq!(parsed.major, 4);
         assert_eq!(parsed.minor, 0);
     }
 
-    /// Regression guard for #606: the 3.0.0 deploy must actually DISCONNECT
-    /// 2.0.0 peers (not just warn). This pins the major-only disconnect
-    /// semantics against the live constants.
+    /// Regression guard (originally #606): a consensus-breaking reset must
+    /// actually DISCONNECT the immediately-preceding major's peers, not just
+    /// warn. Pins the major-only disconnect semantics for the 2.0.0 pre-reset
+    /// chain against the live constants.
     #[test]
     fn test_v2_peers_are_consensus_incompatible_with_current() {
         let local = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
         let old_peer = ProtocolVersion::parse("2.0.0").unwrap();
+        assert!(!old_peer.is_consensus_compatible(&local));
+        assert_eq!(
+            ProtocolVersion::consensus_incompatibility(&Some(old_peer.clone()), &local),
+            Some(old_peer)
+        );
+    }
+
+    /// Regression guard for the #605/#626 reset: the 4.0.0 deploy must
+    /// actually DISCONNECT 3.0.0 peers (the H1 fee-floor chain), not merely
+    /// warn — #626's log-domain fee curve changes the C7 floor, so a 3.0.0
+    /// peer would fork. Pins the major-only disconnect semantics against the
+    /// live constants so a future accidental minor-only bump of a consensus-
+    /// breaking change fails the suite.
+    #[test]
+    fn test_v3_peers_are_consensus_incompatible_with_current() {
+        let local = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
+        let old_peer = ProtocolVersion::parse("3.0.0").unwrap();
         assert!(!old_peer.is_consensus_compatible(&local));
         assert_eq!(
             ProtocolVersion::consensus_incompatibility(&Some(old_peer.clone()), &local),

--- a/docs/design/cluster-tilted-redistribution.md
+++ b/docs/design/cluster-tilted-redistribution.md
@@ -117,6 +117,102 @@ A second-order attack — acquiring low-factor coins from others — is
 self-correcting under global cluster wealth tracking: accumulating a large
 share of a cluster's coins raises that cluster's wealth and hence its factor.
 
+## Cluster Wealth Is Cumulative Lifetime Volume (Design Decision)
+
+**Status: RATIFIED 2026-07-05 (option 2, accept-and-document).** Cycle-6 audit
+item **M2** (#605) asked whether `cluster_wealth_db` — which is
+*monotonically non-decreasing*, since `update_cluster_wealth_for_output`
+(`botho/src/ledger/store.rs`) only ever adds and no decrement path exists —
+should acquire a deterministic decay schedule (option 1) or be accepted and
+documented as the intended semantic (option 2). The operator ratified
+**option 2**.
+
+### The semantic
+
+Cluster wealth is **lifetime cumulative tagged volume**, not current holdings.
+Every output ever attributed to a cluster adds to its tracked wealth and
+nothing is ever subtracted. Decrement is not merely unimplemented — it is
+essentially impossible under ring privacy: you cannot tell when a specific
+tagged value is spent, so there is no privacy-preserving signal on which to
+base a decrement. The progressive fee therefore prices a cluster by the total
+value that has ever flowed through it, and a cluster's factor only ratchets
+upward toward the `max_factor` ceiling.
+
+### Empirical basis (2026-07-05, recalibrated log-domain curve)
+
+The decision follows the empirical program ratified 2026-07-04. All runs use
+the **real production `ClusterFactorCurve`** (log-domain, `w_mid = 100k BTH`)
+merged as part of #626's fix (#627), on the `u128` accumulator (#628) — not
+the #314 hardcoded 1.0/2.0/6.0 factors. Harness pinned at `main @ da24457`,
+seed `626626626`, deterministic. Reproduction: `experiments/M2_RUNBOOK.md`.
+
+**Cumulative (option 2) — the decision-rule primary** (criterion: ΔGini > 0.05
+at long horizons):
+
+| Run | ΔGini | criterion > 0.05 | whale factor |
+|---|---|---|---|
+| 10yr honest | +0.2171 | PASS | 5.646x PASS |
+| 10yr gamed | +0.2242 | PASS | 5.646x PASS |
+| 20yr honest | +0.5644 | PASS | 5.745x PASS |
+| 20yr gamed | +0.5745 | PASS | 5.745x PASS |
+
+Cumulative semantics on the recalibrated curve pass the decision rule with a
+4–11× margin, at both horizons, honest and gamed. Redistribution *strengthens*
+with horizon (Gini 0.93 → 0.37 at 20yr), and the gamed runs do marginally
+better than honest — whale splitting/churning under cumulative tagging simply
+re-tags the value, opening no evasion channel.
+
+**Epoch-halving decay variants (option 1) — for comparison.** Deterministic
+epoch halving (`w >>= 1` once per `half_life_years`, a pure function of the
+epoch index — never per-access, per the M3 determinism lesson), with the
+wash-trading evasion gate (<20%) and ring-identification gate (<50%):
+
+| Half-life | 10yr ΔGini (honest/gamed) | evasion (<20%) | ring-ID (<50%) |
+|---|---|---|---|
+| 2yr | +0.1839 / +0.1897 | 0.0% PASS | 17.8% PASS |
+| 5yr | +0.2096 / +0.2164 | 0.0% PASS | 13.2% PASS |
+| 10yr | +0.2171 / +0.2242 | 1.5% PASS | 11.3% PASS |
+| 5yr @ 20yr gamed | +0.4718 | 0.0% PASS | 13.2% PASS |
+
+Epoch halving is *safe* — nothing like the prior art's 94–99% per-hop-decay
+evasion or 78.7% ring identification (`experiments/ANALYSIS.md`) — but it is
+**strictly weaker on ΔGini at every half-life**, converging up to the
+cumulative result as the half-life grows. Decay buys nothing the criterion
+values and costs both redistribution and new consensus surface.
+
+### Accepted trade-offs
+
+- **Velocity-vs-holdings mispricing.** Because wealth is lifetime volume, an
+  active-commerce cluster prices on everything that has ever flowed through it,
+  not what it currently holds. In the sim's population ladder the merchant
+  cohort (5,000 BTH held, 2×/yr velocity) reaches a **mean factor of ~2.8x at
+  the 10-year horizon** from accumulated volume alone. This ~2.8x figure is the
+  **sim cohort output**, reproducible via
+  `target/release/cluster-tax-sim m2-cumulative --horizon-years 10`; it is *not*
+  one of the ratified ΔGini/whale-factor result-table numbers above. Accepted:
+  the mispricing is bounded by the log-domain curve (a merchant stays well
+  below the whale band) and the redistribution benefit dominates it.
+- **Dormancy is no escape.** Parking coins does not lower a cluster's tracked
+  wealth; the ratchet is permanent. This is intended — it removes hoarding as a
+  factor-reduction strategy.
+- **Residual and headroom.** #581's decoy-sourced tag-inflation residual and
+  M3's saturation-ceiling analysis remain valid; both are held within the
+  `u128` accumulator headroom introduced by #628 (no wrap at realistic
+  lifetime volumes on the log-domain curve).
+
+### Validity scope and remaining verification
+
+These results are valid **only on the #626-recalibrated log-domain curve**
+(`w_mid = 100k BTH`); the pre-#626 step-function curve (`w_mid` in simulator
+units) is not represented. One honest caveat for the record: the harness's
+wash-trading/gaming model is its implementation of the #574-era adversary, and
+the live-testnet phase exists precisely to catch model-vs-reality gaps.
+**Still pending:** live-testnet confirmation of the real factor distribution
+after the 4.0.0 reset, measured against the 2026-07-04 6x-pinned baseline —
+tracked on #605 as the final verification. This documentation records the
+ratified design decision; it does not claim the on-chain confirmation is
+complete.
+
 ## Parameters and Headroom
 
 | Lever | Validated value | Headroom | Cost of turning up |
@@ -225,3 +321,8 @@ state), which bounds seed-grinding gain below the PoW cost of a regrind.
 ## Changelog
 
 - 2026-06-11: Initial proposal from validated experiment results
+- 2026-07-05: Added "Cluster Wealth Is Cumulative Lifetime Volume (Design
+  Decision)" — records the operator-ratified (option 2) semantic that cluster
+  wealth is cumulative lifetime tagged volume with no decay, with the
+  2026-07-05 empirical run matrix on the #626-recalibrated log-domain curve
+  (#605).

--- a/docs/design/cluster-tilted-redistribution.md
+++ b/docs/design/cluster-tilted-redistribution.md
@@ -185,13 +185,18 @@ values and costs both redistribution and new consensus surface.
 - **Velocity-vs-holdings mispricing.** Because wealth is lifetime volume, an
   active-commerce cluster prices on everything that has ever flowed through it,
   not what it currently holds. In the sim's population ladder the merchant
-  cohort (5,000 BTH held, 2×/yr velocity) reaches a **mean factor of ~2.8x at
-  the 10-year horizon** from accumulated volume alone. This ~2.8x figure is the
-  **sim cohort output**, reproducible via
+  cohort (5,000 BTH held, 2×/yr velocity) reaches a **mean factor of 3.53x at
+  the 10-year horizon** from accumulated volume alone — above the harness's
+  own ≥3x mispricing flag, which the run reports as `FLAG`. This 3.53x figure
+  is the **sim cohort output**, reproducible via
   `target/release/cluster-tax-sim m2-cumulative --horizon-years 10`; it is *not*
-  one of the ratified ΔGini/whale-factor result-table numbers above. Accepted:
-  the mispricing is bounded by the log-domain curve (a merchant stays well
-  below the whale band) and the redistribution benefit dominates it.
+  one of the ratified ΔGini/whale-factor result-table numbers above. Accepted
+  with eyes open: the mispricing is real and flagged, but it is bounded by the
+  log-domain curve (the merchant band stays well below the whale band at
+  5.6–5.7x), and the ratified decision weighed the redistribution benefit
+  (ΔGini +0.22 to +0.57) as dominating it. The live-testnet confirmation
+  after the protocol-4.0.0 reset should re-measure merchant-cohort factors
+  against this prediction.
 - **Dormancy is no escape.** Parking coins does not lower a cluster's tracked
   wealth; the ratchet is permanent. This is intended — it removes hoarding as a
   factor-reduction strategy.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -447,8 +447,15 @@ threshold *above* this floor, never below (Bitcoin min-relay vs.
 consensus-validity split).
 
 **Open items from cycle 6 (not consensus-exploitable today, tracked):**
-- Cumulative cluster wealth never decrements (M2) — an economics/design
-  question, deterministic.
+- Cumulative cluster wealth never decrements (M2) — **RATIFIED 2026-07-05 as a
+  design decision** (#605, option 2): cluster wealth is intentionally lifetime
+  cumulative tagged volume with no decay. Deterministic; economics-only.
+  Empirically justified on the #626-recalibrated log-domain curve (cumulative
+  ΔGini +0.2171/+0.2242 at 10yr, +0.5644/+0.5745 at 20yr, honest/gamed — every
+  epoch-halving decay variant strictly weaker). Live-testnet confirmation of
+  the on-chain factor distribution after the 4.0.0 reset remains pending on
+  #605. See
+  [redistribution design doc](../design/cluster-tilted-redistribution.md#cluster-wealth-is-cumulative-lifetime-volume-design-decision).
 - Fee accounting books 100% of fees as burned while 80% is redistributed (M4)
   — no consensus effect today (difficulty ignores burns).
 - No explicit fork-choice/reorg handling in `add_block` beyond exact
@@ -628,7 +635,10 @@ For a block B applied at height H by any honest node:
 - Decoy-sourced tag-mass inflation vs. the C6 guard (**#581**)
 - Spend-time (not continuous) demurrage → "everyone parks" drift (**#314**)
 - Lottery payout privacy: winners visible on-chain, factor distribution leaks
-- Cluster wealth is cumulative and never decrements (M2)
+- Cluster wealth is cumulative and never decrements (M2) — **ratified design
+  decision** (#605, 2026-07-05): intentional lifetime-volume semantic, no
+  decay; empirically justified on the #626 log-domain curve. Live-testnet
+  factor-distribution confirmation after the 4.0.0 reset still pending (#605).
 
 ---
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -485,7 +485,7 @@ shipped. Mainnet regional hostnames are still scaffolding, gated behind
 | DNS poisoning / spoofed TXT seeds | Falls back to hardcoded seeds on DNS failure; block validation rejects any peer's invalid chain regardless of how it was discovered | Partial — DNS records are **not** cryptographically pinned (no DNSSEC dependency); a poisoned resolver can bias peer selection / attempt eclipse |
 | Eclipse via seed-list control | Multi-region seed diversity (testnet regionals live & default-on 2026-07-04, #613; DNS failover and seed-availability alerting still tracked there); per-IP connection caps | Partial |
 | Malicious primary seed | Mainnet primary seed multiaddr pins a peer ID; testnet primary resolves peer ID dynamically (host re-key without client release) | Partial (testnet unpinned by design) |
-| Protocol downgrade / incompatible peers | Major-version mismatch disconnects (`PROTOCOL_VERSION` 3.0.0, `consensus_incompatibility`, #608); minor/patch differences warn only | Mitigated (upgrade hygiene, not a security boundary — see I1) |
+| Protocol downgrade / incompatible peers | Major-version mismatch disconnects (`PROTOCOL_VERSION` 4.0.0, `consensus_incompatibility`, #605/#626); minor/patch differences warn only | Mitigated (upgrade hygiene, not a security boundary — see I1) |
 | Redial storm after version disconnect | Per-IP caps bound cost; no ban/backoff window yet (L1) | Partial |
 
 **Note:** protocol versions are self-reported via libp2p identify. The

--- a/experiments/ANALYSIS.md
+++ b/experiments/ANALYSIS.md
@@ -1187,11 +1187,14 @@ Cumulative passes with a 4–11× margin at both horizons, honest and gamed.
 Redistribution strengthens with horizon (Gini 0.93 → 0.37 at 20yr); gamed
 runs edge out honest because whale split/churn under cumulative tagging just
 re-tags value (no evasion channel). The merchant cohort (5,000 BTH,
-2×/yr velocity) reaches a mean factor of ~2.8x at 10yr from accumulated
-volume alone — the accepted velocity-vs-holdings mispricing, a sim cohort
+2×/yr velocity) reaches a mean factor of 3.53x at 10yr from accumulated
+volume alone — above the harness's ≥3x mispricing flag (`FLAG` in the run
+output) — the accepted velocity-vs-holdings mispricing, a sim cohort
 output (reproducible via
 `target/release/cluster-tax-sim m2-cumulative --horizon-years 10`), not one
-of the ΔGini/whale-factor figures in the table.
+of the ΔGini/whale-factor figures in the table. The ratified decision
+accepted this flagged mispricing as dominated by the redistribution benefit;
+the post-4.0.0-reset live measurement should re-check the merchant band.
 
 ### Run set 2 — epoch-halving decay (option 1), for comparison
 

--- a/experiments/ANALYSIS.md
+++ b/experiments/ANALYSIS.md
@@ -1146,3 +1146,78 @@ mechanism's Δgini > 0.05 claim stands in the gamed equilibrium.
    now enforced in the mempool), no tag-decay dynamics inside this
    experiment. A follow-up should co-simulate redistribution with the
    decay/wash-trading model.
+
+## M2 Resolution — Cumulative vs Epoch-Halving Decay (2026-07-05, issue #605)
+
+This section book-ends the decay findings above. The earlier wash-trading
+analysis (94–99% evasion at aggressive per-hop decay; 78.7% ring
+identification at 20% per-hop decay) established that *aggressive* cluster
+decay is a privacy and evasion hazard. Cycle-6 item **M2** (#605) asked the
+complementary question: given that `cluster_wealth_db` is monotonically
+non-decreasing (cumulative lifetime tagged volume, never decremented —
+decrement is impossible under ring privacy), does the monotonic ratchet
+degrade the validated Gini outcome at realistic horizons, or should a
+*conservative* decay be added?
+
+The operator ratified the empirical program on 2026-07-04 and set the
+decision rule: if recalibrated-**cumulative** semantics hold ΔGini > 0.05 at
+long horizons with a discriminating factor distribution → **option 2**
+(document cumulative); only if it degrades → **option 1** (deterministic
+epoch halving, never per-access), re-cleared against the wash-trading
+metrics.
+
+### Harness
+
+All runs use the **real production `ClusterFactorCurve`** (log-domain,
+`w_mid = 100k BTH`) — the #626 recalibration (#627), on the `u128`
+accumulator (#628) — not the #314 hardcoded 1.0/2.0/6.0 factors. Pinned at
+`main @ da24457`, seed `626626626`, deterministic. Full run matrix and
+one-liners: `experiments/M2_RUNBOOK.md`.
+
+### Run set 1 — cumulative (option 2), the decision-rule primary
+
+| Run | ΔGini | criterion > 0.05 | whale factor |
+|---|---|---|---|
+| 10yr honest | +0.2171 | PASS | 5.646x PASS |
+| 10yr gamed | +0.2242 | PASS | 5.646x PASS |
+| 20yr honest | +0.5644 | PASS | 5.745x PASS |
+| 20yr gamed | +0.5745 | PASS | 5.745x PASS |
+
+Cumulative passes with a 4–11× margin at both horizons, honest and gamed.
+Redistribution strengthens with horizon (Gini 0.93 → 0.37 at 20yr); gamed
+runs edge out honest because whale split/churn under cumulative tagging just
+re-tags value (no evasion channel). The merchant cohort (5,000 BTH,
+2×/yr velocity) reaches a mean factor of ~2.8x at 10yr from accumulated
+volume alone — the accepted velocity-vs-holdings mispricing, a sim cohort
+output (reproducible via
+`target/release/cluster-tax-sim m2-cumulative --horizon-years 10`), not one
+of the ΔGini/whale-factor figures in the table.
+
+### Run set 2 — epoch-halving decay (option 1), for comparison
+
+| Half-life | 10yr ΔGini (honest/gamed) | evasion (<20%) | ring-ID (<50%) |
+|---|---|---|---|
+| 2yr | +0.1839 / +0.1897 | 0.0% PASS | 17.8% PASS |
+| 5yr | +0.2096 / +0.2164 | 0.0% PASS | 13.2% PASS |
+| 10yr | +0.2171 / +0.2242 | 1.5% PASS | 11.3% PASS |
+| 5yr @ 20yr gamed | +0.4718 | 0.0% PASS | 13.2% PASS |
+
+Deterministic epoch halving is *safe* — nowhere near the prior art's
+94–99% evasion or 78.7% ring identification — but **strictly weaker on ΔGini
+at every half-life**, converging up to the cumulative result as the half-life
+grows. Decay buys nothing the decision rule values and adds consensus surface.
+
+### Outcome — RATIFIED 2026-07-05: option 2
+
+Per the decision rule, cumulative passed decisively with a discriminating
+factor distribution (whales pinned high, small users ~1x — the recalibrated
+curve, not a step), so the operator ratified **option 2: cluster wealth is
+intentionally cumulative lifetime tagged volume, no decay.** Documented as a
+first-class design decision in
+`docs/design/cluster-tilted-redistribution.md`; threat-model cross-reference
+updated. #581's residual and M3's saturation ceiling remain valid under the
+#628 `u128` widening. The one remaining verification — live-testnet
+factor-distribution confirmation after the 4.0.0 reset, against the
+2026-07-04 6x-pinned baseline — is tracked on #605 and is **still pending**;
+the sim's wash-trading model is the harness's #574-era adversary, and the
+live phase exists to catch model-vs-reality gaps.

--- a/infra/seed/README.md
+++ b/infra/seed/README.md
@@ -32,7 +32,7 @@ infra/seed/
 
 ## Testnet Reset & Multi-Seed Bootstrap
 
-For the coordinated reset onto current `main` (protocol 3.0.0), the
+For the coordinated reset onto current `main` (protocol 4.0.0), the
 genesis/network-parameter reconciliation table, single-seed vs multi-seed
 quorum config, the regional-seed scaffolding, and the operator deploy steps,
 see **[`TESTNET_RESET.md`](./TESTNET_RESET.md)**.

--- a/infra/seed/TESTNET_RESET.md
+++ b/infra/seed/TESTNET_RESET.md
@@ -1,9 +1,11 @@
 # Testnet Reset & Multi-Seed Bootstrap (operator runbook)
 
 This document covers the **coordinated testnet reset** onto current `main`
-(protocol `3.0.0`) and the **multi-seed bootstrap** plan. It was written for
-the #323 reset (protocol `2.0.0`) and updated for the #606 reset (protocol
-`3.0.0`, H1 consensus fee floor).
+(protocol `4.0.0`) and the **multi-seed bootstrap** plan. It was written for
+the #323 reset (protocol `2.0.0`), updated for the #606 reset (protocol
+`3.0.0`, H1 consensus fee floor), and again for the #605/#626 reset (protocol
+`4.0.0`, log-domain fee curve + u128 cluster wealth + ratified cluster-wealth
+decay).
 
 > **Scope split.** The *code/config* prep (scripts, genesis reconciliation,
 > multi-seed config scaffolding, release-build path) is in the repo. The
@@ -16,7 +18,7 @@ Current `main` values that any reset must match:
 
 | Parameter | Value | Source |
 |-----------|-------|--------|
-| Protocol version | `3.0.0` | `botho/src/network/discovery.rs` (`PROTOCOL_VERSION`, `MIN_SUPPORTED_PROTOCOL_VERSION`). Consensus-breaking resets require a **major** bump — `is_consensus_compatible` compares major only, so a minor bump would merely warn, not disconnect, old peers. |
+| Protocol version | `4.0.0` | `botho/src/network/discovery.rs` (`PROTOCOL_VERSION`, `MIN_SUPPORTED_PROTOCOL_VERSION`). Consensus-breaking resets require a **major** bump — `is_consensus_compatible` compares major only, so a minor bump would merely warn, not disconnect, old peers. |
 | Testnet genesis magic | `BOTHO_TESTNET_GENESIS_V1` (32-byte, in `prev_block_hash`) | `botho/src/block.rs` (`TESTNET_GENESIS_MAGIC`) |
 | Mainnet genesis magic | `BOTHO_MAINNET_GENESIS_V1` | `botho/src/block.rs` (`MAINNET_GENESIS_MAGIC`) |
 | Testnet network magic | `BTHT` (`0x42 0x54 0x48 0x54`) | `transaction/types/src/constants.rs` (`Network::magic_bytes`) |

--- a/mobile/app/src/config/network.test.ts
+++ b/mobile/app/src/config/network.test.ts
@@ -31,23 +31,25 @@ describe("compareNetwork", () => {
 
 describe("isProtocolCompatible", () => {
   it("accepts a node whose major version matches the client", () => {
-    // CLIENT_PROTOCOL_VERSION is 3.x (issue #606 H1 fee-floor reset); node
-    // speaks 3.x and accepts down to 3.x.
-    expect(isProtocolCompatible("3.0.0", "3.0.0")).toBe(true);
-    expect(isProtocolCompatible("3.3.1", "3.0.0")).toBe(true);
+    // CLIENT_PROTOCOL_VERSION is 4.x (issue #605/#626 reset: log-domain fee
+    // curve, u128 cluster wealth); node speaks 4.x and accepts down to 4.x.
+    expect(isProtocolCompatible("4.0.0", "4.0.0")).toBe(true);
+    expect(isProtocolCompatible("4.3.1", "4.0.0")).toBe(true);
   });
 
   it("accepts when the client falls inside the node's accepted window", () => {
-    // Node speaks 4.x but accepts down to 3.x -> client 3.x is fine.
-    expect(isProtocolCompatible("4.0.0", "3.0.0")).toBe(true);
+    // Node speaks 5.x but accepts down to 4.x -> client 4.x is fine.
+    expect(isProtocolCompatible("5.0.0", "4.0.0")).toBe(true);
   });
 
   it("rejects when the node requires a newer protocol than the client", () => {
-    expect(isProtocolCompatible("4.0.0", "4.0.0")).toBe(false);
+    expect(isProtocolCompatible("5.0.0", "5.0.0")).toBe(false);
   });
 
   it("rejects when the node is older than the client", () => {
-    // A pre-reset 2.x node no longer shares consensus rules with this client.
+    // A pre-reset 3.x node (old C7 fee floor) no longer shares consensus
+    // rules with this client.
+    expect(isProtocolCompatible("3.0.0", "3.0.0")).toBe(false);
     expect(isProtocolCompatible("2.0.0", "2.0.0")).toBe(false);
     expect(isProtocolCompatible("1.0.0", "1.0.0")).toBe(false);
   });
@@ -55,11 +57,11 @@ describe("isProtocolCompatible", () => {
   it("rejects when the node's protocol version is missing/unparsable", () => {
     expect(isProtocolCompatible(undefined, undefined)).toBe(false);
     expect(isProtocolCompatible("", "")).toBe(false);
-    expect(isProtocolCompatible("abc", "3.0.0")).toBe(false);
+    expect(isProtocolCompatible("abc", "4.0.0")).toBe(false);
   });
 
   it("defaults the min to the node's own major when min is absent", () => {
-    expect(isProtocolCompatible("3.0.0", undefined)).toBe(true);
-    expect(isProtocolCompatible("4.0.0", undefined)).toBe(false);
+    expect(isProtocolCompatible("4.0.0", undefined)).toBe(true);
+    expect(isProtocolCompatible("5.0.0", undefined)).toBe(false);
   });
 });

--- a/mobile/app/src/config/network.ts
+++ b/mobile/app/src/config/network.ts
@@ -27,7 +27,7 @@ export const EXPECTED_NETWORK = "botho-testnet";
  * we treat a node as compatible when our version is within that node's
  * accepted window (major version match, see `isProtocolCompatible`).
  */
-export const CLIENT_PROTOCOL_VERSION = "3.0.0";
+export const CLIENT_PROTOCOL_VERSION = "4.0.0";
 
 /** Outcome of comparing a node's reported network against this build. */
 export type NetworkMatch = "match" | "mismatch" | "unknown";


### PR DESCRIPTION
## Summary

Bumps the wire protocol version to **4.0.0** (major) for the coordinated testnet reset that deploys the #626 consensus changes and the ratified #605 semantics. Code-only slice; the reset itself (wipe + re-genesis + redeploy) is operator-executed.

`main`'s consensus rules diverge from the running 3.0.0 chain: #626 replaces the C7 consensus fee floor with a **log-domain fee curve** and widens cluster-wealth accounting to **u128** (#627/#628/#629), and #605 ratifies the cluster-wealth decay semantics riding the same reset. Because #626 changes the fee floor a block must satisfy to be accepted, 3.0.0 peers are consensus-incompatible with the reset chain — a rolling upgrade is impossible; a coordinated reset with fresh genesis is required.

## Why 4.0.0 (major) and not 3.1.0 (minor)

The peer-disconnect mechanism (`is_consensus_compatible` / `consensus_incompatibility` in `botho/src/network/discovery.rs`) compares **major versions only** — minor/patch differences within the same major merely warn (graceful soft-fork behavior) and do NOT disconnect. Since #626's fee-curve change is consensus-breaking and 3.0.0 peers must be **disconnected** (not warned) from the reset chain, the bump must be major. This matches the constant's doc contract ("Major: Breaking changes requiring hard fork") and the 2.0.0 -> 3.0.0 precedent (#608).

A new regression test (`test_v3_peers_are_consensus_incompatible_with_current`) pins this: it asserts a 3.0.0 peer is consensus-incompatible with the live `PROTOCOL_VERSION`, so a future accidental minor-only bump of a consensus-breaking change fails the suite. The prior `test_v2_peers_...` guard is retained.

## Changes

- `botho/src/network/discovery.rs`
  - `PROTOCOL_VERSION`: `3.0.0` -> `4.0.0`
  - `MIN_SUPPORTED_PROTOCOL_VERSION`: `3.0.0` -> `4.0.0`
  - Rationale comments in the existing style, citing #626/#627/#628/#629 (consensus changes) and #605 (ratified semantics).
  - `test_protocol_version_constant` / `test_min_supported_protocol_version_constant` assertions -> major 4.
  - New `test_v3_peers_are_consensus_incompatible_with_current` regression guard (v2 guard retained).
- `mobile/app/src/config/network.ts`: `CLIENT_PROTOCOL_VERSION` `3.0.0` -> `4.0.0`.
- `mobile/app/src/config/network.test.ts`: literals shifted to the major-4 window (`isProtocolCompatible` derives majors dynamically; only tests change).
- `infra/seed/TESTNET_RESET.md`, `infra/seed/README.md`, `docs/security/threat-model.md`: version-coupled `3.0.0` -> `4.0.0` protocol references.

## Version references checked

Updated (version-coupled):
- `botho/src/network/discovery.rs` PROTOCOL_VERSION / MIN_SUPPORTED_PROTOCOL_VERSION + constant tests (+ new regression guard)
- `mobile/app/src/config/network.ts` CLIENT_PROTOCOL_VERSION
- `mobile/app/src/config/network.test.ts` (client-major-dependent literals)
- `infra/seed/TESTNET_RESET.md`, `infra/seed/README.md` (operator runbook protocol references — explicitly in scope this cycle)
- `docs/security/threat-model.md` (mitigation row citing the live `PROTOCOL_VERSION` value)

Checked and intentionally left unchanged:
- `PLAN.md:7`: describes the *currently deployed* live 3-node testnet as "protocol 3.0.0 (reset #606)". The reset is operator-executed and has not run, so the live network is still 3.0.0 until then; updating it would misstate current reality. Should be updated by the operator when the reset lands.
- `botho/src/rpc/mod.rs` (`3658`, `3659`, `3681`, `3682`, `4177`, `4199`): test-local `NodeIdentity`/peer fixtures with hardcoded "2.0.0"; assert payload shape, not the real constant. Pass unchanged.
- `botho/src/network/discovery.rs` generic version-comparison unit tests: "2.0.0"/"3.0.0"/"4.0.0" as arbitrary example versions, not the live constant.
- `gossip/src/service.rs:828`: test-local literal, unrelated to node protocol version.
- `mobile/app/src/types/wallet.ts:103`, `botho/src/rpc/mod.rs:103/132`: doc-comment examples ("e.g. \"2.0.0\""), not live values.
- `web/packages/core/package-lock.json`, `web/packages/desktop/package.json`: `@scure/base` / `@tauri-apps/cli` dependency versions — unrelated.
- `CHANGELOG.md`, `.claude/commands/loom/{bump,release}.md`: semver spec URL `semver.org/spec/v2.0.0.html` — unrelated.

## Testing

- `cargo build --workspace`: success (pre-existing warnings only).
- `cargo test -p botho --lib network::discovery`: 48 passed, 0 failed (includes both v2 and new v3 regression guards).
- `cargo fmt --all -- --check`: clean.
- Mobile jest tests not runnable here (node_modules absent); expectations updated in lockstep with the client major and verified by inspection against the pure `isProtocolCompatible` logic (same approach as #608).

## Scope

`Updates #605` (does NOT close it). This PR is the deployment vehicle for #626 + #605; the reset itself (wipe + re-genesis of seeds/faucet, redeploy per the runbook, re-fund, smoke-test the fee-curve accept/reject, verify multi-node SCP externalization) remains operator-executed. No infra actions were taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)