### PR TITLE
chore(deps): bump sentry 0.34 -> 0.46 to move onto the rustls 0.23 stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,8 +652,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -832,7 +832,7 @@ dependencies = [
  "rcgen",
  "reqwest",
  "ring",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2575,7 +2575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2823,7 +2823,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rcgen",
  "ring",
- "rustls 0.23.35",
+ "rustls",
  "sec1",
  "serde",
  "sha1",
@@ -3300,7 +3300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
 ]
 
@@ -4120,7 +4120,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -5013,7 +5013,7 @@ dependencies = [
  "quinn",
  "rand 0.8.6",
  "ring",
- "rustls 0.23.35",
+ "rustls",
  "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
@@ -5100,8 +5100,8 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring",
- "rustls 0.23.35",
- "rustls-webpki 0.103.13",
+ "rustls",
+ "rustls-webpki",
  "thiserror 2.0.17",
  "x509-parser 0.17.0",
  "yasna",
@@ -7116,7 +7116,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.35",
+ "rustls",
  "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
@@ -7137,7 +7137,7 @@ dependencies = [
  "rand_pcg 0.10.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -7518,7 +7518,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7762,20 +7762,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
@@ -7784,7 +7770,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -7806,17 +7792,6 @@ checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "web-time 1.1.0",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -8053,13 +8028,14 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.34.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5484316556650182f03b43d4c746ce0e3e48074a21e2f51244b648b6542e1066"
+checksum = "d92d893ba7469d361a6958522fa440e4e2bc8bf4c5803cd1bf40b9af63f8f9a8"
 dependencies = [
+ "cfg_aliases",
  "httpdate",
  "reqwest",
- "rustls 0.22.4",
+ "rustls",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -8068,26 +8044,24 @@ dependencies = [
  "serde_json",
  "tokio",
  "ureq",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.34.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40aa225bb41e2ec9d7c90886834367f560efc1af028f1c5478a6cce6a59c463a"
+checksum = "5f8784d0a27b5cd4b5f75769ffc84f0b7580e3c35e1af9cd83cb90b612d769cc"
 dependencies = [
  "backtrace",
- "once_cell",
  "regex",
  "sentry-core",
 ]
 
 [[package]]
 name = "sentry-contexts"
-version = "0.34.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a8dd746da3d16cb8c39751619cefd4fcdbd6df9610f3310fd646b55f6e39910"
+checksum = "0e5eb42f4cd4f9fdfec9e3b07b25a4c9769df83d218a7e846658984d5948ad3e"
 dependencies = [
  "hostname 0.4.2",
  "libc",
@@ -8099,22 +8073,22 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.34.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161283cfe8e99c8f6f236a402b9ccf726b201f365988b5bb637ebca0abbd4a30"
+checksum = "b0b1e7ca40f965db239da279bf278d87b7407469b98835f27f0c8e59ed189b06"
 dependencies = [
- "once_cell",
- "rand 0.8.6",
+ "rand 0.9.4",
  "sentry-types",
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]
 name = "sentry-panic"
-version = "0.34.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc74f229c7186dd971a9491ffcbe7883544aa064d1589bd30b83fb856cd22d63"
+checksum = "8906f8be87aea5ac7ef937323fb655d66607427f61007b99b7cb3504dc5a156c"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -8122,10 +8096,11 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.34.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c5faf2103cd01eeda779ea439b68c4ee15adcdb16600836e97feafab362ec"
+checksum = "5b07eefe04486316c57aba08ab53dd44753c25102d1d3fe05775cc93a13262d9"
 dependencies = [
+ "bitflags 2.10.0",
  "sentry-backtrace",
  "sentry-core",
  "tracing-core",
@@ -8134,16 +8109,16 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.34.0"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d68cdf6bc41b8ff3ae2a9c4671e97426dcdd154cc1d4b6b72813f285d6b163f"
+checksum = "567711f01f86a842057e1fc17779eba33a336004227e1a1e7e6cc2599e22e259"
 dependencies = [
  "debugid",
  "hex",
- "rand 0.8.6",
+ "rand 0.9.4",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "time",
  "url",
  "uuid",
@@ -9377,7 +9352,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls",
  "tokio",
 ]
 
@@ -10096,17 +10071,30 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "log",
- "once_cell",
- "rustls 0.23.35",
+ "percent-encoding",
+ "rustls",
  "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -10150,6 +10138,12 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ retry = "2"
 schnorrkel-og = { version = "0.11.0-pre.0", default-features = false }
 secrecy = "0.8"
 semver = "1"
-sentry = { version = "0.34", default-features = false }
+sentry = { version = "0.46", default-features = false }
 serde = { version = "1", default-features = false }
 serde_derive = "1"
 serde_json = { version = "1", default-features = false, features = ["alloc"] }

--- a/deny.toml
+++ b/deny.toml
@@ -62,17 +62,6 @@ ignore = [
     # No fix until the libp2p upgrade (#659). Warning-level.
     "RUSTSEC-2026-0105",  # core2 unmaintained/yanked (libp2p transitive, #659)
 
-    # rustls-webpki 0.102.8 - fires only against the OLD 0.102 line pulled in
-    # via rustls 0.22.4 -> sentry 0.34.0 -> bth-common. The workspace's primary
-    # rustls-webpki 0.103.13 is NOT affected. Fixes land in the 0.103.x line
-    # (rustls 0.23); the 0.102 line has no patched release, so clearing these
-    # requires a sentry / rustls-0.23 bump, not a webpki bump. Tracked for a
-    # sentry-upgrade follow-up.
-    "RUSTSEC-2026-0104",  # rustls-webpki reachable panic in CRL parsing (0.102.8 via sentry; sentry/rustls-0.23 bump tracked in #661)
-    "RUSTSEC-2026-0049",  # rustls-webpki CRL distribution-point authority mismatch (0.102.8 via sentry; sentry/rustls-0.23 bump tracked in #661)
-    "RUSTSEC-2026-0098",  # rustls-webpki URI name-constraint bypass (0.102.8 via sentry; sentry/rustls-0.23 bump tracked in #661)
-    "RUSTSEC-2026-0099",  # rustls-webpki wildcard name-constraint bypass (0.102.8 via sentry; sentry/rustls-0.23 bump tracked in #661)
-
     # bincode 1.3.3 - unmaintained; no safe upgrade (2.x is a different API).
     "RUSTSEC-2025-0141",  # bincode unmaintained (no safe upgrade)
 


### PR DESCRIPTION
## Summary
Bumps the `sentry` workspace dependency from 0.34 to 0.46 (resolves to 0.46.2), moving it off the EOL rustls 0.22 / rustls-webpki 0.102.8 stack and onto the rustls 0.23 / rustls-webpki 0.103 stack the workspace already uses. sentry was the sole dependent of rustls 0.22.4, so the bump removes the entire vulnerable subtree from the lockfile and clears the four node-reachable advisories that were being ignored in `deny.toml`.

0.46 is deliberately chosen over 0.47/0.48: the newer lines require reqwest 0.13 and MSRV 1.88, while the workspace pins reqwest 0.12 and rust-version 1.83.

## Changes
- `Cargo.toml`: sentry workspace dependency `0.34` -> `0.46`
- `Cargo.lock`: regenerated via `cargo update -p sentry` (sentry-* family -> 0.46.2; rustls 0.22.4 and rustls-webpki 0.102.8 removed)
- `deny.toml`: removed RUSTSEC-2026-0104 / -0049 / -0098 / -0099 ignores and their explanatory comment block
- No changes needed to `common/src/sentry.rs` or `common/Cargo.toml` — all APIs and feature flags used are stable across 0.34 -> 0.46

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| sentry on a rustls-0.23-line release (0.35 <= v <= 0.46) | ✅ | Locked at 0.46.2; `cargo tree -i rustls@0.23.35` shows sentry on the 0.23 chain |
| Cargo.lock free of rustls 0.22.x / rustls-webpki 0.102.x | ✅ | `cargo tree -i rustls-webpki@0.102.8` -> "did not match any packages"; cargo update output shows both removed |
| Four RUSTSEC ignores + comment block removed from deny.toml | ✅ | Lines 65-74 deleted |
| `cargo deny check advisories` passes | ✅ | "advisories ok" (two pre-existing `advisory-not-detected` warnings on unrelated ignores also exist on main) |
| Workspace builds; bth-common tests pass; no sentry.rs API changes | ✅ | `cargo build` finished clean; `cargo test -p bth-common`: 44 passed + 1 doc-test, 0 failed |
| No reqwest major bump / no MSRV change | ✅ | Cargo.lock keeps reqwest 0.12.28; rust-version 1.83 untouched |

## Test Plan
- `cargo build` — success
- `cargo test -p bth-common` — 44 unit tests + 1 doc-test pass
- `cargo deny check advisories` — green
- `cargo tree -i rustls-webpki@0.102.8` — package no longer present
- Verified reqwest remains 0.12.28 and no duplicate rustls lineage was introduced

Closes #661