### PR TITLE
fix(web-wallet): WalletGate unlock-mode hydration + explicit overwrite guard on link-flow wallet create/import

### DIFF
--- a/web/packages/web-wallet/src/pages/claim.test.tsx
+++ b/web/packages/web-wallet/src/pages/claim.test.tsx
@@ -259,3 +259,70 @@ describe('ClaimPage in-flow wallet create persists ENCRYPTED (#672)', () => {
     expect(stored!.trim().split(/\s+/).length).toBe(1)
   }, 30000)
 })
+
+/**
+ * Overwrite guard for the in-flow "Create one" wallet (#673): claiming with a
+ * freshly created wallet on a device that ALREADY stores a wallet replaces the
+ * stored seed (funds loss). The claim must stay blocked until the recipient
+ * explicitly acknowledges the replacement, which names the existing address.
+ */
+describe('ClaimPage in-flow create requires overwrite acknowledgement (#673)', () => {
+  const VALID_PASSWORD = 'correct-horse-battery'
+
+  beforeEach(() => {
+    cleanup()
+    scanEphemeralMock.mockReset()
+    scanEphemeralMock.mockResolvedValue({
+      gross: 5_000_000_000_000n,
+      fee: 100_000_000n,
+      net: 4_900_000_000_000n,
+    })
+    sweepEphemeralMock.mockReset()
+    for (const spy of Object.values(adapterSpies)) spy.mockClear()
+    window.history.replaceState(null, '', '/claim')
+    localStorageMock.clear()
+  })
+
+  afterEach(() => {
+    window.location.hash = ''
+    localStorageMock.clear()
+  })
+
+  it('blocks the claim until the stored-wallet replacement is acknowledged', async () => {
+    // A wallet already sits in storage BEFORE the page loads.
+    localStorageMock.setItem('botho-wallet-mnemonic', 'opaque-vault-blob')
+    localStorageMock.setItem('botho-wallet-address', 'tbotho://1/ExistingAddr12345678')
+    localStorageMock.setItem('botho-wallet-encrypted', 'true')
+
+    setClaimHash()
+    renderClaim()
+
+    fireEvent.click(await screen.findByRole('button', { name: /reveal/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /create one/i }))
+
+    // Password valid, destination pre-filled — only the overwrite ack missing.
+    fireEvent.change(screen.getByPlaceholderText(/^Password \(min/i), {
+      target: { value: VALID_PASSWORD },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/Confirm password/i), {
+      target: { value: VALID_PASSWORD },
+    })
+
+    const claimBtn = screen.getByRole('button', { name: /^Claim / }) as HTMLButtonElement
+    expect(screen.getByText(/already has a wallet/i).textContent).toContain(
+      'tbotho://1/E',
+    )
+    expect(claimBtn.disabled).toBe(true)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /already has a wallet/i }))
+    await waitFor(() => expect(claimBtn.disabled).toBe(false))
+  })
+
+  it('shows no overwrite warning when the device has no stored wallet', async () => {
+    setClaimHash()
+    renderClaim()
+    fireEvent.click(await screen.findByRole('button', { name: /reveal/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /create one/i }))
+    expect(screen.queryByText(/already has a wallet/i)).toBeNull()
+  })
+})

--- a/web/packages/web-wallet/src/pages/claim.tsx
+++ b/web/packages/web-wallet/src/pages/claim.tsx
@@ -6,8 +6,10 @@ import {
   isValidAddress,
   formatBTH,
   createMnemonic12,
+  getWalletInfo,
   saveWallet,
   deriveAddress,
+  shortenAddress,
   type ClaimLinkSecret,
 } from '@botho/core'
 import {
@@ -84,6 +86,13 @@ export function ClaimPage() {
   const [confirmNewWalletPassword, setConfirmNewWalletPassword] = useState('')
   const newWalletPasswordValid = isPasswordValid(newWalletPassword, confirmNewWalletPassword)
   const persistingNewWallet = showNewWallet && createdMnemonic !== null
+  // Overwrite guard (#673): persisting the in-flow wallet would silently
+  // replace a wallet already stored on this device (funds loss if it was not
+  // backed up). Require an explicit acknowledgement naming the existing
+  // address before the claim can proceed with the new wallet.
+  const [existingWallet] = useState(() => getWalletInfo())
+  const [overwriteAck, setOverwriteAck] = useState(false)
+  const overwriteBlocked = persistingNewWallet && existingWallet.exists && !overwriteAck
 
   // Track whether we've already begun a sweep so a late re-scan can't downgrade
   // the state out from under the user.
@@ -179,6 +188,10 @@ export function ClaimPage() {
     }
     if (persistingNewWallet && !newWalletPasswordValid) {
       setError('Set a password for your new wallet before claiming.')
+      return
+    }
+    if (overwriteBlocked) {
+      setError('Confirm replacing the wallet already stored on this device before claiming.')
       return
     }
     setError(null)
@@ -343,6 +356,28 @@ export function ClaimPage() {
                         onConfirmPassword={setConfirmNewWalletPassword}
                       />
                     </div>
+                    {existingWallet.exists && (
+                      <label className="flex items-start gap-2 cursor-pointer p-3 rounded-lg bg-danger/10 border border-danger/20">
+                        <input
+                          type="checkbox"
+                          checked={overwriteAck}
+                          onChange={(e) => setOverwriteAck(e.target.checked)}
+                          className="mt-0.5 w-4 h-4 accent-pulse shrink-0"
+                        />
+                        <span className="text-xs text-danger">
+                          <strong className="font-semibold">
+                            This device already has a wallet
+                            {existingWallet.address
+                              ? ` (${shortenAddress(existingWallet.address)})`
+                              : ''}
+                            .
+                          </strong>{' '}
+                          Claiming with this NEW wallet replaces the stored one and
+                          deletes its seed — any funds in it are lost unless you
+                          have its recovery phrase backed up.
+                        </span>
+                      </label>
+                    )}
                   </div>
                 )}
 
@@ -358,7 +393,8 @@ export function ClaimPage() {
                   disabled={
                     state === 'sweeping' ||
                     !destination.trim() ||
-                    (persistingNewWallet && !newWalletPasswordValid)
+                    (persistingNewWallet && !newWalletPasswordValid) ||
+                    overwriteBlocked
                   }
                   className="w-full justify-center"
                 >

--- a/web/packages/web-wallet/src/pages/pay.test.tsx
+++ b/web/packages/web-wallet/src/pages/pay.test.tsx
@@ -31,6 +31,19 @@ vi.mock('../contexts/network', () => ({
 
 const ASYNC_NOOP = async () => {}
 
+// This environment's jsdom does not provide localStorage; mirror the mock used
+// by core's wallet.test.ts. WalletGate reads it via getWalletInfo (#673).
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value },
+    removeItem: (key: string) => { delete store[key] },
+    clear: () => { store = {} },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
 // Two distinct, structurally valid testnet addresses.
 const RECIPIENT = deriveAddressFromMnemonic(createMnemonic12(), 'testnet')
 const OWN = deriveAddressFromMnemonic(createMnemonic12(), 'testnet')
@@ -282,5 +295,89 @@ describe('PayPage WalletGate enforces the required-password policy (#672)', () =
     fireEvent.click(importBtn)
     await waitFor(() => expect(importWallet).toHaveBeenCalledTimes(1))
     expect(importWallet).toHaveBeenCalledWith(expect.any(String), VALID_PASSWORD)
+  })
+})
+
+/**
+ * WalletGate hydration + overwrite safety (#673).
+ *
+ * (1) On a cold `/pay` load the wallet context hydrates AFTER the gate mounts,
+ * so `mode` (initialized once) stayed 'create' even when the device holds a
+ * locked wallet — showing a fresh mnemonic with no path to unlock. (2) The
+ * create/import flows overwrote a stored wallet's seed with no warning.
+ */
+describe('PayPage WalletGate hydration + overwrite guard (#673)', () => {
+  const VALID_PASSWORD = 'correct-horse-battery'
+
+  beforeEach(() => {
+    cleanup()
+    useWalletMock.mockReset()
+    window.location.hash = ''
+    localStorageMock.clear()
+  })
+
+  it('flips to the unlock form when the context resolves to a locked wallet', () => {
+    // Pre-hydration: no wallet known yet -> gate mounts in create mode.
+    useWalletMock.mockReturnValue(
+      baseWallet({ hasWallet: false, isLocked: false, address: null }),
+    )
+    const view = renderPay({ to: RECIPIENT })
+    expect(screen.getByText(/Click to reveal/i)).toBeDefined()
+
+    // Context hydrates: this device has an encrypted (locked) wallet.
+    useWalletMock.mockReturnValue(baseWallet({ hasWallet: true, isLocked: true }))
+    view.rerender(
+      <MemoryRouter>
+        <PayPage />
+      </MemoryRouter>,
+    )
+
+    // The gate must now show the UNLOCK form, not a fresh mnemonic.
+    expect(screen.getByPlaceholderText(/Enter password/i)).toBeDefined()
+    expect(screen.queryByRole('button', { name: /Create & Continue/i })).toBeNull()
+  })
+
+  it('requires an explicit acknowledgement before creating over a stored wallet', () => {
+    // A wallet already sits in storage (context not hydrated yet — the guard
+    // must read storage directly).
+    localStorageMock.setItem('botho-wallet-mnemonic', 'opaque-vault-blob')
+    localStorageMock.setItem('botho-wallet-address', 'tbotho://1/ExistingAddr12345678')
+    localStorageMock.setItem('botho-wallet-encrypted', 'true')
+
+    const createWallet = vi.fn(ASYNC_NOOP)
+    useWalletMock.mockReturnValue(
+      baseWallet({ hasWallet: false, address: null, createWallet }),
+    )
+    renderPay({ to: RECIPIENT })
+
+    // Complete every OTHER requirement of the create flow.
+    fireEvent.click(screen.getByText(/Click to reveal/i))
+    fireEvent.click(
+      screen.getByRole('checkbox', { name: /written down my recovery phrase/i }),
+    )
+    fireEvent.change(screen.getByPlaceholderText(/^Password \(min/i), {
+      target: { value: VALID_PASSWORD },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/Confirm password/i), {
+      target: { value: VALID_PASSWORD },
+    })
+
+    // The warning names the existing address and the button stays disabled.
+    expect(screen.getByText(/already has a wallet/i).textContent).toContain(
+      'tbotho://1/E',
+    )
+    const createBtn = screen.getByRole('button', {
+      name: /Create & Continue/i,
+    }) as HTMLButtonElement
+    expect(createBtn.disabled).toBe(true)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /already has a wallet/i }))
+    expect(createBtn.disabled).toBe(false)
+  })
+
+  it('does not show the overwrite warning on a device with no stored wallet', () => {
+    useWalletMock.mockReturnValue(baseWallet({ hasWallet: false, address: null }))
+    renderPay({ to: RECIPIENT })
+    expect(screen.queryByText(/already has a wallet/i)).toBeNull()
   })
 })

--- a/web/packages/web-wallet/src/pages/pay.tsx
+++ b/web/packages/web-wallet/src/pages/pay.tsx
@@ -6,6 +6,8 @@ import {
   parseBTH,
   isValidAddress,
   createMnemonic12,
+  getWalletInfo,
+  shortenAddress,
   BTH_MULTIPLIER,
   type Contact,
 } from '@botho/core'
@@ -523,6 +525,24 @@ function WalletGate({
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // The wallet context hydrates AFTER a cold mount (#673): the gate can mount
+  // with hasWallet=false / isLocked=false and only learn "a locked wallet
+  // exists" a tick later. `mode` is initialized once, so without this sync an
+  // encrypted-wallet user opening a pay link lands on the CREATE form with no
+  // path to unlock (the mode toggle is hidden while locked).
+  useEffect(() => {
+    if (isLocked) setMode('unlock')
+  }, [isLocked])
+
+  // Overwrite guard (#673): creating/importing while a wallet is already
+  // stored on this device silently replaces its seed — funds loss if it was
+  // not backed up. Read storage directly (not context state, which may not
+  // have hydrated yet) and require an explicit acknowledgement that names
+  // the existing address.
+  const [existingWallet] = useState(() => getWalletInfo())
+  const [overwriteAck, setOverwriteAck] = useState(false)
+  const overwriteBlocked = existingWallet.exists && !overwriteAck
+
   // unlock
   const [password, setPassword] = useState('')
   // create
@@ -552,7 +572,7 @@ function WalletGate({
   }
 
   const handleCreate = async () => {
-    if (!newPasswordValid) return
+    if (!newPasswordValid || overwriteBlocked) return
     setBusy(true)
     setError(null)
     try {
@@ -565,7 +585,7 @@ function WalletGate({
   }
 
   const handleImport = async () => {
-    if (!newPasswordValid) return
+    if (!newPasswordValid || overwriteBlocked) return
     setBusy(true)
     setError(null)
     try {
@@ -681,9 +701,27 @@ function WalletGate({
               onConfirmPassword={setConfirmNewPassword}
             />
           </div>
+          {existingWallet.exists && (
+            <label className="flex items-start gap-2 cursor-pointer p-3 rounded-lg bg-danger/10 border border-danger/20">
+              <input
+                type="checkbox"
+                checked={overwriteAck}
+                onChange={(e) => setOverwriteAck(e.target.checked)}
+                className="mt-0.5 w-4 h-4 accent-pulse shrink-0"
+              />
+              <span className="text-xs text-danger">
+                <strong className="font-semibold">
+                  This device already has a wallet
+                  {existingWallet.address ? ` (${shortenAddress(existingWallet.address)})` : ''}.
+                </strong>{' '}
+                Continuing replaces it and deletes its stored seed — any funds in
+                it are lost unless you have its recovery phrase backed up.
+              </span>
+            </label>
+          )}
           <Button
             onClick={handleCreate}
-            disabled={!revealed || !confirmed || !newPasswordValid || busy}
+            disabled={!revealed || !confirmed || !newPasswordValid || overwriteBlocked || busy}
             className="w-full justify-center"
           >
             {busy ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}
@@ -715,9 +753,27 @@ function WalletGate({
               onConfirmPassword={setConfirmNewPassword}
             />
           </div>
+          {existingWallet.exists && (
+            <label className="flex items-start gap-2 cursor-pointer p-3 rounded-lg bg-danger/10 border border-danger/20">
+              <input
+                type="checkbox"
+                checked={overwriteAck}
+                onChange={(e) => setOverwriteAck(e.target.checked)}
+                className="mt-0.5 w-4 h-4 accent-pulse shrink-0"
+              />
+              <span className="text-xs text-danger">
+                <strong className="font-semibold">
+                  This device already has a wallet
+                  {existingWallet.address ? ` (${shortenAddress(existingWallet.address)})` : ''}.
+                </strong>{' '}
+                Continuing replaces it and deletes its stored seed — any funds in
+                it are lost unless you have its recovery phrase backed up.
+              </span>
+            </label>
+          )}
           <Button
             onClick={handleImport}
-            disabled={(wordCount !== 12 && wordCount !== 24) || !newPasswordValid || busy}
+            disabled={(wordCount !== 12 && wordCount !== 24) || !newPasswordValid || overwriteBlocked || busy}
             className="w-full justify-center"
           >
             {busy ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}


### PR DESCRIPTION
## Summary

Fixes #673 (priority:high). Two related `/pay` WalletGate defects that combined into a wallet-overwrite (funds-loss) hazard:

1. **Hydration race → no unlock path.** The gate's `mode` was initialized once at mount (`isLocked ? 'unlock' : 'create'`). On a cold `/pay` load the wallet context hydrates after mount, so every encrypted-wallet user opening a pay link saw the CREATE form — fresh mnemonic, "Create & Continue", and no way to reach the unlock form (the mode toggle is hidden while locked). Fixed by syncing `mode` to the live `isLocked` in an effect.
2. **Silent overwrite of the stored wallet.** `/pay` create/import and `/claim` "Create one" persisted the new seed unconditionally, replacing any stored (possibly un-backed-up) wallet. Both flows now read storage directly via `getWalletInfo()` — deliberately NOT the context state, which may not have hydrated — and stay disabled until the user ticks an explicit replacement warning that names the existing (shortened) address.

## Acceptance criteria (from #673)

- [x] Cold-loading `/pay#<request>` with an existing locked wallet lands on the unlock form (regression test simulates the hydration race via rerender)
- [x] Overwriting an existing wallet from `/pay` or `/claim` requires explicit confirmation naming the existing address
- [x] Regression test for the hydration race

## Tests

- `pay.test.tsx` (+3): hydration race flips gate to unlock; create-over-existing blocked until ack (warning names the stored address); no warning on clean devices.
- `claim.test.tsx` (+2): claim blocked until replacement ack when a wallet is stored; no warning baseline.
- Full web suite: 48 files / 565 tests pass; `pnpm -r typecheck` clean.

Stacks cleanly on #682 (the #672 password-policy fix in the same components).

🤖 Generated with [Claude Code](https://claude.com/claude-code)