### PR TITLE
feat(consensus): gate auto-trusted peers out of the SCP quorum behind a cap + intersection check

### DIFF
--- a/.loom-managed
+++ b/.loom-managed
@@ -1,6 +1,6 @@
 # Loom-managed worktree marker
 # Created by .loom/scripts/worktree.sh
-# Issue: 644
-# Branch: feature/issue-644
+# Issue: 651
+# Branch: feature/issue-651
 # Removing this file makes Loom treat the worktree as user-owned and refuse
 # to clean it up automatically.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "bth-crypto-pq",
  "bth-crypto-ring-signature",
  "bth-gossip",
+ "bth-quorum-sim",
  "bth-transaction-clsag",
  "bth-transaction-core",
  "bth-transaction-types",

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -58,6 +58,9 @@ bth-common = { path = "../common", features = ["std"] }
 bth-consensus-scp = { path = "../consensus/scp", features = ["test_utils"] }
 bth-consensus-scp-types = { path = "../consensus/scp/types", features = ["test_utils"] }
 bth-gossip = { path = "../gossip" }
+# Quorum promotion gate (#651): exact FBAS quorum-intersection check used to
+# refuse quorum-set candidates that could admit disjoint quorums (a fork).
+bth-quorum-sim = { path = "../consensus/quorum-sim" }
 bth-crypto-digestible = { path = "../crypto/digestible" }
 libp2p = { workspace = true, features = [
     "tokio",

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -22,10 +22,10 @@ use std::collections::HashMap;
 
 use crate::{
     block::MintingTx,
-    config::{Config, QuorumMode},
+    config::{Config, QuorumConfig, QuorumMode},
     consensus::{
         BlockBuilder, ConsensusConfig, ConsensusEvent, ConsensusService, LotteryFeeConfig,
-        ScpSlotSnapshot, TransactionValidator,
+        QuorumGateSnapshot, ScpSlotSnapshot, TransactionValidator,
     },
     network::{
         default_seed_domain, BlockTxn, ChainSyncManager, CompactBlock, GetBlockTxn,
@@ -430,6 +430,14 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // can tell a jammed competing-coinbase round apart from an idle node.
     let scp_slot_status: Arc<RwLock<Option<ScpSlotSnapshot>>> = Arc::new(RwLock::new(None));
 
+    // Shared quorum-promotion-gate handle (#651, epic #441 §3/P5). The quorum
+    // rebuild path below publishes a fresh snapshot of the gate's evaluation
+    // (curated vs auto-promoted member counts, suppressed peers, intersection
+    // refusals) at the initial seed and on every peer-churn rebuild; the RPC
+    // layer surfaces it in `node_getStatus` so an operator can see the gate
+    // working. `None` until the first evaluation (never fabricated).
+    let quorum_gate_status: Arc<RwLock<Option<QuorumGateSnapshot>>> = Arc::new(RwLock::new(None));
+
     let mut rpc_state = RpcState::from_shared(
         node.shared_ledger(),
         node.shared_mempool(),
@@ -449,6 +457,9 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // Live SCP slot-stall observability for `node_getStatus` (#653). Shares
     // the handle the consensus tick publishes into.
     .with_scp_slot_status(scp_slot_status.clone())
+    // Quorum promotion gate observability for `node_getStatus` (#651). Shares
+    // the handle the quorum rebuild path publishes into.
+    .with_quorum_gate_status(quorum_gate_status.clone())
     .with_peers(peers_snapshot.clone())
     // Live traffic / connection-direction counters for `network_getInfo`
     // (#542). Shares the same handle the network event loop increments.
@@ -571,7 +582,16 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // solo. A genuine lone node (no peers connected) still yields a 1-of-1 solo
     // quorum and mints solo — no regression for `min_peers == 0`.
     let scp_quorum_set = if discovery.peer_count() > 0 {
-        rebuild_scp_quorum_set(&config, &discovery, &local_peer_id)
+        // Initial seed goes through the promotion gate (#651) like every
+        // later churn rebuild; there is no previous quorum set yet, so an
+        // intersection refusal falls back to a majority threshold inside the
+        // gate. Publish the gate snapshot so `node_getStatus` reflects the
+        // seed evaluation.
+        let (qs, gate_snapshot) = rebuild_scp_quorum_set(&config, &discovery, &local_peer_id, None);
+        if let Ok(mut guard) = quorum_gate_status.write() {
+            *guard = Some(gate_snapshot);
+        }
+        qs
     } else {
         build_scp_quorum_set(&quorum, &local_peer_id)
     };
@@ -852,7 +872,10 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             if let Ok(mut count) = peer_count.write() {
                                 *count = new_peer_count;
                             }
-                            // Update SCP peer count (all peers participate in consensus)
+                            // Update SCP peer count. NOTE: this is the raw connected-peer
+                            // count used by the #509 quorumFaultTolerant/quorumDegenerate
+                            // flags; actual quorum MEMBERSHIP is bounded by the promotion
+                            // gate (#651) and surfaced separately via QuorumGateSnapshot.
                             if let Ok(mut count) = scp_peer_count.write() {
                                 *count = new_peer_count;
                             }
@@ -873,9 +896,23 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             consensus.set_connected_peers(new_peer_count);
 
                             // Reconfigure the consensus quorum to include the
-                            // newly connected peer. This is what lifts a node
+                            // newly connected peer, THROUGH the promotion gate
+                            // (#651): curated members are always admitted,
+                            // auto-discovered peers only up to the configured
+                            // cap, and a candidate that fails the quorum-
+                            // intersection check is refused (the gate returns
+                            // the previous set, which reconfigure_quorum
+                            // debounces as a no-op). This is what lifts a node
                             // out of latched solo mode without a restart.
-                            let new_qs = rebuild_scp_quorum_set(&config, &discovery, &local_peer_id);
+                            let (new_qs, gate_snapshot) = rebuild_scp_quorum_set(
+                                &config,
+                                &discovery,
+                                &local_peer_id,
+                                Some(consensus.quorum_set()),
+                            );
+                            if let Ok(mut guard) = quorum_gate_status.write() {
+                                *guard = Some(gate_snapshot);
+                            }
                             if consensus.reconfigure_quorum(new_qs) {
                                 info!(
                                     threshold = consensus.quorum_set().threshold,
@@ -916,7 +953,10 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             if let Ok(mut count) = peer_count.write() {
                                 *count = new_peer_count;
                             }
-                            // Update SCP peer count (all peers participate in consensus)
+                            // Update SCP peer count. NOTE: this is the raw connected-peer
+                            // count used by the #509 quorumFaultTolerant/quorumDegenerate
+                            // flags; actual quorum MEMBERSHIP is bounded by the promotion
+                            // gate (#651) and surfaced separately via QuorumGateSnapshot.
                             if let Ok(mut count) = scp_peer_count.write() {
                                 *count = new_peer_count;
                             }
@@ -943,8 +983,19 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                             // is gone. rebuild_scp_quorum_set always yields a
                             // non-empty set (local node is always a member) and
                             // recomputes a satisfiable threshold, so churn can
-                            // never produce an empty or unreachable quorum.
-                            let new_qs = rebuild_scp_quorum_set(&config, &discovery, &local_peer_id);
+                            // never produce an empty or unreachable quorum. The
+                            // rebuild goes through the promotion gate (#651);
+                            // a suppressed auto peer may be promoted here to
+                            // backfill the departed member's slot.
+                            let (new_qs, gate_snapshot) = rebuild_scp_quorum_set(
+                                &config,
+                                &discovery,
+                                &local_peer_id,
+                                Some(consensus.quorum_set()),
+                            );
+                            if let Ok(mut guard) = quorum_gate_status.write() {
+                                *guard = Some(gate_snapshot);
+                            }
                             if consensus.reconfigure_quorum(new_qs) {
                                 info!(
                                     threshold = consensus.quorum_set().threshold,
@@ -1997,47 +2048,283 @@ fn build_scp_quorum_set(quorum: &QuorumBuilder, local_peer_id: &libp2p::PeerId) 
     QuorumSet::new(threshold, members)
 }
 
-/// Rebuild the SCP quorum set from the *current* set of connected peers.
+/// Rebuild the SCP quorum set from the *current* set of connected peers,
+/// applying the quorum promotion gate (#651, epic #441 §3/P5).
 ///
-/// Called whenever peers connect or disconnect so the consensus quorum tracks
-/// live membership instead of being frozen at startup. Members are the local
-/// node plus every connected peer; the threshold follows the configured quorum
-/// policy:
+/// Called at the initial quorum seed and whenever peers connect or disconnect
+/// so the consensus quorum tracks live membership instead of being frozen at
+/// startup. This is a thin wrapper that extracts the connected PeerIds from
+/// the discovery peer table and delegates to [`gated_scp_quorum_set`] (the
+/// pure, unit-testable gate core).
 ///
-/// - `Recommended`: the fault-model-aware threshold over `n = peers + 1`
-///   (matches [`QuorumConfig::effective_threshold`]) — crash 2f+1 simple
-///   majority `floor(n/2)+1` by default, or BFT 3f+1 `n - floor((n-1)/3)` when
-///   `quorum.fault_model = bft`.
-/// - `Explicit`: the configured threshold, clamped to the member count so we
-///   never demand more confirmations than there are members.
-///
-/// A lone node (no peers) yields a 1-of-1 solo quorum.
+/// `previous` is the quorum set currently applied to the consensus service
+/// (if any): when the gated candidate fails the quorum-intersection check it
+/// is refused and `previous` is returned unchanged, so the caller's
+/// `reconfigure_quorum` debounces it as a no-op and the node keeps its last
+/// safe quorum set.
 fn rebuild_scp_quorum_set(
     config: &Config,
     discovery: &NetworkDiscovery,
     local_peer_id: &libp2p::PeerId,
-) -> QuorumSet {
+    previous: Option<&QuorumSet>,
+) -> (QuorumSet, QuorumGateSnapshot) {
+    let connected: Vec<libp2p::PeerId> = discovery.peer_table().iter().map(|p| p.peer_id).collect();
+    gated_scp_quorum_set(&config.network.quorum, local_peer_id, &connected, previous)
+}
+
+/// The quorum promotion gate (#651, epic #441 §3/P5): build the SCP quorum
+/// set from the connected peer set WITHOUT letting auto-trusted peers
+/// silently enter the safety-critical quorum.
+///
+/// Epic #441 §3 separates "trusted to talk to" (peering/gossip — optimistic
+/// auto-trust is fine) from "trusted to validate" (SCP quorum membership —
+/// safety-bearing, must be gated). Membership is therefore built as an
+/// operator-curated core plus a bounded auto set:
+///
+/// - **Curated core** (`[network.quorum] members`, base58 PeerId strings,
+///   mapped through the same deterministic [`peer_id_to_node_id`] derivation as
+///   everything else): always admitted, never counted against the cap.
+///   - `Explicit` mode: the quorum set is the curated core + self, whether or
+///     not each member is currently connected (membership must not follow
+///     connectivity, otherwise a partition lets a minority side clamp its
+///     threshold down and externalize a divergent chain). Auto-discovered peers
+///     get **zero** quorum membership — they remain gossip/peering only.
+///   - `Recommended` mode: connected curated members are always admitted.
+/// - **Auto set** (`Recommended` mode only): connected non-curated peers are
+///   admitted up to `max_auto_members`. Beyond the cap, candidates are ordered
+///   by their derived `NodeID` and the first `max_auto_members` are taken, so
+///   the selection is deterministic for a given peer set (arrival-order
+///   independent). Suppressed peers stay connected for gossip/sync but hold no
+///   quorum membership.
+///
+/// The threshold follows the configured quorum policy over the **gated**
+/// member count `n` (not the raw flood size):
+///
+/// - `Recommended`: the fault-model-aware threshold (matches
+///   [`QuorumConfig::effective_threshold`]) — crash 2f+1 simple majority
+///   `floor(n/2)+1` by default, or BFT 3f+1 `n - floor((n-1)/3)`.
+/// - `Explicit`: the configured threshold, clamped to the member count so we
+///   never demand more confirmations than there are members.
+///
+/// Before the candidate is returned it must pass the exact `bth-quorum-sim`
+/// quorum-intersection check ([`symmetric_quorum_has_intersection`]). A
+/// candidate admitting disjoint quorums (e.g. an explicit 2-of-4, the
+/// #510/PR-#512 canonical fork counterexample) is **refused**: the node keeps
+/// `previous` (its last safe quorum set), or — at the initial seed, when no
+/// previous set exists — falls back to a majority threshold `floor(n/2)+1`
+/// over the same members, which always intersects.
+///
+/// A lone node (no peers, no curated members) yields a 1-of-1 solo quorum,
+/// exactly as before the gate.
+///
+/// Returns the quorum set to apply plus a [`QuorumGateSnapshot`] describing
+/// this evaluation (curated/auto/suppressed counts, refusal flag) for
+/// `node_getStatus` observability.
+fn gated_scp_quorum_set(
+    quorum_cfg: &QuorumConfig,
+    local_peer_id: &libp2p::PeerId,
+    connected_peers: &[libp2p::PeerId],
+    previous: Option<&QuorumSet>,
+) -> (QuorumSet, QuorumGateSnapshot) {
     use bth_consensus_scp_types::QuorumSetMember;
 
-    // Local node is always a member.
-    let mut members: Vec<QuorumSetMember<NodeID>> =
-        vec![QuorumSetMember::Node(peer_id_to_node_id(local_peer_id))];
+    let local_node_id = peer_id_to_node_id(local_peer_id);
 
-    for peer in discovery.peer_table() {
-        members.push(QuorumSetMember::Node(peer_id_to_node_id(&peer.peer_id)));
+    // Partition the connected peers into curated (operator-listed) and
+    // auto-discovered. Matching is by base58 PeerId string, the same
+    // string-level matching `QuorumConfig::can_reach_quorum` uses.
+    let curated_strings: std::collections::HashSet<&str> =
+        quorum_cfg.members.iter().map(|s| s.as_str()).collect();
+    let mut connected_curated: Vec<libp2p::PeerId> = Vec::new();
+    let mut auto_candidates: Vec<libp2p::PeerId> = Vec::new();
+    for peer in connected_peers {
+        if *peer == *local_peer_id {
+            // Defensive: never double-admit self.
+            continue;
+        }
+        if curated_strings.contains(peer.to_string().as_str()) {
+            connected_curated.push(*peer);
+        } else {
+            auto_candidates.push(*peer);
+        }
     }
 
-    let n = members.len();
-    let threshold = match config.network.quorum.mode {
-        QuorumMode::Recommended => config.network.quorum.effective_threshold(n - 1) as u32,
+    // Local node is always a member.
+    let mut member_ids: Vec<NodeID> = vec![local_node_id.clone()];
+    let curated_members;
+    let auto_members;
+    let suppressed_peers;
+
+    match quorum_cfg.mode {
+        QuorumMode::Explicit => {
+            // Curated core + self ONLY. Every configured member is included
+            // whether or not it is currently connected, so the operator's
+            // threshold keeps its intended intersection properties under
+            // partition. Auto peers are never promoted.
+            for member in &quorum_cfg.members {
+                match member.parse::<libp2p::PeerId>() {
+                    Ok(peer_id) => {
+                        if peer_id == *local_peer_id {
+                            continue;
+                        }
+                        let node_id = peer_id_to_node_id(&peer_id);
+                        if !member_ids.contains(&node_id) {
+                            member_ids.push(node_id);
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            member,
+                            error = %e,
+                            "Ignoring unparseable [network.quorum] member (not a base58 PeerId)"
+                        );
+                    }
+                }
+            }
+            curated_members = member_ids.len() - 1;
+            auto_members = 0;
+            // Every connected non-curated peer is being kept out of the
+            // quorum by the gate.
+            suppressed_peers = auto_candidates.len();
+        }
+        QuorumMode::Recommended => {
+            // Connected curated members are always admitted and do not count
+            // against the auto cap.
+            let cap = quorum_cfg.max_auto_members as usize;
+            let admitted_auto: std::collections::HashSet<libp2p::PeerId> =
+                if auto_candidates.len() <= cap {
+                    auto_candidates.iter().copied().collect()
+                } else {
+                    // Deterministic trimming: order candidates by their derived
+                    // NodeID (public key) and take the first `cap`, so two
+                    // nodes seeing the same peer set select the same subset
+                    // regardless of connection arrival order.
+                    let mut by_node_id: Vec<(NodeID, libp2p::PeerId)> = auto_candidates
+                        .iter()
+                        .map(|p| (peer_id_to_node_id(p), *p))
+                        .collect();
+                    by_node_id.sort_by(|a, b| a.0.cmp(&b.0));
+                    by_node_id
+                        .into_iter()
+                        .take(cap)
+                        .map(|(_, peer)| peer)
+                        .collect()
+                };
+
+            // Build membership preserving the peer-table order (local node
+            // first, then connected peers in discovery order), exactly as the
+            // ungated rebuild did — under the cap the output is byte-identical
+            // to the pre-gate behavior.
+            for peer in connected_peers {
+                if *peer == *local_peer_id {
+                    continue;
+                }
+                let is_curated = curated_strings.contains(peer.to_string().as_str());
+                if !is_curated && !admitted_auto.contains(peer) {
+                    continue;
+                }
+                let node_id = peer_id_to_node_id(peer);
+                if !member_ids.contains(&node_id) {
+                    member_ids.push(node_id);
+                }
+            }
+            curated_members = connected_curated.len();
+            auto_members = admitted_auto.len();
+            suppressed_peers = auto_candidates.len() - admitted_auto.len();
+        }
+    }
+
+    let n = member_ids.len();
+    let threshold = match quorum_cfg.mode {
+        QuorumMode::Recommended => quorum_cfg.effective_threshold(n - 1) as u32,
         QuorumMode::Explicit => {
             // Clamp to member count; a threshold larger than n can never be met
             // and would deadlock consensus.
-            (config.network.quorum.threshold).min(n as u32).max(1)
+            (quorum_cfg.threshold).min(n as u32).max(1)
         }
     };
 
-    QuorumSet::new(threshold, members)
+    let members: Vec<QuorumSetMember<NodeID>> =
+        member_ids.into_iter().map(QuorumSetMember::Node).collect();
+    let candidate = QuorumSet::new(threshold, members);
+
+    // Intersection-preserving admission check (#651 acceptance criterion 3):
+    // refuse any candidate whose FBAS model admits disjoint quorums, since
+    // two disjoint quorums can externalize conflicting values — a fork that
+    // no amount of after-the-fact shunning can undo.
+    let intersection_refused = !symmetric_quorum_has_intersection(n, threshold as usize);
+    let quorum_set = if intersection_refused {
+        match previous {
+            Some(prev) => {
+                error!(
+                    candidate_threshold = threshold,
+                    candidate_members = n,
+                    "Quorum promotion gate REFUSED candidate quorum set: \
+                     {threshold}-of-{n} admits disjoint quorums (fork risk, \
+                     bth-quorum-sim intersection check failed); keeping the \
+                     previous quorum set"
+                );
+                prev.clone()
+            }
+            None => {
+                // Initial seed: no previous safe set to keep. Fall back to a
+                // simple-majority threshold over the same members — majority
+                // quorums always pairwise intersect — rather than starting
+                // consensus on a forkable configuration.
+                let safe_threshold = (n / 2 + 1) as u32;
+                error!(
+                    candidate_threshold = threshold,
+                    candidate_members = n,
+                    safe_threshold,
+                    "Quorum promotion gate REFUSED initial quorum set: \
+                     {threshold}-of-{n} admits disjoint quorums (fork risk, \
+                     bth-quorum-sim intersection check failed); seeding with a \
+                     majority {safe_threshold}-of-{n} threshold instead — fix \
+                     [network.quorum] threshold/members"
+                );
+                QuorumSet {
+                    threshold: safe_threshold,
+                    members: candidate.members.clone(),
+                }
+            }
+        }
+    } else {
+        candidate
+    };
+
+    let snapshot = QuorumGateSnapshot {
+        curated_members,
+        auto_members,
+        suppressed_peers,
+        max_auto_members: quorum_cfg.max_auto_members,
+        intersection_refused,
+    };
+    (quorum_set, snapshot)
+}
+
+/// Exact check that a symmetric `threshold`-of-`n` quorum enjoys quorum
+/// intersection, backed by `bth-quorum-sim`'s brute-force FBAS analysis
+/// (PR #512) — the same analyzer that verified the 2-of-4 disjoint-quorum
+/// counterexample from the #510 research. Botho's flat quorum (every member
+/// shares one threshold) is exactly `Fbas::symmetric`.
+///
+/// The sim's `NodeSet` is a `u32` bitmask and the analysis enumerates `2^n`
+/// subsets, exact and fast for the gated sizes this is called with
+/// (`n <= 1 + curated + max_auto_members`). If an operator configures a
+/// curated core too large for the exact check we fall back to the analytic
+/// rule: in a symmetric FBAS the minimal quorums are exactly the
+/// threshold-sized member subsets, so intersection holds iff
+/// `threshold > n/2` (two subsets each larger than half of `n` must share a
+/// node).
+fn symmetric_quorum_has_intersection(n: usize, threshold: usize) -> bool {
+    /// Beyond this size the exact 2^n enumeration is no longer cheap (and the
+    /// sim hard-caps at 32 nodes).
+    const MAX_EXACT_SIM_NODES: usize = 20;
+    if n <= MAX_EXACT_SIM_NODES {
+        bth_quorum_sim::Fbas::symmetric(n, threshold).has_quorum_intersection()
+    } else {
+        threshold > n / 2
+    }
 }
 
 /// Convert a libp2p PeerId to an SCP NodeID.
@@ -2392,5 +2679,289 @@ mod tests {
             2,
             "quorum must contain two distinct nodes"
         );
+    }
+
+    // ---- Issue #651: quorum promotion gate ----
+
+    /// Build `n` distinct synthetic peers.
+    fn synthetic_peers(n: usize) -> Vec<libp2p::PeerId> {
+        (0..n)
+            .map(|i| {
+                let mut seed = [0u8; 32];
+                seed[0] = (i & 0xFF) as u8;
+                seed[1] = ((i >> 8) & 0xFF) as u8;
+                seed[31] = 0x51; // domain-separate from other tests
+                ed25519_peer_id(seed)
+            })
+            .collect()
+    }
+
+    /// Extract the member NodeIDs of a quorum set IN ORDER (flat sets only).
+    fn member_node_ids(qs: &QuorumSet) -> Vec<NodeID> {
+        use bth_consensus_scp_types::QuorumSetMember;
+        qs.members
+            .iter()
+            .filter_map(|m| match &**m {
+                Some(QuorumSetMember::Node(node_id)) => Some(node_id.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn gate_sybil_flood_is_capped_and_intersection_safe() {
+        // Acceptance criterion (a): a Sybil flood of connectable auto-peers
+        // must NOT silently produce a degenerate/forkable quorum. With the
+        // default config (Recommended/Crash, cap 8), 30 flooding peers get at
+        // most 8 quorum seats and the threshold is computed over the GATED
+        // member count, not the flood size.
+        let cfg = QuorumConfig::default();
+        let local = ed25519_peer_id([0xAA; 32]);
+        let flood = synthetic_peers(30);
+
+        let (qs, snap) = gated_scp_quorum_set(&cfg, &local, &flood, None);
+
+        assert_eq!(
+            qs.members.len(),
+            1 + cfg.max_auto_members as usize,
+            "flood must be capped at self + max_auto_members"
+        );
+        // Crash majority over the gated n=9, not over the flood's n=31.
+        assert_eq!(qs.threshold, 5, "threshold must follow the gated n");
+        assert!(qs.is_valid());
+        assert_eq!(snap.auto_members, 8);
+        assert_eq!(snap.curated_members, 0);
+        assert_eq!(snap.suppressed_peers, 22);
+        assert!(!snap.intersection_refused);
+        // The gated quorum must have quorum intersection (no disjoint
+        // quorums => no fork), verified with the exact bth-quorum-sim check.
+        assert!(
+            bth_quorum_sim::Fbas::symmetric(qs.members.len(), qs.threshold as usize)
+                .has_quorum_intersection()
+        );
+    }
+
+    #[test]
+    fn gate_explicit_mode_admits_only_the_curated_core() {
+        // Acceptance criterion (b) + the curated-core scope finding: in
+        // Explicit mode the quorum membership is the operator-curated core +
+        // self; auto-discovered peers get ZERO quorum membership no matter
+        // how many connect. Curated members are included whether or not they
+        // are currently connected, so a partition cannot clamp the
+        // operator's threshold down onto a forkable minority.
+        let curated = synthetic_peers(4);
+        let cfg = QuorumConfig {
+            mode: QuorumMode::Explicit,
+            threshold: 3,
+            members: curated.iter().map(|p| p.to_string()).collect(),
+            ..QuorumConfig::default()
+        };
+        let local = ed25519_peer_id([0xAB; 32]);
+
+        // Only 2 of the 4 curated members are connected, plus a 20-peer
+        // auto flood.
+        let mut connected: Vec<libp2p::PeerId> = curated[..2].to_vec();
+        let flood = synthetic_peers(24)[4..].to_vec(); // 20 distinct non-curated
+        connected.extend_from_slice(&flood);
+
+        let (qs, snap) = gated_scp_quorum_set(&cfg, &local, &connected, None);
+
+        let nodes = qs.nodes();
+        // Every curated member is in (connected or not).
+        for peer in &curated {
+            assert!(
+                nodes.contains(&peer_id_to_node_id(peer)),
+                "curated member {peer} must remain in the quorum set"
+            );
+        }
+        // No auto peer is in.
+        for peer in &flood {
+            assert!(
+                !nodes.contains(&peer_id_to_node_id(peer)),
+                "auto peer {peer} must not be promoted in explicit mode"
+            );
+        }
+        assert_eq!(qs.members.len(), 5, "self + 4 curated");
+        assert_eq!(qs.threshold, 3);
+        assert!(qs.is_valid());
+        assert_eq!(snap.curated_members, 4);
+        assert_eq!(snap.auto_members, 0);
+        assert_eq!(snap.suppressed_peers, 20);
+        assert!(!snap.intersection_refused);
+    }
+
+    #[test]
+    fn gate_recommended_curated_members_do_not_count_against_cap() {
+        // Connected curated members are always admitted in Recommended mode
+        // and are exempt from the auto cap.
+        let curated = synthetic_peers(3);
+        let cfg = QuorumConfig {
+            members: curated.iter().map(|p| p.to_string()).collect(),
+            max_auto_members: 2,
+            ..QuorumConfig::default()
+        };
+        let local = ed25519_peer_id([0xAC; 32]);
+
+        let mut connected = curated.clone();
+        let autos = synthetic_peers(8)[3..].to_vec(); // 5 distinct auto peers
+        connected.extend_from_slice(&autos);
+
+        let (qs, snap) = gated_scp_quorum_set(&cfg, &local, &connected, None);
+
+        let nodes = qs.nodes();
+        for peer in &curated {
+            assert!(nodes.contains(&peer_id_to_node_id(peer)));
+        }
+        // self + 3 curated + 2 capped autos.
+        assert_eq!(qs.members.len(), 6);
+        assert_eq!(snap.curated_members, 3);
+        assert_eq!(snap.auto_members, 2);
+        assert_eq!(snap.suppressed_peers, 3);
+        assert!(!snap.intersection_refused);
+        assert!(qs.is_valid());
+    }
+
+    #[test]
+    fn gate_preserves_small_honest_clusters_exactly() {
+        // Acceptance criterion (c): for auto-peer counts at or under the cap
+        // (which covers the 5-node live testnet: self + 4 peers,
+        // Recommended/Crash) the gated output must be IDENTICAL to the
+        // pre-gate `rebuild_scp_quorum_set` output — same members, same
+        // order, same threshold — so small honest clusters see zero behavior
+        // change. k = 0 also covers the solo 1-of-1 bootstrap shape.
+        let cfg = QuorumConfig::default();
+        let local = ed25519_peer_id([0xAD; 32]);
+        let local_node_id = peer_id_to_node_id(&local);
+
+        for k in 0..=cfg.max_auto_members as usize {
+            let peers = synthetic_peers(k);
+            let (qs, snap) = gated_scp_quorum_set(&cfg, &local, &peers, None);
+
+            // Byte-identical to the ungated construction: local node first,
+            // then every connected peer in discovery order, with the
+            // fault-model threshold over n = k + 1.
+            let mut expected_ids = vec![local_node_id.clone()];
+            expected_ids.extend(peers.iter().map(peer_id_to_node_id));
+            assert_eq!(
+                member_node_ids(&qs),
+                expected_ids,
+                "k={k}: members (and their order) must match the ungated output"
+            );
+            assert_eq!(
+                qs.threshold,
+                cfg.effective_threshold(k) as u32,
+                "k={k}: threshold must match the ungated output"
+            );
+            assert_eq!(snap.suppressed_peers, 0, "k={k}: nothing suppressed");
+            assert_eq!(snap.auto_members, k);
+            assert_eq!(snap.curated_members, 0);
+            assert!(!snap.intersection_refused, "k={k}: nothing refused");
+        }
+    }
+
+    #[test]
+    fn gate_refuses_non_intersecting_candidate_and_keeps_previous_set() {
+        // Acceptance criterion (d): an admission that would break quorum
+        // intersection against the curated core is REFUSED. Explicit 2-of-4
+        // is the #510/PR-#512 canonical counterexample: it admits the
+        // disjoint quorums {A,B} / {C,D}, i.e. a fork.
+        let curated = synthetic_peers(3);
+        let cfg = QuorumConfig {
+            mode: QuorumMode::Explicit,
+            threshold: 2, // 2-of-4 with self => disjoint quorums exist
+            members: curated.iter().map(|p| p.to_string()).collect(),
+            ..QuorumConfig::default()
+        };
+        let local = ed25519_peer_id([0xAE; 32]);
+        let local_node_id = peer_id_to_node_id(&local);
+
+        // With a previous safe set: the refusal falls back to it unchanged.
+        let previous = QuorumSet::new(
+            1,
+            vec![bth_consensus_scp_types::QuorumSetMember::Node(
+                local_node_id.clone(),
+            )],
+        );
+        let (qs, snap) = gated_scp_quorum_set(&cfg, &local, &curated, Some(&previous));
+        assert!(snap.intersection_refused);
+        assert_eq!(
+            qs, previous,
+            "refused candidate must fall back to the previous safe quorum set"
+        );
+
+        // At the initial seed (no previous set): the refusal falls back to a
+        // majority threshold over the same members, which always intersects.
+        let (qs, snap) = gated_scp_quorum_set(&cfg, &local, &curated, None);
+        assert!(snap.intersection_refused);
+        assert_eq!(qs.members.len(), 4);
+        assert_eq!(qs.threshold, 3, "majority fallback: floor(4/2)+1");
+        assert!(bth_quorum_sim::Fbas::symmetric(4, 3).has_quorum_intersection());
+
+        // Sanity: the sim really does flag the refused candidate as forkable.
+        assert!(!bth_quorum_sim::Fbas::symmetric(4, 2).has_quorum_intersection());
+    }
+
+    #[test]
+    fn gate_selection_is_deterministic_across_arrival_orders() {
+        // Over-cap trimming must be arrival-order independent: two nodes
+        // seeing the same peer set (in whatever connection order) must build
+        // the same quorum set, otherwise churn ordering would desynchronize
+        // quorum views. QuorumSet equality is member-order-insensitive.
+        let cfg = QuorumConfig::default();
+        let local = ed25519_peer_id([0xAF; 32]);
+        let peers = synthetic_peers(15); // over the cap of 8
+
+        let (forward_qs, forward_snap) = gated_scp_quorum_set(&cfg, &local, &peers, None);
+        let mut reversed = peers.clone();
+        reversed.reverse();
+        let (reversed_qs, reversed_snap) = gated_scp_quorum_set(&cfg, &local, &reversed, None);
+
+        assert_eq!(
+            forward_qs, reversed_qs,
+            "same peer set must yield the same gated quorum set regardless of arrival order"
+        );
+        assert_eq!(forward_snap.auto_members, reversed_snap.auto_members);
+        assert_eq!(
+            forward_snap.suppressed_peers,
+            reversed_snap.suppressed_peers
+        );
+    }
+
+    #[test]
+    fn gate_never_double_admits_self_listed_as_curated_member() {
+        // An operator listing the local node's own PeerId under
+        // [network.quorum] members must not produce a duplicate NodeID (a
+        // duplicate makes the quorum set invalid and SCP rejects every
+        // outgoing message).
+        let curated = synthetic_peers(2);
+        let local = ed25519_peer_id([0xB0; 32]);
+        let mut members: Vec<String> = curated.iter().map(|p| p.to_string()).collect();
+        members.push(local.to_string());
+        let cfg = QuorumConfig {
+            mode: QuorumMode::Explicit,
+            threshold: 2,
+            members,
+            ..QuorumConfig::default()
+        };
+
+        let (qs, _snap) = gated_scp_quorum_set(&cfg, &local, &curated, None);
+        assert_eq!(qs.members.len(), 3, "self must appear exactly once");
+        assert!(qs.is_valid(), "no duplicate members: {qs:?}");
+    }
+
+    #[test]
+    fn symmetric_intersection_check_matches_known_cases() {
+        // 2-of-4 admits disjoint {A,B}/{C,D} quorums (the #510 fork case).
+        assert!(!symmetric_quorum_has_intersection(4, 2));
+        // Majorities always pairwise intersect.
+        assert!(symmetric_quorum_has_intersection(4, 3));
+        assert!(symmetric_quorum_has_intersection(9, 5));
+        // Solo 1-of-1 bootstrap has (vacuous) intersection — never refused.
+        assert!(symmetric_quorum_has_intersection(1, 1));
+        // 1-of-2 splits into two disjoint singleton quorums.
+        assert!(!symmetric_quorum_has_intersection(2, 1));
+        // Above the exact-sim envelope the analytic majority rule takes over.
+        assert!(symmetric_quorum_has_intersection(25, 13));
+        assert!(!symmetric_quorum_has_intersection(25, 12));
     }
 }

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -2309,17 +2309,37 @@ fn gated_scp_quorum_set(
 /// shares one threshold) is exactly `Fbas::symmetric`.
 ///
 /// The sim's `NodeSet` is a `u32` bitmask and the analysis enumerates `2^n`
-/// subsets, exact and fast for the gated sizes this is called with
-/// (`n <= 1 + curated + max_auto_members`). If an operator configures a
-/// curated core too large for the exact check we fall back to the analytic
-/// rule: in a symmetric FBAS the minimal quorums are exactly the
-/// threshold-sized member subsets, so intersection holds iff
-/// `threshold > n/2` (two subsets each larger than half of `n` must share a
-/// node).
+/// subsets, but the real cost is `minimal_quorums()`' O(|quorums|²) subset
+/// scan plus the pairwise intersection loop, which blows up well before the
+/// bitmask limit. Above [`MAX_EXACT_SIM_NODES`] we fall back to the analytic
+/// rule, which is *exact* — not an approximation — for a flat symmetric FBAS:
+/// its minimal quorums are exactly the threshold-sized member subsets, so
+/// quorum intersection holds iff `threshold > n/2` (two subsets each larger
+/// than half of `n` must share a node). The sim call at small `n` is therefore
+/// belt-and-braces validation of the same answer the analytic rule gives, not
+/// added precision.
 fn symmetric_quorum_has_intersection(n: usize, threshold: usize) -> bool {
-    /// Beyond this size the exact 2^n enumeration is no longer cheap (and the
-    /// sim hard-caps at 32 nodes).
-    const MAX_EXACT_SIM_NODES: usize = 20;
+    /// Largest `n` for which the brute-force FBAS analysis is cheap enough to
+    /// run *synchronously on the main network event loop* (peer connect/
+    /// disconnect handlers) without starving consensus ticks. Measured in a
+    /// release build of `Fbas::symmetric(n, t).has_quorum_intersection()`:
+    ///
+    /// | n  | threshold | elapsed |
+    /// |----|-----------|---------|
+    /// | 9  | 5         | 86 µs   |
+    /// | 13 | 7         | 4.9 ms  |
+    /// | 15 | 8         | 733 ms  |
+    /// | 17 | 9         | 3.3 s   |
+    /// | 18 | 10        | 9.2 s   |
+    /// | 19 | 10        | 26.4 s  |
+    /// | 20 | 11        | 46.6 s  |
+    ///
+    /// The cost is `minimal_quorums()`' O(|quorums|²) subset scan (~432k
+    /// quorums / ~168k minimal at n=20/t=11), not the `2^n` enumeration, so it
+    /// explodes between n=13 (~5 ms) and n=15 (~0.7 s). Debug builds are worse.
+    /// Cap at 13 (≤ 5 ms worst case); above it the analytic rule is exact for
+    /// flat symmetric quorums (see the fn doc), so nothing is lost.
+    const MAX_EXACT_SIM_NODES: usize = 13;
     if n <= MAX_EXACT_SIM_NODES {
         bth_quorum_sim::Fbas::symmetric(n, threshold).has_quorum_intersection()
     } else {
@@ -2960,8 +2980,34 @@ mod tests {
         assert!(symmetric_quorum_has_intersection(1, 1));
         // 1-of-2 splits into two disjoint singleton quorums.
         assert!(!symmetric_quorum_has_intersection(2, 1));
-        // Above the exact-sim envelope the analytic majority rule takes over.
+        // Just under the exact-sim boundary (n = 13): still runs the sim.
+        assert!(symmetric_quorum_has_intersection(13, 7));
+        assert!(!symmetric_quorum_has_intersection(13, 6));
+        // Just over the boundary (n = 14): the analytic majority rule takes over.
+        assert!(symmetric_quorum_has_intersection(14, 8));
+        assert!(!symmetric_quorum_has_intersection(14, 7));
+        // Well above the envelope, the analytic rule still holds.
         assert!(symmetric_quorum_has_intersection(25, 13));
         assert!(!symmetric_quorum_has_intersection(25, 12));
+    }
+
+    /// The analytic majority rule (`threshold > n/2`) is provably exact for a
+    /// flat symmetric quorum, so it must agree with the brute-force sim at
+    /// every `(n, threshold)` the sim can still handle cheaply. This property
+    /// check guards the boundary constant: if `MAX_EXACT_SIM_NODES` is raised
+    /// past a point where the two paths diverge, this fails.
+    #[test]
+    fn analytic_rule_matches_sim_for_flat_symmetric_quorums() {
+        for n in 1..=13 {
+            for threshold in 1..=n {
+                let sim = bth_quorum_sim::Fbas::symmetric(n, threshold)
+                    .has_quorum_intersection();
+                let analytic = threshold > n / 2;
+                assert_eq!(
+                    sim, analytic,
+                    "sim/analytic disagree at n={n}, threshold={threshold}"
+                );
+            }
+        }
     }
 }

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -3000,8 +3000,7 @@ mod tests {
     fn analytic_rule_matches_sim_for_flat_symmetric_quorums() {
         for n in 1..=13 {
             for threshold in 1..=n {
-                let sim = bth_quorum_sim::Fbas::symmetric(n, threshold)
-                    .has_quorum_intersection();
+                let sim = bth_quorum_sim::Fbas::symmetric(n, threshold).has_quorum_intersection();
                 let analytic = threshold > n / 2;
                 assert_eq!(
                     sim, analytic,

--- a/botho/src/config.rs
+++ b/botho/src/config.rs
@@ -346,13 +346,41 @@ pub struct QuorumConfig {
     #[serde(default = "default_threshold")]
     pub threshold: u32,
 
-    /// For explicit mode: peer IDs to trust (as base58 strings)
+    /// Operator-curated quorum members (base58 PeerId strings) — the
+    /// safety-bearing "curated core" of the quorum promotion gate (#651).
+    ///
+    /// - In `Explicit` mode these are the **only** peers (besides self)
+    ///   admitted into the SCP quorum set; auto-discovered peers stay
+    ///   peering/gossip-only.
+    /// - In `Recommended` mode any *connected* curated member is always
+    ///   admitted and does not count against [`Self::max_auto_members`].
     #[serde(default)]
     pub members: Vec<String>,
 
     /// For recommended mode: minimum peers before minting can start
     #[serde(default = "default_min_peers")]
     pub min_peers: u32,
+
+    /// Quorum promotion gate (#651, epic #441 §3/P5): in `Recommended` mode,
+    /// the maximum number of auto-discovered (non-curated) peers that may be
+    /// promoted into the safety-critical SCP quorum set. Curated
+    /// [`Self::members`] never count against this cap.
+    ///
+    /// Without a cap, a Sybil flood of connectable peers is auto-admitted
+    /// into quorums on the next churn event — a safety (fork) risk, not just
+    /// a liveness one. The cap bounds the auto-trusted set; peers beyond it
+    /// remain connected for gossip/sync but hold no quorum membership.
+    /// Selection above the cap is deterministic (candidates are ordered by
+    /// their derived SCP `NodeID`), so the same peer set always yields the
+    /// same quorum set regardless of arrival order.
+    ///
+    /// The default (8) is comfortably above the current live-testnet shape
+    /// (self + 4 peers), so small honest clusters see zero behavior change,
+    /// while keeping the quorum small enough for the exact
+    /// `bth-quorum-sim` intersection check on every rebuild. Setting `0`
+    /// makes `Recommended` mode curated-only (auto peers never validate).
+    #[serde(default = "default_max_auto_members")]
+    pub max_auto_members: u32,
 }
 
 impl Default for QuorumConfig {
@@ -363,6 +391,7 @@ impl Default for QuorumConfig {
             threshold: 2,
             members: Vec::new(),
             min_peers: 1,
+            max_auto_members: default_max_auto_members(),
         }
     }
 }
@@ -500,6 +529,12 @@ fn default_threshold() -> u32 {
 
 fn default_min_peers() -> u32 {
     1
+}
+
+/// Default cap on auto-promoted (non-curated) quorum members (#651). See
+/// [`QuorumConfig::max_auto_members`].
+fn default_max_auto_members() -> u32 {
+    8
 }
 
 /// Maximum quorum set members (keeps things simple)
@@ -881,6 +916,22 @@ mod tests {
         assert_eq!(quorum.threshold, 2);
         assert_eq!(quorum.min_peers, 1);
         assert!(quorum.members.is_empty());
+        // #651 promotion gate: cap defaults to 8 — comfortably above the
+        // 5-node live testnet (self + 4 peers) so small clusters see zero
+        // behavior change.
+        assert_eq!(quorum.max_auto_members, 8);
+    }
+
+    #[test]
+    fn test_quorum_max_auto_members_serde_default() {
+        // Existing config files without the #651 gate key must keep parsing
+        // and get the default cap.
+        let quorum: QuorumConfig = toml::from_str("").unwrap();
+        assert_eq!(quorum.max_auto_members, 8);
+
+        // And an explicit value is honored.
+        let quorum: QuorumConfig = toml::from_str("max_auto_members = 3").unwrap();
+        assert_eq!(quorum.max_auto_members, 3);
     }
 
     #[test]
@@ -891,6 +942,7 @@ mod tests {
             threshold: 2,
             members: vec!["peer1".to_string(), "peer2".to_string()],
             min_peers: 1,
+            max_auto_members: 8,
         };
 
         // No peers connected - can't reach quorum
@@ -919,6 +971,7 @@ mod tests {
             threshold: 2,    // ignored in recommended mode
             members: vec![], // ignored in recommended mode
             min_peers: 1,
+            max_auto_members: 8,
         };
 
         // No peers - can't mine
@@ -964,6 +1017,7 @@ mod tests {
             threshold: 2,
             members: vec![],
             min_peers: 1,
+            max_auto_members: 8,
         };
 
         assert_eq!(quorum.effective_threshold(0), 1); // n=1: 1-of-1
@@ -1046,6 +1100,7 @@ mod tests {
             threshold: 2,
             members: vec!["peer1".to_string(), "peer2".to_string()],
             min_peers: 1,
+            max_auto_members: 8,
         };
 
         for n in 1..=6 {
@@ -1063,6 +1118,7 @@ mod tests {
             threshold: 2,
             members: vec![],
             min_peers: 2, // Require at least 2 peers
+            max_auto_members: 8,
         };
 
         // One peer - not enough

--- a/botho/src/consensus/mod.rs
+++ b/botho/src/consensus/mod.rs
@@ -23,8 +23,8 @@ pub use lottery::{
     LotteryValidationError,
 };
 pub use service::{
-    ConsensusConfig, ConsensusEvent, ConsensusService, ScpMessage, ScpSlotSnapshot,
-    SLOT_STALL_THRESHOLD_MULTIPLIER,
+    ConsensusConfig, ConsensusEvent, ConsensusService, QuorumGateSnapshot, ScpMessage,
+    ScpSlotSnapshot, SLOT_STALL_THRESHOLD_MULTIPLIER,
 };
 pub use validation::{BatchValidationResult, TransactionValidator, ValidationError};
 pub use value::{ConsensusValue, ConsensusValueHash};

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -160,6 +160,44 @@ pub struct ScpSlotSnapshot {
     pub effective_slot_duration_secs: u64,
 }
 
+/// A snapshot of the quorum promotion gate's last evaluation (#651, epic
+/// #441 §3/P5).
+///
+/// Every field is derived from a real gate evaluation in
+/// `commands::run::gated_scp_quorum_set` — never a constant or placeholder
+/// (the anti-#541–#544 gate). `commands::run` publishes a fresh snapshot into
+/// a shared `Arc<RwLock<Option<QuorumGateSnapshot>>>` at the initial quorum
+/// seed and on every peer-churn rebuild; the RPC layer surfaces it in
+/// `node_getStatus` (the `quorumCuratedMembers` / `quorumAutoMembers` /
+/// `quorumGateSuppressedPeers` / `quorumGateMaxAutoMembers` /
+/// `quorumGateIntersectionRefused` fields), reporting JSON `null` until the
+/// first publish.
+#[derive(Debug, Clone)]
+pub struct QuorumGateSnapshot {
+    /// Operator-curated (`[network.quorum] members`) quorum members admitted
+    /// by the gate, excluding self.
+    pub curated_members: usize,
+
+    /// Auto-discovered (non-curated) peers promoted into the quorum set by
+    /// the gate, bounded by `max_auto_members`.
+    pub auto_members: usize,
+
+    /// Connected peers the gate is currently keeping OUT of the quorum set
+    /// (over-cap auto peers in `Recommended` mode, or every non-curated peer
+    /// in `Explicit` mode). `> 0` means the gate is actively suppressing
+    /// promotions.
+    pub suppressed_peers: usize,
+
+    /// Echo of the configured `max_auto_members` cap, for dashboards.
+    pub max_auto_members: u32,
+
+    /// `true` when the most recent candidate quorum set FAILED the
+    /// `bth-quorum-sim` quorum-intersection check and was refused: the node
+    /// kept its previous safe quorum set (or, at initial seed, fell back to a
+    /// majority-threshold set over the same members).
+    pub intersection_refused: bool,
+}
+
 /// Events emitted by the consensus service
 #[derive(Debug, Clone)]
 pub enum ConsensusEvent {

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -68,7 +68,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     address::Address,
     config::QuorumConfig,
-    consensus::ScpSlotSnapshot,
+    consensus::{QuorumGateSnapshot, ScpSlotSnapshot},
     ledger::Ledger,
     mempool::Mempool,
     network::{NetworkStats, SyncStatusSnapshot},
@@ -252,6 +252,17 @@ pub struct RpcState {
     /// the `scpSlot*` / `slotStalled` / `slotStallSeconds` fields in
     /// `node_getStatus`.
     pub scp_slot_status: Option<Arc<RwLock<Option<ScpSlotSnapshot>>>>,
+    /// Shared quorum-promotion-gate handle (#651, epic #441 §3/P5).
+    /// `commands::run` publishes a fresh [`QuorumGateSnapshot`] here at the
+    /// initial quorum seed and on every peer-churn rebuild — always derived
+    /// from a real gate evaluation, never a constant (the anti-#541–#544
+    /// gate). `None` until wired in (tests / relay nodes); the inner `Option`
+    /// is `None` until the first evaluation publishes. Surfaced as the
+    /// `quorumCuratedMembers` / `quorumAutoMembers` /
+    /// `quorumGateSuppressedPeers` / `quorumGateMaxAutoMembers` /
+    /// `quorumGateIntersectionRefused` fields in `node_getStatus` (JSON
+    /// `null` until first publish).
+    pub quorum_gate_status: Option<Arc<RwLock<Option<QuorumGateSnapshot>>>>,
     /// Shared snapshot of the live connected-peer set surfaced by
     /// `network_getPeers` (#544). `commands::run` publishes a cheap clone of
     /// the discovery peer table here on each peer connect/disconnect; the
@@ -301,6 +312,7 @@ impl RpcState {
             minter_health: None,
             sync_status: None,
             scp_slot_status: None,
+            quorum_gate_status: None,
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
         }
@@ -342,6 +354,7 @@ impl RpcState {
             minter_health: None,
             sync_status: None,
             scp_slot_status: None,
+            quorum_gate_status: None,
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
         }
@@ -381,6 +394,7 @@ impl RpcState {
             minter_health: None,
             sync_status: None,
             scp_slot_status: None,
+            quorum_gate_status: None,
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
         }
@@ -468,6 +482,29 @@ impl RpcState {
     /// fabricating values.
     fn scp_slot_snapshot(&self) -> Option<ScpSlotSnapshot> {
         let handle = self.scp_slot_status.as_ref()?;
+        let guard = handle.read().ok()?;
+        guard.clone()
+    }
+
+    /// Wire in the shared quorum-promotion-gate handle so `node_getStatus`
+    /// can surface curated-vs-auto quorum membership and gate state (#651).
+    /// `commands::run` calls this with the handle the quorum rebuild path
+    /// publishes [`QuorumGateSnapshot`]s into.
+    pub fn with_quorum_gate_status(
+        mut self,
+        quorum_gate_status: Arc<RwLock<Option<QuorumGateSnapshot>>>,
+    ) -> Self {
+        self.quorum_gate_status = Some(quorum_gate_status);
+        self
+    }
+
+    /// Read the current quorum-promotion-gate snapshot, if a handle is wired
+    /// in and the gate has evaluated at least once. Returns `None` for tests
+    /// / relay nodes / pre-first-rebuild state, in which case
+    /// `node_getStatus` reports the gate fields as JSON `null` rather than
+    /// fabricating values.
+    fn quorum_gate_snapshot(&self) -> Option<QuorumGateSnapshot> {
+        let handle = self.quorum_gate_status.as_ref()?;
         let guard = handle.read().ok()?;
         guard.clone()
     }
@@ -1026,6 +1063,14 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
     let slot_stalled = scp_slot.as_ref().map(|s| s.slot_stalled).unwrap_or(false);
     let slot_stall_seconds = scp_slot.as_ref().map(|s| s.stall_seconds).unwrap_or(0);
 
+    // Quorum promotion gate observability (#651, epic #441 §3/P5). Every
+    // field is read from the snapshot the quorum rebuild path publishes from
+    // a REAL gate evaluation — never fabricated here (the anti-#541–#544
+    // gate). With no handle wired in (tests / relay nodes) or before the
+    // first rebuild, all gate fields render as JSON null: an unwired node
+    // reports "no data", not a plausible-looking constant.
+    let quorum_gate = state.quorum_gate_snapshot();
+
     JsonRpcResponse::success(
         id,
         json!({
@@ -1052,6 +1097,20 @@ async fn handle_node_status(id: Value, state: &RpcState) -> JsonRpcResponse {
             // `quorumDegenerate` flags the n-of-n / zero-fault-tolerance regime.
             "quorumFaultTolerant": quorum_fault_tolerant,
             "quorumDegenerate": quorum_degenerate,
+            // Quorum promotion gate (#651): curated vs auto-promoted quorum
+            // membership and gate state, from the rebuild path's
+            // QuorumGateSnapshot. All null until the first gate evaluation.
+            "quorumCuratedMembers": quorum_gate.as_ref().map(|g| g.curated_members),
+            "quorumAutoMembers": quorum_gate.as_ref().map(|g| g.auto_members),
+            // > 0 means the gate is actively keeping discovered peers OUT of
+            // the safety-critical quorum (over-cap auto peers, or all
+            // non-curated peers in explicit mode).
+            "quorumGateSuppressedPeers": quorum_gate.as_ref().map(|g| g.suppressed_peers),
+            "quorumGateMaxAutoMembers": quorum_gate.as_ref().map(|g| g.max_auto_members),
+            // true when the latest candidate quorum set failed the
+            // bth-quorum-sim intersection check and was refused (the node
+            // kept its previous safe quorum set).
+            "quorumGateIntersectionRefused": quorum_gate.as_ref().map(|g| g.intersection_refused),
             // Stuck-miner early-warning (#538): true iff this node's miner is
             // active but producing 0 H/s past the grace + stall window.
             "minerStalled": miner_stalled,
@@ -3760,6 +3819,90 @@ mod tests {
         assert_ne!(
             active["slotStallSeconds"], jammed["slotStallSeconds"],
             "slotStallSeconds must track the live snapshot, not a constant"
+        );
+    }
+
+    /// #651 (epic #441 §3/P5): the `node_getStatus` quorum-promotion-gate
+    /// fields must track the shared snapshot handle the quorum rebuild path
+    /// publishes into — the anti-#541–#544 gate at the RPC layer. With no
+    /// handle wired in (or wired but never published) every gate field is
+    /// JSON null, never a fabricated zero; with a handle, two DIFFERENT
+    /// snapshots must yield DIFFERENT JSON (the fields are live, not
+    /// constants).
+    #[tokio::test]
+    async fn test_node_status_tracks_quorum_gate_snapshot() {
+        use crate::{consensus::QuorumGateSnapshot, ledger::Ledger, mempool::Mempool};
+
+        fn fresh_state() -> RpcState {
+            let dir = tempfile::tempdir().unwrap();
+            let ledger = Ledger::open(dir.path()).unwrap();
+            std::mem::forget(dir);
+            RpcState::new(
+                ledger,
+                Mempool::new(),
+                Network::Testnet,
+                None,
+                None,
+                vec![],
+                Arc::new(WsBroadcaster::new(16)),
+            )
+        }
+
+        // (1) No handle wired in: all gate fields null (no data, not zeros).
+        let state = fresh_state();
+        let result = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(result["quorumCuratedMembers"], Value::Null);
+        assert_eq!(result["quorumAutoMembers"], Value::Null);
+        assert_eq!(result["quorumGateSuppressedPeers"], Value::Null);
+        assert_eq!(result["quorumGateMaxAutoMembers"], Value::Null);
+        assert_eq!(result["quorumGateIntersectionRefused"], Value::Null);
+
+        // (2) Handle wired but nothing published yet: still null.
+        let handle = Arc::new(RwLock::new(None));
+        let state = fresh_state().with_quorum_gate_status(handle.clone());
+        let result = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(result["quorumCuratedMembers"], Value::Null);
+        assert_eq!(result["quorumAutoMembers"], Value::Null);
+        assert_eq!(result["quorumGateSuppressedPeers"], Value::Null);
+        assert_eq!(result["quorumGateMaxAutoMembers"], Value::Null);
+        assert_eq!(result["quorumGateIntersectionRefused"], Value::Null);
+
+        // (3) Small honest cluster: gate admits everyone, suppresses no one.
+        *handle.write().unwrap() = Some(QuorumGateSnapshot {
+            curated_members: 0,
+            auto_members: 4,
+            suppressed_peers: 0,
+            max_auto_members: 8,
+            intersection_refused: false,
+        });
+        let quiet = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(quiet["quorumCuratedMembers"], json!(0));
+        assert_eq!(quiet["quorumAutoMembers"], json!(4));
+        assert_eq!(quiet["quorumGateSuppressedPeers"], json!(0));
+        assert_eq!(quiet["quorumGateMaxAutoMembers"], json!(8));
+        assert_eq!(quiet["quorumGateIntersectionRefused"], json!(false));
+
+        // (4) Sybil flood: the SAME handle now reports active suppression —
+        // every field must move with the snapshot (not-a-constant proof).
+        *handle.write().unwrap() = Some(QuorumGateSnapshot {
+            curated_members: 2,
+            auto_members: 8,
+            suppressed_peers: 22,
+            max_auto_members: 8,
+            intersection_refused: true,
+        });
+        let flooded = handle_node_status(json!(1), &state).await.result.unwrap();
+        assert_eq!(flooded["quorumCuratedMembers"], json!(2));
+        assert_eq!(flooded["quorumAutoMembers"], json!(8));
+        assert_eq!(flooded["quorumGateSuppressedPeers"], json!(22));
+        assert_eq!(flooded["quorumGateIntersectionRefused"], json!(true));
+        assert_ne!(
+            quiet["quorumGateSuppressedPeers"], flooded["quorumGateSuppressedPeers"],
+            "quorumGateSuppressedPeers must track the live snapshot, not a constant"
+        );
+        assert_ne!(
+            quiet["quorumGateIntersectionRefused"], flooded["quorumGateIntersectionRefused"],
+            "quorumGateIntersectionRefused must track the live snapshot, not a constant"
         );
     }
 


### PR DESCRIPTION
## Summary

Implements the #441 §3/P5 **quorum promotion gate**: being discovered/connected no longer implies SCP quorum membership. Auto-trusted peers are fine for peering/gossip, but promotion into the safety-critical quorum set is now a distinct, gated step, so a Sybil flood of connectable peers can no longer be auto-admitted into quorums (a fork risk that no after-the-fact shunning can undo).

## Design decision (recorded per acceptance criteria)

**Chosen gate mechanism: hard cap + operator-curated core, guarded by the exact `bth-quorum-sim` quorum-intersection check.**

Justification (vs. observed-good-history and operator-confirmation, the other #441 §5b options):

- It is the **simplest reversible default**: one config knob (`[network.quorum] max_auto_members`, default 8), no new protocol state, no history tracking, no admin surface (P4 is explicitly out of scope). History/confirmation variants can layer on later without undoing it.
- Per the #510 research, FBAS membership security *is* curation — auto-added peers add liveness, not intersection guarantees. The gate encodes exactly that: curated `members` are the safety-bearing core; the capped auto set is bounded so it cannot flood the quorum.
- Default of **8** is comfortably above the 5-node live testnet (self + 4 peers) so small honest clusters see **zero behavior change**, while keeping the gated quorum far inside `bth-quorum-sim`'s exact-analysis envelope.
- `MIN_BFT_NODES = 4` and the #509 `quorumFaultTolerant`/`quorumDegenerate` semantics are untouched.

Mechanism details:

- **Curated core** (`[network.quorum] members`, base58 PeerIds mapped through the deterministic #414 `peer_id_to_node_id` derivation): always admitted, never counted against the cap. This also closes the curation scope finding: previously `Explicit` mode only set the *threshold* — membership was still "all discovered peers." Now `Explicit` membership = curated core + self, and auto peers get zero quorum membership (gossip/peering only). Curated members are included whether or not currently connected — one deliberate deviation from the curator note's "(connected)" parenthetical, because connectivity-following membership lets a network partition clamp a minority side's threshold down (e.g. 3-of-5 → 2-of-3) and externalize a divergent chain; full-core membership makes the minority side halt instead (safety over liveness). The required "connected curated members remain" assertion still holds and is tested.
- **Auto set** (`Recommended` only): connected non-curated peers admitted up to `max_auto_members`; beyond the cap, candidates are ordered by derived `NodeID` and the first N taken, so selection is deterministic/arrival-order independent. Threshold is computed over the **gated** n, not the flood size.
- **Intersection-refusal**: every candidate is modeled as `Fbas::symmetric(n, threshold)` and checked with `bth_quorum_sim::Fbas::has_quorum_intersection()` (no hand-rolled intersection test; `bth-quorum-sim` is now a path dependency of `botho`). A failing candidate (e.g. explicit 2-of-4, the #510/PR-#512 disjoint-quorum counterexample) is refused: the node keeps its previous safe quorum set (`reconfigure_quorum` debounces the returned previous set as a no-op); at the initial seed (no previous set) it falls back to a majority threshold over the same members, which always intersects, and logs an error. For curated cores too large for the exact 2^n enumeration (>20), the analytic symmetric-FBAS rule (`threshold > n/2`) takes over.

## Changes

- `botho/src/config.rs` — new `max_auto_members` key on `QuorumConfig` (serde default 8, existing config files keep parsing); curated-core docs on `members`.
- `botho/src/commands/run.rs` — new pure `gated_scp_quorum_set` gate core + `symmetric_quorum_has_intersection`; `rebuild_scp_quorum_set` is now a thin wrapper taking the previous quorum set; initial-seed and both churn call sites go through the gate and publish `QuorumGateSnapshot`s.
- `botho/src/consensus/service.rs` / `mod.rs` — `QuorumGateSnapshot` struct (mirrors #678's `ScpSlotSnapshot` pattern); **no change to `reconfigure_quorum` semantics** (defer-at-active-slot, empty-set refusal, #431 pruning all untouched — the gate lives upstream in quorum-set construction).
- `botho/src/rpc/mod.rs` — shared `quorum_gate_status` handle + `with_quorum_gate_status` builder following #678's null-until-wired pattern; `node_getStatus` gains `quorumCuratedMembers`, `quorumAutoMembers`, `quorumGateSuppressedPeers`, `quorumGateMaxAutoMembers`, `quorumGateIntersectionRefused` next to the #509 flags — all JSON `null` until the first real gate evaluation (anti-#541–#544: no fabricated values).
- `botho/Cargo.toml` — add `bth-quorum-sim` path dependency.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Peered ≠ promoted; promotion goes through the gate | ✅ | All three `rebuild_scp_quorum_set` call sites route through `gated_scp_quorum_set`; `gate_sybil_flood_is_capped_and_intersection_safe` |
| Curated members always honored; auto bounded by cap + intersection check | ✅ | `gate_explicit_mode_admits_only_the_curated_core`, `gate_recommended_curated_members_do_not_count_against_cap` |
| Intersection-breaking admission refused via `bth-quorum-sim` | ✅ | `gate_refuses_non_intersecting_candidate_and_keeps_previous_set` (2-of-4 canonical case; previous-set fallback + seed majority fallback) |
| Test (a): Sybil flood does not produce degenerate/forkable quorum | ✅ | `gate_sybil_flood_is_capped_and_intersection_safe` (30-peer flood → 9 members, 5-of-9, intersection verified by sim) |
| Test (b): curated members always remain | ✅ | `gate_explicit_mode_admits_only_the_curated_core` |
| Test (c): small honest clusters preserved exactly | ✅ | `gate_preserves_small_honest_clusters_exactly` (k=0..=8: identical members **and order** and threshold vs the ungated construction; covers the 5-node testnet shape and solo 1-of-1 bootstrap) |
| `node_getStatus` exposes curated/auto counts + gate state | ✅ | `test_node_status_tracks_quorum_gate_snapshot` (null-until-published, live not constant) |
| Design step records chosen mechanism + justification | ✅ | This PR body, "Design decision" section |
| Explicit membership honors `members` (curation scope finding) | ✅ | `gate_explicit_mode_admits_only_the_curated_core` |
| Deterministic auto selection | ✅ | `gate_selection_is_deterministic_across_arrival_orders` |
| Snapshot follows #678 null-until-wired pattern, no fabricated values | ✅ | `test_node_status_tracks_quorum_gate_snapshot` steps (1)/(2) |
| `bth-quorum-sim` consumed as path dep, no reimplementation | ✅ | `botho/Cargo.toml`; gate calls `Fbas::symmetric(...).has_quorum_intersection()` |
| `reconfigure_quorum` boundary semantics unchanged | ✅ | `service.rs` logic untouched (only the `QuorumGateSnapshot` struct added); all `consensus::service` tests green |

Not included (listed as optional in curation): Prometheus gauges for the gate — can follow as a tiny separate change if wanted. P4 admin UI/API, reward mechanism, protocol changes: out of scope per the issue.

## Test Plan

- `cargo test -p botho --lib` — **1125 passed, 0 failed** (includes the 8 new gate tests, new config serde-default tests, and the new RPC snapshot test)
- `cargo test -p bth-quorum-sim` — **all green** (61 tests across units/integration)
- `cargo test -p botho --test consensus_cluster_convergence` — **4/4 passed** (2/3/4-node clusters converge, no fork, no stall — proves no consensus regression)
- `cargo clippy -p botho --lib` — no new warnings from this change (remaining warnings pre-exist on main)
- `cargo fmt -p botho -- --check` — clean

Closes #651