### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,35 @@ bumps (`0.X.Y`) are backwards-compatible.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-07
+
+### Fixed
+- **Node: `tx_submit` now relays transactions to peers regardless of minting
+  state** (#674). Previously a non-minting ingress node (the web wallet's
+  default) was a black hole for RPC-submitted transactions — sends, claim
+  links, and pay flows silently never confirmed. Accepted txs are gossiped and
+  SCP-cache-registered at accept time, plus a 30s mempool re-announce tick.
+- Web wallet: `/pay` and `/claim` inline wallet create/import now enforce the
+  required-password policy — no more plaintext seeds from the link funnels
+  (#672); WalletGate lands on the unlock form for locked wallets and
+  overwriting a stored wallet requires explicit confirmation (#673).
+- Web wallet: transaction history shows per-event rows with netted send
+  amounts, real confirmations/status, and block heights instead of fabricated
+  "just now" timestamps (#675).
+- Two broken `network/privacy` doctests; doctests now run in CI (#670).
+- Stale cluster-factor e2e expectations rescaled to the picocredit curve;
+  `e2e_progressive_fees` now runs in CI (#669).
+
+### Changed
+- Release builds enable `overflow-checks` (curve25519-dalek exempted for
+  performance); attacker-influenced sums on consensus paths saturate instead
+  of silently wrapping (#663).
+
+### Security
+- `crossbeam-epoch` 0.9.18 → 0.9.20 (RUSTSEC-2026-0204); cargo-deny PR gate
+  green again (#679).
+- Cycle-7 internal audit report committed (`audits/2026-07-05-cycle7.md`).
+
 ## [0.3.0] - 2026-07-05
 
 ### Summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "botho"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "botho-desktop"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "botho-wallet",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "botho-exchange-scanner"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "botho-metrics-daemon"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "botho-mobile"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bip39",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "botho-wallet"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "bth-bridge-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "hex",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "bth-bridge-service"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bth-bridge-core",
  "chrono",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "bth-cluster-tax"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bth-transaction-types",
  "clap",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "bth-crypto-pq"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "hex",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "bth-crypto-secp256k1"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "hex",
  "hmac",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "bth-discover"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bth-common",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "bth-gossip"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bitflags 2.10.0",
  "bth-common",

--- a/botho-exchange-scanner/Cargo.toml
+++ b/botho-exchange-scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-exchange-scanner"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Exchange deposit scanner for Botho cryptocurrency"
 license = "Apache-2.0"

--- a/botho-wallet/Cargo.toml
+++ b/botho-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-wallet"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Standalone thin wallet client for Botho cryptocurrency"
 license = "Apache-2.0"

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A privacy-preserving mined cryptocurrency"
 license = "GPL-3.0"

--- a/bridge/core/Cargo.toml
+++ b/bridge/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-bridge-core"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Botho"]
 edition = "2021"
 description = "Core types and logic for BTH bridge"

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-bridge-service"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Botho"]
 edition = "2021"
 description = "BTH bridge service for Ethereum and Solana"

--- a/cluster-tax/Cargo.toml
+++ b/cluster-tax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-cluster-tax"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = { workspace = true }

--- a/contracts/ethereum/package.json
+++ b/contracts/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wbth-ethereum",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "description": "Wrapped BTH ERC-20 token for Ethereum",
   "scripts": {
     "compile": "hardhat compile",

--- a/crypto/pq/Cargo.toml
+++ b/crypto/pq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-crypto-pq"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/secp256k1/Cargo.toml
+++ b/crypto/secp256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-crypto-secp256k1"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Botho"]
 edition = "2021"
 description = "Secp256k1 key support for Ethereum compatibility"

--- a/discover/Cargo.toml
+++ b/discover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-discover"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-gossip"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/infra/faucet/metrics-daemon/Cargo.toml
+++ b/infra/faucet/metrics-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-metrics-daemon"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Historical metrics collection daemon for Botho faucet"
 license = "MIT"

--- a/mobile/app/package.json
+++ b/mobile/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botho-mobile",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Botho Mobile Wallet",
   "main": "expo-router/entry",
   "scripts": {

--- a/mobile/rust-bridge/Cargo.toml
+++ b/mobile/rust-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-mobile"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Mobile FFI bindings for Botho wallet"
 license = "Apache-2.0"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botho-web",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @botho/web-wallet dev",

--- a/web/packages/desktop/src-tauri/Cargo.toml
+++ b/web/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-desktop"
-version = "0.3.0"
+version = "0.3.1"
 description = "Botho Desktop Wallet"
 authors = ["Botho"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Version bump 0.3.0 → 0.3.1 + changelog for the testnet deploy of today's merged work. The deploy exists to verify #674's tx-relay fix live (the current testnet build predates it; seed's mempool still holds the two stuck txs from the investigation).

- All version-bearing files bumped via `scripts/version.sh set 0.3.1` (`check` reports all in sync); this also fixes `contracts/ethereum/package.json`, which had drifted at 0.2.0.
- Changelog promotes today's changes: #674 relay, #663 overflow-checks, #672/#673/#675 wallet fixes, #670/#669 test debt, #679 RUSTSEC bump, cycle-7 audit.

After merge: tag `v0.3.1` on main → `release.yml` builds the linux-aarch64 artifacts → `deploy-botho.sh` to the testnet nodes → live relay verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)