### PR TITLE
test: fix two broken privacy doctests and run doctests in CI

### DIFF
--- a/.github/workflows/workspace-build.yml
+++ b/.github/workflows/workspace-build.yml
@@ -78,3 +78,9 @@ jobs:
       # required check fast and deterministic while still failing on rot (#562).
       - name: Compile-check all test targets (no run)
         run: cargo test --workspace --no-run
+
+      # Doctests are NOT compiled by `--no-run` above and no other workflow
+      # runs them, so documentation examples rotted silently (#670). They are
+      # fast (seconds) and deterministic, so run them for real.
+      - name: Run doctests
+        run: cargo test --workspace --doc

--- a/botho/src/network/privacy/capacity.rs
+++ b/botho/src/network/privacy/capacity.rs
@@ -26,7 +26,9 @@
 //! # Example
 //!
 //! ```
-//! use botho::network::privacy::capacity::{RelayCapacity, NatType, SimpleNodeStats, NodeStats};
+//! use botho::network::privacy::capacity::{
+//!     RelayCapacity, RelayCapacityExt, NatType, SimpleNodeStats,
+//! };
 //!
 //! // Create stats for a well-connected node
 //! let stats = SimpleNodeStats {

--- a/botho/src/network/privacy/selection.rs
+++ b/botho/src/network/privacy/selection.rs
@@ -23,28 +23,38 @@
 //! use botho::network::privacy::{
 //!     CircuitSelector, SelectionConfig, RelayPeerInfo, RelayCapacity, NatType,
 //! };
+//! use botho::network::privacy::capacity::{RelayCapacityExt, SimpleNodeStats};
 //! use libp2p::PeerId;
 //! use std::net::Ipv4Addr;
 //!
 //! // Create selector with default config
 //! let selector = CircuitSelector::new(SelectionConfig::default());
 //!
-//! // Create some test peers
+//! // Peers need a measured capacity that clears the config's minimum relay
+//! // score — a default (zeroed) RelayCapacity scores 0 and is never selected.
+//! let capacity = || RelayCapacity::measure(&SimpleNodeStats {
+//!     bandwidth_bps: 10_000_000,
+//!     uptime_ratio: 0.95,
+//!     nat_type: NatType::Open,
+//!     current_load: 0.2,
+//! });
+//!
+//! // Create some test peers on distinct /16 subnets
 //! let peers = vec![
 //!     RelayPeerInfo::new(
 //!         PeerId::random(),
 //!         Some(Ipv4Addr::new(10, 0, 1, 1)),
-//!         RelayCapacity::default(),
+//!         capacity(),
 //!     ),
 //!     RelayPeerInfo::new(
 //!         PeerId::random(),
 //!         Some(Ipv4Addr::new(10, 1, 1, 1)),
-//!         RelayCapacity::default(),
+//!         capacity(),
 //!     ),
 //!     RelayPeerInfo::new(
 //!         PeerId::random(),
 //!         Some(Ipv4Addr::new(10, 2, 1, 1)),
-//!         RelayCapacity::default(),
+//!         capacity(),
 //!     ),
 //! ];
 //!


### PR DESCRIPTION
## Summary

Fixes #670. Two module doctests in `botho/src/network/privacy` failed on unmodified main:

- **`capacity.rs`** — compile error: the example called `RelayCapacity::measure(&stats)` without importing the `RelayCapacityExt` extension trait that provides it. Added the import.
- **`selection.rs`** — runtime panic: peers built with `RelayCapacity::default()` score 0 and can never clear `SelectionConfig::default()`'s `min_score: 0.2`, so `select_diverse_hops` returned `NoQualifiedPeers`. The example now measures a realistic capacity (same `SimpleNodeStats` recipe as `capacity.rs`'s own example) with a comment explaining why a default capacity is never selectable.

## CI gap closed

No workflow ran doctests (`--no-run` does not even compile them), which is why these rotted silently. Added a `cargo test --workspace --doc` step to `workspace-build.yml` — verified green across the whole workspace locally (`25 passed` for botho, all other crates clean), and it's fast/deterministic so it runs for real rather than compile-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)