### PR TITLE
test: rescale cluster-factor e2e expectations to the picocredit curve and run the suite in CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -178,6 +178,11 @@ jobs:
         run: |
           cargo test --package botho --test e2e_consensus_integration -- --test-threads=1
           cargo test --package botho --test network_integration -- --test-threads=1
+          # Progressive-fee curve suite (#669): fast and deterministic, but it
+          # was in no workflow, so the #626/#627 curve recalibration silently
+          # stranded its expectations. Runs here so fee-curve changes must
+          # keep the e2e expectations current.
+          cargo test --package botho --test e2e_progressive_fees -- --test-threads=1
 
   summary:
     name: E2E Test Summary

--- a/botho/tests/e2e_progressive_fees.rs
+++ b/botho/tests/e2e_progressive_fees.rs
@@ -269,7 +269,10 @@ fn test_cluster_factor_wealthy_pay_more() {
     let factor_mid = fee_config.cluster_factor(100_000 * PICO_PER_BTH);
     let factor_max = fee_config.cluster_factor(500_000_000 * PICO_PER_BTH);
 
-    assert_eq!(factor_zero, 1000, "Zero wealth must sit on the exact 1x floor");
+    assert_eq!(
+        factor_zero, 1000,
+        "Zero wealth must sit on the exact 1x floor"
+    );
     assert_eq!(
         factor_floor_edge, 1000,
         "1 BTH is far below W_MID >> 12 and must sit on the exact 1x floor"

--- a/botho/tests/e2e_progressive_fees.rs
+++ b/botho/tests/e2e_progressive_fees.rs
@@ -218,19 +218,23 @@ fn test_cluster_factor_wealthy_pay_more() {
     let fee_config = FeeConfig::default();
     let tx_size = 4000; // ~4KB typical CLSAG transaction
 
-    // Test cluster factors at different wealth levels
+    // Wealth is measured in PICOCREDITS since the #626/#627 recalibration:
+    // the deployed log-domain curve is exactly 1x below `W_MID >> 12`
+    // (~24.4 BTH), exactly 3.5x at `W_MID_PICO` (100k BTH), and exactly 6x
+    // at or above `W_MID << 12` (~409.6M BTH). Cases span the whole curve.
+    const PICO_PER_BTH: u128 = 1_000_000_000_000;
     let test_cases = [
         (0u128, "Zero wealth"),
-        (1_000_000u128, "1M wealth"),
-        (10_000_000u128, "10M wealth (w_mid)"),
-        (50_000_000u128, "50M wealth"),
-        (100_000_000u128, "100M wealth"),
+        (PICO_PER_BTH, "1 BTH (below 1x floor edge)"),
+        (100_000 * PICO_PER_BTH, "100k BTH (w_mid)"),
+        (10_000_000 * PICO_PER_BTH, "10M BTH"),
+        (500_000_000 * PICO_PER_BTH, "500M BTH (6x ceiling)"),
     ];
 
     println!("Testing cluster factor curve:");
     println!(
-        "{:>20} | {:>12} | {:>15}",
-        "Cluster Wealth", "Factor", "Fee (nanoBTH)"
+        "{:>28} | {:>12} | {:>18}",
+        "Cluster Wealth", "Factor", "Fee (picocredits)"
     );
     println!("{:-<20}-+-{:-<12}-+-{:-<15}", "", "", "");
 
@@ -256,22 +260,27 @@ fn test_cluster_factor_wealthy_pay_more() {
         prev_fee = fee;
     }
 
-    // Verify extreme values
+    // Verify the deployed curve's exact invariants (#626 spec):
+    // exact 1x floor below `W_MID >> 12`, exact 3.5x at the midpoint
+    // (sigmoid(0) = 0.5 -> 1000 + 5000/2), exact 6x ceiling at/above
+    // `W_MID << 12`.
     let factor_zero = fee_config.cluster_factor(0);
-    let factor_max = fee_config.cluster_factor(100_000_000);
+    let factor_floor_edge = fee_config.cluster_factor(PICO_PER_BTH);
+    let factor_mid = fee_config.cluster_factor(100_000 * PICO_PER_BTH);
+    let factor_max = fee_config.cluster_factor(500_000_000 * PICO_PER_BTH);
 
-    // Zero wealth should be close to 1x (1000-2000 range due to sigmoid)
-    assert!(
-        factor_zero < 3000,
-        "Zero wealth factor should be low: {}",
-        factor_zero
+    assert_eq!(factor_zero, 1000, "Zero wealth must sit on the exact 1x floor");
+    assert_eq!(
+        factor_floor_edge, 1000,
+        "1 BTH is far below W_MID >> 12 and must sit on the exact 1x floor"
     );
-
-    // Max wealth should be close to 6x (5000-6000 range)
-    assert!(
-        factor_max >= 5000,
-        "Max wealth factor should be high: {}",
-        factor_max
+    assert_eq!(
+        factor_mid, 3500,
+        "The curve midpoint (100k BTH) must be exactly 3.5x"
+    );
+    assert_eq!(
+        factor_max, 6000,
+        "500M BTH is above W_MID << 12 and must hit the exact 6x ceiling"
     );
 
     // Ratio should be significant (at least 2x difference)


### PR DESCRIPTION
## Summary

Fixes #669. `test_cluster_factor_wealthy_pay_more` fed the curve pre-#626 raw values (`1_000_000u128`…`100_000_000u128`, labeled "10M wealth (w_mid)"). Since #627 the production curve measures wealth in **picocredits** (`W_MID_PICO` = 100k BTH = 1e17) and returns an exact 1x below `W_MID >> 12` (~24.4 BTH), so every legacy case scored 1000 and `factor_max >= 5000` could never pass. No workflow ran the suite, so the recalibration stranded it silently.

## Changes

- **Rescaled cases** span the whole deployed curve: 0, 1 BTH (floor), 100k BTH (= `W_MID_PICO`), 10M BTH, 500M BTH (ceiling).
- **Exact invariants pinned** (verified against the live curve before writing them): `1000` on the floor (0 and 1 BTH), `3500` at the midpoint (sigmoid(0)=0.5 → 1000 + 5000/2), `6000` at/above the ceiling. These are the #626 spec's exact-saturation guarantees, so `assert_eq!` is right — no fuzzy ranges.
- **Fee column relabeled** picocredits (nanoBTH is a dead unit, #639-class cleanup).
- **CI**: `e2e_progressive_fees` added to the consensus-integration job in `e2e-tests.yml` (fast + deterministic) so future curve changes must keep the suite current.

## Verification

All 9 tests in the suite pass locally (`cargo test -p botho --test e2e_progressive_fees`), ~30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)