### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ bumps (`0.X.Y`) are backwards-compatible.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-07
+
+### Added
+- Explorer-facing RPC enrichment (#696): `getBlockByHeight`/`getBlockByHash`
+  gain additive `transactions` (hash/fee/ringSize — structure only, never
+  amounts or recipients), `totalFees`, and `lottery` summary fields;
+  `cluster_getAllWealth` gains a per-cluster `factor` from the live fee
+  curve (single source of curve truth for the explorer's wealth histogram).
+- Fleet metrics daemon (#697): multi-node collection with per-node SQLite
+  rollups and a public history API for the wallet's /network dashboard.
+
+### Fixed
+- Nodes re-dial configured bootstrap peers whenever under-connected, not
+  only at zero peers (#690) — rolling deploys can no longer strand the
+  fleet in a star topology that wedges SCP externalization.
+
 ## [0.3.1] - 2026-07-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
 
 [[package]]
 name = "botho"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes",
  "anyhow",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "botho-desktop"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "botho-wallet",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "botho-exchange-scanner"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "botho-metrics-daemon"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "botho-mobile"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "bip39",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "botho-wallet"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1059,7 +1059,7 @@ dependencies = [
 
 [[package]]
 name = "bth-bridge-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "hex",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "bth-bridge-service"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bth-bridge-core",
  "chrono",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "bth-cluster-tax"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bth-transaction-types",
  "clap",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "bth-crypto-pq"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "hex",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "bth-crypto-secp256k1"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "hmac",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "bth-discover"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "bth-common",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "bth-gossip"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bitflags 2.10.0",
  "bth-common",

--- a/botho-exchange-scanner/Cargo.toml
+++ b/botho-exchange-scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-exchange-scanner"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Exchange deposit scanner for Botho cryptocurrency"
 license = "Apache-2.0"

--- a/botho-wallet/Cargo.toml
+++ b/botho-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-wallet"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Standalone thin wallet client for Botho cryptocurrency"
 license = "Apache-2.0"

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "A privacy-preserving mined cryptocurrency"
 license = "GPL-3.0"

--- a/bridge/core/Cargo.toml
+++ b/bridge/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-bridge-core"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Botho"]
 edition = "2021"
 description = "Core types and logic for BTH bridge"

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-bridge-service"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Botho"]
 edition = "2021"
 description = "BTH bridge service for Ethereum and Solana"

--- a/cluster-tax/Cargo.toml
+++ b/cluster-tax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-cluster-tax"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = { workspace = true }

--- a/contracts/ethereum/package.json
+++ b/contracts/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wbth-ethereum",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Wrapped BTH ERC-20 token for Ethereum",
   "scripts": {
     "compile": "hardhat compile",

--- a/crypto/pq/Cargo.toml
+++ b/crypto/pq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-crypto-pq"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/secp256k1/Cargo.toml
+++ b/crypto/secp256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-crypto-secp256k1"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Botho"]
 edition = "2021"
 description = "Secp256k1 key support for Ethereum compatibility"

--- a/discover/Cargo.toml
+++ b/discover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-discover"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-gossip"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/infra/faucet/metrics-daemon/Cargo.toml
+++ b/infra/faucet/metrics-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-metrics-daemon"
-version = "0.4.0"
+version = "0.3.2"
 edition = "2021"
 description = "Fleet metrics collection daemon and history API for the Botho testnet"
 license = "MIT"

--- a/mobile/app/package.json
+++ b/mobile/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botho-mobile",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Botho Mobile Wallet",
   "main": "expo-router/entry",
   "scripts": {

--- a/mobile/rust-bridge/Cargo.toml
+++ b/mobile/rust-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-mobile"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Mobile FFI bindings for Botho wallet"
 license = "Apache-2.0"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botho-web",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @botho/web-wallet dev",

--- a/web/packages/desktop/src-tauri/Cargo.toml
+++ b/web/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-desktop"
-version = "0.3.1"
+version = "0.3.2"
 description = "Botho Desktop Wallet"
 authors = ["Botho"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Version bump 0.3.1 → 0.3.2 for the explorer/stats-phase node deploy. Node-side changes since v0.3.1: #692 (re-dial bootstrap peers whenever under-connected — this deploy is the first one protected by it), #696 (explorer RPC enrichment the new /explorer views consume), #697 (fleet metrics daemon).

`./scripts/version.sh check` reports all files in sync at 0.3.2.

After merge: tag v0.3.2 → release.yml artifacts → rolling fleet deploy → live verification of the enriched RPC shapes (the #696 acceptance item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)