### PR TITLE
feat(explorer): M2 views — cluster-wealth histogram with factor bands, lottery events, block fee detail

### DIFF
--- a/web/packages/adapters/src/__tests__/remote.test.ts
+++ b/web/packages/adapters/src/__tests__/remote.test.ts
@@ -169,6 +169,129 @@ describe('RemoteNodeAdapter.getClusterWealth', () => {
   })
 })
 
+describe('RemoteNodeAdapter.getAllClusterWealth', () => {
+  it('parses the captured live fixture: string wealth -> bigint, missing factor -> 1000 floor', async () => {
+    // The fixture predates #700 (no per-cluster factor) — the adapter must
+    // default to the 1000 floor for old nodes, never re-derive the curve.
+    const adapter = await connectedAdapter({ cluster_getAllWealth: clusterGetAllWealth })
+    const clusters = await adapter.getAllClusterWealth()
+    expect(clusters).toHaveLength(3)
+    expect(clusters[0]).toEqual({
+      clusterId: '7244222622098737154',
+      wealth: 50_000_000_000_000n,
+      factor: 1000,
+    })
+    expect(typeof clusters[0].wealth).toBe('bigint')
+    // cluster_id stays a string — the real captured ids exceed 2^53.
+    expect(typeof clusters[0].clusterId).toBe('string')
+  })
+
+  it('parses enriched #700 responses: u128 wealth exactly + node-supplied factor', async () => {
+    const response = {
+      jsonrpc: '2.0',
+      result: {
+        count: 2,
+        total_tracked_wealth: '340282366920938463463374607431768211455',
+        clusters: [
+          { cluster_id: '1', wealth: '1', factor: 1000 },
+          { cluster_id: '2', wealth: '340282366920938463463374607431768211454', factor: 6000 },
+        ],
+      },
+      id: 1,
+    }
+    const adapter = await connectedAdapter({ cluster_getAllWealth: response })
+    const clusters = await adapter.getAllClusterWealth()
+    expect(clusters[0]).toEqual({ clusterId: '1', wealth: 1n, factor: 1000 })
+    expect(clusters[1].wealth).toBe(340282366920938463463374607431768211454n)
+    expect(clusters[1].wealth.toString()).toBe('340282366920938463463374607431768211454')
+    expect(clusters[1].factor).toBe(6000)
+  })
+
+  it('returns [] when the node sends no clusters array', async () => {
+    const response = {
+      jsonrpc: '2.0',
+      result: { count: 0, total_tracked_wealth: '0' },
+      id: 1,
+    }
+    const adapter = await connectedAdapter({ cluster_getAllWealth: response })
+    expect(await adapter.getAllClusterWealth()).toEqual([])
+  })
+})
+
+describe('RemoteNodeAdapter.getBlock enriched fields (#700)', () => {
+  /** Base pre-#700 block shape, byte-for-byte what old nodes serve. */
+  const legacyBlock = {
+    height: 42,
+    hash: 'f'.repeat(64),
+    prevHash: 'e'.repeat(64),
+    timestamp: 1751840000,
+    difficulty: 12345,
+    nonce: 987,
+    txCount: 1,
+    mintingReward: 4800000000000,
+  }
+
+  function rpc(result: Record<string, unknown>) {
+    return { jsonrpc: '2.0', result, id: 1 }
+  }
+
+  it('maps the enriched #700 shape: per-tx summaries, totalFees, lottery — all bigint amounts', async () => {
+    const adapter = await connectedAdapter({
+      getBlockByHeight: rpc({
+        ...legacyBlock,
+        transactions: [{ hash: 'c0de'.repeat(16), fee: 250, ringSize: 20 }],
+        totalFees: 250,
+        lottery: {
+          totalFees: 250,
+          poolDistributed: 200,
+          amountBurned: 50,
+          lotterySeed: '09'.repeat(32),
+          payoutCount: 2,
+          payoutTotal: 100,
+        },
+      }),
+    })
+    const block = await adapter.getBlock(42)
+    expect(block).not.toBeNull()
+    expect(block!.transactions).toEqual([
+      { hash: 'c0de'.repeat(16), fee: 250n, ringSize: 20 },
+    ])
+    expect(block!.totalFees).toBe(250n)
+    expect(block!.lottery).toEqual({
+      totalFees: 250n,
+      poolDistributed: 200n,
+      amountBurned: 50n,
+      lotterySeed: '09'.repeat(32),
+      payoutCount: 2,
+      payoutTotal: 100n,
+    })
+    // Pre-existing fields are unchanged by the enrichment.
+    expect(block!.height).toBe(42)
+    expect(block!.reward).toBe(4800000000000n)
+    expect(block!.previousHash).toBe('e'.repeat(64))
+  })
+
+  it('leaves enriched fields undefined for old nodes (additive contract — no break)', async () => {
+    const adapter = await connectedAdapter({ getBlockByHeight: rpc(legacyBlock) })
+    const block = await adapter.getBlock(42)
+    expect(block).not.toBeNull()
+    expect(block!.transactions).toBeUndefined()
+    expect(block!.totalFees).toBeUndefined()
+    expect(block!.lottery).toBeUndefined()
+    expect(block!.transactionCount).toBe(1)
+  })
+
+  it('maps the same enrichment on the getBlockByHash path', async () => {
+    const adapter = await connectedAdapter({
+      getBlockByHash: rpc({ ...legacyBlock, totalFees: 99, transactions: [] }),
+    })
+    const block = await adapter.getBlock('f'.repeat(64))
+    expect(block!.totalFees).toBe(99n)
+    expect(block!.transactions).toEqual([])
+    expect(lastCall('getBlockByHash')?.params.hash).toBe('f'.repeat(64))
+  })
+})
+
 describe('u128 / u64 wire-format round-trips', () => {
   it('round-trips BigInt("99999999999999999999") (> u64 max) exactly', () => {
     const big = '99999999999999999999'

--- a/web/packages/adapters/src/remote.ts
+++ b/web/packages/adapters/src/remote.ts
@@ -11,6 +11,7 @@ import type {
 } from '@botho/core'
 import type {
   BlockFetchOptions,
+  ClusterWealthEntry,
   FeeEstimate,
   MempoolUpdate,
   NodeAdapter,
@@ -62,6 +63,74 @@ function leHexToBigInt(hex: string): bigint {
     result = (result << 8n) | BigInt(parseInt(hex.slice(i, i + 2), 16))
   }
   return result
+}
+
+/**
+ * Wire shape of `getBlockByHeight` / `getBlockByHash` results. The
+ * `transactions` / `totalFees` / `lottery` fields are the additive explorer
+ * enrichment from #700 — older nodes omit them, so they are all optional and
+ * the mapping below guards with undefined checks.
+ */
+interface RpcBlockResult {
+  height: number
+  hash: string
+  prevHash: string
+  timestamp: number
+  difficulty: number
+  txCount: number
+  mintingReward: number
+  transactions?: Array<{ hash: string; fee: number; ringSize: number }>
+  totalFees?: number
+  lottery?: {
+    totalFees?: number
+    poolDistributed?: number
+    amountBurned?: number
+    lotterySeed?: string
+    payoutCount?: number
+    payoutTotal?: number
+  }
+}
+
+/**
+ * Map an RPC block result to the core `Block` shape. Fee/lottery amounts go
+ * through `BigInt(String(...))` (never bare `Number()` arithmetic) so future
+ * wide values cannot be silently coerced. Enriched fields stay `undefined`
+ * when an older node omits them (#699 additive contract).
+ */
+function mapRpcBlock(result: RpcBlockResult): Block {
+  const block: Block = {
+    hash: result.hash,
+    height: result.height,
+    timestamp: result.timestamp,
+    previousHash: result.prevHash,
+    transactionCount: result.txCount,
+    size: 0, // Not provided
+    reward: BigInt(result.mintingReward || 0),
+    difficulty: BigInt(result.difficulty || 0),
+  }
+
+  if (Array.isArray(result.transactions)) {
+    block.transactions = result.transactions.map((tx) => ({
+      hash: tx.hash,
+      fee: BigInt(String(tx.fee ?? 0)),
+      ringSize: tx.ringSize ?? 0,
+    }))
+  }
+  if (result.totalFees !== undefined) {
+    block.totalFees = BigInt(String(result.totalFees))
+  }
+  if (result.lottery !== undefined) {
+    block.lottery = {
+      totalFees: BigInt(String(result.lottery.totalFees ?? 0)),
+      poolDistributed: BigInt(String(result.lottery.poolDistributed ?? 0)),
+      amountBurned: BigInt(String(result.lottery.amountBurned ?? 0)),
+      lotterySeed: result.lottery.lotterySeed ?? '',
+      payoutCount: result.lottery.payoutCount ?? 0,
+      payoutTotal: BigInt(String(result.lottery.payoutTotal ?? 0)),
+    }
+  }
+
+  return block
 }
 
 /** JSON-RPC 2.0 request */
@@ -206,48 +275,16 @@ export class RemoteNodeAdapter implements NodeAdapter {
   async getBlock(heightOrHash: BlockHeight | string): Promise<Block | null> {
     try {
       if (typeof heightOrHash === 'number') {
-        const result = await this.call<{
-          height: number
-          hash: string
-          prevHash: string
-          timestamp: number
-          difficulty: number
-          txCount: number
-          mintingReward: number
-        }>('getBlockByHeight', { height: heightOrHash })
-
-        return {
-          hash: result.hash,
-          height: result.height,
-          timestamp: result.timestamp,
-          previousHash: result.prevHash,
-          transactionCount: result.txCount,
-          size: 0, // Not provided
-          reward: BigInt(result.mintingReward || 0),
-          difficulty: BigInt(result.difficulty || 0),
-        }
+        const result = await this.call<RpcBlockResult>('getBlockByHeight', {
+          height: heightOrHash,
+        })
+        return mapRpcBlock(result)
       } else {
         // Resolve by hash via the node's getBlockByHash RPC (issue #330).
-        const result = await this.call<{
-          height: number
-          hash: string
-          prevHash: string
-          timestamp: number
-          difficulty: number
-          txCount: number
-          mintingReward: number
-        }>('getBlockByHash', { hash: heightOrHash })
-
-        return {
-          hash: result.hash,
-          height: result.height,
-          timestamp: result.timestamp,
-          previousHash: result.prevHash,
-          transactionCount: result.txCount,
-          size: 0, // Not provided
-          reward: BigInt(result.mintingReward || 0),
-          difficulty: BigInt(result.difficulty || 0),
-        }
+        const result = await this.call<RpcBlockResult>('getBlockByHash', {
+          hash: heightOrHash,
+        })
+        return mapRpcBlock(result)
       }
     } catch {
       return null
@@ -540,6 +577,32 @@ export class RemoteNodeAdapter implements NodeAdapter {
       total_value: number
     }>('cluster_getWealthByTargetKeys', { target_keys: targetKeys })
     return BigInt(result.max_cluster_wealth || '0')
+  }
+
+  /**
+   * Fetch every tracked cluster's wealth + live fee-curve factor via the
+   * node's `cluster_getAllWealth` RPC (#699/#700), for the explorer's
+   * wealth-distribution histogram.
+   *
+   * - `wealth` is a string-encoded u128 (#628) — parsed with `BigInt()`,
+   *   never `Number()` (precision loss above 2^53).
+   * - `factor` is the node-computed milli-x multiplier (1000..6000) from the
+   *   live Rust fee curve; older nodes omit it and we default to the 1000
+   *   floor rather than re-deriving the curve client-side (#610 drift class).
+   * - `cluster_id` stays a string — real ids exceed `Number.MAX_SAFE_INTEGER`.
+   */
+  async getAllClusterWealth(): Promise<ClusterWealthEntry[]> {
+    const result = await this.call<{
+      count: number
+      total_tracked_wealth: string
+      clusters?: Array<{ cluster_id: string; wealth: string; factor?: number }>
+    }>('cluster_getAllWealth', {})
+
+    return (result.clusters ?? []).map((cluster) => ({
+      clusterId: cluster.cluster_id,
+      wealth: BigInt(cluster.wealth || '0'),
+      factor: cluster.factor ?? 1000,
+    }))
   }
 
   // =========================================================================

--- a/web/packages/adapters/src/types.ts
+++ b/web/packages/adapters/src/types.ts
@@ -82,6 +82,23 @@ export interface BlockFetchOptions {
 }
 
 /**
+ * One cluster's tracked wealth + live fee factor, from `cluster_getAllWealth`
+ * (#699/#700). Powers the explorer's wealth-distribution histogram.
+ */
+export interface ClusterWealthEntry {
+  /** Cluster id as a decimal string (u64 — can exceed 2^53, never parseInt). */
+  clusterId: string
+  /** Tracked wealth in picocredits (string-encoded u128 on the wire). */
+  wealth: bigint
+  /**
+   * Node-computed milli-x fee-curve multiplier (1000 = 1.00x .. 6000 = 6.00x).
+   * Comes from the SAME Rust curve as `tx_estimateFee` — clients must never
+   * re-derive the curve. Older nodes omit it; the adapter defaults to 1000.
+   */
+  factor: number
+}
+
+/**
  * Abstract interface for connecting to Botho nodes
  *
  * This allows the same wallet UI to work with:
@@ -185,6 +202,17 @@ export interface NodeAdapter {
    * @param targetKeys Hex-encoded target keys of the wallet's owned outputs
    */
   getClusterWealth(targetKeys: string[]): Promise<bigint>
+
+  /**
+   * Fetch every tracked cluster's wealth + live fee factor
+   * (`cluster_getAllWealth`, #699/#700) for the explorer's wealth-distribution
+   * view. Wealth is a string-encoded u128 on the wire and MUST be parsed via
+   * `BigInt()` (never `Number()`).
+   *
+   * Optional: not every adapter/node supports it — callers must degrade
+   * gracefully when absent.
+   */
+  getAllClusterWealth?(): Promise<ClusterWealthEntry[]>
 
   // =========================================================================
   // Events

--- a/web/packages/core/src/types/index.ts
+++ b/web/packages/core/src/types/index.ts
@@ -110,6 +110,33 @@ export interface Contact {
 // Block Types
 // ============================================================================
 
+/**
+ * Privacy-safe per-transaction structure inside a block (#699/#700).
+ * Structure only: hash, fee, ring size — never amounts, recipients, or
+ * linkage data.
+ */
+export interface BlockTransactionSummary {
+  hash: TxHash
+  /** Transaction fee in picocredits. */
+  fee: Amount
+  /** Ring-member count of the tx's CLSAG inputs (all inputs share it). */
+  ringSize: number
+}
+
+/**
+ * On-chain lottery summary for a block (#699/#700). All amounts are
+ * picocredits. Blocks without lottery activity carry explicit zeros.
+ */
+export interface BlockLotterySummary {
+  totalFees: Amount
+  poolDistributed: Amount
+  amountBurned: Amount
+  /** Hex-encoded lottery seed for this block. */
+  lotterySeed: string
+  payoutCount: number
+  payoutTotal: Amount
+}
+
 export interface Block {
   hash: BlockHash
   height: BlockHeight
@@ -120,6 +147,15 @@ export interface Block {
   minter?: Address
   reward: Amount
   difficulty: bigint
+  /**
+   * Enriched explorer fields (#700). Optional and additive — older nodes
+   * omit them, and consumers must guard with undefined checks.
+   */
+  transactions?: BlockTransactionSummary[]
+  /** Sum of all tx fees in the block, in picocredits. */
+  totalFees?: Amount
+  /** Lottery summary; present when the node serves the enriched RPC. */
+  lottery?: BlockLotterySummary
 }
 
 // ============================================================================

--- a/web/packages/features/src/explorer/components/block-detail.tsx
+++ b/web/packages/features/src/explorer/components/block-detail.tsx
@@ -1,6 +1,6 @@
 import type { Block } from '@botho/core'
 import { Card, CardHeader, CardTitle, CardContent, Button } from '@botho/ui'
-import { ArrowLeft, Blocks, Package } from 'lucide-react'
+import { ArrowLeft, Blocks, Package, Ticket } from 'lucide-react'
 import { useExplorer } from '../context'
 import { DetailRow } from './detail-row'
 import { formatTime, formatHash, formatAmount, formatDifficulty, formatSize, ZERO_HASH } from '../utils'
@@ -13,7 +13,13 @@ export interface BlockDetailProps {
 }
 
 export function BlockDetail({ block, className }: BlockDetailProps) {
-  const { goBack, viewBlock } = useExplorer()
+  const { goBack, viewBlock, viewTransactionByHash } = useExplorer()
+
+  // Enriched fields (#699/#700) are additive — older nodes omit them, so
+  // every render below guards with undefined checks.
+  const hasLotteryActivity =
+    block.lottery !== undefined &&
+    (block.lottery.payoutCount > 0 || block.lottery.poolDistributed > 0n)
 
   return (
     <div className={`space-y-4 ${className || ''}`}>
@@ -48,6 +54,9 @@ export function BlockDetail({ block, className }: BlockDetailProps) {
               valueClass="text-[--color-success]"
             />
             <DetailRow label="Difficulty" value={formatDifficulty(block.difficulty)} />
+            {block.totalFees !== undefined && (
+              <DetailRow label="Total Fees" value={`${formatAmount(block.totalFees)} BTH`} />
+            )}
             <div className="col-span-2">
               <DetailRow
                 label="Previous Block"
@@ -77,8 +86,33 @@ export function BlockDetail({ block, className }: BlockDetailProps) {
             <CardTitle>Transactions</CardTitle>
           </div>
         </CardHeader>
-        <CardContent>
-          {block.transactionCount === 0 ? (
+        <CardContent className={block.transactions && block.transactions.length > 0 ? 'p-0' : undefined}>
+          {block.transactions && block.transactions.length > 0 ? (
+            /* Enriched per-tx structure (#700): hash, fee, ring size. */
+            <div className="divide-y divide-[--color-slate]/30">
+              {block.transactions.map((tx) => (
+                <div key={tx.hash} className="flex items-center gap-4 px-6 py-3">
+                  <button
+                    onClick={() => viewTransactionByHash(tx.hash)}
+                    className="min-w-0 flex-1 truncate text-left font-mono text-sm text-[--color-ghost] hover:text-[--color-pulse] hover:underline"
+                    title={tx.hash}
+                  >
+                    {formatHash(tx.hash, 12)}
+                  </button>
+                  <div className="text-right">
+                    <p className="text-xs uppercase tracking-wider text-[--color-dim]">Fee</p>
+                    <p className="mt-0.5 font-mono text-sm text-[--color-light]">
+                      {formatAmount(tx.fee)} BTH
+                    </p>
+                  </div>
+                  <div className="w-16 text-right">
+                    <p className="text-xs uppercase tracking-wider text-[--color-dim]">Ring</p>
+                    <p className="mt-0.5 font-mono text-sm text-[--color-light]">{tx.ringSize}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : block.transactionCount === 0 ? (
             <p className="py-8 text-center text-sm text-[--color-dim]">
               No transactions in this block (minting reward only)
             </p>
@@ -90,6 +124,48 @@ export function BlockDetail({ block, className }: BlockDetailProps) {
           )}
         </CardContent>
       </Card>
+
+      {/* Lottery summary (#699): shown only when the block has lottery activity */}
+      {hasLotteryActivity && block.lottery && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Ticket className="h-4 w-4 text-[--color-pulse]" />
+              <CardTitle>Lottery</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <DetailRow label="Payouts" value={block.lottery.payoutCount.toString()} />
+              <DetailRow
+                label="Payout Total"
+                value={`${formatAmount(block.lottery.payoutTotal)} BTH`}
+                valueClass="text-[--color-success]"
+              />
+              <DetailRow
+                label="Pool Distributed"
+                value={`${formatAmount(block.lottery.poolDistributed)} BTH`}
+              />
+              <DetailRow
+                label="Amount Burned"
+                value={`${formatAmount(block.lottery.amountBurned)} BTH`}
+                valueClass="text-[--color-danger]"
+              />
+              <DetailRow
+                label="Lottery Fees"
+                value={`${formatAmount(block.lottery.totalFees)} BTH`}
+              />
+              {block.lottery.lotterySeed && (
+                <DetailRow
+                  label="Lottery Seed"
+                  value={formatHash(block.lottery.lotterySeed, 16)}
+                  mono
+                />
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }

--- a/web/packages/features/src/explorer/components/cluster-wealth.test.tsx
+++ b/web/packages/features/src/explorer/components/cluster-wealth.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The wealth view's contract (#699): a histogram of node-supplied factors
+ * (never a TS re-derivation of the curve), explicit empty state for a young
+ * chain, and explicit unavailable/error states — no fabricated values.
+ */
+import { describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { ClusterWealth } from './cluster-wealth'
+import type { ClusterWealthEntry } from '../wealth'
+
+const BTH = 10n ** 12n
+
+function entry(wealth: bigint, factor: number, clusterId: string): ClusterWealthEntry {
+  return { clusterId, wealth, factor }
+}
+
+function renderWealth(props: Partial<Parameters<typeof ClusterWealth>[0]> = {}) {
+  cleanup()
+  return render(
+    <ClusterWealth clusters={[]} loading={false} error={null} supported {...props} />,
+  )
+}
+
+describe('ClusterWealth', () => {
+  it('renders the histogram, summary stats, and factor-band legend', () => {
+    renderWealth({
+      clusters: [
+        entry(50n * BTH, 1000, '1'),
+        entry(50n * BTH, 1000, '2'),
+        entry(100_000n * BTH, 2500, '3'),
+      ],
+    })
+    expect(screen.getByRole('img', { name: 'Cluster wealth histogram' })).toBeDefined()
+    // Summary stats: 3 clusters, exact BigInt total (100,100 BTH), median 1.00x.
+    expect(screen.getByText('Clusters')).toBeDefined()
+    expect(screen.getByText('3')).toBeDefined()
+    expect(screen.getByText('100,100.00 BTH')).toBeDefined()
+    expect(screen.getByText('Median factor')).toBeDefined()
+    expect(screen.getByText('1.00x')).toBeDefined()
+    // Band legend renders every band label.
+    expect(screen.getByText('1.00x (floor)')).toBeDefined()
+    expect(screen.getByText('2.00x–4.99x')).toBeDefined()
+    expect(screen.getByText('6.00x (ceiling)')).toBeDefined()
+  })
+
+  it('summarizes a > 2^53 whale without precision loss', () => {
+    // 10^20 picocredits = 100,000,000 BTH — beyond Number.MAX_SAFE_INTEGER.
+    renderWealth({ clusters: [entry(10n ** 20n, 6000, 'whale')] })
+    expect(screen.getByText('100,000,000.00 BTH')).toBeDefined()
+    expect(screen.getByText('6.00x')).toBeDefined()
+  })
+
+  it('shows the young-chain empty state for zero clusters', () => {
+    renderWealth({ clusters: [] })
+    expect(screen.getByText('No clusters tracked yet')).toBeDefined()
+    expect(screen.queryByRole('img', { name: 'Cluster wealth histogram' })).toBeNull()
+  })
+
+  it('shows a loading state until the first fetch resolves', () => {
+    const { container } = renderWealth({ clusters: null, loading: true })
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+  })
+
+  it('degrades to an explicit unavailable state when the data source lacks the RPC', () => {
+    renderWealth({ clusters: null, supported: false })
+    expect(screen.getByText(/Wealth distribution is unavailable/)).toBeDefined()
+  })
+
+  it('renders the fetch error explicitly — never stale data', () => {
+    renderWealth({ clusters: null, error: 'node timed out' })
+    expect(screen.getByText(/Failed to load cluster wealth: node timed out/)).toBeDefined()
+  })
+})

--- a/web/packages/features/src/explorer/components/cluster-wealth.tsx
+++ b/web/packages/features/src/explorer/components/cluster-wealth.tsx
@@ -1,0 +1,196 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@botho/ui'
+import { Scale, Loader2 } from 'lucide-react'
+import { formatBTH } from '@botho/core'
+import {
+  FACTOR_BANDS,
+  bucketClusters,
+  formatFactor,
+  summarizeWealth,
+  type ClusterWealthEntry,
+} from '../wealth'
+
+export interface ClusterWealthProps {
+  /** Cluster entries; null = not yet loaded. */
+  clusters: ClusterWealthEntry[] | null
+  /** Fetch in flight. */
+  loading: boolean
+  /** Fetch error message. */
+  error: string | null
+  /** False when the data source has no cluster-wealth method. */
+  supported?: boolean
+  /** Custom class name */
+  className?: string
+}
+
+const W = 600
+const H = 220
+const PAD_X = 8
+const PAD_TOP = 12
+const AXIS_H = 22
+
+/**
+ * Cluster-wealth distribution view (#699): log-scale BTH histogram where
+ * each bar stacks the node-computed factor bands (floor 1.00x .. ceiling
+ * 6.00x), plus summary stats. Dependency-free SVG, matching the network
+ * dashboard's hand-rolled chart idiom.
+ *
+ * Privacy: aggregates only — cluster ids/wealth are already public tracker
+ * state; no addresses, balances, or linkage data appear here.
+ */
+export function ClusterWealth({
+  clusters,
+  loading,
+  error,
+  supported = true,
+  className,
+}: ClusterWealthProps) {
+  let body: React.ReactNode
+
+  if (!supported) {
+    body = (
+      <p className="py-12 text-center text-sm text-[--color-dim]">
+        Wealth distribution is unavailable — the connected node does not expose
+        cluster-wealth data.
+      </p>
+    )
+  } else if (error) {
+    body = (
+      <p className="py-12 text-center text-sm text-[--color-danger]">
+        Failed to load cluster wealth: {error}
+      </p>
+    )
+  } else if (loading || clusters === null) {
+    body = (
+      <div className="flex items-center justify-center py-16">
+        <Loader2 className="h-8 w-8 animate-spin text-[--color-pulse]" />
+      </div>
+    )
+  } else if (clusters.length === 0) {
+    body = (
+      <div className="flex flex-col items-center justify-center py-16">
+        <Scale className="h-12 w-12 text-[--color-dim]" />
+        <p className="mt-4 text-lg text-[--color-ghost]">No clusters tracked yet</p>
+        <p className="mt-2 text-sm text-[--color-dim]">
+          The wealth distribution appears once the chain has spend activity to cluster.
+        </p>
+      </div>
+    )
+  } else {
+    const buckets = bucketClusters(clusters)
+    const summary = summarizeWealth(clusters)
+    const maxTotal = Math.max(...buckets.map((b) => b.total), 1)
+
+    const plotW = W - 2 * PAD_X
+    const plotH = H - PAD_TOP - AXIS_H
+    const slotW = plotW / buckets.length
+    const barW = Math.max(4, slotW * 0.7)
+
+    body = (
+      <div className="space-y-4">
+        {/* Summary stats */}
+        <div className="grid grid-cols-3 gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-wider text-[--color-dim]">Clusters</p>
+            <p className="mt-1 font-mono text-sm text-[--color-light]">
+              {summary.clusterCount.toLocaleString()}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wider text-[--color-dim]">Total wealth</p>
+            <p className="mt-1 font-mono text-sm text-[--color-light]">
+              {formatBTH(summary.totalWealth)} BTH
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wider text-[--color-dim]">Median factor</p>
+            <p className="mt-1 font-mono text-sm text-[--color-light]">
+              {summary.medianFactor === null ? '—' : formatFactor(summary.medianFactor)}
+            </p>
+          </div>
+        </div>
+
+        {/* Histogram: stacked bars per log-scale BTH bucket, colored by factor band */}
+        <svg
+          viewBox={`0 0 ${W} ${H}`}
+          className="w-full"
+          role="img"
+          aria-label="Cluster wealth histogram"
+        >
+          {buckets.map((bucket) => {
+            const xCenter = PAD_X + bucket.index * slotW + slotW / 2
+            const x = xCenter - barW / 2
+            let yCursor = PAD_TOP + plotH
+            return (
+              <g key={bucket.index}>
+                {FACTOR_BANDS.map(({ band, color }) => {
+                  const count = bucket.byBand[band]
+                  if (count === 0) return null
+                  const h = (count / maxTotal) * plotH
+                  yCursor -= h
+                  return (
+                    <rect
+                      key={band}
+                      x={x}
+                      y={yCursor}
+                      width={barW}
+                      height={h}
+                      fill={color}
+                    />
+                  )
+                })}
+                {bucket.total > 0 && (
+                  <text
+                    x={xCenter}
+                    y={yCursor - 4}
+                    textAnchor="middle"
+                    fontSize={10}
+                    fill="currentColor"
+                    opacity={0.7}
+                  >
+                    {bucket.total}
+                  </text>
+                )}
+                <text
+                  x={xCenter}
+                  y={H - 6}
+                  textAnchor="middle"
+                  fontSize={9}
+                  fill="currentColor"
+                  opacity={0.5}
+                >
+                  {bucket.label}
+                </text>
+              </g>
+            )
+          })}
+        </svg>
+        <p className="text-center text-xs text-[--color-dim]">Cluster wealth (BTH, log scale)</p>
+
+        {/* Factor-band legend */}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[--color-dim]">
+          {FACTOR_BANDS.map(({ band, label, color }) => (
+            <span key={band} className="inline-flex items-center gap-1.5">
+              <span
+                className="inline-block h-2 w-2 rounded-full"
+                style={{ backgroundColor: color }}
+              />
+              {label}
+            </span>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Scale className="h-4 w-4 text-[--color-pulse]" />
+          <CardTitle>Wealth Distribution</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent>{body}</CardContent>
+    </Card>
+  )
+}

--- a/web/packages/features/src/explorer/components/explorer.tsx
+++ b/web/packages/features/src/explorer/components/explorer.tsx
@@ -3,11 +3,14 @@ import { Card, CardContent } from '@botho/ui'
 import { motion, AnimatePresence } from 'motion/react'
 import { Database } from 'lucide-react'
 import { useExplorer } from '../context'
+import type { ExplorerTab } from '../types'
 import { SearchBar } from './search-bar'
 import { ErrorMessage } from './error-message'
 import { BlockList } from './block-list'
 import { BlockDetail } from './block-detail'
 import { TransactionDetail } from './transaction-detail'
+import { ClusterWealth } from './cluster-wealth'
+import { LotteryFeed } from './lottery-feed'
 
 export interface ExplorerProps {
   /** Whether the data source is connected/ready */
@@ -18,18 +21,35 @@ export interface ExplorerProps {
   className?: string
 }
 
+const TABS: Array<{ id: ExplorerTab; label: string }> = [
+  { id: 'blocks', label: 'Blocks' },
+  { id: 'wealth', label: 'Wealth distribution' },
+  { id: 'lottery', label: 'Lottery' },
+]
+
 /**
  * Complete blockchain explorer component
  *
- * Renders search bar, block list, block details, and transaction details
- * based on the current view state from ExplorerContext.
+ * Renders search bar, list-mode tabs (blocks / wealth distribution / lottery),
+ * block details, and transaction details based on the current view state from
+ * ExplorerContext.
  */
 export function Explorer({
   isConnected = true,
   notConnectedMessage,
   className,
 }: ExplorerProps) {
-  const { view } = useExplorer()
+  const {
+    view,
+    blocks,
+    activeTab,
+    setActiveTab,
+    viewBlock,
+    clusterWealth,
+    wealthLoading,
+    wealthError,
+    wealthSupported,
+  } = useExplorer()
 
   // Not connected state
   if (!isConnected) {
@@ -62,16 +82,52 @@ export function Explorer({
       {/* Error message */}
       <ErrorMessage />
 
+      {/* List-mode tabs (#699) */}
+      {view.mode === 'list' && (
+        <div
+          role="tablist"
+          aria-label="Explorer views"
+          className="flex gap-1 rounded-lg border border-[--color-slate]/30 bg-[--color-abyss]/40 p-1"
+        >
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`flex-1 rounded-md px-3 py-1.5 text-sm transition-colors ${
+                activeTab === tab.id
+                  ? 'bg-[--color-pulse]/15 text-[--color-pulse]'
+                  : 'text-[--color-ghost] hover:text-[--color-light]'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      )}
+
       {/* Content based on view mode */}
       <AnimatePresence mode="wait">
         {view.mode === 'list' && (
           <motion.div
-            key="list"
+            key={`list-${activeTab}`}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
           >
-            <BlockList />
+            {activeTab === 'blocks' && <BlockList />}
+            {activeTab === 'wealth' && (
+              <ClusterWealth
+                clusters={clusterWealth}
+                loading={wealthLoading}
+                error={wealthError}
+                supported={wealthSupported}
+              />
+            )}
+            {activeTab === 'lottery' && (
+              <LotteryFeed blocks={blocks} onViewBlock={viewBlock} />
+            )}
           </motion.div>
         )}
 

--- a/web/packages/features/src/explorer/components/index.ts
+++ b/web/packages/features/src/explorer/components/index.ts
@@ -18,3 +18,9 @@ export type { ErrorMessageProps } from './error-message'
 
 export { DetailRow } from './detail-row'
 export type { DetailRowProps } from './detail-row'
+
+export { ClusterWealth } from './cluster-wealth'
+export type { ClusterWealthProps } from './cluster-wealth'
+
+export { LotteryFeed } from './lottery-feed'
+export type { LotteryFeedProps } from './lottery-feed'

--- a/web/packages/features/src/explorer/components/lottery-feed.test.tsx
+++ b/web/packages/features/src/explorer/components/lottery-feed.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The lottery feed's contract (#699): list blocks with on-chain lottery
+ * activity (payouts or pool distribution) newest first, showing aggregates
+ * only — never recipients or linkage data — and an explicit empty state.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { Block, BlockLotterySummary } from '@botho/core'
+import { LotteryFeed } from './lottery-feed'
+
+const BTH = 10n ** 12n
+
+function lottery(over: Partial<BlockLotterySummary> = {}): BlockLotterySummary {
+  return {
+    totalFees: 0n,
+    poolDistributed: 0n,
+    amountBurned: 0n,
+    lotterySeed: 'aa'.repeat(32),
+    payoutCount: 0,
+    payoutTotal: 0n,
+    ...over,
+  }
+}
+
+function block(height: number, over: Partial<Block> = {}): Block {
+  return {
+    hash: `hash-${height}`,
+    height,
+    timestamp: Math.floor(Date.now() / 1000) - 60,
+    previousHash: `hash-${height - 1}`,
+    transactionCount: 1,
+    size: 0,
+    reward: 0n,
+    difficulty: 0n,
+    ...over,
+  }
+}
+
+describe('LotteryFeed', () => {
+  it('lists lottery blocks newest first with payout/pool/burn aggregates', () => {
+    cleanup()
+    render(
+      <LotteryFeed
+        blocks={[
+          block(10, {
+            lottery: lottery({
+              payoutCount: 2,
+              payoutTotal: 3n * BTH,
+              poolDistributed: 5n * BTH,
+              amountBurned: 1n * BTH,
+            }),
+          }),
+          block(11), // no lottery field (older node) — excluded
+          block(12, { lottery: lottery({ poolDistributed: 7n * BTH }) }),
+        ]}
+      />,
+    )
+    const heights = screen.getAllByText(/^#\d+$/).map((el) => el.textContent)
+    expect(heights).toEqual(['#12', '#10']) // newest first, non-events dropped
+    expect(screen.getByText('3.00 BTH')).toBeDefined() // payout total
+    expect(screen.getByText('5.00 BTH')).toBeDefined() // pool distributed
+    expect(screen.getByText('1.00 BTH')).toBeDefined() // burned
+    expect(screen.getByText('7.00 BTH')).toBeDefined()
+  })
+
+  it('navigates to the block detail when a row is clicked', () => {
+    cleanup()
+    const onViewBlock = vi.fn()
+    const target = block(20, { lottery: lottery({ payoutCount: 1 }) })
+    render(<LotteryFeed blocks={[target]} onViewBlock={onViewBlock} />)
+    fireEvent.click(screen.getByText('#20'))
+    expect(onViewBlock).toHaveBeenCalledWith(target)
+  })
+
+  it('shows an explicit empty state scoped to the loaded window', () => {
+    cleanup()
+    render(<LotteryFeed blocks={[block(1), block(2, { lottery: lottery() })]} />)
+    expect(screen.getByText('No lottery activity')).toBeDefined()
+    expect(screen.getByText(/2 most recent loaded blocks/)).toBeDefined()
+  })
+})

--- a/web/packages/features/src/explorer/components/lottery-feed.tsx
+++ b/web/packages/features/src/explorer/components/lottery-feed.tsx
@@ -1,0 +1,104 @@
+import type { Block } from '@botho/core'
+import { Card, CardHeader, CardTitle, CardContent } from '@botho/ui'
+import { Ticket, Clock } from 'lucide-react'
+import { formatBTH } from '@botho/core'
+import { selectLotteryBlocks } from '../lottery'
+import { formatTime } from '../utils'
+
+export interface LotteryFeedProps {
+  /** Recent blocks to scan for lottery activity (the explorer's loaded window). */
+  blocks: Block[]
+  /** Navigate to a block's detail view. */
+  onViewBlock?: (block: Block) => void
+  /** Custom class name */
+  className?: string
+}
+
+/**
+ * Lottery events feed (#699): blocks in the loaded window with on-chain
+ * lottery activity (payouts or pool distribution), newest first.
+ *
+ * Privacy: on-chain aggregates only — payout counts and totals, never
+ * recipients or linkage tooling.
+ */
+export function LotteryFeed({ blocks, onViewBlock, className }: LotteryFeedProps) {
+  const events = selectLotteryBlocks(blocks)
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Ticket className="h-4 w-4 text-[--color-pulse]" />
+          <CardTitle>Lottery Events</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className={events.length === 0 ? undefined : 'p-0'}>
+        {events.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16">
+            <Ticket className="h-12 w-12 text-[--color-dim]" />
+            <p className="mt-4 text-lg text-[--color-ghost]">No lottery activity</p>
+            <p className="mt-2 text-sm text-[--color-dim]">
+              No payouts or pool distributions in the {blocks.length} most recent loaded
+              block{blocks.length !== 1 ? 's' : ''}. Load more blocks to widen the window.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y divide-[--color-slate]/30">
+            {events.map((block) => {
+              const lottery = block.lottery!
+              return (
+                <div
+                  key={block.hash}
+                  onClick={onViewBlock ? () => onViewBlock(block) : undefined}
+                  className={`flex flex-wrap items-center gap-x-6 gap-y-2 px-6 py-4 ${
+                    onViewBlock
+                      ? 'cursor-pointer transition-colors hover:bg-[--color-abyss]/50'
+                      : ''
+                  }`}
+                >
+                  <div className="flex h-12 w-16 flex-shrink-0 items-center justify-center rounded-lg bg-[--color-pulse]/10">
+                    <span className="font-mono text-sm font-bold text-[--color-pulse]">
+                      #{block.height}
+                    </span>
+                  </div>
+                  <div className="min-w-[6rem]">
+                    <p className="text-xs uppercase tracking-wider text-[--color-dim]">Payouts</p>
+                    <p className="mt-1 font-mono text-sm text-[--color-light]">
+                      {lottery.payoutCount}
+                    </p>
+                  </div>
+                  <div className="min-w-[8rem]">
+                    <p className="text-xs uppercase tracking-wider text-[--color-dim]">
+                      Payout total
+                    </p>
+                    <p className="mt-1 font-mono text-sm text-[--color-success]">
+                      {formatBTH(lottery.payoutTotal)} BTH
+                    </p>
+                  </div>
+                  <div className="min-w-[8rem]">
+                    <p className="text-xs uppercase tracking-wider text-[--color-dim]">
+                      Pool distributed
+                    </p>
+                    <p className="mt-1 font-mono text-sm text-[--color-light]">
+                      {formatBTH(lottery.poolDistributed)} BTH
+                    </p>
+                  </div>
+                  <div className="min-w-[8rem]">
+                    <p className="text-xs uppercase tracking-wider text-[--color-dim]">Burned</p>
+                    <p className="mt-1 font-mono text-sm text-[--color-danger]">
+                      {formatBTH(lottery.amountBurned)} BTH
+                    </p>
+                  </div>
+                  <span className="ml-auto flex items-center gap-1 text-xs text-[--color-dim]">
+                    <Clock className="h-3 w-3" />
+                    {formatTime(block.timestamp)}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/packages/features/src/explorer/context.tsx
+++ b/web/packages/features/src/explorer/context.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react'
 import type { Block, Transaction } from '@botho/core'
-import type { ExplorerDataSource, ExplorerView, ExplorerContextValue } from './types'
+import type { ExplorerDataSource, ExplorerTab, ExplorerView, ExplorerContextValue } from './types'
+import type { ClusterWealthEntry } from './wealth'
 
 const ExplorerContext = createContext<ExplorerContextValue | null>(null)
 
@@ -25,6 +26,12 @@ export function ExplorerProvider({ dataSource, isReady = true, initialQuery, onV
   const [error, setError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState(initialQuery ?? '')
   const [initialQueryProcessed, setInitialQueryProcessed] = useState(false)
+  const [activeTab, setActiveTabInternal] = useState<ExplorerTab>('blocks')
+  const [clusterWealth, setClusterWealth] = useState<ClusterWealthEntry[] | null>(null)
+  const [wealthLoading, setWealthLoading] = useState(false)
+  const [wealthError, setWealthError] = useState<string | null>(null)
+
+  const wealthSupported = typeof dataSource.getAllClusterWealth === 'function'
 
   // Wrapper to notify parent of view changes
   const setView = useCallback((newView: ExplorerView) => {
@@ -173,6 +180,57 @@ export function ExplorerProvider({ dataSource, isReady = true, initialQuery, onV
     setError(null)
   }, [setView])
 
+  // Fetch a transaction by hash and view it (block-detail per-tx links, #699)
+  const viewTransactionByHash = useCallback(
+    async (txHash: string) => {
+      if (!isReady) return
+
+      setLoading(true)
+      setError(null)
+
+      try {
+        const tx = await dataSource.getTransaction(txHash)
+        if (tx) {
+          setView({ mode: 'transaction', transaction: tx })
+        } else {
+          setError('Transaction not found')
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load transaction')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [dataSource, isReady, setView]
+  )
+
+  // Refresh cluster-wealth data (wealth-distribution tab, #699)
+  const refreshWealth = useCallback(async () => {
+    if (!isReady || !dataSource.getAllClusterWealth) return
+
+    setWealthLoading(true)
+    setWealthError(null)
+
+    try {
+      const clusters = await dataSource.getAllClusterWealth()
+      setClusterWealth(clusters)
+    } catch (err) {
+      setWealthError(err instanceof Error ? err.message : 'Failed to load cluster wealth')
+    } finally {
+      setWealthLoading(false)
+    }
+  }, [dataSource, isReady])
+
+  // Switch the list-mode tab; always lands back on the list view
+  const setActiveTab = useCallback(
+    (tab: ExplorerTab) => {
+      setActiveTabInternal(tab)
+      setView({ mode: 'list' })
+      setError(null)
+    },
+    [setView]
+  )
+
   // Go back to list
   const goBack = useCallback(() => {
     setView({ mode: 'list' })
@@ -194,6 +252,13 @@ export function ExplorerProvider({ dataSource, isReady = true, initialQuery, onV
       search()
     }
   }, [isReady, initialQuery, initialQueryProcessed, search])
+
+  // Lazily fetch cluster wealth the first time the wealth tab is opened
+  useEffect(() => {
+    if (activeTab === 'wealth' && isReady && clusterWealth === null && !wealthLoading) {
+      refreshWealth()
+    }
+  }, [activeTab, isReady, clusterWealth, wealthLoading, refreshWealth])
 
   // Subscribe to new blocks
   useEffect(() => {
@@ -221,9 +286,17 @@ export function ExplorerProvider({ dataSource, isReady = true, initialQuery, onV
     search,
     viewBlock,
     viewTransaction,
+    viewTransactionByHash,
     goBack,
     loadMore,
     refresh,
+    activeTab,
+    setActiveTab,
+    clusterWealth,
+    wealthLoading,
+    wealthError,
+    wealthSupported,
+    refreshWealth,
   }
 
   return <ExplorerContext.Provider value={value}>{children}</ExplorerContext.Provider>

--- a/web/packages/features/src/explorer/index.ts
+++ b/web/packages/features/src/explorer/index.ts
@@ -6,6 +6,7 @@ export type { ExplorerProviderProps } from './context'
 export type {
   ExplorerDataSource,
   ExplorerView,
+  ExplorerTab,
   ExplorerContextValue,
 } from './types'
 
@@ -18,6 +19,8 @@ export {
   TransactionDetail,
   ErrorMessage,
   DetailRow,
+  ClusterWealth,
+  LotteryFeed,
 } from './components'
 
 export type {
@@ -28,6 +31,8 @@ export type {
   TransactionDetailProps,
   ErrorMessageProps,
   DetailRowProps,
+  ClusterWealthProps,
+  LotteryFeedProps,
 } from './components'
 
 // Utilities
@@ -41,3 +46,24 @@ export {
   isValidBlockHeight,
   ZERO_HASH,
 } from './utils'
+
+// Wealth-distribution derivations (#699)
+export {
+  FACTOR_BANDS,
+  PICO_PER_BTH,
+  factorBand,
+  formatFactor,
+  wealthBucketIndex,
+  bucketLabel,
+  bucketClusters,
+  summarizeWealth,
+} from './wealth'
+export type {
+  ClusterWealthEntry,
+  FactorBand,
+  WealthBucket,
+  WealthSummary,
+} from './wealth'
+
+// Lottery-feed derivations (#699)
+export { selectLotteryBlocks } from './lottery'

--- a/web/packages/features/src/explorer/lottery.test.ts
+++ b/web/packages/features/src/explorer/lottery.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { Block, BlockLotterySummary } from '@botho/core'
+import { selectLotteryBlocks } from './lottery'
+
+function lottery(over: Partial<BlockLotterySummary> = {}): BlockLotterySummary {
+  return {
+    totalFees: 0n,
+    poolDistributed: 0n,
+    amountBurned: 0n,
+    lotterySeed: '',
+    payoutCount: 0,
+    payoutTotal: 0n,
+    ...over,
+  }
+}
+
+function block(height: number, over: Partial<Block> = {}): Block {
+  return {
+    hash: `hash-${height}`,
+    height,
+    timestamp: 1_751_840_000 + height,
+    previousHash: `hash-${height - 1}`,
+    transactionCount: 0,
+    size: 0,
+    reward: 0n,
+    difficulty: 0n,
+    ...over,
+  }
+}
+
+describe('selectLotteryBlocks', () => {
+  it('keeps blocks with payouts OR pool distribution, newest first', () => {
+    const selected = selectLotteryBlocks([
+      block(10, { lottery: lottery({ payoutCount: 2, payoutTotal: 100n }) }),
+      block(12, { lottery: lottery() }), // zero activity — dropped
+      block(11, { lottery: lottery({ poolDistributed: 200n }) }), // pool only — kept
+      block(13, { lottery: lottery({ payoutCount: 1 }) }),
+    ])
+    expect(selected.map((b) => b.height)).toEqual([13, 11, 10])
+  })
+
+  it('excludes blocks from older nodes without the lottery field', () => {
+    expect(selectLotteryBlocks([block(5), block(6)])).toEqual([])
+  })
+
+  it('returns [] for an empty window and never mutates the input', () => {
+    expect(selectLotteryBlocks([])).toEqual([])
+
+    const input = [
+      block(1, { lottery: lottery({ payoutCount: 1 }) }),
+      block(2, { lottery: lottery({ payoutCount: 1 }) }),
+    ]
+    selectLotteryBlocks(input)
+    expect(input.map((b) => b.height)).toEqual([1, 2]) // original order intact
+  })
+
+  it('treats a burn-only block (fees burned, nothing distributed) as no activity', () => {
+    const burnOnly = block(7, { lottery: lottery({ amountBurned: 50n, totalFees: 50n }) })
+    expect(selectLotteryBlocks([burnOnly])).toEqual([])
+  })
+})

--- a/web/packages/features/src/explorer/lottery.ts
+++ b/web/packages/features/src/explorer/lottery.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure derivations for the explorer's lottery events feed (#699).
+ *
+ * Displays on-chain facts only — per-block aggregates (payout count/total,
+ * pool distributed, fee burn). No payout-recipient linkage tooling, per the
+ * privacy posture of the handoff.
+ */
+import type { Block } from '@botho/core'
+
+/**
+ * Select blocks with lottery activity: payoutCount > 0 OR poolDistributed > 0.
+ *
+ * Blocks from older nodes (no `lottery` field) are excluded rather than
+ * rendered as zeros. Returns a NEW array sorted newest first; the input is
+ * never mutated.
+ */
+export function selectLotteryBlocks(blocks: Block[]): Block[] {
+  return blocks
+    .filter(
+      (block) =>
+        block.lottery !== undefined &&
+        (block.lottery.payoutCount > 0 || block.lottery.poolDistributed > 0n),
+    )
+    .sort((a, b) => b.height - a.height)
+}

--- a/web/packages/features/src/explorer/types.ts
+++ b/web/packages/features/src/explorer/types.ts
@@ -1,4 +1,5 @@
 import type { Block, Transaction } from '@botho/core'
+import type { ClusterWealthEntry } from './wealth'
 
 /**
  * Explorer data source interface
@@ -18,6 +19,13 @@ export interface ExplorerDataSource {
 
   /** Subscribe to new blocks (returns unsubscribe function) */
   onNewBlock?(callback: (block: Block) => void): () => void
+
+  /**
+   * Get every tracked cluster's wealth + node-computed fee factor (#699).
+   * Optional — when absent, the wealth-distribution tab shows an
+   * "unavailable" state instead of breaking.
+   */
+  getAllClusterWealth?(): Promise<ClusterWealthEntry[]>
 }
 
 /**
@@ -27,6 +35,11 @@ export type ExplorerView =
   | { mode: 'list' }
   | { mode: 'block'; block: Block }
   | { mode: 'transaction'; transaction: Transaction }
+
+/**
+ * List-mode tabs: recent blocks, cluster-wealth distribution, lottery feed.
+ */
+export type ExplorerTab = 'blocks' | 'wealth' | 'lottery'
 
 /**
  * Explorer context value
@@ -63,6 +76,9 @@ export interface ExplorerContextValue {
   /** View a specific transaction */
   viewTransaction: (tx: Transaction) => void
 
+  /** Fetch a transaction by hash and view it (block-detail tx links, #699) */
+  viewTransactionByHash: (txHash: string) => Promise<void>
+
   /** Go back to list view */
   goBack: () => void
 
@@ -71,4 +87,25 @@ export interface ExplorerContextValue {
 
   /** Refresh blocks */
   refresh: () => Promise<void>
+
+  /** Active list-mode tab (#699) */
+  activeTab: ExplorerTab
+
+  /** Switch the list-mode tab (also returns to the list view) */
+  setActiveTab: (tab: ExplorerTab) => void
+
+  /** Cluster-wealth entries; null until the first fetch resolves */
+  clusterWealth: ClusterWealthEntry[] | null
+
+  /** Cluster-wealth fetch in flight */
+  wealthLoading: boolean
+
+  /** Cluster-wealth fetch error */
+  wealthError: string | null
+
+  /** Whether the data source supports cluster-wealth queries */
+  wealthSupported: boolean
+
+  /** Refresh the cluster-wealth data */
+  refreshWealth: () => Promise<void>
 }

--- a/web/packages/features/src/explorer/wealth.test.ts
+++ b/web/packages/features/src/explorer/wealth.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  bucketClusters,
+  bucketLabel,
+  factorBand,
+  formatFactor,
+  summarizeWealth,
+  wealthBucketIndex,
+  PICO_PER_BTH,
+  type ClusterWealthEntry,
+} from './wealth'
+
+function cluster(wealth: bigint, factor = 1000, clusterId = '1'): ClusterWealthEntry {
+  return { clusterId, wealth, factor }
+}
+
+describe('wealthBucketIndex', () => {
+  it('puts sub-1-BTH wealth (including zero) in bucket 0', () => {
+    expect(wealthBucketIndex(0n)).toBe(0)
+    expect(wealthBucketIndex(1n)).toBe(0)
+    expect(wealthBucketIndex(PICO_PER_BTH - 1n)).toBe(0)
+  })
+
+  it('buckets by BTH decade: bucket k = [10^(k-1), 10^k) BTH', () => {
+    expect(wealthBucketIndex(PICO_PER_BTH)).toBe(1) // exactly 1 BTH
+    expect(wealthBucketIndex(PICO_PER_BTH * 10n - 1n)).toBe(1) // just under 10 BTH
+    expect(wealthBucketIndex(PICO_PER_BTH * 10n)).toBe(2) // exactly 10 BTH
+    expect(wealthBucketIndex(PICO_PER_BTH * 100_000n)).toBe(6) // 100k BTH (w_mid)
+  })
+
+  it('handles values far above 2^53 exactly (BigInt-safe, never Number)', () => {
+    // 10^18 BTH = 10^30 picocredits — decades above Number.MAX_SAFE_INTEGER.
+    expect(wealthBucketIndex(10n ** 30n)).toBe(19)
+    expect(wealthBucketIndex(10n ** 30n - 1n)).toBe(18)
+    // u128 max: ~3.4e26 BTH -> bucket 27.
+    expect(wealthBucketIndex(340282366920938463463374607431768211455n)).toBe(27)
+    // 2^53 picocredits itself (~9007 BTH) lands in the 1k–10k BTH bucket.
+    expect(wealthBucketIndex(2n ** 53n)).toBe(4)
+  })
+})
+
+describe('bucketLabel', () => {
+  it('labels the sub-1-BTH bucket and decade ranges', () => {
+    expect(bucketLabel(0)).toBe('<1')
+    expect(bucketLabel(1)).toBe('1–10')
+    expect(bucketLabel(4)).toBe('1k–10k')
+    expect(bucketLabel(7)).toBe('1M–10M')
+    expect(bucketLabel(10)).toBe('1B–10B')
+  })
+})
+
+describe('factorBand', () => {
+  it('classifies band boundaries exactly per the display spec', () => {
+    expect(factorBand(1000)).toBe('floor') // 1.00x exactly
+    expect(factorBand(1001)).toBe('low')
+    expect(factorBand(1999)).toBe('low')
+    expect(factorBand(2000)).toBe('mid')
+    expect(factorBand(4999)).toBe('mid')
+    expect(factorBand(5000)).toBe('high')
+    expect(factorBand(5999)).toBe('high')
+    expect(factorBand(6000)).toBe('ceiling') // 6.00x exactly
+  })
+
+  it('clamps out-of-range factors into the edge bands (node-bug defense)', () => {
+    expect(factorBand(999)).toBe('floor')
+    expect(factorBand(6001)).toBe('ceiling')
+  })
+})
+
+describe('formatFactor', () => {
+  it('renders milli-x factors as 2-decimal multipliers', () => {
+    expect(formatFactor(1000)).toBe('1.00x')
+    expect(formatFactor(1260)).toBe('1.26x')
+    expect(formatFactor(6000)).toBe('6.00x')
+  })
+})
+
+describe('bucketClusters', () => {
+  it('returns [] for an empty input (young chain -> empty state)', () => {
+    expect(bucketClusters([])).toEqual([])
+  })
+
+  it('produces contiguous buckets with per-band counts', () => {
+    const buckets = bucketClusters([
+      cluster(0n, 1000), // bucket 0, floor
+      cluster(PICO_PER_BTH * 5n, 1200), // bucket 1, low
+      cluster(PICO_PER_BTH * 5n, 1000), // bucket 1, floor
+      cluster(PICO_PER_BTH * 5000n, 3500), // bucket 4, mid
+    ])
+    expect(buckets).toHaveLength(5) // indices 0..4, gaps included
+    expect(buckets.map((b) => b.total)).toEqual([1, 2, 0, 0, 1])
+    expect(buckets[1].byBand.low).toBe(1)
+    expect(buckets[1].byBand.floor).toBe(1)
+    expect(buckets[4].byBand.mid).toBe(1)
+    expect(buckets[2].total).toBe(0) // empty intermediate bucket kept
+    expect(buckets[0].label).toBe('<1')
+    expect(buckets[4].label).toBe('1k–10k')
+  })
+
+  it('buckets a > 2^53 whale exactly', () => {
+    const whale = cluster(340282366920938463463374607431768211454n, 6000)
+    const buckets = bucketClusters([whale])
+    expect(buckets).toHaveLength(28)
+    expect(buckets[27].total).toBe(1)
+    expect(buckets[27].byBand.ceiling).toBe(1)
+  })
+})
+
+describe('summarizeWealth', () => {
+  it('returns zeros and a null median for an empty set', () => {
+    expect(summarizeWealth([])).toEqual({
+      clusterCount: 0,
+      totalWealth: 0n,
+      medianFactor: null,
+    })
+  })
+
+  it('sums total wealth exactly beyond 2^53 (BigInt, no precision loss)', () => {
+    const a = 2n ** 60n
+    const b = 2n ** 60n + 1n
+    const summary = summarizeWealth([cluster(a, 1000), cluster(b, 2000)])
+    expect(summary.totalWealth).toBe(a + b)
+    expect(summary.totalWealth.toString()).toBe('2305843009213693953')
+    expect(summary.clusterCount).toBe(2)
+  })
+
+  it('takes the middle factor for odd counts and the middle-pair average for even', () => {
+    expect(
+      summarizeWealth([cluster(0n, 3000), cluster(0n, 1000), cluster(0n, 6000)]).medianFactor,
+    ).toBe(3000)
+    expect(
+      summarizeWealth([cluster(0n, 1000), cluster(0n, 2000)]).medianFactor,
+    ).toBe(1500)
+  })
+})

--- a/web/packages/features/src/explorer/wealth.ts
+++ b/web/packages/features/src/explorer/wealth.ts
@@ -1,0 +1,162 @@
+/**
+ * Pure derivations for the explorer's cluster-wealth distribution view (#699).
+ *
+ * All wealth math is BigInt-safe: cluster wealth is a u128 in picocredits
+ * (1 BTH = 1e12) and can exceed 2^53, so nothing here routes a raw wealth
+ * value through `Number()`. Factors come from the node's live Rust fee curve
+ * (milli-x, 1000 = 1.00x .. 6000 = 6.00x) — this module classifies them into
+ * display bands but never re-derives the curve (#610 drift class).
+ */
+
+/** One cluster's tracked wealth + node-computed fee factor. */
+export interface ClusterWealthEntry {
+  /** Cluster id as a decimal string (u64 — can exceed 2^53, never parseInt). */
+  clusterId: string
+  /** Tracked wealth in picocredits (parsed from the wire's string u128). */
+  wealth: bigint
+  /** Node-supplied milli-x fee-curve multiplier (1000..6000). */
+  factor: number
+}
+
+/** Picocredits per BTH (12 decimals). */
+export const PICO_PER_BTH = 10n ** 12n
+
+// ---------------------------------------------------------------------------
+// Factor bands
+// ---------------------------------------------------------------------------
+
+export type FactorBand = 'floor' | 'low' | 'mid' | 'high' | 'ceiling'
+
+/** Band order + display metadata (histogram stacking + legend). */
+export const FACTOR_BANDS: ReadonlyArray<{
+  band: FactorBand
+  label: string
+  color: string
+}> = [
+  { band: 'floor', label: '1.00x (floor)', color: '#34d399' },
+  { band: 'low', label: '1.01x–1.99x', color: '#06b6d4' },
+  { band: 'mid', label: '2.00x–4.99x', color: '#f59e0b' },
+  { band: 'high', label: '5.00x–5.99x', color: '#f97316' },
+  { band: 'ceiling', label: '6.00x (ceiling)', color: '#ef4444' },
+]
+
+/**
+ * Classify a node-supplied milli-x factor into its display band.
+ *
+ * The curve clamps to [1000, 6000] in Rust; out-of-range values (which would
+ * indicate a node bug) are clamped into the floor/ceiling bands rather than
+ * dropped, so every cluster is always visible in the histogram.
+ */
+export function factorBand(factor: number): FactorBand {
+  if (factor <= 1000) return 'floor'
+  if (factor < 2000) return 'low'
+  if (factor < 5000) return 'mid'
+  if (factor < 6000) return 'high'
+  return 'ceiling'
+}
+
+/** Format a milli-x factor for display, e.g. 1260 -> "1.26x". */
+export function formatFactor(factor: number): string {
+  return `${(factor / 1000).toFixed(2)}x`
+}
+
+// ---------------------------------------------------------------------------
+// Log-scale BTH bucketing
+// ---------------------------------------------------------------------------
+
+/**
+ * Log10 bucket index for a wealth value (picocredits), in BTH decades:
+ * - index 0: < 1 BTH
+ * - index k (k >= 1): [10^(k-1), 10^k) BTH
+ *
+ * Pure BigInt comparisons — safe for the full u128 range.
+ */
+export function wealthBucketIndex(wealthPico: bigint): number {
+  if (wealthPico < PICO_PER_BTH) return 0
+  let index = 1
+  let upperBound = PICO_PER_BTH * 10n
+  while (wealthPico >= upperBound) {
+    index++
+    upperBound *= 10n
+  }
+  return index
+}
+
+/** Human label for 10^exp BTH, e.g. 0 -> "1", 4 -> "10k", 7 -> "10M". */
+function pow10Label(exp: number): string {
+  if (exp >= 12) return `1e${exp}`
+  if (exp >= 9) return `${10 ** (exp - 9)}B`
+  if (exp >= 6) return `${10 ** (exp - 6)}M`
+  if (exp >= 3) return `${10 ** (exp - 3)}k`
+  return String(10 ** exp)
+}
+
+/** Display label (in BTH) for a bucket index. */
+export function bucketLabel(index: number): string {
+  if (index === 0) return '<1'
+  return `${pow10Label(index - 1)}–${pow10Label(index)}`
+}
+
+/** One histogram bucket: total cluster count plus per-band breakdown. */
+export interface WealthBucket {
+  index: number
+  /** BTH range label, e.g. "<1", "1–10", "10k–100k". */
+  label: string
+  total: number
+  byBand: Record<FactorBand, number>
+}
+
+/**
+ * Bucket clusters into contiguous log-scale BTH buckets (empty intermediate
+ * buckets included so the histogram axis is honest). Returns [] for an empty
+ * input — the component renders the young-chain empty state.
+ */
+export function bucketClusters(clusters: ClusterWealthEntry[]): WealthBucket[] {
+  if (clusters.length === 0) return []
+
+  const indices = clusters.map((c) => wealthBucketIndex(c.wealth))
+  const maxIndex = Math.max(...indices)
+
+  const buckets: WealthBucket[] = Array.from({ length: maxIndex + 1 }, (_, index) => ({
+    index,
+    label: bucketLabel(index),
+    total: 0,
+    byBand: { floor: 0, low: 0, mid: 0, high: 0, ceiling: 0 },
+  }))
+
+  clusters.forEach((cluster, i) => {
+    const bucket = buckets[indices[i]]
+    bucket.total++
+    bucket.byBand[factorBand(cluster.factor)]++
+  })
+
+  return buckets
+}
+
+// ---------------------------------------------------------------------------
+// Summary stats
+// ---------------------------------------------------------------------------
+
+export interface WealthSummary {
+  clusterCount: number
+  /** Exact BigInt sum of all cluster wealth, in picocredits. */
+  totalWealth: bigint
+  /** Median milli-x factor (average of middle pair for even counts); null when empty. */
+  medianFactor: number | null
+}
+
+/** Summarize the cluster set. Pure; BigInt-exact total. */
+export function summarizeWealth(clusters: ClusterWealthEntry[]): WealthSummary {
+  if (clusters.length === 0) {
+    return { clusterCount: 0, totalWealth: 0n, medianFactor: null }
+  }
+
+  const totalWealth = clusters.reduce((acc, c) => acc + c.wealth, 0n)
+
+  const factors = clusters.map((c) => c.factor).sort((a, b) => a - b)
+  const mid = Math.floor(factors.length / 2)
+  const medianFactor =
+    factors.length % 2 === 1 ? factors[mid] : (factors[mid - 1] + factors[mid]) / 2
+
+  return { clusterCount: clusters.length, totalWealth, medianFactor }
+}

--- a/web/packages/web-wallet/src/pages/explorer.tsx
+++ b/web/packages/web-wallet/src/pages/explorer.tsx
@@ -35,6 +35,8 @@ export function ExplorerPage() {
       getBlock: (heightOrHash) => adapter.getBlock(heightOrHash),
       getTransaction: (txHash) => adapter.getTransaction(txHash),
       onNewBlock: (callback) => adapter.onNewBlock(callback),
+      // Wealth-distribution tab (#699): all tracked clusters + live factors.
+      getAllClusterWealth: () => adapter.getAllClusterWealth(),
     }
   }, [adapter])
 


### PR DESCRIPTION
## Summary

Fixes #699. Implements the analytical M2 explorer views deferred from #605, consuming the #700 RPC enrichment (`getBlockByHeight`/`getBlockByHash` tx structure + lottery summary, `cluster_getAllWealth` per-cluster factor). The explorer's list mode now has three tabs: **Blocks / Wealth distribution / Lottery**.

## Views

### Wealth distribution (`cluster-wealth.tsx` + pure `wealth.ts`)
- Fetches `cluster_getAllWealth` via a new optional `ExplorerDataSource.getAllClusterWealth()` (lazy, on first tab open).
- Buckets clusters into **log-scale BTH decades** with pure BigInt comparisons — wealth is a string-encoded u128 parsed via `BigInt()`, never `Number()`, so values above 2^53 (and up to u128 max) bucket exactly.
- Dependency-free SVG histogram (network-dashboard idiom): each bar stacks the **node-supplied** factor bands — 1.00x exactly (floor), 1.01x–1.99x, 2.00x–4.99x, 5.00x–5.99x, 6.00x exactly (ceiling). The TS side only classifies the milli-x value into a display band; the curve itself is never re-derived client-side (#610 drift class). Old nodes omitting `factor` default to the 1000 floor.
- Summary stats: cluster count, exact BigInt total wealth (BTH), median factor.
- Explicit states: young-chain empty, loading, fetch error, and "unavailable" when the data source lacks the RPC.

### Lottery events (`lottery-feed.tsx` + pure `lottery.ts`)
- Walks the recent blocks the explorer context already holds (now carrying the additive `lottery` field) and lists blocks with `payoutCount > 0 OR poolDistributed > 0`, newest first: height, payout count, payout total, pool distributed, amount burned, relative time. Rows navigate to block detail.
- Blocks from pre-#700 nodes (no `lottery` field) are excluded rather than rendered as fabricated zeros; the empty state names the scanned window size.

### Block detail enrichment (`block-detail.tsx`)
- `Total Fees` row (when present), per-tx list (hash → existing tx detail view via a new `viewTransactionByHash`, fee, ring size), and a Lottery card (payouts, payout total, pool distributed, burn, lottery fees, seed) shown only when the block has activity. Existing DetailRow/Card layout idiom preserved.

## Adapter plumbing

- `@botho/core`: new `BlockTransactionSummary` / `BlockLotterySummary` types; `Block` gains optional `transactions` / `totalFees` / `lottery`.
- `RemoteNodeAdapter`: both `getBlock` branches now share one `mapRpcBlock` mapper; enriched fields are undefined-guarded so **old nodes without them keep working unchanged**. Fee/lottery amounts parse through `BigInt(String(...))`.
- New `RemoteNodeAdapter.getAllClusterWealth()` returning `{clusterId: string, wealth: bigint, factor: number}[]`; `cluster_id` stays a string (real ids exceed 2^53). Declared optional on `NodeAdapter` so `LocalNodeAdapter` is untouched and consumers degrade gracefully.
- Wired into the wallet's explorer page data source.

## Privacy posture

Structure and aggregates only: tx hashes, ring sizes, fees, block-level lottery totals, and cluster-level wealth/factor (already-public tracker state). No balances, recipients, payout-recipient linkage, or flow-inference tooling anywhere in these views — matching the handoff caveat and the #700 RPC's privacy-safe shape.

## Tests

- `wealth.test.ts` (13): bucket boundaries, >2^53 and u128-max bucketing, empty input, factor-band edges (1000/6000 exact), BigInt-exact summary totals, median odd/even.
- `lottery.test.ts` (4): payout/pool filter, newest-first order, old-node exclusion, burn-only non-event, input immutability.
- `cluster-wealth.test.tsx` (6, jsdom): histogram + summary + legend render, >2^53 whale display, empty/loading/unavailable/error states.
- `lottery-feed.test.tsx` (3, jsdom): aggregate rows newest first, row click navigation, empty state.
- `remote.test.ts` (+6): `getAllClusterWealth` against the captured live fixture (missing factor → 1000 floor) and enriched #700 shapes (u128 exact); `getBlock` enriched mapping, old-node additive contract, `getBlockByHash` path.

## Verification

- `npx vitest run packages/features/src/explorer packages/adapters` — 44 passed
- `pnpm -r typecheck` — clean (all 8 projects)
- `pnpm test:run` — full suite green: 619 passed, 10 skipped

Note: the adapter tests pin the live-captured `cluster_getAllWealth` fixture (pre-#700, no factor) plus the #700 PR's documented shapes; a curl against a deployed testnet node once #700 is rolled out remains the live-acceptance step, as with #700 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)