### PR TITLE
docs(security): cycle-7 internal audit report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ go_build_artifacts/
 *.private
 .loom/state.json
 .loom/worktrees/
+.loom/sweep-checkpoint/
 .loom/*.log
 .loom/*.sock
 .loom-in-use

--- a/audits/2026-07-05-cycle7.md
+++ b/audits/2026-07-05-cycle7.md
@@ -1,0 +1,181 @@
+# Internal Security Audit Report - Cycle 7
+
+**Date**: 2026-07-05
+**Auditor**: Internal (Claude Code assisted, main-session review)
+**Scope**: The ~167 commits since cycle 6 (`620f359` → `cd3407a`). Focus areas:
+(1) the consensus block-acceptance path where cycle-6's five Criticals lived,
+(2) the new u64→u128 cluster-wealth widening (#626 epic, protocol 4.0.0),
+(3) the new consensus fee floor (#578) and decoy-resistant demurrage (#596/#582),
+(4) the entirely-new BaaS control-plane Worker (#522/#526/#527/#529),
+(5) dependency advisories, (6) panic-on-untrusted-input in network/block parsing.
+**Commit**: `cd3407a`
+
+---
+
+## Executive Summary
+
+Cycle 7 is primarily a **verification cycle**: it confirms that the block-acceptance
+hardening promised in cycle 6 actually landed and is enforced on the gossip/sync
+path, and that the large volume of new economic-consensus and product code added
+since did not open fresh consensus holes. The result is reassuring.
+
+- **All five cycle-6 Criticals (C1–C5) are now enforced in `Ledger::add_block_inner`**
+  (`botho/src/ledger/store.rs:683`), with two more consensus rules added beyond the
+  original five (C6 cluster-tag inflation, C7 consensus fee floor). Each is a pure
+  function of the block plus committed UTXO state — integer/`BTreeMap` only — so a
+  proposer and every validator reach the identical verdict (no fork). Regression
+  tests accompany each.
+- **Cycle-6 Highs are addressed**: H1 (fee floor is now a consensus rule, C7),
+  H2 (spender-chosen decoys no longer defeat the demurrage clock — max-quantile age
+  + ring-centroid-floored cluster factor, #596/#582), H3 (block + emission state are
+  crash-atomic in one LMDB txn, `add_block_with_emission`).
+- **The u64→u128 cluster-wealth widening (#626) is done carefully**: the on-disk
+  decoder fails **closed** on any non-16-byte value (`decode_cluster_wealth`,
+  store.rs:234), and the fee-floor consumes u128 wealth end-to-end with saturating
+  math pinned to the conservative consensus direction — deterministic across nodes.
+- **The new BaaS Worker is well-built**: Stripe webhook signature is verified over
+  the raw body BEFORE any side effect, there is no public `/provision` route, the
+  AWS region is allowlisted at BOTH checkout validation and again in the provisioner,
+  and `/status`+`/portal` derive the customer id only from a verified magic-link
+  token. Fail-closed on missing config throughout.
+- **No panic-on-untrusted-input** was found in the network/block wire paths: the
+  wire types use fixed-size arrays and variable-length parsing goes through serde,
+  returning `Result` handled with `?`.
+
+The one **new actionable finding** is a set of **node-reachable dependency
+advisories** (DNS + TLS DoS/panic) that have grown since cycle 6's L2. Everything
+else is a carry-forward or a documented design decision.
+
+**Overall Status**: Healthy — cycle-6 findings verified closed; one new Medium (deps).
+
+| Severity | Cycle 6 open | Cycle 7 new | Verified closed | Open after cycle 7 |
+|----------|--------------|-------------|-----------------|--------------------|
+| Critical | 5            | 0           | 5 (C1–C5)       | 0                  |
+| High     | 4            | 0           | 3 (H1–H3)       | 1 (H4, carried)    |
+| Medium   | 7            | 1 (deps)    | 2 (M1, M7)      | 6                  |
+| Low      | 3            | 0           | —               | 3                  |
+
+---
+
+## Verification of Cycle-6 Findings
+
+| ID | Cycle-6 finding | Cycle-7 status | Evidence |
+|----|-----------------|----------------|----------|
+| C1 | Blocks accepted at self-declared difficulty | **Closed** | store.rs:742 — `header.difficulty != state.difficulty` rejects before PoW check |
+| C2 | Minting reward + timestamp unvalidated | **Closed** | store.rs:759 recomputes `calculate_block_reward`; :777–797 timestamp monotonicity + future bound |
+| C3 | Ring members not verified vs UTXO set | **Closed** | `verify_ring_members` (store.rs:1552) binds every member to a real UTXO; pseudo-output amount bound to a resolved member |
+| C4 | `tx_root` never verified | **Closed** | store.rs:804 recomputes `compute_tx_root` and compares |
+| C5 | Float in live difficulty controller | **Closed** | #553 single integer controller; #557 drives difficulty from block time |
+| H1 | Demurrage/fees are mempool policy, not consensus | **Closed** | C7 `verify_consensus_fee_floor` (store.rs:889) — congestion-free deterministic floor enforced at block acceptance |
+| H2 | Spender-chosen decoys defeat demurrage/factor | **Closed** | max-quantile age (`ring_elapsed_quantile`) + `ring_centroid_floored_factor` (#596/#582) |
+| H3 | Difficulty/emission persisted non-atomically | **Closed** | `add_block_with_emission` folds emission writes into the block's single `wtxn` (#558) |
+| H4 | Lottery candidate cap grindable at scale | **Open (carried)** | Not re-deep-audited this cycle; seed-rotated window (#573) mitigates offset-grinding but the cap-at-scale concern stands |
+| M7 | Consensus DB checks fail-open | **Closed** | `is_key_image_spent`/`verify_transaction` now propagate DB errors with `?` (fail-closed); #564/#600 |
+
+---
+
+## New Finding
+
+### [MEDIUM] D1: Node-reachable dependency advisories (DNS DoS)
+
+**Status**: Open (new; supersedes/grows cycle-6 L2)
+
+> **Refinement (2026-07-05, settled by the #658 sweep's build+judge verification):**
+> the rustls-webpki finding is **real but version-split** — an intermediate
+> "withdrawn" note during the sweep over-corrected and is itself wrong. Ground
+> truth (`cargo deny check advisories` + `cargo tree -p botho -i rustls-webpki@0.102.8`):
+>   - **0.103.13** (primary, via `rustls 0.23`) — **clean**, no advisories.
+>   - **0.102.8** (via `rustls 0.22.4 → sentry 0.34.0 → bth-common → botho`) —
+>     **fires** RUSTSEC-2026-0104 / -0049 / -0098 / -0099, and is node-reachable.
+>     No in-semver 0.102 patch exists; the fix is a `sentry`/`rustls-0.23` bump →
+>     tracked in **#661** (ignored-with-tracking in `deny.toml` meanwhile).
+> The **hickory-proto** DNS pair below remains the other genuine node-reachable
+> item. `quinn-proto` RUSTSEC-2026-0185 is a lockfile-only flag — **not compiled
+> into the node binary** (reqwest `default-features=false` excludes http3) — and was
+> cleared by a lockfile bump anyway. Two advisories the audit under-counted,
+> **anyhow** (RUSTSEC-2026-0190) and **rand** (-0097), turned out node-reachable AND
+> cleanly fixable and were **fixed** (bumped past the advisory) in #658, not ignored.
+> Tracked/fixed via **#658** (CI cargo-deny PR gate + justified `deny.toml` ignores +
+> anyhow/rand/quinn-proto lockfile bumps + pre-existing GPL license-exception fix),
+> **#659** (hickory 0.26 path + DNS-timeout mitigation), **#661** (sentry/rustls-0.23).
+> Lesson: the RustSec DB and the *exact resolved version per dep path* both matter —
+> confirm with `cargo deny`/`cargo tree` on the specific version, not the crate name.
+
+`cargo audit` at `cd3407a` flags advisories in crates that are reachable from the
+**botho node binary** (not just the desktop wallet), via the libp2p networking stack:
+
+- **`hickory-proto` 0.25.2** (libp2p DNS resolver):
+  - RUSTSEC-2026-0119 — O(n²) CPU exhaustion during message name-compression encoding.
+  - RUSTSEC-2026-0118 — unbounded loop in NSEC3 closest-encloser proof validation on
+    cross-zone responses.
+  Both are triggerable by a hostile or spoofed DNS response and map to a node
+  liveness DoS (peg CPU / hang the resolver task).
+- **`rustls-webpki` 0.102.8** (TLS cert path, via `rustls 0.22.4 → sentry 0.34.0`):
+  RUSTSEC-2026-0104 / -0049 / -0098 / -0099 — node-reachable, no in-semver 0.102 fix;
+  fix is a sentry/rustls-0.23 bump (**#661**). The primary `rustls-webpki` 0.103.13
+  (via `rustls 0.23`) is clean. See the refinement box above.
+
+Reachability confirmed with `cargo tree -p botho -i <crate>` (hickory-resolver lists
+`botho` as a parent via three paths: the direct `hickory-resolver = "0.25"` pin,
+libp2p-dns, and libp2p-mdns; rustls-webpki@0.102.8 via the sentry chain).
+
+**Not node-reachable (lower priority):** `quick-xml` (RUSTSEC-2026-0194/0195) is only
+pulled in via `tauri`/`plist` for the **desktop wallet**, not the node. `quinn-proto`
+RUSTSEC-2026-0185 is a lockfile-only flag — `cargo tree -p botho -i quinn-proto` is
+empty because reqwest is `default-features=false` (no http3), so it is not compiled
+into the node binary.
+
+**Nuance / why Medium not High:** the hickory fix requires `hickory-resolver` 0.26.x
+(a semver bump currently pinned transitively by `libp2p` 0.56) — so it is not a
+one-line `Cargo.toml` bump; it needs either a libp2p upgrade or a `[patch]`. The
+rustls-webpki panic is the more directly actionable item (patch releases in the
+0.103.x line address several of these).
+
+**Recommended action:**
+1. Bump `rustls-webpki` to the latest 0.103.x patch (addresses the reachable panic).
+2. Track the libp2p → hickory 0.26 upgrade path; if it stalls, evaluate a `[patch]`
+   to a fixed hickory build, or bound DNS resolution with a timeout/circuit-breaker
+   at the call site as a mitigation.
+3. Re-run `cargo audit` in CI as a gate (cycle-6 recommended this; still not wired).
+
+---
+
+## Carried Forward (unchanged from cycle 6)
+
+- **H4** lottery candidate cap grindability (not re-audited this cycle).
+- **M2** cluster wealth is cumulative volume, not holdings — **ratified as a design
+  decision 2026-07-05** (#605/#630), so this is now intended behavior, not a finding.
+- **M3–M6**, **L1**, **L3** — unchanged; see cycle 6.
+- **`overflow-checks = false`** in release builds remains a latent footgun. The hot
+  consensus paths defensively use `checked_*`/`saturating_*` (e.g. `checked_block_fees`,
+  the u128 saturating wealth math), which is the right mitigation, but the global
+  setting means any *un*-guarded `+`/`*` on attacker-influenced values wraps silently.
+  Recommend a follow-up to enable `overflow-checks = true` for release and measure the
+  cost, or document the audited-safe invariant per hot path.
+
+---
+
+## What Was Confirmed Healthy (no finding)
+
+- `add_block_inner` end-to-end: height/prev-hash, header↔minting-tx consistency
+  (difficulty/height/prev-hash/keys/timestamp all cross-checked), reward recompute,
+  tx_root, ring resolution, cluster-tag inheritance, fee floor, lottery accounting,
+  then a single crash-atomic write txn.
+- `effective_cluster_wealth_from_outputs`: division-by-zero guarded (store.rs:1831).
+- BaaS Worker router: signature-before-side-effect ordering, no `/provision` route,
+  region allowlist ×2, token-gated status/portal, fail-closed config, constant-time
+  signature compare, past+future timestamp tolerance.
+- Network/block parsing: no panic-on-untrusted-length (fixed-size arrays + serde).
+
+---
+
+## Automated Checks
+
+| Check | Cycle 6 (after fixes) | Cycle 7 |
+|-------|------------------------|---------|
+| `cargo audit` | 6 remaining | node-reachable: hickory-proto ×2, rustls-webpki ×4; desktop-only: quick-xml ×2; + unmaintained gtk3/atk (desktop wallet), yanked core2/keccak |
+| Block-acceptance Criticals enforced | 0 of 5 | **7 of 7** (C1–C7) |
+
+*(Full `cargo test` suite not re-run this cycle; the block-acceptance regression tests
+referenced above exist in `botho/src/ledger/store.rs` tests and were added with their
+respective fixes #560/#564/#578/#580/#582/#600/#601.)*


### PR DESCRIPTION
## Summary

Internal security audit **cycle 7** (2026-07-05) — a verification pass over the ~167 commits since cycle 6 (`620f359`→`cd3407a`). Adds `audits/2026-07-05-cycle7.md` and gitignores the sweep runtime checkpoint dir.

## Findings

**Reassuring — cycle-6 hardening held.** All five cycle-6 Criticals (C1–C5) plus two added consensus rules (C6 tag-inheritance, C7 fee floor) are enforced in `Ledger::add_block_inner` on the gossip/sync path; Highs H1–H3 and M7 confirmed closed. Each new rule is a pure function of block + committed UTXO state (integer/`BTreeMap` only) → no fork.

**New surfaces confirmed healthy:** the u64→u128 cluster-wealth widening (#626, fail-closed decode + saturating math + div-by-zero guard) and the BaaS Worker (signature-before-side-effect, no `/provision` route, region allowlist ×2, token-gated status/portal). No panic-on-untrusted-input in network/block wire parsing.

**One new node-reachable dependency finding (D1)**, now split and (partly) fixed:
- **#658** (MERGED) — made `cargo-deny` a real PR gate, fixed the cleanly-fixable advisories (anyhow, rand) rather than ignoring them, justified-ignored the rest, and fixed a pre-existing latent GPL license-exception failure.
- **#659** — hickory-proto DNS DoS (blocked on libp2p 0.57; DNS-timeout mitigation actionable now).
- **#661** — sentry/rustls-0.23 bump to clear rustls-webpki 0.102.8 advisories.

The report also records two in-report corrections made during the #658 sweep (the rustls-webpki finding is real but version-split — clean on 0.103.13, firing on 0.102.8-via-sentry).

## Also

Gitignores `.loom/sweep-checkpoint/` — sweep runtime state that was untracked (like `.loom/worktrees/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)