### PR TITLE
fix(web-wallet): per-event transaction history — unique row ids, netted sends, honest time/status fields

### DIFF
--- a/web/packages/features/src/wallet/components/transaction-row.tsx
+++ b/web/packages/features/src/wallet/components/transaction-row.tsx
@@ -89,9 +89,11 @@ export function TransactionRow({
     tx.type === 'minting' ? 'Minting Reward' : isReceive ? 'Received' : 'Sent'
 
   // Prefer a friendly contact name for the counterparty, falling back to the
-  // raw address (truncated via CSS) and finally the tx id.
+  // raw address (truncated via CSS). No fallback to tx.id: netted history
+  // rows (#675) carry synthetic ids, and the ring hides the real
+  // counterparty anyway — an empty slot beats a meaningless token.
   const counterpartyName = tx.counterparty ? resolveName?.(tx.counterparty) : undefined
-  const counterparty = counterpartyName || tx.counterparty || tx.id
+  const counterparty = counterpartyName || tx.counterparty || ''
 
   return (
     <motion.div
@@ -115,13 +117,17 @@ export function TransactionRow({
           {showPrivacy && <PrivacyBadge cryptoType={tx.cryptoType} />}
         </div>
         <div className="mt-0.5 flex items-center gap-2">
-          <span
-            className={`max-w-[180px] truncate text-xs text-[--color-dim] ${counterpartyName ? '' : 'font-mono'}`}
-            title={tx.counterparty}
-          >
-            {counterparty}
-          </span>
-          <span className="text-[--color-muted]">•</span>
+          {counterparty && (
+            <>
+              <span
+                className={`max-w-[180px] truncate text-xs text-[--color-dim] ${counterpartyName ? '' : 'font-mono'}`}
+                title={tx.counterparty}
+              >
+                {counterparty}
+              </span>
+              <span className="text-[--color-muted]">•</span>
+            </>
+          )}
           {/* A zero timestamp means "no wall-clock time known" (client-side
               history has only block heights, #675): show the height rather
               than fabricating a relative time. */}

--- a/web/packages/features/src/wallet/components/transaction-row.tsx
+++ b/web/packages/features/src/wallet/components/transaction-row.tsx
@@ -122,11 +122,20 @@ export function TransactionRow({
             {counterparty}
           </span>
           <span className="text-[--color-muted]">•</span>
+          {/* A zero timestamp means "no wall-clock time known" (client-side
+              history has only block heights, #675): show the height rather
+              than fabricating a relative time. */}
           <span
             className="text-xs text-[--color-dim]"
-            title={formatAbsoluteTime(tx.timestamp)}
+            title={tx.timestamp > 0 ? formatAbsoluteTime(tx.timestamp) : undefined}
           >
-            {formatRelativeTime(tx.timestamp)}
+            {tx.timestamp > 0
+              ? formatRelativeTime(tx.timestamp)
+              : tx.blockHeight != null
+                ? `Block #${tx.blockHeight}`
+                : tx.status === 'pending'
+                  ? 'Pending'
+                  : '—'}
           </span>
         </div>
       </div>

--- a/web/packages/wasm-signer/src/index.ts
+++ b/web/packages/wasm-signer/src/index.ts
@@ -238,6 +238,7 @@ export function setSigner(signer: WasmSigner): void {
 export {
   buildSendTransaction,
   buildOwnedHistory,
+  netOwnedHistory,
   spendableBalance,
   spendableOwnedOutputs,
   ownedOutputTargetKeys,
@@ -245,6 +246,7 @@ export {
   type BuildSendResult,
   type ChainOutputWithMeta,
   type HistoryEntry,
+  type NettedHistoryEntry,
   type HistoryRpc,
   type KeyImageSpentStatus,
   type SendRpc,

--- a/web/packages/wasm-signer/src/send.ts
+++ b/web/packages/wasm-signer/src/send.ts
@@ -299,6 +299,131 @@ export async function buildOwnedHistory(
   return entries
 }
 
+/**
+ * A history ROW ready for UI rendering: one row per user-visible event, with a
+ * unique id, rather than one row per owned output (#675).
+ */
+export interface NettedHistoryEntry {
+  /** Stable, unique row id (safe as a React key). */
+  id: string
+  type: 'receive' | 'send'
+  /**
+   * Net amount in picocredits, always positive. For a send this is the net
+   * outflow after subtracting same-block change; for a receive it is the sum
+   * of the tx's owned outputs.
+   */
+  amount: bigint
+  /** Block height of the event; 0 for a not-yet-mined (pending) spend. */
+  blockHeight: number
+  /** 'pending' while an outflow's key image is only in mempools. */
+  status: 'pending' | 'confirmed'
+}
+
+/**
+ * Collapse per-output {@link HistoryEntry} rows into per-event rows (#675).
+ *
+ * `buildOwnedHistory` intentionally reports raw per-output facts; rendered
+ * as-is they have three defects: (a) a spent output emits a receive AND a
+ * spend entry with the SAME txHash (duplicate React keys), (b) a multi-output
+ * receive emits one row per output with the same txHash, and (c) a send shows
+ * "-<whole input>" plus "+<change>" instead of the net outflow.
+ *
+ * Netting heuristic: the ring signature hides which tx consumed an output, so
+ * a spend only knows its `spentHeight`. Owned outputs RECEIVED in that same
+ * block are treated as the spend's change and subtracted — for a single-user
+ * wallet that is exactly the change output. If the subtraction would go
+ * negative (e.g. a genuine incoming payment landed in the same block), the
+ * receives are kept as their own rows instead, so an incoming amount is never
+ * silently swallowed.
+ */
+export function netOwnedHistory(entries: HistoryEntry[]): NettedHistoryEntry[] {
+  // Group receives by creating tx: one row per receiving tx.
+  const receiveByTx = new Map<string, { amount: bigint; blockHeight: number }>()
+  // Group spends by the block they were spent in (null = still pending).
+  const spendByHeight = new Map<number, bigint>()
+  let pendingSpend = 0n
+
+  for (const e of entries) {
+    if (e.type === 'receive') {
+      const g = receiveByTx.get(e.txHash)
+      if (g) {
+        g.amount += e.amount
+      } else {
+        receiveByTx.set(e.txHash, { amount: e.amount, blockHeight: e.blockHeight })
+      }
+    } else if (e.spentHeight != null) {
+      spendByHeight.set(e.spentHeight, (spendByHeight.get(e.spentHeight) ?? 0n) + e.amount)
+    } else {
+      pendingSpend += e.amount
+    }
+  }
+
+  const rows: NettedHistoryEntry[] = []
+  const consumedAsChange = new Set<string>()
+
+  for (const [height, spentSum] of spendByHeight) {
+    // Candidate change: receives that landed in the spend's block.
+    const changeTxs: string[] = []
+    let changeSum = 0n
+    for (const [txHash, g] of receiveByTx) {
+      if (g.blockHeight === height) {
+        changeTxs.push(txHash)
+        changeSum += g.amount
+      }
+    }
+    if (changeSum <= spentSum) {
+      for (const txHash of changeTxs) consumedAsChange.add(txHash)
+      rows.push({
+        id: `send-${height}`,
+        type: 'send',
+        amount: spentSum - changeSum,
+        blockHeight: height,
+        status: 'confirmed',
+      })
+    } else {
+      // More received than spent in this block: don't guess which part is
+      // change — show the gross spend and keep the receives visible.
+      rows.push({
+        id: `send-${height}`,
+        type: 'send',
+        amount: spentSum,
+        blockHeight: height,
+        status: 'confirmed',
+      })
+    }
+  }
+
+  if (pendingSpend > 0n) {
+    // The unmined spend's change is also unmined, so nothing to net against;
+    // the row corrects itself to the net amount once the tx confirms.
+    rows.push({
+      id: 'send-pending',
+      type: 'send',
+      amount: pendingSpend,
+      blockHeight: 0,
+      status: 'pending',
+    })
+  }
+
+  for (const [txHash, g] of receiveByTx) {
+    if (consumedAsChange.has(txHash)) continue
+    rows.push({
+      id: `recv-${txHash}`,
+      type: 'receive',
+      amount: g.amount,
+      blockHeight: g.blockHeight,
+      status: 'confirmed',
+    })
+  }
+
+  // Pending first, then newest first.
+  rows.sort((a, b) => {
+    if (a.status !== b.status) return a.status === 'pending' ? -1 : 1
+    return b.blockHeight - a.blockHeight
+  })
+  return rows
+}
+
 /** Inputs to {@link buildSendTransaction}. */
 export interface BuildSendParams {
   /** Account keys derived from the wallet mnemonic. */

--- a/web/packages/wasm-signer/test/history.test.ts
+++ b/web/packages/wasm-signer/test/history.test.ts
@@ -156,3 +156,117 @@ describe('buildOwnedHistory (#459)', () => {
     expect(await buildOwnedHistory(KEYS, rpcWith(outputs))).toEqual([])
   })
 })
+
+// ============================================================================
+// netOwnedHistory (#675)
+// ============================================================================
+
+import { netOwnedHistory, type HistoryEntry } from '../src/index'
+
+/**
+ * Unit tests for the per-event netting layer (#675). `buildOwnedHistory`
+ * reports raw per-output facts; rendering them 1:1 produced duplicate React
+ * keys (receive + spend of the same output share a txHash), one row per
+ * output for multi-output receives, and "-<whole input> / +<change>" instead
+ * of the net send amount. Pure function — no signer/rpc needed.
+ */
+describe('netOwnedHistory', () => {
+  const recv = (txHash: string, amount: bigint, blockHeight: number): HistoryEntry => ({
+    txHash,
+    type: 'receive',
+    amount,
+    blockHeight,
+    spent: false,
+    spentHeight: null,
+  })
+  const spend = (
+    txHash: string,
+    amount: bigint,
+    spentHeight: number | null,
+  ): HistoryEntry => ({
+    txHash,
+    type: 'spend',
+    amount,
+    blockHeight: spentHeight ?? 0,
+    spent: true,
+    spentHeight,
+  })
+
+  it('produces unique row ids (no duplicate React keys)', () => {
+    // One output received in tx A at h=5, later spent at h=9 with change
+    // received in tx B at h=9 — the raw entries carry duplicate txHashes.
+    const rows = netOwnedHistory([
+      recv('txA', 1_000n, 5),
+      spend('txA', 1_000n, 9),
+      recv('txB', 800n, 9),
+    ])
+    const ids = rows.map((r) => r.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('nets a send against its same-block change', () => {
+    const rows = netOwnedHistory([
+      recv('txA', 1_000n, 5),
+      spend('txA', 1_000n, 9),
+      recv('txB', 800n, 9), // change
+    ])
+    const send = rows.find((r) => r.type === 'send')!
+    expect(send.amount).toBe(200n) // 1000 spent - 800 change
+    expect(send.blockHeight).toBe(9)
+    expect(send.status).toBe('confirmed')
+    // The change receive is folded into the send, the original receive stays.
+    expect(rows.filter((r) => r.type === 'receive')).toHaveLength(1)
+    expect(rows.find((r) => r.type === 'receive')!.amount).toBe(1_000n)
+  })
+
+  it('collapses a multi-output receive into one row with the summed amount', () => {
+    const rows = netOwnedHistory([recv('txM', 300n, 4), recv('txM', 700n, 4)])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].type).toBe('receive')
+    expect(rows[0].amount).toBe(1_000n)
+  })
+
+  it('keeps a same-block incoming payment visible when it exceeds the spend', () => {
+    // Spent 100 at h=9 but received 800 at h=9 (a genuine incoming payment,
+    // not change) — netting would go negative, so nothing is swallowed.
+    const rows = netOwnedHistory([
+      recv('txA', 100n, 5),
+      spend('txA', 100n, 9),
+      recv('txB', 800n, 9),
+    ])
+    const send = rows.find((r) => r.type === 'send')!
+    expect(send.amount).toBe(100n) // gross, un-netted
+    const receives = rows.filter((r) => r.type === 'receive')
+    expect(receives.map((r) => r.amount).sort()).toEqual([100n, 800n].sort())
+  })
+
+  it('surfaces an unmined spend as a single pending send row, sorted first', () => {
+    const rows = netOwnedHistory([
+      recv('txA', 1_000n, 5),
+      spend('txA', 1_000n, null), // key image only pending in mempools
+      recv('txOld', 50n, 2),
+    ])
+    expect(rows[0].type).toBe('send')
+    expect(rows[0].status).toBe('pending')
+    expect(rows[0].amount).toBe(1_000n)
+    // Confirmed rows follow, newest first.
+    expect(rows.slice(1).every((r) => r.status === 'confirmed')).toBe(true)
+  })
+
+  it('merges multi-input spends confirmed in the same block', () => {
+    const rows = netOwnedHistory([
+      recv('txA', 600n, 3),
+      recv('txB', 500n, 4),
+      spend('txA', 600n, 9),
+      spend('txB', 500n, 9),
+      recv('txC', 100n, 9), // change
+    ])
+    const sends = rows.filter((r) => r.type === 'send')
+    expect(sends).toHaveLength(1)
+    expect(sends[0].amount).toBe(1_000n) // 1100 spent - 100 change
+  })
+
+  it('returns an empty list for no entries', () => {
+    expect(netOwnedHistory([])).toEqual([])
+  })
+})

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -10,7 +10,7 @@ import {
 import { RemoteNodeAdapter, type FeeEstimate, type WsConnectionStatus } from '@botho/adapters'
 import { AddressBook, EncryptedAddressBook, ClaimLinkStore, EncryptedClaimLinks, saveWallet, loadWallet, loadWalletWithKey, getWalletInfo, deriveAddress, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet, createClaimLinkMnemonic, buildClaimLink, assertClaimLinkAmountWithinCap, VaultKey, MIN_PASSWORD_LENGTH } from '@botho/core'
 import type { Balance, Contact, NodeInfo, Transaction, ClaimLinkRecord, Timestamp } from '@botho/core'
-import { buildSendTransaction, spendableBalance, buildOwnedHistory, ownedOutputTargetKeys } from '@botho/wasm-signer'
+import { buildSendTransaction, spendableBalance, buildOwnedHistory, netOwnedHistory, ownedOutputTargetKeys } from '@botho/wasm-signer'
 import { buildAndSubmitSend, scanEphemeral, sweepEphemeral, SWEEP_FEE_RESERVE } from '../lib/claim-link-ops'
 import { type NetworkConfig, loadSelectedNetwork, loadSelectedIngress, NETWORKS, DEFAULT_NETWORK_ID, DEFAULT_INGRESS_ID, createCustomNetwork, networkForIngress, getIngressNode } from '../config/networks'
 
@@ -252,17 +252,29 @@ async function fetchHistory(
         areKeyImagesSpent: (keyImages) => adapter.areKeyImagesSpent(keyImages),
       },
     )
-    return entries.map((e) => ({
-      id: e.txHash,
-      type: e.type === 'spend' ? ('send' as const) : ('receive' as const),
+    // Collapse per-output entries into per-event rows (#675): unique ids (no
+    // duplicate React keys), sends netted against same-block change, and a
+    // real pending/confirmed status instead of a hardcoded one.
+    const chainHeight = await adapter.getBlockHeight()
+    return netOwnedHistory(entries).map((e) => ({
+      id: e.id,
+      type: e.type,
       amount: e.amount,
+      // Fee is not knowable client-side (the ring hides the consuming tx);
+      // 0n is the type's "unknown" and the row does not render it.
       fee: 0n,
       privacyLevel: 'private' as const,
       cryptoType: 'clsag' as const,
-      status: 'confirmed' as const,
-      timestamp: Date.now(),
-      blockHeight: e.blockHeight,
-      confirmations: 0,
+      status: e.status,
+      // Block timestamps are not exposed by the outputs RPC. 0 marks "no
+      // wall-clock time known": the row falls back to showing the block
+      // height instead of fabricating "just now" on every refresh (#675).
+      timestamp: 0,
+      blockHeight: e.blockHeight > 0 ? e.blockHeight : undefined,
+      confirmations:
+        e.status === 'confirmed' && e.blockHeight > 0
+          ? Math.max(0, chainHeight - e.blockHeight + 1)
+          : 0,
     }))
   } catch {
     // wasm artifact missing or scan failed: show no history rather than spam.


### PR DESCRIPTION
## Summary

Fixes #675 (priority:medium). `fetchHistory` rendered `buildOwnedHistory`'s raw per-output entries 1:1, causing all three reported defects plus two more hardcoded-observability artifacts (#541-class):

| Defect | Cause | Fix |
|---|---|---|
| Duplicate React keys | receive + spend of one output share a txHash; multi-output receives repeat theirs | stable per-event ids (`recv-<txHash>`, `send-<height>`, `send-pending`) |
| "Sent -1.00 / Received +0.7997" | input + change rendered separately | send netted against same-block change |
| Every tx "just now", forever | `timestamp: Date.now()` on each refresh | `timestamp: 0` = explicit "unknown"; row renders `Block #N` (or `Pending`) |
| Every tx spins "Confirming" forever | `confirmations: 0` hardcoded (row treats <6 conf as confirming) | real `chainHeight - blockHeight + 1` |
| Mempool-pending spends shown "confirmed" | `status` hardcoded | real `pending`/`confirmed` from the key-image scan |

## Design

New **`netOwnedHistory`** lives in `wasm-signer` next to `buildOwnedHistory` (shared with `mobile/app` per the #637 guardrail) as a **pure function** over `HistoryEntry[]` — fully unit-testable without wasm or a node.

**Netting heuristic, documented inline:** the ring signature hides which tx consumed an output, so a spend only knows its `spentHeight`. Owned outputs received in that same block are treated as change and subtracted. If the subtraction would go negative (a genuine same-block incoming payment), the function refuses to net and keeps the receives visible — an incoming amount is never silently swallowed. Fee stays `0n` (not knowable client-side; the row does not render it).

## Tests

- 7 new `netOwnedHistory` unit tests: unique ids, change netting, multi-output grouping, negative-net guard (incoming payment preserved), pending-spend sorting, multi-input same-block merge, empty input.
- Full web suite 572/572 passes; `pnpm -r typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)