### PR TITLE
fix(infra): retry release-artifact downloads in deploy-botho.sh

### DIFF
--- a/infra/seed/deploy-botho.sh
+++ b/infra/seed/deploy-botho.sh
@@ -89,8 +89,10 @@ deploy_from_release() {
     if ! ssh $SSH_OPTS "$HOST" "set -euo pipefail
         rm -rf /tmp/botho-release && mkdir -p /tmp/botho-release
         cd /tmp/botho-release
-        curl -fsSL -o botho.tar.gz '$base/botho-$tag-$platform.tar.gz'
-        curl -fsSL -o checksums.txt '$base/checksums-$platform.txt'
+        # --retry: GitHub artifact downloads fail transiently from some
+        # regions (observed from ap-southeast-1 on two consecutive deploys).
+        curl -fsSL --retry 3 --retry-delay 2 -o botho.tar.gz '$base/botho-$tag-$platform.tar.gz'
+        curl -fsSL --retry 3 --retry-delay 2 -o checksums.txt '$base/checksums-$platform.txt'
         tar xzf botho.tar.gz"; then
         log_error "Release download failed (no $tag release, or missing $platform asset)"
         return 1


### PR DESCRIPTION
One-line resilience fix: the ap-southeast-1 node failed the GitHub release-artifact download transiently on BOTH the v0.3.1 and v0.3.2 rolling deploys (manual retry succeeded immediately each time). `curl --retry 3 --retry-delay 2` absorbs it so the rolling deploy loop doesn't need manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)