### PR TITLE
feat(web): P4.1 operator dashboard — public /operator fleet + trust views (#706)

### DIFF
--- a/web/packages/features/package.json
+++ b/web/packages/features/package.json
@@ -9,7 +9,11 @@
     "./explorer": "./src/explorer/index.ts",
     "./explorer/*": "./src/explorer/*",
     "./wallet": "./src/wallet/index.ts",
-    "./wallet/*": "./src/wallet/*"
+    "./wallet/*": "./src/wallet/*",
+    "./network": "./src/network/index.ts",
+    "./network/*": "./src/network/*",
+    "./operator": "./src/operator/index.ts",
+    "./operator/*": "./src/operator/*"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/web/packages/features/src/index.ts
+++ b/web/packages/features/src/index.ts
@@ -2,3 +2,4 @@
 export * from './explorer'
 export * from './wallet'
 export * from './network'
+export * from './operator'

--- a/web/packages/features/src/network/hooks.test.tsx
+++ b/web/packages/features/src/network/hooks.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The polling/history hooks extracted from the `/network` page (#706) so
+ * `/network` and `/operator` share one implementation. Contract under test:
+ * the first poll populates per-node snapshots (failures as explicit
+ * `reachable: false`), and a missing metrics backend degrades history to
+ * `unavailable` without throwing.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useFleetHistory, useFleetStatus } from './hooks'
+import type { FleetNode } from './types'
+
+const NODES: FleetNode[] = [
+  { id: 'seed', name: 'Seed', rpcEndpoint: 'https://seed.test/rpc' },
+  { id: 'eu', name: 'EU', rpcEndpoint: 'https://eu.test/rpc' },
+]
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('useFleetStatus', () => {
+  it('populates statuses from the first poll and derives the consensus height', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: unknown, init?: { body?: string }) => {
+        const method = (JSON.parse(init?.body ?? '{}') as { method?: string }).method
+        if (method === 'node_getStatus') {
+          const height = String(url).includes('seed.test') ? 221 : 219
+          return { ok: true, json: async () => ({ result: { chainHeight: height } }) }
+        }
+        // getBlockByHeight (block-spacing derivation): 20s per block.
+        const { height } = JSON.parse(init?.body ?? '{}').params as { height: number }
+        return {
+          ok: true,
+          json: async () => ({ result: { height, timestamp: height * 20 } }),
+        }
+      }),
+    )
+
+    const { result, unmount } = renderHook(() => useFleetStatus(NODES))
+    await waitFor(() => expect(result.current.consensusHeight).toBe(221))
+    expect(result.current.statuses.seed).toMatchObject({ reachable: true, chainHeight: 221 })
+    expect(result.current.statuses.eu).toMatchObject({ reachable: true, chainHeight: 219 })
+    await waitFor(() => expect(result.current.avgBlockSeconds).toBe(20))
+    unmount()
+  })
+
+  it('resolves failed polls to explicit unreachable snapshots', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('down') }))
+    const { result, unmount } = renderHook(() => useFleetStatus(NODES))
+    await waitFor(() => expect(result.current.statuses.seed?.reachable).toBe(false))
+    expect(result.current.statuses.eu?.reachable).toBe(false)
+    expect(result.current.consensusHeight).toBeNull()
+    unmount()
+  })
+})
+
+describe('useFleetHistory', () => {
+  it('degrades to unavailable when the metrics backend is absent', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 502 })))
+    const { result, unmount } = renderHook(() =>
+      useFleetHistory(NODES, 'https://metrics.test'),
+    )
+    await waitFor(() => expect(result.current.historyState).toBe('unavailable'))
+    unmount()
+  })
+
+  it('loads per-node samples and reports ok', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => [{ timestamp: 1, height: 2, peerCount: 3, mempoolSize: 0 }],
+      })),
+    )
+    const { result, unmount } = renderHook(() =>
+      useFleetHistory(NODES, 'https://metrics.test'),
+    )
+    await waitFor(() => expect(result.current.historyState).toBe('ok'))
+    expect(result.current.history.seed).toHaveLength(1)
+    unmount()
+  })
+})

--- a/web/packages/features/src/network/hooks.ts
+++ b/web/packages/features/src/network/hooks.ts
@@ -1,0 +1,176 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { averageBlockSeconds, fetchFleetNodeStatus } from './fleet'
+import type { FleetNode, FleetNodeStatus, MetricsHistorySample } from './types'
+
+/**
+ * Reusable polling/history hooks for the fleet dashboard (#706).
+ *
+ * Extracted from the `/network` page so `/operator` (the P4 dashboard, #695)
+ * shares one implementation instead of a forked copy. The hooks own the
+ * wiring; `NetworkDashboard` stays pure presentation.
+ *
+ * Callers must pass a referentially-stable `nodes` array (module-level
+ * constant) — it is an effect dependency, so a fresh array per render would
+ * restart polling every render.
+ */
+
+export interface UseFleetStatusOptions {
+  /** Live-grid poll cadence in ms. */
+  pollMs?: number
+  /** Blocks/hour derivation window (block spacing sample width). */
+  blockWindow?: number
+}
+
+export interface UseFleetStatusResult {
+  /** Latest live snapshot per node id; missing key = first poll in flight. */
+  statuses: Record<string, FleetNodeStatus>
+  /** Highest height any reachable node reports; null before the first result. */
+  consensusHeight: number | null
+  /** Average seconds per block over the recent window; null = unknown. */
+  avgBlockSeconds: number | null
+}
+
+/**
+ * Poll every node's `node_getStatus` and derive the average block spacing
+ * from two block timestamps on the freshest reachable node.
+ *
+ * Failed polls resolve to explicit `reachable: false` snapshots (the
+ * anti-#541 contract in `fetchFleetNodeStatus`) — never stale values.
+ */
+export function useFleetStatus(
+  nodes: FleetNode[],
+  { pollMs = 15_000, blockWindow = 20 }: UseFleetStatusOptions = {},
+): UseFleetStatusResult {
+  const [statuses, setStatuses] = useState<Record<string, FleetNodeStatus>>({})
+  const [avgBlockSecs, setAvgBlockSecs] = useState<number | null>(null)
+  // The block-time derivation reuses the freshest reachable node endpoint.
+  const bestEndpointRef = useRef<string | null>(null)
+
+  // Live fleet polling.
+  useEffect(() => {
+    let cancelled = false
+    const poll = async () => {
+      const results = await Promise.all(nodes.map((n) => fetchFleetNodeStatus(n)))
+      if (cancelled) return
+      const byId: Record<string, FleetNodeStatus> = {}
+      let bestHeight = -1
+      for (const [i, s] of results.entries()) {
+        byId[s.nodeId] = s
+        if (s.reachable && (s.chainHeight ?? -1) > bestHeight) {
+          bestHeight = s.chainHeight ?? -1
+          bestEndpointRef.current = nodes[i].rpcEndpoint
+        }
+      }
+      setStatuses(byId)
+    }
+    poll()
+    const id = setInterval(poll, pollMs)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [nodes, pollMs])
+
+  // Average block time from two block timestamps on the freshest node.
+  const consensusHeight = useMemo(() => {
+    const heights = Object.values(statuses)
+      .filter((s) => s.reachable && typeof s.chainHeight === 'number')
+      .map((s) => s.chainHeight as number)
+    return heights.length ? Math.max(...heights) : null
+  }, [statuses])
+
+  useEffect(() => {
+    const endpoint = bestEndpointRef.current
+    if (consensusHeight === null || consensusHeight < 2 || !endpoint) return
+    let cancelled = false
+    const older = Math.max(1, consensusHeight - blockWindow)
+    const fetchBlock = async (height: number) => {
+      const r = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'getBlockByHeight',
+          params: { height },
+          id: 1,
+        }),
+      })
+      const json = (await r.json()) as {
+        result?: { height: number; timestamp: number }
+      }
+      return json.result ?? null
+    }
+    Promise.all([fetchBlock(older), fetchBlock(consensusHeight)])
+      .then(([a, b]) => {
+        if (!cancelled && a && b) setAvgBlockSecs(averageBlockSeconds(a, b))
+      })
+      .catch(() => {
+        /* leave the empty state; live grid is unaffected */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [consensusHeight, blockWindow])
+
+  return { statuses, consensusHeight, avgBlockSeconds: avgBlockSecs }
+}
+
+export interface UseFleetHistoryOptions {
+  /** History refresh cadence in ms (the daemon samples every ~5 min). */
+  refreshMs?: number
+  /** How far back to fetch, in seconds. */
+  windowSeconds?: number
+}
+
+export interface UseFleetHistoryResult {
+  /** History series per node id (may be empty). */
+  history: Record<string, MetricsHistorySample[]>
+  historyState: 'ok' | 'empty' | 'unavailable'
+}
+
+/**
+ * Fetch per-node history from the metrics-daemon fleet API (#697), degrading
+ * gracefully to `unavailable` when the backend is absent (it ships/deploys
+ * independently).
+ */
+export function useFleetHistory(
+  nodes: FleetNode[],
+  metricsApiBase: string,
+  { refreshMs = 120_000, windowSeconds = 24 * 3600 }: UseFleetHistoryOptions = {},
+): UseFleetHistoryResult {
+  const [history, setHistory] = useState<Record<string, MetricsHistorySample[]>>({})
+  const [historyState, setHistoryState] = useState<'ok' | 'empty' | 'unavailable'>('empty')
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const since = Math.floor(Date.now() / 1000) - windowSeconds
+        const results = await Promise.all(
+          nodes.map(async (n) => {
+            const r = await fetch(
+              `${metricsApiBase}/api/metrics/history?node=${encodeURIComponent(n.id)}&resolution=5min&since=${since}`,
+            )
+            if (!r.ok) throw new Error(`history ${r.status}`)
+            return [n.id, (await r.json()) as MetricsHistorySample[]] as const
+          }),
+        )
+        if (cancelled) return
+        const byNode = Object.fromEntries(results)
+        const any = results.some(([, samples]) => samples.length > 0)
+        setHistory(byNode)
+        setHistoryState(any ? 'ok' : 'empty')
+      } catch {
+        if (!cancelled) setHistoryState('unavailable')
+      }
+    }
+    load()
+    const id = setInterval(load, refreshMs)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [nodes, metricsApiBase, refreshMs, windowSeconds])
+
+  return { history, historyState }
+}

--- a/web/packages/features/src/network/index.ts
+++ b/web/packages/features/src/network/index.ts
@@ -1,5 +1,6 @@
 export * from './types'
 export * from './fleet'
+export * from './hooks'
 export { NodeCard, type NodeCardProps } from './components/node-card'
 export { FleetSummaryStrip, type FleetSummaryStripProps } from './components/fleet-summary'
 export { HistoryChart, type HistoryChartProps } from './components/history-chart'

--- a/web/packages/features/src/operator/components/trust-dashboard.test.tsx
+++ b/web/packages/features/src/operator/components/trust-dashboard.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The trust view's contract (#706): unreachable nodes render an EXPLICIT
+ * error card (never stale or fabricated values — the #541 lesson), gate
+ * fields the node omits render as absent ("—") rather than zero, and
+ * `quorumGateIntersectionRefused` / `quorumDegenerate` surface as prominent
+ * warning banners (#509 warn-don't-refuse).
+ */
+import { describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { TrustDashboard } from './trust-dashboard'
+import type { FleetNode } from '../../network/types'
+import type { NodeTrustStatus, TrustPeer } from '../types'
+
+const NODES: FleetNode[] = [
+  { id: 'seed', name: 'Seed (validator)', rpcEndpoint: 'https://seed.test/rpc' },
+  { id: 'eu', name: 'EU seed (Frankfurt)', rpcEndpoint: 'https://eu.test/rpc' },
+  { id: 'ap', name: 'AP seed (Singapore)', rpcEndpoint: 'https://ap.test/rpc' },
+]
+
+const PEERS: TrustPeer[] = [
+  {
+    peerId: '12D3KooWJ5U2gk6Pe9ehZb6aHng2zu7RnUwAKzEYxHbaM6VRo592',
+    address: null,
+    protocolVersion: '4.0.0 (block v5)',
+    versionWarning: false,
+    lastSeenSecs: 44,
+  },
+  {
+    peerId: '12D3KooWRubuvzRNxbxHH5BdzgxQNqMoWyQtdxKXUdNWJt5huTpk',
+    address: null,
+    protocolVersion: null,
+    versionWarning: true,
+    lastSeenSecs: 0,
+  },
+]
+
+function live(id: string, over: Partial<NodeTrustStatus> = {}): NodeTrustStatus {
+  return {
+    nodeId: id,
+    reachable: true,
+    polledAt: Date.now(),
+    quorumFaultTolerant: true,
+    quorumDegenerate: false,
+    quorumCuratedMembers: 0,
+    quorumAutoMembers: 3,
+    quorumGateSuppressedPeers: 0,
+    quorumGateMaxAutoMembers: 8,
+    quorumGateIntersectionRefused: false,
+    scpPeerCount: 3,
+    peers: PEERS,
+    ...over,
+  }
+}
+
+function renderDash(statuses: Record<string, NodeTrustStatus>) {
+  cleanup()
+  return render(<TrustDashboard nodes={NODES} statuses={statuses} />)
+}
+
+describe('TrustDashboard', () => {
+  it('renders per-node gate counts, posture badges, and the peer table', () => {
+    renderDash({ seed: live('seed'), eu: live('eu'), ap: live('ap') })
+    expect(screen.getAllByText('Curated')).toHaveLength(3)
+    expect(screen.getAllByText('Auto-promoted')).toHaveLength(3)
+    expect(screen.getAllByText('Suppressed')).toHaveLength(3)
+    expect(screen.getAllByText('Auto cap')).toHaveLength(3)
+    expect(screen.getAllByText('BFT fault tolerant')).toHaveLength(3)
+    expect(screen.getAllByText('Connected peers (2)')).toHaveLength(3)
+    expect(
+      screen.getAllByText('12D3KooWJ5U2gk6Pe9ehZb6aHng2zu7RnUwAKzEYxHbaM6VRo592'),
+    ).toHaveLength(3)
+    // A peer with an outdated protocol version is flagged.
+    expect(screen.getAllByText('outdated')).toHaveLength(3)
+    // No warning banners in the healthy state.
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('renders an explicit error card for an unreachable node — no stale values', () => {
+    renderDash({
+      seed: live('seed'),
+      eu: { nodeId: 'eu', reachable: false, polledAt: Date.now() },
+      ap: live('ap'),
+    })
+    expect(screen.getByText('Unreachable')).toBeDefined()
+    expect(screen.getByText(/1 of 3 nodes unreachable/)).toBeDefined()
+    // Only the two live cards show gate counts.
+    expect(screen.getAllByText('Curated')).toHaveLength(2)
+  })
+
+  it('shows checking state for nodes whose first poll is in flight', () => {
+    renderDash({ seed: live('seed') })
+    expect(screen.getAllByText('Checking…')).toHaveLength(2)
+    // Nodes never polled don't count as unreachable.
+    expect(screen.queryByText(/unreachable/)).toBeNull()
+  })
+
+  it('surfaces quorumGateIntersectionRefused as a prominent warning', () => {
+    renderDash({
+      seed: live('seed', { quorumGateIntersectionRefused: true }),
+      eu: live('eu'),
+      ap: live('ap'),
+    })
+    const banner = screen.getByRole('alert')
+    expect(banner.textContent).toContain(
+      'Quorum intersection check refused the latest candidate',
+    )
+    expect(banner.textContent).toContain('Seed (validator)')
+    expect(screen.getByText('intersection check refused last candidate')).toBeDefined()
+  })
+
+  it('surfaces quorumDegenerate as a prominent warning', () => {
+    renderDash({
+      seed: live('seed'),
+      eu: live('eu', { quorumDegenerate: true, quorumFaultTolerant: false }),
+      ap: live('ap'),
+    })
+    const banner = screen.getByRole('alert')
+    expect(banner.textContent).toContain('Degenerate quorum — zero fault tolerance')
+    expect(banner.textContent).toContain('EU seed (Frankfurt)')
+    expect(screen.getByText(/degenerate quorum — zero fault/)).toBeDefined()
+  })
+
+  it('renders absent gate fields as "—", never zero (anti-#541)', () => {
+    renderDash({
+      seed: live('seed', {
+        quorumCuratedMembers: undefined,
+        quorumAutoMembers: undefined,
+        quorumGateSuppressedPeers: undefined,
+        quorumGateMaxAutoMembers: undefined,
+        quorumGateIntersectionRefused: undefined,
+        scpPeerCount: undefined,
+      }),
+    })
+    const card = screen.getByTestId('trust-card-seed')
+    // All five stats render the absent marker; no fabricated zeros.
+    expect(card.textContent?.match(/—/g)?.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('renders an explicit unavailable state when the peer list call failed', () => {
+    renderDash({ seed: live('seed', { peers: undefined }) })
+    expect(screen.getByText(/Peer list unavailable/)).toBeDefined()
+  })
+
+  it('distinguishes a genuinely empty peer list from an unavailable one', () => {
+    renderDash({ seed: live('seed', { peers: [] }) })
+    expect(screen.getByText('No connected peers')).toBeDefined()
+    expect(screen.queryByText(/Peer list unavailable/)).toBeNull()
+  })
+
+  it('renders a null peer protocol version as "—"', () => {
+    renderDash({ seed: live('seed') })
+    const card = screen.getByTestId('trust-card-seed')
+    expect(card.textContent).toContain('—')
+  })
+})

--- a/web/packages/features/src/operator/components/trust-dashboard.tsx
+++ b/web/packages/features/src/operator/components/trust-dashboard.tsx
@@ -1,0 +1,92 @@
+import { AlertTriangle, ShieldAlert } from 'lucide-react'
+import { Card, CardContent } from '@botho/ui'
+import type { FleetNode } from '../../network/types'
+import type { NodeTrustStatus } from '../types'
+import { deriveTrustSummary } from '../quorum'
+import { TrustNodeCard } from './trust-node-card'
+
+export interface TrustDashboardProps {
+  nodes: FleetNode[]
+  /** Latest trust snapshot per node id; missing key = first poll in flight. */
+  statuses: Record<string, NodeTrustStatus>
+  className?: string
+}
+
+/**
+ * The trust/quorum tab body (#706): fleet-level warning banners + per-node
+ * posture cards. Pure presentation — polling lives in `useTrustStatus` so
+ * this composes into other surfaces.
+ *
+ * `quorumGateIntersectionRefused: true` and `quorumDegenerate: true` are
+ * surfaced as prominent banners above the grid (the #509 warn-don't-refuse
+ * posture): the fleet is still running, but the operator must see it.
+ */
+export function TrustDashboard({ nodes, statuses, className }: TrustDashboardProps) {
+  const statusList = nodes
+    .map((n) => statuses[n.id])
+    .filter((s): s is NodeTrustStatus => s !== undefined)
+  const summary = deriveTrustSummary(statusList)
+  const nameOf = (id: string) => nodes.find((n) => n.id === id)?.name ?? id
+
+  return (
+    <div className={`space-y-4 ${className ?? ''}`}>
+      {summary.intersectionRefusedNodeIds.length > 0 && (
+        <WarningBanner
+          icon={<AlertTriangle className="h-5 w-5 shrink-0" />}
+          title="Quorum intersection check refused the latest candidate"
+          detail={`${summary.intersectionRefusedNodeIds
+            .map(nameOf)
+            .join(
+              ', ',
+            )} refused a candidate quorum set that failed the bth-quorum-sim intersection check and kept the previous safe set. Peer churn or curation is proposing an unsafe quorum.`}
+        />
+      )}
+      {summary.degenerateNodeIds.length > 0 && (
+        <WarningBanner
+          icon={<ShieldAlert className="h-5 w-5 shrink-0" />}
+          title="Degenerate quorum — zero fault tolerance"
+          detail={`${summary.degenerateNodeIds
+            .map(nameOf)
+            .join(
+              ', ',
+            )} report an n-of-n quorum below 4 participating nodes: a single crashed node stalls consensus. The network keeps running (warn, don't refuse — #509), but this posture tolerates ZERO faults.`}
+        />
+      )}
+
+      {summary.nodesReachable < summary.nodesTotal && statusList.length > 0 && (
+        <p className="text-xs text-[--color-dim]">
+          {summary.nodesTotal - summary.nodesReachable} of {summary.nodesTotal} nodes
+          unreachable — their posture is unknown, not healthy.
+        </p>
+      )}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {nodes.map((node) => (
+          <TrustNodeCard key={node.id} node={node} status={statuses[node.id]} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function WarningBanner({
+  icon,
+  title,
+  detail,
+}: {
+  icon: React.ReactNode
+  title: string
+  detail: string
+}) {
+  return (
+    <Card className="border-[--color-danger]/60 bg-[--color-danger]/10" role="alert">
+      <CardContent className="flex items-start gap-3 p-4 text-[--color-danger]">
+        {icon}
+        <div>
+          <div className="font-display font-semibold">{title}</div>
+          <p className="mt-1 text-sm text-[--color-light]">{detail}</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/packages/features/src/operator/components/trust-node-card.tsx
+++ b/web/packages/features/src/operator/components/trust-node-card.tsx
@@ -1,0 +1,193 @@
+import { Card, CardContent } from '@botho/ui'
+import { AlertTriangle, Server, ShieldAlert, ShieldCheck, WifiOff } from 'lucide-react'
+import type { FleetNode } from '../../network/types'
+import type { NodeTrustStatus, TrustPeer } from '../types'
+
+export interface TrustNodeCardProps {
+  node: FleetNode
+  /** Trust snapshot; undefined while the first poll is in flight. */
+  status?: NodeTrustStatus
+  className?: string
+}
+
+/**
+ * One node's quorum-trust posture: promotion-gate counts (#651), BFT posture
+ * (#509), and the live peer table (#544).
+ *
+ * Renders exactly three shapes: loading (first poll pending), unreachable
+ * (explicit error card — never stale values), and live posture. Gate fields
+ * the node reports as null render as "—" (no gate evaluation yet), never as
+ * zero. `quorumGateIntersectionRefused` and `quorumDegenerate` render as
+ * prominent warnings.
+ */
+export function TrustNodeCard({ node, status, className }: TrustNodeCardProps) {
+  if (status && !status.reachable) {
+    return (
+      <Card className={`border-[--color-danger]/40 ${className ?? ''}`}>
+        <CardContent className="p-4">
+          <TrustNodeCardHeader node={node} />
+          <div className="mt-3 flex items-center gap-2 text-sm text-[--color-danger]">
+            <WifiOff className="h-4 w-4 shrink-0" />
+            <span>Unreachable</span>
+          </div>
+          <p className="mt-1 text-xs text-[--color-dim]">
+            node_getStatus failed or timed out at{' '}
+            {new Date(status.polledAt).toLocaleTimeString()}
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const warned =
+    status?.quorumGateIntersectionRefused === true || status?.quorumDegenerate === true
+
+  return (
+    <Card
+      className={`${warned ? 'border-[--color-danger]/50' : ''} ${className ?? ''}`}
+      data-testid={`trust-card-${node.id}`}
+    >
+      <CardContent className="p-4">
+        <TrustNodeCardHeader node={node} />
+
+        {!status ? (
+          <p className="mt-3 text-sm text-[--color-dim]">Checking…</p>
+        ) : (
+          <>
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+              {status.quorumFaultTolerant === true && (
+                <span className="inline-flex items-center gap-1 rounded bg-[--color-pulse]/15 px-1.5 py-0.5 text-[--color-pulse]">
+                  <ShieldCheck className="h-3 w-3" /> BFT fault tolerant
+                </span>
+              )}
+              {status.quorumFaultTolerant === false &&
+                status.quorumDegenerate !== true && (
+                  <span className="inline-flex items-center gap-1 rounded bg-[--color-warning]/15 px-1.5 py-0.5 text-[--color-warning]">
+                    <AlertTriangle className="h-3 w-3" /> not fault tolerant
+                  </span>
+                )}
+              {status.quorumDegenerate === true && (
+                <span className="inline-flex items-center gap-1 rounded bg-[--color-danger]/15 px-1.5 py-0.5 text-[--color-danger]">
+                  <ShieldAlert className="h-3 w-3" /> degenerate quorum — zero fault
+                  tolerance
+                </span>
+              )}
+              {status.quorumGateIntersectionRefused === true && (
+                <span className="inline-flex items-center gap-1 rounded bg-[--color-danger]/15 px-1.5 py-0.5 text-[--color-danger]">
+                  <AlertTriangle className="h-3 w-3" /> intersection check refused last
+                  candidate
+                </span>
+              )}
+            </div>
+
+            <div className="mt-3 grid grid-cols-2 gap-x-8 gap-y-1.5 text-sm">
+              <Stat label="Curated" value={formatCount(status.quorumCuratedMembers)} />
+              <Stat label="Auto-promoted" value={formatCount(status.quorumAutoMembers)} />
+              <Stat
+                label="Suppressed"
+                value={formatCount(status.quorumGateSuppressedPeers)}
+                warn={(status.quorumGateSuppressedPeers ?? 0) > 0}
+              />
+              <Stat label="Auto cap" value={formatCount(status.quorumGateMaxAutoMembers)} />
+              <Stat label="SCP peers" value={formatCount(status.scpPeerCount)} />
+            </div>
+
+            <PeerTable peers={status.peers} />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+/** "—" for absent fields — a node that omits a field reported nothing (anti-#541). */
+function formatCount(value: number | undefined): string {
+  return typeof value === 'number' ? value.toLocaleString() : '—'
+}
+
+function TrustNodeCardHeader({ node }: { node: FleetNode }) {
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <Server className="h-4 w-4 shrink-0 text-[--color-pulse]" />
+      <span className="truncate font-display font-medium text-[--color-light]">
+        {node.name}
+      </span>
+    </div>
+  )
+}
+
+function Stat({ label, value, warn }: { label: string; value: string; warn?: boolean }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="text-[--color-dim]">{label}</span>
+      <span
+        className={`font-mono ${warn ? 'text-[--color-warning]' : 'text-[--color-light]'}`}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+/**
+ * Live connected-peer table. Three explicit shapes: unavailable (the
+ * `network_getPeers` call failed — never an empty table pretending to be
+ * "no peers"), genuinely empty, and populated.
+ */
+function PeerTable({ peers }: { peers?: TrustPeer[] }) {
+  if (peers === undefined) {
+    return (
+      <p className="mt-3 flex items-center gap-2 text-xs text-[--color-danger]">
+        <WifiOff className="h-3.5 w-3.5 shrink-0" />
+        Peer list unavailable (network_getPeers failed)
+      </p>
+    )
+  }
+  if (peers.length === 0) {
+    return <p className="mt-3 text-xs text-[--color-dim]">No connected peers</p>
+  }
+  return (
+    <div className="mt-3">
+      <div className="text-xs text-[--color-dim]">Connected peers ({peers.length})</div>
+      <table className="mt-1 w-full text-xs">
+        <thead>
+          <tr className="text-left text-[--color-dim]">
+            <th className="py-0.5 pr-2 font-normal">Peer</th>
+            <th className="py-0.5 pr-2 font-normal">Version</th>
+            <th className="py-0.5 text-right font-normal">Seen</th>
+          </tr>
+        </thead>
+        <tbody>
+          {peers.map((p) => (
+            <tr key={p.peerId} className="border-t border-[--color-slate]/50">
+              <td
+                className="max-w-0 truncate py-1 pr-2 font-mono text-[--color-light]"
+                title={p.address ?? p.peerId}
+              >
+                {p.peerId}
+              </td>
+              <td className="whitespace-nowrap py-1 pr-2 font-mono text-[--color-ghost]">
+                {p.protocolVersion ?? '—'}
+                {p.versionWarning && (
+                  <span className="ml-1 inline-flex items-center gap-0.5 rounded bg-[--color-warning]/15 px-1 py-0.5 text-[--color-warning]">
+                    <AlertTriangle className="h-3 w-3" /> outdated
+                  </span>
+                )}
+              </td>
+              <td className="whitespace-nowrap py-1 text-right font-mono text-[--color-ghost]">
+                {formatLastSeen(p.lastSeenSecs)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function formatLastSeen(secs: number | undefined): string {
+  if (typeof secs !== 'number') return '—'
+  if (secs < 90) return `${secs}s ago`
+  if (secs < 5400) return `${Math.round(secs / 60)}m ago`
+  return `${(secs / 3600).toFixed(1)}h ago`
+}

--- a/web/packages/features/src/operator/hooks.ts
+++ b/web/packages/features/src/operator/hooks.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import type { FleetNode } from '../network/types'
+import { fetchTrustStatuses } from './quorum'
+import type { NodeTrustStatus } from './types'
+
+/**
+ * Polling hook for the operator trust view (#706), mirroring
+ * `useFleetStatus` in `../network/hooks.ts`.
+ *
+ * Callers must pass a referentially-stable `nodes` array (module-level
+ * constant) — it is an effect dependency.
+ */
+
+export interface UseTrustStatusOptions {
+  /** Poll cadence in ms. */
+  pollMs?: number
+}
+
+export interface UseTrustStatusResult {
+  /** Latest trust snapshot per node id; missing key = first poll in flight. */
+  statuses: Record<string, NodeTrustStatus>
+}
+
+/**
+ * Poll every node's trust posture (`node_getStatus` gate fields +
+ * `network_getPeers`). Failed polls resolve to explicit `reachable: false`
+ * snapshots — never stale values (anti-#541).
+ */
+export function useTrustStatus(
+  nodes: FleetNode[],
+  { pollMs = 15_000 }: UseTrustStatusOptions = {},
+): UseTrustStatusResult {
+  const [statuses, setStatuses] = useState<Record<string, NodeTrustStatus>>({})
+
+  useEffect(() => {
+    let cancelled = false
+    const poll = async () => {
+      const results = await fetchTrustStatuses(nodes)
+      if (cancelled) return
+      setStatuses(Object.fromEntries(results.map((s) => [s.nodeId, s])))
+    }
+    poll()
+    const id = setInterval(poll, pollMs)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [nodes, pollMs])
+
+  return { statuses }
+}

--- a/web/packages/features/src/operator/index.ts
+++ b/web/packages/features/src/operator/index.ts
@@ -1,0 +1,8 @@
+export * from './types'
+export * from './quorum'
+export * from './hooks'
+export { TrustNodeCard, type TrustNodeCardProps } from './components/trust-node-card'
+export {
+  TrustDashboard,
+  type TrustDashboardProps,
+} from './components/trust-dashboard'

--- a/web/packages/features/src/operator/quorum.test.ts
+++ b/web/packages/features/src/operator/quorum.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { deriveTrustSummary, fetchNodeTrustStatus } from './quorum'
+import type { NodeTrustStatus } from './types'
+
+const node = { id: 'seed', name: 'Seed (validator)', rpcEndpoint: 'https://seed.test/rpc' }
+
+/**
+ * Wire fixtures captured from the live testnet (seed.botho.io, 2026-07-07):
+ * the exact camelCase field names `handle_node_status` and
+ * `handle_get_peers` serialize (`botho/src/rpc/mod.rs`).
+ */
+const STATUS_FIXTURE = {
+  chainHeight: 716,
+  mempoolSize: 0,
+  nodeVersion: '0.3.2',
+  peerCount: 3,
+  quorumAutoMembers: 3,
+  quorumCuratedMembers: 0,
+  quorumDegenerate: false,
+  quorumFaultTolerant: true,
+  quorumGateIntersectionRefused: false,
+  quorumGateMaxAutoMembers: 8,
+  quorumGateSuppressedPeers: 0,
+  scpPeerCount: 3,
+  synced: true,
+}
+
+const PEERS_FIXTURE = {
+  peerCount: 3,
+  peers: [
+    {
+      address: null,
+      lastSeenSecs: 44,
+      peerId: '12D3KooWJ5U2gk6Pe9ehZb6aHng2zu7RnUwAKzEYxHbaM6VRo592',
+      protocolVersion: '4.0.0 (block v5)',
+      versionWarning: false,
+    },
+    {
+      address: null,
+      lastSeenSecs: 0,
+      peerId: '12D3KooWRubuvzRNxbxHH5BdzgxQNqMoWyQtdxKXUdNWJt5huTpk',
+      protocolVersion: null,
+      versionWarning: false,
+    },
+    {
+      address: '/ip4/10.0.0.1/tcp/4001',
+      lastSeenSecs: 1,
+      peerId: '12D3KooWBDKQDQQkK5rLmSnke2hiWVaZ9qNGuuBhxFdxyqxaTvwK',
+      protocolVersion: '4.0.0 (block v5)',
+      versionWarning: true,
+    },
+  ],
+}
+
+/** Stub fetch with per-RPC-method responses. `Error` values throw. */
+function stubRpc(handlers: Record<string, unknown>) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: unknown, init?: { body?: string }) => {
+      const method = (JSON.parse(init?.body ?? '{}') as { method?: string }).method ?? ''
+      const h = handlers[method]
+      if (h instanceof Error) throw h
+      return { ok: true, json: async () => h }
+    }),
+  )
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('fetchNodeTrustStatus', () => {
+  it('merges node_getStatus gate fields with the network_getPeers table', async () => {
+    stubRpc({
+      node_getStatus: { result: STATUS_FIXTURE },
+      network_getPeers: { result: PEERS_FIXTURE },
+    })
+    const s = await fetchNodeTrustStatus(node)
+    expect(s).toMatchObject({
+      nodeId: 'seed',
+      reachable: true,
+      quorumFaultTolerant: true,
+      quorumDegenerate: false,
+      quorumCuratedMembers: 0,
+      quorumAutoMembers: 3,
+      quorumGateSuppressedPeers: 0,
+      quorumGateMaxAutoMembers: 8,
+      quorumGateIntersectionRefused: false,
+      scpPeerCount: 3,
+    })
+    expect(s.peers).toHaveLength(3)
+    expect(s.peers?.[0]).toEqual({
+      peerId: '12D3KooWJ5U2gk6Pe9ehZb6aHng2zu7RnUwAKzEYxHbaM6VRo592',
+      address: null,
+      protocolVersion: '4.0.0 (block v5)',
+      versionWarning: false,
+      lastSeenSecs: 44,
+    })
+    // Null protocolVersion stays null (renders "—"), never a fabricated string.
+    expect(s.peers?.[1].protocolVersion).toBeNull()
+    expect(s.peers?.[2].versionWarning).toBe(true)
+    expect(s.peers?.[2].address).toBe('/ip4/10.0.0.1/tcp/4001')
+  })
+
+  it('maps null gate fields (no gate evaluation yet) to absent — never zero', async () => {
+    stubRpc({
+      node_getStatus: {
+        result: {
+          ...STATUS_FIXTURE,
+          quorumCuratedMembers: null,
+          quorumAutoMembers: null,
+          quorumGateSuppressedPeers: null,
+          quorumGateMaxAutoMembers: null,
+          quorumGateIntersectionRefused: null,
+        },
+      },
+      network_getPeers: { result: { peers: [], peerCount: 0 } },
+    })
+    const s = await fetchNodeTrustStatus(node)
+    expect(s.reachable).toBe(true)
+    expect(s.quorumCuratedMembers).toBeUndefined()
+    expect(s.quorumAutoMembers).toBeUndefined()
+    expect(s.quorumGateSuppressedPeers).toBeUndefined()
+    expect(s.quorumGateMaxAutoMembers).toBeUndefined()
+    expect(s.quorumGateIntersectionRefused).toBeUndefined()
+    // Genuinely-empty peer list is [], distinct from an unavailable one.
+    expect(s.peers).toEqual([])
+  })
+
+  it('resolves unreachable when node_getStatus throws — never throws into the poller', async () => {
+    stubRpc({
+      node_getStatus: new Error('boom'),
+      network_getPeers: { result: PEERS_FIXTURE },
+    })
+    const s = await fetchNodeTrustStatus(node)
+    expect(s.reachable).toBe(false)
+    expect(s.quorumCuratedMembers).toBeUndefined()
+    expect(s.peers).toBeUndefined()
+  })
+
+  it('resolves unreachable on an RPC-level error object', async () => {
+    stubRpc({
+      node_getStatus: { error: { code: -32000 } },
+      network_getPeers: { result: PEERS_FIXTURE },
+    })
+    expect((await fetchNodeTrustStatus(node)).reachable).toBe(false)
+  })
+
+  it('keeps the node reachable but marks peers unavailable when only network_getPeers fails', async () => {
+    stubRpc({
+      node_getStatus: { result: STATUS_FIXTURE },
+      network_getPeers: new Error('boom'),
+    })
+    const s = await fetchNodeTrustStatus(node)
+    expect(s.reachable).toBe(true)
+    expect(s.quorumAutoMembers).toBe(3)
+    // undefined = "call failed", NOT an empty list masquerading as no peers.
+    expect(s.peers).toBeUndefined()
+  })
+
+  it('marks peers unavailable on an unrecognized peers shape', async () => {
+    stubRpc({
+      node_getStatus: { result: STATUS_FIXTURE },
+      network_getPeers: { result: { peers: 'nope' } },
+    })
+    expect((await fetchNodeTrustStatus(node)).peers).toBeUndefined()
+  })
+})
+
+describe('deriveTrustSummary', () => {
+  function status(overrides: Partial<NodeTrustStatus>): NodeTrustStatus {
+    return { nodeId: 'n', reachable: true, polledAt: 0, ...overrides }
+  }
+
+  it('collects refused/degenerate node ids and counts posture', () => {
+    const s = deriveTrustSummary([
+      status({ nodeId: 'a', quorumFaultTolerant: true }),
+      status({ nodeId: 'b', quorumGateIntersectionRefused: true, quorumFaultTolerant: true }),
+      status({ nodeId: 'c', quorumDegenerate: true, quorumFaultTolerant: false }),
+      status({ nodeId: 'd', reachable: false }),
+    ])
+    expect(s.nodesReachable).toBe(3)
+    expect(s.nodesTotal).toBe(4)
+    expect(s.intersectionRefusedNodeIds).toEqual(['b'])
+    expect(s.degenerateNodeIds).toEqual(['c'])
+    expect(s.faultTolerantCount).toBe(2)
+  })
+
+  it('never counts an unreachable node as warning OR healthy', () => {
+    const s = deriveTrustSummary([
+      status({
+        nodeId: 'dead',
+        reachable: false,
+        quorumGateIntersectionRefused: true,
+        quorumDegenerate: true,
+        quorumFaultTolerant: true,
+      }),
+    ])
+    expect(s.intersectionRefusedNodeIds).toEqual([])
+    expect(s.degenerateNodeIds).toEqual([])
+    expect(s.faultTolerantCount).toBe(0)
+  })
+
+  it('treats absent gate fields as no signal', () => {
+    const s = deriveTrustSummary([status({ nodeId: 'relay' })])
+    expect(s.intersectionRefusedNodeIds).toEqual([])
+    expect(s.degenerateNodeIds).toEqual([])
+    expect(s.faultTolerantCount).toBe(0)
+  })
+})

--- a/web/packages/features/src/operator/quorum.ts
+++ b/web/packages/features/src/operator/quorum.ts
@@ -1,0 +1,140 @@
+import type { FleetNode } from '../network/types'
+import type { NodeTrustStatus, TrustPeer, TrustSummary } from './types'
+
+/**
+ * Fetch + derive for the operator trust view (#706).
+ *
+ * Same anti-#541 contract as `../network/fleet.ts` (`fetchFleetNodeStatus`):
+ * hard timeout, failures resolve to explicit error states, wire `null`s map
+ * to `undefined` (absent), never to fabricated zeros.
+ */
+
+/**
+ * One JSON-RPC call that resolves to the `result` object, or `null` on ANY
+ * failure (transport, HTTP, RPC-level error, malformed body). Never throws.
+ */
+async function rpcResult(
+  endpoint: string,
+  method: string,
+  signal: AbortSignal,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      signal,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method, params: {}, id: 1 }),
+    })
+    if (!response.ok) return null
+    const json = (await response.json()) as {
+      result?: Record<string, unknown>
+      error?: unknown
+    }
+    if (json.error || !json.result || typeof json.result !== 'object') return null
+    return json.result
+  } catch {
+    return null
+  }
+}
+
+/** Wire value -> field: numbers pass through, `null`/anything else is absent. */
+function asNumber(v: unknown): number | undefined {
+  return typeof v === 'number' ? v : undefined
+}
+
+/** Wire value -> field: booleans pass through, `null`/anything else is absent. */
+function asBoolean(v: unknown): boolean | undefined {
+  return typeof v === 'boolean' ? v : undefined
+}
+
+/**
+ * Parse a `network_getPeers` result into peer rows.
+ *
+ * Returns `undefined` when the call failed or the shape is unrecognized —
+ * the UI renders an explicit "peer list unavailable" state, never an empty
+ * table masquerading as "no peers".
+ */
+function parsePeers(result: Record<string, unknown> | null): TrustPeer[] | undefined {
+  if (!result || !Array.isArray(result.peers)) return undefined
+  const peers: TrustPeer[] = []
+  for (const raw of result.peers as unknown[]) {
+    if (typeof raw !== 'object' || raw === null) continue
+    const p = raw as Record<string, unknown>
+    if (typeof p.peerId !== 'string') continue
+    peers.push({
+      peerId: p.peerId,
+      address: typeof p.address === 'string' ? p.address : null,
+      protocolVersion: typeof p.protocolVersion === 'string' ? p.protocolVersion : null,
+      versionWarning: p.versionWarning === true,
+      lastSeenSecs: asNumber(p.lastSeenSecs),
+    })
+  }
+  return peers
+}
+
+/**
+ * Poll one node's trust posture with a hard timeout: `node_getStatus` gate
+ * fields merged with the `network_getPeers` peer table (both public).
+ *
+ * - `node_getStatus` failure ⇒ `reachable: false` (explicit error card).
+ * - `network_getPeers` failure alone ⇒ reachable snapshot with
+ *   `peers: undefined` (explicit "unavailable" table state).
+ */
+export async function fetchNodeTrustStatus(
+  node: FleetNode,
+  timeoutMs = 5000,
+): Promise<NodeTrustStatus> {
+  const polledAt = Date.now()
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const [status, peersResult] = await Promise.all([
+      rpcResult(node.rpcEndpoint, 'node_getStatus', controller.signal),
+      rpcResult(node.rpcEndpoint, 'network_getPeers', controller.signal),
+    ])
+    if (!status) return { nodeId: node.id, reachable: false, polledAt }
+
+    return {
+      nodeId: node.id,
+      reachable: true,
+      polledAt,
+      quorumFaultTolerant: asBoolean(status.quorumFaultTolerant),
+      quorumDegenerate: asBoolean(status.quorumDegenerate),
+      quorumCuratedMembers: asNumber(status.quorumCuratedMembers),
+      quorumAutoMembers: asNumber(status.quorumAutoMembers),
+      quorumGateSuppressedPeers: asNumber(status.quorumGateSuppressedPeers),
+      quorumGateMaxAutoMembers: asNumber(status.quorumGateMaxAutoMembers),
+      quorumGateIntersectionRefused: asBoolean(status.quorumGateIntersectionRefused),
+      scpPeerCount: asNumber(status.scpPeerCount),
+      peers: parsePeers(peersResult),
+    }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+/** Poll the whole fleet concurrently; one slow/dead node never blocks the rest. */
+export async function fetchTrustStatuses(nodes: FleetNode[]): Promise<NodeTrustStatus[]> {
+  return Promise.all(nodes.map((n) => fetchNodeTrustStatus(n)))
+}
+
+/**
+ * Derive fleet-level trust facts from live snapshots. Pure.
+ *
+ * Only reachable nodes contribute: an unreachable node's last-known posture
+ * is unknown, not "healthy" and not "warning" (anti-#541).
+ */
+export function deriveTrustSummary(statuses: NodeTrustStatus[]): TrustSummary {
+  const reachable = statuses.filter((s) => s.reachable)
+  return {
+    nodesReachable: reachable.length,
+    nodesTotal: statuses.length,
+    intersectionRefusedNodeIds: reachable
+      .filter((s) => s.quorumGateIntersectionRefused === true)
+      .map((s) => s.nodeId),
+    degenerateNodeIds: reachable
+      .filter((s) => s.quorumDegenerate === true)
+      .map((s) => s.nodeId),
+    faultTolerantCount: reachable.filter((s) => s.quorumFaultTolerant === true).length,
+  }
+}

--- a/web/packages/features/src/operator/types.ts
+++ b/web/packages/features/src/operator/types.ts
@@ -1,0 +1,78 @@
+/**
+ * Operator trust/quorum view types (#706, P4.1 of the #695 proposal).
+ *
+ * Public read surface only: every field maps 1:1 to a public RPC response —
+ * the quorum promotion-gate fields of `node_getStatus` (#651/#509) and the
+ * connected-peer table of `network_getPeers` (#544). No auth, no writes.
+ *
+ * Anti-#541 contract (mirrors `../network/types`):
+ * - `reachable: false` means the poll failed — the card renders an explicit
+ *   error state, never stale or fabricated values.
+ * - Fields the node reports as JSON `null` (no gate evaluation yet — relay
+ *   node or pre-first-rebuild) are `undefined` here and render as absent
+ *   ("—"), never zero-filled.
+ */
+
+/** One connected-peer row from `network_getPeers` (`PeerInfoSnapshot`, #544). */
+export interface TrustPeer {
+  /** libp2p peer ID string. */
+  peerId: string
+  /** Last known multiaddr; null when none has been observed. */
+  address: string | null
+  /** Advertised protocol version; null when the peer is not yet identified. */
+  protocolVersion: string | null
+  /** True when the peer's protocol version is below the node's minimum. */
+  versionWarning: boolean
+  /** Seconds since the peer was last seen, at snapshot time. */
+  lastSeenSecs?: number
+}
+
+/**
+ * Per-node trust posture: `node_getStatus` gate fields merged with the
+ * `network_getPeers` peer table for one ingress node.
+ */
+export interface NodeTrustStatus {
+  nodeId: string
+  /** False when the `node_getStatus` poll failed (timeout / network / RPC error). */
+  reachable: boolean
+  /** Unix millis when this snapshot was taken. */
+  polledAt: number
+  /** BFT posture (#509): true only with >= 4 participating nodes in recommended mode. */
+  quorumFaultTolerant?: boolean
+  /** The n-of-n / zero-fault-tolerance regime (#509). Warn, don't refuse. */
+  quorumDegenerate?: boolean
+  /** Curated (`[network.quorum] members`) quorum members. */
+  quorumCuratedMembers?: number
+  /** Auto-promoted quorum members (deterministic selection under the cap). */
+  quorumAutoMembers?: number
+  /** Discovered peers the gate is keeping OUT of the safety-critical quorum. */
+  quorumGateSuppressedPeers?: number
+  /** Configured cap on auto-promoted members. */
+  quorumGateMaxAutoMembers?: number
+  /**
+   * True when the latest candidate quorum set failed the bth-quorum-sim
+   * intersection check and was refused (the node kept its previous safe set).
+   */
+  quorumGateIntersectionRefused?: boolean
+  /** Peers participating in SCP consensus. */
+  scpPeerCount?: number
+  /**
+   * Live connected peers. `undefined` means `network_getPeers` failed — the
+   * table renders an explicit unavailable state, NOT an empty list.
+   */
+  peers?: TrustPeer[]
+}
+
+/** Fleet-level trust facts derived from the live snapshots (pure function). */
+export interface TrustSummary {
+  /** Reachable node count. */
+  nodesReachable: number
+  /** Total nodes watched. */
+  nodesTotal: number
+  /** Reachable node ids whose latest gate candidate was intersection-refused. */
+  intersectionRefusedNodeIds: string[]
+  /** Reachable node ids reporting a degenerate (zero-fault-tolerance) quorum. */
+  degenerateNodeIds: string[]
+  /** Reachable nodes reporting `quorumFaultTolerant: true`. */
+  faultTolerantCount: number
+}

--- a/web/packages/web-wallet/src/App.tsx
+++ b/web/packages/web-wallet/src/App.tsx
@@ -9,6 +9,7 @@ import { ContactsPage } from './pages/contacts'
 import { DocsPage } from './pages/docs'
 import { ExplorerPage } from './pages/explorer'
 import { NetworkPage } from './pages/network'
+import { OperatorPage } from './pages/operator'
 import { RigPage, RigSuccessPage, RigStatusPage } from './pages/rig'
 
 /**
@@ -52,6 +53,8 @@ function App() {
             <Route path="/contacts" element={<ContactsPage />} />
             <Route path="/explorer" element={<ExplorerPage />} />
             <Route path="/network" element={<NetworkPage />} />
+            {/* Operator dashboard — public read surface (#706, #695 P4.1). */}
+            <Route path="/operator" element={<OperatorPage />} />
             <Route path="/explorer/tx/:hash" element={<ExplorerPage />} />
             <Route path="/explorer/block/:hash" element={<ExplorerPage />} />
             <Route path="/docs" element={<DocsPage />} />

--- a/web/packages/web-wallet/src/config/fleet.ts
+++ b/web/packages/web-wallet/src/config/fleet.ts
@@ -1,0 +1,23 @@
+import type { FleetNode } from '@botho/features'
+import { INGRESS_NODES } from './networks'
+
+/**
+ * Shared fleet-dashboard configuration for the `/network` and `/operator`
+ * pages (#698, #706) — one source of truth so the two surfaces can never
+ * drift apart on which nodes they watch.
+ */
+
+/** Metrics-daemon fleet API (#697), served via the faucet's nginx. */
+export const METRICS_API_BASE = 'https://faucet.botho.io/metrics-api'
+
+/**
+ * The dashboards watch every ingress node plus region labels.
+ *
+ * Module-level constant on purpose: the fleet hooks take it as an effect
+ * dependency, so it must be referentially stable.
+ */
+export const FLEET: FleetNode[] = INGRESS_NODES.map((n) => ({
+  id: n.id,
+  name: n.name,
+  rpcEndpoint: n.rpcEndpoint,
+}))

--- a/web/packages/web-wallet/src/pages/network.tsx
+++ b/web/packages/web-wallet/src/pages/network.tsx
@@ -1,139 +1,14 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Logo } from '@botho/ui'
-import {
-  NetworkDashboard,
-  fetchFleetNodeStatus,
-  averageBlockSeconds,
-  type FleetNode,
-  type FleetNodeStatus,
-  type MetricsHistorySample,
-} from '@botho/features'
+import { NetworkDashboard, useFleetHistory, useFleetStatus } from '@botho/features'
 import { ArrowLeft } from 'lucide-react'
-import { INGRESS_NODES } from '../config/networks'
-
-/** Live-grid poll cadence. */
-const POLL_MS = 15_000
-/** History refresh cadence (the daemon samples every ~5 min; no need to hammer). */
-const HISTORY_MS = 120_000
-/** Metrics-daemon fleet API (#697), served via the faucet's nginx. */
-const METRICS_API_BASE = 'https://faucet.botho.io/metrics-api'
-/** Blocks/hour derivation window. */
-const BLOCK_WINDOW = 20
-
-/** The dashboard watches every ingress node plus region labels. */
-const FLEET: FleetNode[] = INGRESS_NODES.map((n) => ({
-  id: n.id,
-  name: n.name,
-  rpcEndpoint: n.rpcEndpoint,
-}))
+import { FLEET, METRICS_API_BASE } from '../config/fleet'
 
 export function NetworkPage() {
-  const [statuses, setStatuses] = useState<Record<string, FleetNodeStatus>>({})
-  const [avgBlockSecs, setAvgBlockSecs] = useState<number | null>(null)
-  const [history, setHistory] = useState<Record<string, MetricsHistorySample[]>>({})
-  const [historyState, setHistoryState] = useState<'ok' | 'empty' | 'unavailable'>('empty')
-  // The block-time derivation reuses the freshest reachable node endpoint.
-  const bestEndpointRef = useRef<string | null>(null)
-
-  // Live fleet polling.
-  useEffect(() => {
-    let cancelled = false
-    const poll = async () => {
-      const results = await Promise.all(FLEET.map((n) => fetchFleetNodeStatus(n)))
-      if (cancelled) return
-      const byId: Record<string, FleetNodeStatus> = {}
-      let bestHeight = -1
-      for (const [i, s] of results.entries()) {
-        byId[s.nodeId] = s
-        if (s.reachable && (s.chainHeight ?? -1) > bestHeight) {
-          bestHeight = s.chainHeight ?? -1
-          bestEndpointRef.current = FLEET[i].rpcEndpoint
-        }
-      }
-      setStatuses(byId)
-    }
-    poll()
-    const id = setInterval(poll, POLL_MS)
-    return () => {
-      cancelled = true
-      clearInterval(id)
-    }
-  }, [])
-
-  // Average block time from two block timestamps on the freshest node.
-  const consensusHeight = useMemo(() => {
-    const heights = Object.values(statuses)
-      .filter((s) => s.reachable && typeof s.chainHeight === 'number')
-      .map((s) => s.chainHeight as number)
-    return heights.length ? Math.max(...heights) : null
-  }, [statuses])
-
-  useEffect(() => {
-    const endpoint = bestEndpointRef.current
-    if (consensusHeight === null || consensusHeight < 2 || !endpoint) return
-    let cancelled = false
-    const older = Math.max(1, consensusHeight - BLOCK_WINDOW)
-    const fetchBlock = async (height: number) => {
-      const r = await fetch(endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'getBlockByHeight',
-          params: { height },
-          id: 1,
-        }),
-      })
-      const json = (await r.json()) as {
-        result?: { height: number; timestamp: number }
-      }
-      return json.result ?? null
-    }
-    Promise.all([fetchBlock(older), fetchBlock(consensusHeight)])
-      .then(([a, b]) => {
-        if (!cancelled && a && b) setAvgBlockSecs(averageBlockSeconds(a, b))
-      })
-      .catch(() => {
-        /* leave the empty state; live grid is unaffected */
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [consensusHeight])
-
-  // History from the metrics-daemon fleet API — degrade gracefully when the
-  // backend is absent (it ships/deploys independently, #697).
-  useEffect(() => {
-    let cancelled = false
-    const load = async () => {
-      try {
-        const since = Math.floor(Date.now() / 1000) - 24 * 3600
-        const results = await Promise.all(
-          FLEET.map(async (n) => {
-            const r = await fetch(
-              `${METRICS_API_BASE}/api/metrics/history?node=${encodeURIComponent(n.id)}&resolution=5min&since=${since}`,
-            )
-            if (!r.ok) throw new Error(`history ${r.status}`)
-            return [n.id, (await r.json()) as MetricsHistorySample[]] as const
-          }),
-        )
-        if (cancelled) return
-        const byNode = Object.fromEntries(results)
-        const any = results.some(([, samples]) => samples.length > 0)
-        setHistory(byNode)
-        setHistoryState(any ? 'ok' : 'empty')
-      } catch {
-        if (!cancelled) setHistoryState('unavailable')
-      }
-    }
-    load()
-    const id = setInterval(load, HISTORY_MS)
-    return () => {
-      cancelled = true
-      clearInterval(id)
-    }
-  }, [])
+  // Polling/history wiring lives in @botho/features hooks (#706) so the
+  // /operator fleet tab shares this exact implementation — no forked copies.
+  const { statuses, avgBlockSeconds } = useFleetStatus(FLEET)
+  const { history, historyState } = useFleetHistory(FLEET, METRICS_API_BASE)
 
   return (
     <div className="min-h-screen">
@@ -147,12 +22,20 @@ export function NetworkPage() {
             </span>
             <span className="font-display text-base font-semibold sm:hidden">Network</span>
           </Link>
-          <Link
-            to="/explorer"
-            className="text-sm text-ghost hover:text-light transition-colors"
-          >
-            Block Explorer
-          </Link>
+          <nav className="flex items-center gap-4">
+            <Link
+              to="/operator"
+              className="text-sm text-ghost hover:text-light transition-colors"
+            >
+              Operator
+            </Link>
+            <Link
+              to="/explorer"
+              className="text-sm text-ghost hover:text-light transition-colors"
+            >
+              Block Explorer
+            </Link>
+          </nav>
         </div>
       </header>
 
@@ -161,7 +44,7 @@ export function NetworkPage() {
           <NetworkDashboard
             nodes={FLEET}
             statuses={statuses}
-            avgBlockSeconds={avgBlockSecs}
+            avgBlockSeconds={avgBlockSeconds}
             history={history}
             historyState={historyState}
           />

--- a/web/packages/web-wallet/src/pages/operator.tsx
+++ b/web/packages/web-wallet/src/pages/operator.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Logo } from '@botho/ui'
+import {
+  NetworkDashboard,
+  TrustDashboard,
+  useFleetHistory,
+  useFleetStatus,
+  useTrustStatus,
+} from '@botho/features'
+import { ArrowLeft } from 'lucide-react'
+import { FLEET, METRICS_API_BASE } from '../config/fleet'
+
+/**
+ * Operator dashboard — public read surface (#706, P4.1 of the #695 proposal).
+ *
+ * Two tabs over exclusively public RPC data — reads only, no auth, no write
+ * affordances:
+ * - Fleet: the same `NetworkDashboard` + fleet hooks as `/network` (one
+ *   implementation, re-parented — not a forked copy).
+ * - Trust: per-node quorum posture from the promotion gate (#651/#509)
+ *   merged with the live `network_getPeers` table (#544).
+ *
+ * Each tab mounts its own polling hook, so only the visible tab polls.
+ */
+type OperatorTab = 'fleet' | 'trust'
+
+export function OperatorPage() {
+  const [tab, setTab] = useState<OperatorTab>('fleet')
+
+  return (
+    <div className="min-h-screen">
+      <header className="border-b border-steel bg-abyss/50 backdrop-blur-md sticky top-0 z-40">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between">
+          <Link to="/" className="flex items-center gap-2 sm:gap-3">
+            <ArrowLeft size={18} className="text-ghost" />
+            <Logo size="sm" showText={false} />
+            <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">
+              Operator
+            </span>
+            <span className="font-display text-base font-semibold sm:hidden">Operator</span>
+          </Link>
+          <nav className="flex items-center gap-4">
+            <Link
+              to="/network"
+              className="text-sm text-ghost hover:text-light transition-colors"
+            >
+              Network
+            </Link>
+            <Link
+              to="/explorer"
+              className="text-sm text-ghost hover:text-light transition-colors"
+            >
+              Block Explorer
+            </Link>
+          </nav>
+        </div>
+      </header>
+
+      <main className="py-6 sm:py-8">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 space-y-4">
+          <div role="tablist" aria-label="Operator views" className="flex gap-1">
+            <TabButton active={tab === 'fleet'} onClick={() => setTab('fleet')}>
+              Fleet
+            </TabButton>
+            <TabButton active={tab === 'trust'} onClick={() => setTab('trust')}>
+              Trust
+            </TabButton>
+          </div>
+
+          {tab === 'fleet' ? <FleetTab /> : <TrustTab />}
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`rounded px-3 py-1.5 text-sm transition-colors ${
+        active
+          ? 'bg-[--color-slate] font-medium text-[--color-light]'
+          : 'text-ghost hover:text-light'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+/** Identical wiring to `/network` — the shared hooks ARE the page logic. */
+function FleetTab() {
+  const { statuses, avgBlockSeconds } = useFleetStatus(FLEET)
+  const { history, historyState } = useFleetHistory(FLEET, METRICS_API_BASE)
+  return (
+    <NetworkDashboard
+      nodes={FLEET}
+      statuses={statuses}
+      avgBlockSeconds={avgBlockSeconds}
+      history={history}
+      historyState={historyState}
+    />
+  )
+}
+
+function TrustTab() {
+  const { statuses } = useTrustStatus(FLEET)
+  return <TrustDashboard nodes={FLEET} statuses={statuses} />
+}


### PR DESCRIPTION
Fixes #706. Implements P4.1 (public read surface) of the architecture proposal on #695 — reads only, public RPC data only, **no auth, no write affordances**.

## What

New `/operator` route group in the web wallet with two tabs:

### Fleet tab — the shipped dashboard, re-parented (no forked copies)
- The polling/history wiring formerly inline in `web/packages/web-wallet/src/pages/network.tsx` is extracted into reusable hooks: `useFleetStatus` / `useFleetHistory` in `web/packages/features/src/network/hooks.ts`. `/network` and the `/operator` fleet tab now run the exact same implementation over the same `NetworkDashboard` component.
- Shared fleet config (`FLEET`, `METRICS_API_BASE`) moves to `web-wallet/src/config/fleet.ts` so the two pages can never drift on which nodes they watch.
- `/network` behavior is unchanged; its tests pass untouched.

### Trust tab — new `web/packages/features/src/operator/` module
Per ingress node, merges:
- quorum promotion-gate fields from `node_getStatus` (#651/#509): curated / auto-promoted / suppressed counts, auto cap, intersection-refused flag, fault-tolerant / degenerate posture,
- the live peer table from `network_getPeers` (#544): peer id, protocol version (+ outdated badge on `versionWarning`), last-seen.

Field names were verified against `botho/src/rpc/mod.rs` (`handle_node_status`, `handle_get_peers`) **and** fixtures captured live from `seed.botho.io` — the test fixtures are the real wire shapes.

## Anti-#541 contract (mirrors `features/network/fleet.ts`)
- Hard 5s timeout per node; any `node_getStatus` failure resolves to an explicit `reachable: false` error card — never stale or placeholder values.
- Gate fields the node reports as `null` (no gate evaluation yet — relay / pre-first-rebuild) map to `undefined` and render as "—", never zero.
- A failed `network_getPeers` renders an explicit "peer list unavailable" state, distinct from a genuinely empty peer list.
- `quorumGateIntersectionRefused: true` and `quorumDegenerate: true` render as prominent `role="alert"` banners above the grid plus per-card danger badges (the #509 warn-don't-refuse posture).
- Fleet-level derivation only counts reachable nodes — an unreachable node is neither "healthy" nor "warning".

## Tests
- `operator/quorum.test.ts` — 9 tests: fetch/merge on real wire fixtures, null→absent mapping, unreachable, peers-only failure, derive logic.
- `operator/components/trust-dashboard.test.tsx` — 9 jsdom tests: ok / unreachable / pre-first-poll states, both prominent warnings, "—" for absent fields, unavailable-vs-empty peer list.
- `network/hooks.test.tsx` — 4 tests protecting the extraction.
- Full run: `pnpm -r typecheck` clean; `pnpm test:run` **641 passed / 10 skipped** (was 621).

## Live verification
Drove `http://localhost:3002/operator` with Chrome/Playwright against the real 5-node testnet: fleet tab reaches **5/5 nodes in sync at height 728** (identical to `/network`); trust tab renders real gate counts (auto-promoted 3–4, cap 8, all BFT fault tolerant) and live peer tables for all five nodes, with null peer versions rendering as "—". `/network` still works and now links to `/operator` from its header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)