### PR TITLE
chore(web): consolidate onto a single "botho" Pages project at botho.io

### DIFF
--- a/web/packages/baas-worker/wrangler.toml
+++ b/web/packages/baas-worker/wrangler.toml
@@ -63,7 +63,7 @@ ALLOWED_ORIGINS = "https://botho.io,https://wallet.botho.io"
 
 # --- status page / magic-link lookup (P6.3, #458 §4/§6) -------------------
 # Wallet origin used to build the "open in wallet" deep link (#458 §3 step 5).
-WALLET_BASE_URL = "https://wallet.botho.io"
+WALLET_BASE_URL = "https://botho.io"
 # Where Stripe returns the user after they close the Customer Portal.
 PORTAL_RETURN_URL = "https://botho.io/rig/status"
 

--- a/web/packages/web-wallet/package.json
+++ b/web/packages/web-wallet/package.json
@@ -10,8 +10,8 @@
     "build:all": "pnpm build:wasm && pnpm build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "deploy": "pnpm build && wrangler pages deploy dist --project-name=botho-wallet",
-    "deploy:all": "pnpm build:all && wrangler pages deploy dist --project-name=botho-wallet"
+    "deploy": "pnpm build && wrangler pages deploy dist --project-name=botho",
+    "deploy:all": "pnpm build:all && wrangler pages deploy dist --project-name=botho"
   },
   "dependencies": {
     "@botho/adapters": "workspace:*",

--- a/web/packages/web-wallet/wrangler.toml
+++ b/web/packages/web-wallet/wrangler.toml
@@ -5,7 +5,7 @@
 # which runs `wrangler pages deploy dist --project-name=botho-wallet`.
 #
 # Requires CLOUDFLARE_API_TOKEN with the "Cloudflare Pages: Edit" permission.
-name = "botho-wallet"
+name = "botho"
 compatibility_date = "2024-01-01"
 
 # Pages serves the built SPA from dist/ (Vite build output).


### PR DESCRIPTION
## Why

Two Cloudflare Pages projects were serving the same SPA — `botho` (botho.io) and `botho-wallet` (wallet.botho.io) — but `pnpm --filter @botho/web-wallet deploy` only targeted **`botho-wallet`**. So **botho.io silently froze on a ~3-week-old build** while wallet.botho.io stayed current. That stale build is why botho.io showed phantom "Received / +0.00 BTH / 0 conf" transactions dated **year 58486**: it predates #685, which fixed the `timestamp: Date.now()` (ms-read-as-seconds → `new Date(ms*1000)`) bug, the hardcoded 0-confirmations, and the un-netted per-output rows.

## Changes (code)

- Repoint `deploy` / `deploy:all` scripts **and** the Pages project `name` from `botho-wallet` → **`botho`**, so future deploys land on botho.io and can't drift again.
- Point `WALLET_BASE_URL` (the node "open in wallet" deep link) at `https://botho.io`.

## Live infra done alongside (production)

- Redeployed the **current** main build to the `botho` project → botho.io now serves the fixed build (`index-BWECip6c.js`); phantom transactions gone.
- Retired **wallet.botho.io** entirely per product decision: removed the Pages custom domain, deleted its DNS record, and deleted the `botho-wallet` project. Only the `botho` project remains.

## Follow-up

The BaaS worker's deployed `WALLET_BASE_URL` var still reads `wallet.botho.io` until the worker is redeployed (bundled with the rig→node infra sync). No user impact yet — no nodes are provisioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)