### PR TITLE
feat(web-wallet): add eu/ap regional seeds to the ingress selector (TLS-first, #636)

### DIFF
--- a/infra/seed/regional-rpc-nginx.conf.tmpl
+++ b/infra/seed/regional-rpc-nginx.conf.tmpl
@@ -1,0 +1,116 @@
+# Botho regional seed RPC ingress — TLS termination for the web wallet (#636).
+# Adapted from infra/seed/seed-nginx.conf: RPC proxy + WebSocket only, no
+# static site (regional seeds are relay-only; no status page deployed).
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name __HOST__;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name __HOST__;
+
+    ssl_certificate /etc/letsencrypt/live/__HOST__/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/__HOST__/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # WebSocket proxy for RPC subscriptions (external /rpc/ws -> node /ws)
+    location = /rpc/ws {
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Content-Type, Upgrade, Connection' always;
+            add_header 'Access-Control-Max-Age' 86400 always;
+            add_header 'Content-Length' 0;
+            add_header 'Content-Type' 'text/plain';
+            return 204;
+        }
+
+        proxy_pass http://127.0.0.1:17101/ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_hide_header 'Access-Control-Allow-Origin';
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 3600s;
+        proxy_read_timeout 3600s;
+        add_header 'Access-Control-Allow-Origin' '*' always;
+    }
+
+    location /rpc {
+        limit_except POST OPTIONS {
+            deny all;
+        }
+
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Content-Type' always;
+            add_header 'Access-Control-Max-Age' 86400 always;
+            add_header 'Content-Length' 0;
+            add_header 'Content-Type' 'text/plain';
+            return 204;
+        }
+
+        proxy_pass http://127.0.0.1:17101;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # The node echoes the request Origin in its own CORS headers; nginx
+        # adds a wildcard below. Both surviving = duplicate
+        # Access-Control-Allow-Origin values = browser rejects the response.
+        proxy_hide_header 'Access-Control-Allow-Origin';
+        proxy_hide_header 'Access-Control-Allow-Methods';
+        proxy_hide_header 'Access-Control-Allow-Headers';
+        proxy_hide_header 'Vary';
+
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Content-Type' always;
+        client_max_body_size 64k;
+    }
+
+    location /health {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "OK";
+    }
+
+    location ~ /\. {
+        deny all;
+    }
+}

--- a/web/packages/web-wallet/src/config/networks.ts
+++ b/web/packages/web-wallet/src/config/networks.ts
@@ -50,12 +50,12 @@ function getEnvFaucetEndpoint(): string | undefined {
 }
 
 /**
- * The live testnet SCP nodes the user can select as their trusted ingress.
+ * The live testnet nodes the user can select as their trusted ingress.
  *
- * Each is a real validator/faucet node with CORS enabled for browser access.
- * `seed2` is a second validator — kept in the list so the picker always offers
- * three SCP ingress options; its health check surfaces reachability so users
- * can see when it is down (e.g. no public DNS/TLS) before selecting it.
+ * Each is a real node with TLS + CORS enabled for browser access: three US
+ * validators (seed/seed2/faucet) and two regional relay seeds (eu/ap, #613).
+ * Health checks surface reachability so users can see when a node is down
+ * before selecting it.
  */
 export const INGRESS_NODES: IngressNode[] = [
   {
@@ -78,6 +78,23 @@ export const INGRESS_NODES: IngressNode[] = [
     role: 'SCP validator + faucet',
     rpcEndpoint: 'https://faucet.botho.io/rpc',
     servesFaucet: true,
+  },
+  // Regional relay seeds (#613), TLS-terminated on-box via nginx + Let's
+  // Encrypt (#636) — the wallet is an HTTPS PWA, so plain-HTTP :17101
+  // endpoints would be blocked as mixed content.
+  {
+    id: 'eu',
+    name: 'EU seed (Frankfurt)',
+    role: 'Regional relay seed',
+    rpcEndpoint: 'https://eu.seed.botho.io/rpc',
+    servesFaucet: false,
+  },
+  {
+    id: 'ap',
+    name: 'AP seed (Singapore)',
+    role: 'Regional relay seed',
+    rpcEndpoint: 'https://ap.seed.botho.io/rpc',
+    servesFaucet: false,
   },
 ]
 


### PR DESCRIPTION
## Summary

Closes #636. Decision ratified: **TLS-first via on-box nginx + Let's Encrypt**, consistent with the existing seed/seed2/faucet pattern. (The curator's Cloudflare-proxy option was not viable as written — Cloudflare's proxy can't reach origin port 17101 without an Origin Rule port-override.)

## Infra (already deployed and verified live)

- nginx + certbot installed on both regional boxes; LE certs issued for `eu.seed.botho.io` and `ap.seed.botho.io` (ports 80/443 were already open in the SGs).
- RPC-only nginx config (adapted from `seed-nginx.conf`: `/rpc` + `/rpc/ws` proxy, upstream-CORS dedupe, `/health`; no static site — regional seeds are relay-only). Committed as `infra/seed/regional-rpc-nginx.conf.tmpl` (templated on `__HOST__`) so the runbook is durable.
- Verified: `https://eu.seed.botho.io/rpc` and `https://ap.seed.botho.io/rpc` both answer `node_getStatus` (v0.3.1, height 221).

## Code

One-file change, as the curator predicted: two `INGRESS_NODES` entries with region labels. The selector UI, 20s health polling, localStorage persistence, and offline detection all iterate the array — no other changes. Stale "three SCP ingress options" doc comment updated.

## Tests

Web-wallet suite 168/168 passes; `pnpm -r typecheck` clean. Wallet deploy to production happens after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)