### PR TITLE
test(e2e): don't count CSP-violation noise as wasm console errors in live-smoke

### DIFF
--- a/web/e2e/tests/live/smoke.spec.ts
+++ b/web/e2e/tests/live/smoke.spec.ts
@@ -67,7 +67,10 @@ test.describe('Live smoke @ wallet.botho.io', () => {
     const wasmErrors: string[] = []
     const failedWasm: string[] = []
     page.on('console', (msg) => {
-      if (msg.type() === 'error' && /wasm|bth_wasm_signer|\/pkg\//i.test(msg.text())) {
+      // Match the signer artifact specifically — a bare /wasm/ also matches
+      // "wasm-unsafe-eval" inside unrelated CSP-violation messages (e.g. the
+      // Cloudflare analytics beacon being blocked by our own script-src).
+      if (msg.type() === 'error' && /bth_wasm_signer|\/pkg\/|\.wasm\b/i.test(msg.text())) {
         wasmErrors.push(msg.text())
       }
     })


### PR DESCRIPTION
## Summary

Follow-up to #689 found during the deployed-site acceptance run for #676: the wasm console-error filter matched the bare word "wasm", which also appears in `wasm-unsafe-eval` inside CSP-violation messages — the Cloudflare analytics beacon being blocked by the wallet's own `script-src` produced exactly that, failing the deploy-404 guard as a false positive. The request-level assertion (no failed `/pkg/` fetches) was already green.

Filter now matches the signer artifact specifically (`bth_wasm_signer`, `/pkg/`, `.wasm`).

## Verification

`BOTHO_LIVE=1` against the deployed **wallet.botho.io** (fresh v0.3.1-era bundle): **7/7 passed** — completing the #676 acceptance criterion "passes against the deployed wallet".

🤖 Generated with [Claude Code](https://claude.com/claude-code)