### PR TITLE
security(web-wallet): enforce required-password policy on /pay and /claim inline wallet flows

### DIFF
--- a/web/packages/web-wallet/src/pages/claim.test.tsx
+++ b/web/packages/web-wallet/src/pages/claim.test.tsx
@@ -181,3 +181,81 @@ describe('ClaimPage valid-link survives StrictMode double-invoke (#654)', () => 
     await screen.findByText(/no claim link found|not valid/i)
   })
 })
+
+// This environment's jsdom does not provide localStorage; mirror the mock used
+// by core's wallet.test.ts so the REAL saveWallet can persist through it.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+/**
+ * Required-password policy for the in-flow "Create one" wallet (#672).
+ *
+ * `handleSweep` previously persisted the freshly created wallet with
+ * `saveWallet(mnemonic)` — no password — writing the raw 12-word seed to
+ * localStorage in plaintext (`botho-wallet-encrypted = 'false'`), bypassing the
+ * #475 policy for exactly the users whose first wallet arrives via a claim
+ * link. This locks in: no claim while the password is missing, and the
+ * persisted seed is an encrypted vault blob.
+ */
+describe('ClaimPage in-flow wallet create persists ENCRYPTED (#672)', () => {
+  const VALID_PASSWORD = 'correct-horse-battery'
+
+  beforeEach(() => {
+    cleanup()
+    scanEphemeralMock.mockReset()
+    scanEphemeralMock.mockResolvedValue({
+      gross: 5_000_000_000_000n,
+      fee: 100_000_000n,
+      net: 4_900_000_000_000n,
+    })
+    sweepEphemeralMock.mockReset()
+    sweepEphemeralMock.mockResolvedValue({ txHash: 'tx' })
+    for (const spy of Object.values(adapterSpies)) spy.mockClear()
+    window.history.replaceState(null, '', '/claim')
+    localStorageMock.clear()
+  })
+
+  afterEach(() => {
+    window.location.hash = ''
+    localStorageMock.clear()
+  })
+
+  it('requires a password before claiming and stores a vault blob, not plaintext', async () => {
+    setClaimHash()
+    renderClaim()
+
+    fireEvent.click(await screen.findByRole('button', { name: /reveal/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /create one/i }))
+
+    // Destination is pre-filled from the new wallet, but there is no password
+    // yet — the Claim button must stay disabled.
+    const claimBtn = screen.getByRole('button', { name: /^Claim / }) as HTMLButtonElement
+    expect(claimBtn.disabled).toBe(true)
+
+    fireEvent.change(screen.getByPlaceholderText(/^Password \(min/i), {
+      target: { value: VALID_PASSWORD },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/Confirm password/i), {
+      target: { value: VALID_PASSWORD },
+    })
+    await waitFor(() => expect(claimBtn.disabled).toBe(false))
+
+    fireEvent.click(claimBtn)
+    // Real saveWallet + PBKDF2 (600k iterations) runs here — allow extra time.
+    await screen.findByText(/on their way to your address/i, {}, { timeout: 20000 })
+
+    expect(localStorageMock.getItem('botho-wallet-encrypted')).toBe('true')
+    const stored = localStorageMock.getItem('botho-wallet-mnemonic')
+    expect(stored).not.toBeNull()
+    // An encrypted vault blob is one opaque token — never a 12-word phrase.
+    expect(stored!.trim().split(/\s+/).length).toBe(1)
+  }, 30000)
+})

--- a/web/packages/web-wallet/src/pages/claim.tsx
+++ b/web/packages/web-wallet/src/pages/claim.tsx
@@ -23,6 +23,7 @@ import {
 } from 'lucide-react'
 import { useAdapter } from '../contexts/wallet'
 import { useNetwork } from '../contexts/network'
+import { PasswordFields, isPasswordValid } from '../components/PasswordSettingsModal'
 import { scanEphemeral, sweepEphemeral, type EphemeralScan } from '../lib/claim-link-ops'
 
 /**
@@ -76,6 +77,13 @@ export function ClaimPage() {
   const [claimTxHash, setClaimTxHash] = useState<string | null>(null)
   const [createdMnemonic, setCreatedMnemonic] = useState<string | null>(null)
   const [showNewWallet, setShowNewWallet] = useState(false)
+  // SECURITY (#672): an in-flow-created wallet follows the same #475 policy as
+  // the main setup — a password is REQUIRED so the persisted seed is encrypted
+  // at rest, not written to localStorage in plaintext.
+  const [newWalletPassword, setNewWalletPassword] = useState('')
+  const [confirmNewWalletPassword, setConfirmNewWalletPassword] = useState('')
+  const newWalletPasswordValid = isPasswordValid(newWalletPassword, confirmNewWalletPassword)
+  const persistingNewWallet = showNewWallet && createdMnemonic !== null
 
   // Track whether we've already begun a sweep so a late re-scan can't downgrade
   // the state out from under the user.
@@ -169,14 +177,19 @@ export function ClaimPage() {
       setError('Enter a valid destination address (tbotho://… or botho://…).')
       return
     }
+    if (persistingNewWallet && !newWalletPasswordValid) {
+      setError('Set a password for your new wallet before claiming.')
+      return
+    }
     setError(null)
     sweepingRef.current = true
     setState('sweeping')
     try {
       // If the recipient created a new wallet in-flow, persist it so they can
-      // use it afterwards in this browser.
+      // use it afterwards in this browser — encrypted under their password
+      // (#672/#475; saveWallet with a password writes a vault blob).
       if (createdMnemonic && showNewWallet) {
-        await saveWallet(createdMnemonic)
+        await saveWallet(createdMnemonic, newWalletPassword)
       }
       const { txHash } = await sweepEphemeral(adapter, secret.mnemonic, dest)
       setClaimTxHash(txHash)
@@ -317,8 +330,19 @@ export function ClaimPage() {
                     </p>
                     <p className="text-xs text-amber-200/80">
                       Write this down and keep it safe — it is the ONLY way to recover this
-                      wallet. We&apos;ll save it in this browser when you claim.
+                      wallet. We&apos;ll save it encrypted in this browser when you claim.
                     </p>
+                    <div className="pt-1">
+                      <p className="text-xs text-amber-200/80 mb-2">
+                        Set a password — your wallet is encrypted on this device with it.
+                      </p>
+                      <PasswordFields
+                        password={newWalletPassword}
+                        confirmPassword={confirmNewWalletPassword}
+                        onPassword={setNewWalletPassword}
+                        onConfirmPassword={setConfirmNewWalletPassword}
+                      />
+                    </div>
                   </div>
                 )}
 
@@ -331,7 +355,11 @@ export function ClaimPage() {
 
                 <Button
                   onClick={handleSweep}
-                  disabled={state === 'sweeping' || !destination.trim()}
+                  disabled={
+                    state === 'sweeping' ||
+                    !destination.trim() ||
+                    (persistingNewWallet && !newWalletPasswordValid)
+                  }
                   className="w-full justify-center"
                 >
                   {state === 'sweeping' ? (

--- a/web/packages/web-wallet/src/pages/pay.test.tsx
+++ b/web/packages/web-wallet/src/pages/pay.test.tsx
@@ -9,7 +9,7 @@
  */
 import { StrictMode } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import {
   createMnemonic12,
@@ -198,5 +198,89 @@ describe('PayPage valid-link survives StrictMode double-invoke (#654)', () => {
 
     // A malformed fragment must still reach the invalid state (no regression).
     expect(screen.getByText(/No payment request found|not valid/i)).toBeDefined()
+  })
+})
+
+/**
+ * Required-password policy on the link-flow WalletGate (#672).
+ *
+ * The main `/wallet` setup enforces #475 (password REQUIRED, seed encrypted at
+ * rest), but the /pay gate's create/import previously called
+ * `createWallet`/`importWallet` with NO password — persisting a plaintext seed
+ * for exactly the users whose first touch of Botho is a shared link. These
+ * tests pin the gate to the same policy: the buttons stay disabled without a
+ * valid password, and the password is plumbed through to the context.
+ */
+describe('PayPage WalletGate enforces the required-password policy (#672)', () => {
+  const VALID_PASSWORD = 'correct-horse-battery'
+
+  beforeEach(() => {
+    cleanup()
+    useWalletMock.mockReset()
+    window.location.hash = ''
+  })
+
+  it('create flow: stays disabled without a password, passes it to createWallet', async () => {
+    const createWallet = vi.fn(ASYNC_NOOP)
+    useWalletMock.mockReturnValue(
+      baseWallet({ hasWallet: false, address: null, createWallet }),
+    )
+    renderPay({ to: RECIPIENT })
+
+    // Reveal the phrase and tick the stored-safely box — previously sufficient.
+    fireEvent.click(screen.getByText(/Click to reveal/i))
+    fireEvent.click(screen.getByRole('checkbox'))
+
+    const createBtn = screen.getByRole('button', {
+      name: /Create & Continue/i,
+    }) as HTMLButtonElement
+    expect(createBtn.disabled).toBe(true)
+
+    // A too-short password is not enough.
+    const pw = screen.getByPlaceholderText(/^Password \(min/i)
+    const confirm = screen.getByPlaceholderText(/Confirm password/i)
+    fireEvent.change(pw, { target: { value: 'short' } })
+    fireEvent.change(confirm, { target: { value: 'short' } })
+    expect(createBtn.disabled).toBe(true)
+
+    fireEvent.change(pw, { target: { value: VALID_PASSWORD } })
+    fireEvent.change(confirm, { target: { value: VALID_PASSWORD } })
+    expect(createBtn.disabled).toBe(false)
+
+    fireEvent.click(createBtn)
+    await waitFor(() => expect(createWallet).toHaveBeenCalledTimes(1))
+    // The seed is encrypted at rest because the password reaches the context.
+    expect(createWallet).toHaveBeenCalledWith(expect.any(String), VALID_PASSWORD)
+  })
+
+  it('import flow: stays disabled without a password, passes it to importWallet', async () => {
+    const importWallet = vi.fn(ASYNC_NOOP)
+    useWalletMock.mockReturnValue(
+      baseWallet({ hasWallet: false, address: null, importWallet }),
+    )
+    renderPay({ to: RECIPIENT })
+
+    fireEvent.click(screen.getByRole('button', { name: /Import Existing/i }))
+    fireEvent.change(screen.getByPlaceholderText(/recovery phrase/i), {
+      target: { value: createMnemonic12() },
+    })
+
+    const importBtn = screen.getByRole('button', {
+      name: /Import & Continue/i,
+    }) as HTMLButtonElement
+    // A valid seed alone must NOT enable the button.
+    expect(importBtn.disabled).toBe(true)
+
+    fireEvent.change(screen.getByPlaceholderText(/^Password \(min/i), {
+      target: { value: VALID_PASSWORD },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/Confirm password/i), {
+      target: { value: VALID_PASSWORD },
+    })
+    expect(importBtn.disabled).toBe(false)
+
+    fireEvent.click(importBtn)
+    await waitFor(() => expect(importWallet).toHaveBeenCalledTimes(1))
+    expect(importWallet).toHaveBeenCalledWith(expect.any(String), VALID_PASSWORD)
   })
 })

--- a/web/packages/web-wallet/src/pages/pay.tsx
+++ b/web/packages/web-wallet/src/pages/pay.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react'
 import { useWallet } from '../contexts/wallet'
 import { useNetwork } from '../contexts/network'
+import { PasswordFields, isPasswordValid } from '../components/PasswordSettingsModal'
 import { parsePaymentRequestFragment, type PaymentRequest } from '../lib/payment-request'
 
 /**
@@ -530,6 +531,13 @@ function WalletGate({
   const [confirmed, setConfirmed] = useState(false)
   // import
   const [seedPhrase, setSeedPhrase] = useState('')
+  // create + import — SECURITY (#672): link-flow wallets follow the same #475
+  // policy as the main setup: a password is REQUIRED and the seed is encrypted
+  // at rest. Without this, a visitor whose first touch is a pay/claim link
+  // ends up with a plaintext seed in localStorage.
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmNewPassword, setConfirmNewPassword] = useState('')
+  const newPasswordValid = isPasswordValid(newPassword, confirmNewPassword)
 
   const handleUnlock = async () => {
     setBusy(true)
@@ -544,10 +552,11 @@ function WalletGate({
   }
 
   const handleCreate = async () => {
+    if (!newPasswordValid) return
     setBusy(true)
     setError(null)
     try {
-      await onCreate(newMnemonic)
+      await onCreate(newMnemonic, newPassword)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not create wallet.')
     } finally {
@@ -556,10 +565,11 @@ function WalletGate({
   }
 
   const handleImport = async () => {
+    if (!newPasswordValid) return
     setBusy(true)
     setError(null)
     try {
-      await onImport(seedPhrase)
+      await onImport(seedPhrase, newPassword)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Import failed.')
     } finally {
@@ -660,9 +670,20 @@ function WalletGate({
               I&apos;ve written down my recovery phrase and stored it safely.
             </span>
           </label>
+          <div>
+            <p className="text-xs text-ghost mb-2">
+              Set a password — your wallet is encrypted on this device with it.
+            </p>
+            <PasswordFields
+              password={newPassword}
+              confirmPassword={confirmNewPassword}
+              onPassword={setNewPassword}
+              onConfirmPassword={setConfirmNewPassword}
+            />
+          </div>
           <Button
             onClick={handleCreate}
-            disabled={!revealed || !confirmed || busy}
+            disabled={!revealed || !confirmed || !newPasswordValid || busy}
             className="w-full justify-center"
           >
             {busy ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}
@@ -683,9 +704,20 @@ function WalletGate({
             rows={3}
             className="w-full p-3 rounded-lg bg-abyss border border-steel font-mono text-xs leading-relaxed resize-none focus:outline-none focus:ring-2 focus:ring-pulse/50 focus:border-pulse placeholder:text-ghost/50"
           />
+          <div>
+            <p className="text-xs text-ghost mb-2">
+              Set a password — your wallet is encrypted on this device with it.
+            </p>
+            <PasswordFields
+              password={newPassword}
+              confirmPassword={confirmNewPassword}
+              onPassword={setNewPassword}
+              onConfirmPassword={setConfirmNewPassword}
+            />
+          </div>
           <Button
             onClick={handleImport}
-            disabled={(wordCount !== 12 && wordCount !== 24) || busy}
+            disabled={(wordCount !== 12 && wordCount !== 24) || !newPasswordValid || busy}
             className="w-full justify-center"
           >
             {busy ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}


### PR DESCRIPTION
## Summary

Closes #672 (loom:urgent). Both link-entry funnels bypassed the #475 required-password policy and persisted the raw 12-word seed to `localStorage` in **plaintext** — for exactly the users whose first touch of Botho is a shared pay/claim link.

- **`/pay` → `WalletGate`**: both create and import modes now render the shared `PasswordFields` (same #475 policy as `WalletSetup`: min 8 chars, confirm field, strength hint). The Create/Import buttons stay disabled until the password is valid, and the password is plumbed through to `createWallet`/`importWallet` (which already forward it to `saveWallet`).
- **`/claim` → "Create one"**: the in-flow wallet panel now includes the password fields; the Claim button stays disabled until the password is valid, and `handleSweep` persists with `saveWallet(mnemonic, password)` so the stored seed is an encrypted vault blob. Copy updated to say the wallet is saved *encrypted*.

No changes to the wallet context or `saveWallet` were needed — both already accept and honor a password; the bug was purely the two call sites omitting it.

## Acceptance criteria (from #672)

- [x] `/pay` WalletGate create persists an encrypted seed — password required, plumbed to context
- [x] `/pay` WalletGate import — same
- [x] `/claim` "Create one" wallet persisted encrypted — `saveWallet(mnemonic, password)`
- [x] Tests asserting the encrypted-at-rest outcome for each of the three flows

## Tests

- `pay.test.tsx` (+2): create and import flows — buttons blocked without a valid password (including too-short), password reaches the context call.
- `claim.test.tsx` (+1): full flow with the REAL `saveWallet` (PBKDF2 600k) — asserts `botho-wallet-encrypted === 'true'` and the stored value is one opaque token, never a 12-word phrase.
- Full web suite: 48 files / 560 tests pass; `pnpm -r typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)