### PR TITLE
feat(node+web): P4.2 operator-only reads — node-verified magic-link token + per-peer gate RPCs (#707)

### DIFF
--- a/botho/src/commands/mod.rs
+++ b/botho/src/commands/mod.rs
@@ -6,6 +6,7 @@
 pub mod address;
 pub mod balance;
 pub mod init;
+pub mod operator;
 pub mod run;
 pub mod send;
 pub mod snapshot;

--- a/botho/src/commands/operator.rs
+++ b/botho/src/commands/operator.rs
@@ -1,0 +1,159 @@
+//! `botho operator …` — operator tooling (#707, P4.2 of the #695 proposal).
+//!
+//! Today this hosts a single subcommand, `mint-read-link`, which mints a
+//! node-verified magic-link READ token from the `[rpc.operator]
+//! read_token_secret` in the node's config file and prints the dashboard URL
+//! the operator opens:
+//!
+//!     https://<dashboard>/operator#token=op.<exp>.<hmac>
+//!
+//! The token is a bearer credential granting READS ONLY (per-peer gate
+//! classification, configured quorum contents, audit log) — it can never
+//! change node state. The key is never mailed; the operator carries the link.
+
+use std::{
+    path::Path,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{anyhow, Result};
+
+use crate::{
+    config::Config,
+    rpc::auth::{mint_operator_read_token, DEFAULT_OPERATOR_TOKEN_TTL_SECONDS},
+};
+
+/// Default dashboard base URL the minted link points at.
+pub const DEFAULT_DASHBOARD_URL: &str = "https://wallet.botho.io";
+
+/// Build the operator read-link URL from a config file, without printing it.
+///
+/// Split out from [`mint_read_link`] so it is unit-testable: it takes the clock
+/// as an argument and returns the URL string instead of writing to stdout.
+///
+/// Fails closed when `[rpc.operator] read_token_secret` is absent or empty —
+/// the same condition under which the node's operator RPCs are OFF, so a link
+/// minted here would be useless anyway.
+pub fn build_read_link(
+    config_path: &Path,
+    dashboard: &str,
+    ttl_seconds: u64,
+    now_unix_seconds: u64,
+) -> Result<String> {
+    let config = Config::load(config_path)?;
+
+    let secret = config.rpc.operator_read_token_secret().ok_or_else(|| {
+        anyhow!(
+            "[rpc.operator] read_token_secret is not configured in {} — \
+             add a [rpc.operator] section with a read_token_secret to enable \
+             the operator read surface",
+            config_path.display()
+        )
+    })?;
+
+    let exp = now_unix_seconds.saturating_add(ttl_seconds);
+    let token = mint_operator_read_token(secret, exp);
+
+    // Trim a trailing slash so we don't emit `.../operator` with a double slash.
+    let base = dashboard.trim_end_matches('/');
+    Ok(format!("{base}/operator#token={token}"))
+}
+
+/// `botho operator mint-read-link`: mint a read link and print it to stdout.
+pub fn mint_read_link(config_path: &Path, dashboard: &str, ttl_seconds: Option<u64>) -> Result<()> {
+    let ttl = ttl_seconds.unwrap_or(DEFAULT_OPERATOR_TOKEN_TTL_SECONDS);
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .map_err(|_| anyhow!("system clock is before the Unix epoch"))?;
+
+    let url = build_read_link(config_path, dashboard, ttl, now)?;
+
+    // Operator-facing tooling: stdout is the deliverable.
+    println!("{url}");
+    eprintln!(
+        "Operator read link minted (valid for {} days). This is a bearer \
+         credential granting READ-ONLY access — anyone with the link can view \
+         operator trust internals until it expires; it grants no write \
+         capability.",
+        ttl / (24 * 60 * 60)
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::auth::{verify_operator_read_token, OperatorTokenError};
+    use std::io::Write;
+
+    /// Write a minimal config.toml carrying an `[rpc.operator]
+    /// read_token_secret` (or not) and return its path (kept alive by the
+    /// returned TempDir).
+    fn write_config(operator_secret: Option<&str>) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "network_type = \"testnet\"").unwrap();
+        writeln!(f, "[network]").unwrap();
+        writeln!(f, "[minting]").unwrap();
+        if let Some(secret) = operator_secret {
+            writeln!(f, "[rpc.operator]").unwrap();
+            writeln!(f, "read_token_secret = \"{secret}\"").unwrap();
+        }
+        (dir, path)
+    }
+
+    #[test]
+    fn mint_round_trips_against_a_config_file() {
+        let secret = "operator-cli-round-trip-secret";
+        let (_dir, path) = write_config(Some(secret));
+        let now = 1_700_000_000;
+        let ttl = 3600;
+
+        let url = build_read_link(&path, "https://dash.example", ttl, now).unwrap();
+
+        // URL shape.
+        let prefix = "https://dash.example/operator#token=";
+        assert!(url.starts_with(prefix), "unexpected url: {url}");
+        let token = &url[prefix.len()..];
+
+        // The node would verify this token with the SAME secret — round trip.
+        let verified = verify_operator_read_token(token, secret, now + 10);
+        assert_eq!(verified, Ok(now + ttl));
+
+        // And it is rejected once expired (proving the exp is real).
+        assert_eq!(
+            verify_operator_read_token(token, secret, now + ttl + 1),
+            Err(OperatorTokenError::Expired)
+        );
+    }
+
+    #[test]
+    fn trailing_slash_on_dashboard_is_normalized() {
+        let (_dir, path) = write_config(Some("s3cr3t"));
+        let url = build_read_link(&path, "https://dash.example/", 3600, 1_700_000_000).unwrap();
+        assert!(url.starts_with("https://dash.example/operator#token="));
+        assert!(!url.contains("//operator"));
+    }
+
+    #[test]
+    fn refuses_to_mint_without_configured_secret() {
+        let (_dir, path) = write_config(None);
+        let err = build_read_link(&path, "https://dash.example", 3600, 1_700_000_000).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("read_token_secret is not configured"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn refuses_to_mint_with_empty_secret() {
+        let (_dir, path) = write_config(Some(""));
+        let err = build_read_link(&path, "https://dash.example", 3600, 1_700_000_000).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("read_token_secret is not configured"));
+    }
+}

--- a/botho/src/commands/operator.rs
+++ b/botho/src/commands/operator.rs
@@ -5,7 +5,9 @@
 //! read_token_secret` in the node's config file and prints the dashboard URL
 //! the operator opens:
 //!
-//!     https://<dashboard>/operator#token=op.<exp>.<hmac>
+//! ```text
+//! https://<dashboard>/operator#token=op.<exp>.<hmac>
+//! ```
 //!
 //! The token is a bearer credential granting READS ONLY (per-peer gate
 //! classification, configured quorum contents, audit log) — it can never

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -480,6 +480,9 @@ async fn run_async(config: Config, config_path: &Path, mint: bool) -> Result<()>
         ws_broadcaster.clone(),
     )
     .with_quorum(config.network.quorum.clone())
+    // Operator read surface (#707, P4.2). Absent [rpc.operator] ⇒ None ⇒ the
+    // operator_* RPCs stay OFF and the node behaves exactly as today.
+    .with_operator_read_token_secret(config.rpc.operator_read_token_secret().map(str::to_string))
     .with_identity(node_identity)
     .with_minter_health(minter_health.clone())
     .with_sync_status(sync_status.clone())
@@ -2245,6 +2248,12 @@ fn gated_scp_quorum_set(
     let curated_members;
     let auto_members;
     let suppressed_peers;
+    // Per-peer classification (#707): the base58 PeerId strings behind the
+    // counts above, computed HERE (the gate) and nowhere else. Surfaced by the
+    // operator-only `operator_getQuorumInfo` RPC.
+    let curated_peer_ids: Vec<String>;
+    let auto_peer_ids: Vec<String>;
+    let suppressed_peer_ids: Vec<String>;
 
     match quorum_cfg.mode {
         QuorumMode::Explicit => {
@@ -2277,6 +2286,12 @@ fn gated_scp_quorum_set(
             // Every connected non-curated peer is being kept out of the
             // quorum by the gate.
             suppressed_peers = auto_candidates.len();
+            // Per-peer (#707): connected curated peers are the classification's
+            // "curated"; auto is empty in Explicit mode; every connected
+            // non-curated peer is "suppressed".
+            curated_peer_ids = connected_curated.iter().map(|p| p.to_string()).collect();
+            auto_peer_ids = Vec::new();
+            suppressed_peer_ids = auto_candidates.iter().map(|p| p.to_string()).collect();
         }
         QuorumMode::Recommended => {
             // Connected curated members are always admitted and do not count
@@ -2322,6 +2337,22 @@ fn gated_scp_quorum_set(
             curated_members = connected_curated.len();
             auto_members = admitted_auto.len();
             suppressed_peers = auto_candidates.len() - admitted_auto.len();
+            // Per-peer (#707): curated = connected curated; auto = the peers
+            // actually admitted under the cap; suppressed = connected
+            // non-curated peers the cap left out. Derived straight from the
+            // same `admitted_auto` set the membership above was built from, so
+            // the lists cannot drift from the counts.
+            curated_peer_ids = connected_curated.iter().map(|p| p.to_string()).collect();
+            auto_peer_ids = auto_candidates
+                .iter()
+                .filter(|p| admitted_auto.contains(p))
+                .map(|p| p.to_string())
+                .collect();
+            suppressed_peer_ids = auto_candidates
+                .iter()
+                .filter(|p| !admitted_auto.contains(p))
+                .map(|p| p.to_string())
+                .collect();
         }
     }
 
@@ -2389,6 +2420,9 @@ fn gated_scp_quorum_set(
         suppressed_peers,
         max_auto_members: quorum_cfg.max_auto_members,
         intersection_refused,
+        curated_peer_ids,
+        auto_peer_ids,
+        suppressed_peer_ids,
     };
     (quorum_set, snapshot)
 }

--- a/botho/src/config.rs
+++ b/botho/src/config.rs
@@ -23,6 +23,69 @@ pub struct Config {
     /// Telemetry configuration for distributed tracing
     #[serde(default)]
     pub telemetry: TelemetryConfig,
+    /// RPC-server configuration, including the optional operator surface
+    /// (#707, P4.2 of the #695 proposal). Absent by default so existing
+    /// configs and node behavior are unchanged.
+    #[serde(default)]
+    pub rpc: RpcConfig,
+}
+
+/// RPC-server configuration.
+///
+/// Today this only carries the optional `[rpc.operator]` block. When the whole
+/// `[rpc]` section is absent from `config.toml`, this deserializes to its
+/// default (operator surface OFF) and the node behaves exactly as before.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RpcConfig {
+    /// Operator read-surface configuration (#707). Absent ⇒ the whole
+    /// operator feature is OFF: `operator_*` RPCs return a clean "not enabled"
+    /// error and the `botho operator mint-read-link` CLI refuses to mint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operator: Option<OperatorConfig>,
+}
+
+/// Operator read-surface configuration (`[rpc.operator]`, #707).
+///
+/// The mere PRESENCE of this section (with a non-empty secret) turns the
+/// operator read RPCs on. It is deliberately a separate opt-in from the rest
+/// of the RPC surface: the operator-only reads (per-peer gate classification,
+/// configured quorum contents, audit log) are a targeting map an adversary
+/// must not get for free, so they are gated behind a node-verified magic-link
+/// token keyed on `read_token_secret`.
+///
+/// This surface is READ-ONLY by construction. The write path (operator-signed
+/// quorum curation) is a separate, separately-reviewed deliverable (#709,
+/// governed by `docs/security/quorum-write-path.md`); no field here grants any
+/// write capability.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorConfig {
+    /// HMAC-SHA256 secret the node uses to verify operator read tokens of the
+    /// form `op.<expUnixSeconds>.<hmacSha256Hex(secret, "op.<exp>")>`. Minted
+    /// off-node by `botho operator mint-read-link`. An empty secret is treated
+    /// as "not configured" (fail closed).
+    pub read_token_secret: String,
+}
+
+impl OperatorConfig {
+    /// The configured secret if it is present AND non-empty; `None` otherwise.
+    /// An empty secret must not enable the feature (fail closed).
+    pub fn effective_secret(&self) -> Option<&str> {
+        let s = self.read_token_secret.trim();
+        if s.is_empty() {
+            None
+        } else {
+            Some(self.read_token_secret.as_str())
+        }
+    }
+}
+
+impl RpcConfig {
+    /// The effective operator read-token secret, or `None` when the operator
+    /// surface is not configured (absent section OR empty secret). When this
+    /// is `None` the operator RPCs are OFF and the node behaves as today.
+    pub fn operator_read_token_secret(&self) -> Option<&str> {
+        self.operator.as_ref().and_then(|o| o.effective_secret())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -709,6 +772,7 @@ impl Config {
             minting: MintingConfig::default(),
             faucet: FaucetConfig::default(),
             telemetry: TelemetryConfig::default(),
+            rpc: RpcConfig::default(),
         }
     }
 
@@ -721,6 +785,7 @@ impl Config {
             minting: MintingConfig::default(),
             faucet: FaucetConfig::default(),
             telemetry: TelemetryConfig::default(),
+            rpc: RpcConfig::default(),
         }
     }
 

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -196,6 +196,32 @@ pub struct QuorumGateSnapshot {
     /// kept its previous safe quorum set (or, at initial seed, fell back to a
     /// majority-threshold set over the same members).
     pub intersection_refused: bool,
+
+    /// Per-peer gate classification (#707, P4.2). These are the base58 PeerId
+    /// strings of the CONNECTED peers, partitioned exactly as the gate
+    /// evaluation above partitioned them — the single source of truth for the
+    /// classification (it is NEVER recomputed anywhere else). They back the
+    /// operator-only `operator_getQuorumInfo` RPC, which the public
+    /// `node_getStatus` deliberately does not expose (the per-peer map is a
+    /// targeting map for an adversary; the public surface reports counts only).
+    ///
+    /// Anti-#541: these lists are populated ONLY by a real gate evaluation.
+    /// Until the first evaluation the whole [`QuorumGateSnapshot`] is absent
+    /// (the shared handle holds `None`), so the RPC reports the classification
+    /// as `null`, never a fabricated or zero-filled list.
+    ///
+    /// Connected curated members admitted by the gate (operator-listed
+    /// `[network.quorum] members` that are currently connected).
+    pub curated_peer_ids: Vec<String>,
+
+    /// Connected auto-discovered peers PROMOTED into the quorum set by the gate
+    /// (bounded by `max_auto_members`; empty in `Explicit` mode).
+    pub auto_peer_ids: Vec<String>,
+
+    /// Connected non-curated peers the gate is keeping OUT of the quorum set
+    /// (over-cap auto peers in `Recommended` mode; every non-curated peer in
+    /// `Explicit` mode).
+    pub suppressed_peer_ids: Vec<String>,
 }
 
 /// Events emitted by the consensus service

--- a/botho/src/main.rs
+++ b/botho/src/main.rs
@@ -111,6 +111,30 @@ enum Commands {
         #[command(subcommand)]
         action: SnapshotAction,
     },
+
+    /// Operator tooling (read-only trust surface, #707)
+    Operator {
+        #[command(subcommand)]
+        action: OperatorAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum OperatorAction {
+    /// Mint a node-verified magic-link READ token and print the dashboard URL.
+    ///
+    /// Reads the `[rpc.operator] read_token_secret` from the node config file.
+    /// The link is a bearer credential granting READ-ONLY access to operator
+    /// trust internals; it grants no write capability.
+    MintReadLink {
+        /// Dashboard base URL the link points at.
+        #[arg(long, default_value = commands::operator::DEFAULT_DASHBOARD_URL)]
+        dashboard: String,
+
+        /// Token lifetime in seconds (default: 7 days).
+        #[arg(long)]
+        ttl: Option<u64>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -221,6 +245,11 @@ fn main() -> Result<()> {
                 commands::snapshot::load(&config_path, &input, verify_hash.as_deref())
             }
             SnapshotAction::Info { file } => commands::snapshot::info(&file),
+        },
+        Commands::Operator { action } => match action {
+            OperatorAction::MintReadLink { dashboard, ttl } => {
+                commands::operator::mint_read_link(&config_path, &dashboard, ttl)
+            }
         },
     }
 }

--- a/botho/src/rpc/auth.rs
+++ b/botho/src/rpc/auth.rs
@@ -266,6 +266,126 @@ impl HmacAuthenticator {
     }
 }
 
+// ============================================================================
+// Operator read-token (magic link) — #707, P4.2 of the #695 proposal
+// ============================================================================
+//
+// A node-verified, expiring, read-only bearer token that unlocks the
+// operator-only read RPCs (`operator_getQuorumInfo`, `operator_getAuditLog`).
+// It is the exact shape of the BaaS status link
+// (`web/packages/baas-worker/src/status-link.ts`), with the node as verifier:
+//
+//     op.<expUnixSeconds>.<hmacSha256Hex(secret, "op.<exp>")>
+//
+// The HMAC reuses the SAME `HmacSha256` primitive and the SAME
+// `constant_time_eq` compare as the exchange API-key auth above — there is a
+// single audited HMAC path in this module, never a second hand-rolled one.
+//
+// SECURITY POSTURE (mirrors status-link.ts):
+//   - The signature is verified BEFORE the expiry field is trusted. An attacker
+//     cannot forge or extend a token by tampering with the (unauthenticated)
+//     `exp` field: the HMAC covers `"op.<exp>"`, so any change to `exp` fails
+//     the constant-time compare before the expiry check ever runs.
+//   - The compare is constant-time.
+//   - The token is a bearer credential that grants READS ONLY. No RPC reachable
+//     with it mutates any state (the write path is #709, gated on a separate
+//     security review — `docs/security/quorum-write-path.md`).
+
+/// Fixed subject/domain tag for operator read tokens. Also acts as a domain
+/// separator so an operator token can never be confused with any other
+/// dot-delimited HMAC token shape.
+pub const OPERATOR_TOKEN_SUBJECT: &str = "op";
+
+/// Default lifetime of a freshly minted operator read token: 7 days. Parity
+/// with `DEFAULT_STATUS_TOKEN_TTL_SECONDS` in `status-link.ts`.
+pub const DEFAULT_OPERATOR_TOKEN_TTL_SECONDS: u64 = 7 * 24 * 60 * 60;
+
+/// Why an operator read token was rejected.
+///
+/// The RPC layer collapses ALL of these into a single generic client-facing
+/// error (it must not leak whether a token was malformed vs forged vs expired).
+/// The variants exist so tests can assert the internal verification ORDER —
+/// specifically that a bad signature is reported even when the token is also
+/// expired (signature is checked first, exactly like `status-link.ts`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperatorTokenError {
+    /// Empty, wrong field count, wrong subject tag, or non-integer expiry.
+    Malformed,
+    /// The HMAC over `"op.<exp>"` did not match (tampered/forged token, or a
+    /// token signed with a different secret).
+    BadSignature,
+    /// The signature was valid but the token's (now-trusted) expiry has passed.
+    Expired,
+}
+
+/// Compute the hex HMAC-SHA256 of `payload` under `secret`, using the same
+/// `HmacSha256` primitive as the exchange API-key auth.
+fn hmac_sha256_hex(secret: &str, payload: &str) -> String {
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts keys of any length");
+    mac.update(payload.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+
+/// Mint an operator read token valid until `exp_unix_seconds`.
+///
+/// `op.<exp>.<hmacSha256Hex(secret, "op.<exp>")>`. Minted off-node by the
+/// `botho operator mint-read-link` CLI; the node is the verifier.
+pub fn mint_operator_read_token(secret: &str, exp_unix_seconds: u64) -> String {
+    let payload = format!("{OPERATOR_TOKEN_SUBJECT}.{exp_unix_seconds}");
+    let sig = hmac_sha256_hex(secret, &payload);
+    format!("{payload}.{sig}")
+}
+
+/// Verify an operator read token and return its (trusted) expiry on success.
+///
+/// Verification order (parity with `status-link.ts`, fail closed):
+///   1. structural parse: exactly three dot-delimited fields, subject == `op`,
+///      integer expiry > 0 (else [`OperatorTokenError::Malformed`]);
+///   2. recompute the HMAC over `"op.<exp>"` and compare in CONSTANT TIME —
+///      **before** trusting any field ([`OperatorTokenError::BadSignature`]);
+///   3. only after the signature passes, honor the (now-trusted) expiry
+///      ([`OperatorTokenError::Expired`]).
+///
+/// `now_unix_seconds` is injectable so tests can pin the clock.
+pub fn verify_operator_read_token(
+    token: &str,
+    secret: &str,
+    now_unix_seconds: u64,
+) -> Result<u64, OperatorTokenError> {
+    if token.is_empty() {
+        return Err(OperatorTokenError::Malformed);
+    }
+
+    // Expect exactly three fields: subject . exp . signature.
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return Err(OperatorTokenError::Malformed);
+    }
+    let (subject, exp_str, sig) = (parts[0], parts[1], parts[2]);
+
+    if subject != OPERATOR_TOKEN_SUBJECT {
+        return Err(OperatorTokenError::Malformed);
+    }
+    let exp: u64 = match exp_str.parse() {
+        Ok(v) if v > 0 => v,
+        _ => return Err(OperatorTokenError::Malformed),
+    };
+
+    // Verify the signature BEFORE trusting the expiry. Constant-time compare.
+    let expected = hmac_sha256_hex(secret, &format!("{OPERATOR_TOKEN_SUBJECT}.{exp}"));
+    if !constant_time_eq(expected.as_bytes(), sig.as_bytes()) {
+        return Err(OperatorTokenError::BadSignature);
+    }
+
+    // Only now is `exp` trusted — honor it.
+    if now_unix_seconds >= exp {
+        return Err(OperatorTokenError::Expired);
+    }
+
+    Ok(exp)
+}
+
 /// Constant-time byte comparison.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
@@ -409,5 +529,110 @@ mod tests {
         assert!(constant_time_eq(b"hello", b"hello"));
         assert!(!constant_time_eq(b"hello", b"world"));
         assert!(!constant_time_eq(b"hello", b"hell"));
+    }
+
+    // ------------------------------------------------------------------
+    // Operator read-token (#707)
+    // ------------------------------------------------------------------
+
+    const OP_SECRET: &str = "operator-read-token-secret";
+    const NOW: u64 = 1_700_000_000;
+
+    #[test]
+    fn operator_token_round_trips() {
+        let exp = NOW + DEFAULT_OPERATOR_TOKEN_TTL_SECONDS;
+        let token = mint_operator_read_token(OP_SECRET, exp);
+        // Shape: op.<exp>.<hex-sig>
+        let parts: Vec<&str> = token.split('.').collect();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(parts[0], "op");
+        assert_eq!(parts[1], exp.to_string());
+        assert_eq!(parts[2].len(), 64, "hex sha256 is 64 hex chars");
+
+        let got = verify_operator_read_token(&token, OP_SECRET, NOW + 10);
+        assert_eq!(got, Ok(exp));
+    }
+
+    #[test]
+    fn operator_token_missing_or_malformed_rejected() {
+        assert_eq!(
+            verify_operator_read_token("", OP_SECRET, NOW),
+            Err(OperatorTokenError::Malformed)
+        );
+        assert_eq!(
+            verify_operator_read_token("garbage", OP_SECRET, NOW),
+            Err(OperatorTokenError::Malformed)
+        );
+        // Wrong field count.
+        assert_eq!(
+            verify_operator_read_token("op.123", OP_SECRET, NOW),
+            Err(OperatorTokenError::Malformed)
+        );
+        // Wrong subject tag.
+        let exp = NOW + 1000;
+        let sig = hmac_sha256_hex(OP_SECRET, &format!("op.{exp}"));
+        assert_eq!(
+            verify_operator_read_token(&format!("xx.{exp}.{sig}"), OP_SECRET, NOW),
+            Err(OperatorTokenError::Malformed)
+        );
+        // Non-integer expiry.
+        assert_eq!(
+            verify_operator_read_token(&format!("op.notanumber.{sig}"), OP_SECRET, NOW),
+            Err(OperatorTokenError::Malformed)
+        );
+    }
+
+    #[test]
+    fn operator_token_tampered_signature_rejected() {
+        let exp = NOW + 1000;
+        let token = mint_operator_read_token(OP_SECRET, exp);
+        // Tamper the expiry but keep the original signature: the HMAC covers
+        // "op.<exp>", so bumping exp must fail the signature check.
+        let parts: Vec<&str> = token.split('.').collect();
+        let forged = format!("op.{}.{}", exp + 999_999, parts[2]);
+        assert_eq!(
+            verify_operator_read_token(&forged, OP_SECRET, NOW),
+            Err(OperatorTokenError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn operator_token_wrong_secret_rejected() {
+        let exp = NOW + 1000;
+        let token = mint_operator_read_token("other-secret", exp);
+        assert_eq!(
+            verify_operator_read_token(&token, OP_SECRET, NOW),
+            Err(OperatorTokenError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn operator_token_expired_rejected_only_after_signature_passes() {
+        let exp = NOW + 60;
+        let token = mint_operator_read_token(OP_SECRET, exp);
+        // Valid signature, but the clock is past expiry.
+        assert_eq!(
+            verify_operator_read_token(&token, OP_SECRET, exp + 1),
+            Err(OperatorTokenError::Expired)
+        );
+    }
+
+    #[test]
+    fn operator_token_signature_checked_before_expiry() {
+        // A token that is BOTH expired AND has a bad signature must report the
+        // SIGNATURE failure, proving the signature is verified before the
+        // expiry is trusted (parity with status-link.ts verification order).
+        let exp = NOW - 100; // already expired
+        let token = mint_operator_read_token(OP_SECRET, exp);
+        let parts: Vec<&str> = token.split('.').collect();
+        // Corrupt the signature.
+        let mut bad_sig: String = parts[2].to_string();
+        bad_sig.replace_range(0..1, if &bad_sig[0..1] == "a" { "b" } else { "a" });
+        let both_bad = format!("op.{exp}.{bad_sig}");
+        assert_eq!(
+            verify_operator_read_token(&both_bad, OP_SECRET, NOW),
+            Err(OperatorTokenError::BadSignature),
+            "signature must be checked before expiry"
+        );
     }
 }

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -7,6 +7,7 @@ pub mod auth;
 pub mod deposit_scanner;
 pub mod faucet;
 pub mod metrics;
+pub mod operator;
 pub mod rate_limit;
 pub mod view_keys;
 pub mod websocket;
@@ -18,6 +19,7 @@ pub use metrics::{
     calculate_dir_size, check_health, check_ready, init_metrics, start_metrics_server,
     HealthResponse, HealthStatus, MetricsUpdater, NodeMetrics, ReadyResponse, DATA_DIR_USAGE_BYTES,
 };
+pub use operator::{OperatorAuditEntry, OperatorAuditLog};
 pub use rate_limit::{KeyTier, RateLimitInfo, RateLimiter};
 pub use view_keys::{RegistryError, ViewKeyInfo, ViewKeyRegistry};
 pub use websocket::WsBroadcaster;
@@ -26,6 +28,16 @@ use anyhow::Result;
 
 /// JSON-RPC internal error code
 const INTERNAL_ERROR: i32 = -32603;
+
+/// Operator surface is not configured (`[rpc.operator]` absent / empty secret).
+/// A clean, stable "feature off" signal — distinct from an auth failure so the
+/// dashboard can degrade to the public read-only view (#707).
+const OPERATOR_NOT_ENABLED: i32 = -32020;
+
+/// Operator read token missing, malformed, expired, or forged. Deliberately
+/// GENERIC: the node must not leak which check failed (expiry vs signature vs
+/// shape) — fail closed with one reason (#707).
+const OPERATOR_TOKEN_REJECTED: i32 = -32021;
 
 /// Helper macro to acquire a read lock, returning a JSON-RPC error if poisoned
 macro_rules! read_lock {
@@ -287,6 +299,18 @@ pub struct RpcState {
     /// loop, in which case submission remains mempool-local (previous
     /// behavior).
     pub tx_relay: Option<tokio::sync::mpsc::UnboundedSender<crate::transaction::Transaction>>,
+    /// Operator read-token secret from `[rpc.operator] read_token_secret`
+    /// (#707, P4.2). `None` ⇒ the operator surface is OFF: `operator_*` RPCs
+    /// return a clean "not enabled" error and the node behaves exactly as
+    /// today. `Some` ⇒ the node verifies magic-link READ tokens (constant-time
+    /// HMAC, signature-before-expiry — see
+    /// [`auth::verify_operator_read_token`]) before serving the
+    /// operator-only reads. This grants READS ONLY; there is no operator
+    /// write RPC (that is #709).
+    pub operator_read_token_secret: Option<String>,
+    /// Operator audit-log store (#707). Present-but-empty in P4.2; #709 wires
+    /// the append side. Surfaced by `operator_getAuditLog`.
+    pub operator_audit_log: Arc<OperatorAuditLog>,
 }
 
 impl RpcState {
@@ -326,6 +350,8 @@ impl RpcState {
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
             tx_relay: None,
+            operator_read_token_secret: None,
+            operator_audit_log: OperatorAuditLog::new(),
         }
     }
 
@@ -369,6 +395,8 @@ impl RpcState {
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
             tx_relay: None,
+            operator_read_token_secret: None,
+            operator_audit_log: OperatorAuditLog::new(),
         }
     }
 
@@ -410,6 +438,8 @@ impl RpcState {
             peers: Arc::new(RwLock::new(Vec::new())),
             network_stats: None,
             tx_relay: None,
+            operator_read_token_secret: None,
+            operator_audit_log: OperatorAuditLog::new(),
         }
     }
 
@@ -516,6 +546,16 @@ impl RpcState {
     /// / relay nodes / pre-first-rebuild state, in which case
     /// `node_getStatus` reports the gate fields as JSON `null` rather than
     /// fabricating values.
+    /// Enable the operator read surface (#707) by wiring in the
+    /// `[rpc.operator] read_token_secret`. An empty/whitespace secret is
+    /// treated as "not configured" (fail closed) and leaves the surface OFF.
+    /// `commands::run` calls this with
+    /// `Config::rpc.operator_read_token_secret()`.
+    pub fn with_operator_read_token_secret(mut self, secret: Option<String>) -> Self {
+        self.operator_read_token_secret = secret.filter(|s| !s.trim().is_empty());
+        self
+    }
+
     fn quorum_gate_snapshot(&self) -> Option<QuorumGateSnapshot> {
         let handle = self.quorum_gate_status.as_ref()?;
         let guard = handle.read().ok()?;
@@ -880,6 +920,12 @@ async fn handle_rpc_method(request: &JsonRpcRequest, state: &RpcState) -> JsonRp
         // Network methods
         "network_getInfo" => handle_network_info(id, state).await,
         "network_getPeers" => handle_get_peers(id, state).await,
+
+        // Operator-only READ methods (#707, P4.2). Token-gated; fail closed
+        // when `[rpc.operator]` is absent. READS ONLY — there is deliberately
+        // no operator write method here (that is #709).
+        "operator_getQuorumInfo" => handle_operator_quorum_info(id, &request.params, state).await,
+        "operator_getAuditLog" => handle_operator_audit_log(id, &request.params, state).await,
 
         // Exchange integration methods
         "exchange_registerViewKey" => handle_register_view_key(id, &request.params, state).await,
@@ -2286,6 +2332,148 @@ async fn handle_get_peers(id: Value, state: &RpcState) -> JsonRpcResponse {
         json!({
             "peers": peers_json,
             "peerCount": peers_json.len(),
+        }),
+    )
+}
+
+/// Shared gate for the operator-only READ RPCs (#707, P4.2).
+///
+/// Fail closed, in order:
+///   1. `[rpc.operator]` absent / empty secret ⇒ `OPERATOR_NOT_ENABLED` (a
+///      clean "feature off" signal; the node behaves exactly as today).
+///   2. the `token` param is verified with [`auth::verify_operator_read_token`]
+///      (constant-time HMAC, signature-before-expiry). ANY failure —
+///      missing/malformed/forged/expired — collapses to one GENERIC
+///      `OPERATOR_TOKEN_REJECTED` error: the node never leaks which check
+///      failed.
+///
+/// Returns `Ok(())` only when a valid, unexpired token was presented. This is
+/// a READ gate: it authorizes viewing operator-only data and grants no write
+/// capability whatsoever.
+fn operator_read_gate(id: &Value, params: &Value, state: &RpcState) -> Result<(), JsonRpcResponse> {
+    let secret = match state.operator_read_token_secret.as_deref() {
+        Some(s) => s,
+        None => {
+            return Err(JsonRpcResponse::error(
+                id.clone(),
+                OPERATOR_NOT_ENABLED,
+                "operator features are not enabled on this node ([rpc.operator] not configured)",
+            ));
+        }
+    };
+
+    let token = params.get("token").and_then(|v| v.as_str()).unwrap_or("");
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    match auth::verify_operator_read_token(token, secret, now) {
+        Ok(_exp) => Ok(()),
+        // Deliberately generic: do not reveal expiry-vs-signature-vs-malformed.
+        Err(_) => Err(JsonRpcResponse::error(
+            id.clone(),
+            OPERATOR_TOKEN_REJECTED,
+            "operator token invalid or expired",
+        )),
+    }
+}
+
+/// `operator_getQuorumInfo` (#707): the node's configured `[network.quorum]`
+/// plus the PER-PEER gate classification from the last real gate evaluation.
+///
+/// The public `node_getStatus` exposes only COUNTS; this operator-only method
+/// adds (a) the configured quorum contents (members list, mode, threshold,
+/// caps) and (b) which specific connected peers are curated / auto-promoted /
+/// suppressed — a targeting map the public surface must not hand out.
+///
+/// Anti-#541: the per-peer classification is `null` until the gate has run at
+/// least once (relay nodes / pre-first-rebuild), never a fabricated or
+/// zero-filled list. The classification comes verbatim from the gate's
+/// [`QuorumGateSnapshot`]; nothing is recomputed here.
+async fn handle_operator_quorum_info(
+    id: Value,
+    params: &Value,
+    state: &RpcState,
+) -> JsonRpcResponse {
+    if let Err(resp) = operator_read_gate(&id, params, state) {
+        return resp;
+    }
+
+    let q = &state.quorum;
+    let mode = match q.mode {
+        crate::config::QuorumMode::Explicit => "explicit",
+        crate::config::QuorumMode::Recommended => "recommended",
+    };
+    let fault_model = match q.fault_model {
+        crate::config::FaultModel::Crash => "crash",
+        crate::config::FaultModel::Bft => "bft",
+    };
+
+    // Per-peer classification from the last REAL gate evaluation, or null.
+    let gate = state.quorum_gate_snapshot();
+    let per_peer = gate.as_ref().map(|g| {
+        json!({
+            "curated": g.curated_peer_ids,
+            "auto": g.auto_peer_ids,
+            "suppressed": g.suppressed_peer_ids,
+        })
+    });
+
+    JsonRpcResponse::success(
+        id,
+        json!({
+            // Configured [network.quorum] contents (operator-only read).
+            "quorum": {
+                "mode": mode,
+                "faultModel": fault_model,
+                "threshold": q.threshold,
+                "members": q.members,
+                "minPeers": q.min_peers,
+                "maxAutoMembers": q.max_auto_members,
+            },
+            // Per-peer gate classification, or null until the first evaluation
+            // (anti-#541 — never fabricated).
+            "perPeer": per_peer,
+            // The same aggregate counts node_getStatus exposes, echoed for
+            // convenience; null until the first evaluation.
+            "gate": gate.as_ref().map(|g| json!({
+                "curatedMembers": g.curated_members,
+                "autoMembers": g.auto_members,
+                "suppressedPeers": g.suppressed_peers,
+                "maxAutoMembers": g.max_auto_members,
+                "intersectionRefused": g.intersection_refused,
+            })),
+        }),
+    )
+}
+
+/// `operator_getAuditLog` (#707): the operator audit log (read-token gated).
+///
+/// Present-but-empty in P4.2 — there is no write path to append to it yet
+/// (that is #709). Returns an empty `entries` list rather than a placeholder
+/// (anti-#541). An optional `limit` param bounds the returned entries.
+async fn handle_operator_audit_log(id: Value, params: &Value, state: &RpcState) -> JsonRpcResponse {
+    if let Err(resp) = operator_read_gate(&id, params, state) {
+        return resp;
+    }
+
+    let limit = params
+        .get("limit")
+        .and_then(|v| v.as_u64())
+        .map(|n| n as usize)
+        .unwrap_or(200)
+        .min(1000);
+
+    let entries = state.operator_audit_log.recent(limit);
+    let count = entries.len();
+
+    JsonRpcResponse::success(
+        id,
+        json!({
+            "entries": entries,
+            "count": count,
         }),
     )
 }
@@ -3955,6 +4143,9 @@ mod tests {
             suppressed_peers: 0,
             max_auto_members: 8,
             intersection_refused: false,
+            curated_peer_ids: Vec::new(),
+            auto_peer_ids: Vec::new(),
+            suppressed_peer_ids: Vec::new(),
         });
         let quiet = handle_node_status(json!(1), &state).await.result.unwrap();
         assert_eq!(quiet["quorumCuratedMembers"], json!(0));
@@ -3971,6 +4162,9 @@ mod tests {
             suppressed_peers: 22,
             max_auto_members: 8,
             intersection_refused: true,
+            curated_peer_ids: Vec::new(),
+            auto_peer_ids: Vec::new(),
+            suppressed_peer_ids: Vec::new(),
         });
         let flooded = handle_node_status(json!(1), &state).await.result.unwrap();
         assert_eq!(flooded["quorumCuratedMembers"], json!(2));

--- a/botho/src/rpc/operator.rs
+++ b/botho/src/rpc/operator.rs
@@ -1,0 +1,72 @@
+//! Operator read surface (#707, P4.2 of the #695 proposal).
+//!
+//! This module holds the node-side state for the operator-only READ RPCs
+//! (`operator_getQuorumInfo`, `operator_getAuditLog`). The token machinery
+//! itself lives in [`super::auth`] (reusing the single audited HMAC path); the
+//! request handlers live in [`super`] (`mod.rs`) alongside the other JSON-RPC
+//! handlers.
+//!
+//! SCOPE: reads only. Nothing here mutates node state. The operator WRITE path
+//! (signed quorum curation) is a separate, separately-reviewed deliverable
+//! (#709, governed by `docs/security/quorum-write-path.md`).
+
+use std::sync::{Arc, RwLock};
+
+use serde::{Deserialize, Serialize};
+
+/// One operator audit-log entry.
+///
+/// This is the wire+storage shape the write path (#709) will append to on
+/// every verification outcome (applied / gate-refused / verify-refused), per
+/// `docs/security/quorum-write-path.md` §6. In P4.2 the store is present but
+/// always empty — there is no write path yet to append to it — so the shape is
+/// defined here and `operator_getAuditLog` returns an empty list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorAuditEntry {
+    /// Unix seconds when the action was processed.
+    pub ts: u64,
+    /// Fingerprint of the signing key (`signerKeyId`).
+    pub signer_key_id: String,
+    /// The attempted action (`quorum.pin_member`, etc.).
+    pub action: String,
+    /// Outcome: `applied` | `gate_refused` | `verify_refused:<reason>`.
+    pub outcome: String,
+}
+
+/// Operator audit-log store: append-only, node-local.
+///
+/// P4.2 ships it EMPTY-BUT-PRESENT: the RPC surface and the store type exist so
+/// the dashboard can render an (empty) audit panel today, and #709 only has to
+/// wire the append side. Reads never fabricate entries (anti-#541): an empty
+/// store returns an empty list, not a placeholder.
+#[derive(Debug, Default)]
+pub struct OperatorAuditLog {
+    entries: RwLock<Vec<OperatorAuditEntry>>,
+}
+
+impl OperatorAuditLog {
+    /// A fresh, empty audit-log store.
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// The most recent `limit` entries, newest first. Empty until #709 wires
+    /// the write path in.
+    pub fn recent(&self, limit: usize) -> Vec<OperatorAuditEntry> {
+        let guard = match self.entries.read() {
+            Ok(g) => g,
+            // A poisoned lock must not fabricate data; report "no entries".
+            Err(_) => return Vec::new(),
+        };
+        guard.iter().rev().take(limit).cloned().collect()
+    }
+
+    /// Append an entry (used by #709; unused in P4.2). Kept crate-visible so
+    /// the write path has an obvious, single seam to call.
+    #[allow(dead_code)]
+    pub(crate) fn append(&self, entry: OperatorAuditEntry) {
+        if let Ok(mut guard) = self.entries.write() {
+            guard.push(entry);
+        }
+    }
+}

--- a/botho/tests/rpc_integration.rs
+++ b/botho/tests/rpc_integration.rs
@@ -1228,6 +1228,288 @@ async fn test_websocket_subscribe_roundtrip() {
     assert!(events.contains(&"peers".to_string()));
 }
 
+// ============================================================================
+// Operator read-surface Tests (#707, P4.2)
+// ============================================================================
+
+use std::sync::RwLock as StdRwLock;
+
+use botho::{
+    consensus::QuorumGateSnapshot,
+    rpc::auth::{mint_operator_read_token, DEFAULT_OPERATOR_TOKEN_TTL_SECONDS},
+};
+
+/// Spawn an RPC server with the operator read surface enabled under `secret`.
+/// If `gate` is provided, it is published into the shared gate handle so
+/// `operator_getQuorumInfo` can surface per-peer classification.
+async fn spawn_operator_rpc_server(
+    secret: Option<&str>,
+    gate: Option<QuorumGateSnapshot>,
+) -> (TempDir, SocketAddr, tokio::task::JoinHandle<()>) {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let ledger = Ledger::open(&temp_dir.path().join("ledger")).expect("ledger");
+    let mempool = Mempool::new();
+    let ws_broadcaster = Arc::new(WsBroadcaster::new(100));
+
+    let mut state = RpcState::new(
+        ledger,
+        mempool,
+        Network::Testnet,
+        None,
+        None,
+        vec!["*".to_string()],
+        ws_broadcaster,
+    )
+    .with_operator_read_token_secret(secret.map(str::to_string));
+
+    // A gate handle is always wired; it stays `None` (unevaluated) unless a
+    // snapshot is supplied — exercising the anti-#541 "null until evaluated"
+    // contract.
+    let gate_handle = Arc::new(StdRwLock::new(gate));
+    state = state.with_quorum_gate_status(gate_handle);
+
+    let state = Arc::new(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    drop(listener);
+
+    let state_clone = state.clone();
+    let handle = tokio::spawn(async move {
+        let _ = botho::rpc::start_rpc_server(addr, state_clone).await;
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    (temp_dir, addr, handle)
+}
+
+/// A valid token for `secret` expiring in the default TTL.
+fn valid_operator_token(secret: &str) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    mint_operator_read_token(secret, now + DEFAULT_OPERATOR_TOKEN_TTL_SECONDS)
+}
+
+/// Acceptance criterion 1: with NO `[rpc.operator]` config, the operator RPCs
+/// return a clean "not enabled" error (and the node otherwise behaves as
+/// today).
+#[tokio::test]
+#[serial]
+async fn test_operator_disabled_without_config() {
+    let (_temp_dir, addr, _handle) = spawn_operator_rpc_server(None, None).await;
+    let client = Client::new();
+
+    for method in ["operator_getQuorumInfo", "operator_getAuditLog"] {
+        // Even WITH a plausible token, no secret ⇒ feature off.
+        let resp = rpc_call(
+            &client,
+            addr,
+            method,
+            json!({ "token": "op.9999999999.deadbeef" }),
+        )
+        .await;
+        assert!(
+            resp["result"].is_null(),
+            "{method} should not succeed when disabled"
+        );
+        assert_eq!(
+            resp["error"]["code"].as_i64(),
+            Some(-32020),
+            "{method} not-enabled code"
+        );
+        let msg = resp["error"]["message"].as_str().unwrap_or_default();
+        assert!(msg.contains("not enabled"), "{method}: {msg}");
+    }
+
+    // The node still serves its normal public surface unchanged.
+    let status = rpc_call(&client, addr, "node_getStatus", json!({})).await;
+    assert!(status["result"].is_object());
+}
+
+/// Missing / expired / tampered tokens are all rejected with the SAME generic
+/// reason (no leak of which check failed).
+#[tokio::test]
+#[serial]
+async fn test_operator_token_rejections_are_generic() {
+    let secret = "integration-operator-secret";
+    let (_temp_dir, addr, _handle) = spawn_operator_rpc_server(Some(secret), None).await;
+    let client = Client::new();
+
+    // (a) Missing token.
+    let missing = rpc_call(&client, addr, "operator_getQuorumInfo", json!({})).await;
+    // (b) Malformed token.
+    let malformed = rpc_call(
+        &client,
+        addr,
+        "operator_getQuorumInfo",
+        json!({ "token": "not-a-token" }),
+    )
+    .await;
+    // (c) Expired-but-validly-signed token.
+    let expired_tok = mint_operator_read_token(secret, 1_000_000_000); // year 2001
+    let expired = rpc_call(
+        &client,
+        addr,
+        "operator_getQuorumInfo",
+        json!({ "token": expired_tok }),
+    )
+    .await;
+    // (d) Tampered token (valid shape, wrong signature).
+    let good = valid_operator_token(secret);
+    let mut parts: Vec<&str> = good.split('.').collect();
+    let forged_exp = format!("op.{}.{}", 9_999_999_999u64, parts.pop().unwrap());
+    let tampered = rpc_call(
+        &client,
+        addr,
+        "operator_getQuorumInfo",
+        json!({ "token": forged_exp }),
+    )
+    .await;
+    // (e) Token signed with a DIFFERENT secret.
+    let wrong_secret_tok = valid_operator_token("some-other-secret");
+    let wrong_secret = rpc_call(
+        &client,
+        addr,
+        "operator_getQuorumInfo",
+        json!({ "token": wrong_secret_tok }),
+    )
+    .await;
+
+    for (label, resp) in [
+        ("missing", &missing),
+        ("malformed", &malformed),
+        ("expired", &expired),
+        ("tampered", &tampered),
+        ("wrong-secret", &wrong_secret),
+    ] {
+        assert!(resp["result"].is_null(), "{label} must not succeed");
+        assert_eq!(
+            resp["error"]["code"].as_i64(),
+            Some(-32021),
+            "{label} must use the generic rejection code"
+        );
+        // Every rejection reason is byte-for-byte identical (no oracle).
+        assert_eq!(
+            resp["error"]["message"].as_str(),
+            Some("operator token invalid or expired"),
+            "{label} reason must be generic"
+        );
+    }
+}
+
+/// A valid token unlocks `operator_getQuorumInfo`; with no gate evaluation yet
+/// the per-peer classification is `null` (anti-#541), never fabricated.
+#[tokio::test]
+#[serial]
+async fn test_operator_quorum_info_per_peer_null_until_evaluated() {
+    let secret = "integration-operator-secret-2";
+    let (_temp_dir, addr, _handle) = spawn_operator_rpc_server(Some(secret), None).await;
+    let client = Client::new();
+    let token = valid_operator_token(secret);
+
+    let resp = rpc_call(
+        &client,
+        addr,
+        "operator_getQuorumInfo",
+        json!({ "token": token }),
+    )
+    .await;
+    assert!(
+        resp["error"].is_null(),
+        "valid token must succeed: {:?}",
+        resp["error"]
+    );
+    let result = &resp["result"];
+    // Configured quorum contents are present.
+    assert!(result["quorum"].is_object());
+    assert!(result["quorum"]["members"].is_array());
+    // Per-peer classification is null until the gate runs — NOT an empty map.
+    assert!(
+        result["perPeer"].is_null(),
+        "perPeer must be null pre-evaluation"
+    );
+    assert!(result["gate"].is_null(), "gate must be null pre-evaluation");
+}
+
+/// After a REAL gate evaluation publishes a snapshot, `operator_getQuorumInfo`
+/// surfaces the exact per-peer classification the gate produced.
+#[tokio::test]
+#[serial]
+async fn test_operator_quorum_info_per_peer_after_evaluation() {
+    let secret = "integration-operator-secret-3";
+    let snapshot = QuorumGateSnapshot {
+        curated_members: 1,
+        auto_members: 1,
+        suppressed_peers: 1,
+        max_auto_members: 8,
+        intersection_refused: false,
+        curated_peer_ids: vec!["12D3KooWCurated".to_string()],
+        auto_peer_ids: vec!["12D3KooWAuto".to_string()],
+        suppressed_peer_ids: vec!["12D3KooWSuppressed".to_string()],
+    };
+    let (_temp_dir, addr, _handle) = spawn_operator_rpc_server(Some(secret), Some(snapshot)).await;
+    let client = Client::new();
+    let token = valid_operator_token(secret);
+
+    let resp = rpc_call(
+        &client,
+        addr,
+        "operator_getQuorumInfo",
+        json!({ "token": token }),
+    )
+    .await;
+    let per_peer = &resp["result"]["perPeer"];
+    assert_eq!(per_peer["curated"][0], "12D3KooWCurated");
+    assert_eq!(per_peer["auto"][0], "12D3KooWAuto");
+    assert_eq!(per_peer["suppressed"][0], "12D3KooWSuppressed");
+    assert_eq!(resp["result"]["gate"]["intersectionRefused"], json!(false));
+}
+
+/// `operator_getAuditLog` is present-but-empty in P4.2 (writes are #709).
+#[tokio::test]
+#[serial]
+async fn test_operator_audit_log_empty_but_present() {
+    let secret = "integration-operator-secret-4";
+    let (_temp_dir, addr, _handle) = spawn_operator_rpc_server(Some(secret), None).await;
+    let client = Client::new();
+    let token = valid_operator_token(secret);
+
+    let resp = rpc_call(
+        &client,
+        addr,
+        "operator_getAuditLog",
+        json!({ "token": token }),
+    )
+    .await;
+    assert!(resp["error"].is_null());
+    assert!(resp["result"]["entries"].is_array());
+    assert_eq!(resp["result"]["entries"].as_array().unwrap().len(), 0);
+    assert_eq!(resp["result"]["count"], json!(0));
+}
+
+/// The token grants READS ONLY: there is no operator write RPC. A plausible
+/// write method name must be an unknown method, even WITH a valid token.
+#[tokio::test]
+#[serial]
+async fn test_operator_token_grants_no_write_method() {
+    let secret = "integration-operator-secret-5";
+    let (_temp_dir, addr, _handle) = spawn_operator_rpc_server(Some(secret), None).await;
+    let client = Client::new();
+    let token = valid_operator_token(secret);
+
+    // #709's write method must NOT exist in this build.
+    let resp = rpc_call(
+        &client,
+        addr,
+        "operator_submitAction",
+        json!({ "token": token }),
+    )
+    .await;
+    assert!(resp["result"].is_null());
+    // Method-not-found (-32601), i.e. no write surface is reachable at all.
+    assert_eq!(resp["error"]["code"].as_i64(), Some(-32601));
+}
+
 #[tokio::test]
 #[serial]
 async fn test_websocket_plain_get_returns_400() {

--- a/web/packages/features/src/operator/components/trust-dashboard.test.tsx
+++ b/web/packages/features/src/operator/components/trust-dashboard.test.tsx
@@ -11,7 +11,12 @@ import { describe, expect, it } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
 import { TrustDashboard } from './trust-dashboard'
 import type { FleetNode } from '../../network/types'
-import type { NodeTrustStatus, TrustPeer } from '../types'
+import type {
+  NodeTrustStatus,
+  OperatorFetchResult,
+  OperatorQuorumInfo,
+  TrustPeer,
+} from '../types'
 
 const NODES: FleetNode[] = [
   { id: 'seed', name: 'Seed (validator)', rpcEndpoint: 'https://seed.test/rpc' },
@@ -153,5 +158,99 @@ describe('TrustDashboard', () => {
     renderDash({ seed: live('seed') })
     const card = screen.getByTestId('trust-card-seed')
     expect(card.textContent).toContain('—')
+  })
+})
+
+describe('TrustDashboard operator view (#707)', () => {
+  const okInfo = (over: Partial<OperatorQuorumInfo> = {}): OperatorFetchResult<OperatorQuorumInfo> => ({
+    status: 'ok',
+    data: {
+      mode: 'recommended',
+      faultModel: 'crash',
+      threshold: 2,
+      members: ['12D3KooWCuratedMemberAAAA'],
+      minPeers: 1,
+      maxAutoMembers: 8,
+      perPeer: {
+        curated: ['12D3KooWCuratedMemberAAAA'],
+        auto: ['12D3KooWAutoPeerBBBB'],
+        suppressed: ['12D3KooWSuppressedCCCC'],
+      },
+      ...over,
+    },
+  })
+
+  it('shows NO operator panels or banner in the public view (no token)', () => {
+    cleanup()
+    render(<TrustDashboard nodes={NODES} statuses={{ seed: live('seed') }} operatorMode="disabled" />)
+    expect(screen.queryByText('Operator detail')).toBeNull()
+    expect(screen.queryByText(/Operator view/)).toBeNull()
+  })
+
+  it('renders the configured-members panel and per-peer badges with a valid token', () => {
+    cleanup()
+    render(
+      <TrustDashboard
+        nodes={NODES}
+        statuses={{ seed: live('seed') }}
+        operatorInfo={{ seed: okInfo() }}
+        operatorMode="active"
+      />,
+    )
+    expect(screen.getByText('Operator detail')).toBeDefined()
+    // Active-session banner.
+    expect(screen.getByText(/Operator view/)).toBeDefined()
+    // Configured members panel.
+    expect(screen.getByText('Configured members (1)')).toBeDefined()
+    expect(screen.getByText('12D3KooWCuratedMemberAAAA')).toBeDefined()
+    // Per-peer classification badges (curated / auto / suppressed).
+    expect(screen.getByText('curated')).toBeDefined()
+    expect(screen.getByText('auto')).toBeDefined()
+    expect(screen.getByText('suppressed')).toBeDefined()
+  })
+
+  it('renders "no gate evaluation yet" for perPeer:absent (anti-#541)', () => {
+    cleanup()
+    render(
+      <TrustDashboard
+        nodes={NODES}
+        statuses={{ seed: live('seed') }}
+        operatorInfo={{ seed: okInfo({ perPeer: undefined }) }}
+        operatorMode="active"
+      />,
+    )
+    expect(screen.getByText(/no gate evaluation yet/)).toBeDefined()
+    // No fabricated classification badges.
+    expect(screen.queryByText('curated')).toBeNull()
+  })
+
+  it('degrades to the public view with an expired-link banner on unauthorized', () => {
+    cleanup()
+    render(
+      <TrustDashboard
+        nodes={NODES}
+        statuses={{ seed: live('seed') }}
+        operatorInfo={{ seed: { status: 'unauthorized' } }}
+        operatorMode="unauthorized"
+      />,
+    )
+    // Both the fleet banner and the per-node panel flag the expired link.
+    expect(screen.getAllByText(/Operator link expired or invalid/).length).toBeGreaterThan(0)
+    expect(screen.getByText(/showing the public read-only view/)).toBeDefined()
+    // No operator detail data is shown.
+    expect(screen.queryByText('Configured members (1)')).toBeNull()
+  })
+
+  it('explains a fleet with no operator surface (not-enabled)', () => {
+    cleanup()
+    render(
+      <TrustDashboard
+        nodes={NODES}
+        statuses={{ seed: live('seed') }}
+        operatorInfo={{ seed: { status: 'not-enabled' } }}
+        operatorMode="not-enabled"
+      />,
+    )
+    expect(screen.getByText(/Operator reads are not enabled/)).toBeDefined()
   })
 })

--- a/web/packages/features/src/operator/components/trust-dashboard.tsx
+++ b/web/packages/features/src/operator/components/trust-dashboard.tsx
@@ -1,7 +1,7 @@
-import { AlertTriangle, ShieldAlert } from 'lucide-react'
+import { AlertTriangle, Lock, ShieldAlert } from 'lucide-react'
 import { Card, CardContent } from '@botho/ui'
 import type { FleetNode } from '../../network/types'
-import type { NodeTrustStatus } from '../types'
+import type { NodeTrustStatus, OperatorFetchResult, OperatorQuorumInfo } from '../types'
 import { deriveTrustSummary } from '../quorum'
 import { TrustNodeCard } from './trust-node-card'
 
@@ -9,6 +9,13 @@ export interface TrustDashboardProps {
   nodes: FleetNode[]
   /** Latest trust snapshot per node id; missing key = first poll in flight. */
   statuses: Record<string, NodeTrustStatus>
+  /**
+   * Operator-only detail per node id (#707), present only when a read token is
+   * in use. Absent ⇒ the public read-only view (no operator panels).
+   */
+  operatorInfo?: Record<string, OperatorFetchResult<OperatorQuorumInfo>>
+  /** Fleet-level operator posture, from `useOperatorQuorumInfo`. */
+  operatorMode?: 'disabled' | 'active' | 'unauthorized' | 'not-enabled'
   className?: string
 }
 
@@ -21,7 +28,13 @@ export interface TrustDashboardProps {
  * surfaced as prominent banners above the grid (the #509 warn-don't-refuse
  * posture): the fleet is still running, but the operator must see it.
  */
-export function TrustDashboard({ nodes, statuses, className }: TrustDashboardProps) {
+export function TrustDashboard({
+  nodes,
+  statuses,
+  operatorInfo,
+  operatorMode = 'disabled',
+  className,
+}: TrustDashboardProps) {
   const statusList = nodes
     .map((n) => statuses[n.id])
     .filter((s): s is NodeTrustStatus => s !== undefined)
@@ -30,6 +43,7 @@ export function TrustDashboard({ nodes, statuses, className }: TrustDashboardPro
 
   return (
     <div className={`space-y-4 ${className ?? ''}`}>
+      <OperatorModeBanner mode={operatorMode} />
       {summary.intersectionRefusedNodeIds.length > 0 && (
         <WarningBanner
           icon={<AlertTriangle className="h-5 w-5 shrink-0" />}
@@ -62,9 +76,65 @@ export function TrustDashboard({ nodes, statuses, className }: TrustDashboardPro
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {nodes.map((node) => (
-          <TrustNodeCard key={node.id} node={node} status={statuses[node.id]} />
+          <TrustNodeCard
+            key={node.id}
+            node={node}
+            status={statuses[node.id]}
+            operatorInfo={operatorInfo?.[node.id]}
+          />
         ))}
       </div>
+    </div>
+  )
+}
+
+/**
+ * A small banner announcing the operator posture (#707): whether the view is
+ * the public read-only one, an active operator session, an expired link, or a
+ * fleet with no operator surface. `disabled` renders nothing — the public view
+ * needs no chrome.
+ */
+function OperatorModeBanner({
+  mode,
+}: {
+  mode: 'disabled' | 'active' | 'unauthorized' | 'not-enabled'
+}) {
+  if (mode === 'disabled') return null
+
+  if (mode === 'active') {
+    return (
+      <div
+        className="flex items-center gap-2 rounded border border-[--color-pulse]/40 bg-[--color-pulse]/10 p-2 text-xs text-[--color-pulse]"
+        role="status"
+      >
+        <Lock className="h-3.5 w-3.5 shrink-0" />
+        Operator view — showing per-peer classification and configured quorum
+        members (read-only).
+      </div>
+    )
+  }
+  if (mode === 'unauthorized') {
+    return (
+      <div
+        className="flex items-center gap-2 rounded border border-[--color-warning]/40 bg-[--color-warning]/10 p-2 text-xs text-[--color-warning]"
+        role="status"
+      >
+        <Lock className="h-3.5 w-3.5 shrink-0" />
+        Operator link expired or invalid — showing the public read-only view.
+        Mint a fresh link with{' '}
+        <code className="font-mono">botho operator mint-read-link</code>.
+      </div>
+    )
+  }
+  // not-enabled
+  return (
+    <div
+      className="flex items-center gap-2 rounded border border-[--color-slate] p-2 text-xs text-[--color-dim]"
+      role="status"
+    >
+      <Lock className="h-3.5 w-3.5 shrink-0" />
+      Operator reads are not enabled on these nodes — showing the public
+      read-only view.
     </div>
   )
 }

--- a/web/packages/features/src/operator/components/trust-node-card.tsx
+++ b/web/packages/features/src/operator/components/trust-node-card.tsx
@@ -1,12 +1,22 @@
 import { Card, CardContent } from '@botho/ui'
-import { AlertTriangle, Server, ShieldAlert, ShieldCheck, WifiOff } from 'lucide-react'
+import { AlertTriangle, Lock, Server, ShieldAlert, ShieldCheck, WifiOff } from 'lucide-react'
 import type { FleetNode } from '../../network/types'
-import type { NodeTrustStatus, TrustPeer } from '../types'
+import type {
+  NodeTrustStatus,
+  OperatorFetchResult,
+  OperatorQuorumInfo,
+  TrustPeer,
+} from '../types'
 
 export interface TrustNodeCardProps {
   node: FleetNode
   /** Trust snapshot; undefined while the first poll is in flight. */
   status?: NodeTrustStatus
+  /**
+   * Operator-only detail (#707) for this node, present only when a read token
+   * is being used. `undefined` ⇒ public read-only view (no operator panel).
+   */
+  operatorInfo?: OperatorFetchResult<OperatorQuorumInfo>
   className?: string
 }
 
@@ -20,7 +30,12 @@ export interface TrustNodeCardProps {
  * zero. `quorumGateIntersectionRefused` and `quorumDegenerate` render as
  * prominent warnings.
  */
-export function TrustNodeCard({ node, status, className }: TrustNodeCardProps) {
+export function TrustNodeCard({
+  node,
+  status,
+  operatorInfo,
+  className,
+}: TrustNodeCardProps) {
   if (status && !status.reachable) {
     return (
       <Card className={`border-[--color-danger]/40 ${className ?? ''}`}>
@@ -93,10 +108,127 @@ export function TrustNodeCard({ node, status, className }: TrustNodeCardProps) {
             </div>
 
             <PeerTable peers={status.peers} />
+            <OperatorDetail info={operatorInfo} />
           </>
         )}
       </CardContent>
     </Card>
+  )
+}
+
+/**
+ * Operator-only detail (#707), rendered ONLY when a read token is in use.
+ *
+ * Shows the configured `[network.quorum]` members panel and per-peer
+ * classification badges (curated / auto / suppressed) — data the public
+ * surface deliberately withholds. Degrades explicitly:
+ *   - `unauthorized`: the token was rejected — prompt for a fresh link.
+ *   - `not-enabled`: this node has no operator surface — say so, don't nag.
+ *   - `perPeer` absent: the gate has not evaluated yet ("—", anti-#541).
+ */
+function OperatorDetail({ info }: { info?: OperatorFetchResult<OperatorQuorumInfo> }) {
+  if (!info) return null
+
+  if (info.status === 'unauthorized') {
+    return (
+      <div className="mt-3 flex items-center gap-2 rounded border border-[--color-warning]/40 bg-[--color-warning]/10 p-2 text-xs text-[--color-warning]">
+        <Lock className="h-3.5 w-3.5 shrink-0" />
+        Operator link expired or invalid — mint a fresh link to view trust internals.
+      </div>
+    )
+  }
+  if (info.status === 'not-enabled') {
+    return (
+      <p className="mt-3 text-xs text-[--color-dim]">
+        Operator reads not enabled on this node.
+      </p>
+    )
+  }
+  if (info.status === 'unreachable') {
+    return (
+      <p className="mt-3 flex items-center gap-2 text-xs text-[--color-danger]">
+        <WifiOff className="h-3.5 w-3.5 shrink-0" />
+        Operator detail unavailable (operator_getQuorumInfo failed)
+      </p>
+    )
+  }
+
+  const q = info.data
+  const pp = q.perPeer
+  return (
+    <div className="mt-3 rounded border border-[--color-pulse]/30 bg-[--color-pulse]/5 p-2.5">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-[--color-pulse]">
+        <Lock className="h-3.5 w-3.5 shrink-0" /> Operator detail
+      </div>
+
+      <div className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-xs">
+        <Stat label="Mode" value={q.mode} />
+        <Stat label="Fault model" value={q.faultModel} />
+        <Stat label="Threshold" value={q.threshold.toLocaleString()} />
+        <Stat label="Min peers" value={q.minPeers.toLocaleString()} />
+      </div>
+
+      <div className="mt-2 text-xs text-[--color-dim]">
+        Configured members ({q.members.length})
+      </div>
+      {q.members.length === 0 ? (
+        <p className="text-xs text-[--color-dim]">No curated members configured</p>
+      ) : (
+        <ul className="mt-0.5 space-y-0.5">
+          {q.members.map((m) => (
+            <li key={m} className="truncate font-mono text-xs text-[--color-light]" title={m}>
+              {m}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-2 text-xs text-[--color-dim]">Per-peer classification</div>
+      {pp === undefined ? (
+        <p className="text-xs text-[--color-dim]">— no gate evaluation yet</p>
+      ) : (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {pp.curated.map((p) => (
+            <ClassBadge key={`c-${p}`} peerId={p} kind="curated" />
+          ))}
+          {pp.auto.map((p) => (
+            <ClassBadge key={`a-${p}`} peerId={p} kind="auto" />
+          ))}
+          {pp.suppressed.map((p) => (
+            <ClassBadge key={`s-${p}`} peerId={p} kind="suppressed" />
+          ))}
+          {pp.curated.length + pp.auto.length + pp.suppressed.length === 0 && (
+            <span className="text-xs text-[--color-dim]">No connected peers classified</span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** A per-peer classification badge, colored by kind. */
+function ClassBadge({
+  peerId,
+  kind,
+}: {
+  peerId: string
+  kind: 'curated' | 'auto' | 'suppressed'
+}) {
+  const style =
+    kind === 'curated'
+      ? 'bg-[--color-pulse]/15 text-[--color-pulse]'
+      : kind === 'auto'
+        ? 'bg-[--color-warning]/15 text-[--color-warning]'
+        : 'bg-[--color-danger]/15 text-[--color-danger]'
+  const short = peerId.length > 12 ? `${peerId.slice(0, 8)}…${peerId.slice(-4)}` : peerId
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[10px] ${style}`}
+      title={`${peerId} (${kind})`}
+    >
+      <span className="uppercase">{kind}</span>
+      <span className="text-[--color-light]">{short}</span>
+    </span>
   )
 }
 

--- a/web/packages/features/src/operator/hooks.ts
+++ b/web/packages/features/src/operator/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import type { FleetNode } from '../network/types'
-import { fetchTrustStatuses } from './quorum'
-import type { NodeTrustStatus } from './types'
+import { fetchOperatorQuorumInfo, fetchTrustStatuses } from './quorum'
+import type { NodeTrustStatus, OperatorFetchResult, OperatorQuorumInfo } from './types'
 
 /**
  * Polling hook for the operator trust view (#706), mirroring
@@ -48,4 +48,75 @@ export function useTrustStatus(
   }, [nodes, pollMs])
 
   return { statuses }
+}
+
+export interface UseOperatorQuorumInfoResult {
+  /** Per-node operator fetch result; missing key = first poll in flight. */
+  info: Record<string, OperatorFetchResult<OperatorQuorumInfo>>
+  /**
+   * Fleet-level operator posture, derived from the per-node results:
+   *   - `disabled`: no token is present, so we never call the operator RPCs.
+   *   - `active`: at least one node returned operator data for the token.
+   *   - `unauthorized`: a token is present but every reachable node rejected
+   *     it (expired / wrong secret) — prompt for a fresh link.
+   *   - `not-enabled`: a token is present but no node exposes the operator
+   *     surface — nothing to unlock here.
+   */
+  mode: 'disabled' | 'active' | 'unauthorized' | 'not-enabled'
+}
+
+/**
+ * Poll every node's operator-only `operator_getQuorumInfo` using `token`
+ * (#707). When `token` is falsy the hook does nothing and reports
+ * `mode: 'disabled'` — the dashboard then renders the public read-only view.
+ *
+ * Callers must pass a referentially-stable `nodes` array (module-level
+ * constant) — it is an effect dependency.
+ */
+export function useOperatorQuorumInfo(
+  nodes: FleetNode[],
+  token: string | null,
+  { pollMs = 30_000 }: UseTrustStatusOptions = {},
+): UseOperatorQuorumInfoResult {
+  const [info, setInfo] = useState<Record<string, OperatorFetchResult<OperatorQuorumInfo>>>({})
+
+  useEffect(() => {
+    if (!token) {
+      setInfo({})
+      return
+    }
+    let cancelled = false
+    const poll = async () => {
+      const results = await Promise.all(
+        nodes.map(async (n) => [n.id, await fetchOperatorQuorumInfo(n, token)] as const),
+      )
+      if (cancelled) return
+      setInfo(Object.fromEntries(results))
+    }
+    poll()
+    const id = setInterval(poll, pollMs)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [nodes, token, pollMs])
+
+  const results = Object.values(info)
+  let mode: UseOperatorQuorumInfoResult['mode']
+  if (!token) {
+    mode = 'disabled'
+  } else if (results.some((r) => r.status === 'ok')) {
+    mode = 'active'
+  } else if (results.length > 0 && results.every((r) => r.status === 'not-enabled')) {
+    mode = 'not-enabled'
+  } else if (results.some((r) => r.status === 'unauthorized')) {
+    mode = 'unauthorized'
+  } else {
+    // A token is present but no result has landed yet (first poll in flight) or
+    // every node was unreachable — treat as active-pending so the UI shows the
+    // operator affordance rather than flashing the public view.
+    mode = 'active'
+  }
+
+  return { info, mode }
 }

--- a/web/packages/features/src/operator/index.ts
+++ b/web/packages/features/src/operator/index.ts
@@ -1,6 +1,7 @@
 export * from './types'
 export * from './quorum'
 export * from './hooks'
+export * from './token'
 export { TrustNodeCard, type TrustNodeCardProps } from './components/trust-node-card'
 export {
   TrustDashboard,

--- a/web/packages/features/src/operator/quorum.test.ts
+++ b/web/packages/features/src/operator/quorum.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
-import { deriveTrustSummary, fetchNodeTrustStatus } from './quorum'
+import { deriveTrustSummary, fetchNodeTrustStatus, fetchOperatorQuorumInfo } from './quorum'
 import type { NodeTrustStatus } from './types'
 
 const node = { id: 'seed', name: 'Seed (validator)', rpcEndpoint: 'https://seed.test/rpc' }
@@ -204,5 +204,64 @@ describe('deriveTrustSummary', () => {
     expect(s.intersectionRefusedNodeIds).toEqual([])
     expect(s.degenerateNodeIds).toEqual([])
     expect(s.faultTolerantCount).toBe(0)
+  })
+})
+
+describe('fetchOperatorQuorumInfo (#707)', () => {
+  const QUORUM_OK = {
+    quorum: {
+      mode: 'recommended',
+      faultModel: 'crash',
+      threshold: 2,
+      members: ['12D3KooWCurated'],
+      minPeers: 1,
+      maxAutoMembers: 8,
+    },
+    perPeer: {
+      curated: ['12D3KooWCurated'],
+      auto: ['12D3KooWAuto'],
+      suppressed: ['12D3KooWSuppressed'],
+    },
+  }
+
+  it('parses a successful response including per-peer classification', async () => {
+    stubRpc({ operator_getQuorumInfo: { result: QUORUM_OK } })
+    const r = await fetchOperatorQuorumInfo(node, 'op.9999999999.sig')
+    expect(r.status).toBe('ok')
+    if (r.status === 'ok') {
+      expect(r.data.mode).toBe('recommended')
+      expect(r.data.members).toEqual(['12D3KooWCurated'])
+      expect(r.data.perPeer).toEqual({
+        curated: ['12D3KooWCurated'],
+        auto: ['12D3KooWAuto'],
+        suppressed: ['12D3KooWSuppressed'],
+      })
+    }
+  })
+
+  it('maps perPeer:null (no gate evaluation yet) to undefined — never fabricated', async () => {
+    stubRpc({
+      operator_getQuorumInfo: { result: { ...QUORUM_OK, perPeer: null } },
+    })
+    const r = await fetchOperatorQuorumInfo(node, 'tok')
+    expect(r.status).toBe('ok')
+    if (r.status === 'ok') expect(r.data.perPeer).toBeUndefined()
+  })
+
+  it('reports not-enabled on the -32020 error code', async () => {
+    stubRpc({ operator_getQuorumInfo: { error: { code: -32020 } } })
+    expect((await fetchOperatorQuorumInfo(node, 'tok')).status).toBe('not-enabled')
+  })
+
+  it('reports unauthorized on the -32021 error code (missing/expired/tampered)', async () => {
+    stubRpc({ operator_getQuorumInfo: { error: { code: -32021 } } })
+    expect((await fetchOperatorQuorumInfo(node, 'tok')).status).toBe('unauthorized')
+    // A null token still calls the node and surfaces its rejection.
+    expect((await fetchOperatorQuorumInfo(node, null)).status).toBe('unauthorized')
+  })
+
+  it('reports unreachable when the call throws — never throws into the poller', async () => {
+    stubRpc({ operator_getQuorumInfo: new Error('boom') })
+    expect((await fetchOperatorQuorumInfo(node, 'tok')).status).toBe('unreachable')
   })
 })

--- a/web/packages/features/src/operator/quorum.ts
+++ b/web/packages/features/src/operator/quorum.ts
@@ -1,5 +1,16 @@
 import type { FleetNode } from '../network/types'
-import type { NodeTrustStatus, TrustPeer, TrustSummary } from './types'
+import type {
+  NodeTrustStatus,
+  OperatorFetchResult,
+  OperatorQuorumInfo,
+  PerPeerClassification,
+  TrustPeer,
+  TrustSummary,
+} from './types'
+
+/** Node RPC error codes for the operator surface (`botho/src/rpc/mod.rs`). */
+const OPERATOR_NOT_ENABLED = -32020
+const OPERATOR_TOKEN_REJECTED = -32021
 
 /**
  * Fetch + derive for the operator trust view (#706).
@@ -116,6 +127,91 @@ export async function fetchNodeTrustStatus(
 /** Poll the whole fleet concurrently; one slow/dead node never blocks the rest. */
 export async function fetchTrustStatuses(nodes: FleetNode[]): Promise<NodeTrustStatus[]> {
   return Promise.all(nodes.map((n) => fetchNodeTrustStatus(n)))
+}
+
+/** Parse a string array field, dropping non-strings. `null`/absent ⇒ undefined. */
+function asStringArray(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined
+  return v.filter((x): x is string => typeof x === 'string')
+}
+
+/**
+ * Parse the `perPeer` object from `operator_getQuorumInfo`. The node reports
+ * `null` until the first gate evaluation — we map that (and any malformed
+ * shape) to `undefined`, so the UI shows "no evaluation yet" rather than an
+ * empty classification (anti-#541).
+ */
+function parsePerPeer(v: unknown): PerPeerClassification | undefined {
+  if (!v || typeof v !== 'object') return undefined
+  const o = v as Record<string, unknown>
+  const curated = asStringArray(o.curated)
+  const auto = asStringArray(o.auto)
+  const suppressed = asStringArray(o.suppressed)
+  if (curated === undefined || auto === undefined || suppressed === undefined) return undefined
+  return { curated, auto, suppressed }
+}
+
+/**
+ * Fetch the operator-only `operator_getQuorumInfo` for one node with a hard
+ * timeout. Distinguishes not-enabled / unauthorized / unreachable so the UI
+ * degrades correctly (see [`OperatorFetchResult`]).
+ *
+ * The token is passed straight through as a param; the NODE verifies it. An
+ * empty/absent token still calls the node, which rejects it — so the
+ * `unauthorized` path is exercised identically whether the token is missing or
+ * simply wrong.
+ */
+export async function fetchOperatorQuorumInfo(
+  node: FleetNode,
+  token: string | null,
+  timeoutMs = 5000,
+): Promise<OperatorFetchResult<OperatorQuorumInfo>> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(node.rpcEndpoint, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'operator_getQuorumInfo',
+        params: { token: token ?? '' },
+        id: 1,
+      }),
+    })
+    if (!response.ok) return { status: 'unreachable' }
+    const json = (await response.json()) as {
+      result?: Record<string, unknown>
+      error?: { code?: number }
+    }
+    if (json.error) {
+      if (json.error.code === OPERATOR_NOT_ENABLED) return { status: 'not-enabled' }
+      if (json.error.code === OPERATOR_TOKEN_REJECTED) return { status: 'unauthorized' }
+      return { status: 'unreachable' }
+    }
+    const result = json.result
+    if (!result || typeof result !== 'object') return { status: 'unreachable' }
+    const quorum = result.quorum as Record<string, unknown> | undefined
+    if (!quorum || typeof quorum !== 'object') return { status: 'unreachable' }
+
+    return {
+      status: 'ok',
+      data: {
+        mode: typeof quorum.mode === 'string' ? quorum.mode : 'unknown',
+        faultModel: typeof quorum.faultModel === 'string' ? quorum.faultModel : 'unknown',
+        threshold: asNumber(quorum.threshold) ?? 0,
+        members: asStringArray(quorum.members) ?? [],
+        minPeers: asNumber(quorum.minPeers) ?? 0,
+        maxAutoMembers: asNumber(quorum.maxAutoMembers) ?? 0,
+        perPeer: parsePerPeer(result.perPeer),
+      },
+    }
+  } catch {
+    return { status: 'unreachable' }
+  } finally {
+    clearTimeout(timeoutId)
+  }
 }
 
 /**

--- a/web/packages/features/src/operator/token.test.ts
+++ b/web/packages/features/src/operator/token.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Operator read-token capture (#707): the magic-link token is lifted from the
+ * URL fragment into sessionStorage and stripped from the address bar, so the
+ * bearer credential is neither persisted to disk nor left in the URL.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { captureOperatorToken, clearOperatorToken, getStoredOperatorToken } from './token'
+
+const TOKEN = 'op.1799999999.deadbeefcafef00d'
+
+beforeEach(() => {
+  window.sessionStorage.clear()
+  window.history.replaceState(null, '', '/operator')
+})
+afterEach(() => {
+  window.sessionStorage.clear()
+})
+
+describe('captureOperatorToken', () => {
+  it('lifts a #token fragment into sessionStorage and strips it from the URL', () => {
+    window.history.replaceState(null, '', `/operator#token=${TOKEN}`)
+    const captured = captureOperatorToken()
+    expect(captured).toBe(TOKEN)
+    expect(getStoredOperatorToken()).toBe(TOKEN)
+    // The fragment is stripped so the credential doesn't linger in the URL.
+    expect(window.location.hash).toBe('')
+  })
+
+  it('returns the previously stored token when no fragment is present', () => {
+    window.sessionStorage.setItem('botho.operator.readToken', TOKEN)
+    expect(captureOperatorToken()).toBe(TOKEN)
+  })
+
+  it('returns null when neither a fragment nor a stored token exists', () => {
+    expect(captureOperatorToken()).toBeNull()
+  })
+
+  it('ignores an empty #token= fragment', () => {
+    window.history.replaceState(null, '', '/operator#token=')
+    expect(captureOperatorToken()).toBeNull()
+  })
+
+  it('clearOperatorToken forgets the stored token', () => {
+    window.sessionStorage.setItem('botho.operator.readToken', TOKEN)
+    clearOperatorToken()
+    expect(getStoredOperatorToken()).toBeNull()
+  })
+})

--- a/web/packages/features/src/operator/token.ts
+++ b/web/packages/features/src/operator/token.ts
@@ -1,0 +1,67 @@
+/**
+ * Operator read-token capture + session storage (#707, P4.2 of #695).
+ *
+ * The node mints a magic-link READ token (`botho operator mint-read-link`) and
+ * the operator opens `https://<dashboard>/operator#token=op.<exp>.<hmac>`. This
+ * module lifts that token out of the URL fragment into `sessionStorage` and
+ * strips it from the address bar, so:
+ *   - the credential is never persisted to disk (sessionStorage clears when the
+ *     tab closes) — the #474 no-plaintext-at-rest posture, applied to a bearer
+ *     read credential;
+ *   - it is not left sitting in `location.href` (browser history / referer).
+ *
+ * The token is opaque to the client: only the NODE verifies it (constant-time
+ * HMAC, signature-before-expiry). The dashboard just carries it as a `token`
+ * param on `operator_*` calls and degrades gracefully to the public read-only
+ * view when it is absent or rejected.
+ */
+
+const STORAGE_KEY = 'botho.operator.readToken'
+const HASH_PREFIX = '#token='
+
+/** Best-effort `sessionStorage` access (guards SSR / privacy-mode throws). */
+function safeSession(): Storage | null {
+  try {
+    return typeof window !== 'undefined' ? window.sessionStorage : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Capture an operator token from the URL fragment (`#token=...`) into
+ * sessionStorage, then strip it from the address bar. Returns the effective
+ * token (freshly captured, or the previously stored one), or `null` if none.
+ *
+ * Idempotent: safe to call on every mount.
+ */
+export function captureOperatorToken(): string | null {
+  const store = safeSession()
+
+  if (typeof window !== 'undefined' && window.location.hash.startsWith(HASH_PREFIX)) {
+    const token = window.location.hash.slice(HASH_PREFIX.length).trim()
+    if (token) {
+      store?.setItem(STORAGE_KEY, token)
+      // Strip the fragment so the credential doesn't linger in the URL.
+      try {
+        const url = window.location.pathname + window.location.search
+        window.history.replaceState(null, '', url)
+      } catch {
+        // Non-fatal: worst case the token stays in the hash for this load.
+      }
+      return token
+    }
+  }
+
+  return store?.getItem(STORAGE_KEY) ?? null
+}
+
+/** The stored operator token, if any. Does not read the URL fragment. */
+export function getStoredOperatorToken(): string | null {
+  return safeSession()?.getItem(STORAGE_KEY) ?? null
+}
+
+/** Forget the stored operator token (sign-out / after a rejection). */
+export function clearOperatorToken(): void {
+  safeSession()?.removeItem(STORAGE_KEY)
+}

--- a/web/packages/features/src/operator/types.ts
+++ b/web/packages/features/src/operator/types.ts
@@ -63,6 +63,52 @@ export interface NodeTrustStatus {
   peers?: TrustPeer[]
 }
 
+/**
+ * Per-peer gate classification from the operator-only `operator_getQuorumInfo`
+ * (#707). `undefined` (not empty arrays) when the node has not yet run a gate
+ * evaluation — the node reports `perPeer: null` and we preserve that "no data"
+ * distinction (anti-#541).
+ */
+export interface PerPeerClassification {
+  /** Connected curated (operator-listed) members admitted by the gate. */
+  curated: string[]
+  /** Connected auto-discovered peers promoted into the quorum set. */
+  auto: string[]
+  /** Connected non-curated peers the gate is keeping OUT of the quorum. */
+  suppressed: string[]
+}
+
+/**
+ * Configured `[network.quorum]` contents for one node, from the operator-only
+ * `operator_getQuorumInfo` (#707). These are the gate's INPUTS the public
+ * surface does not expose.
+ */
+export interface OperatorQuorumInfo {
+  mode: string
+  faultModel: string
+  threshold: number
+  /** Operator-curated member PeerId strings. */
+  members: string[]
+  minPeers: number
+  maxAutoMembers: number
+  /** Per-peer classification, or `undefined` until the first gate evaluation. */
+  perPeer?: PerPeerClassification
+}
+
+/**
+ * Result of an operator-only fetch. Distinguishes the three states the
+ * token-gated read can be in, so the UI degrades correctly:
+ *   - `not-enabled`: the node has no `[rpc.operator]` config — operator reads
+ *     are impossible here; render the public view without an "expired" nag.
+ *   - `unauthorized`: token missing / rejected / expired — prompt for a link.
+ *   - `unreachable`: the call itself failed (transport/timeout).
+ */
+export type OperatorFetchResult<T> =
+  | { status: 'ok'; data: T }
+  | { status: 'not-enabled' }
+  | { status: 'unauthorized' }
+  | { status: 'unreachable' }
+
 /** Fleet-level trust facts derived from the live snapshots (pure function). */
 export interface TrustSummary {
   /** Reachable node count. */

--- a/web/packages/web-wallet/src/pages/operator.tsx
+++ b/web/packages/web-wallet/src/pages/operator.tsx
@@ -2,10 +2,12 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Logo } from '@botho/ui'
 import {
+  captureOperatorToken,
   NetworkDashboard,
   TrustDashboard,
   useFleetHistory,
   useFleetStatus,
+  useOperatorQuorumInfo,
   useTrustStatus,
 } from '@botho/features'
 import { ArrowLeft } from 'lucide-react'
@@ -27,6 +29,9 @@ type OperatorTab = 'fleet' | 'trust'
 
 export function OperatorPage() {
   const [tab, setTab] = useState<OperatorTab>('fleet')
+  // Lift any magic-link read token out of the URL fragment into sessionStorage
+  // on mount (#707), then strip it from the address bar. Null ⇒ public view.
+  const [token] = useState<string | null>(() => captureOperatorToken())
 
   return (
     <div className="min-h-screen">
@@ -68,7 +73,7 @@ export function OperatorPage() {
             </TabButton>
           </div>
 
-          {tab === 'fleet' ? <FleetTab /> : <TrustTab />}
+          {tab === 'fleet' ? <FleetTab /> : <TrustTab token={token} />}
         </div>
       </main>
     </div>
@@ -116,7 +121,21 @@ function FleetTab() {
   )
 }
 
-function TrustTab() {
+/**
+ * Trust tab (#706), upgraded for #707: when a valid read token is present it
+ * additionally polls `operator_getQuorumInfo` and renders per-peer
+ * classification badges + the configured-members panel. Without a token it
+ * degrades cleanly to the public read-only view.
+ */
+function TrustTab({ token }: { token: string | null }) {
   const { statuses } = useTrustStatus(FLEET)
-  return <TrustDashboard nodes={FLEET} statuses={statuses} />
+  const { info, mode } = useOperatorQuorumInfo(FLEET, token)
+  return (
+    <TrustDashboard
+      nodes={FLEET}
+      statuses={statuses}
+      operatorInfo={token ? info : undefined}
+      operatorMode={mode}
+    />
+  )
 }


### PR DESCRIPTION
Implements **P4.2** of the #695 architecture proposal (read path governed by `docs/security/quorum-write-path.md` §2). Adds a node-verified, expiring, **READ-ONLY** magic-link token that unlocks operator-only trust internals the public RPC must not expose. Deliberately grants **zero** write capability — the write path is #709 and is untouched here.

Closes #707

## Token format & verification
```
op.<expUnixSeconds>.<hmacSha256Hex(secret, "op.<exp>")>
```
- Secret = new `[rpc.operator] read_token_secret` in `config.toml` (serde-default). **Absent ⇒ the whole operator feature is OFF**: `operator_*` RPCs return a clean `-32020` "not enabled" error and the node behaves exactly as today (acceptance criterion 1, tested).
- Verification **reuses the single audited HMAC path** in `botho/src/rpc/auth.rs` (`HmacSha256` + `constant_time_eq`) — no second hand-rolled HMAC.
- **Signature is verified BEFORE the expiry is trusted** (parity with `status-link.ts`): the HMAC covers `"op.<exp>"`, so tampering with the unauthenticated `exp` fails the constant-time compare first. Internal `OperatorTokenError` enum lets tests assert the order; the RPC collapses ALL failures (`missing`/`malformed`/`expired`/`forged`) to one **generic** `-32021` reason — no oracle. Default TTL 7 days.

## New operator READ RPCs (token required; fail closed)
- **`operator_getQuorumInfo`**: configured `[network.quorum]` contents (mode, fault model, threshold, members, min_peers, max_auto_members) + **per-peer classification** (curated / auto-promoted / suppressed).
- **`operator_getAuditLog`**: returns the operator audit log — present-but-empty store (`OperatorAuditLog`); #709 wires the append side.

## Per-peer gate-snapshot extension
`QuorumGateSnapshot` (`botho/src/consensus/service.rs`) previously carried **counts only**. It now also carries `curated_peer_ids` / `auto_peer_ids` / `suppressed_peer_ids` (base58 PeerId strings of the connected peers). These are produced **only** inside `gated_scp_quorum_set` (`botho/src/commands/run.rs`) — the same single source of truth as the counts, derived from the same `connected_curated` / `admitted_auto` / `auto_candidates` partition, so the lists cannot drift from the counts. They ride the existing publish path (initial seed + every churn rebuild) verbatim. The classification is **never recomputed** in the web tier or the RPC layer.

## Fail-closed / anti-#541
- Absent config → feature off; any token failure → one generic rejection.
- `perPeer` is **`null` until the first real gate evaluation**, never fabricated or zero-filled (the shared handle holds `None` until the gate runs). The web layer maps `perPeer: null` to `undefined` and renders "no gate evaluation yet".
- **Reads only**: no `operator_*` method mutates state. There is deliberately no `operator_submitAction` (a test asserts it is method-not-found even with a valid token). Constant-time HMAC compare; signature-before-expiry order.

## CLI
`botho operator mint-read-link` reads the secret from the config file and prints `https://<dashboard>/operator#token=...`. Fails closed when the secret is absent/empty.

## Web (`web/packages/features/src/operator/`)
Token captured from the URL fragment into `sessionStorage` and stripped from the address bar (bearer credential never persisted to disk / left in the URL). The Trust tab (#706/#711) upgrades to per-peer classification badges + a configured-members panel when a valid token is present, and degrades cleanly to the public read-only view — with explicit `expired-link` and `not-enabled` banners — without one.

## Test coverage
- **Rust unit** (`auth.rs`): mint→verify round trip; missing/malformed/wrong-subject/non-integer-exp; tampered signature; wrong secret; expired; **signature-checked-before-expiry** (both-bad ⇒ reports signature failure).
- **Rust unit** (`commands/operator.rs`): CLI mint round-trip against a config file; trailing-slash normalization; refuses without/with-empty secret.
- **Rust integration** (`rpc_integration.rs`): no-config→disabled (public surface unchanged); missing/malformed/expired/tampered/wrong-secret→identical generic rejection; perPeer null-until-evaluated; perPeer populated-after-evaluation; audit log empty-but-present; token grants no write method.
- **Web** (`vitest`): token capture (fragment→sessionStorage, hash stripped, stored/cleared); `fetchOperatorQuorumInfo` mapping of ok / perPeer-null / not-enabled / unauthorized / unreachable; TrustDashboard public-vs-operator states, per-peer badges, expired-link and not-enabled degradation.

`cargo test -p botho --lib` (1147) and `--test rpc_integration` (46) green; `pnpm -r typecheck` + web `vitest` (656) green; nightly rustfmt applied.

## For the reviewer to scrutinize (consensus-node auth code)
- `verify_operator_read_token` in `botho/src/rpc/auth.rs` — the signature-before-expiry ordering and the constant-time compare (this is the whole security property).
- `operator_read_gate` in `botho/src/rpc/mod.rs` — that the generic rejection genuinely leaks nothing and that no operator method is reachable that could mutate state.
- The per-peer lists in `gated_scp_quorum_set` (`run.rs`) — that the classification matches the gate's actual admission decision and is the sole producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)