### PR TITLE
feat(baas): consume v0.3.0 release tarballs in rig-bootstrap with latest-release fallback

### DIFF
--- a/infra/baas/README.md
+++ b/infra/baas/README.md
@@ -26,11 +26,15 @@ recipe in `infra/seed/` and `infra/faucet/`:
 ## What it does (idempotent, logged to `/var/log/botho-rig-bootstrap.log`)
 
 1. **Install deps** — nginx, certbot, curl, jq, ca-certificates.
-2. **Download the prebuilt `botho` linux-aarch64 binary** from
-   `BOTHO_BINARY_URL` (the `binaries-linux-aarch64` release artifact; never
-   built from source on the box, which is slow / OOM-prone). Optional
-   `BOTHO_BINARY_SHA256` (the `linux-aarch64` line from the `release-checksums`
-   artifact) is verified; the file is checked to be `aarch64`.
+2. **Download the prebuilt `botho` linux-aarch64 binary** — from
+   `BOTHO_BINARY_URL` if set (the release tarball
+   `botho-vX.Y.Z-linux-aarch64.tar.gz`, or a bare-binary mirror), else reuse an
+   already-installed `/usr/local/bin/botho`, else **resolve the latest GitHub
+   release automatically** and checksum-pin it. Never built from source on the
+   box (slow / OOM-prone). Tarballs are extracted (`botho` member); optional
+   `BOTHO_BINARY_SHA256` (the `botho` line of `checksums-linux-aarch64.txt`)
+   is verified against the (extracted) binary, which is also checked to be
+   `aarch64` and installed mode `0755`.
 3. **Generate identity + config** — a per-rig 24-word wallet mnemonic and
    `~/.botho/testnet/config.toml` (testnet, RandomX minting on, faucet off,
    `quorum.mode = recommended` / `min_peers = 1`, `bootstrap_peers = []`,
@@ -56,8 +60,9 @@ recipe in `infra/seed/` and `infra/faucet/`:
 
 | Variable              | Required | Default            | Purpose |
 |-----------------------|----------|--------------------|---------|
-| `BOTHO_BINARY_URL`    | yes\*    | —                  | URL to the prebuilt linux-aarch64 `botho` binary — the `binaries-linux-aarch64` release artifact (see **Binary source** below). \*Not required on an idempotent re-run if `/usr/local/bin/botho` already exists. |
-| `BOTHO_BINARY_SHA256` | no       | —                  | Expected sha256; verified if set. Pass the `linux-aarch64` line from the release's `release-checksums` artifact to pin the exact published build. |
+| `BOTHO_BINARY_URL`    | no       | latest GitHub release | URL to the prebuilt linux-aarch64 build: the release tarball `botho-vX.Y.Z-linux-aarch64.tar.gz` (canonical since v0.3.0; the `botho` member is extracted) or a bare `botho` binary (S3/R2 mirror, legacy). When unset, an existing `/usr/local/bin/botho` is reused (idempotent re-run), else the latest GitHub release's tarball is resolved via the GitHub API (see **Binary source** below). |
+| `BOTHO_BINARY_SHA256` | no       | auto-pinned in latest-release mode | Expected sha256 of the `botho` **binary**; verified if set. Pass the `botho` line of the release asset `checksums-linux-aarch64.txt` (per-binary digests of the **extracted** files — the tarball's own digest is not published; do **not** use `SHA256SUMS.txt`, which mixes all platforms unlabelled). In bare-binary mode the downloaded file itself is verified. |
+| `BOTHO_REPO`          | no       | `botho-project/botho` | GitHub `owner/repo` used for latest-release resolution. |
 | `RIG_ID`              | no       | —                  | Short opaque rig id (e.g. `abc123`). When set and `RIG_HOSTNAME` is unset, the hostname is derived as `rig-<RIG_ID>.<RIG_DOMAIN>`. Recorded in `rig-info.txt`. |
 | `RIG_DOMAIN`          | no       | `testnet.botho.io` | Zone for `rig-<RIG_ID>` hostnames; combined with `RIG_ID` to derive `RIG_HOSTNAME`. |
 | `RIG_HOSTNAME`        | no       | —                  | Public hostname, e.g. `rig-abc123.testnet.botho.io`. Takes precedence over `RIG_ID`/`RIG_DOMAIN`. If neither is set, public nginx/TLS is skipped (RPC still on `localhost:17101`). |
@@ -91,30 +96,49 @@ journalctl -u botho -f
 ### 1. Binary source (`BOTHO_BINARY_URL`)
 
 The rig **downloads the prebuilt arm64 binary** — it never builds from source on
-the box (t4g release builds are slow and RandomX-linked crates can OOM). The
-canonical source is the **`binaries-linux-aarch64`** artifact built by
-`.github/workflows/release.yml` (target `aarch64-unknown-linux-gnu`), and the
-matching checksum is the `linux-aarch64/...` line in the **`release-checksums`**
-artifact (`all-checksums.txt`).
+the box (t4g release builds are slow and RandomX-linked crates can OOM).
 
-However, the latest GitHub release (`v0.2.0`) ships **no downloadable asset** —
-the workflow produces the artifact, but the operator hasn't attached/mirrored a
-GET-able copy. So the bootstrap **cannot resolve a URL on its own**; it consumes
-`BOTHO_BINARY_URL` (and, ideally, `BOTHO_BINARY_SHA256`).
+Since **v0.3.0** (2026-07-05) the canonical source is the **GitHub release
+asset** published by `.github/workflows/release.yml`:
 
-**#458 (P6.2) must publish the current `linux-aarch64` `botho` artifact and pass
-its URL + checksum**, for example:
+- `botho-vX.Y.Z-linux-aarch64.tar.gz` — gzip tarball with top-level members
+  `botho`, `botho-wallet`, `botho-exchange-scanner` (mode `0644` inside the
+  archive; the bootstrap extracts `botho` and installs it `0755`).
+- `checksums-linux-aarch64.txt` — sha256 digests of each **extracted binary**
+  (one per line). **The tarball's own digest is published nowhere**, so in
+  tarball mode `BOTHO_BINARY_SHA256` is compared against the extracted `botho`.
+- Do **not** verify against `SHA256SUMS.txt`: it is an unlabelled concatenation
+  of every platform's checksums, so `botho` appears once per platform with
+  conflicting digests. Always use `checksums-<platform>.txt`.
 
-- On a release tag, attach the `binaries-linux-aarch64` binary to the GitHub
-  release and use the asset's download URL; pass the matching `linux-aarch64`
-  sha256 from `release-checksums` as `BOTHO_BINARY_SHA256`; or
-- Build via `scripts/build-release.sh` (or the `release.yml` workflow on a tag),
-  then mirror `target/aarch64-unknown-linux-gnu/release/botho` to an S3/R2 object
-  the rig can `GET`, and pass that object URL as `BOTHO_BINARY_URL`.
+The bootstrap resolves the binary in this order (Step 2 of the script):
 
-Interim stand-in (used for the live verification of this PR): copy the binary
-already running on a live seed (it is the exact network build) to a temporary
-HTTP location and pass that URL — see the verification notes in the PR.
+1. **Explicit `BOTHO_BINARY_URL`** — the release tarball URL, or a bare
+   aarch64 `botho` binary (e.g. an S3/R2 mirror object; legacy path, still
+   supported — in that mode the sha256 is of the downloaded file itself).
+2. **Existing `/usr/local/bin/botho`** — reused on idempotent re-runs; no
+   network access is attempted.
+3. **Latest GitHub release fallback** — resolves the newest release of
+   `BOTHO_REPO` via `https://api.github.com/repos/<repo>/releases/latest`,
+   downloads `botho-<tag>-linux-aarch64.tar.gz`, and (when
+   `BOTHO_BINARY_SHA256` is unset) auto-pins the `botho` digest from the same
+   release's `checksums-linux-aarch64.txt`. If the GitHub API is unreachable,
+   the script fails with instructions to pass `BOTHO_BINARY_URL` explicitly.
+
+So the provisioner (#458 P6.2) may omit both variables entirely (track the
+latest release), or pin an exact build:
+
+```bash
+export BOTHO_BINARY_URL="https://github.com/botho-project/botho/releases/download/v0.3.0/botho-v0.3.0-linux-aarch64.tar.gz"
+# the `botho` line of that release's checksums-linux-aarch64.txt:
+export BOTHO_BINARY_SHA256="019f31e8e29cf482567be1c51f65d499aeffda1b63f57098a99106a31053aab1"
+```
+
+> **Obsolete guidance (pre-v0.3.0):** earlier releases (≤ `v0.2.0`) shipped no
+> downloadable assets, which forced an interim "copy the binary from a live
+> seed to a temporary HTTP location" stand-in. That workaround is no longer
+> needed and must not be used — release assets are the canonical source
+> (see #638, "prefer release artifacts in deploys").
 
 ### 2. DNS pre-creation (`RIG_HOSTNAME` / `RIG_ID`)
 
@@ -133,8 +157,10 @@ DNS-less local testing use `TLS_MODE=skip`.
 export RIG_ID="abc123"                 # -> rig-abc123.testnet.botho.io
 export REGION="us-west-2"
 export TIER="t4g.medium"
-export BOTHO_BINARY_URL="https://artifacts.botho.io/botho/<rev>/botho-aarch64"
-export BOTHO_BINARY_SHA256="<linux-aarch64 sha256 from release-checksums>"
+# Binary: omit both exports to track the latest GitHub release (auto-pinned
+# from checksums-linux-aarch64.txt), or pin an exact release build:
+export BOTHO_BINARY_URL="https://github.com/botho-project/botho/releases/download/v0.3.0/botho-v0.3.0-linux-aarch64.tar.gz"
+export BOTHO_BINARY_SHA256="<the 'botho' line of that release's checksums-linux-aarch64.txt>"
 export MINT_THREADS=1
 # ... then the contents of rig-bootstrap.sh ...
 ```
@@ -150,3 +176,79 @@ the instance's user-data. cloud-init runs it as root on first boot.)
 - `t4g.medium` (arm64, 2 vCPU, ~4 GB; RandomX needs ~2 GB), Ubuntu 24.04 arm64.
 - Security group must allow inbound `17100` (gossip), `80`/`443` (nginx/ACME),
   and `22` only for break-glass (the bootstrap needs no inbound SSH).
+
+## Operator validation runbook (protocol 4.0.0 / release-asset flow)
+
+> **Status: pending live validation.** This runbook is the end-to-end check for
+> issue #652 — execute it after any change to the binary-acquisition flow (and
+> after protocol resets) and record the results on the tracking issue. It
+> requires AWS access and is **not** exercised by CI.
+
+### 1. Launch
+
+Launch a fresh instance (matching the provisioner's parameters, #502):
+
+- **AMI**: Ubuntu 24.04 LTS arm64 (`ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*`).
+- **Type**: `t4g.medium`; root volume ≥ 16 GB gp3.
+- **Security group**: inbound `17100/tcp` (gossip), `80`/`443` (only if testing
+  TLS), `22` for break-glass.
+- **User data**: the exports below followed by the full contents of
+  `rig-bootstrap.sh`:
+
+```bash
+#!/usr/bin/env bash
+export TIER="t4g.medium"
+export TLS_MODE="skip"       # DNS-less validation; use RIG_ID + webroot to also test TLS
+# No BOTHO_BINARY_URL / BOTHO_BINARY_SHA256: exercises the latest-release
+# resolution + auto checksum pinning (the default provisioner path).
+# ... contents of rig-bootstrap.sh ...
+```
+
+### 2. Verify provisioning
+
+SSH in (break-glass) and check:
+
+```bash
+sudo tail -50 /var/log/botho-rig-bootstrap.log
+# Expect: "latest release: vX.Y.Z", "pinned sha256 from checksums-linux-aarch64.txt: ...",
+#         "gzip tarball detected; extracting 'botho' member", "sha256 verified: ...",
+#         "installed botho (aarch64)", "=== Botho rig bootstrap complete ==="
+ls -l /usr/local/bin/botho      # mode 0755
+systemctl is-active botho       # active
+```
+
+### 3. Verify the node joined protocol-4.0.0 testnet and mints
+
+```bash
+# Network / sync / peers / minting (node_getStatus):
+curl -s -X POST http://localhost:17101 -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"node_getStatus","params":{},"id":1}' \
+  | jq '{network:.result.network, height:.result.chainHeight, peers:.result.peerCount,
+         synced:.result.synced, syncStatus:.result.syncStatus,
+         mintingActive:.result.mintingActive, nodeVersion:.result.nodeVersion}'
+
+# Wire-protocol version (node_getIdentity — protocolVersion is NOT in node_getStatus):
+curl -s -X POST http://localhost:17101 -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"node_getIdentity","params":{},"id":1}' \
+  | jq '{protocolVersion:.result.protocolVersion, network:.result.network,
+         dnsSeedDomain:.result.dnsSeedDomain}'
+```
+
+Pass criteria (record actual values on the tracking issue):
+
+- [ ] `network` = `botho-testnet` (both calls).
+- [ ] `protocolVersion` = `4.0.0`.
+- [ ] `peerCount` ≥ 1 within a few minutes — peers discovered via DNS-seed
+      discovery (`seeds.testnet.botho.io`; seed/seed2/faucet). No
+      `BOOTSTRAP_PEERS` needed.
+- [ ] `synced` = `true` and `chainHeight` tracks the live cluster tip
+      (compare against a seed's `/rpc`).
+- [ ] `mintingActive` = `true` (RandomX; 1 thread by default) and, after a
+      while, `journalctl -u botho` shows minting activity with no restarts.
+
+### 4. Idempotency spot-check
+
+Re-run the script on the same box (`sudo bash rig-bootstrap.sh` with the same
+env): Step 2 must log `reusing existing /usr/local/bin/botho (idempotent
+re-run)` (no download/API call), the wallet mnemonic must be preserved, and the
+service must come back healthy.

--- a/infra/baas/rig-bootstrap.sh
+++ b/infra/baas/rig-bootstrap.sh
@@ -20,9 +20,14 @@
 # exports below) into the instance launch's "User data" field. cloud-init runs
 # it as root on first boot. It is also safe to run by hand:
 #
+#     sudo RIG_ID=demo REGION=us-west-2 TIER=t4g.medium ./rig-bootstrap.sh
+#
+# (with no BOTHO_BINARY_URL, the latest GitHub release's linux-aarch64 tarball
+# is resolved and checksum-pinned automatically), or with an explicit pin:
+#
 #     sudo RIG_ID=demo REGION=us-west-2 TIER=t4g.medium \
-#          BOTHO_BINARY_URL=https://example.com/botho-aarch64 \
-#          BOTHO_BINARY_SHA256=<sha256 from release-checksums> \
+#          BOTHO_BINARY_URL=https://github.com/botho-project/botho/releases/download/v0.3.0/botho-v0.3.0-linux-aarch64.tar.gz \
+#          BOTHO_BINARY_SHA256=<'botho' line from checksums-linux-aarch64.txt> \
 #          ./rig-bootstrap.sh
 #
 # (RIG_ID=demo derives RIG_HOSTNAME=rig-demo.testnet.botho.io.)
@@ -32,21 +37,33 @@
 # ---------------------------------------------------------------------------
 # PARAMETERS (environment variables / user-data exports)
 # ---------------------------------------------------------------------------
-#   BOTHO_BINARY_URL   (REQUIRED unless a binary is already installed)
-#                      URL to the prebuilt linux-aarch64 `botho` binary. This is
-#                      the `binaries-linux-aarch64` artifact produced by
-#                      .github/workflows/release.yml (target
-#                      aarch64-unknown-linux-gnu) — the rig is arm64, so it
-#                      DOWNLOADS this prebuilt binary rather than building from
-#                      source on the box. The provisioner (#458 P6.2) resolves a
-#                      GET-able URL (GitHub release asset, or a mirror in S3/R2)
-#                      and passes it here. See BINARY SOURCE note at the bottom
-#                      of this file and infra/baas/README.md.
-#   BOTHO_BINARY_SHA256 (optional) expected sha256 of the downloaded binary.
-#                      Verified if set. The provisioner should pass the
-#                      linux-aarch64 checksum from the release's
-#                      `release-checksums` artifact (all-checksums.txt) so each
-#                      rig pins the exact published build.
+#   BOTHO_BINARY_URL   (optional) URL to the prebuilt linux-aarch64 botho
+#                      build. Accepts EITHER the published GitHub release
+#                      tarball (`botho-vX.Y.Z-linux-aarch64.tar.gz`, the
+#                      canonical source since v0.3.0 — the `botho` member is
+#                      extracted and installed) OR a bare aarch64 `botho`
+#                      binary (e.g. an S3/R2 mirror object; legacy path, still
+#                      supported). The rig is arm64, so it DOWNLOADS a prebuilt
+#                      binary rather than building from source on the box.
+#                      When unset: an already-installed /usr/local/bin/botho is
+#                      reused (idempotent re-run); otherwise the latest GitHub
+#                      release's linux-aarch64 tarball is resolved via the
+#                      GitHub API and used automatically. See BINARY SOURCE
+#                      note at the bottom of this file and infra/baas/README.md.
+#   BOTHO_BINARY_SHA256 (optional) expected sha256 of the `botho` BINARY —
+#                      verified if set. In tarball mode this is compared against
+#                      the EXTRACTED `botho` (the release publishes per-binary
+#                      digests: pass the `botho` line of the release asset
+#                      `checksums-linux-aarch64.txt`; the tarball's own digest
+#                      is published nowhere). In bare-binary mode the downloaded
+#                      file itself is verified. Do NOT take digests from
+#                      SHA256SUMS.txt — it concatenates all platforms without
+#                      labels and lists `botho` multiple times. When both this
+#                      and BOTHO_BINARY_URL are unset (latest-release mode), the
+#                      digest is fetched from the same release's
+#                      checksums-linux-aarch64.txt and pinned automatically.
+#   BOTHO_REPO         (optional, default "botho-project/botho") GitHub
+#                      owner/repo used for latest-release resolution.
 #   RIG_ID             (optional) short opaque rig identifier (e.g. abc123),
 #                      assigned by the provisioner / Stripe subscription mapping.
 #                      When set and RIG_HOSTNAME is unset, the public hostname is
@@ -125,6 +142,7 @@ REGION="${REGION:-}"
 TIER="${TIER:-t4g.medium}"
 BOTHO_BINARY_URL="${BOTHO_BINARY_URL:-}"
 BOTHO_BINARY_SHA256="${BOTHO_BINARY_SHA256:-}"
+BOTHO_REPO="${BOTHO_REPO:-botho-project/botho}"
 BOOTSTRAP_PEERS="${BOOTSTRAP_PEERS:-}"
 MINT_THREADS="${MINT_THREADS:-1}"
 CERTBOT_EMAIL="${CERTBOT_EMAIL:-admin@botho.io}"
@@ -158,7 +176,7 @@ if [[ -z "$RIG_HOSTNAME" && -n "$RIG_ID" ]]; then
 fi
 
 log "Params: NETWORK=$NETWORK RIG_ID='${RIG_ID:-<none>}' RIG_HOSTNAME='${RIG_HOSTNAME:-<none>}' REGION='${REGION:-<unset>}' TIER=$TIER TLS_MODE=$TLS_MODE MINT_THREADS=$MINT_THREADS"
-log "Binary source: ${BOTHO_BINARY_URL:-<none, will require existing $BIN_PATH>}"
+log "Binary source: ${BOTHO_BINARY_URL:-<unset: reuse existing $BIN_PATH, else latest GitHub release>}"
 
 # ===========================================================================
 # Step 1: Install dependencies (idempotent)
@@ -182,26 +200,49 @@ fi
 # Step 2: Obtain the botho linux-aarch64 binary
 # ===========================================================================
 # PREFER fetching a published binary over building on the box (t4g release
-# builds take ~20+ min and can OOM RandomX-linked crates). The source is the
-# BOTHO_BINARY_URL parameter; #458's provisioner publishes the release artifact
-# (e.g. to S3/R2) and supplies the URL.
+# builds take ~20+ min and can OOM RandomX-linked crates). Source resolution
+# order (see BINARY SOURCE NOTE at the bottom of this file):
+#   1. explicit BOTHO_BINARY_URL (release tarball or bare-binary mirror),
+#   2. existing $BIN_PATH (idempotent re-run — never re-downloads),
+#   3. the latest GitHub release's linux-aarch64 tarball, checksum-pinned from
+#      the same release's checksums-linux-aarch64.txt (canonical since v0.3.0;
+#      release assets preferred per #638).
 log "Step 2: obtaining botho binary"
 install_binary() {
-    local url="$1" tmp
+    # $1 = URL to EITHER the release tarball botho-vX.Y.Z-linux-aarch64.tar.gz
+    # (gzip; top-level `botho` member, mode 0644 inside the archive) OR a bare
+    # aarch64 `botho` binary (legacy S3/R2 mirror path). Either way the
+    # resulting binary is installed 0755 at $BIN_PATH.
+    local url="$1" tmp candidate extract_dir=""
     tmp="$(mktemp /tmp/botho.XXXXXX)"
     log "  downloading $url"
     curl -fSL --retry 5 --retry-delay 5 -o "$tmp" "$url" \
         || fail "failed to download botho binary from $url"
+    candidate="$tmp"
+    if file "$tmp" | grep -qi "gzip compressed"; then
+        log "  gzip tarball detected; extracting 'botho' member"
+        extract_dir="$(mktemp -d /tmp/botho-extract.XXXXXX)"
+        tar -xzf "$tmp" -C "$extract_dir" \
+            || fail "failed to extract release tarball downloaded from $url"
+        candidate="$extract_dir/botho"
+        [[ -f "$candidate" ]] \
+            || fail "release tarball from $url has no top-level 'botho' member"
+    fi
     if [[ -n "$BOTHO_BINARY_SHA256" ]]; then
+        # In tarball mode this verifies the EXTRACTED `botho` binary: the
+        # release publishes per-binary digests (checksums-linux-aarch64.txt),
+        # not a tarball digest. In bare-binary mode it verifies the download.
         local got
-        got="$(sha256sum "$tmp" | awk '{print $1}')"
+        got="$(sha256sum "$candidate" | awk '{print $1}')"
         [[ "$got" == "$BOTHO_BINARY_SHA256" ]] \
             || fail "binary sha256 mismatch: got $got expected $BOTHO_BINARY_SHA256"
         log "  sha256 verified: $got"
     fi
-    file "$tmp" | grep -q "aarch64" || fail "downloaded binary is not aarch64: $(file "$tmp")"
-    install -m 0755 "$tmp" "$BIN_PATH"
+    file "$candidate" | grep -q "aarch64" \
+        || fail "botho binary is not aarch64: $(file "$candidate")"
+    install -m 0755 "$candidate" "$BIN_PATH"
     rm -f "$tmp"
+    if [[ -n "$extract_dir" ]]; then rm -rf "$extract_dir"; fi
 }
 
 if [[ -n "$BOTHO_BINARY_URL" ]]; then
@@ -209,7 +250,29 @@ if [[ -n "$BOTHO_BINARY_URL" ]]; then
 elif [[ -x "$BIN_PATH" ]]; then
     log "  BOTHO_BINARY_URL unset; reusing existing $BIN_PATH (idempotent re-run)"
 else
-    fail "no BOTHO_BINARY_URL and no existing $BIN_PATH. The provisioner (#458) must publish a linux-aarch64 binary and pass BOTHO_BINARY_URL. See infra/baas/README.md."
+    # Latest-release fallback: resolve the newest GitHub release and consume
+    # its linux-aarch64 tarball, pinning the published `botho` digest unless
+    # the operator already supplied one.
+    log "  BOTHO_BINARY_URL unset and no $BIN_PATH; resolving latest GitHub release of $BOTHO_REPO"
+    LATEST_TAG="$(curl -fsSL --retry 3 --retry-delay 2 \
+        "https://api.github.com/repos/${BOTHO_REPO}/releases/latest" 2>/dev/null \
+        | grep -m1 '"tag_name"' | cut -d'"' -f4 || true)"
+    [[ -n "$LATEST_TAG" ]] \
+        || fail "could not resolve the latest release tag of $BOTHO_REPO from the GitHub API. Pass BOTHO_BINARY_URL explicitly (release tarball or bare-binary mirror URL). See infra/baas/README.md."
+    RELEASE_BASE="https://github.com/${BOTHO_REPO}/releases/download/${LATEST_TAG}"
+    log "  latest release: $LATEST_TAG"
+    if [[ -z "$BOTHO_BINARY_SHA256" ]]; then
+        # Pin the digest of the extracted `botho` binary — the `botho` line of
+        # checksums-linux-aarch64.txt. (Do NOT use SHA256SUMS.txt: it is a
+        # platform-unlabelled concatenation with multiple `botho` lines.)
+        BOTHO_BINARY_SHA256="$(curl -fsSL --retry 3 --retry-delay 2 \
+            "${RELEASE_BASE}/checksums-linux-aarch64.txt" 2>/dev/null \
+            | awk '$2 == "botho" {print $1; exit}' || true)"
+        [[ -n "$BOTHO_BINARY_SHA256" ]] \
+            || fail "could not fetch the 'botho' digest from ${RELEASE_BASE}/checksums-linux-aarch64.txt. Pass BOTHO_BINARY_SHA256 (or an explicit BOTHO_BINARY_URL) instead."
+        log "  pinned sha256 from checksums-linux-aarch64.txt: $BOTHO_BINARY_SHA256"
+    fi
+    install_binary "${RELEASE_BASE}/botho-${LATEST_TAG}-linux-aarch64.tar.gz"
 fi
 # The binary has no `--version` flag; the version is reported via RPC
 # (nodeVersion) once the node is up. Record the architecture here; resolve the
@@ -638,19 +701,38 @@ log "Read back any time: sudo rig-status   |   cat ${RUN_HOME}/rig-info.txt"
 # ---------------------------------------------------------------------------
 # This bootstrap DOWNLOADS the prebuilt arm64 binary (it never builds from
 # source on the box — t4g release builds are slow and RandomX-linked crates can
-# OOM). The canonical source is the `binaries-linux-aarch64` artifact built by
-# .github/workflows/release.yml (target aarch64-unknown-linux-gnu), with its
-# checksum in the `release-checksums` artifact (all-checksums.txt, the
-# `linux-aarch64/...` line). Pass:
-#     BOTHO_BINARY_URL=<GET-able URL to the aarch64 botho binary>
-#     BOTHO_BINARY_SHA256=<that binary's sha256 from release-checksums>
+# OOM). Since v0.3.0 (2026-07-05) the canonical source is the GitHub RELEASE
+# ASSET published by .github/workflows/release.yml:
 #
-# As of this writing the latest GitHub release (v0.2.0) has NO published binary
-# ASSET (the workflow produces the artifact, but the operator hasn't attached a
-# downloadable release asset / mirror yet), so the bootstrap cannot resolve a
-# public URL on its own. The provisioner (#458 P6.2) MUST publish the current
-# linux-aarch64 `botho` artifact (attach it to the GitHub release, or mirror to
-# S3/R2) and pass its URL as BOTHO_BINARY_URL (and the checksum as
-# BOTHO_BINARY_SHA256). See infra/baas/README.md for the recommended
-# distribution flow and the interim "copy from a live seed" stand-in used
-# during verification.
+#     botho-vX.Y.Z-linux-aarch64.tar.gz   (gzip tarball; top-level members
+#                                          `botho`, `botho-wallet`,
+#                                          `botho-exchange-scanner`, mode 0644
+#                                          inside the archive — this script
+#                                          extracts `botho` and installs it
+#                                          0755)
+#     checksums-linux-aarch64.txt         (sha256 of each EXTRACTED binary,
+#                                          one per line — the tarball's own
+#                                          digest is published nowhere)
+#
+# Verification: BOTHO_BINARY_SHA256 must be the `botho` line of
+# checksums-linux-aarch64.txt (i.e. the digest of the extracted binary). Do
+# NOT take digests from SHA256SUMS.txt — it concatenates every platform's
+# checksums with no platform labels, so `botho` appears multiple times with
+# conflicting digests.
+#
+# Resolution order implemented in Step 2:
+#   1. BOTHO_BINARY_URL set  -> download it. Accepts the release tarball OR a
+#      bare aarch64 binary (legacy S3/R2 mirror path, kept for backward
+#      compatibility; in that mode the digest is of the downloaded file).
+#   2. else, $BIN_PATH exists -> reuse it (idempotent re-run; no network).
+#   3. else -> resolve the latest GitHub release of $BOTHO_REPO via the GitHub
+#      API and consume its linux-aarch64 tarball, auto-pinning the `botho`
+#      digest from checksums-linux-aarch64.txt when BOTHO_BINARY_SHA256 is
+#      unset. If the API is unreachable, the script fails with instructions to
+#      pass BOTHO_BINARY_URL explicitly.
+#
+# The provisioner (#458 P6.2) may therefore omit both variables entirely
+# (latest release), or pin an exact build by passing the release-asset URL +
+# the published `botho` digest. (Historical: pre-v0.3.0 releases shipped no
+# downloadable assets, which required an interim "copy from a live seed"
+# stand-in — that guidance is obsolete.) See infra/baas/README.md.


### PR DESCRIPTION
## Summary

Reconciles `infra/baas/rig-bootstrap.sh` with the release-asset format that ships since v0.3.0 (2026-07-05). The script previously required a bare aarch64 ELF at `BOTHO_BINARY_URL` and would hard-fail on the actual release asset (a gzip tarball), and its BINARY SOURCE NOTE / README still claimed "v0.2.0 ships no downloadable asset — copy from a live seed". This PR teaches Step 2 to consume the published tarball, adds a latest-GitHub-release fallback with automatic checksum pinning, refreshes all stale docs, and adds the operator validation runbook for the post-merge live `t4g.medium` protocol-4.0.0 check.

## Changes

- `install_binary()` detects gzip tarballs (`botho-vX.Y.Z-linux-aarch64.tar.gz`), extracts the top-level `botho` member (archive members are mode `0644`), verifies `BOTHO_BINARY_SHA256` against the **extracted** binary (the release publishes per-binary digests in `checksums-<platform>.txt`; no tarball digest exists), runs the `aarch64` file gate on the extracted binary, and installs it `0755`. Bare-binary (S3/R2 mirror) behavior is byte-for-byte the legacy flow: digest + gate on the raw download.
- New dispatch fallback: explicit `BOTHO_BINARY_URL` → existing `$BIN_PATH` (idempotent reuse, still checked **before** any network access) → latest GitHub release resolution via the API (pattern ported from `infra/seed/deploy-botho.sh:64-106`, #638), auto-pinning the `botho` line of the same release's `checksums-linux-aarch64.txt` when `BOTHO_BINARY_SHA256` is unset. `BOTHO_REPO` (default `botho-project/botho`) is overridable. Clear failure message directing operators to pass `BOTHO_BINARY_URL` if the API is unreachable.
- Rewrote the BINARY SOURCE NOTE (`rig-bootstrap.sh`) and the README binary-source section: v0.3.0+ asset names/layout, exact checksum line to pass, explicit warning that `SHA256SUMS.txt` is a platform-unlabelled concatenation (multiple conflicting `botho` lines) and must not be used; pre-v0.3.0 "copy from a live seed" guidance marked obsolete.
- Refreshed README `:30-32` (what-it-does), the `BOTHO_BINARY_URL`/`BOTHO_BINARY_SHA256` parameter-table rows (+ new `BOTHO_REPO` row), and the example user-data (now shows both zero-config latest-release mode and an exact-pin example with the real v0.3.0 asset URL).
- Added an **operator validation runbook** to `infra/baas/README.md` (labeled *pending live validation*): launch parameters, expected bootstrap-log lines, and `node_getStatus` + `node_getIdentity` pass criteria (`network=botho-testnet`, `protocolVersion=4.0.0`, DNS-seed peers, synced, `mintingActive=true`) — note `protocolVersion` is served by `node_getIdentity`, not `node_getStatus` (verified in `botho/src/rpc/mod.rs`).
- Config writer verified-only, no change needed (per curation: `protocolVersion` comes from the binary). `infra/seed/*` and `web/packages/baas-worker/*` untouched.

## Acceptance Criteria Verification (Builder scope / PR gate)

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Tarball URL installs a working binary (extract `botho`, exec bit via `install -m 0755`); bare-binary path unchanged | ✅ | Local harness against the REAL downloaded `botho-v0.3.0-linux-aarch64.tar.gz`: tarball + bare-binary installs both succeed, installed file mode `755`, digest equals the published `botho` digest (T1, T3, T4) |
| Checksum verified against the extracted `botho` in tarball mode (the `checksums-linux-aarch64.txt` line); raw download in bare mode; docs warn against `SHA256SUMS.txt` | ✅ | T1/T4 pass with `019f31e8…aab1`; wrong-digest negative tests fail with the mismatch message in BOTH modes (T2, T5); docs updated in script header, BINARY SOURCE NOTE, and README |
| Unset URL + no `$BIN_PATH` resolves latest release + auto-pins digest from `checksums-linux-aarch64.txt`; explicit URL/mirror override preserved | ✅ | T9 (live GitHub API): constructed URL is exactly `https://github.com/botho-project/botho/releases/download/v0.3.0/botho-v0.3.0-linux-aarch64.tar.gz`, pinned sha `019f31e8…aab1`; T10: explicit URL takes precedence |
| Stale v0.2.0 / "copy from a live seed" guidance removed/marked obsolete everywhere (incl. README `:30-32`, `:59-60`, `:91-140`, `:136-137`) | ✅ | All enumerated spots rewritten; `grep -n 'v0.2.0\|live seed'` in `infra/baas/` now matches only the explicitly-labeled "Obsolete guidance (pre-v0.3.0)" callouts |
| Idempotent re-run: `$BIN_PATH` reuse checked before any network resolution | ✅ | Reuse branch kept as dispatch step 2, ahead of the API fallback; T8 proves a re-run with an existing binary makes zero `curl`/install calls |
| `infra/seed/*` untouched; changes additive to the baas script | ✅ | `git diff --stat`: only `infra/baas/rig-bootstrap.sh` + `infra/baas/README.md` |
| README gains operator validation runbook for the live `t4g.medium` run | ✅ | New "Operator validation runbook" section with launch params, log expectations, RPC pass criteria, idempotency spot-check; labeled **pending live validation** |

The fresh `t4g.medium` end-to-end run is an **operator step post-merge, not a PR gate** (per the curator's 2026-07-06 restructure of #652): the Builder has no AWS access, so the runbook is included and marked *pending live validation*; results are to be recorded on the issue after the operator executes it.

## Test Plan

All local (macOS; extraction/verification logic is portable — harness shims nothing except `log`/`fail`; full-script runs remain Ubuntu-only as documented):

- `bash -n infra/baas/rig-bootstrap.sh` — pass.
- `shellcheck infra/baas/rig-bootstrap.sh` (v0.11.0) — **zero findings** (baseline on main was also zero; no new warnings).
- Harness extracts `install_binary()` + the dispatch block verbatim from the script and runs **10/10 passing** cases against the real downloaded v0.3.0 asset: tarball install w/ correct digest, tarball+bare wrong-digest failures, no-digest aarch64 gate, bare-binary regression, non-ELF rejection, tarball-without-`botho` rejection, idempotent reuse with zero network calls, live latest-release URL/digest resolution, explicit-URL precedence.
- Verified curator's asset facts first-hand: tarball members `./botho`, `./botho-wallet`, `./botho-exchange-scanner` all mode `0644`; `checksums-linux-aarch64.txt` digests the extracted binaries.

Closes #652