### PR TITLE
chore(release): bump workspace to 0.3.0 + v0.3.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,64 @@ bumps (`0.X.Y`) are backwards-compatible.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-05
+
+### Summary
+
+Consensus-breaking release (requires a coordinated network reset). Ships two
+protocol bumps — `2.0.0 → 3.0.0 → 4.0.0` — that pin the current testnet: a
+deterministic consensus fee floor (H1) and a log-domain cluster-factor curve
+with recalibrated `w_mid` and `u128` cluster-wealth accounting (#626). Also
+lands the CLI thin wallet's real CLSAG ring transactions, regional testnet
+seeds on by default, and a validated, reproducible release pipeline.
+
+### Changed (consensus-breaking — requires network reset)
+
+- **Deterministic consensus fee floor in `add_block`.** The minimum-fee rule is
+  now enforced in the consensus path with integer-only arithmetic; the mempool
+  relay fee may only tighten *above* the consensus floor, never below it (H1).
+  Block fee-sum arithmetic rejects/saturates on overflow instead of wrapping.
+  Protocol version bumped to `3.0.0` for the required reset. (#600, #601, #602,
+  #603, #606, #608)
+- **Log-domain cluster-factor curve in picocredits.** The cluster-tax factor is
+  computed on a log-domain curve with a recalibrated `w_mid`, the
+  `cluster_wealth_db` accumulator is widened `u64 → u128` to avoid overflow at
+  full-supply scale, and the real curve is exercised by an M2 simulation
+  harness. Protocol version bumped to `4.0.0` for the required reset. (#626,
+  #627, #628, #629, #631)
+- **M2 cumulative cluster-wealth semantic ratified** as a design decision
+  (spend-time cumulative accrual). (#605, #630)
+- **Cluster-wealth rebuild uses `saturating_add`** for determinism parity (M3).
+  (#607)
+
+### Added
+
+- **Real CLSAG ring transactions in the CLI thin wallet** — the wallet now
+  builds actual ring signatures instead of placeholder transactions. (#614,
+  #620)
+- **Live testnet regional seeds included in the fallback set by default**, so a
+  fresh node can discover the network without manual seed configuration. (#613,
+  #624)
+
+### Fixed
+
+- **Wallet RPC serde field-case drift** vs the current node repaired — restores
+  wallet ↔ node compatibility. (#610, #617)
+- **Decoy selection clamp panic** — phase-1 in-band draw is skipped when the age
+  band is degenerate, avoiding an out-of-range clamp. (#611, #618)
+- **Reproducible release pipeline portability.** Portable `sha256` wrapper for
+  macOS runners (`sha256sum` is Linux-only), and the `botho-wallet` Windows
+  file-ACL code fixed to compile against `windows` 0.58 (module paths, features,
+  `WIN32_ERROR`). Validated across all five release targets. (#615, #619, #621,
+  #622)
+
+### Docs & Security
+
+- **Threat model refreshed** for audit cycle-6 and the economic mechanism.
+  (#616, #625)
+- **Testnet runbook updated** for the protocol resets; stale `--relay` flag
+  references removed; mainnet-blocker list refreshed. (#609, #612, #623)
+
 ## [0.2.0] - 2026-06-15
 
 ### Summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "botho"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "botho-desktop"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "botho-wallet",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "botho-exchange-scanner"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "botho-metrics-daemon"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "botho-mobile"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bip39",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "botho-wallet"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "bth-bridge-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "hex",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "bth-bridge-service"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bth-bridge-core",
  "chrono",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "bth-cluster-tax"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bth-transaction-types",
  "clap",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "bth-crypto-pq"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "bth-crypto-secp256k1"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "hex",
  "hmac",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "bth-discover"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bth-common",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "bth-gossip"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags 2.10.0",
  "bth-common",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "bth-transaction-clsag"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes",
  "bth-account-keys",

--- a/botho-exchange-scanner/Cargo.toml
+++ b/botho-exchange-scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-exchange-scanner"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Exchange deposit scanner for Botho cryptocurrency"
 license = "Apache-2.0"

--- a/botho-wallet/Cargo.toml
+++ b/botho-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-wallet"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Standalone thin wallet client for Botho cryptocurrency"
 license = "Apache-2.0"

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "A privacy-preserving mined cryptocurrency"
 license = "GPL-3.0"

--- a/bridge/core/Cargo.toml
+++ b/bridge/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-bridge-core"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Botho"]
 edition = "2021"
 description = "Core types and logic for BTH bridge"

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-bridge-service"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Botho"]
 edition = "2021"
 description = "BTH bridge service for Ethereum and Solana"

--- a/cluster-tax/Cargo.toml
+++ b/cluster-tax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-cluster-tax"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = { workspace = true }

--- a/crypto/pq/Cargo.toml
+++ b/crypto/pq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-crypto-pq"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/secp256k1/Cargo.toml
+++ b/crypto/secp256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-crypto-secp256k1"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Botho"]
 edition = "2021"
 description = "Secp256k1 key support for Ethereum compatibility"

--- a/discover/Cargo.toml
+++ b/discover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-discover"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-gossip"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/infra/faucet/metrics-daemon/Cargo.toml
+++ b/infra/faucet/metrics-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-metrics-daemon"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Historical metrics collection daemon for Botho faucet"
 license = "MIT"

--- a/mobile/app/package.json
+++ b/mobile/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botho-mobile",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Botho Mobile Wallet",
   "main": "expo-router/entry",
   "scripts": {

--- a/mobile/rust-bridge/Cargo.toml
+++ b/mobile/rust-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-mobile"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Mobile FFI bindings for Botho wallet"
 license = "Apache-2.0"

--- a/transaction/clsag/Cargo.toml
+++ b/transaction/clsag/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-transaction-clsag"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Botho"]
 edition = "2021"
 description = "Self-contained CLSAG ring-signature transaction types for Botho (stealth addresses + ring signatures)"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botho-web",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @botho/web-wallet dev",

--- a/web/packages/desktop/src-tauri/Cargo.toml
+++ b/web/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-desktop"
-version = "0.2.0"
+version = "0.3.0"
 description = "Botho Desktop Wallet"
 authors = ["Botho"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Prepares the v0.3.0 release version bump (mainnet blocker 5, #615). The release
pipeline is already validated across all five targets (PRs #619/#622); this PR
pins what the testnet now runs — protocol 4.0.0, main @ 4f944e0 — so the operator
can tag `v0.3.0` on the merge commit and trigger `release.yml`.

## Changes

- **Bumped every workspace crate at `0.2.0` → `0.3.0` (14 crates):** botho,
  botho-wallet, botho-exchange-scanner, cluster-tax, discover, gossip,
  bridge/core, bridge/service, crypto/pq, crypto/secp256k1, mobile/rust-bridge,
  transaction/clsag, infra/faucet/metrics-daemon, web/packages/desktop/src-tauri.
  Regenerated `Cargo.lock` via `cargo build --workspace`.
- **Bumped the two release-tracking app configs:** `web/package.json` and
  `mobile/app/package.json` (`0.2.0 → 0.3.0`). Web sub-packages stay at `0.1.0`
  (independent versioning) and were left untouched.
- **Added a v0.3.0 CHANGELOG section** in the existing Keep-a-Changelog style,
  summarizing highlights since v0.2.0: protocol `2.0.0 → 3.0.0 → 4.0.0` resets
  (H1 consensus fee floor #602/#606/#608; log-domain cluster-factor curve +
  u128 cluster wealth #626–#631), M2 cumulative semantics ratified (#605/#630),
  CLI wallet CLSAG (#614/#620), serde wire fix (#610/#617), decoy clamp fix
  (#611/#618), regional seeds default-on (#613/#624), release pipeline
  portability (#619/#622), and threat-model refresh (#616/#625).

### Hardcoded `0.2.0` references — checked and skipped

`nodeVersion` is derived from `CARGO_PKG_VERSION` (automatic). Grepped src/docs/infra
for literal `0.2.0`; the following are intentionally not version-coupled to the node
release and were left as-is:

- `contracts/ethereum/package.json` — Wrapped-BTH contracts, independent versioning (workspace-excluded).
- `web/packages/*/package.json` — all at `0.1.0`, independent sub-package versions.
- `mobile/app/src/types/wallet.ts` — doc-comment example (`e.g. "0.2.0"`), not a pin.
- `docs/specification/protocol-v0.2.0.md`, `docs/specification/README.md` — protocol spec artifact (separate versioning); out of scope.
- `PLAN.md` — historical v0.2.0 milestone references.
- `crypto/box/README.md` — third-party `aead` crate docs URL.
- `*/pnpm-lock.yaml` — third-party dependency versions (eastasianwidth, etc.).
- `infra/baas/README.md`, `infra/baas/rig-bootstrap.sh` — note that the v0.2.0 GH release shipped no downloadable asset. These belong to the operator-gated "prefer released artifacts over build-on-host" runbook update (buildable once the real release exists), not this version bump.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| All 0.2.0 workspace crates bumped to 0.3.0 | Done | `grep -r 'version = "0.2.0"' --include=Cargo.toml` → none remaining; 14 now at 0.3.0 |
| Cargo.lock regenerated | Done | `cargo build --workspace` updated lock entries |
| Version-coupled hardcoded refs updated | Done | mobile/app + web configs bumped; rest listed above |
| CHANGELOG v0.3.0 section added | Done | Keep-a-Changelog style, mirrors 0.2.0 structure |
| Build passes | Done | `cargo build --workspace` finished clean |
| Tests pass | Done | `cargo test -p botho --lib` → 1094 passed, 0 failed, 2 ignored |
| Format clean | Done | `cargo fmt --all -- --check` exit 0 |

## Test Plan

- `cargo build --workspace` — clean (warnings pre-existing only)
- `cargo test -p botho --lib` — 1094 passed, 0 failed, 2 ignored
- `cargo fmt --all -- --check` — exit 0

## Post-merge

After merge, the operator tags `v0.3.0` on the merge commit, which triggers
`.github/workflows/release.yml` to build and publish the checksummed artifacts.

Updates #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)