### PR TITLE
feat(units): migrate fee/display/policy layer from nanoBTH to picocredits end-to-end (#694)

### DIFF
--- a/botho-wallet/src/commands/send.rs
+++ b/botho-wallet/src/commands/send.rs
@@ -118,8 +118,8 @@ async fn run_classical(
     apply_pending_change_tags(&mut utxos, &mut pending_tags);
 
     // Calculate progressive fee using cluster-tax model
-    // Use default base rate of 1 nanoBTH/byte (dynamic rate would come from
-    // network)
+    // Use default base rate of 1 picocredit/byte (dynamic rate would come
+    // from network)
     let fee_estimator = FeeEstimator::new();
 
     // Select UTXOs that would be used for this transaction (preview selection)

--- a/botho-wallet/src/fee_estimation.rs
+++ b/botho-wallet/src/fee_estimation.rs
@@ -76,11 +76,11 @@ pub const MINIMUM_BASE_RATE: u64 = 1;
 /// let mut cache = CachedFeeRate::default();
 ///
 /// // After fetching from network:
-/// cache.update(5); // 5 nanoBTH/byte
+/// cache.update(5); // 5 picocredits/byte
 ///
 /// // Get rate (returns None if expired)
 /// if let Some(rate) = cache.rate() {
-///     println!("Using cached rate: {} nanoBTH/byte", rate);
+///     println!("Using cached rate: {} picocredits/byte", rate);
 /// } else {
 ///     println!("Cache expired, refresh needed");
 /// }
@@ -90,7 +90,7 @@ pub const MINIMUM_BASE_RATE: u64 = 1;
 /// ```
 #[derive(Debug, Clone)]
 pub struct CachedFeeRate {
-    /// Current base rate in nanoBTH per byte.
+    /// Current base rate in picocredits per byte.
     base_rate: u64,
 
     /// Time when this rate was last updated.
@@ -156,7 +156,7 @@ impl CachedFeeRate {
     /// Get the cached rate or the default minimum rate.
     ///
     /// Use this when you always need a rate value. Falls back to
-    /// [`MINIMUM_BASE_RATE`] (1 nanoBTH/byte) if the cache is expired
+    /// [`MINIMUM_BASE_RATE`] (1 picocredit/byte) if the cache is expired
     /// or was never updated.
     pub fn rate_or_default(&self) -> u64 {
         self.rate().unwrap_or(MINIMUM_BASE_RATE)
@@ -359,7 +359,7 @@ pub struct FeeEstimator {
     /// Full fee configuration for output penalties.
     fee_config: FeeConfig,
 
-    /// Base fee rate in nanoBTH per byte (dynamic, from network).
+    /// Base fee rate in picocredits per byte (dynamic, from network).
     base_rate: u64,
 }
 
@@ -374,7 +374,7 @@ impl FeeEstimator {
     pub fn new() -> Self {
         Self {
             fee_config: FeeConfig::default(),
-            base_rate: 1, // 1 nanoBTH per byte (minimum)
+            base_rate: 1, // 1 picocredit per byte (minimum)
         }
     }
 

--- a/botho-wallet/src/rpc_pool.rs
+++ b/botho-wallet/src/rpc_pool.rs
@@ -545,7 +545,7 @@ pub struct FaucetRequestResult {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkFeeRate {
-    /// Current base fee rate in nanoBTH per byte.
+    /// Current base fee rate in picocredits per byte.
     pub base_rate: u64,
 
     /// Minimum possible base rate (floor).

--- a/botho/src/block.rs
+++ b/botho/src/block.rs
@@ -644,39 +644,29 @@ pub fn calculate_block_reward(height: u64, total_supply: u128) -> u64 {
     } else {
         // Phase 2: Calculate tail reward based on supply.
         //
-        // `MonetaryPolicy::calculate_tail_reward` (cluster-tax crate) takes a
-        // `u64` supply, but by the time the chain reaches Phase 2 the real
-        // picocredit supply (~1.2e21) far exceeds `u64::MAX`. Truncating to
-        // `u64` would compute a wildly wrong tail reward, so we recompute the
-        // identical integer formula in `u128` here rather than widen the
-        // cluster-tax simulation crate (out of scope per #333). This MUST stay
-        // bit-for-bit equivalent to `MonetaryPolicy::calculate_tail_reward`.
+        // By the time the chain reaches Phase 2 the real picocredit supply
+        // (~1.2e21) far exceeds `u64::MAX`, so the `u128` entry point must be
+        // used — truncating through the `u64` API would compute a wildly
+        // wrong tail reward. The formula used to be reimplemented locally
+        // while the cluster-tax crate was `u64`-only (#333); the #694
+        // picocredit migration widened the crate itself, so this now
+        // delegates to the single canonical implementation.
         calculate_tail_reward_u128(&policy, total_supply)
     }
 }
 
-/// `u128` reimplementation of `MonetaryPolicy::calculate_tail_reward`.
+/// `u128`-supply tail-reward computation.
 ///
-/// Kept byte-for-byte identical to the cluster-tax crate's `u64` version
-/// (which already does its internal arithmetic in `u128`); the only
-/// difference is that the `supply` input is accepted as `u128` so realistic
-/// picocredit supplies above `u64::MAX` do not truncate. See #333.
+/// Thin wrapper over
+/// [`bth_cluster_tax::MonetaryPolicy::calculate_tail_reward_u128`],
+/// kept so existing callers/tests retain their entry point. The `supply`
+/// input is `u128` so realistic picocredit supplies above `u64::MAX` do not
+/// truncate. See #333/#694.
 fn calculate_tail_reward_u128(
     policy: &bth_cluster_tax::MonetaryPolicy,
     supply_at_transition: u128,
 ) -> u64 {
-    // Target annual NET emission.
-    let target_net = supply_at_transition * policy.tail_inflation_bps as u128 / 10_000;
-    // Expected annual fee burns.
-    let expected_burns = supply_at_transition * policy.expected_fee_burn_rate_bps as u128 / 10_000;
-    // Gross emission needed.
-    let gross_needed = target_net + expected_burns;
-    // Blocks per year at target rate.
-    let secs_per_year: u128 = 365 * 24 * 3600;
-    let blocks_per_year = secs_per_year / policy.target_block_time_secs as u128;
-    // Reward per block (a single block reward never approaches u64::MAX).
-    let reward = gross_needed / blocks_per_year;
-    reward.max(1) as u64
+    policy.calculate_tail_reward_u128(supply_at_transition)
 }
 
 /// Dynamic block timing based on network load.

--- a/botho/src/commands/balance.rs
+++ b/botho/src/commands/balance.rs
@@ -7,11 +7,8 @@ use crate::{
     wallet::Wallet,
 };
 
-/// Picocredits per BTH (10^12) - internal precision
+/// Picocredits per BTH (10^12) - the single base unit (#649/#694)
 const PICOCREDITS_PER_BTH: u64 = 1_000_000_000_000;
-
-/// Picocredits per nanoBTH (10^3) - for nanoBTH display
-const PICOCREDITS_PER_NANOBTH: u64 = 1_000;
 
 /// Show wallet balance
 pub fn run(config_path: &Path) -> Result<()> {
@@ -43,15 +40,15 @@ pub fn run(config_path: &Path) -> Result<()> {
     let balance_picocredits: u64 = utxos.iter().map(|u| u.output.amount).sum();
     let utxo_count = utxos.len();
 
-    // Convert to display units
+    // Convert to display units: BTH (formatted) with the raw picocredit base
+    // amount alongside. Picocredits are the only unit below the UI edge
+    // (#649/#694); the former nanoBTH display tier is retired.
     let balance_bth = balance_picocredits as f64 / PICOCREDITS_PER_BTH as f64;
-    let balance_nanobth = balance_picocredits / PICOCREDITS_PER_NANOBTH;
 
     println!();
     println!("=== Wallet Balance ===");
     println!("Balance: {:.12} BTH", balance_bth);
-    println!("         {} nanoBTH", balance_nanobth);
-    println!("         {} picocredits (internal)", balance_picocredits);
+    println!("         {} picocredits (base unit)", balance_picocredits);
     println!("UTXOs: {}", utxo_count);
     println!();
     println!("Chain height: {}", state.height);

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -525,7 +525,7 @@ impl Mempool {
             .update(tx_count, max_tx_count, at_min_block_time)
     }
 
-    /// Get the current dynamic fee base (in nanoBTH per byte)
+    /// Get the current dynamic fee base (in picocredits per byte)
     pub fn current_fee_base(&self) -> u64 {
         self.dynamic_fee.compute_base(self.at_min_block_time)
     }
@@ -552,7 +552,7 @@ impl Mempool {
     /// * `num_memos` - Number of outputs with memos
     ///
     /// # Returns
-    /// The minimum fee in nanoBTH
+    /// The minimum fee in picocredits
     pub fn estimate_fee(&self, tx_type: FeeTransactionType, _amount: u64, num_memos: usize) -> u64 {
         // Use 0 for estimation - wallets should use Wallet::compute_cluster_wealth()
         // and call suggest_fees() with their actual cluster wealth for accurate
@@ -598,7 +598,7 @@ impl Mempool {
     ///   cluster_getWealthByTargetKeys
     ///
     /// # Returns
-    /// Estimated fee in nanoBTH including cluster factor multiplier
+    /// Estimated fee in picocredits including cluster factor multiplier
     pub fn estimate_fee_with_wealth(
         &self,
         tx_type: FeeTransactionType,

--- a/botho/src/network/discovery.rs
+++ b/botho/src/network/discovery.rs
@@ -95,7 +95,18 @@ use crate::{
 /// compare major versions only, so only a major bump disconnects 3.0.0 peers
 /// rather than letting them silently fork. `MIN_SUPPORTED_PROTOCOL_VERSION` is
 /// raised in lockstep.
-pub const PROTOCOL_VERSION: &str = "4.0.0";
+///
+/// Bumped to 4.1.0 for the #694 nanoBTH -> picocredits unit migration
+/// (decision #649). This retires the two-tier unit system: the RPC contract's
+/// unit declarations change (`baseRate` and cluster-wealth fields are
+/// picocredit-denominated), and wallets/adapters must be updated in lockstep.
+/// The bump is MINOR, not major, because no consensus rule changes: the fee
+/// curve, consensus fee floor (`CONSENSUS_FEE_BASE`), emission constants
+/// (`mainnet_policy`) and all on-chain amounts were already picocredit-native
+/// since the 4.0.0 reset (#626) — every migrated value is identical in BTH
+/// terms, so 4.0.0 peers accept exactly the same blocks. Per the #608 lesson:
+/// major = consensus-breaking disconnect, minor = warn (soft, RPC-shape-only).
+pub const PROTOCOL_VERSION: &str = "4.1.0";
 
 /// Minimum supported protocol version.
 /// Peers below this version are consensus-incompatible and are disconnected.
@@ -105,6 +116,10 @@ pub const PROTOCOL_VERSION: &str = "4.0.0";
 /// accept/produce blocks the reset chain rejects, so they must be dropped
 /// rather than allowed to fork. The bump is MAJOR because the disconnect check
 /// (`is_consensus_compatible`) is major-only; a minor bump would only warn.
+///
+/// Deliberately NOT raised for the 4.1.0 minor bump (#694 unit migration):
+/// 4.0.0 peers remain consensus-compatible (no block-acceptance rule changed),
+/// so they must keep connecting rather than be disconnected.
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "4.0.0";
 
 /// Topic for block announcements
@@ -2177,11 +2192,28 @@ mod tests {
         // A MAJOR bump is required because `is_consensus_compatible` (the
         // peer-disconnect gate) compares majors only — a minor bump would
         // merely warn, leaving 3.0.0 peers connected and silently forking.
-        assert_eq!(PROTOCOL_VERSION, "4.0.0");
+        //
+        // Bumped to 4.1.0 (MINOR) for the #694 nanoBTH -> picocredits
+        // migration: the RPC contract's declared units change but no
+        // consensus rule does, so 4.0.x peers stay connected (warn-only).
+        assert_eq!(PROTOCOL_VERSION, "4.1.0");
         let parsed = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
         assert_eq!(parsed.major, 4);
-        assert_eq!(parsed.minor, 0);
+        assert_eq!(parsed.minor, 1);
         assert_eq!(parsed.patch, 0);
+    }
+
+    /// The #694 unit migration must NOT disconnect 4.0.0 peers: it is a
+    /// minor (RPC-shape-only) bump and 4.0.0 is consensus-compatible.
+    #[test]
+    fn test_v4_peers_remain_consensus_compatible_with_current() {
+        let local = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
+        let v4_peer = ProtocolVersion::parse("4.0.0").unwrap();
+        assert!(v4_peer.is_consensus_compatible(&local));
+        assert_eq!(
+            ProtocolVersion::consensus_incompatibility(&Some(v4_peer), &local),
+            None
+        );
     }
 
     #[test]

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -1474,7 +1474,7 @@ async fn handle_estimate_fee(id: Value, params: &Value, state: &RpcState) -> Jso
 /// use this to update their local FeeEstimator for accurate fee estimation.
 ///
 /// # Returns
-/// - `baseRate`: Current base fee rate in nanoBTH per byte
+/// - `baseRate`: Current base fee rate in picocredits per byte
 /// - `baseMin`: Minimum possible base rate (floor)
 /// - `baseMax`: Maximum possible base rate (ceiling)
 /// - `multiplier`: Current multiplier (baseRate / baseMin)
@@ -2622,7 +2622,8 @@ async fn handle_list_view_keys(id: Value, params: &Value, state: &RpcState) -> J
 /// - `cluster_id`: The cluster identifier (numeric string or number)
 ///
 /// # Returns
-/// The total wealth in nanoBTH attributed to this cluster across all UTXOs.
+/// The total wealth in picocredits attributed to this cluster across all
+/// UTXOs.
 async fn handle_cluster_get_wealth(id: Value, params: &Value, state: &RpcState) -> JsonRpcResponse {
     // Parse cluster_id parameter (accept both string and number)
     let cluster_id = if let Some(id_str) = params.get("cluster_id").and_then(|v| v.as_str()) {

--- a/cluster-tax/src/dynamic_fee.rs
+++ b/cluster-tax/src/dynamic_fee.rs
@@ -83,11 +83,11 @@ use std::collections::VecDeque;
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DynamicFeeBase {
-    /// Minimum fee base (floor), in nanoBTH per byte.
+    /// Minimum fee base (floor), in picocredits per byte.
     /// Fees never go below this, even when network is empty.
     pub base_min: u64,
 
-    /// Maximum fee base (ceiling), in nanoBTH per byte.
+    /// Maximum fee base (ceiling), in picocredits per byte.
     /// Prevents runaway fees during extreme scenarios.
     pub base_max: u64,
 
@@ -121,7 +121,7 @@ pub struct DynamicFeeBase {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DynamicFeeState {
-    /// Current fee base in nanoBTH per byte.
+    /// Current fee base in picocredits per byte.
     pub current_base: u64,
 
     /// Current fee multiplier (1.0 = base_min).
@@ -143,7 +143,7 @@ pub struct DynamicFeeState {
 impl Default for DynamicFeeBase {
     fn default() -> Self {
         Self {
-            base_min: 1,           // 1 nanoBTH/byte floor
+            base_min: 1,           // 1 picocredit/byte floor
             base_max: 100,         // 100x max multiplier
             target_fullness: 0.75, // 75% target
             response_k: 8.0,       // Strong exponential response

--- a/cluster-tax/src/monetary.rs
+++ b/cluster-tax/src/monetary.rs
@@ -3,18 +3,24 @@
 //! # BTH Tokenomics Summary
 //!
 //! - **Initial supply**: 0 BTH (100% mined, no pre-mine)
-//! - **Unit**: 1 BTH = 10^9 nanoBTH (9 decimal places)
+//! - **Unit**: 1 BTH = 10^12 picocredits (12 decimal places; picocredits are
+//!   the single base unit below the UI edge, decision #649)
 //! - **Phase 1 (Years 0-10)**: Halving schedule distributes ~100M BTH
 //! - **Phase 2 (Year 10+)**: 2% target annual inflation
 //! - **Fee burns**: All cluster taxes are burned, reducing effective inflation
 //!
 //! # Overflow Safety
 //!
-//! With nanoBTH (10^9) as the smallest unit:
-//! - 100M BTH at year 10 = 10^17 nanoBTH
-//! - u64::MAX ≈ 1.84 × 10^19, giving ~184x growth capacity
-//! - At 2% annual inflation: (1.02)^263 ≈ 184x is the limit
-//! - Safe for ~260 years after Phase 1 (~270 years from genesis)
+//! With picocredits (10^12 per BTH) as the base unit, realistic full-scale
+//! supplies exceed `u64::MAX` (~1.84 × 10^19 picocredits ≈ 18.4M BTH):
+//! - 100M BTH = 10^20 picocredits.
+//!
+//! The node therefore performs its supply accounting and tail-reward
+//! computation in `u128` (issues #333/#626); see
+//! [`MonetaryPolicy::calculate_tail_reward_u128`]. The `u64` fields on
+//! [`MonetaryState`] / [`DifficultyController`] in this crate are simulation
+//! tooling used at horizon-scaled magnitudes, where totals stay far below
+//! `u64::MAX`.
 //!
 //! # Design Goals
 //!
@@ -74,14 +80,14 @@
 
 /// Monetary policy configuration.
 ///
-/// All monetary values are denominated in nanoBTH (10^-9 BTH).
+/// All monetary values are denominated in picocredits (10^-12 BTH).
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MonetaryPolicy {
     // === Phase 1: Halving ===
-    /// Initial block reward in nanoBTH.
+    /// Initial block reward in picocredits.
     ///
-    /// Default: 50 BTH = 50_000_000_000 nanoBTH
+    /// Default: 50 BTH = 50_000_000_000_000 picocredits
     pub initial_reward: u64,
 
     /// Number of blocks between halvings.
@@ -142,10 +148,10 @@ impl Default for MonetaryPolicy {
     fn default() -> Self {
         Self {
             // Phase 1: ~10 years of halvings
-            // Initial reward: 50 BTH = 50_000_000_000 nanoBTH
+            // Initial reward: 50 BTH = 50_000_000_000_000 picocredits
             // Over 5 halvings: 50 + 25 + 12.5 + 6.25 + 3.125 ≈ 96.9 BTH/block-equivalent
             // With ~1.05M blocks/halving → ~100M BTH distributed in Phase 1
-            initial_reward: 50_000_000_000,
+            initial_reward: 50_000_000_000_000,
             halving_interval: 1_051_200, // ~2 years at 1 min blocks (525,600 blocks/year)
             halving_count: 5,            // 5 halvings = 10 years
 
@@ -172,7 +178,8 @@ impl MonetaryPolicy {
     /// halvings).
     pub fn bitcoin_like() -> Self {
         Self {
-            initial_reward: 50_000_000_000,
+            // 50 BTH = 50_000_000_000_000 picocredits
+            initial_reward: 50_000_000_000_000,
             halving_interval: 210_000, // ~4 years at 10 min blocks
             halving_count: 5,
 
@@ -300,12 +307,27 @@ impl MonetaryPolicy {
     /// The reward is set to achieve target_net + expected_fees at target block
     /// rate.
     pub fn calculate_tail_reward(&self, supply_at_transition: u64) -> u64 {
+        self.calculate_tail_reward_u128(supply_at_transition as u128)
+    }
+
+    /// `u128`-input variant of [`Self::calculate_tail_reward`].
+    ///
+    /// At picocredit scale (1 BTH = 10^12 picocredits, decision #649) realistic
+    /// full-scale supplies exceed `u64::MAX` (~1.84e19 picocredits ≈ 18.4M
+    /// BTH), so callers that track supply in `u128` (the node's ledger, #333;
+    /// the emission sweep's analytic track) must not truncate through the `u64`
+    /// entry point. The arithmetic is identical to the `u64` version (which
+    /// already computed internally in `u128`) — only the input width differs.
+    ///
+    /// A single block reward never approaches `u64::MAX`, so the return type
+    /// stays `u64`.
+    pub fn calculate_tail_reward_u128(&self, supply_at_transition: u128) -> u64 {
         // Target annual NET emission
-        let target_net = supply_at_transition as u128 * self.tail_inflation_bps as u128 / 10_000;
+        let target_net = supply_at_transition * self.tail_inflation_bps as u128 / 10_000;
 
         // Expected annual fee burns
         let expected_burns =
-            supply_at_transition as u128 * self.expected_fee_burn_rate_bps as u128 / 10_000;
+            supply_at_transition * self.expected_fee_burn_rate_bps as u128 / 10_000;
 
         // Gross emission needed
         let gross_needed = target_net + expected_burns;
@@ -1336,6 +1358,40 @@ mod tests {
 
     // === BTH Tokenomics Tests ===
 
+    /// Picocredits per BTH (1 BTH = 10^12 picocredits).
+    const PICOCREDITS_PER_BTH: u128 = 1_000_000_000_000;
+
+    /// Pin the BTH-denominated value of the library default policies after the
+    /// nanoBTH -> picocredits re-denomination (#694): the initial block reward
+    /// must still be exactly 50 BTH, now expressed in picocredits.
+    #[test]
+    fn test_initial_reward_is_50_bth_in_picocredits() {
+        assert_eq!(
+            MonetaryPolicy::default().initial_reward as u128,
+            50 * PICOCREDITS_PER_BTH,
+            "default initial_reward must be 50 BTH in picocredits"
+        );
+        assert_eq!(
+            MonetaryPolicy::bitcoin_like().initial_reward as u128,
+            50 * PICOCREDITS_PER_BTH,
+            "bitcoin_like initial_reward must be 50 BTH in picocredits"
+        );
+    }
+
+    /// The `u128` tail-reward entry point must be bit-for-bit identical to the
+    /// `u64` version over the shared input range.
+    #[test]
+    fn test_tail_reward_u128_matches_u64_variant() {
+        let policy = MonetaryPolicy::default();
+        for supply in [0u64, 1, 999, 100_000_000, u64::MAX / 2, u64::MAX] {
+            assert_eq!(
+                policy.calculate_tail_reward(supply),
+                policy.calculate_tail_reward_u128(supply as u128),
+                "divergence at supply {supply}"
+            );
+        }
+    }
+
     /// Verify the documented BTH emission schedule produces ~100M BTH in Phase
     /// 1.
     #[test]
@@ -1356,15 +1412,14 @@ mod tests {
         let r = policy.initial_reward as u128;
         let h = policy.halving_interval as u128;
 
-        let total_phase1_nanobth = h * r +           // Halving 0: 50 BTH/block
+        let total_phase1_picocredits = h * r +           // Halving 0: 50 BTH/block
             h * (r / 2) +     // Halving 1: 25 BTH/block
             h * (r / 4) +     // Halving 2: 12.5 BTH/block
             h * (r / 8) +     // Halving 3: 6.25 BTH/block
             h * (r / 16); // Halving 4: 3.125 BTH/block
 
-        // Convert to BTH (from nanoBTH)
-        let bth_to_nanobth = 1_000_000_000u128;
-        let total_phase1_bth = total_phase1_nanobth / bth_to_nanobth;
+        // Convert to BTH (from picocredits)
+        let total_phase1_bth = total_phase1_picocredits / PICOCREDITS_PER_BTH;
 
         // Should be approximately 100M BTH (within 5% tolerance)
         let expected = 100_000_000u128;
@@ -1383,10 +1438,12 @@ mod tests {
     fn test_bth_phase2_tail_reward() {
         let policy = MonetaryPolicy::default();
 
-        // At end of Phase 1, supply is ~100M BTH = 10^17 nanoBTH
-        let supply_at_phase2 = 100_000_000u64 * 1_000_000_000u64; // 100M BTH in nanoBTH
+        // At end of Phase 1, supply is ~100M BTH = 10^20 picocredits. This
+        // exceeds u64::MAX, so the u128 entry point must be used (as the
+        // node's ledger does, #333).
+        let supply_at_phase2 = 100_000_000u128 * PICOCREDITS_PER_BTH; // 100M BTH
 
-        let tail_reward = policy.calculate_tail_reward(supply_at_phase2);
+        let tail_reward = policy.calculate_tail_reward_u128(supply_at_phase2);
 
         // Expected calculation:
         // Target NET inflation: 2% of 100M = 2M BTH/year
@@ -1395,7 +1452,7 @@ mod tests {
         // Blocks per year at 1 min: 525,600
         // Tail reward = 2.5M BTH / 525,600 ≈ 4.76 BTH/block
         let expected_bth_per_block = 4.76;
-        let actual_bth_per_block = tail_reward as f64 / 1_000_000_000.0;
+        let actual_bth_per_block = tail_reward as f64 / PICOCREDITS_PER_BTH as f64;
 
         assert!(
             (actual_bth_per_block - expected_bth_per_block).abs() < 0.5,
@@ -1405,31 +1462,36 @@ mod tests {
         );
     }
 
-    /// Verify u64 overflow safety for 260+ years.
+    /// Verify the overflow envelope at picocredit scale (#694).
+    ///
+    /// At the pico scale, full Phase-1 supply no longer fits in u64 — that is
+    /// expected, and it is why the node's supply accounting is u128 (#333) and
+    /// why [`MonetaryPolicy::calculate_tail_reward_u128`] exists. u128 has
+    /// astronomically more headroom than 250 years of 2% inflation needs.
     #[test]
     fn test_bth_overflow_safety() {
-        // Phase 1 supply: 100M BTH = 10^17 nanoBTH
-        let phase1_supply_nanobth = 100_000_000u128 * 1_000_000_000u128;
+        // Phase 1 supply: 100M BTH = 10^20 picocredits.
+        let phase1_supply_pico = 100_000_000u128 * PICOCREDITS_PER_BTH;
 
-        // Maximum multiplier before u64 overflow
-        let max_multiplier = u64::MAX as u128 / phase1_supply_nanobth;
-
-        // Should have at least 184x growth capacity
+        // Exceeds u64::MAX — the reason full-scale supply tracking is u128.
         assert!(
-            max_multiplier >= 184,
-            "Should support 184x growth (got {}x)",
-            max_multiplier
+            phase1_supply_pico > u64::MAX as u128,
+            "100M BTH in picocredits ({}) must exceed u64::MAX",
+            phase1_supply_pico
         );
 
-        // Verify 250 years of 2% inflation fits
-        // (1.02)^250 ≈ 144.2
-        let supply_250y = phase1_supply_nanobth * 144_210 / 1_000;
+        // 250 years of 2% inflation: (1.02)^250 ≈ 144.2 — trivially fits u128.
+        let supply_250y = phase1_supply_pico * 144_210 / 1_000;
         assert!(
-            supply_250y < u64::MAX as u128,
-            "250-year supply {} should fit in u64 (max {})",
-            supply_250y,
-            u64::MAX
+            supply_250y < u128::MAX / 1_000_000,
+            "250-year supply {} must fit u128 with ample headroom",
+            supply_250y
         );
+
+        // Per-block quantities stay in u64: the initial (largest) block reward
+        // is 50 BTH = 5e13 picocredits, far below u64::MAX.
+        let initial_reward = MonetaryPolicy::default().initial_reward;
+        assert!(initial_reward < u64::MAX / 100_000);
     }
 
     /// Simulate full Phase 1 with default policy and verify supply.
@@ -1439,7 +1501,7 @@ mod tests {
             // Use smaller intervals for faster test
             halving_interval: 100,
             halving_count: 5,
-            initial_reward: 50_000_000_000,       // 50 BTH in nanoBTH
+            initial_reward: 50_000_000_000_000, // 50 BTH in picocredits
             difficulty_adjustment_interval: 1000, // Avoid adjustments during test
             ..Default::default()
         };
@@ -1458,7 +1520,7 @@ mod tests {
 
         // Verify supply was created (exact calculation for test params)
         // R × 100 × (1 + 0.5 + 0.25 + 0.125 + 0.0625) = R × 100 × 1.9375
-        let expected_supply = 50_000_000_000u128 * 100 * 1937 / 1000;
+        let expected_supply = 50_000_000_000_000u128 * 100 * 1937 / 1000;
         let actual_supply = controller.state.total_supply as u128;
 
         assert!(

--- a/cluster-tax/src/simulation/emission_sweep.rs
+++ b/cluster-tax/src/simulation/emission_sweep.rs
@@ -44,8 +44,8 @@ use crate::{
     MonetaryPolicy,
 };
 
-/// 1 BTH expressed in nanoBTH (the smallest unit used by the policy).
-const NANOBTH_PER_BTH: u128 = 1_000_000_000;
+/// 1 BTH expressed in picocredits (the base unit used by the policy, #649).
+const PICOCREDITS_PER_BTH: u128 = 1_000_000_000_000;
 
 /// Real-world blocks per year at 5-second blocks (issue #350 grid assumption).
 pub const BLOCKS_PER_YEAR: u64 = 6_307_200;
@@ -83,8 +83,8 @@ impl Schedule {
 /// real levers are `R0`, `H`, `K`, and the tail rate; the "100M vs 1.22B"
 /// framing is just the value of `H`.
 pub fn candidate_schedules() -> Vec<Schedule> {
-    // 50 BTH initial reward, in nanoBTH.
-    let r0: u64 = 50 * NANOBTH_PER_BTH as u64;
+    // 50 BTH initial reward, in picocredits.
+    let r0: u64 = 50 * PICOCREDITS_PER_BTH as u64;
 
     // Shared block-time / difficulty parameters: 5s blocks (mainnet timing).
     let base = MonetaryPolicy {
@@ -154,9 +154,9 @@ pub fn candidate_schedules() -> Vec<Schedule> {
 // Analytic monetary track (real-world scale, exact)
 // ===========================================================================
 
-/// Total Phase-1 supply (nanoBTH) emitted by `policy` over its real-world
+/// Total Phase-1 supply (picocredits) emitted by `policy` over its real-world
 /// halving schedule. Exact sum of `R0 >> h` over each halving epoch.
-pub fn phase1_supply_nanobth(policy: &MonetaryPolicy) -> u128 {
+pub fn phase1_supply_picocredits(policy: &MonetaryPolicy) -> u128 {
     let h = policy.halving_interval as u128;
     let r0 = policy.initial_reward as u128;
     let mut total = 0u128;
@@ -166,8 +166,8 @@ pub fn phase1_supply_nanobth(policy: &MonetaryPolicy) -> u128 {
     total
 }
 
-/// Cumulative supply (nanoBTH) emitted by the end of block `height` under the
-/// real-world schedule, including tail emission after Phase 1.
+/// Cumulative supply (picocredits) emitted by the end of block `height` under
+/// the real-world schedule, including tail emission after Phase 1.
 pub fn cumulative_supply_at(policy: &MonetaryPolicy, height: u64) -> u128 {
     let tail_start = policy.tail_emission_start_height();
     if height <= tail_start {
@@ -191,10 +191,12 @@ pub fn cumulative_supply_at(policy: &MonetaryPolicy, height: u64) -> u128 {
         }
         total
     } else {
-        let phase1 = phase1_supply_nanobth(policy);
-        // Tail reward is calibrated from supply at transition.
-        let tail_reward =
-            policy.calculate_tail_reward((phase1.min(u64::MAX as u128)) as u64) as u128;
+        let phase1 = phase1_supply_picocredits(policy);
+        // Tail reward is calibrated from supply at transition. Phase-1 supply
+        // in picocredits exceeds u64::MAX for every candidate schedule, so
+        // this MUST go through the u128 entry point — clamping to u64 would
+        // silently compute a wildly wrong tail reward (#694).
+        let tail_reward = policy.calculate_tail_reward_u128(phase1) as u128;
         let tail_blocks = (height - tail_start) as u128;
         phase1 + tail_blocks * tail_reward
     }
@@ -212,7 +214,7 @@ pub fn early_issuance_share(policy: &MonetaryPolicy, frac: f64) -> f64 {
     }
     let cutoff = (tail_start as f64 * frac).round() as u64;
     let early = cumulative_supply_at(policy, cutoff) as f64;
-    let total = phase1_supply_nanobth(policy) as f64;
+    let total = phase1_supply_picocredits(policy) as f64;
     if total == 0.0 {
         0.0
     } else {
@@ -224,7 +226,7 @@ pub fn early_issuance_share(policy: &MonetaryPolicy, frac: f64) -> f64 {
 /// simulated/real year `year`.
 pub fn pct_issued_by_year(policy: &MonetaryPolicy, year: u64) -> f64 {
     let height = year.saturating_mul(BLOCKS_PER_YEAR);
-    let total = phase1_supply_nanobth(policy) as f64;
+    let total = phase1_supply_picocredits(policy) as f64;
     if total == 0.0 {
         return 0.0;
     }
@@ -241,11 +243,13 @@ pub fn pct_issued_by_year(policy: &MonetaryPolicy, year: u64) -> f64 {
 /// gross tail emission rate. The net rate is lower by the fee-burn rate; the
 /// policy targets `tail_inflation_bps` net, so we report both.
 pub fn steady_state_inflation_pct(policy: &MonetaryPolicy) -> (f64, f64) {
-    let supply = phase1_supply_nanobth(policy);
+    let supply = phase1_supply_picocredits(policy);
     if supply == 0 {
         return (0.0, 0.0);
     }
-    let tail_reward = policy.calculate_tail_reward((supply.min(u64::MAX as u128)) as u64) as f64;
+    // See cumulative_supply_at: pico-scale supplies exceed u64::MAX, so the
+    // u128 entry point is required for a correct tail reward.
+    let tail_reward = policy.calculate_tail_reward_u128(supply) as f64;
     let gross_annual = tail_reward * BLOCKS_PER_YEAR as f64;
     let gross_pct = gross_annual / supply as f64 * 100.0;
     let net_pct = policy.tail_inflation_bps as f64 / 100.0; // bps -> %
@@ -271,7 +275,7 @@ pub fn monetary_metrics(schedule: &Schedule) -> MonetaryMetrics {
     let policy = &schedule.policy;
     let (gross, net) = steady_state_inflation_pct(policy);
     MonetaryMetrics {
-        total_supply_bth: phase1_supply_nanobth(policy) as f64 / NANOBTH_PER_BTH as f64,
+        total_supply_bth: phase1_supply_picocredits(policy) as f64 / PICOCREDITS_PER_BTH as f64,
         time_to_tail_years: schedule.time_to_tail_years(),
         early_share_10pct: early_issuance_share(policy, 0.10),
         early_share_25pct: early_issuance_share(policy, 0.25),
@@ -438,7 +442,7 @@ pub struct DistributionMetrics {
     pub gini_trajectory: Vec<(u64, f64)>,
     pub final_top_1_pct: f64,
     pub final_top_10_pct: f64,
-    /// Total block subsidy emitted over the run (nanoBTH-scale sim units).
+    /// Total block subsidy emitted over the run (picocredit-scale sim units).
     pub subsidy_emitted: u128,
     /// Total fees burned/recycled over the run.
     pub fees_recycled: u128,
@@ -521,8 +525,8 @@ pub fn run_schedule(
         0.0
     };
     // Turnover expressed as transactions per 1M BTH of final supply, so the
-    // figure is readable at nanoBTH scale (raw tx/nanoBTH is ~1e-12).
-    let supply_in_million_bth = final_supply as f64 / NANOBTH_PER_BTH as f64 / 1.0e6;
+    // figure is readable at picocredit scale (raw tx/picocredit is tiny).
+    let supply_in_million_bth = final_supply as f64 / PICOCREDITS_PER_BTH as f64 / 1.0e6;
     let turnover_per_supply = if supply_in_million_bth > 0.0 {
         tx_count as f64 / supply_in_million_bth
     } else {
@@ -745,7 +749,7 @@ agent RNG is seeded from agent IDs, so the run is reproducible.\n\n",
             "- **{}** ({}): R0={} BTH, H={} blocks (~{:.2} yr), K={}, tail={}bps.\n",
             sch.id,
             sch.label,
-            sch.policy.initial_reward / NANOBTH_PER_BTH as u64,
+            sch.policy.initial_reward / PICOCREDITS_PER_BTH as u64,
             sch.policy.halving_interval,
             sch.policy.halving_interval as f64 / BLOCKS_PER_YEAR as f64,
             sch.policy.halving_count,

--- a/cluster-tax/src/simulation/runner.rs
+++ b/cluster-tax/src/simulation/runner.rs
@@ -340,9 +340,13 @@ pub fn run_simulation(
                         let final_rate = agents[sender_idx]
                             .effective_fee_rate(&state.cluster_wealth, &config.fee_curve);
 
-                        // Calculate if it was worth it
+                        // Calculate if it was worth it. i128 intermediate
+                        // (#694): pico-scale amounts × bps can exceed
+                        // i64::MAX; the divided result fits i64 at sim scale.
                         let rate_reduction = initial_rate as i64 - final_rate as i64;
-                        let savings_per_tx = rate_reduction as i64 * amount as i64 / 10_000;
+                        let savings_per_tx = (rate_reduction as i128 * amount as i128 / 10_000)
+                            .clamp(i64::MIN as i128, i64::MAX as i128)
+                            as i64;
                         let net_savings = savings_per_tx - total_wash_fees as i64;
 
                         metrics.record_wash_trade(total_wash_fees, net_savings);

--- a/cluster-tax/src/simulation/state.rs
+++ b/cluster-tax/src/simulation/state.rs
@@ -348,8 +348,8 @@ mod tests {
     /// Previously the sort was stable on balance only, so tied balances kept
     /// their `HashMap` iteration order — randomly seeded per process — which
     /// let a downstream fee/cluster consumer sum in a process-dependent
-    /// order and drift the result (S3 `fees_recycled` differed by ~3
-    /// nanoBTH across runs).
+    /// order and drift the result (S3 `fees_recycled` differed by ~3 base
+    /// units across runs).
     ///
     /// This test inserts the *same* agents in two opposite orders and asserts
     /// the output is byte-identical, then checks the explicit tie-break

--- a/cluster-tax/src/tag.rs
+++ b/cluster-tax/src/tag.rs
@@ -114,7 +114,8 @@ impl TagVector {
     /// - `incoming`: tag vector of incoming coins
     /// - `incoming_value`: value of incoming coins
     pub fn mix(&mut self, self_value: u64, incoming: &TagVector, incoming_value: u64) {
-        let total_value = self_value + incoming_value;
+        // u128: two u64 values can sum past u64::MAX.
+        let total_value = self_value as u128 + incoming_value as u128;
         if total_value == 0 {
             return;
         }
@@ -127,14 +128,22 @@ impl TagVector {
             }
         }
 
-        // Compute weighted average for each cluster
+        // Compute weighted average for each cluster.
+        //
+        // Widened to u128 (#694): at picocredit scale a value can exceed
+        // u64::MAX / TAG_WEIGHT_SCALE (~1.84e13 picocredits ≈ 18.4 BTH), so
+        // `value * weight` must not be computed in u64. The result is a
+        // weighted average of weights (<= TAG_WEIGHT_SCALE), so it always fits
+        // TagWeight; the wider intermediate changes no result that did not
+        // previously overflow.
         for cluster in all_clusters {
-            let self_weight = self.get(cluster) as u64;
-            let incoming_weight = incoming.get(cluster) as u64;
+            let self_weight = self.get(cluster) as u128;
+            let incoming_weight = incoming.get(cluster) as u128;
 
             // new_weight = (self_value * self_weight + incoming_value * incoming_weight) /
             // total_value
-            let numerator = self_value * self_weight + incoming_value * incoming_weight;
+            let numerator =
+                self_value as u128 * self_weight + incoming_value as u128 * incoming_weight;
             let new_weight = (numerator / total_value) as TagWeight;
 
             self.set(cluster, new_weight);

--- a/cluster-tax/src/transfer.rs
+++ b/cluster-tax/src/transfer.rs
@@ -158,16 +158,25 @@ pub fn execute_transfer(
     transferred_tags.apply_decay(config.decay_rate);
 
     // 4. Update cluster wealth (before mixing, to reflect decay)
-    // The sender's contribution to each cluster decreases
+    // The sender's contribution to each cluster decreases.
+    //
+    // The `value * weight` intermediates are computed in i128 (#694): at
+    // picocredit scale an amount can exceed i64::MAX / TAG_WEIGHT_SCALE, so
+    // the former i64 multiply could overflow. The divided mass is <= amount,
+    // so it fits back into i64 for all simulation magnitudes; clamp defends
+    // the (unreachable at sim scale) amount > i64::MAX case. The wider
+    // intermediate changes no result that did not previously overflow.
     for (cluster, weight) in sender.tags.iter() {
         // Mass leaving sender for this cluster
-        let mass_leaving = amount as i64 * weight as i64 / TAG_WEIGHT_SCALE as i64;
+        let mass_leaving = (amount as i128 * weight as i128 / TAG_WEIGHT_SCALE as i128)
+            .min(i64::MAX as i128) as i64;
         cluster_wealth.apply_delta(cluster, -mass_leaving);
     }
 
     // Mass arriving at receiver (after decay)
     for (cluster, weight) in transferred_tags.iter() {
-        let mass_arriving = net_amount as i64 * weight as i64 / TAG_WEIGHT_SCALE as i64;
+        let mass_arriving = (net_amount as i128 * weight as i128 / TAG_WEIGHT_SCALE as i128)
+            .min(i64::MAX as i128) as i64;
         cluster_wealth.apply_delta(cluster, mass_arriving);
     }
 

--- a/transaction/core/src/token.rs
+++ b/transaction/core/src/token.rs
@@ -19,7 +19,7 @@ pub trait Token {
 /// external.proto
 pub mod tokens {
     use super::*;
-    use crate::constants::MICROBTH_TO_NANOBTH;
+    use crate::constants::MICROBTH_TO_PICOCREDITS;
 
     /// The BTH token.
     pub struct Bth;
@@ -27,15 +27,16 @@ pub mod tokens {
         /// Token Id.
         const ID: TokenId = TokenId::BTH;
 
-        /// Minimum fee, denominated in nanoBTH.
-        const MINIMUM_FEE: u64 = 400 * MICROBTH_TO_NANOBTH;
+        /// Minimum fee, denominated in picocredits (#694; formerly the same
+        /// 400 microBTH expressed in nanoBTH).
+        const MINIMUM_FEE: u64 = 400 * MICROBTH_TO_PICOCREDITS;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::constants::MICROBTH_TO_NANOBTH;
+    use crate::constants::MICROBTH_TO_PICOCREDITS;
 
     #[test]
     fn test_bth_token_id() {
@@ -44,9 +45,13 @@ mod tests {
 
     #[test]
     fn test_bth_minimum_fee() {
-        // Minimum fee should be 400 microBTH in nanoBTH
-        let expected_fee = 400 * MICROBTH_TO_NANOBTH;
+        // Minimum fee should be 400 microBTH in picocredits.
+        let expected_fee = 400 * MICROBTH_TO_PICOCREDITS;
         assert_eq!(tokens::Bth::MINIMUM_FEE, expected_fee);
+        // Pin the BTH-denominated value across the #694 re-denomination:
+        // 400 microBTH = 0.0004 BTH = 400,000,000 picocredits (raw value
+        // scaled x1000 from the former 400,000 nanoBTH; identical in BTH).
+        assert_eq!(tokens::Bth::MINIMUM_FEE, 400_000_000);
     }
 
     #[test]

--- a/transaction/core/src/validation/cluster_fee.rs
+++ b/transaction/core/src/validation/cluster_fee.rs
@@ -221,7 +221,7 @@ pub fn validate_cluster_fee(
 /// * `num_memos` - Number of outputs with encrypted memos
 /// * `fee_config` - The fee configuration
 /// * `cluster_wealth` - Lookup for total wealth of each cluster
-/// * `dynamic_base` - Current dynamic fee base (nanoBTH per byte)
+/// * `dynamic_base` - Current dynamic fee base (picocredits per byte)
 pub fn validate_cluster_fee_dynamic(
     declared_fee: u64,
     tx_size_bytes: usize,
@@ -516,7 +516,7 @@ pub fn validate_ring_cluster_fee(
 /// * `num_memos` - Number of outputs with encrypted memos
 /// * `fee_config` - The fee configuration
 /// * `cluster_wealth` - Lookup for total wealth of each cluster
-/// * `dynamic_base` - Current dynamic fee base (nanoBTH per byte)
+/// * `dynamic_base` - Current dynamic fee base (picocredits per byte)
 pub fn validate_ring_cluster_fee_dynamic(
     declared_fee: u64,
     tx_size_bytes: usize,

--- a/transaction/core/src/validation/error.rs
+++ b/transaction/core/src/validation/error.rs
@@ -176,7 +176,7 @@ pub enum TransactionValidationError {
     /// cluster_wealth {cluster_wealth}
     #[cfg(feature = "cluster-tax")]
     InsufficientClusterFee {
-        /// Required minimum fee in nanoBTH
+        /// Required minimum fee in picocredits
         required: u64,
         /// Actual fee declared in transaction
         actual: u64,

--- a/transaction/types/src/constants.rs
+++ b/transaction/types/src/constants.rs
@@ -205,36 +205,36 @@ pub const MAX_TOMBSTONE_BLOCKS: u64 = 20160;
 pub const PHASE1_BTH_DISTRIBUTION: u64 = 100_000_000;
 
 // =============================================================================
-// BTH Unit System
+// BTH Unit System (single unit: picocredits, decision #649)
 // =============================================================================
 //
 // BTH uses a 12-decimal precision system for maximum accounting accuracy.
-// The smallest unit is the "picocredit" (10^-12 BTH).
+// The one and only base unit is the "picocredit" (10^-12 BTH). Every amount
+// below the UI edge — transaction amounts, fees, fee curves, cluster wealth,
+// emission/monetary policy — is denominated in picocredits. Formatting into
+// BTH happens only in display components.
+//
+// (The former two-tier system, with a separate nanoBTH fee/display tier, was
+// retired by #694 per the #649 decision: it was the root of a recurring
+// unit-confusion bug class — see #626/#628.)
 //
 // Unit Hierarchy (all relative to picocredits):
-//   1 picocredit    = 1                    (smallest, internal base unit)
-//   1 nanoBTH       = 1,000 picocredits    (10^-9 BTH, fee display unit)
+//   1 picocredit    = 1                     (the base unit)
 //   1 microBTH      = 1,000,000 picocredits (10^-6 BTH)
 //   1 milliBTH      = 1,000,000,000 picocredits (10^-3 BTH)
 //   1 BTH           = 1,000,000,000,000 picocredits (10^12)
 //
-// Two-Tier Usage:
-//   - Picocredits (10^12): Internal transaction amounts, bridge contracts
-//   - NanoBTH (10^9): Fee calculations, user-facing display, cluster-tax
-//
-// The conversion factor is: 1 nanoBTH = 1,000 picocredits
-//
 // Overflow Safety:
-//   - 100M BTH at year 10 = 10^20 picocredits
-//   - Using u64 for picocredits: u64::MAX / 10^20 ≈ 184x max growth
-//   - At 2% annual inflation: (1.02)^263 ≈ 184x is the limit
-//   - Safe for ~260 years after Phase 1 (~270 years from genesis)
+//   - Individual transaction amounts stay in u64: u64::MAX ≈ 1.84 × 10^19
+//     picocredits ≈ 18.4M BTH per amount.
+//   - Aggregate supply exceeds u64 (100M BTH = 10^20 picocredits), so supply
+//     accounting is u128 throughout the node (issues #333/#626).
 
 // -----------------------------------------------------------------------------
-// Picocredit-based constants (internal precision, 12 decimals)
+// Picocredit constants (12-decimal precision)
 // -----------------------------------------------------------------------------
 
-/// One BTH = 10^12 picocredits (internal base unit)
+/// One BTH = 10^12 picocredits (the base unit)
 pub const BTH_TO_PICOCREDITS: u64 = 1_000_000_000_000;
 
 /// One milliBTH = 10^9 picocredits
@@ -242,22 +242,6 @@ pub const MILLIBTH_TO_PICOCREDITS: u64 = 1_000_000_000;
 
 /// One microBTH = 10^6 picocredits
 pub const MICROBTH_TO_PICOCREDITS: u64 = 1_000_000;
-
-/// One nanoBTH = 10^3 picocredits (conversion between fee and amount systems)
-pub const NANOBTH_TO_PICOCREDITS: u64 = 1_000;
-
-// -----------------------------------------------------------------------------
-// NanoBTH-based constants (fee/display precision, 9 decimals)
-// -----------------------------------------------------------------------------
-
-/// One microBTH = 10^3 nanoBTH
-pub const MICROBTH_TO_NANOBTH: u64 = 1_000;
-
-/// One milliBTH = 10^6 nanoBTH
-pub const MILLIBTH_TO_NANOBTH: u64 = 1_000_000;
-
-/// One BTH = 10^9 nanoBTH
-pub const BTH_TO_NANOBTH: u64 = 1_000_000_000;
 
 /// Blinding for the implicit fee outputs.
 pub const FEE_BLINDING: Scalar = Scalar::ZERO;
@@ -417,102 +401,27 @@ mod tests {
     }
 
     #[test]
-    fn test_microbth_to_nanobth() {
-        // 1 microBTH = 1e3 nanoBTH
-        assert_eq!(MICROBTH_TO_NANOBTH, 1_000);
-    }
-
-    #[test]
-    fn test_millibth_to_nanobth() {
-        // 1 milliBTH = 1e6 nanoBTH
-        assert_eq!(MILLIBTH_TO_NANOBTH, 1_000_000);
-        // milliBTH should be 1000x microBTH
-        assert_eq!(MILLIBTH_TO_NANOBTH, MICROBTH_TO_NANOBTH * 1000);
-    }
-
-    #[test]
-    fn test_bth_to_nanobth() {
-        // 1 BTH = 1e9 nanoBTH
-        assert_eq!(BTH_TO_NANOBTH, 1_000_000_000);
-        // BTH should be 1000x milliBTH
-        assert_eq!(BTH_TO_NANOBTH, MILLIBTH_TO_NANOBTH * 1000);
-    }
-
-    #[test]
     fn test_fee_blinding() {
         // Fee blinding should be zero (fees are public)
         assert_eq!(FEE_BLINDING, Scalar::ZERO);
     }
 
     #[test]
-    fn test_unit_conversions_consistency() {
-        // Verify unit conversion relationships
-        // 1 BTH = 1e9 nanoBTH
-        assert_eq!(BTH_TO_NANOBTH, 1_000_000_000u64);
-
-        // Phase 1 distribution in nanoBTH should NOT overflow u64
-        let phase1_nanobth = PHASE1_BTH_DISTRIBUTION.checked_mul(BTH_TO_NANOBTH);
-        assert!(
-            phase1_nanobth.is_some(),
-            "Phase 1 distribution in nanoBTH fits in u64"
-        );
-        assert_eq!(phase1_nanobth.unwrap(), 100_000_000_000_000_000u64); // 10^17
-
-        // With 2% annual inflation over 100 years from year 10 (~7.24x), still fits
-        // (1.02)^100 ≈ 7.244
-        let max_inflated_supply = (phase1_nanobth.unwrap() as f64 * 7.244) as u64;
-        assert!(
-            max_inflated_supply < u64::MAX,
-            "100-year inflated supply fits in u64"
-        );
-    }
-
-    #[test]
     fn test_inflation_headroom() {
-        // Verify we have headroom for 2% annual inflation over 250+ years
-        // Starting from 100M BTH at end of Phase 1
-        let phase1_supply_nanobth = PHASE1_BTH_DISTRIBUTION as u128 * BTH_TO_NANOBTH as u128;
+        // Verify u128 supply accounting has headroom for 2% annual inflation
+        // over 250+ years, starting from 100M BTH at end of Phase 1.
+        // (Supply-scale quantities are u128 in the node — #333/#626 — because
+        // 100M BTH = 10^20 picocredits already exceeds u64::MAX.)
+        let phase1_supply_pico = PHASE1_BTH_DISTRIBUTION as u128 * BTH_TO_PICOCREDITS as u128;
 
-        // (1.02)^100 ≈ 7.244
-        let inflation_factor_100y = 7244u128; // scaled by 1000
-        let supply_100y = phase1_supply_nanobth * inflation_factor_100y / 1000;
+        // (1.02)^250 ≈ 144.2 (scaled by 1000)
+        let supply_250y = phase1_supply_pico * 144_210 / 1_000;
 
-        // (1.02)^200 ≈ 52.5
-        let inflation_factor_200y = 52485u128; // scaled by 1000
-        let supply_200y = phase1_supply_nanobth * inflation_factor_200y / 1000;
-
-        // (1.02)^250 ≈ 144.2
-        let inflation_factor_250y = 144210u128; // scaled by 1000
-        let supply_250y = phase1_supply_nanobth * inflation_factor_250y / 1000;
-
+        // ~1.44e22 picocredits — u128 (max ~3.4e38) has ~16 orders of
+        // magnitude of headroom beyond that.
         assert!(
-            supply_100y < u64::MAX as u128,
-            "100-year supply fits in u64"
-        );
-        assert!(
-            supply_200y < u64::MAX as u128,
-            "200-year supply fits in u64"
-        );
-        assert!(
-            supply_250y < u64::MAX as u128,
-            "250-year supply fits in u64"
-        );
-
-        // Calculate the theoretical maximum years before overflow
-        // max_multiplier = u64::MAX / phase1_supply_nanobth
-        //                = 1.84e19 / 1e17 = 184
-        // (1.02)^x = 184 → x = ln(184) / ln(1.02) ≈ 263 years
-        //
-        // So we're safe for ~260 years after Phase 1 (year 10)
-        // That means safe until approximately year 270 from genesis
-        let max_safe_multiplier = u64::MAX as u128 / phase1_supply_nanobth;
-        assert!(
-            max_safe_multiplier > 100,
-            "At least 100x growth capacity (>230 years)"
-        );
-        assert!(
-            max_safe_multiplier > 180,
-            "At least 180x growth capacity (>260 years)"
+            supply_250y < u128::MAX / 1_000_000_000_000,
+            "250-year supply must fit u128 with ample headroom"
         );
     }
 
@@ -605,47 +514,25 @@ mod tests {
     }
 
     #[test]
-    fn test_nanobth_to_picocredits() {
-        // 1 nanoBTH = 10^3 picocredits
-        assert_eq!(NANOBTH_TO_PICOCREDITS, 1_000);
-        // nanoBTH should be 1/1000 of microBTH
-        assert_eq!(NANOBTH_TO_PICOCREDITS * 1000, MICROBTH_TO_PICOCREDITS);
-    }
-
-    #[test]
-    fn test_picocredit_nanobth_consistency() {
-        // Verify: 1 BTH = 10^9 nanoBTH = 10^12 picocredits
-        // Therefore: 1 nanoBTH = 1000 picocredits
-        assert_eq!(
-            BTH_TO_PICOCREDITS,
-            BTH_TO_NANOBTH * NANOBTH_TO_PICOCREDITS,
-            "BTH conversion should be consistent between picocredits and nanoBTH"
-        );
-    }
-
-    #[test]
     fn test_picocredit_supply_limits() {
         // Phase 1 distributes 100M BTH.
-        // In picocredits: 100M * 10^12 = 10^20, which overflows u64 (max ~1.84 * 10^19)
-        // In nanoBTH: 100M * 10^9 = 10^17, which fits in u64
+        // In picocredits: 100M * 10^12 = 10^20, which overflows u64
+        // (max ~1.84 * 10^19).
         //
-        // This is why supply tracking uses nanoBTH, not picocredits.
-        // Picocredits are used for individual transaction amounts (much smaller).
+        // This is why aggregate supply tracking is u128 in the node
+        // (#333/#626), while individual transaction amounts (much smaller)
+        // stay in u64 picocredits.
 
-        // Verify Phase 1 fits in nanoBTH
-        let phase1_nanobth = PHASE1_BTH_DISTRIBUTION.checked_mul(BTH_TO_NANOBTH);
-        assert!(
-            phase1_nanobth.is_some(),
-            "Phase 1 distribution fits in u64 nanoBTH"
-        );
-        assert_eq!(phase1_nanobth.unwrap(), 100_000_000_000_000_000u64); // 10^17
-
-        // Verify Phase 1 overflows in picocredits (expected behavior)
+        // Verify Phase 1 overflows u64 in picocredits (expected behavior)
         let phase1_picocredits = PHASE1_BTH_DISTRIBUTION.checked_mul(BTH_TO_PICOCREDITS);
         assert!(
             phase1_picocredits.is_none(),
             "Phase 1 in picocredits overflows u64 (expected)"
         );
+
+        // And fits comfortably in u128.
+        let phase1_pico_u128 = PHASE1_BTH_DISTRIBUTION as u128 * BTH_TO_PICOCREDITS as u128;
+        assert_eq!(phase1_pico_u128, 100_000_000_000_000_000_000u128); // 10^20
     }
 
     #[test]

--- a/web/packages/web-wallet/src/pages/docs.tsx
+++ b/web/packages/web-wallet/src/pages/docs.tsx
@@ -1150,19 +1150,19 @@ Botho (BTH) uses a two-phase emission model designed for long-term sustainabilit
 | Parameter | Value |
 |-----------|-------|
 | Token symbol | BTH |
-| Smallest unit | nanoBTH (10⁻⁹ BTH) |
+| Smallest unit | picocredit (10⁻¹² BTH) |
 | Pre-mine | None (100% mined) |
 | Phase 1 supply | ~100 million BTH |
 | Target block time | 20 seconds |
 
 ### Unit System
 
-BTH uses 9-decimal precision:
+BTH uses 12-decimal precision. The picocredit is the single base unit — every amount on the wire (balances, fees, cluster wealth) is denominated in picocredits, and formatting into BTH happens only in the display layer:
 
-- **1 nanoBTH** = 0.000000001 BTH (smallest unit)
-- **1 microBTH (µBTH)** = 1,000 nanoBTH = 0.000001 BTH
-- **1 milliBTH (mBTH)** = 1,000,000 nanoBTH = 0.001 BTH
-- **1 BTH** = 1,000,000,000 nanoBTH
+- **1 picocredit** = 0.000000000001 BTH (smallest unit)
+- **1 microBTH (µBTH)** = 1,000,000 picocredits = 0.000001 BTH
+- **1 milliBTH (mBTH)** = 1,000,000,000 picocredits = 0.001 BTH
+- **1 BTH** = 1,000,000,000,000 picocredits
 
 ---
 


### PR DESCRIPTION
## Summary

Implements the #649 decision: the two-tier unit system (picocredits + nanoBTH) is retired. **Picocredits (10^-12 BTH) are the only unit below the UI edge**; formatting into BTH happens only in display components. Fixes #694.

## The invariant

> Every migrated constant/value is **identical in BTH terms** before and after. Raw values scale ×1000 where they were genuinely nanoBTH-denominated; values that were already picocredits (but mislabeled "nanoBTH" in docs) are relabeled and NOT scaled. Behavior does not change.

A key finding drove the shape of this PR: **the consensus layer was already fully picocredit-native** since the #626 4.0.0 reset — `FeeConfig`/fee curve (`fee_curve.rs`), the consensus fee floor (`CONSENSUS_FEE_BASE = 1` picocredit/byte), on-chain amounts, cluster-wealth DB (u128 pico), and `mainnet_policy()`/`testnet_policy()` (`initial_reward: 50_000_000_000_000`). The nanoBTH remnants were (a) genuinely nanoBTH-denominated **simulation/library** values, and (b) **mislabeled doc comments** on picocredit values. Scaling category (b) would have changed fee-floor verdicts ×1000 — so those are relabels only.

## Surface inventory

### Re-denominated ×1000 (BTH value unchanged)

| Constant | Old raw (nanoBTH) | New raw (picocredits) | BTH value (unchanged) | Consumers |
|---|---|---|---|---|
| `cluster-tax` `MonetaryPolicy::default().initial_reward` | 50_000_000_000 | 50_000_000_000_000 | 50 BTH | simulation/library only (node uses `mainnet_policy()`, already pico) |
| `cluster-tax` `MonetaryPolicy::bitcoin_like().initial_reward` | 50_000_000_000 | 50_000_000_000_000 | 50 BTH | simulation only |
| `emission_sweep` `r0` (candidate grid) | 50 × 10^9 | 50 × 10^12 | 50 BTH | #350 sweep tooling |
| `tokens::Bth::MINIMUM_FEE` | 400_000 (`400 * MICROBTH_TO_NANOBTH`) | 400_000_000 (`400 * MICROBTH_TO_PICOCREDITS`) | 400 microBTH = 0.0004 BTH | `FeeMap` only (library-internal, MobileCoin heritage; not in the node's live fee path — that is `MIN_TX_FEE = 100_000_000` pico, untouched) |

### Renamed / re-derived (simulation analytics)

- `emission_sweep::phase1_supply_nanobth()` → `phase1_supply_picocredits()` (u128; exact ×1000).
- `emission_sweep::cumulative_supply_at` / `steady_state_inflation_pct`: the old code clamped supply via `.min(u64::MAX)` before `calculate_tail_reward(u64)`. At pico scale **every** candidate schedule exceeds u64::MAX, so the clamp would have silently corrupted the tail-reward analytics. Fixed by adding `MonetaryPolicy::calculate_tail_reward_u128(u128)` (identical integer formula, wider input) and using it. The sweep's BTH-term goldens (`s1_supply_is_about_1_22b`, `s3_supply_is_about_100m`) pass **unchanged**.
- `botho::block::calculate_tail_reward_u128` (the node's consensus tail-reward path) now delegates to the new canonical `MonetaryPolicy::calculate_tail_reward_u128` instead of duplicating the formula. Existing node tests (`tail_reward_u128_matches_*`, `test_block_reward_correct_past_u64_max`, `test_block_reward_no_overflow_at_max_height_and_supply`) pin equality.

### u128 widening required by the ×1000 scale (simulation-only code)

Three latent `u64`/`i64` multiply-overflow sites in cluster-tax **simulation** paths were triggered by pico-scale values (caught by `overflow-checks`; results unchanged for all previously non-overflowing inputs):

- `tag.rs` `TagVector::mix` — `value * weight` widened to u128
- `transfer.rs` `execute_transfer` — `value * weight` mass deltas widened to i128
- `simulation/runner.rs` — wash-trade `rate × amount` widened to i128

None of these types are in the consensus path (consensus uses `ClusterTagVector` in `transaction/core`, which was already u128-safe).

### Relabel-only (values already picocredits; scaling would have been a behavior-changing bug)

- `cluster-tax/src/dynamic_fee.rs` — `base_min`/`base_max`/`current_base` docs (feeds the pico-native curve; `base_min = 1` also pins `CONSENSUS_FEE_BASE`)
- `botho/src/mempool.rs` — fee-estimate doc comments
- `botho/src/rpc/mod.rs` — `baseRate` (fee_getRate) and `cluster_getWealth` doc comments; **numeric wire values unchanged** (already pico)
- `botho-wallet` — `fee_estimation.rs` (`CachedFeeRate`, `MINIMUM_BASE_RATE` docs), `rpc_pool.rs` (`NetworkFeeRate.base_rate` doc), `commands/send.rs` comment
- `transaction/core` — `validation/error.rs` (`InsufficientClusterFee.required` doc), `validation/cluster_fee.rs` (`dynamic_base` param docs)
- `cluster-tax/src/simulation/state.rs` — test comment

### Deleted

- `transaction/types/src/constants.rs`: the "Two-Tier Usage" contract and all nanoBTH constants (`MICROBTH_TO_NANOBTH`, `MILLIBTH_TO_NANOBTH`, `BTH_TO_NANOBTH`, `NANOBTH_TO_PICOCREDITS`) — no remaining consumers after the `token.rs` migration. Replaced with the single-unit doc. (Recoverable from git history.)

### Display / docs

- `botho/src/commands/balance.rs`: CLI prints formatted BTH + raw picocredits; the nanoBTH display line is removed.
- `web/packages/web-wallet/src/pages/docs.tsx`: the stale "smallest unit = nanoBTH (10⁻⁹)" table entry and 9-decimal unit hierarchy corrected to picocredits / 12 decimals (pre-existing error the issue names).

## Protocol version: 4.0.0 → **4.1.0 (MINOR)**

- **Why a bump at all**: the RPC contract's declared units change (`baseRate`, cluster-wealth fields are now officially picocredit-denominated), and wallet/adapters must deploy in lockstep with the node's contract.
- **Why MINOR, not major**: no consensus rule changes. The fee curve, consensus fee floor, emission constants, and all on-chain amounts were already picocredit-native since 4.0.0 (#626); every migrated value is identical in BTH terms, so 4.0.0 peers accept exactly the same blocks. Per the #608 lesson: major = consensus-breaking disconnect, minor = warn. `MIN_SUPPORTED_PROTOCOL_VERSION` stays 4.0.0, and a new regression test (`test_v4_peers_remain_consensus_compatible_with_current`) pins that 4.0.0 peers are NOT disconnected.
- **No testnet reset needed**: no consensus-adjacent constant changes value (the issue's reset trigger does not fire).

## Web coordination

- Web adapters (`web/packages/adapters`) and core formatters were already picocredit-native (types documented as picocredits, `formatBTH` uses 10^12); grep confirms no web consumer of `baseRate` exists today, so the docs.tsx fix is the only web change. Node + wallet remain deploy-lockstep-safe because no wire value changed.

## Invariant evidence (pinning tests)

- `bth-cluster-tax`: `test_initial_reward_is_50_bth_in_picocredits` (new), `test_tail_reward_u128_matches_u64_variant` (new), `test_bth_phase1_total_emission` (~100M BTH, unchanged in BTH terms), `test_bth_phase2_tail_reward` (~4.76 BTH/block, unchanged), `s1_supply_is_about_1_22b` / `s3_supply_is_about_100m` (sweep BTH goldens, unchanged)
- `bth-transaction-core`: `test_bth_minimum_fee` pins `MINIMUM_FEE == 400_000_000` pico == 400 microBTH
- `botho`: `test_mainnet_policy` / `test_mainnet_emission_schedule_locked` (50 BTH reward, 611,010,000 BTH Phase-1 supply — pre-existing, pass unchanged, proving the consensus schedule is untouched)
- **#626/#627 curve calibration goldens** (`test_golden_vector_factor_table`, `test_testnet_baseline_factors`, `test_unit_consistency_guard` in `fee_curve.rs`): already picocredit-based — **untouched and passing unchanged**
- `botho --test e2e_progressive_fees`: **file untouched**, suite passes unchanged (pins live curve behavior)

## Test results

- `cargo build --workspace` ✅
- `cargo test --workspace --lib` ✅
- `cargo test -p bth-cluster-tax` ✅
- `cargo test -p botho --test rpc_integration` ✅
- `cargo test -p botho --test e2e_progressive_fees` ✅ (unchanged)
- web: `pnpm -r typecheck` ✅, `pnpm test:run` ✅ (619 passed)
- nightly rustfmt applied

## Deliberately out of scope

- `botho/tests/e2e_progressive_fees.rs` retains internal nanoBTH-named helpers (it multiplies the already-pico curve output by another ×1000 before paying — harmless overpayment). Left untouched because the issue requires this suite to pass unchanged; cleanup can ride #639-era sweeps.
- Prose docs sweep (#639) — unblocked by this PR, not performed here.
- Historical references to nanoBTH in doc comments explaining the migration itself are intentional.

Fixes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)
