### PR TITLE
fix(web-wallet): redirect /docs/<section> deep links to canonical /docs#<section>

### DIFF
--- a/web/packages/web-wallet/src/pages/docs-deep-link.test.tsx
+++ b/web/packages/web-wallet/src/pages/docs-deep-link.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Docs path deep links (#656).
+ *
+ * The docs page selects its active section from the URL hash (`/docs#<id>`),
+ * but the router also registers a `/docs/*` catchall. Before #656 any
+ * path-style deep link (`/docs/cluster-tags`) silently rendered the default
+ * "Getting Started" section. The guarantees under test:
+ *
+ * - `/docs/<known-id>` redirects (history `replace`) to the canonical
+ *   `/docs#<known-id>` form and renders that section.
+ * - `/docs/<unknown>` renders Getting Started WITH a visible "not found"
+ *   hint naming the requested segment (no redirect — the bad URL stays
+ *   visible for debugging).
+ * - Plain `/docs`, `/docs/`, and hash links behave exactly as before.
+ * - When both a path segment and a hash are present, the hash wins.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom'
+import { DocsPage } from './docs'
+
+/** Every valid section id and its page heading, mirroring `sections` in docs.tsx. */
+const SECTION_TITLES: Record<string, string> = {
+  'getting-started': 'Getting Started',
+  privacy: 'Privacy Features',
+  'cluster-tags': 'Cluster Tags',
+  'privacy-progressivity': 'Privacy + Progressivity',
+  consensus: 'Consensus',
+  'running-node': 'Running a Node',
+  api: 'API Reference',
+  network: 'Network',
+  tokenomics: 'Tokenomics',
+}
+
+const NOT_FOUND_HINT = /not found — showing Getting Started/
+
+/** Exposes the router location and a Back button for history assertions. */
+function LocationProbe() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  return (
+    <div>
+      <span data-testid="location">{location.pathname + location.hash}</span>
+      <button onClick={() => navigate(-1)}>go back</button>
+    </div>
+  )
+}
+
+/** Renders DocsPage with the same `/docs` + `/docs/*` route pair as App.tsx. */
+function renderDocs(initialEntries: string[], initialIndex?: number) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries} initialIndex={initialIndex}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/docs" element={<DocsPage />} />
+        <Route path="/docs/*" element={<DocsPage />} />
+        <Route path="*" element={<div data-testid="other-page">other page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function activeHeading(): string | null {
+  return screen.getByRole('heading', { level: 1 }).textContent
+}
+
+afterEach(cleanup)
+
+describe('docs path deep links redirect to the canonical hash form (#656)', () => {
+  it('/docs/cluster-tags lands on /docs#cluster-tags and renders Cluster Tags', async () => {
+    renderDocs(['/docs/cluster-tags'])
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe('/docs#cluster-tags'),
+    )
+    expect(activeHeading()).toBe('Cluster Tags')
+    expect(screen.queryByText(NOT_FOUND_HINT)).toBeNull()
+  })
+
+  it.each(Object.entries(SECTION_TITLES))(
+    '/docs/%s resolves via the path form',
+    async (id, title) => {
+      renderDocs([`/docs/${id}`])
+      await waitFor(() => expect(screen.getByTestId('location').textContent).toBe(`/docs#${id}`))
+      expect(activeHeading()).toBe(title)
+      expect(screen.queryByText(NOT_FOUND_HINT)).toBeNull()
+    },
+  )
+
+  it('matches section ids case-insensitively (/docs/Cluster-Tags)', async () => {
+    renderDocs(['/docs/Cluster-Tags'])
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe('/docs#cluster-tags'),
+    )
+    expect(activeHeading()).toBe('Cluster Tags')
+  })
+
+  it('redirect uses history replace — Back skips the path form (no loop)', async () => {
+    renderDocs(['/home', '/docs/consensus'], 1)
+    await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/docs#consensus'))
+
+    fireEvent.click(screen.getByText('go back'))
+
+    // With `replace: true` the path entry is gone; Back exits docs entirely
+    // instead of bouncing back through /docs/consensus.
+    await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('/home'))
+    expect(screen.getByTestId('other-page')).toBeTruthy()
+  })
+})
+
+describe('unknown docs path segments show a not-found hint (#656)', () => {
+  it('/docs/protocol renders Getting Started with a hint naming the segment', () => {
+    renderDocs(['/docs/protocol'])
+    expect(activeHeading()).toBe('Getting Started')
+    const hint = screen.getByText(NOT_FOUND_HINT)
+    expect(hint.textContent).toContain('protocol')
+    // No redirect: the bad URL stays visible in the address bar.
+    expect(screen.getByTestId('location').textContent).toBe('/docs/protocol')
+  })
+
+  it('nested segments (/docs/a/b) are treated as unknown, not a crash', () => {
+    renderDocs(['/docs/a/b'])
+    expect(activeHeading()).toBe('Getting Started')
+    expect(screen.getByText(NOT_FOUND_HINT).textContent).toContain('a/b')
+  })
+})
+
+describe('existing docs URL forms are unchanged (#656 regression guard)', () => {
+  it('/docs renders Getting Started with no hint and no redirect', () => {
+    renderDocs(['/docs'])
+    expect(activeHeading()).toBe('Getting Started')
+    expect(screen.queryByText(NOT_FOUND_HINT)).toBeNull()
+    expect(screen.getByTestId('location').textContent).toBe('/docs')
+  })
+
+  it('/docs/ (trailing slash) renders Getting Started with no hint and no redirect', () => {
+    renderDocs(['/docs/'])
+    expect(activeHeading()).toBe('Getting Started')
+    expect(screen.queryByText(NOT_FOUND_HINT)).toBeNull()
+    expect(screen.getByTestId('location').textContent).toBe('/docs/')
+  })
+
+  it('/docs#consensus renders Consensus with no hint (hash path untouched)', () => {
+    renderDocs(['/docs#consensus'])
+    expect(activeHeading()).toBe('Consensus')
+    expect(screen.queryByText(NOT_FOUND_HINT)).toBeNull()
+    expect(screen.getByTestId('location').textContent).toBe('/docs#consensus')
+  })
+
+  it('hash wins when both a path segment and a hash are present', () => {
+    renderDocs(['/docs/consensus#privacy'])
+    expect(activeHeading()).toBe('Privacy Features')
+    expect(screen.queryByText(NOT_FOUND_HINT)).toBeNull()
+    // No redirect — the hash already picked the section.
+    expect(screen.getByTestId('location').textContent).toBe('/docs/consensus#privacy')
+  })
+})

--- a/web/packages/web-wallet/src/pages/docs.tsx
+++ b/web/packages/web-wallet/src/pages/docs.tsx
@@ -1,7 +1,21 @@
-import { useState } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { Logo } from '@botho/ui'
-import { ArrowLeft, Book, Code, Shield, Zap, Globe, Terminal, Menu, X, Coins, Tag, Scale } from 'lucide-react'
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Book,
+  Code,
+  Shield,
+  Zap,
+  Globe,
+  Terminal,
+  Menu,
+  X,
+  Coins,
+  Tag,
+  Scale,
+} from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
@@ -1256,8 +1270,31 @@ Botho implements a novel **progressive fee system** that taxes wealth concentrat
 
 export function DocsPage() {
   const location = useLocation()
+  const navigate = useNavigate()
+
+  // Path-style deep links (`/docs/<section>`) land here via the `/docs/*`
+  // catchall route in App.tsx. The hash form (`/docs#<section>`) is the
+  // canonical URL every internal link generates, so known path segments are
+  // redirected to it (history `replace` keeps Back from bouncing through the
+  // path form). Unknown segments fall through and render a visible
+  // "section not found" hint instead of silently showing Getting Started (#656).
+  const splat = useParams()['*'] ?? ''
+  const pathSegment = splat.replace(/\/+$/, '')
+  const normalizedSegment = pathSegment.toLowerCase()
+  // A hash always wins over a path segment (e.g. /docs/consensus#privacy).
+  const hasHash = location.hash.slice(1) !== ''
+  const segmentIsKnown = normalizedSegment !== '' && sections.some((s) => s.id === normalizedSegment)
+  const shouldRedirect = segmentIsKnown && !hasHash
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      navigate(`/docs#${normalizedSegment}`, { replace: true })
+    }
+  }, [shouldRedirect, normalizedSegment, navigate])
+
   const hash = location.hash.slice(1) || 'getting-started'
   const currentSection = sections.find((s) => s.id === hash) || sections[0]
+  const notFoundSegment = !hasHash && pathSegment !== '' && !segmentIsKnown ? pathSegment : null
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   const handleNavClick = () => {
@@ -1378,6 +1415,17 @@ export function DocsPage() {
       {/* Main content */}
       <main className="flex-1 md:ml-64">
         <div className="max-w-3xl mx-auto px-4 sm:px-8 md:px-12 py-8 md:py-16">
+          {notFoundSegment && (
+            <div
+              role="status"
+              className="mb-6 flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-200/90 text-sm"
+            >
+              <AlertTriangle size={16} className="shrink-0 mt-0.5 text-amber-400" />
+              <span>
+                Section &ldquo;{notFoundSegment}&rdquo; not found — showing Getting Started.
+              </span>
+            </div>
+          )}
           <div className="flex items-center gap-3 mb-6 md:mb-8">
             <currentSection.icon className="text-pulse shrink-0" size={28} />
             <h1 className="font-display text-2xl md:text-3xl font-bold">{currentSection.title}</h1>


### PR DESCRIPTION
## Summary

The docs page selects its active section from the URL hash (`/docs#<id>`), but the router's `/docs/*` catchall meant any path-style deep link (`/docs/cluster-tags`) silently rendered the default Getting Started section. Per the curator's recommended option (b), known path segments now redirect to the canonical hash form with `navigate(..., { replace: true })`, and unknown segments render Getting Started with a visible "section not found" hint instead of failing silently.

## Changes

- `web/packages/web-wallet/src/pages/docs.tsx`: read the `/docs/*` splat via `useParams()['*']`; when it names a known section id (case-insensitive, trailing slashes stripped) and no hash is present, redirect to `/docs#<id>` in a `useEffect` with history `replace`. Unknown non-empty segments set a `notFoundSegment` that renders an inline amber hint above the content ("Section "X" not found — showing Getting Started."). A hash always wins over a path segment.
- `web/packages/web-wallet/src/pages/docs-deep-link.test.tsx` (new): 18 vitest/@testing-library tests rendering `DocsPage` inside `MemoryRouter` with the same `/docs` + `/docs/*` route pair as `App.tsx`.
- `App.tsx` unchanged (routes already registered), as anticipated by curation.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `/docs/cluster-tags` lands on `/docs#cluster-tags` (history replace) and renders Cluster Tags as active | Pass | Test "lands on /docs#cluster-tags"; replace semantics proven by the back-button test (Back from `/docs#consensus` returns to the prior page, not the path form) |
| All 9 valid section ids resolve via the path form | Pass | `it.each` over all 9 id/title pairs asserts redirect target and active h1 |
| `/docs/<unknown>` renders Getting Started with a visible hint naming the segment; no redirect | Pass | Tests for `/docs/protocol` (hint contains "protocol", location stays `/docs/protocol`) and nested `/docs/a/b` |
| Plain `/docs`, `/docs/`, and existing `/docs#<id>` links behave exactly as before (no hint, no redirect loop) | Pass | Three regression-guard tests assert unchanged location, correct section, and no hint |
| When both a path segment and a hash are present, the hash wins | Pass | `/docs/consensus#privacy` renders Privacy Features with no redirect and no hint |
| `pnpm typecheck` passes in `web/` | Pass | All 9 workspace packages typecheck clean |

## Test Plan

- `pnpm typecheck` (web workspace root): all packages pass.
- `pnpm test:run`: 48 files / 557 tests passed (10 pre-existing skips), including the 18 new deep-link tests.
- `pnpm --filter @botho/baas-worker exec wrangler deploy --dry-run` (third leg of `check:ci`): passes.
- Edge cases covered in tests: trailing slash, nested splat, path+hash precedence, case normalization (`/docs/Cluster-Tags`), and history-replace back-button behavior.

Closes #656