### PR TITLE
feat(network): bound DNS seed lookups with a 5s timeout

### DIFF
--- a/botho/src/network/dns_seeds.rs
+++ b/botho/src/network/dns_seeds.rs
@@ -60,6 +60,44 @@ const MAX_CACHE_TTL: Duration = Duration::from_secs(3600);
 /// Default TTL when DNS doesn't provide one
 const DEFAULT_TTL: Duration = Duration::from_secs(300);
 
+/// Upper bound on a single DNS seed lookup.
+///
+/// Mitigation for RUSTSEC-2026-0118/-0119 (hickory-proto 0.25: DNS-response
+/// triggered CPU exhaustion / unbounded loop). A hostile or hanging DNS
+/// response must not stall node bootstrap: on timeout the caller falls back
+/// to hardcoded seeds via the existing [`DnsSeedError::DnsQuery`] path.
+///
+/// Note: `tokio::time::timeout` cancels at await points, so this bounds the
+/// hang and caps the blast radius but cannot preempt a purely synchronous CPU
+/// spin between awaits. Tracking note (#659): the full fix is the
+/// libp2p 0.57+ / hickory-proto 0.26 upgrade — when libp2p ships a release on
+/// hickory 0.26, bump it, drop the direct `hickory-resolver = "0.25"` pin in
+/// `botho/Cargo.toml`, and remove the RUSTSEC-2026-0118/-0119 ignores from
+/// `deny.toml`.
+const DNS_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Drive a DNS lookup future with a hard upper bound.
+///
+/// Production callers pass [`DNS_QUERY_TIMEOUT`]; the duration is a parameter
+/// so tests can prove the bound with a tiny timeout instead of sleeping.
+/// Maps both a timeout and an inner lookup failure into
+/// [`DnsSeedError::DnsQuery`], which callers already handle by falling back to
+/// hardcoded seeds.
+async fn lookup_with_timeout<F, T, E>(timeout: Duration, fut: F) -> Result<T, DnsSeedError>
+where
+    F: std::future::Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
+{
+    match tokio::time::timeout(timeout, fut).await {
+        Ok(Ok(response)) => Ok(response),
+        Ok(Err(e)) => Err(DnsSeedError::DnsQuery(format!("DNS lookup failed: {}", e))),
+        Err(_elapsed) => Err(DnsSeedError::DnsQuery(format!(
+            "DNS lookup timed out after {:?}",
+            timeout
+        ))),
+    }
+}
+
 /// Cached seed entries with expiration
 #[derive(Debug, Clone)]
 struct CachedSeeds {
@@ -163,10 +201,7 @@ impl DnsSeedDiscovery {
         )
         .build();
 
-        let response = resolver
-            .txt_lookup(domain)
-            .await
-            .map_err(|e| DnsSeedError::DnsQuery(format!("DNS lookup failed: {}", e)))?;
+        let response = lookup_with_timeout(DNS_QUERY_TIMEOUT, resolver.txt_lookup(domain)).await?;
 
         let mut peers = Vec::new();
 
@@ -443,6 +478,58 @@ mod tests {
         discovery.invalidate_cache();
 
         assert!(!discovery.is_cache_valid());
+    }
+
+    /// A lookup that never resolves must error out at the timeout bound
+    /// instead of hanging bootstrap (#659, RUSTSEC-2026-0118/-0119).
+    ///
+    /// Uses a tiny timeout (the helper is duration-parameterised; production
+    /// passes `DNS_QUERY_TIMEOUT`) so the test completes in milliseconds
+    /// without tokio's `test-util` feature.
+    #[tokio::test]
+    async fn test_lookup_with_timeout_bounds_hanging_lookup() {
+        let bound = Duration::from_millis(25);
+        let start = Instant::now();
+
+        let result: Result<(), DnsSeedError> =
+            lookup_with_timeout(bound, std::future::pending::<Result<(), std::io::Error>>()).await;
+
+        match result {
+            Err(DnsSeedError::DnsQuery(msg)) => {
+                assert!(
+                    msg.contains("timed out"),
+                    "expected timeout message, got: {msg}"
+                );
+            }
+            other => panic!("expected DnsQuery timeout error, got {other:?}"),
+        }
+
+        // The bound fired: a never-resolving lookup returned promptly rather
+        // than hanging (generous ceiling to avoid CI-scheduling flakiness).
+        assert!(start.elapsed() >= bound);
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn test_lookup_with_timeout_passes_through_success() {
+        let result =
+            lookup_with_timeout(DNS_QUERY_TIMEOUT, async { Ok::<_, std::io::Error>(42u32) }).await;
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn test_lookup_with_timeout_maps_inner_error() {
+        let result: Result<u32, DnsSeedError> = lookup_with_timeout(DNS_QUERY_TIMEOUT, async {
+            Err::<u32, _>(std::io::Error::other("resolver exploded"))
+        })
+        .await;
+
+        match result {
+            Err(DnsSeedError::DnsQuery(msg)) => {
+                assert!(msg.contains("resolver exploded"), "got: {msg}");
+            }
+            other => panic!("expected DnsQuery error, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Node bootstrap peer discovery (`NetworkConfig::bootstrap_peers_async()` → `DnsSeedDiscovery::discover_seeds()` → `query_dns_seeds()`) awaited `resolver.txt_lookup(domain)` with no bound, so a hanging or hostile DNS response could stall node startup indefinitely. This PR wraps the lookup in `tokio::time::timeout` with a named 5s constant. This is the node-controlled mitigation for RUSTSEC-2026-0118/-0119 (hickory-proto 0.25 DNS-response DoS, cycle-7 audit finding D1 Slice B); the full fix — libp2p 0.57+ on hickory-proto 0.26 — is recorded as a tracking note in the code.

## Changes

- Add `DNS_QUERY_TIMEOUT` (5s) next to the existing TTL constants in `botho/src/network/dns_seeds.rs`, with a doc comment that (a) explains the RUSTSEC mitigation and its honest limits (`tokio::time::timeout` cancels at await points, cannot preempt a synchronous CPU spin), and (b) records the tracking note for the full fix: when libp2p ships a release on hickory 0.26, bump it, drop the direct `hickory-resolver = "0.25"` pin, and remove the `deny.toml` RUSTSEC ignores.
- Factor the lookup into a small duration-parameterised `lookup_with_timeout()` helper; both timeout and inner lookup failure map into the existing `DnsSeedError::DnsQuery` variant, so `discover_seeds()` degrades to hardcoded fallback seeds exactly as before (no new plumbing).
- The helper takes the timeout as a parameter (production passes `DNS_QUERY_TIMEOUT`) so the bound is unit-testable with a tiny real-time duration. The curator-suggested `#[tokio::test(start_paused = true)]` needs tokio's `test-util` feature, which is not enabled and would require a `Cargo.toml` change (explicitly out of scope), so the test uses a 25ms bound instead — it completes in milliseconds without sleeping.
- Three new unit tests: never-resolving lookup errors at the bound instead of hanging; success passes through; inner resolver errors map to `DnsQuery`.

## Out of scope (per issue #659 curation)

No changes to `deny.toml` (lines 52-55 already carry the RUSTSEC-2026-0118/-0119 ignores referencing #659), `Cargo.toml`, dependency versions, or libp2p.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| DNS lookup wrapped in `tokio::time::timeout` with named constant (3-10s) | Done | `DNS_QUERY_TIMEOUT = 5s`; `query_dns_seeds()` calls `lookup_with_timeout(DNS_QUERY_TIMEOUT, resolver.txt_lookup(domain))` |
| On timeout, `discover_seeds()` returns hardcoded fallback seeds (no panic/hang) | Done | Timeout maps into `DnsSeedError::DnsQuery`, handled by the existing `Err` arm in `discover_seeds()` that calls `hardcoded_seeds()` |
| Unit test proves a never-resolving lookup errors at the bound | Done | `test_lookup_with_timeout_bounds_hanging_lookup` drives the helper with `std::future::pending()` |
| Tracking note records the libp2p-upgrade dependency for the full fix | Done | Doc comment on `DNS_QUERY_TIMEOUT` (see Changes); `deny.toml` ignores also reference #659 |
| No changes to `deny.toml`, dependency versions, or libp2p | Done | `git diff --stat` shows only `botho/src/network/dns_seeds.rs` |
| All existing `dns_seeds` tests pass | Done | 18/18 dns_seeds tests pass; full `cargo test -p botho --lib` = 1109 passed, 0 failed |

## Test Plan

- `cargo test -p botho --lib dns_seeds`: 18 passed (15 existing + 3 new)
- `cargo test -p botho --lib`: 1109 passed, 0 failed, 2 ignored
- `cargo check -p botho` clean; `cargo clippy -p botho --lib --tests` reports nothing for `dns_seeds.rs` (8 pre-existing `println!` lints in `transport/fingerprint.rs` are untouched by this PR)
- `cargo fmt` applied

Closes #659