### PR TITLE
feat(consensus): expose live SCP slot-stall observability via node_getStatus and Prometheus

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -25,7 +25,7 @@ use crate::{
     config::{Config, QuorumMode},
     consensus::{
         BlockBuilder, ConsensusConfig, ConsensusEvent, ConsensusService, LotteryFeeConfig,
-        TransactionValidator,
+        ScpSlotSnapshot, TransactionValidator,
     },
     network::{
         default_seed_domain, BlockTxn, ChainSyncManager, CompactBlock, GetBlockTxn,
@@ -423,6 +423,13 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // instead of always claiming to be synced.
     let sync_status: Arc<RwLock<Option<SyncStatusSnapshot>>> = Arc::new(RwLock::new(None));
 
+    // Shared SCP slot-progress handle (#653, epic #532 Phase 0). The consensus
+    // tick below publishes a fresh snapshot of the live SCP slot state
+    // (nomination counters, phase, ballot counter, stall verdict) here on
+    // every tick; the RPC layer surfaces it in `node_getStatus` so an operator
+    // can tell a jammed competing-coinbase round apart from an idle node.
+    let scp_slot_status: Arc<RwLock<Option<ScpSlotSnapshot>>> = Arc::new(RwLock::new(None));
+
     let mut rpc_state = RpcState::from_shared(
         node.shared_ledger(),
         node.shared_mempool(),
@@ -439,6 +446,9 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     .with_identity(node_identity)
     .with_minter_health(minter_health.clone())
     .with_sync_status(sync_status.clone())
+    // Live SCP slot-stall observability for `node_getStatus` (#653). Shares
+    // the handle the consensus tick publishes into.
+    .with_scp_slot_status(scp_slot_status.clone())
     .with_peers(peers_snapshot.clone())
     // Live traffic / connection-direction counters for `network_getInfo`
     // (#542). Shares the same handle the network event loop increments.
@@ -687,6 +697,11 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // Track pending compact blocks awaiting missing transactions
     // Key: block hash, Value: (compact block, missing indices)
     let mut pending_compact_blocks: HashMap<[u8; 32], (CompactBlock, Vec<u16>)> = HashMap::new();
+
+    // Edge-trigger for the SCP slot-stall warning (#653): warn once when the
+    // stall verdict flips true, not on every 500ms consensus tick while it
+    // stays jammed (the metric/RPC snapshot keeps reporting continuously).
+    let mut slot_stall_warned = false;
 
     loop {
         if shutdown.load(Ordering::SeqCst) {
@@ -1557,6 +1572,32 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             debug!(slot = slot_index, phase = %phase, "Consensus progress");
                         }
                     }
+                }
+
+                // Publish the live SCP slot-progress snapshot (#653, epic #532
+                // Phase 0) AFTER the event drain, so a just-externalized slot
+                // is reflected (stall clock reset, advanced slot index) rather
+                // than reported one tick stale. The RPC layer reads the shared
+                // handle for `node_getStatus`; the Prometheus gauges mirror the
+                // stall verdict for the Grafana dashboard / alarms.
+                let slot_snapshot = consensus.slot_status();
+                metrics_updater.set_scp_slot_stalled(slot_snapshot.slot_stalled);
+                metrics_updater.set_scp_slot_stall_seconds(slot_snapshot.stall_seconds);
+                if slot_snapshot.slot_stalled && !slot_stall_warned {
+                    slot_stall_warned = true;
+                    warn!(
+                        slot = slot_snapshot.slot_index,
+                        stall_seconds = slot_snapshot.stall_seconds,
+                        phase = %slot_snapshot.phase,
+                        ballot_counter = slot_snapshot.ballot_counter,
+                        "SCP slot is ACTIVE but has not externalized past the stall \
+                         threshold — possible jammed round (#532 Phase 0 signal)"
+                    );
+                } else if !slot_snapshot.slot_stalled {
+                    slot_stall_warned = false;
+                }
+                if let Ok(mut guard) = scp_slot_status.write() {
+                    *guard = Some(slot_snapshot);
                 }
             }
 

--- a/botho/src/consensus/mod.rs
+++ b/botho/src/consensus/mod.rs
@@ -22,6 +22,9 @@ pub use lottery::{
     verify_lottery_result, BlockLotteryResult, LotteryFeeConfig, LotteryStats,
     LotteryValidationError,
 };
-pub use service::{ConsensusConfig, ConsensusEvent, ConsensusService, ScpMessage};
+pub use service::{
+    ConsensusConfig, ConsensusEvent, ConsensusService, ScpMessage, ScpSlotSnapshot,
+    SLOT_STALL_THRESHOLD_MULTIPLIER,
+};
 pub use validation::{BatchValidationResult, TransactionValidator, ValidationError};
 pub use value::{ConsensusValue, ConsensusValueHash};

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -72,6 +72,94 @@ impl ConsensusConfig {
     }
 }
 
+/// Stall threshold multiplier for [`ConsensusService::slot_status`] (issue
+/// #653, epic #532 Phase 0).
+///
+/// A slot is reported as STALLED when it is active (nomination/ballot state
+/// present) but has not externalized for more than
+/// `SLOT_STALL_THRESHOLD_MULTIPLIER x` the EFFECTIVE slot duration. The
+/// threshold is derived from [`ConsensusService::current_slot_duration`]
+/// (dynamic timing adjusts the slot duration at runtime between 3s and the
+/// configured default of 20s), NOT a hardcoded wall-clock constant, so the
+/// verdict stays meaningful across timing levels. `3x` gives federated voting
+/// a couple of full round-trips of slack before alarming: a healthy slot
+/// externalizes within ~1 slot duration, so 3 missed durations on an ACTIVE
+/// slot is a genuinely jammed round, not ordinary latency.
+pub const SLOT_STALL_THRESHOLD_MULTIPLIER: u32 = 3;
+
+/// Read-only snapshot of the current SCP slot's progress, for operator
+/// observability (issue #653, epic #532 Phase 0).
+///
+/// Every field is derived from LIVE consensus state at the moment
+/// [`ConsensusService::slot_status`] is called — the SCP node's
+/// [`SlotMetrics`] (nomination sets / ballot counter / phase), the current
+/// slot index, and the service's externalization history. Nothing here is a
+/// constant or placeholder (the anti-#541–#544 gate): unit tests drive the
+/// service through idle / active / jammed states and assert these fields
+/// change accordingly.
+///
+/// `commands::run` publishes a fresh snapshot into a shared
+/// `Arc<RwLock<Option<ScpSlotSnapshot>>>` on every consensus tick; the RPC
+/// layer surfaces it in `node_getStatus` and the Prometheus exporter mirrors
+/// the stall verdict as `botho_scp_slot_stalled` /
+/// `botho_scp_slot_stall_seconds`.
+#[derive(Debug, Clone)]
+pub struct ScpSlotSnapshot {
+    /// The SCP slot currently being worked on (== the block height being
+    /// built).
+    pub slot_index: SlotIndex,
+
+    /// Current slot phase (`NominatePrepare`, `Prepare`, `Commit`,
+    /// `Externalize`), pre-rendered as a string so the RPC layer needs no SCP
+    /// types.
+    pub phase: String,
+
+    /// Number of values voted nominated (the slot's `X` set).
+    pub num_voted_nominated: usize,
+
+    /// Number of values accepted nominated (the slot's `Y` set).
+    pub num_accepted_nominated: usize,
+
+    /// Number of values confirmed nominated (the slot's `Z` set).
+    pub num_confirmed_nominated: usize,
+
+    /// Current nomination round within the slot.
+    pub nomination_round: u32,
+
+    /// Highest ballot counter (`bN`); `0` until balloting starts.
+    pub ballot_counter: u32,
+
+    /// The `scp_slot_active` predicate: the slot holds nomination or ballot
+    /// state (or has progressed past `NominatePrepare`). This is the SAME
+    /// predicate `reconfigure_quorum` uses to detect an in-flight round (both
+    /// call [`ConsensusService::slot_metrics_indicate_active`], so they cannot
+    /// drift). `false` == idle (nothing to propose is NOT a stall).
+    pub scp_slot_active: bool,
+
+    /// Derived stall verdict: the slot is ACTIVE but has not externalized for
+    /// more than [`SLOT_STALL_THRESHOLD_MULTIPLIER`] x the effective slot
+    /// duration. Distinguishes a jammed round from an idle node — the empirical
+    /// signal that gates #532 Phase 1.
+    pub slot_stalled: bool,
+
+    /// Seconds since the last externalization (or service start, before the
+    /// first one) WHILE the slot is active; `0` when the slot is idle. This is
+    /// the stall clock: it advances monotonically while a round stays jammed,
+    /// so the operator can quantify how long, not just whether.
+    pub stall_seconds: u64,
+
+    /// Highest slot index this service has surfaced as externalized, if any.
+    pub last_externalized_slot: Option<SlotIndex>,
+
+    /// Seconds since the last externalization, `None` until the first one.
+    pub last_externalized_seconds_ago: Option<u64>,
+
+    /// The effective slot duration (dynamic or fixed) the stall threshold was
+    /// derived from, in seconds, so the operator can interpret
+    /// `stall_seconds` in context.
+    pub effective_slot_duration_secs: u64,
+}
+
 /// Events emitted by the consensus service
 #[derive(Debug, Clone)]
 pub enum ConsensusEvent {
@@ -172,6 +260,18 @@ pub struct ConsensusService {
     /// (the SCP node auto-advances on externalize, so the just-externalized
     /// slot stays readable for several ticks).
     last_externalized_slot: Option<SlotIndex>,
+
+    /// When the last slot externalized (issue #653). Set at BOTH
+    /// externalization points — the solo direct-externalize path in
+    /// `propose_pending_values` and the SCP-driven `check_externalized` — so
+    /// [`Self::slot_status`] can derive a live stall duration. `None` until
+    /// the first externalization (the stall clock then falls back to
+    /// `started_at`).
+    last_externalized_at: Option<Instant>,
+
+    /// When this service was constructed. The baseline for the slot-stall
+    /// clock before the first externalization (issue #653).
+    started_at: Instant,
 
     /// A quorum set reconfiguration that arrived mid-round and was deferred to
     /// the next slot boundary to avoid stranding an in-flight slot.
@@ -355,6 +455,8 @@ impl ConsensusService {
             last_slot_attempt: Instant::now(),
             externalized: None,
             last_externalized_slot: None,
+            last_externalized_at: None,
+            started_at: Instant::now(),
             pending_quorum_set: None,
             // Default to 0 = no participation gate (genuine solo / dev / tests).
             // The node run loop calls `set_min_peers` to enable the gate when
@@ -478,11 +580,7 @@ impl ConsensusService {
         // `bN == 0`; the empty-nomination-sets + `bN == 0` signal is the robust
         // boundary indicator, with the phase check as a secondary guard.
         let metrics = self.scp_node.get_current_slot_metrics();
-        let scp_slot_active = metrics.num_voted_nominated > 0
-            || metrics.num_accepted_nominated > 0
-            || metrics.num_confirmed_nominated > 0
-            || metrics.bN > 0
-            || metrics.phase != ScpPhase::NominatePrepare;
+        let scp_slot_active = Self::slot_metrics_indicate_active(&metrics);
         let at_slot_boundary =
             self.proposed_values.is_empty() && self.externalized.is_none() && !scp_slot_active;
 
@@ -602,6 +700,80 @@ impl ConsensusService {
     /// Get current slot index
     pub fn current_slot(&self) -> SlotIndex {
         self.scp_node.current_slot_index()
+    }
+
+    /// The `scp_slot_active` predicate (issue #653): does this slot hold ANY
+    /// nomination or ballot state, or has it progressed past the initial
+    /// `NominatePrepare` phase?
+    ///
+    /// This is the single shared definition used by BOTH
+    /// [`Self::reconfigure_quorum`] (to detect an in-flight round that must
+    /// defer a quorum swap) and [`Self::slot_status`] (the operator-observable
+    /// snapshot), so the two consumers cannot drift.
+    fn slot_metrics_indicate_active(metrics: &SlotMetrics) -> bool {
+        metrics.num_voted_nominated > 0
+            || metrics.num_accepted_nominated > 0
+            || metrics.num_confirmed_nominated > 0
+            || metrics.bN > 0
+            || metrics.phase != ScpPhase::NominatePrepare
+    }
+
+    /// Read-only snapshot of the current SCP slot's progress for operator
+    /// observability (issue #653, epic #532 Phase 0).
+    ///
+    /// Every field is computed from LIVE state at call time:
+    /// - the raw nomination counters / ballot counter / phase come straight
+    ///   from `scp_node.get_current_slot_metrics()` (the slot's real X/Y/Z/B
+    ///   sets),
+    /// - `scp_slot_active` is the shared [`Self::slot_metrics_indicate_active`]
+    ///   predicate,
+    /// - the stall clock is `now - last_externalized_at` (service start before
+    ///   the first externalization), and
+    /// - `slot_stalled` is true iff the slot is ACTIVE and the stall clock
+    ///   exceeds [`SLOT_STALL_THRESHOLD_MULTIPLIER`] x the EFFECTIVE slot
+    ///   duration ([`Self::current_slot_duration`], which dynamic timing
+    ///   adjusts at runtime — never a hardcoded wall-clock threshold).
+    ///
+    /// An IDLE slot (nothing to propose) is never "stalled": `slot_stalled`
+    /// requires active nomination/ballot state, which is exactly what
+    /// distinguishes a jammed competing-coinbase round from a quiet node.
+    pub fn slot_status(&self) -> ScpSlotSnapshot {
+        let metrics = self.scp_node.get_current_slot_metrics();
+        let scp_slot_active = Self::slot_metrics_indicate_active(&metrics);
+
+        let slot_duration = self.current_slot_duration();
+        let last_externalized_seconds_ago =
+            self.last_externalized_at.map(|t| t.elapsed().as_secs());
+        // Stall clock: time since we last made externalization progress,
+        // falling back to service start before the first externalization.
+        let since_progress = self
+            .last_externalized_at
+            .unwrap_or(self.started_at)
+            .elapsed();
+        let slot_stalled =
+            scp_slot_active && since_progress > slot_duration * SLOT_STALL_THRESHOLD_MULTIPLIER;
+
+        ScpSlotSnapshot {
+            slot_index: self.scp_node.current_slot_index(),
+            phase: format!("{:?}", metrics.phase),
+            num_voted_nominated: metrics.num_voted_nominated,
+            num_accepted_nominated: metrics.num_accepted_nominated,
+            num_confirmed_nominated: metrics.num_confirmed_nominated,
+            nomination_round: metrics.cur_nomination_round,
+            ballot_counter: metrics.bN,
+            scp_slot_active,
+            slot_stalled,
+            // The stall clock is only meaningful while the slot is active; an
+            // idle node (nothing to propose) is not "N seconds stalled".
+            stall_seconds: if scp_slot_active {
+                since_progress.as_secs()
+            } else {
+                0
+            },
+            last_externalized_slot: self.last_externalized_slot,
+            last_externalized_seconds_ago,
+            effective_slot_duration_secs: slot_duration.as_secs(),
+        }
     }
 
     /// Submit a transaction for consensus.
@@ -936,6 +1108,10 @@ impl ConsensusService {
             self.pending_values.retain(|v| !v.is_minting_tx);
 
             self.externalized = Some(values.clone());
+            // Slot-stall clock (issue #653): record the externalization time
+            // on the solo direct-externalize path too, so `slot_status` keeps
+            // an honest stall baseline in every mode.
+            self.last_externalized_at = Some(Instant::now());
             self.events.push_back(ConsensusEvent::SlotExternalized {
                 slot_index: slot,
                 values,
@@ -1042,6 +1218,9 @@ impl ConsensusService {
             self.pending_values.retain(|v| !v.is_minting_tx);
 
             self.externalized = Some(values.clone());
+            // Slot-stall clock (issue #653): a fresh externalization resets
+            // the stall baseline `slot_status` measures against.
+            self.last_externalized_at = Some(Instant::now());
 
             self.events.push_back(ConsensusEvent::SlotExternalized {
                 slot_index: externalized_slot,
@@ -3331,5 +3510,295 @@ mod tests {
             "SAFETY: a slot holding ballot/commit state must NEVER be abandoned by \
              the forward anchor — that could re-open a committed value and fork"
         );
+    }
+
+    // ----------------------------------------------------------------------
+    // Issue #653 (epic #532 Phase 0): operator-observable SCP slot status
+    // ----------------------------------------------------------------------
+
+    /// The shared `scp_slot_active` predicate must be a genuine function of
+    /// the slot metrics: false only for a pristine slot, true when ANY
+    /// nomination/ballot indicator is set. This is the single helper both
+    /// `reconfigure_quorum` and `slot_status` consume, so proving it here
+    /// pins both consumers.
+    #[test]
+    fn slot_active_predicate_tracks_each_metrics_field() {
+        let pristine = SlotMetrics {
+            phase: ScpPhase::NominatePrepare,
+            num_voted_nominated: 0,
+            num_accepted_nominated: 0,
+            num_confirmed_nominated: 0,
+            cur_nomination_round: 1,
+            bN: 0,
+        };
+        assert!(
+            !ConsensusService::slot_metrics_indicate_active(&pristine),
+            "a pristine slot must be inactive"
+        );
+
+        // Each indicator alone must flip the predicate.
+        for (label, metrics) in [
+            (
+                "voted-nominated",
+                SlotMetrics {
+                    num_voted_nominated: 1,
+                    ..pristine_metrics()
+                },
+            ),
+            (
+                "accepted-nominated",
+                SlotMetrics {
+                    num_accepted_nominated: 1,
+                    ..pristine_metrics()
+                },
+            ),
+            (
+                "confirmed-nominated",
+                SlotMetrics {
+                    num_confirmed_nominated: 1,
+                    ..pristine_metrics()
+                },
+            ),
+            (
+                "ballot counter",
+                SlotMetrics {
+                    bN: 1,
+                    ..pristine_metrics()
+                },
+            ),
+            (
+                "phase past NominatePrepare",
+                SlotMetrics {
+                    phase: ScpPhase::Prepare,
+                    ..pristine_metrics()
+                },
+            ),
+        ] {
+            assert!(
+                ConsensusService::slot_metrics_indicate_active(&metrics),
+                "{label} alone must make the slot active"
+            );
+        }
+    }
+
+    /// Helper for the predicate truth-table test above.
+    fn pristine_metrics() -> SlotMetrics {
+        SlotMetrics {
+            phase: ScpPhase::NominatePrepare,
+            num_voted_nominated: 0,
+            num_accepted_nominated: 0,
+            num_confirmed_nominated: 0,
+            cur_nomination_round: 1,
+            bN: 0,
+        }
+    }
+
+    /// THE anti-#541–#544 gate for issue #653: `slot_status()` must be
+    /// genuinely derived from live SCP state, not constants. Drive the service
+    /// through (a) idle, (b) active-progressing, and (c) jammed-slot states
+    /// and assert the snapshot fields CHANGE accordingly.
+    ///
+    /// The jam uses the same harness as
+    /// `reconfigure_during_peer_populated_slot_is_deferred`: a peer
+    /// nominate/prepare message populates the slot, but the peer (1 of 2)
+    /// never confirms, so the round can never complete — the exact
+    /// competing-coinbase wedge shape Phase 0 must observe. The stall clock is
+    /// backdated deterministically instead of sleeping.
+    #[test]
+    fn slot_status_distinguishes_idle_active_and_jammed_states() {
+        // fixed_timing(1) => effective slot duration 1s => stall threshold 3s.
+        let mut svc = peered_service(&[1, 2]);
+
+        // --- (a) IDLE: fresh slot, nothing proposed, no peer state. ---
+        let idle = svc.slot_status();
+        assert!(!idle.scp_slot_active, "fresh slot must be inactive");
+        assert!(!idle.slot_stalled, "an idle slot is never stalled");
+        assert_eq!(idle.stall_seconds, 0, "idle slot has no stall clock");
+        assert_eq!(idle.num_voted_nominated, 0);
+        assert_eq!(idle.num_accepted_nominated, 0);
+        assert_eq!(idle.num_confirmed_nominated, 0);
+        assert_eq!(idle.ballot_counter, 0);
+        assert_eq!(idle.phase, "NominatePrepare");
+        assert_eq!(idle.last_externalized_slot, None);
+        assert_eq!(idle.last_externalized_seconds_ago, None);
+        assert_eq!(idle.effective_slot_duration_secs, 1);
+        assert_eq!(idle.slot_index, svc.current_slot());
+
+        // --- (b) ACTIVE-PROGRESSING: a peer populates the slot. ---
+        let tx = valid_transfer_tx();
+        let tx_bytes = bincode::serialize(&tx).expect("tx serializes");
+        let tx_hash = [7u8; 32];
+        if let Ok(mut state) = svc.shared_state.write() {
+            state.tx_cache.insert(
+                tx_hash,
+                TxCacheEntry {
+                    data: tx_bytes,
+                    is_minting_tx: false,
+                },
+            );
+        }
+        let value = ConsensusValue::from_transaction(tx_hash, tx.fee);
+        let peer_msg = peer_nominate_prepare(
+            node(2),
+            recommended_quorum(&[1, 2]),
+            svc.scp_node.current_slot_index(),
+            value,
+        );
+        let _ = svc
+            .scp_node
+            .handle_message(&peer_msg)
+            .expect("peer message should be accepted");
+
+        let active = svc.slot_status();
+        assert!(
+            active.scp_slot_active,
+            "peer nomination must flip the slot active"
+        );
+        assert!(
+            !active.slot_stalled,
+            "a freshly-active slot inside the threshold is progressing, not stalled"
+        );
+        assert!(
+            active.num_voted_nominated > 0
+                || active.num_accepted_nominated > 0
+                || active.ballot_counter > 0
+                || active.phase != "NominatePrepare",
+            "the raw counters must reflect the peer-driven slot state \
+             (voted {}, accepted {}, bN {}, phase {})",
+            active.num_voted_nominated,
+            active.num_accepted_nominated,
+            active.ballot_counter,
+            active.phase
+        );
+        // Explicit not-a-constant proof: idle and active snapshots differ.
+        assert_ne!(
+            idle.scp_slot_active, active.scp_slot_active,
+            "scpSlotActive must be a live signal, not a constant"
+        );
+        assert!(
+            idle.num_voted_nominated != active.num_voted_nominated
+                || idle.num_accepted_nominated != active.num_accepted_nominated
+                || idle.ballot_counter != active.ballot_counter
+                || idle.phase != active.phase,
+            "the raw slot counters must change between idle and active states"
+        );
+
+        // --- (c) JAMMED: the active slot fails to externalize past the ---
+        // --- threshold. Backdate the stall baseline deterministically.  ---
+        svc.last_externalized_at = Some(
+            Instant::now()
+                .checked_sub(Duration::from_secs(30))
+                .expect("monotonic clock supports 30s backdating"),
+        );
+        let jammed = svc.slot_status();
+        assert!(jammed.scp_slot_active, "the jammed slot is still active");
+        assert!(
+            jammed.slot_stalled,
+            "active + 30s without externalization (threshold 3s) must report a stall"
+        );
+        assert!(
+            jammed.stall_seconds >= 30,
+            "stall clock must quantify the jam (got {}s)",
+            jammed.stall_seconds
+        );
+        assert!(
+            jammed.last_externalized_seconds_ago.unwrap_or(0) >= 30,
+            "externalization age must reflect the backdated timestamp"
+        );
+
+        // The stall clock ADVANCES while the jam persists (monotonic).
+        svc.last_externalized_at = Some(
+            Instant::now()
+                .checked_sub(Duration::from_secs(90))
+                .expect("monotonic clock supports 90s backdating"),
+        );
+        let later = svc.slot_status();
+        assert!(later.slot_stalled, "still jammed");
+        assert!(
+            later.stall_seconds > jammed.stall_seconds,
+            "stall duration must advance while jammed ({} -> {})",
+            jammed.stall_seconds,
+            later.stall_seconds
+        );
+
+        // Final not-a-constant proof across all three states.
+        assert!(
+            !idle.slot_stalled && !active.slot_stalled && jammed.slot_stalled,
+            "slotStalled must be false/false/true across idle/active/jammed — \
+             it is derived from live state, not fixed"
+        );
+        assert!(
+            idle.stall_seconds == 0 && jammed.stall_seconds > active.stall_seconds,
+            "slotStallSeconds must track the live stall clock, not a constant"
+        );
+    }
+
+    /// Both externalization paths must stamp the stall baseline: the solo
+    /// direct-externalize path resets the clock the moment it externalizes,
+    /// so a healthy node never drifts toward a phantom stall.
+    #[test]
+    fn solo_externalization_stamps_the_stall_clock() {
+        let mut svc = solo_service();
+        assert!(svc.last_externalized_at.is_none());
+        assert_eq!(svc.slot_status().last_externalized_seconds_ago, None);
+
+        svc.submit_transaction([7u8; 32], 0, vec![1, 2, 3]);
+        svc.propose_pending_values();
+        assert!(
+            svc.externalized.is_some(),
+            "solo mode externalizes directly"
+        );
+        assert!(
+            svc.last_externalized_at.is_some(),
+            "solo externalize must stamp the stall baseline (issue #653)"
+        );
+        let snap = svc.slot_status();
+        assert_eq!(
+            snap.last_externalized_seconds_ago,
+            Some(0),
+            "the externalization just happened"
+        );
+        assert!(!snap.slot_stalled);
+    }
+
+    /// Multi-node observation (accessor-level, per the #653 loopback
+    /// criterion): a clean 2-node federated convergence externalizes via
+    /// `check_externalized`, which must stamp the stall baseline on BOTH
+    /// nodes, and neither node may report a stall after healthy progress.
+    #[test]
+    fn multi_node_convergence_stamps_stall_clock_and_reports_no_stall() {
+        let cfg = ConsensusConfig::fixed_timing(0);
+        let qs = recommended_quorum(&[1, 2]);
+        let mut a = ConsensusService::new(node(1), qs.clone(), cfg.clone(), genesis_chain_state());
+        let mut b = ConsensusService::new(node(2), qs, cfg, genesis_chain_state());
+
+        let prev = [0u8; 32];
+        let a_tx = intrinsic_valid_minting_tx(1, prev, 1);
+        let b_tx = intrinsic_valid_minting_tx(50, prev, 1);
+        submit_and_register(&mut a, &mut b, &a_tx);
+        submit_and_register(&mut b, &mut a, &b_tx);
+
+        let (a_ext, b_ext) = run_two_services(&mut a, &mut b, 2000);
+        assert!(a_ext.is_some() && b_ext.is_some(), "both must externalize");
+
+        for (label, svc) in [("A", &a), ("B", &b)] {
+            let snap = svc.slot_status();
+            assert_eq!(
+                snap.last_externalized_slot,
+                Some(1),
+                "node {label} must report the externalized slot"
+            );
+            let age = snap
+                .last_externalized_seconds_ago
+                .expect("federated externalize must stamp the stall baseline");
+            assert!(
+                age <= 5,
+                "node {label}: externalization age must be fresh (got {age}s)"
+            );
+            assert!(
+                !snap.slot_stalled,
+                "node {label}: healthy convergence must never report a slot stall"
+            );
+        }
     }
 }

--- a/botho/src/rpc/metrics.rs
+++ b/botho/src/rpc/metrics.rs
@@ -15,6 +15,10 @@
 //! - `botho_consensus_round_duration_seconds` - SCP consensus round duration
 //!   (histogram)
 //! - `botho_consensus_nominations_total` - Total SCP nominations (counter)
+//! - `botho_scp_slot_stalled` - Current SCP slot stalled: active but not
+//!   externalizing (gauge, 0/1)
+//! - `botho_scp_slot_stall_seconds` - Seconds the active SCP slot has gone
+//!   without externalizing, 0 while idle (gauge)
 //!
 //! ### System Metrics
 //! - `botho_data_dir_usage_bytes` - Bytes used by the data directory (gauge)
@@ -328,6 +332,23 @@ lazy_static! {
         "Whether minting is active (1) or not (0)"
     ).expect("Failed to create minting_active metric");
 
+    /// Whether the current SCP slot is stalled (1) or not (0) — active
+    /// nomination/ballot state with no externalization past the stall
+    /// threshold (#653, epic #532 Phase 0). Updated from the live
+    /// `ScpSlotSnapshot` on every consensus tick.
+    pub static ref SCP_SLOT_STALLED: IntGauge = IntGauge::new(
+        "botho_scp_slot_stalled",
+        "Whether the current SCP slot is stalled: active but not externalizing (1) or not (0)"
+    ).expect("Failed to create scp_slot_stalled metric");
+
+    /// Seconds the current ACTIVE SCP slot has gone without an
+    /// externalization (0 while idle). Advances while a round stays jammed,
+    /// so operators can quantify a stall, not just detect it (#653).
+    pub static ref SCP_SLOT_STALL_SECONDS: IntGauge = IntGauge::new(
+        "botho_scp_slot_stall_seconds",
+        "Seconds the active SCP slot has gone without externalizing (0 while idle)"
+    ).expect("Failed to create scp_slot_stall_seconds metric");
+
     // ============================================================================
     // System Metrics
     // ============================================================================
@@ -424,6 +445,12 @@ pub fn init_metrics() {
     REGISTRY
         .register(Box::new(MINTING_ACTIVE.clone()))
         .expect("Failed to register minting_active");
+    REGISTRY
+        .register(Box::new(SCP_SLOT_STALLED.clone()))
+        .expect("Failed to register scp_slot_stalled");
+    REGISTRY
+        .register(Box::new(SCP_SLOT_STALL_SECONDS.clone()))
+        .expect("Failed to register scp_slot_stall_seconds");
 
     // Register histograms
     REGISTRY
@@ -608,6 +635,18 @@ impl MetricsUpdater {
         MINTING_ACTIVE.set(if active { 1 } else { 0 });
     }
 
+    /// Update the SCP slot-stalled metric (#653). Called from the consensus
+    /// tick with the live `ScpSlotSnapshot.slot_stalled` verdict.
+    pub fn set_scp_slot_stalled(&self, stalled: bool) {
+        SCP_SLOT_STALLED.set(if stalled { 1 } else { 0 });
+    }
+
+    /// Update the SCP slot stall-duration metric (#653). Called from the
+    /// consensus tick with the live `ScpSlotSnapshot.stall_seconds`.
+    pub fn set_scp_slot_stall_seconds(&self, seconds: u64) {
+        SCP_SLOT_STALL_SECONDS.set(seconds.min(i64::MAX as u64) as i64);
+    }
+
     /// Record a validation latency observation.
     pub fn observe_validation_latency(&self, seconds: f64) {
         VALIDATION_LATENCY.observe(seconds);
@@ -783,6 +822,24 @@ mod tests {
 
         updater.set_minting_active(false);
         assert_eq!(MINTING_ACTIVE.get(), 0);
+    }
+
+    /// #653: the SCP slot-stall gauges must track the values the consensus
+    /// tick pushes — both directions (set and clear), so a stall showing on
+    /// the dashboard is live state, not a latched constant.
+    #[test]
+    fn test_scp_slot_stall_gauges() {
+        let updater = MetricsUpdater::new();
+
+        updater.set_scp_slot_stalled(true);
+        updater.set_scp_slot_stall_seconds(61);
+        assert_eq!(SCP_SLOT_STALLED.get(), 1);
+        assert_eq!(SCP_SLOT_STALL_SECONDS.get(), 61);
+
+        updater.set_scp_slot_stalled(false);
+        updater.set_scp_slot_stall_seconds(0);
+        assert_eq!(SCP_SLOT_STALLED.get(), 0);
+        assert_eq!(SCP_SLOT_STALL_SECONDS.get(), 0);
     }
 
     #[test]

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -68,6 +68,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     address::Address,
     config::QuorumConfig,
+    consensus::ScpSlotSnapshot,
     ledger::Ledger,
     mempool::Mempool,
     network::{NetworkStats, SyncStatusSnapshot},
@@ -242,6 +243,15 @@ pub struct RpcState {
     /// caught-up node. Surfaced as `synced`, `syncStatus`, and
     /// `syncProgress` in `node_getStatus`.
     pub sync_status: Option<Arc<RwLock<Option<SyncStatusSnapshot>>>>,
+    /// Shared SCP slot-progress handle for slot-stall observability (#653,
+    /// epic #532 Phase 0). `commands::run` publishes a fresh
+    /// [`ScpSlotSnapshot`] here on every consensus tick, derived from the live
+    /// SCP slot metrics + externalization history (never a constant — the
+    /// anti-#541–#544 gate). `None` until wired in (tests / relay nodes); the
+    /// inner `Option` is `None` until the first tick publishes. Surfaced as
+    /// the `scpSlot*` / `slotStalled` / `slotStallSeconds` fields in
+    /// `node_getStatus`.
+    pub scp_slot_status: Option<Arc<RwLock<Option<ScpSlotSnapshot>>>>,
     /// Shared snapshot of the live connected-peer set surfaced by
     /// `network_getPeers` (#544). `commands::run` publishes a cheap clone of
     /// the discovery peer table here on each peer connect/disconnect; the
@@ -290,6 +300,7 @@ impl RpcState {
             identity: NodeIdentity::default(),
             minter_health: None,
             sync_status: None,
+            scp_slot_status: None,
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
         }
@@ -330,6 +341,7 @@ impl RpcState {
             identity: NodeIdentity::default(),
             minter_health: None,
             sync_status: None,
+            scp_slot_status: None,
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
         }
@@ -368,6 +380,7 @@ impl RpcState {
             identity: NodeIdentity::default(),
             minter_health: None,
             sync_status: None,
+            scp_slot_status: None,
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
         }
@@ -432,6 +445,29 @@ impl RpcState {
     /// pre-sync state, in which case `node_getStatus` assumes a caught-up node.
     fn sync_status_snapshot(&self) -> Option<SyncStatusSnapshot> {
         let handle = self.sync_status.as_ref()?;
+        let guard = handle.read().ok()?;
+        guard.clone()
+    }
+
+    /// Wire in the shared SCP slot-progress handle so `node_getStatus` can
+    /// surface live slot-stall observability (#653). `commands::run` calls
+    /// this with the handle the consensus tick publishes
+    /// [`ScpSlotSnapshot`]s into.
+    pub fn with_scp_slot_status(
+        mut self,
+        scp_slot_status: Arc<RwLock<Option<ScpSlotSnapshot>>>,
+    ) -> Self {
+        self.scp_slot_status = Some(scp_slot_status);
+        self
+    }
+
+    /// Read the current SCP slot-progress snapshot, if a handle is wired in
+    /// and the consensus tick has published at least once. Returns `None` for
+    /// tests / relay nodes / pre-first-tick state, in which case
+    /// `node_getStatus` reports the slot fields as absent/idle rather than
+    /// fabricating values.
+    fn scp_slot_snapshot(&self) -> Option<ScpSlotSnapshot> {
+        let handle = self.scp_slot_status.as_ref()?;
         let guard = handle.read().ok()?;
         guard.clone()
     }
@@ -975,6 +1011,21 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
         .map(|s| s.stalled)
         .unwrap_or(false);
 
+    // SCP slot-stall observability (#653, epic #532 Phase 0). Every field is
+    // read from the snapshot the consensus tick publishes from LIVE SCP slot
+    // state (SlotMetrics + externalization history) — never fabricated here
+    // (the anti-#541–#544 gate). With no handle wired in (tests / relay
+    // nodes) or before the first tick, the counters render as JSON null and
+    // the booleans default to false: an unwired node reports "no data", not a
+    // plausible-looking constant.
+    let scp_slot = state.scp_slot_snapshot();
+    let scp_slot_active = scp_slot
+        .as_ref()
+        .map(|s| s.scp_slot_active)
+        .unwrap_or(false);
+    let slot_stalled = scp_slot.as_ref().map(|s| s.slot_stalled).unwrap_or(false);
+    let slot_stall_seconds = scp_slot.as_ref().map(|s| s.stall_seconds).unwrap_or(0);
+
     JsonRpcResponse::success(
         id,
         json!({
@@ -1004,6 +1055,25 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
             // Stuck-miner early-warning (#538): true iff this node's miner is
             // active but producing 0 H/s past the grace + stall window.
             "minerStalled": miner_stalled,
+            // SCP slot-stall observability (#653, #532 Phase 0): live slot
+            // progress from the consensus tick's ScpSlotSnapshot. Index /
+            // phase / counters are null until the first snapshot is published.
+            "scpSlotIndex": scp_slot.as_ref().map(|s| s.slot_index),
+            "scpSlotPhase": scp_slot.as_ref().map(|s| s.phase.clone()),
+            "scpSlotActive": scp_slot_active,
+            "scpNominationRound": scp_slot.as_ref().map(|s| s.nomination_round),
+            "scpVotedNominated": scp_slot.as_ref().map(|s| s.num_voted_nominated),
+            "scpAcceptedNominated": scp_slot.as_ref().map(|s| s.num_accepted_nominated),
+            "scpConfirmedNominated": scp_slot.as_ref().map(|s| s.num_confirmed_nominated),
+            "scpBallotCounter": scp_slot.as_ref().map(|s| s.ballot_counter),
+            // Derived stall verdict: slot ACTIVE but no externalization for >
+            // SLOT_STALL_THRESHOLD_MULTIPLIER x the effective slot duration.
+            // An idle node (nothing to propose) is never "stalled".
+            "slotStalled": slot_stalled,
+            "slotStallSeconds": slot_stall_seconds,
+            "lastExternalizedSlot": scp_slot.as_ref().and_then(|s| s.last_externalized_slot),
+            "lastExternalizedSecondsAgo": scp_slot.as_ref().and_then(|s| s.last_externalized_seconds_ago),
+            "effectiveSlotDurationSecs": scp_slot.as_ref().map(|s| s.effective_slot_duration_secs),
         }),
     )
 }
@@ -3582,6 +3652,115 @@ mod tests {
         assert_eq!(minting["stalled"], json!(false));
         let node = handle_node_status(json!(1), &state).await.result.unwrap();
         assert_eq!(node["minerStalled"], json!(false));
+    }
+
+    /// #653 (epic #532 Phase 0): the `node_getStatus` SCP slot fields must
+    /// track the shared snapshot handle the consensus tick publishes into —
+    /// the anti-#541–#544 gate at the RPC layer. With no handle wired in the
+    /// fields report absent/idle (null counters, false booleans) instead of
+    /// fabricated values; with a handle, two DIFFERENT snapshots must yield
+    /// DIFFERENT JSON (the fields are live, not constants).
+    #[tokio::test]
+    async fn test_node_status_tracks_scp_slot_snapshot() {
+        use crate::{consensus::ScpSlotSnapshot, ledger::Ledger, mempool::Mempool};
+
+        fn fresh_state() -> RpcState {
+            let dir = tempfile::tempdir().unwrap();
+            let ledger = Ledger::open(dir.path()).unwrap();
+            std::mem::forget(dir);
+            RpcState::new(
+                ledger,
+                Mempool::new(),
+                Network::Testnet,
+                None,
+                None,
+                vec![],
+                Arc::new(WsBroadcaster::new(16)),
+            )
+        }
+
+        // (1) No handle wired in: absent/idle defaults, never fabricated data.
+        let state = fresh_state();
+        let result = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(result["scpSlotActive"], json!(false));
+        assert_eq!(result["slotStalled"], json!(false));
+        assert_eq!(result["slotStallSeconds"], json!(0));
+        assert_eq!(result["scpSlotIndex"], Value::Null);
+        assert_eq!(result["scpSlotPhase"], Value::Null);
+        assert_eq!(result["scpVotedNominated"], Value::Null);
+        assert_eq!(result["scpBallotCounter"], Value::Null);
+        assert_eq!(result["lastExternalizedSlot"], Value::Null);
+        assert_eq!(result["lastExternalizedSecondsAgo"], Value::Null);
+
+        // (2) Handle wired but nothing published yet: same absent/idle shape.
+        let handle = Arc::new(RwLock::new(None));
+        let state = fresh_state().with_scp_slot_status(handle.clone());
+        let result = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(result["scpSlotActive"], json!(false));
+        assert_eq!(result["scpSlotIndex"], Value::Null);
+
+        // (3) Active-progressing snapshot published by the consensus tick.
+        *handle.write().unwrap() = Some(ScpSlotSnapshot {
+            slot_index: 42,
+            phase: "NominatePrepare".to_string(),
+            num_voted_nominated: 2,
+            num_accepted_nominated: 1,
+            num_confirmed_nominated: 0,
+            nomination_round: 3,
+            ballot_counter: 0,
+            scp_slot_active: true,
+            slot_stalled: false,
+            stall_seconds: 4,
+            last_externalized_slot: Some(41),
+            last_externalized_seconds_ago: Some(4),
+            effective_slot_duration_secs: 20,
+        });
+        let active = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(active["scpSlotIndex"], json!(42));
+        assert_eq!(active["scpSlotPhase"], json!("NominatePrepare"));
+        assert_eq!(active["scpSlotActive"], json!(true));
+        assert_eq!(active["scpNominationRound"], json!(3));
+        assert_eq!(active["scpVotedNominated"], json!(2));
+        assert_eq!(active["scpAcceptedNominated"], json!(1));
+        assert_eq!(active["scpConfirmedNominated"], json!(0));
+        assert_eq!(active["scpBallotCounter"], json!(0));
+        assert_eq!(active["slotStalled"], json!(false));
+        assert_eq!(active["slotStallSeconds"], json!(4));
+        assert_eq!(active["lastExternalizedSlot"], json!(41));
+        assert_eq!(active["lastExternalizedSecondsAgo"], json!(4));
+        assert_eq!(active["effectiveSlotDurationSecs"], json!(20));
+
+        // (4) Jammed snapshot: the SAME handle now reports a stall — every
+        // field must move with the snapshot (not-a-constant proof).
+        *handle.write().unwrap() = Some(ScpSlotSnapshot {
+            slot_index: 42,
+            phase: "Prepare".to_string(),
+            num_voted_nominated: 2,
+            num_accepted_nominated: 2,
+            num_confirmed_nominated: 1,
+            nomination_round: 9,
+            ballot_counter: 7,
+            scp_slot_active: true,
+            slot_stalled: true,
+            stall_seconds: 61,
+            last_externalized_slot: Some(41),
+            last_externalized_seconds_ago: Some(61),
+            effective_slot_duration_secs: 20,
+        });
+        let jammed = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(jammed["slotStalled"], json!(true));
+        assert_eq!(jammed["slotStallSeconds"], json!(61));
+        assert_eq!(jammed["scpSlotPhase"], json!("Prepare"));
+        assert_eq!(jammed["scpBallotCounter"], json!(7));
+        assert_eq!(jammed["scpNominationRound"], json!(9));
+        assert_ne!(
+            active["slotStalled"], jammed["slotStalled"],
+            "slotStalled must track the live snapshot, not a constant"
+        );
+        assert_ne!(
+            active["slotStallSeconds"], jammed["slotStallSeconds"],
+            "slotStallSeconds must track the live snapshot, not a constant"
+        );
     }
 
     /// #543: `minting_getStatus.blocksFound` reflects the live count from the

--- a/consensus/scp/src/node/node_impl.rs
+++ b/consensus/scp/src/node/node_impl.rs
@@ -309,7 +309,7 @@ impl<V: Value, ValidationError: Clone + Display + 'static> ScpNode<V> for Node<V
     }
 
     /// Get metrics for the current slot.
-    fn get_current_slot_metrics(&mut self) -> SlotMetrics {
+    fn get_current_slot_metrics(&self) -> SlotMetrics {
         self.current_slot.get_metrics()
     }
 

--- a/consensus/scp/src/node/node_trait.rs
+++ b/consensus/scp/src/node/node_trait.rs
@@ -48,7 +48,12 @@ pub trait ScpNode<V: Value>: Send {
     fn current_slot_index(&self) -> SlotIndex;
 
     /// Get metrics for the current slot.
-    fn get_current_slot_metrics(&mut self) -> SlotMetrics;
+    ///
+    /// Read-only (`&self`): the underlying
+    /// [`crate::slot::ScpSlot::get_metrics`] only reads the slot's X/Y/Z/B
+    /// state, and observability consumers (issue #653) need to snapshot slot
+    /// progress without exclusive access.
+    fn get_current_slot_metrics(&self) -> SlotMetrics;
 
     /// Additional debug info, e.g. a JSON representation of the Slot's state.
     fn get_slot_debug_snapshot(&mut self, slot_index: SlotIndex) -> Option<String>;

--- a/consensus/scp/src/scp_log.rs
+++ b/consensus/scp/src/scp_log.rs
@@ -301,7 +301,7 @@ impl<V: Value, N: ScpNode<V>> ScpNode<V> for LoggingScpNode<V, N> {
         self.node.current_slot_index()
     }
 
-    fn get_current_slot_metrics(&mut self) -> SlotMetrics {
+    fn get_current_slot_metrics(&self) -> SlotMetrics {
         self.node.get_current_slot_metrics()
     }
 

--- a/infra/grafana/dashboards/botho-node.json
+++ b/infra/grafana/dashboards/botho-node.json
@@ -1575,6 +1575,205 @@
       ],
       "title": "RPC Error Rate by Method",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 54
+      },
+      "id": 106,
+      "panels": [],
+      "title": "Consensus Slot Health (#653 / #532 Phase 0)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "SCP slot-stall verdict (botho_scp_slot_stalled): the current slot holds active nomination/ballot state but has not externalized past the stall threshold (3x the effective slot duration). Distinguishes a jammed competing-coinbase round from an idle node. 0 = OK, 1 = STALLED.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "OK"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "STALLED"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 55
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "botho_scp_slot_stalled{instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SCP Slot Stalled",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Seconds the ACTIVE SCP slot has gone without externalizing (botho_scp_slot_stall_seconds, 0 while idle). A sustained climb on an active slot is the empirical slot-jam signal that gates #532 Phase 1.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 60
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 55
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "botho_scp_slot_stall_seconds{instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "SCP Slot Stall Duration",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
## Summary

Implements #532 Phase 0's operator-observable SCP slot-stall metric: a read-only `ConsensusService::slot_status()` accessor snapshots the LIVE SCP slot state and a derived stall verdict, published on every consensus tick into a shared handle that `node_getStatus` and the Prometheus exporter read. An operator watching the live cluster can now tell a jammed competing-coinbase round apart from an idle node — the empirical data that would gate any future Phase 1 (view-change).

## Changes

- **`botho/src/consensus/service.rs`**
  - Factored the `scp_slot_active` predicate into a single shared helper (`slot_metrics_indicate_active`) used by BOTH `reconfigure_quorum` and the new snapshot, so the two consumers cannot drift.
  - Added `last_externalized_at` / `started_at` fields, stamped at BOTH externalization points (the solo direct-externalize path and `check_externalized`).
  - New `ScpSlotSnapshot` + read-only `slot_status()` accessor. `slot_stalled` = slot ACTIVE (nomination/ballot state present) AND no externalization for > `SLOT_STALL_THRESHOLD_MULTIPLIER (3) x` the **effective** slot duration (`current_slot_duration()`, dynamic-timing aware — not a hardcoded 5s/20s constant). An idle slot is never "stalled". `stall_seconds` quantifies the jam; `lastExternalizedSecondsAgo`/`lastExternalizedSlot` give the externalization history.
- **`botho/src/rpc/mod.rs`** — `RpcState.scp_slot_status` handle + `with_scp_slot_status(...)` builder + accessor (the `minter_health`/`sync_status` snapshot pattern); `node_getStatus` gains `scpSlotIndex`, `scpSlotPhase`, `scpSlotActive`, `scpNominationRound`, `scpVotedNominated`, `scpAcceptedNominated`, `scpConfirmedNominated`, `scpBallotCounter`, `slotStalled`, `slotStallSeconds`, `lastExternalizedSlot`, `lastExternalizedSecondsAgo`, `effectiveSlotDurationSecs`. Unwired/pre-first-tick state reports null counters + false booleans — "no data", never fabricated values.
- **`botho/src/commands/run.rs`** — creates the shared handle, wires the builder, and publishes a fresh snapshot from the consensus tick arm (after the event drain, so a just-externalized slot is reflected immediately); updates the Prometheus gauges each tick and emits an edge-triggered (once-per-episode, not per-500ms-tick) `warn!` when the stall verdict flips true.
- **`botho/src/rpc/metrics.rs`** — new gauges `botho_scp_slot_stalled` (0/1) and `botho_scp_slot_stall_seconds` + `MetricsUpdater` setters.
- **`infra/grafana/dashboards/botho-node.json`** — new "Consensus Slot Health" row: a stalled OK/STALLED stat panel and a stall-duration timeseries (additive only).
- **`consensus/scp/`** — relaxed `ScpNode::get_current_slot_metrics` from `&mut self` to `&self` (3 sites: trait, impl, scp_log wrapper). The underlying `Slot::get_metrics` was already `&self`; this keeps the observability accessor genuinely read-only.

**No consensus behavior change** — `reconfigure_quorum` semantics are untouched (it now calls the factored helper computing the identical expression), and everything added is read-only observation.

**Deferred (per curator scope note):** the optional CloudWatch alarm in `infra/monitoring/create-alarms.sh` — the RPC fields + Prometheus gauges + Grafana panel are the load-bearing core; the alarm can be a small follow-up.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `node_getStatus` exposes `currentSlotIndex`/`scpSlotActive`/nomination counters/`slotStalled` + stall duration/last-externalization time | ✅ | 13 new fields in the payload (incl. `cur_nomination_round` per curator note); asserted in `rpc::tests::test_node_status_tracks_scp_slot_snapshot` |
| Anti-#541–#544 gate: fields derived from live `SlotMetrics`/SCP state, unit test drives (a) idle, (b) active-progressing, (c) jammed states and asserts fields CHANGE and are NOT constants | ✅ | `slot_status_distinguishes_idle_and_active_and_jammed_states` (see evidence below): idle→active flips `scpSlotActive` + raw counters via a real `peer_nominate_prepare` fed through `scp_node.handle_message`; jam asserts `slotStalled` flips true and `stall_seconds` advances monotonically (30s → 90s backdate); explicit false/false/true not-a-constant assertion. RPC layer: two distinct snapshots through the same handle yield different JSON. Predicate truth-table test pins each metrics field |
| Multi-node observation: stall metric changing on a real multi-node run | ✅ | Accessor-level per curator guidance (RPC is not in the loopback harness): `multi_node_convergence_stamps_stall_clock_and_reports_no_stall` runs two real `ConsensusService`s through federated SCP to externalization — both stamp the stall baseline via the production `check_externalized` path, report `lastExternalizedSlot=Some(1)`, fresh age, and `slotStalled=false`; the jammed direction is the (c) state above (peer-populated slot that can never confirm — the exact wedge shape). `consensus_cluster_convergence` integration suite (2/3/4 nodes) also passes |
| No change to consensus behavior | ✅ | Read-only accessor + shared predicate helper only; full `botho` lib suite (1115 tests) + SCP cluster convergence suite pass unchanged |
| Metric visible on operator monitoring surface | ✅ | `botho_scp_slot_stalled` / `botho_scp_slot_stall_seconds` Prometheus gauges (updated every consensus tick) + Grafana "Consensus Slot Health" row in `infra/grafana/dashboards/botho-node.json`; gauge round-trip asserted in `test_scp_slot_stall_gauges` |

## Test Plan

New tests (all passing):

```
test consensus::service::tests::slot_active_predicate_tracks_each_metrics_field ... ok
test consensus::service::tests::slot_status_distinguishes_idle_active_and_jammed_states ... ok
test consensus::service::tests::solo_externalization_stamps_the_stall_clock ... ok
test consensus::service::tests::multi_node_convergence_stamps_stall_clock_and_reports_no_stall ... ok
test rpc::tests::test_node_status_tracks_scp_slot_snapshot ... ok
test rpc::metrics::tests::test_scp_slot_stall_gauges ... ok
```

State-transition evidence from the anti-cosmetic gate test (a/b/c):
- **(a) idle**: `scpSlotActive=false`, `slotStalled=false`, `stall_seconds=0`, counters all 0, phase `NominatePrepare`, `lastExternalized*=None`
- **(b) active-progressing**: after a real peer `NominatePrepare` message through `scp_node.handle_message`: `scpSlotActive=true`, counters non-zero, `slotStalled=false` (inside 3x threshold)
- **(c) jammed**: same active slot with the externalization baseline backdated 30s (threshold 3s at fixed 1s slots): `slotStalled=true`, `stall_seconds>=30`; backdated 90s: `stall_seconds` strictly greater (clock advances while jammed)

Regression:
- `cargo test -p botho --lib` — **1115 passed, 0 failed**
- `cargo test -p botho --test consensus_cluster_convergence` — 4/4 passed (2/3/4-node loopback clusters converge, no fork, no stall)
- `cargo check --workspace`, `cargo clippy -p botho -p bth-consensus-scp` (no new lints), `cargo fmt --all --check` clean

Closes #653