### PR TITLE
security: enable release-profile overflow-checks (curve25519-dalek exempt) and fix silent-wrap sums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,24 @@ opt-level = 3
 rpath = false
 lto = false
 debug-assertions = false
+# Panic-on-overflow backstop for consensus/economics arithmetic (#663).
+# Unchecked +/-/* on attacker-influenced values must never wrap silently in
+# production; hot paths use checked_/saturating_ ops and return typed errors,
+# and this flag protects future code that hasn't been hand-audited. Measured
+# cost on hash-dominated validation benches (pow_hash, verify_pow, block hash)
+# was within noise; see the PR for #663 for the full criterion numbers.
+# The `mobile` profiles inherit this. `bench` inherits `release`, so criterion
+# numbers reflect production codegen.
+overflow-checks = true
+
+# Exemption: curve25519-dalek's constant-time Ristretto/Ed25519 limb
+# arithmetic is audited upstream crypto, not the consensus/economics code the
+# backstop above targets, and compiling it with overflow checks measurably
+# regressed EC-heavy paths 20-30% (schnorr_prove/verify, cluster_generator,
+# committed-tag conservation proofs, MintingTx one-time keys — #663 bench
+# runs). Ring-signature and tag verification dominate block validation cost,
+# so the checks stay off for this one package. Botho's own crates keep them.
+[profile.release.package.curve25519-dalek]
 overflow-checks = false
 
 [profile.mobile]

--- a/botho/src/block.rs
+++ b/botho/src/block.rs
@@ -570,8 +570,15 @@ impl Block {
     }
 
     /// Get total lottery payouts in this block.
+    ///
+    /// Saturating for the same reason as [`Block::total_fees`]: payouts in a
+    /// gossiped block are attacker-influenced, and with `overflow-checks =
+    /// true` on the release profile (#663) an unchecked `sum()` would panic
+    /// on a crafted block instead of letting validation reject it.
     pub fn total_lottery_payouts(&self) -> u64 {
-        self.lottery_outputs.iter().map(|o| o.payout).sum()
+        self.lottery_outputs
+            .iter()
+            .fold(0u64, |acc, o| acc.saturating_add(o.payout))
     }
 
     /// Compute the transaction root committed by the block header.
@@ -1956,6 +1963,19 @@ mod tests {
             reward, truncated_reward,
             "u128 path must differ from u64-truncated path at this supply",
         );
+    }
+
+    /// #663: with `overflow-checks = true` now on the release profile, the
+    /// reward path must stay panic-free at the extreme corner — max height
+    /// with a supply far past `u64::MAX`. The tail formula is pure `u128`
+    /// arithmetic whose intermediates (supply × bps) stay orders of magnitude
+    /// below `u128::MAX` at any reachable supply; this pins that invariant
+    /// under checked release builds (`cargo test --release`).
+    #[test]
+    fn test_block_reward_no_overflow_at_max_height_and_supply() {
+        let real_supply_cap: u128 = 1_220_000_000_000_000_000_000; // ~1.22e21 picocredits
+        let reward = calculate_block_reward(u64::MAX, real_supply_cap);
+        assert!(reward >= 1, "tail reward is floored at 1");
     }
 
     /// Phase-1 halving reward is height-driven and independent of supply, so

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -2126,7 +2126,10 @@ fn apply_lottery_to_block(
     block: crate::block::Block,
     shared_ledger: &SharedLedger,
 ) -> crate::block::Block {
-    let total_fees: u64 = block.transactions.iter().map(|tx| tx.fee).sum();
+    // Saturating (block.rs::total_fees): a plain sum() panics under
+    // release overflow-checks on this every-node externalize path before
+    // add_block's checked_block_fees can reject the block gracefully.
+    let total_fees: u64 = block.total_fees();
     let emission_share = block.minting_tx.lottery_emission_share();
 
     // Helper for error cases: burn only the fee burn share (the pool share

--- a/botho/src/consensus/block_builder.rs
+++ b/botho/src/consensus/block_builder.rs
@@ -125,7 +125,27 @@ impl BlockBuilder {
                     // the apply-time backstop never fires for our own blocks
                     // (no externalize-then-reject halt — the #449/#421 failure
                     // mode).
-                    if tx.created_at_height + MAX_TX_AGE < block_height {
+                    //
+                    // `created_at_height` is attacker-set and is NOT bounded
+                    // anywhere (mempool admission, the SCP intrinsic validity
+                    // gate, and gossip all leave it unconstrained), so the age
+                    // bound must saturate. With `overflow-checks = true` on the
+                    // release profile (#663) an unchecked `+` here would let a
+                    // crafted `created_at_height` near `u64::MAX` panic — and
+                    // because `build_from_externalized` runs deterministically
+                    // on EVERY node after externalization (run.rs), that is a
+                    // network-wide halt, not just a proposer-local one.
+                    // Saturation preserves the rule's semantics and matches the
+                    // apply-side store.rs `first_stale_transfer_tx` exactly: a
+                    // saturated sum is `u64::MAX`, which is never `<
+                    // block_height`, so a tx claiming a far-future
+                    // `created_at_height` is treated as "not stale" here (it is
+                    // instead rejected by the later validity gates — e.g. C3
+                    // ring resolution — rather than by this staleness filter).
+                    // Both paths run the same binary on the same block height,
+                    // so the build and apply verdicts cannot diverge across
+                    // nodes.
+                    if tx.created_at_height.saturating_add(MAX_TX_AGE) < block_height {
                         warn!(
                             tx_hash = hex::encode(&value.tx_hash[0..8]),
                             created_at_height = tx.created_at_height,
@@ -532,6 +552,79 @@ mod tests {
         assert!(
             !built.transfer_tx_hashes.contains(&stale_hash),
             "stale tx hash must not be recorded in the built block"
+        );
+    }
+
+    /// Issue #663 (overflow-checks hardening): `created_at_height` is
+    /// attacker-set and unbounded, so the staleness age bound
+    /// (`created_at_height + MAX_TX_AGE`) must not panic under
+    /// `overflow-checks = true` (the release profile). A tx with
+    /// `created_at_height == u64::MAX` must build cleanly — never panic with
+    /// "attempt to add with overflow" — because `build_from_externalized` runs
+    /// deterministically on every validating node after externalization, so a
+    /// panic here is a network-wide halt vector (not just a proposer-local
+    /// crash).
+    ///
+    /// Semantics: with `saturating_add`, `u64::MAX + MAX_TX_AGE` saturates to
+    /// `u64::MAX`, which is never `< block_height`, so the far-future tx is
+    /// classified "not stale" here and simply retained by this filter (it is
+    /// rejected downstream by the ordinary validity gates, e.g. C3 ring
+    /// resolution, on real crafted inputs). This deterministically matches the
+    /// apply-side `first_stale_transfer_tx` in store.rs, so build and apply
+    /// verdicts cannot diverge across nodes.
+    #[test]
+    fn test_build_from_externalized_no_overflow_on_max_created_at_height() {
+        use crate::transaction::TxInputs;
+
+        let block_height = 200u64;
+
+        // Attacker-crafted tx: created_at_height == u64::MAX. Under the old
+        // unchecked `+ MAX_TX_AGE` this panicked "attempt to add with overflow"
+        // with overflow-checks enabled.
+        let crafted = Transaction {
+            inputs: TxInputs::new(vec![]),
+            outputs: vec![],
+            fee: 0,
+            created_at_height: u64::MAX,
+        };
+        let crafted_hash = crafted.hash();
+
+        let values = vec![
+            ConsensusValue::from_minting_tx([9u8; 32], 0),
+            ConsensusValue::from_transaction(crafted_hash, 0),
+        ];
+
+        let minting_tx = mock_minting_tx(block_height);
+        let get_minting = |_: &[u8; 32]| Some(minting_tx.clone());
+        let get_transfer = move |h: &[u8; 32]| {
+            if *h == crafted_hash {
+                Some(crafted.clone())
+            } else {
+                None
+            }
+        };
+
+        // Must not panic under overflow-checks. Build twice to pin determinism.
+        let built_a =
+            BlockBuilder::build_from_externalized(&values, get_minting, get_transfer.clone())
+                .expect("build must not panic on u64::MAX created_at_height");
+        let built_b = BlockBuilder::build_from_externalized(&values, get_minting, get_transfer)
+            .expect("second build must not panic either");
+
+        // Deterministic inclusion: saturated sum (u64::MAX) is never
+        // < block_height, so the far-future tx is "not stale" and retained here.
+        assert_eq!(
+            built_a.block.transactions.len(),
+            1,
+            "u64::MAX-created tx is not stale (saturated sum >= block_height) and is retained"
+        );
+        assert_eq!(
+            built_a.transfer_tx_hashes, built_b.transfer_tx_hashes,
+            "inclusion/exclusion of the crafted tx must be deterministic across builds"
+        );
+        assert!(
+            built_a.transfer_tx_hashes.contains(&crafted_hash),
+            "crafted tx must be deterministically recorded in the built block"
         );
     }
 

--- a/botho/src/consensus/block_builder.rs
+++ b/botho/src/consensus/block_builder.rs
@@ -299,8 +299,11 @@ impl BlockBuilder {
     where
         F: Fn(&[u8; 36]) -> Option<Utxo>,
     {
-        // Calculate total fees from transactions
-        let total_fees: u64 = block.transactions.iter().map(|tx| tx.fee).sum();
+        // Calculate total fees from transactions. Saturating
+        // (block.rs::total_fees) — a plain sum() panics under release
+        // overflow-checks on this every-node externalize path before
+        // add_block's checked_block_fees can reject the block gracefully.
+        let total_fees: u64 = block.total_fees();
 
         // Pool accounting: carryover + emission share + fee pool share,
         // payouts capped at one block reward (anti-grinding bound). Must

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -38,10 +38,18 @@ const MAX_FUTURE_TIMESTAMP_SECS: u64 = 2 * 60 * 60;
 /// fires for blocks we build (no externalize-then-reject halt).
 fn first_stale_transfer_tx(block: &Block) -> Option<usize> {
     let block_height = block.height();
+    // `created_at_height` is attacker-influenced (it arrives in a gossiped
+    // block, before signature validation), so the age bound must saturate:
+    // with `overflow-checks = true` on the release profile (#663) an unchecked
+    // `+` here would let a crafted `created_at_height` near `u64::MAX` panic
+    // every validating node. Saturation preserves the rule's semantics — a
+    // saturated sum is `u64::MAX`, which is never `< block_height`, so such a
+    // tx is simply "not stale" here and is rejected by the later gates (C3
+    // ring resolution) instead.
     block
         .transactions
         .iter()
-        .position(|tx| tx.created_at_height + MAX_TX_AGE < block_height)
+        .position(|tx| tx.created_at_height.saturating_add(MAX_TX_AGE) < block_height)
 }
 
 /// Consensus decay rate for the cluster-tag inflation guard (issue #576).
@@ -808,6 +816,18 @@ impl Ledger {
             ));
         }
 
+        // Fee-sum overflow guard (#599, #663). Per-tx fees are
+        // attacker-influenced, so accumulate with `checked_add` and reject on
+        // overflow with a typed error rather than wrapping silently or (under
+        // `overflow-checks = true`, which the release profile now carries)
+        // panicking the node. Runs here — right after the tx list is bound to
+        // the header (C4) and before the expensive gates — so a crafted
+        // overflow block is rejected early and deterministically: the check is
+        // a pure function of the block contents, so proposer and validators
+        // reach the same verdict (no fork). The validated sum is reused by the
+        // fee-accounting section below.
+        let block_fees: u64 = checked_block_fees(block)?;
+
         // C5 (issue #451): Deterministic height-based staleness backstop.
         //
         // Reject any block that contains a transfer tx that is too old relative
@@ -966,10 +986,9 @@ impl Ledger {
         // (audit cycle 6, M4). The lottery summary's burn amount was verified
         // against the pool accounting by `validate_block_lottery` above.
         //
-        // Fees are attacker-influenced, so accumulate with `checked_add` and
-        // reject on overflow rather than wrapping silently (release) or
-        // panicking (debug). See issue #599 (mirrors the #340 balance guard).
-        let block_fees: u64 = checked_block_fees(block)?;
+        // `block_fees` was already validated overflow-free by the fee-sum
+        // overflow guard up front (#599, #663 — mirrors the #340 balance
+        // guard).
         let actually_burned = block.lottery_summary.amount_burned;
         let new_total_fees_burned = state.total_fees_burned + actually_burned as u128;
 
@@ -3982,12 +4001,11 @@ mod tests {
     // #599: the block-fee accumulation in `add_block_inner` must reject a
     // fee-sum overflow with a typed error rather than wrapping silently
     // (release) or panicking (debug). `checked_block_fees` is the exact
-    // reduction `add_block_inner` invokes; we test it directly because driving
-    // an overflowing-fee block all the way to the fee-accounting line would
-    // require it to first pass every prior consensus gate (PoW, ring
-    // signatures, lottery validation), which an attacker cannot do for a
-    // u64::MAX fee total. This test is meaningful in BOTH build modes: the old
-    // `.sum()` panicked here in debug and wrapped to 1 in release.
+    // reduction `add_block_inner` invokes; this unit test pins the reduction
+    // directly, and `test_add_block_rejects_fee_overflow_block` below drives
+    // a crafted block through the real `add_block` path (#663). This test is
+    // meaningful in BOTH build modes: the old `.sum()` panicked here in debug
+    // and wrapped to 1 in release.
     #[test]
     fn test_checked_block_fees_rejects_overflow() {
         use crate::transaction::Transaction;
@@ -4020,6 +4038,62 @@ mod tests {
         ];
 
         assert_eq!(checked_block_fees(&block).unwrap(), 1000);
+    }
+
+    // #663 (overflow-checks in release): integration-level companion to
+    // `test_checked_block_fees_rejects_overflow`. A crafted gossiped block
+    // whose per-tx fees sum past `u64::MAX` must be rejected by the REAL
+    // block-acceptance path (`add_block`) with a clean typed
+    // `Err(LedgerError::FeeOverflow)` — never a node panic. With
+    // `overflow-checks = true` now set on the release profile, an unguarded
+    // `.sum()` on this path would abort the node instead of wrapping, so this
+    // test (run under `cargo test --release` in CI-equivalent verification)
+    // proves the guard fires before any unchecked arithmetic can.
+    //
+    // The block is honest on every gate that precedes the fee-sum guard
+    // (height, prev hash, minting-tx consistency, expected difficulty, PoW,
+    // expected reward, timestamps, tx_root) so the rejection observed is the
+    // fee-overflow rejection specifically, not an earlier structural one.
+    #[test]
+    fn test_add_block_rejects_fee_overflow_block() {
+        use crate::{block::calculate_block_reward, transaction::Transaction};
+        use bth_account_keys::AccountKey;
+        use rand::{rngs::StdRng, SeedableRng};
+
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        // Make PoW trivially satisfiable so the crafted block reaches the
+        // fee-sum guard instead of stopping at the PoW gate.
+        ledger.set_difficulty(u64::MAX).unwrap();
+        let state = ledger.get_chain_state().unwrap();
+        let genesis = ledger.get_block(0).unwrap();
+
+        let mut rng = StdRng::seed_from_u64(663);
+        let minter = AccountKey::random(&mut rng);
+
+        // Two fees whose sum exceeds u64::MAX.
+        let txs = vec![
+            Transaction::new_stub_with_fee(u64::MAX),
+            Transaction::new_stub_with_fee(3),
+        ];
+        let block = Block::new_template_with_txs(
+            &genesis,
+            &minter.default_subaddress(),
+            state.difficulty,
+            calculate_block_reward(1, state.total_mined),
+            txs,
+        );
+
+        let result = ledger.add_block(&block);
+        assert!(
+            matches!(result, Err(LedgerError::FeeOverflow)),
+            "overflow-fee block must be rejected via Err(LedgerError::FeeOverflow), got {:?}",
+            result
+        );
+
+        // The rejected block must not have advanced the chain.
+        assert_eq!(ledger.get_chain_state().unwrap().height, 0);
     }
 
     #[test]

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -138,7 +138,18 @@ fn compute_ring_centroid(
 ) -> bth_transaction_types::ClusterTagVector {
     use bth_transaction_types::{ClusterId, ClusterTagVector};
 
-    let total_value: u64 = ring_tags.iter().map(|(_, v)| *v).sum();
+    // Ring member values are attacker-influenced (the sender picks which UTXOs
+    // decoy the ring), so this sum must saturate: a plain `.sum()` panics on
+    // overflow once `overflow-checks = true` is on the release profile (#663).
+    // Saturation is semantics-preserving here — `total_value` is only used as
+    // the normalization denominator for a heuristic tag-similarity score (never
+    // a consensus value), and the per-cluster mass accumulation below already
+    // widens to `u128`, so a saturated `u64::MAX` denominator stays finite,
+    // stays nonzero, and merely bounds the (ratio-based) centroid rather than
+    // crashing the node's mempool-admission path.
+    let total_value: u64 = ring_tags
+        .iter()
+        .fold(0u64, |acc, (_, v)| acc.saturating_add(*v));
     if total_value == 0 {
         return ClusterTagVector::empty();
     }

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -1233,9 +1233,17 @@ impl Mempool {
         self.txs.is_empty()
     }
 
-    /// Get total fees of all pending transactions
+    /// Get total fees of all pending transactions.
+    ///
+    /// Saturating: admitted fees are balance-validated (bounded by real input
+    /// value), but total picocredit supply exceeds `u64::MAX`, so an extreme
+    /// aggregate could still overflow. This is a stats/RPC value — with
+    /// `overflow-checks = true` on the release profile (#663) an unchecked
+    /// `sum()` here could panic the node instead of clamping a statistic.
     pub fn total_fees(&self) -> u64 {
-        self.txs.values().map(|p| p.tx.fee).sum()
+        self.txs
+            .values()
+            .fold(0u64, |acc, p| acc.saturating_add(p.tx.fee))
     }
 
     /// Check if a transaction is in the mempool


### PR DESCRIPTION
## Summary

Implements Option A of #663 with one measured, surgical refinement: `[profile.release]` now carries `overflow-checks = true` (inherited by `mobile`, `mobile-release`, and Cargo's `bench` profile), while `curve25519-dalek` — audited upstream constant-time EC limb arithmetic, not the consensus/economics code this backstop targets — is exempted via a per-package profile override because the naive flip measurably regressed every EC-backed validation path 20-30%. Three sites that would newly panic on crafted input under checks are converted to saturating/checked arithmetic, and a crafted overflow-fee block is proven to be rejected with a typed `Err` (not a panic) through the real `add_block` path under release codegen.

## Decision record (acceptance requires this)

**Decision: Option A (compiler backstop), hybrid form — global release `overflow-checks = true` + `[profile.release.package.curve25519-dalek] overflow-checks = false`.**

### Measurement 1 — naive flip, everything checked (criterion vs saved `ocfalse` baseline, quiet machine)

Hash / PoW / integer consensus math: within noise.

| Bench | Change |
|---|---|
| BlockHeader hash | -4.8% |
| BlockHeader pow_hash | -2.6% (p=0.08, no change) |
| MintingTx hash | -0.1% (p=0.86) |
| MintingTx verify_pow | +1.7% (p=0.25) |
| Block hash | +2.5% |
| collision_entropy (sum/calc/threshold, all sizes) | -7.1% … +5.5%, mostly ~0 |

curve25519-dalek-backed paths: **fails the <5% gate** on consensus-critical verification.

| Bench | Change |
|---|---|
| schnorr_verify | **+30.6%** |
| cluster_generator | **+27.1%** |
| proof_sizes/measure/1-8 (conservation proofs) | **+21.2% … +26.1%** |
| commitment_create | **+24.8%** |
| schnorr_prove | **+23.2%** |
| Block template creation (0/10/50 txs) | +18.5% / +21.5% / +21.2% |
| MintingTx new | +19.6% |

(`is_valid_pow` printed +7.7% while its dominant component `pow_hash` printed -2.6% — the ms-scale RandomX benches are the noisiest in the suite; treated as noise.)

Root cause: `[profile.release]` settings apply to **all dependency crates**, and ristretto/ed25519 limb math in curve25519-dalek pays the full checked-arithmetic tax. Ring-signature and committed-tag verification dominate block-validation cost, so shipping that regression fails the curator's threshold.

### Measurement 2 — hybrid (this PR) vs fully-unchecked baseline, interleaved A/B under identical machine load (criterion `--save-baseline cv` / `--baseline cv`)

| Bench | Hybrid cost vs baseline |
|---|---|
| BlockHeader hash | ~0 (+0.15%, p=0.54) |
| MintingTx new | -1.5% (hybrid faster; noise) |
| Block template creation txs/0 / txs/10 / txs/50 | +0.8% / -1.4% / ~+1% (medians; txs/50 CI wide from one disturbed sample) |
| Block hash (420ns microbench) | +2% … +4.6% (CI wide; naive-flip run bounded it at +2.5%) |
| commitment_create | ~+3% (medians) |
| cluster_generator | -1.1% (p=0.49, noise) |
| schnorr_prove | +1.1% |
| schnorr_verify | +1.9% |

Everything is ≤ ~3% and mostly within noise — **under the <5% acceptance threshold**, with the compiler backstop retained for every Botho workspace crate (all consensus, economics, fee, lottery, and demurrage arithmetic).

## Changes

- `Cargo.toml`: `overflow-checks = true` in `[profile.release]` with rationale comment; `[profile.release.package.curve25519-dalek] overflow-checks = false` carve-out with measured justification. `debug-assertions` untouched (out of scope per curation).
- `botho/src/ledger/store.rs`:
  - `first_stale_transfer_tx`: `created_at_height.saturating_add(MAX_TX_AGE)` — previously a crafted `created_at_height` near `u64::MAX` in a gossiped block would panic every validating node under checks (silent-wrap bug before; the wrapped sum could also mislabel a tx as stale). Saturation preserves semantics: a saturated sum is never `< block_height`.
  - Hoisted the #599 `checked_block_fees` guard to run right after the C4 tx_root binding and before C5, so a crafted overflow-fee block is rejected early, deterministically, with `Err(LedgerError::FeeOverflow)` — before any unchecked arithmetic could observe the sum.
  - New integration test `test_add_block_rejects_fee_overflow_block` (see Test Plan).
- `botho/src/block.rs`: `total_lottery_payouts` saturating fold (payouts in gossiped blocks are attacker-influenced; a saturated total can only fail validation); new bounds test `test_block_reward_no_overflow_at_max_height_and_supply`.
- `botho/src/mempool.rs`: `total_fees` saturating fold (stats/RPC aggregate; admitted fees are balance-validated but total picocredit supply exceeds `u64::MAX`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Decision recorded with measured bench deltas | ✅ | Decision record above; raw logs preserved during the run (baseline / naive-flip / hybrid A/B) |
| `[profile.release]` carries `overflow-checks = true` | ✅ | Cargo.toml; `mobile` inherits `release`, `bench` inherits `release` |
| `cargo test` (debug) green | ✅ | Debug already runs with overflow checks (test profile); the full suite was green on main pre-PR and the three failures listed below reproduce on unmodified main in debug |
| `cargo test --release` green (new signal) | ✅ | `cargo test --release -p botho -p bth-cluster-tax --no-fail-fast`: 1111 lib tests + all integration/cluster-tax suites pass. Exactly 3 failures, each reproduced identically on **unmodified main** (pre-existing, not caused by this change): stale fee-curve e2e test → #669; two broken `network/privacy` doctests → #670 |
| Crafted overflow block rejected via `Err(LedgerError::FeeOverflow)`, not panic, under `--release` | ✅ | `test_add_block_rejects_fee_overflow_block`: block with fees `u64::MAX + 3`, honest on every gate preceding the fee guard (trivial difficulty, valid template/tx_root), driven through the real `add_block`; asserts the typed error and that the chain did not advance. Passed in the release run |
| Newly-panicking sites fixed, not shipped | ✅ | Three sites converted (store.rs stale-tx bound, block.rs lottery payouts, mempool.rs fee total); release suite ran clean of overflow panics |
| Before/after criterion numbers for block_benchmarks + committed_tags_benchmarks recorded | ✅ | Tables above |

## Test Plan

- `cargo test --release -p botho -p bth-cluster-tax --no-fail-fast` — green except the 3 pre-existing failures above (verified pre-existing by running them on unmodified main; filed #669, #670).
- New: `test_add_block_rejects_fee_overflow_block` (release-profile crafted-block rejection), `test_block_reward_no_overflow_at_max_height_and_supply` (u128 tail-reward corner at max height/supply), both green in release.
- Benches: `cargo bench -p botho --bench block_benchmarks`, `cargo bench -p bth-cluster-tax --bench committed_tags_benchmarks`, three configurations (baseline / naive flip / hybrid), including an interleaved A/B under identical load for the final numbers.
- `rustfmt --check` clean on changed files; `cargo clippy --release -p botho -p bth-cluster-tax --lib --tests` — only pre-existing findings (all 8 clippy errors are `println!` uses in untouched `network/transport/fingerprint.rs`).
- Smoke: release `botho` binary built with the new profile; `init --relay` + 90s verbose `run` on testnet starts cleanly (consensus loop starts at height 0, no panics/overflow aborts). Live block sync was not observable from this sandboxed environment (no peer connectivity); recommend the usual testnet deploy as the final live check.

Closes #663