### PR TITLE
fix(network): relay RPC-submitted transactions to peers regardless of minting state

### DIFF
--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -438,6 +438,15 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // working. `None` until the first evaluation (never fabricated).
     let quorum_gate_status: Arc<RwLock<Option<QuorumGateSnapshot>>> = Arc::new(RwLock::new(None));
 
+    // Relay channel from the RPC layer into this event loop (#674): every
+    // mempool-accepted `tx_submit` is gossiped to peers and registered in the
+    // SCP tx cache immediately, independent of local minting state. Before
+    // this, mempool contents were only announced from inside the
+    // active-minting path, so a non-minting ingress node (the web-wallet
+    // default) was a black hole for submitted transactions.
+    let (tx_relay_tx, mut tx_relay_rx) =
+        tokio::sync::mpsc::unbounded_channel::<crate::transaction::Transaction>();
+
     let mut rpc_state = RpcState::from_shared(
         node.shared_ledger(),
         node.shared_mempool(),
@@ -463,7 +472,9 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     .with_peers(peers_snapshot.clone())
     // Live traffic / connection-direction counters for `network_getInfo`
     // (#542). Shares the same handle the network event loop increments.
-    .with_network_stats(discovery.stats());
+    .with_network_stats(discovery.stats())
+    // RPC -> event-loop tx relay (#674), consumed in the select! loop below.
+    .with_tx_relay(tx_relay_tx);
 
     // Initialize wallet for RPC (balance checking, faucet, etc.)
     if let Some(mnemonic) = config.mnemonic() {
@@ -713,6 +724,12 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
     // node that lost its only connection right after startup can rejoin
     // (issue #409). Cheap and a no-op once peers are connected.
     let mut reconnect_interval = tokio::time::interval(Duration::from_secs(5));
+    // Periodically re-announce mempool contents to peers, independent of
+    // minting state (#674). Catches txs that were submitted while we had no
+    // peers (or while peers were offline) and would otherwise never propagate
+    // from a non-minting node. Gossipsub message ids are source+seqno, so a
+    // re-publish is a fresh message to peers whose mempools then dedupe it.
+    let mut mempool_rebroadcast_interval = tokio::time::interval(Duration::from_secs(30));
 
     // Track pending compact blocks awaiting missing transactions
     // Key: block hash, Value: (compact block, missing indices)
@@ -1702,6 +1719,53 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
                                 metrics_updater.set_minting_active(false);
                                 ws_broadcaster.minting_status(false, 0.0, 0);
                             }
+                        }
+                    }
+                }
+            }
+
+            // RPC-submitted transaction relay (#674): gossip every
+            // mempool-accepted `tx_submit` to peers and seed the SCP tx cache
+            // NOW, regardless of whether this node is minting. Mirrors the
+            // NewTransaction gossip-receive path: mempool acceptance (in the
+            // RPC handler) was the validity gate, and `register_transfer_tx`
+            // is cache-only — a non-minting node does not start proposing
+            // consensus values, it just lets peers' SCP messages referencing
+            // the tx validate (#449).
+            Some(tx) = tx_relay_rx.recv() => {
+                let tx_hash = tx.hash();
+                let tx_bytes = bincode::serialize(&tx)
+                    .expect("Failed to serialize transaction");
+                if let Err(e) =
+                    NetworkDiscovery::broadcast_transaction(&mut swarm, discovery.stats_ref(), &tx)
+                {
+                    // No peers yet is normal at startup; the rebroadcast tick
+                    // below retries until the tx propagates.
+                    debug!("Failed to broadcast RPC-submitted tx: {}", e);
+                } else {
+                    info!(
+                        "Relayed RPC-submitted tx {} to network",
+                        hex::encode(&tx_hash[0..8])
+                    );
+                }
+                consensus.register_transfer_tx(tx_hash, tx_bytes);
+            }
+
+            // Periodic mempool re-announce (#674): retries propagation for
+            // txs that were submitted while this node had no (or stale) peer
+            // connections. Peers dedupe via their own mempool acceptance, so
+            // a re-publish of an already-known tx is a no-op for them.
+            _ = mempool_rebroadcast_interval.tick() => {
+                let pending = node.get_pending_transactions(32);
+                if !pending.is_empty() && discovery.peer_count() > 0 {
+                    debug!("Re-announcing {} mempool tx(s) to peers", pending.len());
+                    for tx in &pending {
+                        if let Err(e) = NetworkDiscovery::broadcast_transaction(
+                            &mut swarm,
+                            discovery.stats_ref(),
+                            tx,
+                        ) {
+                            debug!("Failed to re-announce mempool tx: {}", e);
                         }
                     }
                 }

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -277,6 +277,16 @@ pub struct RpcState {
     /// that never start the network loop, in which case those fields fall back
     /// to `0`.
     pub network_stats: Option<Arc<NetworkStats>>,
+    /// Relay channel from the RPC layer into the network event loop (#674).
+    /// `handle_submit_tx` pushes every mempool-accepted transaction here so
+    /// `commands::run` can gossip it to peers and register it in the SCP tx
+    /// cache immediately — independent of local minting state. Without this, a
+    /// non-minting node is a black hole for RPC-submitted transactions: they
+    /// sit in the local mempool and are only ever announced from inside the
+    /// active-minting code path. `None` in tests / setups without a network
+    /// loop, in which case submission remains mempool-local (previous
+    /// behavior).
+    pub tx_relay: Option<tokio::sync::mpsc::UnboundedSender<crate::transaction::Transaction>>,
 }
 
 impl RpcState {
@@ -315,6 +325,7 @@ impl RpcState {
             quorum_gate_status: None,
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
+            tx_relay: None,
         }
     }
 
@@ -357,6 +368,7 @@ impl RpcState {
             quorum_gate_status: None,
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
+            tx_relay: None,
         }
     }
 
@@ -397,6 +409,7 @@ impl RpcState {
             quorum_gate_status: None,
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
+            tx_relay: None,
         }
     }
 
@@ -523,6 +536,15 @@ impl RpcState {
     /// [`NetworkStats`] handle the network event loop increments.
     pub fn with_network_stats(mut self, network_stats: Arc<NetworkStats>) -> Self {
         self.network_stats = Some(network_stats);
+        self
+    }
+
+    /// Wire in the tx-relay channel into the network event loop (#674).
+    pub fn with_tx_relay(
+        mut self,
+        sender: tokio::sync::mpsc::UnboundedSender<crate::transaction::Transaction>,
+    ) -> Self {
+        self.tx_relay = Some(sender);
         self
     }
 }
@@ -1772,13 +1794,33 @@ async fn handle_submit_tx(id: Value, params: &Value, state: &RpcState) -> JsonRp
     let ledger = read_lock!(state.ledger, id.clone());
     let mut mempool = write_lock!(state.mempool, id.clone());
 
+    // Keep a copy for relay: `add_tx` consumes the tx, and the network event
+    // loop needs the full transaction to gossip it to peers (#674).
+    let relay_tx = tx.clone();
+
     match mempool.add_tx(tx, &ledger) {
-        Ok(hash) => JsonRpcResponse::success(
-            id,
-            json!({
-                "txHash": hex::encode(hash),
-            }),
-        ),
+        Ok(hash) => {
+            // Hand the accepted tx to the network event loop for immediate
+            // gossip + SCP tx-cache registration (#674). Mempool acceptance
+            // above is the validity gate (full structural + UTXO + signature
+            // checks), so only validated txs are relayed. Without this, a
+            // non-minting node never announces RPC-submitted txs — they sit in
+            // the local mempool forever because the steady-state broadcast
+            // only ran inside the active-minting path.
+            if let Some(relay) = &state.tx_relay {
+                if relay.send(relay_tx).is_err() {
+                    // Event loop gone (shutdown); the tx is still in the local
+                    // mempool, matching pre-#674 behavior.
+                    warn!("tx relay channel closed; submitted tx not gossiped");
+                }
+            }
+            JsonRpcResponse::success(
+                id,
+                json!({
+                    "txHash": hex::encode(hash),
+                }),
+            )
+        }
         Err(e) => JsonRpcResponse::error(id, -32000, &format!("Failed to add transaction: {}", e)),
     }
 }

--- a/botho/tests/tx_lifecycle_integration.rs
+++ b/botho/tests/tx_lifecycle_integration.rs
@@ -1267,3 +1267,120 @@ fn test_mempool_transactions_sorted_by_fee() {
     // Lowest fee should be last (1x base)
     assert_eq!(sorted_txs[2].fee, base_fee);
 }
+
+// ============================================================================
+// RPC tx_submit relay (#674)
+// ============================================================================
+
+/// #674: a mempool-accepted `tx_submit` must be handed to the network relay
+/// channel so the event loop gossips it to peers immediately — independent of
+/// local minting state. Before the fix, RPC-submitted txs sat in the receiving
+/// node's mempool forever on a non-minting node (the web-wallet's default
+/// ingress), so send / claim-link / pay flows silently never confirmed.
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn test_rpc_tx_submit_relays_accepted_tx() {
+    // -- Fund a wallet on a real ledger (same recipe as the tests above) --
+    let (_temp_dir, ledger) = create_test_ledger();
+    let mempool = Mempool::new();
+    let miner_wallet = create_wallet(1);
+    let recipient_wallet = create_wallet(2);
+    mine_decoy_blocks(&ledger, &miner_wallet);
+
+    let utxos = scan_wallet_utxos(&ledger, &miner_wallet);
+    let (sender_utxo, subaddr_idx) = &utxos[0];
+    let send_amount = 10 * PICOCREDITS_PER_CREDIT;
+    let fee = calculate_fee_for_outputs(&mempool, sender_utxo.output.amount);
+    let state = ledger.get_chain_state().unwrap();
+    let tx = create_signed_transaction(
+        &miner_wallet,
+        sender_utxo,
+        *subaddr_idx,
+        &recipient_wallet.public_address(),
+        send_amount,
+        fee,
+        state.height,
+        &ledger,
+    );
+    let expected_hash = tx.hash();
+    let tx_hex = hex::encode(bincode::serialize(&tx).expect("serialize tx"));
+
+    // -- RPC server whose state carries the #674 relay channel --
+    let (relay_sender, mut relay_rx) = tokio::sync::mpsc::unbounded_channel();
+    let rpc_state = std::sync::Arc::new(
+        botho::rpc::RpcState::new(
+            ledger,
+            mempool,
+            bth_transaction_types::constants::Network::Testnet,
+            None,
+            None,
+            vec!["*".to_string()],
+            std::sync::Arc::new(botho::rpc::WsBroadcaster::new(16)),
+        )
+        .with_tx_relay(relay_sender),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("local addr");
+    drop(listener);
+    let state_clone = rpc_state.clone();
+    tokio::spawn(async move {
+        let _ = botho::rpc::start_rpc_server(addr, state_clone).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let client = reqwest::Client::new();
+    let submit = |tx_hex: String| {
+        let client = client.clone();
+        async move {
+            client
+                .post(format!("http://{}", addr))
+                .json(&serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tx_submit",
+                    "params": { "tx_hex": tx_hex },
+                }))
+                .send()
+                .await
+                .expect("send")
+                .json::<serde_json::Value>()
+                .await
+                .expect("parse")
+        }
+    };
+
+    // A valid, mempool-accepted submission is pushed onto the relay channel.
+    let resp = submit(tx_hex.clone()).await;
+    assert!(
+        resp["error"].is_null(),
+        "tx_submit failed: {:?}",
+        resp["error"]
+    );
+    assert_eq!(
+        resp["result"]["txHash"].as_str().expect("txHash"),
+        hex::encode(expected_hash)
+    );
+    let relayed = relay_rx
+        .try_recv()
+        .expect("accepted tx was not pushed to the relay channel (#674)");
+    assert_eq!(
+        relayed.hash(),
+        expected_hash,
+        "relay channel must carry the exact accepted tx"
+    );
+
+    // A REJECTED submission (duplicate spend of the same key images) must not
+    // be relayed: mempool acceptance is the relay's validity gate.
+    let resp2 = submit(tx_hex).await;
+    assert!(
+        resp2["error"].is_object(),
+        "duplicate submit should be rejected by the mempool"
+    );
+    assert!(
+        relay_rx.try_recv().is_err(),
+        "rejected tx must NOT reach the relay channel"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #674 (priority:high). `tx_submit` added transactions to the receiving node's local mempool and stopped — mempool contents were only gossiped from inside the active-minting code path. On the live testnet (minting balance-paused, faucet mints on demand per #386), any transaction submitted through a non-minting ingress — the web wallet's default — never reached the minting node and never confirmed: send, claim-link, and pay flows silently stalled.

## Design

Mirrors the existing `NewTransaction` gossip-receive path rather than inventing a new one:

- **`RpcState.tx_relay`** (optional mpsc sender): `handle_submit_tx` pushes every mempool-**accepted** transaction onto it. Mempool acceptance is the validity gate (full structural + UTXO + signature checks), so only validated txs are relayed; rejected submissions never reach the channel.
- **Event-loop consumer** in `commands::run`: gossips the tx on `TRANSACTIONS_TOPIC` and registers it in the SCP tx cache via `register_transfer_tx` — deliberately **cache-only**, exactly like the gossip-receive path (#449). A non-minting node does NOT start proposing consensus values; it just lets peers' SCP messages referencing the tx validate. Nodes that mint keep submitting mempool txs to consensus from the existing minting branch, unchanged.
- **30s mempool re-announce tick**, independent of minting state: retries propagation for txs submitted while the node had no (or stale) peer connections. Gossipsub message ids are source+seqno (not content hash), so a re-publish is a fresh message; peers dedupe via their own mempool acceptance, and the receive handler never re-publishes, so there is no amplification loop.

## Tests

- New integration test (`tx_lifecycle_integration.rs`): a valid CLSAG tx submitted over real HTTP RPC returns success AND lands on the relay channel with the same hash; a rejected duplicate submission does not touch the channel. Runs the full real pipeline (funded ledger → signed tx → HTTP `tx_submit` → mempool validation → relay).
- `tx_lifecycle_integration` 14/14, `rpc_integration` 39/39 pass.

## Acceptance criteria (from #674)

- [x] Accepted `tx_submit` is announced to peers at accept time (relay channel + gossip broadcast, minting-independent)
- [x] Periodic mempool rebroadcast independent of minting
- [ ] Live-testnet verification (claim link funded via seed ingress becomes claimable; stuck txs drain) — requires deploy, tracked as the deploy-verification step on #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)