### PR TITLE
feat(sync): penalise and rotate peers that persistently re-serve held ranges

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 640
-# Branch: feature/issue-640
+# Issue: 644
+# Branch: feature/issue-644
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -1019,6 +1019,7 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                                             .map(|s| s.height)
                                             .unwrap_or(0);
                                         let mut applied_any = false;
+                                        let mut had_failure = false;
                                         for block in &blocks {
                                             // Already have this block — skip it rather than
                                             // fail. A pure-overlap batch (all blocks known)
@@ -1031,6 +1032,7 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                                             if let Err(e) = node.add_block_from_network(block) {
                                                 warn!("Failed to add synced block {}: {}", block.height(), e);
                                                 sync_manager.on_failure(Some(&peer), e.to_string());
+                                                had_failure = true;
                                                 break;
                                             }
                                             applied_any = true;
@@ -1081,6 +1083,16 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                                                     }
                                                 }
                                             }
+                                        } else if !had_failure {
+                                            // Pure-overlap batch: every block was at or
+                                            // below our committed height, so nothing was
+                                            // applied and no failure was raised. Notify the
+                                            // sync manager so it can track consecutive
+                                            // zero-progress responses and, past a threshold,
+                                            // penalise a peer that persistently re-serves a
+                                            // range we already hold (#644). A one-off overlap
+                                            // stays below the threshold and is tolerated.
+                                            sync_manager.on_zero_progress(&peer);
                                         }
                                     }
                                 }

--- a/botho/src/network/mod.rs
+++ b/botho/src/network/mod.rs
@@ -47,7 +47,7 @@ pub use seeds::{fallback_seeds, include_regional_seeds};
 pub use sync::{
     create_sync_behaviour, ChainSyncManager, SyncAction, SyncCodec, SyncRateLimiter, SyncRequest,
     SyncResponse, SyncState, SyncStatusSnapshot, BLOCKS_PER_REQUEST, MAX_REQUESTS_PER_MINUTE,
-    MAX_REQUEST_SIZE, MAX_RESPONSE_SIZE,
+    MAX_REQUEST_SIZE, MAX_RESPONSE_SIZE, OVERLAP_THRESHOLD,
 };
 pub use transport::{
     negotiate_transport_initiator,

--- a/botho/src/network/sync.rs
+++ b/botho/src/network/sync.rs
@@ -92,6 +92,22 @@ pub const INITIAL_RETRY_BACKOFF: Duration = Duration::from_secs(5);
 /// network heals, while still throttling a persistently failing peer.
 pub const MAX_RETRY_BACKOFF: Duration = Duration::from_secs(60);
 
+/// Consecutive pure-overlap (zero-progress) responses tolerated from one peer
+/// before a soft failure is applied (#644).
+///
+/// A response batch that contains no novel blocks — every block is at or below
+/// our committed height — makes no forward progress. The overlap-tolerance path
+/// (#643) correctly refuses to hard-fail on such a batch, so a genuinely
+/// misbehaving peer that keeps re-serving a range we already hold would
+/// otherwise spin the ~2s sync tick indefinitely with no backoff and no
+/// reputation consequence. Past this many *consecutive* zero-progress responses
+/// from the same peer, [`ChainSyncManager::on_zero_progress`] dings reputation
+/// and rotates the download peer (or engages backoff when no alternative
+/// exists). Three balances responsiveness against false positives from benign
+/// batch-boundary transients: one or two overlaps can be coincidental; three
+/// consecutive from the same peer indicates persistent misbehaviour.
+pub const OVERLAP_THRESHOLD: u32 = 3;
+
 // ============================================================================
 // Protocol Messages
 // ============================================================================
@@ -512,6 +528,17 @@ pub struct ChainSyncManager {
     reputation: ReputationManager,
     /// Last time we re-polled peers for status while synced
     last_status_refresh: Instant,
+    /// Consecutive pure-overlap (zero-progress) response counts per peer
+    /// (#644).
+    ///
+    /// Incremented by [`on_zero_progress`] each time a peer's response batch
+    /// applied no novel blocks. Past [`OVERLAP_THRESHOLD`] the peer is treated
+    /// as persistently misbehaving (soft failure). Cleared entirely on any real
+    /// forward progress ([`on_blocks_added`]) and the peer's entry is removed
+    /// on disconnect ([`on_peer_disconnected`]), so a peer is never
+    /// penalised for a stale overlap after it resumes normal service or
+    /// reconnects.
+    peer_overlap_counts: HashMap<PeerId, u32>,
 }
 
 impl ChainSyncManager {
@@ -526,6 +553,7 @@ impl ChainSyncManager {
             retry_backoff: INITIAL_RETRY_BACKOFF,
             reputation: ReputationManager::new(),
             last_status_refresh: Instant::now(),
+            peer_overlap_counts: HashMap::new(),
         }
     }
 
@@ -763,11 +791,95 @@ impl ChainSyncManager {
         // earlier in the sync does not keep recovery latency inflated (#641).
         self.retry_backoff = INITIAL_RETRY_BACKOFF;
 
+        // Forward progress wipes the slate clean for every peer: a batch that
+        // advances our tip proves the download is making progress, so no peer
+        // should carry a stale consecutive-overlap count into the next batch
+        // (#644).
+        self.peer_overlap_counts.clear();
+
         // Check if we've caught up
         if let SyncState::Downloading { target_height, .. } = self.state {
             if new_height >= target_height {
                 debug!(height = new_height, "Sync complete");
                 self.state = SyncState::Synced;
+            }
+        }
+    }
+
+    /// Handle a response batch that applied no novel blocks (pure overlap).
+    ///
+    /// Called by the run loop when every block in a peer's response was at or
+    /// below our committed height, so the batch made zero forward progress. The
+    /// overlap-tolerance path (#643) deliberately does NOT hard-fail on such a
+    /// batch — a one-off duplicate near a batch boundary is benign and must be
+    /// tolerated. But a peer that *persistently* ignores the requested
+    /// `start_height` and keeps re-serving a range we already hold would spin
+    /// the fixed-interval sync tick forever with no backoff and no reputation
+    /// consequence (#644).
+    ///
+    /// This tracks consecutive zero-progress responses per peer. Below
+    /// [`OVERLAP_THRESHOLD`] nothing happens (benign transient overlap is
+    /// tolerated). At the threshold the offending peer's reputation is dinged
+    /// and, if it is the current download peer:
+    /// - it is rotated out in favour of an alternative unbanned peer (the sync
+    ///   manager stays in `Downloading` — less disruptive than a full reset);
+    ///   or
+    /// - when no alternative exists, [`on_failure`] engages the jittered
+    ///   exponential backoff so the tick is no longer spun in a tight loop.
+    ///
+    /// The counter resets after action so it does not wrap, and forward
+    /// progress ([`on_blocks_added`]) or disconnect
+    /// ([`on_peer_disconnected`]) clears it.
+    pub fn on_zero_progress(&mut self, peer: &PeerId) {
+        let count = self.peer_overlap_counts.entry(*peer).or_insert(0);
+        *count += 1;
+        if *count < OVERLAP_THRESHOLD {
+            return;
+        }
+        // Reset the counter now that we are taking action, so it does not wrap
+        // and a peer that keeps misbehaving is penalised once per threshold
+        // window rather than on every subsequent response.
+        *count = 0;
+
+        warn!(
+            %peer,
+            threshold = OVERLAP_THRESHOLD,
+            "Peer persistently re-serving already-held range; applying soft failure"
+        );
+
+        // Ding reputation exactly once, up front. This both records the penalty
+        // and worsens the offender's selection score, so the `best_peer()` call
+        // below deterministically prefers an alternative peer when one exists.
+        self.reputation.request_failed(peer);
+
+        // Only rotate/backoff when the offender is the peer we are actively
+        // downloading from; a stale response from a peer we already rotated away
+        // from is still worth a reputation ding but must not disturb the current
+        // download.
+        let is_download_peer = matches!(
+            &self.state,
+            SyncState::Downloading { peer: dp, .. } if dp == peer
+        );
+
+        if is_download_peer {
+            // Prefer a soft rotate to a *different* unbanned peer over a full
+            // `Failed` reset. Having just dinged the offender, `best_peer()`
+            // returns it again only when it is the sole candidate.
+            match self.best_peer() {
+                Some((next_peer, _)) if next_peer != *peer => {
+                    if let SyncState::Downloading { peer: dp, .. } = &mut self.state {
+                        *dp = next_peer;
+                    }
+                    // The stale in-flight request (if any) targets the rotated
+                    // peer; drop the guard so the next tick queries the new peer.
+                    self.pending_request = None;
+                }
+                _ => {
+                    // No alternative peer: full soft-fail with backoff. Pass
+                    // `None` so `on_failure` does not double-ding the reputation
+                    // already recorded above.
+                    self.on_failure(None, "persistent zero-progress overlap".to_string());
+                }
             }
         }
     }
@@ -814,6 +926,11 @@ impl ChainSyncManager {
     /// Handle peer disconnection
     pub fn on_peer_disconnected(&mut self, peer: &PeerId) {
         self.peer_statuses.remove(peer);
+
+        // Drop any consecutive-overlap count for this peer so a reconnecting
+        // peer starts with a clean slate rather than inheriting a stale count
+        // (#644).
+        self.peer_overlap_counts.remove(peer);
 
         // If we were downloading from this peer, go back to discovery
         if let SyncState::Downloading {
@@ -1579,6 +1696,170 @@ mod tests {
         // The peer should have a reputation entry
         let rep = manager.reputation_mut().get(&peer);
         assert!(rep.is_some());
+    }
+
+    // ========================================================================
+    // on_zero_progress (persistent-overlap soft failure) tests (#644)
+    // ========================================================================
+
+    #[test]
+    fn test_on_zero_progress_below_threshold_no_penalty() {
+        // A peer that delivers fewer than OVERLAP_THRESHOLD consecutive
+        // pure-overlap batches incurs no backoff and no reputation penalty:
+        // benign transient overlap must be tolerated.
+        let mut manager = ChainSyncManager::new(0);
+        let peer = make_peer_id();
+        manager.on_status(peer, 100, [1u8; 32]);
+        assert!(matches!(manager.state(), SyncState::Downloading { .. }));
+
+        for _ in 0..(OVERLAP_THRESHOLD - 1) {
+            manager.on_zero_progress(&peer);
+        }
+
+        // Still downloading from the same peer, no failure recorded.
+        assert!(
+            matches!(manager.state(), SyncState::Downloading { peer: p, .. } if *p == peer),
+            "below threshold must stay Downloading from the same peer"
+        );
+        let failures = manager
+            .reputation_mut()
+            .get(&peer)
+            .map(|r| r.failures)
+            .unwrap_or(0);
+        assert_eq!(failures, 0, "below threshold must not ding reputation");
+    }
+
+    #[test]
+    fn test_on_zero_progress_at_threshold_dings_reputation() {
+        // At OVERLAP_THRESHOLD consecutive pure-overlap batches with no
+        // alternative peer available, the manager dings reputation and engages
+        // the backoff path (enters Failed).
+        let mut manager = ChainSyncManager::new(0);
+        let peer = make_peer_id();
+        manager.on_status(peer, 100, [1u8; 32]);
+        assert!(matches!(manager.state(), SyncState::Downloading { .. }));
+
+        for _ in 0..OVERLAP_THRESHOLD {
+            manager.on_zero_progress(&peer);
+        }
+
+        let failures = manager
+            .reputation_mut()
+            .get(&peer)
+            .map(|r| r.failures)
+            .unwrap_or(0);
+        assert_eq!(
+            failures, 1,
+            "reaching the threshold must record exactly one failure"
+        );
+        // No alternative peer exists, so on_failure engages the backoff path.
+        assert!(
+            matches!(manager.state(), SyncState::Failed { .. }),
+            "no alternative peer -> soft-fail into Failed with backoff"
+        );
+    }
+
+    #[test]
+    fn test_on_zero_progress_at_threshold_rotates_to_alternative_peer() {
+        // With an alternative unbanned peer available, the offending peer is
+        // rotated out and the manager stays in Downloading (not Failed).
+        let mut manager = ChainSyncManager::new(0);
+        let peer_a = make_peer_id();
+        let peer_b = make_peer_id();
+        manager.on_status(peer_a, 100, [1u8; 32]);
+        manager.on_status(peer_b, 100, [2u8; 32]);
+
+        // Identify which peer the manager chose to download from, and the other.
+        let (download_peer, other_peer) = match manager.state() {
+            SyncState::Downloading { peer, .. } if *peer == peer_a => (peer_a, peer_b),
+            SyncState::Downloading { peer, .. } if *peer == peer_b => (peer_b, peer_a),
+            other => panic!("expected Downloading, got {other:?}"),
+        };
+
+        for _ in 0..OVERLAP_THRESHOLD {
+            manager.on_zero_progress(&download_peer);
+        }
+
+        // Reputation dinged, but rotated to the alternative rather than failing.
+        assert_eq!(
+            manager
+                .reputation_mut()
+                .get(&download_peer)
+                .map(|r| r.failures)
+                .unwrap_or(0),
+            1,
+            "the offending peer's reputation must be dinged"
+        );
+        assert!(
+            matches!(manager.state(), SyncState::Downloading { peer: p, .. } if *p == other_peer),
+            "an available alternative peer must be rotated in without entering Failed"
+        );
+    }
+
+    #[test]
+    fn test_on_zero_progress_resets_on_forward_progress() {
+        // Forward progress clears the consecutive-overlap slate, so overlaps
+        // that straddle a successful batch never accumulate to the threshold.
+        let mut manager = ChainSyncManager::new(0);
+        let peer = make_peer_id();
+        manager.on_status(peer, 100, [1u8; 32]);
+
+        // Two overlaps (below threshold), then real forward progress.
+        manager.on_zero_progress(&peer);
+        manager.on_zero_progress(&peer);
+        manager.on_blocks_added(50); // still below target 100 -> stays Downloading
+
+        // Two more overlaps: the counter restarted from zero, so no penalty.
+        manager.on_zero_progress(&peer);
+        manager.on_zero_progress(&peer);
+
+        assert_eq!(
+            manager
+                .reputation_mut()
+                .get(&peer)
+                .map(|r| r.failures)
+                .unwrap_or(0),
+            0,
+            "forward progress must reset the overlap counter"
+        );
+        assert!(
+            matches!(manager.state(), SyncState::Downloading { .. }),
+            "no soft failure should fire when progress reset the counter"
+        );
+    }
+
+    #[test]
+    fn test_on_zero_progress_clears_on_disconnect() {
+        // A reconnecting peer starts with a clean slate: overlaps from before a
+        // disconnect must not carry over.
+        let mut manager = ChainSyncManager::new(0);
+        let peer = make_peer_id();
+        manager.on_status(peer, 100, [1u8; 32]);
+
+        // Two overlaps (below threshold), then the peer disconnects.
+        manager.on_zero_progress(&peer);
+        manager.on_zero_progress(&peer);
+        manager.on_peer_disconnected(&peer);
+        assert!(matches!(manager.state(), SyncState::Discovery));
+
+        // Peer reconnects and delivers two more overlaps: counter restarted.
+        manager.on_status(peer, 100, [1u8; 32]);
+        manager.on_zero_progress(&peer);
+        manager.on_zero_progress(&peer);
+
+        assert_eq!(
+            manager
+                .reputation_mut()
+                .get(&peer)
+                .map(|r| r.failures)
+                .unwrap_or(0),
+            0,
+            "disconnect must clear the overlap counter for the peer"
+        );
+        assert!(
+            matches!(manager.state(), SyncState::Downloading { .. }),
+            "no soft failure should fire after a disconnect reset the counter"
+        );
     }
 
     // ========================================================================

--- a/botho/tests/chain_sync_catchup_integration.rs
+++ b/botho/tests/chain_sync_catchup_integration.rs
@@ -27,7 +27,9 @@ use tempfile::TempDir;
 use botho::{
     block::{Block, BlockHeader, BlockLotterySummary, MintingTx},
     ledger::Ledger,
-    network::{ChainSyncManager, SyncAction, SyncRequest, SyncResponse, SyncState},
+    network::{
+        ChainSyncManager, SyncAction, SyncRequest, SyncResponse, SyncState, OVERLAP_THRESHOLD,
+    },
     transaction::{Transaction, PICOCREDITS_PER_CREDIT},
 };
 use botho_wallet::WalletKeys;
@@ -840,5 +842,125 @@ fn test_duplicate_batch_response_tolerated() {
     assert!(
         iterations < 50,
         "catch-up after overlap took too many iterations: {iterations}"
+    );
+}
+
+/// Regression test for #644: a peer that *persistently* re-serves an
+/// already-held range (pure overlap, zero forward progress) must, past
+/// `OVERLAP_THRESHOLD` consecutive such responses, be dinged and rotated out in
+/// favour of an alternative peer — rather than spinning the sync tick forever
+/// with no backoff and no reputation consequence (the concern #641/#643 left
+/// open).
+///
+/// This models the production run-loop path: a pure-overlap batch (every block
+/// at or below our committed height) applies nothing and, per #644, calls
+/// `on_zero_progress`. With a second healthy peer available, the misbehaving
+/// download peer is rotated out (the manager stays in `Downloading`, not
+/// `Failed`) and sync completes via the alternative.
+#[test]
+#[serial]
+fn test_persistent_overlap_peer_triggers_soft_failure() {
+    let target_height = 145;
+
+    // --- Source node: chain to 145 ---
+    let source_dir = TempDir::new().unwrap();
+    let source = Ledger::open(source_dir.path()).unwrap();
+    source.set_difficulty(TRIVIAL_DIFFICULTY).unwrap();
+    let minter = create_test_wallet().public_address();
+    build_chain_to_height(&source, &minter, target_height);
+    let source_state = source.get_chain_state().unwrap();
+    assert_eq!(source_state.height, target_height);
+
+    // --- Fresh node at genesis ---
+    let node_dir = TempDir::new().unwrap();
+    let node = Ledger::open(node_dir.path()).unwrap();
+    node.set_difficulty(TRIVIAL_DIFFICULTY).unwrap();
+
+    let mut sync_manager = ChainSyncManager::new(0);
+    let peer_a = PeerId::random();
+    let peer_b = PeerId::random();
+
+    // Two peers both at the tip, so an alternative download peer is always
+    // available when we rotate the misbehaving one out.
+    sync_manager.on_status(peer_a, source_state.height, source_state.tip_hash);
+    sync_manager.on_status(peer_b, source_state.height, source_state.tip_hash);
+
+    // Identify which peer the manager chose to download from, and the other.
+    let (bad_peer, alt_peer) = match sync_manager.state() {
+        SyncState::Downloading { peer, .. } if *peer == peer_a => (peer_a, peer_b),
+        SyncState::Downloading { peer, .. } if *peer == peer_b => (peer_b, peer_a),
+        other => panic!("expected Downloading, got {other:?}"),
+    };
+
+    // --- Batch 1 [1..100] applied normally from the download peer ---
+    let action = sync_manager
+        .tick(&[bad_peer, alt_peer])
+        .expect("should request first batch");
+    let SyncAction::RequestBlocks {
+        start_height,
+        count,
+        ..
+    } = action
+    else {
+        panic!("expected RequestBlocks, got {action:?}");
+    };
+    assert_eq!(start_height, 1, "first request anchored at genesis + 1");
+    sync_manager.on_request_sent(bad_peer);
+    let applied = apply_batch_with_overlap_skip(
+        &mut sync_manager,
+        &node,
+        bad_peer,
+        serve_get_blocks(&source, start_height, count),
+    );
+    assert_eq!(applied, 100, "first batch applies 100 novel blocks");
+    assert_eq!(node.get_chain_state().unwrap().height, 100);
+
+    // --- The misbehaving peer persistently re-serves [1..100] (pure overlap) ---
+    for i in 0..OVERLAP_THRESHOLD {
+        sync_manager.set_local_height(node.get_chain_state().unwrap().height);
+        let dup_applied = apply_batch_with_overlap_skip(
+            &mut sync_manager,
+            &node,
+            bad_peer,
+            serve_get_blocks(&source, 1, 100),
+        );
+        assert_eq!(dup_applied, 0, "overlap response {i} must apply nothing");
+        // Production path: a zero-progress batch notifies the sync manager.
+        sync_manager.on_zero_progress(&bad_peer);
+    }
+
+    // --- Threshold reached: ding + rotate to the alternative, NOT Failed ---
+    assert_eq!(
+        sync_manager
+            .reputation_mut()
+            .get(&bad_peer)
+            .map(|r| r.failures)
+            .unwrap_or(0),
+        1,
+        "the persistently-overlapping peer must be dinged exactly once"
+    );
+    assert!(
+        matches!(sync_manager.state(), SyncState::Downloading { peer, .. } if *peer == alt_peer),
+        "an available alternative peer must be rotated in without entering Failed"
+    );
+
+    // --- Sync completes via the alternative peer ---
+    let iterations = run_catchup(&mut sync_manager, &node, &source, alt_peer);
+    let node_state = node.get_chain_state().unwrap();
+    assert_eq!(
+        node_state.height, target_height,
+        "node must reach the source tip via the rotated-in peer"
+    );
+    assert_eq!(
+        node_state.tip_hash, source_state.tip_hash,
+        "node tip hash must match the source after rotation"
+    );
+    assert!(
+        sync_manager.is_synced(),
+        "sync manager must report Synced after completing via the alternative peer"
+    );
+    assert!(
+        iterations < 50,
+        "catch-up via the alternative peer took too many iterations: {iterations}"
     );
 }


### PR DESCRIPTION
## Summary

Hardens chain sync against a peer that persistently re-serves a block range the node already holds. Since #643, a pure-overlap batch (every block at or below our committed height) applies zero blocks and correctly does **not** hard-fail — but nothing tracked *repeated* zero-progress responses. A peer that ignores the requested `start_height` and keeps echoing a stale range would spin the ~2s sync tick forever with no backoff and no reputation consequence (the follow-up concern raised in #644).

This adds per-peer consecutive zero-progress tracking to `ChainSyncManager`, and past a small threshold applies a soft failure: ding reputation and rotate to an alternative peer, falling back to backoff when none exists.

## Changes

- `botho/src/network/sync.rs`
  - New `OVERLAP_THRESHOLD: u32 = 3` constant and `peer_overlap_counts: HashMap<PeerId, u32>` field on `ChainSyncManager`.
  - New `on_zero_progress(&mut self, peer)`: increments the per-peer counter; below threshold does nothing (benign transient overlap tolerated); at threshold dings reputation **once** (up front, which also worsens the offender's selection score so `best_peer()` deterministically prefers an alternative), then either soft-rotates the download peer to a different unbanned peer (staying in `Downloading`) or, when no alternative exists, calls `on_failure(None, ...)` to engage the jittered exponential backoff. `None` is passed to avoid double-dinging reputation.
  - `on_blocks_added` clears the map (forward progress resets all counters).
  - `on_peer_disconnected` removes the peer's entry (reconnect starts fresh).
  - 5 new unit tests.
- `botho/src/commands/run.rs` — on the pure-overlap path (`applied_any` stays false and no apply failure occurred, tracked via a new `had_failure` flag), call `sync_manager.on_zero_progress(&peer)`.
- `botho/src/network/mod.rs` — re-export `OVERLAP_THRESHOLD`.
- `botho/tests/chain_sync_catchup_integration.rs` — new `test_persistent_overlap_peer_triggers_soft_failure` (rotation to a healthy second peer, sync completes via it, no `Failed`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `N < THRESHOLD` overlaps → no backoff / no reputation penalty | ✅ | `test_on_zero_progress_below_threshold_no_penalty` |
| `N >= THRESHOLD` → `reputation.request_failed()` called | ✅ | `test_on_zero_progress_at_threshold_dings_reputation` / `..._rotates_to_alternative_peer` assert `failures == 1` |
| Rotated out if an alternative unbanned peer exists; NOT `Failed` | ✅ | `test_on_zero_progress_at_threshold_rotates_to_alternative_peer`; integration `test_persistent_overlap_peer_triggers_soft_failure` |
| No alternative → `on_failure()`, enters `Failed` with backoff | ✅ | `test_on_zero_progress_at_threshold_dings_reputation` (single peer → `Failed`) |
| Forward progress resets the counter | ✅ | `test_on_zero_progress_resets_on_forward_progress` |
| Peer disconnect clears the counter | ✅ | `test_on_zero_progress_clears_on_disconnect` |
| `test_duplicate_batch_response_tolerated` still passes unmodified | ✅ | Ran integration suite; test unchanged and green |
| No regression in sync + catchup suites | ✅ | `cargo test -p botho --lib network::` 706 passed; `--test chain_sync_catchup_integration` 10 passed |

## Test Plan

- `cargo test -p botho --lib network::sync` — 71 passed (incl. 5 new).
- `cargo test -p botho --lib network::` — 706 passed; 0 failed.
- `cargo test -p botho --test chain_sync_catchup_integration` — 10 passed; 0 failed (incl. new test and unmodified `test_duplicate_batch_response_tolerated`).
- `cargo check -p botho`, `cargo fmt`, `cargo clippy` — clean (no new warnings from these changes).

Closes #644