### PR TITLE
docs: sweep stale nanoBTH references to picocredits (Closes #639)

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -678,6 +678,7 @@ External audit will be commissioned when:
 | Error message leakage | MEDIUM | Generic error messages |
 | Password strength validation | MEDIUM | 8-char minimum enforced |
 | Timing attack in word verification | LOW | Constant-time comparison |
+| Unit naming confusion | MEDIUM | Unified all amounts to a single base unit (picocredits); the former dual-unit tier was removed end-to-end in #694/#712 |
 
 ### Remaining Issues
 
@@ -687,7 +688,6 @@ External audit will be commissioned when:
 | Sync response bandwidth | MEDIUM | `sync.rs` | 600 MB/min theoretical |
 | Cluster wealth tracking disabled | MEDIUM | `mempool.rs:408` | Hardcoded to 0 |
 | Block timing inconsistency | MEDIUM | Multiple | 60s vs 5-40s dynamic |
-| Unit naming confusion | MEDIUM | 62 files | picocredits vs nanoBTH |
 | Unsound glib v0.18.5 | MEDIUM | Tauri/GTK3 | Upstream issue |
 | Deprecated derive_pq_keys() | LOW | `derive.rs:114` | Kept for tests |
 | Version warnings not enforced | LOW | `discovery.rs` | Warns but doesn't disconnect |

--- a/PLAN.md
+++ b/PLAN.md
@@ -92,7 +92,7 @@ Performance benchmarks ─────────→ v0.2.0 Release
    - [ ] Update `clap` to fix unsound `anstream`
 
 9. **Documentation & Standards**
-   - [ ] Standardize unit naming (nanoBTH vs picocredits)
+   - [x] Standardize unit naming — unified all amounts to a single base unit (picocredits) end-to-end in #694/#712
    - [ ] Clarify block timing (60s vs 5-40s dynamic)
    - [ ] Document LION rejection sampling margin justification
 

--- a/cluster-tax/README.md
+++ b/cluster-tax/README.md
@@ -81,7 +81,7 @@ fee = fee_per_byte × tx_size × cluster_factor(sender_wealth)
 
 | Component | Description |
 |-----------|-------------|
-| `fee_per_byte` | Base rate (default: 1 nanoBTH/byte) |
+| `fee_per_byte` | Base rate (default: 1 picocredit/byte) |
 | `tx_size` | Transaction size in bytes |
 | `cluster_factor` | 1x-6x based on sender's cluster wealth |
 
@@ -115,11 +115,11 @@ let config = FeeConfig::default();
 
 // Small holder: pays base fee
 let fee = config.compute_fee(TransactionType::Hidden, 2000, 1_000, 0);
-// ≈ 2000 nanoBTH
+// ≈ 2000 picocredits
 
 // Large holder: pays 6x premium
 let fee = config.compute_fee(TransactionType::Hidden, 2000, 100_000_000, 0);
-// ≈ 12000 nanoBTH
+// ≈ 12000 picocredits
 ```
 
 ## Fee Distribution: Lottery + Burn
@@ -255,8 +255,8 @@ For detailed analysis and rationale:
 use bth_cluster_tax::{FeeConfig, ClusterFactorCurve};
 
 let config = FeeConfig {
-    fee_per_byte: 1,              // 1 nanoBTH per byte
-    fee_per_memo: 100,            // 100 nanoBTH per memo
+    fee_per_byte: 1,              // 1 picocredit per byte
+    fee_per_memo: 100,            // 100 picocredits per memo
     cluster_curve: ClusterFactorCurve {
         factor_min: 100,          // 1.00x minimum
         factor_max: 600,          // 6.00x maximum

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,7 +100,7 @@ Botho combines:
 - **Progressive Fees**: Cluster-based taxation that discourages wealth concentration
 - **Network Privacy**: Onion Gossip for transaction origin hiding (planned)
 
-The native currency unit is **BTH** (1 BTH = 1,000,000,000 nanoBTH).
+The native currency unit is **BTH** (1 BTH = 1,000,000,000,000 picocredits).
 
 ## Quick Start
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -242,9 +242,9 @@ Get blockchain information including supply metrics.
 | `height` | integer | Current block height |
 | `tipHash` | string | Hash of the latest block (hex) |
 | `difficulty` | integer | Current mining difficulty |
-| `totalMined` | integer | Gross emission (all BTH ever minted), in nanoBTH |
-| `totalFeesBurned` | integer | Cumulative transaction fees burned, in nanoBTH |
-| `circulatingSupply` | integer | Net supply (totalMined - totalFeesBurned), in nanoBTH |
+| `totalMined` | integer | Gross emission (all BTH ever minted), in picocredits |
+| `totalFeesBurned` | integer | Cumulative transaction fees burned, in picocredits |
+| `circulatingSupply` | integer | Net supply (totalMined - totalFeesBurned), in picocredits |
 | `mempoolSize` | integer | Pending transaction count |
 | `mempoolFees` | integer | Total fees in mempool |
 
@@ -267,11 +267,11 @@ Get circulating supply information. Useful for exchanges and block explorers to 
 | Field | Type | Description |
 |-------|------|-------------|
 | `height` | integer | Current block height |
-| `totalMined` | integer | Gross emission (all BTH ever minted), in nanoBTH |
-| `totalFeesBurned` | integer | Cumulative transaction fees burned, in nanoBTH |
-| `circulatingSupply` | integer | Net supply (totalMined - totalFeesBurned), in nanoBTH |
+| `totalMined` | integer | Gross emission (all BTH ever minted), in picocredits |
+| `totalFeesBurned` | integer | Cumulative transaction fees burned, in picocredits |
+| `circulatingSupply` | integer | Net supply (totalMined - totalFeesBurned), in picocredits |
 
-**Note:** All values are in nanoBTH (1 BTH = 1,000,000,000 nanoBTH). Collected transaction fees are split 80% into the cluster-tilted redistribution lottery and 20% burned; only the burned 20% (`totalFeesBurned`) is removed from circulation, which is why circulating supply = totalMined - totalFeesBurned.
+**Note:** All values are in picocredits (1 BTH = 1,000,000,000,000 picocredits). Collected transaction fees are split 80% into the cluster-tilted redistribution lottery and 20% burned; only the burned 20% (`totalFeesBurned`) is removed from circulation, which is why circulating supply = totalMined - totalFeesBurned.
 
 **Example:**
 ```bash
@@ -421,7 +421,7 @@ Estimate the transaction fee.
 **Parameters:**
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `amount` | integer | No | 0 | Transaction amount in nanoBTH |
+| `amount` | integer | No | 0 | Transaction amount in picocredits |
 | `private` | boolean | No | true | Whether transaction uses privacy features |
 | `memos` | integer | No | 0 | Number of encrypted memos |
 
@@ -667,7 +667,7 @@ Estimate the additional fee for including an entropy proof in a transaction.
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `cluster_count` | integer | No | 3 | Number of clusters involved (affects proof size) |
-| `amount` | integer | No | 0 | Transaction amount in nanoBTH |
+| `amount` | integer | No | 0 | Transaction amount in picocredits |
 | `cluster_wealth` | integer | No | 0 | Sender's cluster wealth for progressive fee |
 
 **Response:**

--- a/docs/concepts/monetary-policy.md
+++ b/docs/concepts/monetary-policy.md
@@ -508,7 +508,7 @@ pub struct MonetaryEpoch {
 
     // ─── Fee Parameters ───────────────────────────────────────────
 
-    /// Minimum transaction fee in nanoBTH
+    /// Minimum transaction fee in picocredits
     pub min_fee: u64,
 
     /// Cluster fee curve: min rate in basis points (5 = 0.05%)
@@ -517,7 +517,7 @@ pub struct MonetaryEpoch {
     /// Cluster fee curve: max rate in basis points (3000 = 30%)
     pub cluster_fee_max_bps: u16,
 
-    /// Cluster wealth midpoint (sigmoid inflection) in nanoBTH
+    /// Cluster wealth midpoint (sigmoid inflection) in picocredits
     pub cluster_midpoint: u64,
 
     /// Tag decay per transaction hop in basis points (500 = 5%)
@@ -544,7 +544,7 @@ pub struct MonetaryEpoch {
     /// Blocks to transition from previous epoch's expectations
     pub transition_blocks: u64,
 
-    /// Expected burn rate per block in nanoBTH (for transition calibration)
+    /// Expected burn rate per block in picocredits (for transition calibration)
     pub expected_burn_rate: u64,
 }
 ```
@@ -568,10 +568,10 @@ MonetaryEpoch {
     activation_height: 0,
 
     // Fees
-    min_fee: 400_000,                              // 400 µBTH
+    min_fee: 400_000_000,                          // 400 µBTH
     cluster_fee_min_bps: 5,                        // 0.05%
     cluster_fee_max_bps: 3000,                     // 30%
-    cluster_midpoint: 10_000_000_000_000_000_000,  // 10M BTH in nanoBTH
+    cluster_midpoint: 10_000_000_000_000_000_000,  // 10M BTH in picocredits
     cluster_decay_bps: 500,                        // 5% per hop
 
     // Emission
@@ -595,7 +595,7 @@ MonetaryEpoch {
     activation_height: 31_536_000,                 // ~5 years (5 × 6,307,200)
 
     // Fees (halved 5 times from genesis)
-    min_fee: 12_500,                               // 12.5 µBTH
+    min_fee: 12_500_000,                           // 12.5 µBTH
     cluster_fee_min_bps: 5,
     cluster_fee_max_bps: 3000,
     cluster_midpoint: 10_000_000_000_000_000_000,
@@ -622,9 +622,9 @@ When parameters change at a fork, the difficulty adjustment needs to handle the 
 ### The Problem
 
 ```
-Before fork: burns averaging 1000 nanoBTH/block
+Before fork: burns averaging 1000 picocredits/block
 Fork activates: fee floor halves
-After fork: burns might be 500-2000 nanoBTH/block (unknown)
+After fork: burns might be 500-2000 picocredits/block (unknown)
 
 If we immediately use actual burns:
 - First epoch after fork sees huge deviation

--- a/docs/concepts/privacy.md
+++ b/docs/concepts/privacy.md
@@ -285,7 +285,7 @@ Botho uses size-based fees: `fee = fee_per_byte × tx_size × cluster_factor`
 | Transaction Type | Signature Size | Typical Total Size | Fee (1x cluster) |
 |-----------------|----------------|-------------------|------------------|
 | Minting | ~3.3 KB (ML-DSA) | ~1.5 KB | 0 |
-| Private | ~0.7 KB (CLSAG) | ~4 KB | ~4,000 nanoBTH |
+| Private | ~0.7 KB (CLSAG) | ~4 KB | ~4,000 picocredits |
 
 **Why these sizes?**
 
@@ -303,7 +303,7 @@ total_fee = fee_per_byte * tx_size * cluster_factor
 ```
 
 Where:
-- `fee_per_byte` = 1 nanoBTH per byte (default)
+- `fee_per_byte` = 1 picocredit per byte (default)
 - `tx_size` = transaction size in bytes
 - `cluster_factor` = progressive multiplier (1x to 6x) based on sender's cluster wealth
 

--- a/docs/concepts/tokenomics.md
+++ b/docs/concepts/tokenomics.md
@@ -7,8 +7,8 @@ Botho (BTH) uses a two-phase emission model designed for long-term sustainabilit
 | Parameter | Value |
 |-----------|-------|
 | Token symbol | BTH |
-| Internal precision | picocredits (10⁻¹² BTH) |
-| Display unit | nanoBTH (10⁻⁹ BTH) |
+| Base unit | picocredits (10⁻¹² BTH) |
+| Display unit | BTH (formatted from picocredits at the UI edge) |
 | Pre-mine | None (100% mined) |
 | Phase 1 supply | ~611 million BTH (~5 years of halvings) |
 | Block time | 5-40 seconds (dynamic based on load); 5s baseline for monetary calculations |
@@ -16,37 +16,21 @@ Botho (BTH) uses a two-phase emission model designed for long-term sustainabilit
 
 ## Unit System
 
-BTH uses a **two-tier precision system** for optimal balance between accuracy and usability:
-
-### Internal Precision (12 decimals)
-
-Transaction amounts use picocredits for maximum accounting precision:
+BTH uses a **single base unit** — the **picocredit** (10⁻¹² BTH). Every amount in
+the protocol (transaction values, fees, emission, and monetary policy) is
+denominated in picocredits. Amounts are formatted into BTH, or convenient
+multiples like milliBTH and microBTH, only at the user-interface edge.
 
 | Unit | Picocredits | BTH |
 |------|-------------|-----|
 | 1 picocredit | 1 | 0.000000000001 |
-| 1 nanoBTH | 1,000 | 0.000000001 |
 | 1 microBTH (µBTH) | 1,000,000 | 0.000001 |
 | 1 milliBTH (mBTH) | 1,000,000,000 | 0.001 |
 | 1 BTH | 1,000,000,000,000 | 1 |
 
-### Display Precision (9 decimals)
-
-User interfaces and fee calculations use nanoBTH for manageable numbers:
-
-| Unit | nanoBTH | BTH |
-|------|---------|-----|
-| 1 nanoBTH | 1 | 0.000000001 |
-| 1 microBTH (µBTH) | 1,000 | 0.000001 |
-| 1 milliBTH (mBTH) | 1,000,000 | 0.001 |
-| 1 BTH | 1,000,000,000 | 1 |
-
-### Why Two Tiers?
-
-- **Picocredits (10¹²)**: Used by bridge contracts, transaction amounts, and internal accounting. Provides sub-nanoBTH precision for exact calculations.
-- **NanoBTH (10⁹)**: Used for supply tracking, fee calculations, and user display. Fits in u64 for 100M+ BTH totals.
-
-**Conversion**: 1 nanoBTH = 1,000 picocredits
+Picocredits provide 12 decimals of precision. Aggregate supply exceeds u64 when
+expressed in picocredits (100M BTH = 10²⁰ picocredits), so supply totals are
+tracked in **u128**; individual transaction amounts fit comfortably in u64.
 
 ## Emission Schedule
 
@@ -115,10 +99,10 @@ fee = dynamic_base × tx_size × cluster_factor + memo_fees
 
 | Component | Range | Description |
 |-----------|-------|-------------|
-| `dynamic_base` | 1-100 nanoBTH/byte | Adjusts based on network congestion |
+| `dynamic_base` | 1-100 picocredits/byte | Adjusts based on network congestion |
 | `tx_size` | ~4-65 KB | Transaction size in bytes |
 | `cluster_factor` | 1x-6x | Progressive multiplier based on sender's cluster wealth |
-| `memo_fees` | 100 nanoBTH/memo | Additional fee for encrypted memos |
+| `memo_fees` | 100 picocredits/memo | Additional fee for encrypted memos |
 
 #### Fee Destination: Redistribution Lottery + Burn (80/20)
 
@@ -139,7 +123,7 @@ Fees are proportional to transaction size, ensuring larger transactions pay more
 
 | Type | Ring Size | Typical Size | Base Fee (1x cluster) |
 |------|-----------|--------------|----------------------|
-| Private (CLSAG) | 20 | ~4 KB | ~4,000 nanoBTH |
+| Private (CLSAG) | 20 | ~4 KB | ~4,000 picocredits |
 | Minting | — | ~1.5 KB | 0 (no fee) |
 
 ### Dynamic Congestion Pricing
@@ -318,10 +302,10 @@ This ensures:
 
 ### Overflow Safety
 
-- Phase 1 completion (~year 5): ~611M BTH = ~6.11 × 10¹⁷ nanoBTH
-- Maximum representable (u64): ~1.84 × 10¹⁹ nanoBTH
-- Growth capacity: ~30× tail-onset supply
-- At 2% annual inflation: **~170 years before overflow** (internal accounting uses picocredits in u128, so this u64 nanoBTH headroom is a display-tier bound, not a hard limit)
+- Phase 1 completion (~year 5): ~611M BTH = ~6.11 × 10²⁰ picocredits
+- Maximum representable (u128): ~3.4 × 10³⁸ picocredits
+- Growth capacity: ~18 orders of magnitude above tail-onset supply
+- At 2% annual inflation: **no practical overflow risk** — all monetary accounting uses picocredits in u128, which retains ~16 orders of magnitude of headroom above the entire projected supply
 
 ## Economic Design Philosophy
 

--- a/docs/concepts/transactions.md
+++ b/docs/concepts/transactions.md
@@ -318,7 +318,7 @@ fee = fee_per_byte × tx_size × cluster_factor
 | Type | Ring Size | Signature Size | Typical Total Size | Fee (1x cluster) | Fee (6x cluster) |
 |------|-----------|----------------|-------------------|------------------|------------------|
 | Minting | — | ~3.3 KB (ML-DSA) | ~1.5 KB | 0 | 0 |
-| Private | 20 | ~0.7 KB (CLSAG) | ~4 KB | ~4,000 nanoBTH | ~24,000 nanoBTH |
+| Private | 20 | ~0.7 KB (CLSAG) | ~4 KB | ~4,000 picocredits | ~24,000 picocredits |
 
 ### Transaction Limits
 

--- a/docs/exchange-integration.md
+++ b/docs/exchange-integration.md
@@ -327,31 +327,31 @@ Botho transactions are built and signed by the node's integrated wallet:
 def process_withdrawal(user_address, amount_bth):
     """
     Process a withdrawal request.
-    Amount is in BTH, converted to nanoBTH internally.
+    Amount is in BTH, converted to picocredits internally.
     """
-    amount_nanobth = int(amount_bth * 1e9)
+    amount_picocredits = int(amount_bth * 1e12)
 
     # 1. Estimate fee
     fee_response = rpc('estimateFee', {
-        'amount': amount_nanobth,
+        'amount': amount_picocredits,
         'private': True
     })
     fee = fee_response['recommendedFee']
 
     # 2. Check balance
     balance = rpc('wallet_getBalance')
-    if balance['confirmed'] < amount_nanobth + fee:
+    if balance['confirmed'] < amount_picocredits + fee:
         raise InsufficientFundsError()
 
     # 3. Build and submit transaction
     # Note: This requires the node to support tx building via RPC
     # Currently, use the CLI or Rust crates for transaction building
-    result = execute_withdrawal_cli(user_address, amount_nanobth)
+    result = execute_withdrawal_cli(user_address, amount_picocredits)
 
     return {
         'tx_hash': result['txHash'],
         'fee': fee,
-        'amount': amount_nanobth
+        'amount': amount_picocredits
     }
 
 def execute_withdrawal_cli(address, amount):

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -23,11 +23,9 @@ A collection of transactions bundled together and added to the blockchain. Each 
 The amount of BTH created when a new block is mined. Botho starts at 50 BTH per block, halving every ~1 year until reaching tail emission.
 
 ### BTH
-The native currency unit of Botho. BTH uses a two-tier precision system:
-- **For individual transactions**: 1 BTH = 1,000,000,000,000 picocredits (10^12, internal precision)
-- **For supply tracking/display**: 1 BTH = 1,000,000,000 nanoBTH (10^9, user-facing)
-
-The conversion factor is: 1 nanoBTH = 1,000 picocredits. See [Unit System](tokenomics.md#unit-system) for details.
+The native currency unit of Botho. All amounts are denominated in a single base
+unit, the **picocredit**: 1 BTH = 1,000,000,000,000 picocredits (10^12). BTH is a
+human-facing formatting of picocredit amounts at the UI edge. See [Unit System](tokenomics.md#unit-system) for details.
 
 ### Bulletproofs
 A type of zero-knowledge proof used for range proofs. Ensures transaction amounts are positive without revealing the actual values. Used in Private transactions to hide amounts.
@@ -171,9 +169,6 @@ A sequence of words (typically 24) that encodes your wallet's master seed. Used 
 
 ## N
 
-### nanoBTH
-A display-friendly unit of BTH used for fee calculations and user interfaces. 1 BTH = 1,000,000,000 nanoBTH (10^9). 1 nanoBTH = 1,000 picocredits. NanoBTH is preferred for user-facing amounts because the numbers are more manageable.
-
 ### Node
 A computer running Botho software that participates in the network. Nodes relay transactions, validate blocks, and optionally mine.
 
@@ -201,7 +196,7 @@ Another node connected to your node in the P2P network.
 A cryptographic commitment that hides a value while allowing mathematical operations. Used in confidential transactions.
 
 ### Picocredits
-The smallest internal unit of BTH, used for transaction amounts and accounting precision. 1 BTH = 1,000,000,000,000 picocredits (10^12). This provides higher precision than nanoBTH for individual transaction calculations. The bridge contracts and core transaction system use picocredits internally, while user interfaces typically display amounts in nanoBTH or BTH for readability.
+The single base unit of BTH, used for all amounts — transaction values, fees, emission, and monetary policy. 1 BTH = 1,000,000,000,000 picocredits (10^12). Every amount in the protocol is denominated in picocredits (stored as u128 for supply-scale totals); user interfaces format picocredit amounts into BTH for readability.
 
 ### Post-Quantum Cryptography
 Cryptographic algorithms believed to be secure against quantum computer attacks. Botho uses ML-KEM-768 for all stealth addresses (permanent recipient privacy) and ML-DSA-65 for minting transaction signatures. Ring signatures use classical CLSAG for efficiency—sender privacy is ephemeral and degrades over time.

--- a/docs/merchant-guide.md
+++ b/docs/merchant-guide.md
@@ -93,7 +93,7 @@ class PaymentRequest:
         # Store pending payment
         self.pending_payments[memo] = {
             'order_id': order_id,
-            'amount': int(amount_bth * 1e9),  # Convert to nanoBTH
+            'amount': int(amount_bth * 1e12),  # Convert to picocredits
             'created_at': time.time(),
             'expires_at': time.time() + 3600,  # 1 hour expiry
             'status': 'pending'
@@ -102,7 +102,7 @@ class PaymentRequest:
         return {
             'address': address,
             'amount_bth': amount_bth,
-            'amount_nanobth': int(amount_bth * 1e9),
+            'amount_picocredits': int(amount_bth * 1e12),
             'memo': memo,
             'expires_at': self.pending_payments[memo]['expires_at'],
             'payment_uri': self.build_payment_uri(address, amount_bth, memo)

--- a/docs/specification/protocol-v0.2.0.md
+++ b/docs/specification/protocol-v0.2.0.md
@@ -730,7 +730,6 @@ struct Block {
 | 1 BTH | 10^12 | BTH |
 | 1 milliBTH | 10^9 | mBTH |
 | 1 microBTH | 10^6 | uBTH |
-| 1 nanoBTH | 10^3 | nBTH |
 | 1 picocredit | 1 | pico |
 
 The **picocredit** is the atomic unit used in all protocol calculations.


### PR DESCRIPTION
Closes #639

## Summary

Now that the picocredit migration (#694 / PR #712) made **picocredits the single canonical unit end-to-end** (below the UI edge), the former two-tier nanoBTH/picocredit system no longer exists. That removes the earlier 1000x-error hazard the prior builder-notes flagged, so a prose-docs sweep of stale `nanoBTH` references is now safe. This PR restores #639’s original scope.

Prose/docs only — the code and code-doc-comments were already handled in #694/#712.

## What changed

For each prose reference, `nanoBTH` → `picocredits`, fixing stated conversions to **1 BTH = 10^12 picocredits** (not 10^9) and correcting embedded example code (BTH → picocredits is `* 1e12`).

**13 files changed, 40 references swept:**

- `docs/README.md` — currency-unit line: `1,000,000,000 nanoBTH` → `1,000,000,000,000 picocredits`.
- `docs/api.md` — `getChainInfo` / `getSupplyInfo` field units + the supply note (fixed conversion to 10^12); two `estimateFee` `amount` param rows.
- `docs/glossary.md` — rewrote the **BTH** and **Picocredits** entries for the single-unit model; removed the now-defunct **nanoBTH** entry.
- `docs/concepts/tokenomics.md` — replaced the two-tier "Unit System" section (internal/display/why-two-tiers tables) with a single-unit picocredit description; overview table; fee tables (`dynamic_base` 1-100, `memo_fees` 100, private-tx fee); rewrote the "Overflow Safety" section for u128 picocredits.
- `docs/concepts/monetary-policy.md` — `MonetaryEpoch` field doc-comments (`min_fee`, `cluster_midpoint`, `expected_burn_rate`); relabeled the `cluster_midpoint` comment (its value `1e19` was already picocredit-correct for 10M BTH); updated the two example `min_fee` values to picocredits to stay consistent with their µBTH anchors (`400_000` → `400_000_000`, `12_500` → `12_500_000`); burn-rate prose.
- `docs/concepts/privacy.md` — private-tx fee estimate; `fee_per_byte` default.
- `docs/concepts/transactions.md` — private-tx fee column (1x and 6x cluster).
- `docs/exchange-integration.md` — withdrawal example: `amount_nanobth` → `amount_picocredits`, `* 1e9` → `* 1e12`.
- `docs/merchant-guide.md` — payment example: `* 1e9` → `* 1e12`, `amount_nanobth` key → `amount_picocredits`.
- `docs/specification/protocol-v0.2.0.md` (active draft) — removed the `nanoBTH` row from the base-units table to match the canonical hierarchy (picocredit / microBTH / milliBTH / BTH in `transaction/types/src/constants.rs`).
- `cluster-tax/README.md` — `fee_per_byte` default, two computed fee comments, and the `FeeConfig` example comments.
- `AUDIT.md` — moved "Unit naming confusion" from **Remaining Issues** to **Issues Resolved** (unified to a single base unit in #694/#712).
- `PLAN.md` — checked off "Standardize unit naming".

## Intentionally left as historical / archive records

These are the only remaining `nanoBTH` hits, deliberately preserved (rewriting them would falsify a record of past state):

- `docs/design/archive/wealth-privacy-simulation.md` — `**ARCHIVED**`, withdrawn design; nanoBTH appears in that proposal’s example code.
- `docs/design/archive/wealth-conditional-privacy.md` — `**ARCHIVED**`, withdrawn design.
- `docs/specification/protocol-v0.1.0.md` — `**SUPERSEDED**` protocol spec (replaced by v0.2.0); base-units table left intact as a snapshot of that version.

The four `audits/2025-12-30-*` / `audits/2026-01-03-*` cycle reports are also historical records and were out of scope.

## Verification

`grep -rin nanobth docs/ *.md README.md` returns only the three historical/archive files listed above. No code or code-doc-comments were touched (already done in #712); the e2e test helper internals flagged in #712 were left as separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)