### PR TITLE
feat(web-wallet): /network fleet dashboard — live 5-node grid, summary strip, history charts

### DIFF
--- a/web/packages/features/src/index.ts
+++ b/web/packages/features/src/index.ts
@@ -1,3 +1,4 @@
 // Re-export all features
 export * from './explorer'
 export * from './wallet'
+export * from './network'

--- a/web/packages/features/src/network/components/fleet-summary.tsx
+++ b/web/packages/features/src/network/components/fleet-summary.tsx
@@ -1,0 +1,104 @@
+import { Card, CardContent } from '@botho/ui'
+import { Activity, AlertTriangle, Blocks, Layers, Timer } from 'lucide-react'
+import type { FleetSummary } from '../types'
+
+export interface FleetSummaryStripProps {
+  summary: FleetSummary
+  /** Average seconds per block over a recent window; null = unknown. */
+  avgBlockSeconds: number | null
+  className?: string
+}
+
+/** Fleet-level facts in one strip above the node grid. */
+export function FleetSummaryStrip({
+  summary,
+  avgBlockSeconds,
+  className,
+}: FleetSummaryStripProps) {
+  return (
+    <Card className={className}>
+      <CardContent className="grid grid-cols-2 gap-4 p-4 sm:grid-cols-4">
+        <Metric
+          icon={<Blocks className="h-4 w-4" />}
+          label="Consensus height"
+          value={summary.consensusHeight?.toLocaleString() ?? '—'}
+        />
+        <Metric
+          icon={
+            summary.anySlotStalled ? (
+              <AlertTriangle className="h-4 w-4 text-[--color-danger]" />
+            ) : (
+              <Activity className="h-4 w-4" />
+            )
+          }
+          label="Nodes in sync"
+          value={`${summary.nodesInSync}/${summary.nodesTotal}`}
+          sub={
+            summary.nodesReachable < summary.nodesTotal
+              ? `${summary.nodesTotal - summary.nodesReachable} unreachable`
+              : undefined
+          }
+          warn={summary.nodesInSync < summary.nodesReachable || summary.anySlotStalled}
+        />
+        <Metric
+          icon={<Layers className="h-4 w-4" />}
+          label="Fleet mempool"
+          value={summary.totalMempool.toLocaleString()}
+          sub="txs across reachable nodes"
+        />
+        <Metric
+          icon={<Timer className="h-4 w-4" />}
+          label="Avg block spacing"
+          value={formatSpacing(avgBlockSeconds)}
+          sub={
+            avgBlockSeconds === null
+              ? 'not enough blocks'
+              : 'last 20 blocks — testnet mints on demand, idle gaps included'
+          }
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+/**
+ * Human-readable spacing. The testnet mints on demand, so spacing routinely
+ * reaches hours while idle — render h/m rather than a wall of seconds.
+ */
+function formatSpacing(seconds: number | null): string {
+  if (seconds === null) return '—'
+  if (seconds < 90) return `${seconds.toFixed(0)}s`
+  if (seconds < 5400) return `${(seconds / 60).toFixed(0)}m`
+  return `${(seconds / 3600).toFixed(1)}h`
+}
+
+function Metric({
+  icon,
+  label,
+  value,
+  sub,
+  warn,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string
+  sub?: string
+  warn?: boolean
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-xs text-[--color-dim]">
+        {icon}
+        {label}
+      </div>
+      <div
+        className={`mt-1 font-display text-xl font-semibold ${
+          warn ? 'text-[--color-warning]' : 'text-[--color-light]'
+        }`}
+      >
+        {value}
+      </div>
+      {sub && <div className="text-xs text-[--color-dim]">{sub}</div>}
+    </div>
+  )
+}

--- a/web/packages/features/src/network/components/history-chart.tsx
+++ b/web/packages/features/src/network/components/history-chart.tsx
@@ -1,0 +1,110 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@botho/ui'
+import { TrendingUp } from 'lucide-react'
+import type { MetricsHistorySample } from '../types'
+
+export interface HistoryChartProps {
+  title: string
+  /** Series keyed by node id; each series oldest-first. */
+  series: Record<string, MetricsHistorySample[]>
+  /** Which sample field to plot. */
+  metric: 'height' | 'mempoolSize' | 'peerCount'
+  /**
+   * Backend state: 'ok' renders the chart, 'empty' the no-data-yet state,
+   * 'unavailable' the degraded state (metrics API unreachable — the live
+   * grid above still works, so this is informational, not an error page).
+   */
+  state: 'ok' | 'empty' | 'unavailable'
+  className?: string
+}
+
+/** Distinct line colors per node (cycled). */
+const LINE_COLORS = ['#06b6d4', '#a78bfa', '#f59e0b', '#34d399', '#f472b6']
+
+const W = 600
+const H = 160
+const PAD = 8
+
+/**
+ * Dependency-free multi-series SVG line chart.
+ *
+ * Deliberately hand-rolled: the wallet has no chart library, and one metric
+ * line per node doesn't justify adding one. Scales are shared across series
+ * so per-node divergence (e.g. a stale height) is visible.
+ */
+export function HistoryChart({ title, series, metric, state, className }: HistoryChartProps) {
+  const entries = Object.entries(series).filter(([, samples]) => samples.length > 0)
+
+  let body: React.ReactNode
+  if (state === 'unavailable') {
+    body = (
+      <p className="py-8 text-center text-sm text-[--color-dim]">
+        History unavailable — the metrics API could not be reached. Live status above is
+        unaffected.
+      </p>
+    )
+  } else if (state === 'empty' || entries.length === 0) {
+    body = (
+      <p className="py-8 text-center text-sm text-[--color-dim]">
+        No history yet — samples appear as the metrics daemon collects them.
+      </p>
+    )
+  } else {
+    const allSamples = entries.flatMap(([, s]) => s)
+    const tMin = Math.min(...allSamples.map((s) => s.timestamp))
+    const tMax = Math.max(...allSamples.map((s) => s.timestamp))
+    const vMin = Math.min(...allSamples.map((s) => s[metric]))
+    const vMax = Math.max(...allSamples.map((s) => s[metric]))
+    const tSpan = Math.max(1, tMax - tMin)
+    const vSpan = Math.max(1, vMax - vMin)
+
+    const x = (t: number) => PAD + ((t - tMin) / tSpan) * (W - 2 * PAD)
+    const y = (v: number) => H - PAD - ((v - vMin) / vSpan) * (H - 2 * PAD)
+
+    body = (
+      <>
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="w-full"
+          role="img"
+          aria-label={`${title} chart`}
+        >
+          {entries.map(([nodeId, samples], i) => (
+            <polyline
+              key={nodeId}
+              fill="none"
+              stroke={LINE_COLORS[i % LINE_COLORS.length]}
+              strokeWidth={1.5}
+              points={samples.map((s) => `${x(s.timestamp)},${y(s[metric])}`).join(' ')}
+            />
+          ))}
+        </svg>
+        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[--color-dim]">
+          {entries.map(([nodeId], i) => (
+            <span key={nodeId} className="inline-flex items-center gap-1.5">
+              <span
+                className="inline-block h-2 w-2 rounded-full"
+                style={{ backgroundColor: LINE_COLORS[i % LINE_COLORS.length] }}
+              />
+              {nodeId}
+            </span>
+          ))}
+          <span className="ml-auto font-mono">
+            {vMin.toLocaleString()} – {vMax.toLocaleString()}
+          </span>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <TrendingUp className="h-4 w-4 text-[--color-pulse]" />
+          <CardTitle>{title}</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>{body}</CardContent>
+    </Card>
+  )
+}

--- a/web/packages/features/src/network/components/network-dashboard.test.tsx
+++ b/web/packages/features/src/network/components/network-dashboard.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The dashboard's contract (#698): unreachable nodes render an EXPLICIT error
+ * card (never stale or fabricated values — the #541 lesson), lagging nodes
+ * are highlighted against the fleet consensus height, and a missing history
+ * backend degrades to an informational state without breaking the live grid.
+ */
+import { describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { NetworkDashboard } from './network-dashboard'
+import type { FleetNode, FleetNodeStatus } from '../types'
+
+const NODES: FleetNode[] = [
+  { id: 'seed', name: 'Seed (validator)', rpcEndpoint: 'https://seed.test/rpc' },
+  { id: 'eu', name: 'EU seed (Frankfurt)', rpcEndpoint: 'https://eu.test/rpc' },
+  { id: 'ap', name: 'AP seed (Singapore)', rpcEndpoint: 'https://ap.test/rpc' },
+]
+
+function live(id: string, over: Partial<FleetNodeStatus> = {}): FleetNodeStatus {
+  return {
+    nodeId: id,
+    reachable: true,
+    polledAt: Date.now(),
+    chainHeight: 221,
+    peerCount: 4,
+    scpPeerCount: 4,
+    mempoolSize: 0,
+    mintingActive: false,
+    nodeVersion: '0.3.1',
+    slotStalled: false,
+    ...over,
+  }
+}
+
+function renderDash(statuses: Record<string, FleetNodeStatus>) {
+  cleanup()
+  return render(
+    <NetworkDashboard
+      nodes={NODES}
+      statuses={statuses}
+      avgBlockSeconds={20}
+      history={{}}
+      historyState="unavailable"
+    />,
+  )
+}
+
+describe('NetworkDashboard', () => {
+  it('renders live stats per node and the fleet summary', () => {
+    renderDash({ seed: live('seed'), eu: live('eu'), ap: live('ap') })
+    expect(screen.getByText('Consensus height')).toBeDefined()
+    expect(screen.getAllByText('221')).toHaveLength(4) // summary + 3 node cards
+    expect(screen.getByText('3/3')).toBeDefined() // nodes in sync
+  })
+
+  it('renders an explicit error card for an unreachable node — no stale values', () => {
+    renderDash({
+      seed: live('seed'),
+      eu: { nodeId: 'eu', reachable: false, polledAt: Date.now() },
+      ap: live('ap'),
+    })
+    expect(screen.getByText('Unreachable')).toBeDefined()
+    expect(screen.getByText(/1 unreachable/)).toBeDefined()
+    // The unreachable card must not show any height number.
+    expect(screen.getAllByText('221')).toHaveLength(3) // summary + 2 live cards only
+  })
+
+  it('highlights a lagging node against the consensus height', () => {
+    renderDash({
+      seed: live('seed', { chainHeight: 221 }),
+      eu: live('eu', { chainHeight: 210 }),
+      ap: live('ap', { chainHeight: 221 }),
+    })
+    expect(screen.getByText(/11 blocks behind/)).toBeDefined()
+    expect(screen.getByText('2/3')).toBeDefined()
+  })
+
+  it('surfaces a stalled SCP slot as a warning badge', () => {
+    renderDash({
+      seed: live('seed', { slotStalled: true }),
+      eu: live('eu'),
+      ap: live('ap'),
+    })
+    expect(screen.getByText('SCP slot stalled')).toBeDefined()
+  })
+
+  it('shows checking state for nodes whose first poll is in flight', () => {
+    renderDash({ seed: live('seed') })
+    expect(screen.getAllByText('Checking…')).toHaveLength(2)
+  })
+
+  it('degrades history to an informational state when the metrics API is unreachable', () => {
+    renderDash({ seed: live('seed'), eu: live('eu'), ap: live('ap') })
+    expect(screen.getAllByText(/History unavailable/)).toHaveLength(2)
+    // The live grid is unaffected.
+    expect(screen.getByText('3/3')).toBeDefined()
+  })
+})

--- a/web/packages/features/src/network/components/network-dashboard.tsx
+++ b/web/packages/features/src/network/components/network-dashboard.tsx
@@ -1,0 +1,72 @@
+import type { FleetNode, FleetNodeStatus, MetricsHistorySample } from '../types'
+import { deriveFleetSummary } from '../fleet'
+import { FleetSummaryStrip } from './fleet-summary'
+import { NodeCard } from './node-card'
+import { HistoryChart } from './history-chart'
+
+export interface NetworkDashboardProps {
+  nodes: FleetNode[]
+  /** Latest live snapshot per node id; missing key = first poll in flight. */
+  statuses: Record<string, FleetNodeStatus>
+  avgBlockSeconds: number | null
+  /** History series per node id (may be empty). */
+  history: Record<string, MetricsHistorySample[]>
+  historyState: 'ok' | 'empty' | 'unavailable'
+  className?: string
+}
+
+/**
+ * The fleet dashboard body: summary strip, per-node live grid, history
+ * charts. Pure presentation — polling and history fetching live in the page
+ * so this composes into other surfaces (e.g. the P4 admin dashboard, #695).
+ */
+export function NetworkDashboard({
+  nodes,
+  statuses,
+  avgBlockSeconds,
+  history,
+  historyState,
+  className,
+}: NetworkDashboardProps) {
+  const statusList = nodes
+    .map((n) => statuses[n.id])
+    .filter((s): s is FleetNodeStatus => s !== undefined)
+  const summary = deriveFleetSummary(
+    // Nodes never polled yet don't count as unreachable — only real results.
+    statusList,
+  )
+  // Until at least one poll resolves, show totals over the configured fleet.
+  const displaySummary = { ...summary, nodesTotal: nodes.length }
+
+  return (
+    <div className={`space-y-4 ${className ?? ''}`}>
+      <FleetSummaryStrip summary={displaySummary} avgBlockSeconds={avgBlockSeconds} />
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {nodes.map((node) => (
+          <NodeCard
+            key={node.id}
+            node={node}
+            status={statuses[node.id]}
+            consensusHeight={displaySummary.consensusHeight}
+          />
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <HistoryChart
+          title="Chain height"
+          series={history}
+          metric="height"
+          state={historyState}
+        />
+        <HistoryChart
+          title="Mempool depth"
+          series={history}
+          metric="mempoolSize"
+          state={historyState}
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/packages/features/src/network/components/node-card.tsx
+++ b/web/packages/features/src/network/components/node-card.tsx
@@ -1,0 +1,122 @@
+import { Card, CardContent } from '@botho/ui'
+import { AlertTriangle, Pickaxe, Server, WifiOff } from 'lucide-react'
+import type { FleetNode, FleetNodeStatus } from '../types'
+
+export interface NodeCardProps {
+  node: FleetNode
+  /** Live snapshot; undefined while the first poll is in flight. */
+  status?: FleetNodeStatus
+  /** Fleet consensus height, for lag highlighting. */
+  consensusHeight: number | null
+  className?: string
+}
+
+/**
+ * One fleet node's live status.
+ *
+ * Renders exactly three shapes: loading (first poll pending), unreachable
+ * (explicit error card — never stale values), and live stats. A node more
+ * than 1 block behind the fleet's consensus height gets a lag highlight; a
+ * stalled SCP slot gets a warning row.
+ */
+export function NodeCard({ node, status, consensusHeight, className }: NodeCardProps) {
+  if (status && !status.reachable) {
+    return (
+      <Card className={`border-[--color-danger]/40 ${className ?? ''}`}>
+        <CardContent className="p-4">
+          <NodeCardHeader node={node} />
+          <div className="mt-3 flex items-center gap-2 text-sm text-[--color-danger]">
+            <WifiOff className="h-4 w-4 shrink-0" />
+            <span>Unreachable</span>
+          </div>
+          <p className="mt-1 text-xs text-[--color-dim]">
+            node_getStatus failed or timed out at{' '}
+            {new Date(status.polledAt).toLocaleTimeString()}
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const height = status?.chainHeight
+  const lagging =
+    consensusHeight !== null && typeof height === 'number' && consensusHeight - height > 1
+
+  return (
+    <Card
+      className={`${lagging ? 'border-[--color-warning]/50' : ''} ${className ?? ''}`}
+      data-testid={`node-card-${node.id}`}
+    >
+      <CardContent className="p-4">
+        <NodeCardHeader node={node} version={status?.nodeVersion} />
+
+        {!status ? (
+          <p className="mt-3 text-sm text-[--color-dim]">Checking…</p>
+        ) : (
+          <>
+            <div className="mt-3 grid grid-cols-2 gap-x-8 gap-y-1.5 text-sm">
+              <Stat
+                label="Height"
+                value={height?.toLocaleString() ?? '—'}
+                warn={lagging}
+              />
+              <Stat label="Mempool" value={status.mempoolSize?.toLocaleString() ?? '—'} />
+              <Stat label="Peers" value={status.peerCount?.toLocaleString() ?? '—'} />
+              <Stat label="SCP peers" value={status.scpPeerCount?.toLocaleString() ?? '—'} />
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+              {status.mintingActive && (
+                <span className="inline-flex items-center gap-1 rounded bg-[--color-pulse]/15 px-1.5 py-0.5 text-[--color-pulse]">
+                  <Pickaxe className="h-3 w-3" /> minting
+                </span>
+              )}
+              {lagging && (
+                <span className="inline-flex items-center gap-1 rounded bg-[--color-warning]/15 px-1.5 py-0.5 text-[--color-warning]">
+                  <AlertTriangle className="h-3 w-3" />
+                  {consensusHeight! - height!} blocks behind
+                </span>
+              )}
+              {status.slotStalled === true && (
+                <span className="inline-flex items-center gap-1 rounded bg-[--color-danger]/15 px-1.5 py-0.5 text-[--color-danger]">
+                  <AlertTriangle className="h-3 w-3" /> SCP slot stalled
+                </span>
+              )}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function NodeCardHeader({ node, version }: { node: FleetNode; version?: string }) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex min-w-0 items-center gap-2">
+        <Server className="h-4 w-4 shrink-0 text-[--color-pulse]" />
+        <span className="truncate font-display font-medium text-[--color-light]">
+          {node.name}
+        </span>
+      </div>
+      {version && (
+        <span className="shrink-0 rounded bg-[--color-slate] px-1.5 py-0.5 font-mono text-xs text-[--color-ghost]">
+          v{version}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function Stat({ label, value, warn }: { label: string; value: string; warn?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="text-[--color-dim]">{label}</span>
+      <span
+        className={`font-mono ${warn ? 'text-[--color-warning]' : 'text-[--color-light]'}`}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/web/packages/features/src/network/fleet.test.ts
+++ b/web/packages/features/src/network/fleet.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { averageBlockSeconds, deriveFleetSummary, fetchFleetNodeStatus } from './fleet'
+import type { FleetNodeStatus } from './types'
+
+function status(overrides: Partial<FleetNodeStatus>): FleetNodeStatus {
+  return { nodeId: 'n', reachable: true, polledAt: 0, ...overrides }
+}
+
+describe('deriveFleetSummary', () => {
+  it('takes the max reachable height as consensus and counts in-sync within 1 block', () => {
+    const s = deriveFleetSummary([
+      status({ nodeId: 'a', chainHeight: 220, mempoolSize: 2 }),
+      status({ nodeId: 'b', chainHeight: 219, mempoolSize: 1 }),
+      status({ nodeId: 'c', chainHeight: 210 }), // lagging
+      status({ nodeId: 'd', reachable: false }),
+    ])
+    expect(s.consensusHeight).toBe(220)
+    expect(s.nodesInSync).toBe(2)
+    expect(s.nodesReachable).toBe(3)
+    expect(s.nodesTotal).toBe(4)
+    expect(s.totalMempool).toBe(3)
+  })
+
+  it('reports null consensus height when nothing is reachable', () => {
+    const s = deriveFleetSummary([status({ reachable: false }), status({ reachable: false })])
+    expect(s.consensusHeight).toBeNull()
+    expect(s.nodesInSync).toBe(0)
+  })
+
+  it('flags a stalled SCP slot anywhere in the fleet', () => {
+    expect(
+      deriveFleetSummary([status({ chainHeight: 5 }), status({ chainHeight: 5, slotStalled: true })])
+        .anySlotStalled,
+    ).toBe(true)
+  })
+
+  it('never counts an unreachable node toward mempool or stall', () => {
+    const s = deriveFleetSummary([
+      status({ reachable: false, mempoolSize: 99, slotStalled: true }),
+      status({ chainHeight: 1 }),
+    ])
+    expect(s.totalMempool).toBe(0)
+    expect(s.anySlotStalled).toBe(false)
+  })
+})
+
+describe('averageBlockSeconds', () => {
+  it('computes seconds per block over the window', () => {
+    expect(averageBlockSeconds({ height: 200, timestamp: 1000 }, { height: 220, timestamp: 1400 })).toBe(20)
+  })
+
+  it('returns null for degenerate windows instead of fabricating a rate', () => {
+    expect(averageBlockSeconds({ height: 220, timestamp: 1000 }, { height: 220, timestamp: 1400 })).toBeNull()
+    expect(averageBlockSeconds({ height: 200, timestamp: 1400 }, { height: 220, timestamp: 1000 })).toBeNull()
+  })
+})
+
+describe('fetchFleetNodeStatus', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const node = { id: 'seed', name: 'Seed', rpcEndpoint: 'https://seed.test/rpc' }
+
+  it('maps a node_getStatus result to a reachable snapshot', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          result: {
+            chainHeight: 221,
+            peerCount: 4,
+            scpPeerCount: 4,
+            mempoolSize: 0,
+            mintingActive: false,
+            nodeVersion: '0.3.1',
+            slotStalled: false,
+          },
+        }),
+      })),
+    )
+    const s = await fetchFleetNodeStatus(node)
+    expect(s).toMatchObject({
+      nodeId: 'seed',
+      reachable: true,
+      chainHeight: 221,
+      peerCount: 4,
+      nodeVersion: '0.3.1',
+      slotStalled: false,
+    })
+  })
+
+  it('resolves unreachable on fetch failure — never throws into the poller', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('boom') }))
+    const s = await fetchFleetNodeStatus(node)
+    expect(s.reachable).toBe(false)
+    expect(s.chainHeight).toBeUndefined()
+  })
+
+  it('resolves unreachable on an RPC-level error object', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ error: { code: -32000 } }) })),
+    )
+    expect((await fetchFleetNodeStatus(node)).reachable).toBe(false)
+  })
+})

--- a/web/packages/features/src/network/fleet.ts
+++ b/web/packages/features/src/network/fleet.ts
@@ -1,0 +1,103 @@
+import type { FleetNode, FleetNodeStatus, FleetSummary } from './types'
+
+/**
+ * Poll one node's `node_getStatus` with a hard timeout.
+ *
+ * Failures resolve to `reachable: false` — the caller renders an explicit
+ * error state. No field is ever carried over from a previous poll.
+ */
+export async function fetchFleetNodeStatus(
+  node: FleetNode,
+  timeoutMs = 5000,
+): Promise<FleetNodeStatus> {
+  const polledAt = Date.now()
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+    const response = await fetch(node.rpcEndpoint, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'node_getStatus', params: {}, id: 1 }),
+    })
+    clearTimeout(timeoutId)
+    if (!response.ok) return { nodeId: node.id, reachable: false, polledAt }
+
+    const json = (await response.json()) as {
+      result?: {
+        chainHeight?: number
+        peerCount?: number
+        scpPeerCount?: number
+        mempoolSize?: number
+        mintingActive?: boolean
+        nodeVersion?: string
+        slotStalled?: boolean
+        synced?: boolean
+      }
+      error?: unknown
+    }
+    if (json.error || !json.result) return { nodeId: node.id, reachable: false, polledAt }
+
+    const r = json.result
+    return {
+      nodeId: node.id,
+      reachable: true,
+      polledAt,
+      chainHeight: r.chainHeight,
+      peerCount: r.peerCount,
+      scpPeerCount: r.scpPeerCount,
+      mempoolSize: r.mempoolSize,
+      mintingActive: r.mintingActive,
+      nodeVersion: r.nodeVersion,
+      slotStalled: r.slotStalled,
+      synced: r.synced,
+    }
+  } catch {
+    return { nodeId: node.id, reachable: false, polledAt }
+  }
+}
+
+/** Poll the whole fleet concurrently; one slow/dead node never blocks the rest. */
+export async function fetchFleetStatus(nodes: FleetNode[]): Promise<FleetNodeStatus[]> {
+  return Promise.all(nodes.map((n) => fetchFleetNodeStatus(n)))
+}
+
+/** Derive fleet-level facts from live snapshots. Pure. */
+export function deriveFleetSummary(statuses: FleetNodeStatus[]): FleetSummary {
+  const reachable = statuses.filter((s) => s.reachable)
+  const heights = reachable
+    .map((s) => s.chainHeight)
+    .filter((h): h is number => typeof h === 'number')
+  const consensusHeight = heights.length > 0 ? Math.max(...heights) : null
+
+  return {
+    consensusHeight,
+    nodesInSync:
+      consensusHeight === null
+        ? 0
+        : reachable.filter(
+            (s) => typeof s.chainHeight === 'number' && consensusHeight - s.chainHeight <= 1,
+          ).length,
+    nodesReachable: reachable.length,
+    nodesTotal: statuses.length,
+    totalMempool: reachable.reduce((acc, s) => acc + (s.mempoolSize ?? 0), 0),
+    anySlotStalled: reachable.some((s) => s.slotStalled === true),
+  }
+}
+
+/**
+ * Average seconds per block over a recent window, from two block timestamps.
+ *
+ * Returns null when the window is degenerate (fewer than 2 blocks, or a
+ * clock-skewed non-positive span) — the UI shows an empty state instead of a
+ * fabricated rate.
+ */
+export function averageBlockSeconds(
+  olderBlock: { height: number; timestamp: number },
+  newerBlock: { height: number; timestamp: number },
+): number | null {
+  const blocks = newerBlock.height - olderBlock.height
+  const seconds = newerBlock.timestamp - olderBlock.timestamp
+  if (blocks <= 0 || seconds <= 0) return null
+  return seconds / blocks
+}

--- a/web/packages/features/src/network/index.ts
+++ b/web/packages/features/src/network/index.ts
@@ -1,0 +1,9 @@
+export * from './types'
+export * from './fleet'
+export { NodeCard, type NodeCardProps } from './components/node-card'
+export { FleetSummaryStrip, type FleetSummaryStripProps } from './components/fleet-summary'
+export { HistoryChart, type HistoryChartProps } from './components/history-chart'
+export {
+  NetworkDashboard,
+  type NetworkDashboardProps,
+} from './components/network-dashboard'

--- a/web/packages/features/src/network/types.ts
+++ b/web/packages/features/src/network/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Network fleet dashboard types (#698).
+ *
+ * The dashboard has two data planes:
+ * - LIVE: the browser polls every ingress node's `node_getStatus` directly
+ *   (all five testnet nodes serve TLS + CORS since #636).
+ * - HISTORY: the metrics-daemon fleet API (#697) serves per-node samples
+ *   with 5min/hourly/daily rollups.
+ */
+
+/** A node the dashboard watches (mirrors the wallet's IngressNode). */
+export interface FleetNode {
+  /** Stable id (e.g. 'seed', 'eu'). */
+  id: string
+  /** Display name (e.g. 'EU seed (Frankfurt)'). */
+  name: string
+  /** Absolute JSON-RPC endpoint. */
+  rpcEndpoint: string
+}
+
+/**
+ * Live status snapshot for one node, from `node_getStatus`.
+ *
+ * `reachable: false` means the poll failed (timeout / network / RPC error) —
+ * the card must render an explicit error state, never stale or fabricated
+ * values (the #541 hardcoded-observability lesson).
+ */
+export interface FleetNodeStatus {
+  nodeId: string
+  reachable: boolean
+  /** Unix millis when this snapshot was taken. */
+  polledAt: number
+  chainHeight?: number
+  peerCount?: number
+  scpPeerCount?: number
+  mempoolSize?: number
+  mintingActive?: boolean
+  nodeVersion?: string
+  /** SCP slot-stall verdict (#653); undefined when the node predates it. */
+  slotStalled?: boolean
+  synced?: boolean
+}
+
+/** Fleet-level facts derived from the live snapshots (pure function). */
+export interface FleetSummary {
+  /** Highest height any reachable node reports (consensus tip). */
+  consensusHeight: number | null
+  /** Reachable nodes at the consensus height (within 1 block). */
+  nodesInSync: number
+  /** Reachable node count. */
+  nodesReachable: number
+  /** Total nodes watched. */
+  nodesTotal: number
+  /** Sum of mempool sizes across reachable nodes. */
+  totalMempool: number
+  /** True when any reachable node reports a stalled SCP slot. */
+  anySlotStalled: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Metrics-daemon fleet API (#697 contract)
+// ---------------------------------------------------------------------------
+
+/** One entry of `GET /api/metrics/latest`. */
+export interface MetricsLatestEntry {
+  node: string
+  timestamp: number
+  height: number
+  peerCount: number
+  scpPeerCount: number
+  mempoolSize: number
+  mintingActive: boolean
+  uptimeSeconds: number
+  heightStale: boolean
+}
+
+/** One sample of `GET /api/metrics/history`. */
+export interface MetricsHistorySample {
+  timestamp: number
+  height: number
+  peerCount: number
+  mempoolSize: number
+}
+
+/** History fetcher the page injects (so components stay backend-agnostic). */
+export interface NetworkHistorySource {
+  /** Per-node history samples, oldest first. Empty array = no data yet. */
+  getHistory(
+    node: string,
+    resolution: '5min' | 'hourly' | 'daily',
+    sinceUnixSeconds: number,
+  ): Promise<MetricsHistorySample[]>
+}

--- a/web/packages/web-wallet/src/App.tsx
+++ b/web/packages/web-wallet/src/App.tsx
@@ -8,6 +8,7 @@ import { PayPage } from './pages/pay'
 import { ContactsPage } from './pages/contacts'
 import { DocsPage } from './pages/docs'
 import { ExplorerPage } from './pages/explorer'
+import { NetworkPage } from './pages/network'
 import { RigPage, RigSuccessPage, RigStatusPage } from './pages/rig'
 
 /**
@@ -50,6 +51,7 @@ function App() {
             <Route path="/pay" element={<PayPage />} />
             <Route path="/contacts" element={<ContactsPage />} />
             <Route path="/explorer" element={<ExplorerPage />} />
+            <Route path="/network" element={<NetworkPage />} />
             <Route path="/explorer/tx/:hash" element={<ExplorerPage />} />
             <Route path="/explorer/block/:hash" element={<ExplorerPage />} />
             <Route path="/docs" element={<DocsPage />} />

--- a/web/packages/web-wallet/src/pages/explorer.tsx
+++ b/web/packages/web-wallet/src/pages/explorer.tsx
@@ -49,7 +49,12 @@ export function ExplorerPage() {
             <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">Block Explorer</span>
             <span className="font-display text-base font-semibold sm:hidden">Explorer</span>
           </Link>
-          <NetworkSelector />
+          <div className="flex items-center gap-4">
+            <Link to="/network" className="text-sm text-ghost hover:text-light transition-colors">
+              Network
+            </Link>
+            <NetworkSelector />
+          </div>
         </div>
       </header>
 

--- a/web/packages/web-wallet/src/pages/landing.tsx
+++ b/web/packages/web-wallet/src/pages/landing.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Button, Logo } from '@botho/ui'
-import { Shield, Scale, Atom, Zap, ArrowRight, Github, Menu, X, FileText, Blocks, Server } from 'lucide-react'
+import {Activity, Shield, Scale, Atom, Zap, ArrowRight, Github, Menu, X, FileText, Blocks, Server} from 'lucide-react'
 
 const features = [
   {
@@ -51,6 +51,10 @@ export function LandingPage() {
             <Link to="/explorer" className="text-ghost hover:text-light transition-colors flex items-center gap-2">
               <Blocks size={18} />
               Explorer
+            </Link>
+            <Link to="/network" className="text-ghost hover:text-light transition-colors flex items-center gap-2">
+              <Activity size={18} />
+              Network
             </Link>
             <Link to="/docs" className="text-ghost hover:text-light transition-colors">
               Docs

--- a/web/packages/web-wallet/src/pages/network.tsx
+++ b/web/packages/web-wallet/src/pages/network.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Logo } from '@botho/ui'
+import {
+  NetworkDashboard,
+  fetchFleetNodeStatus,
+  averageBlockSeconds,
+  type FleetNode,
+  type FleetNodeStatus,
+  type MetricsHistorySample,
+} from '@botho/features'
+import { ArrowLeft } from 'lucide-react'
+import { INGRESS_NODES } from '../config/networks'
+
+/** Live-grid poll cadence. */
+const POLL_MS = 15_000
+/** History refresh cadence (the daemon samples every ~5 min; no need to hammer). */
+const HISTORY_MS = 120_000
+/** Metrics-daemon fleet API (#697), served via the faucet's nginx. */
+const METRICS_API_BASE = 'https://faucet.botho.io/metrics-api'
+/** Blocks/hour derivation window. */
+const BLOCK_WINDOW = 20
+
+/** The dashboard watches every ingress node plus region labels. */
+const FLEET: FleetNode[] = INGRESS_NODES.map((n) => ({
+  id: n.id,
+  name: n.name,
+  rpcEndpoint: n.rpcEndpoint,
+}))
+
+export function NetworkPage() {
+  const [statuses, setStatuses] = useState<Record<string, FleetNodeStatus>>({})
+  const [avgBlockSecs, setAvgBlockSecs] = useState<number | null>(null)
+  const [history, setHistory] = useState<Record<string, MetricsHistorySample[]>>({})
+  const [historyState, setHistoryState] = useState<'ok' | 'empty' | 'unavailable'>('empty')
+  // The block-time derivation reuses the freshest reachable node endpoint.
+  const bestEndpointRef = useRef<string | null>(null)
+
+  // Live fleet polling.
+  useEffect(() => {
+    let cancelled = false
+    const poll = async () => {
+      const results = await Promise.all(FLEET.map((n) => fetchFleetNodeStatus(n)))
+      if (cancelled) return
+      const byId: Record<string, FleetNodeStatus> = {}
+      let bestHeight = -1
+      for (const [i, s] of results.entries()) {
+        byId[s.nodeId] = s
+        if (s.reachable && (s.chainHeight ?? -1) > bestHeight) {
+          bestHeight = s.chainHeight ?? -1
+          bestEndpointRef.current = FLEET[i].rpcEndpoint
+        }
+      }
+      setStatuses(byId)
+    }
+    poll()
+    const id = setInterval(poll, POLL_MS)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [])
+
+  // Average block time from two block timestamps on the freshest node.
+  const consensusHeight = useMemo(() => {
+    const heights = Object.values(statuses)
+      .filter((s) => s.reachable && typeof s.chainHeight === 'number')
+      .map((s) => s.chainHeight as number)
+    return heights.length ? Math.max(...heights) : null
+  }, [statuses])
+
+  useEffect(() => {
+    const endpoint = bestEndpointRef.current
+    if (consensusHeight === null || consensusHeight < 2 || !endpoint) return
+    let cancelled = false
+    const older = Math.max(1, consensusHeight - BLOCK_WINDOW)
+    const fetchBlock = async (height: number) => {
+      const r = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'getBlockByHeight',
+          params: { height },
+          id: 1,
+        }),
+      })
+      const json = (await r.json()) as {
+        result?: { height: number; timestamp: number }
+      }
+      return json.result ?? null
+    }
+    Promise.all([fetchBlock(older), fetchBlock(consensusHeight)])
+      .then(([a, b]) => {
+        if (!cancelled && a && b) setAvgBlockSecs(averageBlockSeconds(a, b))
+      })
+      .catch(() => {
+        /* leave the empty state; live grid is unaffected */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [consensusHeight])
+
+  // History from the metrics-daemon fleet API — degrade gracefully when the
+  // backend is absent (it ships/deploys independently, #697).
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const since = Math.floor(Date.now() / 1000) - 24 * 3600
+        const results = await Promise.all(
+          FLEET.map(async (n) => {
+            const r = await fetch(
+              `${METRICS_API_BASE}/api/metrics/history?node=${encodeURIComponent(n.id)}&resolution=5min&since=${since}`,
+            )
+            if (!r.ok) throw new Error(`history ${r.status}`)
+            return [n.id, (await r.json()) as MetricsHistorySample[]] as const
+          }),
+        )
+        if (cancelled) return
+        const byNode = Object.fromEntries(results)
+        const any = results.some(([, samples]) => samples.length > 0)
+        setHistory(byNode)
+        setHistoryState(any ? 'ok' : 'empty')
+      } catch {
+        if (!cancelled) setHistoryState('unavailable')
+      }
+    }
+    load()
+    const id = setInterval(load, HISTORY_MS)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [])
+
+  return (
+    <div className="min-h-screen">
+      <header className="border-b border-steel bg-abyss/50 backdrop-blur-md sticky top-0 z-40">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between">
+          <Link to="/" className="flex items-center gap-2 sm:gap-3">
+            <ArrowLeft size={18} className="text-ghost" />
+            <Logo size="sm" showText={false} />
+            <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">
+              Network
+            </span>
+            <span className="font-display text-base font-semibold sm:hidden">Network</span>
+          </Link>
+          <Link
+            to="/explorer"
+            className="text-sm text-ghost hover:text-light transition-colors"
+          >
+            Block Explorer
+          </Link>
+        </div>
+      </header>
+
+      <main className="py-6 sm:py-8">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6">
+          <NetworkDashboard
+            nodes={FLEET}
+            statuses={statuses}
+            avgBlockSeconds={avgBlockSecs}
+            history={history}
+            historyState={historyState}
+          />
+        </div>
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Refs #698 (P3 of the explorer/stats phase; placement ratified 2026-07-07: wallet `/network` page). Two data planes:

- **Live** (works today): browser polls all five ingress nodes' `node_getStatus` every 15s (possible since #636 gave eu/ap TLS+CORS). Per-node cards show height, mempool, peers, SCP peers, version, minting badge, lag-vs-consensus badge, and the #653 `slotStalled` flag. Unreachable nodes render an explicit error card — never stale or fabricated values.
- **History** (activates when #697 deploys): charts read the metrics-daemon fleet API per its contract; while absent the charts show an informational degraded state and the live grid is unaffected — verified in the live check below.

## Design notes

- `features/network` mirrors `features/explorer`: pure presentation components + pure derivation functions, so the #695 P4 admin dashboard can compose the same pieces.
- Charts are a dependency-free multi-series SVG — one line per node doesn't justify a chart library.
- "Avg block spacing" is labeled and captioned honestly: the testnet mints on demand, so idle gaps are included (h/m formatting; `null` on degenerate windows rather than a fabricated rate).

## Verification

- 15 new tests (pure derivations + dashboard states incl. unreachable/lagging/stalled/checking/degraded-history); full web suite 587/587; typecheck clean.
- Driven live against the real testnet: 5/5 nodes in sync at h=221, all v0.3.1, history degraded gracefully (screenshot in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)