### PR TITLE
fix(baas-worker): drop customer_creation param (invalid in subscription mode)

### DIFF
--- a/web/packages/baas-worker/src/checkout.test.ts
+++ b/web/packages/baas-worker/src/checkout.test.ts
@@ -143,8 +143,8 @@ describe('buildCheckoutSessionParams', () => {
     expect(params.get('subscription_data[metadata][region]')).toBe('us-west-2')
   })
 
-  it('always creates a customer for renewals/portal', () => {
-    expect(params.get('customer_creation')).toBe('always')
+  it('does not set customer_creation (subscription mode creates a Customer implicitly; Stripe rejects the param)', () => {
+    expect(params.has('customer_creation')).toBe(false)
   })
 
   it('omits customer_email when no email given', () => {

--- a/web/packages/baas-worker/src/checkout.ts
+++ b/web/packages/baas-worker/src/checkout.ts
@@ -166,8 +166,9 @@ export function buildCheckoutSessionParams(
     params.set('customer_email', req.email)
   }
 
-  // Let Stripe create/reuse a Customer so renewals + the customer portal work.
-  params.set('customer_creation', 'always')
+  // Subscription mode always creates a Customer (so renewals + the customer
+  // portal work) — `customer_creation` is a payment-mode-only param and Stripe
+  // rejects it here, so we don't set it.
   params.set('billing_address_collection', 'auto')
 
   return params

--- a/web/packages/baas-worker/wrangler.toml
+++ b/web/packages/baas-worker/wrangler.toml
@@ -51,7 +51,7 @@ crons = ["*/15 * * * *"]
 [[d1_databases]]
 binding = "DB"
 database_name = "botho-baas"
-database_id = "REPLACE_WITH_D1_DATABASE_ID"
+database_id = "876905b5-a42f-4735-b888-4f9e898751c6"
 
 [vars]
 # Where Stripe redirects after a successful / cancelled checkout. These point at


### PR DESCRIPTION
## Problem

Every `/checkout` call to the deployed BaaS worker returned `502 {"error":"could not create checkout session"}`. `wrangler tail` surfaced the real cause:

```
checkout: stripe error 400 `customer_creation` can only be used in `payment` mode.
```

The checkout session is created in `subscription` mode, but `createCheckoutParams` unconditionally set `customer_creation=always` — a param Stripe only accepts in `payment` mode.

## Fix

- Remove `customer_creation`. Subscription mode **always** creates a Customer, so renewals and the customer portal keep working; the param was redundant and fatal.
- Invert the unit test that pinned the buggy behavior (`always creates a customer` → asserts the param is absent).
- Wire the D1 `DB` binding to the live `botho-baas` database id (was the `REPLACE_WITH_D1_DATABASE_ID` placeholder) so the deployed worker resolves its database.

## Verification

- `vitest run packages/baas-worker/src/checkout.test.ts` → **26/26 pass**
- Live `/checkout` on the deployed worker (Stripe **TEST** mode) now returns a real `cs_test_…` session id + `https://checkout.stripe.com/...` URL.

Part of the #721 go-to-live wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)