### PR TITLE
docs: correct dynamic_fee module summary to ~7.4x congestion cap

### DIFF
--- a/cluster-tax/src/dynamic_fee.rs
+++ b/cluster-tax/src/dynamic_fee.rs
@@ -46,9 +46,11 @@
 //! ```
 //!
 //! Under extreme conditions (network saturated + wealthy sender):
-//! - dynamic_base: up to 100x
+//! - dynamic_base: up to ~7.4x (e² at 100% fullness with a 75% target; the
+//!   `base_max: 100` ceiling is a safety clamp that the response curve never
+//!   reaches — see `response_k` docs and `test_full_blocks_strong_response`)
 //! - cluster_factor: up to 6x
-//! - Combined: up to 600x base fee
+//! - Combined: up to ~44x base fee (~7.4x congestion × 6x cluster factor)
 //!
 //! This is intentional egalitarian design: wealthy users pay significantly more
 //! during congestion, ensuring small users maintain network access.


### PR DESCRIPTION
## Summary

Fixes a factual error in the `cluster-tax/src/dynamic_fee.rs` module-level docs. The summary claimed the congestion multiplier reaches "up to 100x" and a combined "up to 600x" base fee, but the response curve cannot reach those values.

The dynamic base uses `fee_base = base_min × e^(k × max(0, ema_fullness − target))` with defaults `k = 8.0`, `target = 0.75`. At maximum fullness (1.0) the excess is `0.25`, so the multiplier tops out at `e^(8 × 0.25) = e² ≈ 7.39x`. The `base_max: 100` field is a safety clamp the curve never reaches. Combined with the up-to-6x cluster factor, the real worst case is ~44x, not 600x.

This aligns the module summary with two places that already state the correct value: the `response_k` field doc ("~7.4x at 100% fullness with 75% target") and the `test_full_blocks_strong_response` test assertion.

## Changes

- `cluster-tax/src/dynamic_fee.rs` module docs: `up to 100x` -> `up to ~7.4x` (with note that `base_max: 100` is an unreachable clamp), and `up to 600x` -> `up to ~44x`.

**Docs only.** No code, constants, or calibration changed.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Module summary matches actual response curve (~7.4x) | ✅ | e^(8×0.25)=e²≈7.39x; combined 7.4×6≈44x |
| Consistent with `test_full_blocks_strong_response` (~line 461) | ✅ | Test comment/assert already state e²≈7.4x |
| Consistent with `response_k` field doc | ✅ | Field doc already states "~7.4x at 100% fullness" |
| No code/calibration change | ✅ | `git diff --stat`: 1 file, doc comments only |

## Test Plan

`cargo test -p bth-cluster-tax` — **429 passed; 0 failed** (exit 0). No test logic touched.

## Scope note

This PR intentionally does **not** perform the nanoBTH doc sweep that #639 asks for. That sweep is blocked on an architecture decision (whether the fee/display layer migrates from nanoBTH to picocredits, or the two-tier unit system is ratified as canonical) — filed as #649. The "~7.4x" doc bug is independent of that decision, so it lands separately here.

Updates #639
Refs #649