### PR TITLE
docs(web-wallet): point stale wallet.botho.io / botho-wallet Pages refs at botho.io

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -124,7 +124,7 @@ E2E_BROWSER_CHANNEL=chrome \
 
 The hermetic suite above can never catch a **deploy** regression (it builds the
 app fresh and mocks `/rpc`). The live-smoke suite (`e2e/tests/live/smoke.spec.ts`)
-drives the **deployed** wallet at `https://wallet.botho.io` against the **live**
+drives the **deployed** wallet at `https://botho.io` against the **live**
 testnet SCP nodes, catching exactly the class of bug a hermetic run misses — e.g.
 the wasm-404 when a build lands on a Pages preview instead of production and
 `/pkg/bth_wasm_signer_bg.wasm` stops being served.
@@ -151,7 +151,7 @@ client-side (address renders), and `/claim` loads its empty/invalid state.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `BOTHO_LIVE` | _(unset)_ | Must be `1` or the whole live suite is skipped. |
-| `BOTHO_LIVE_URL` | `https://wallet.botho.io` | Override the deployed wallet URL under test. |
+| `BOTHO_LIVE_URL` | `https://botho.io` | Override the deployed wallet URL under test. |
 
 No default on-chain steps run (testnet mints on demand + faucet rate limits +
 ~30–80s block time make a full faucet→send→claim cycle flaky); any such step

--- a/web/e2e/playwright.live.config.ts
+++ b/web/e2e/playwright.live.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
 
 /**
- * Live-smoke Playwright config — runs the deployed wallet (wallet.botho.io) +
+ * Live-smoke Playwright config — runs the deployed wallet (botho.io) +
  * the LIVE testnet, NOT a local build/mock.
  *
  * This is SEPARATE from playwright.config.ts on purpose:
@@ -17,10 +17,10 @@ import { defineConfig, devices } from '@playwright/test'
  *     BOTHO_LIVE=1 npx playwright test --config e2e/playwright.live.config.ts
  *
  * Override the target deployment with BOTHO_LIVE_URL (default
- * https://wallet.botho.io). This config is intentionally NOT wired into CI: it
+ * https://botho.io). This config is intentionally NOT wired into CI: it
  * hits live infrastructure and the faucet's rate limits.
  */
-const BASE_URL = process.env.BOTHO_LIVE_URL ?? 'https://wallet.botho.io'
+const BASE_URL = process.env.BOTHO_LIVE_URL ?? 'https://botho.io'
 
 export default defineConfig({
   testDir: './tests/live',

--- a/web/e2e/tests/live/smoke.spec.ts
+++ b/web/e2e/tests/live/smoke.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Live-smoke e2e — runs against the DEPLOYED wallet (https://wallet.botho.io)
+ * Live-smoke e2e — runs against the DEPLOYED wallet (https://botho.io)
  * and the LIVE testnet SCP nodes, complementing the hermetic local-mock suite.
  *
  * WHY THIS EXISTS
@@ -21,7 +21,7 @@
  *
  *   (or from web/e2e: `BOTHO_LIVE=1 npx playwright test --config playwright.live.config.ts`)
  *
- * Override the target with BOTHO_LIVE_URL (defaults to https://wallet.botho.io).
+ * Override the target with BOTHO_LIVE_URL (defaults to https://botho.io).
  * Without BOTHO_LIVE=1 every test in this file is skipped, so even if this file
  * were ever picked up by the default config it would be a no-op there.
  *
@@ -35,7 +35,7 @@ import { test, expect, type Page } from '@playwright/test'
 // CI / `pnpm test` (which hits live infra + faucet rate limits).
 const LIVE = process.env.BOTHO_LIVE === '1'
 
-const BASE_URL = process.env.BOTHO_LIVE_URL ?? 'https://wallet.botho.io'
+const BASE_URL = process.env.BOTHO_LIVE_URL ?? 'https://botho.io'
 
 // A vite DEV server does not emit /sw.js or the precache manifest — only a
 // built bundle does. Skip the PWA assertions when pointed at local dev so a
@@ -57,7 +57,7 @@ const TEST_MNEMONIC_12 =
 const NAV_TIMEOUT = 30_000
 const UI_TIMEOUT = 20_000
 
-test.describe('Live smoke @ wallet.botho.io', () => {
+test.describe('Live smoke @ botho.io', () => {
   test.skip(!LIVE, 'Set BOTHO_LIVE=1 to run the live-smoke suite (hits live infra + faucet limits).')
 
   // The deployed bundle dynamic-imports the wasm signer from /pkg/*; a 404 there

--- a/web/packages/core/src/wallet/claim-link.ts
+++ b/web/packages/core/src/wallet/claim-link.ts
@@ -10,7 +10,7 @@
  *
  * Link format (issue #460, architect "Option A"):
  *
- *   https://wallet.botho.io/claim#v1.<base58(16-byte entropy)>[.<amount-hint-pc>]
+ *   https://botho.io/claim#v1.<base58(16-byte entropy)>[.<amount-hint-pc>]
  *
  * - `v1`           one-char-ish version tag so the format can evolve.
  * - base58 entropy the 12-word (128-bit) mnemonic's raw 16-byte entropy,
@@ -136,7 +136,7 @@ export function encodeClaimLinkFragment(mnemonic: string, amountHint?: bigint): 
 /**
  * Build the full shareable claim URL for an ephemeral mnemonic.
  *
- * @param origin      e.g. `https://wallet.botho.io` (no trailing slash needed)
+ * @param origin      e.g. `https://botho.io` (no trailing slash needed)
  * @param mnemonic    the ephemeral 12-word mnemonic
  * @param amountHint  optional cosmetic picocredit hint
  */

--- a/web/packages/web-wallet/SECURITY.md
+++ b/web/packages/web-wallet/SECURITY.md
@@ -1,6 +1,6 @@
 # Botho Web Wallet — Security & Threat Model
 
-This document states honestly what the Botho web wallet (`wallet.botho.io`)
+This document states honestly what the Botho web wallet (`botho.io`)
 does and does not protect, so users can make an informed decision about how to
 hold value in it. It reflects the code as shipped, not aspirations.
 
@@ -51,7 +51,7 @@ If you create a wallet **without a password**, there is no vault key, so:
 Encryption-at-rest does not defend against an attacker who can run code on the
 origin or read process memory **while the wallet is unlocked**:
 
-- **XSS / malicious dependency.** Any JavaScript running on `wallet.botho.io`
+- **XSS / malicious dependency.** Any JavaScript running on `botho.io`
   can read `localStorage` and, once you have unlocked, the decrypted seed and
   vault key live in memory and can be read by that code. The at-rest encryption
   protects a *locked* wallet (cold storage, shared device, another extension
@@ -67,13 +67,13 @@ origin or read process memory **while the wallet is unlocked**:
   thin-client privacy cost. Botho's on-chain privacy (ring signatures,
   stealth addresses) still protects observers of the chain itself, but your
   chosen ingress node sees your interest. Run your own node for maximum privacy.
-- **Phishing / fake sites.** Always confirm the origin is `wallet.botho.io`.
+- **Phishing / fake sites.** Always confirm the origin is `botho.io`.
 
 ## Hardening shipped
 
 ### Content-Security-Policy (#476)
 
-`public/_headers` ships a strict CSP on `wallet.botho.io` (Cloudflare Pages):
+`public/_headers` ships a strict CSP on `botho.io` (Cloudflare Pages):
 
 ```
 default-src 'self';

--- a/web/packages/web-wallet/public/_headers
+++ b/web/packages/web-wallet/public/_headers
@@ -1,4 +1,4 @@
-# Cloudflare Pages headers for wallet.botho.io (#476)
+# Cloudflare Pages headers for botho.io (#476)
 #
 # A strict Content-Security-Policy so that an XSS or malicious-dependency bug
 # cannot execute injected script: scripts are pinned to our own origin (no

--- a/web/packages/web-wallet/src/lib/custom-rpc-link.ts
+++ b/web/packages/web-wallet/src/lib/custom-rpc-link.ts
@@ -3,7 +3,7 @@
  *
  * A managed-node owner is handed a link like:
  *
- *     https://wallet.botho.io/wallet?rpc=https%3A%2F%2Fnode-abc.testnet.botho.io%2Frpc
+ *     https://botho.io/wallet?rpc=https%3A%2F%2Fnode-abc.testnet.botho.io%2Frpc
  *
  * Opening it should point the wallet's RPC ingress at their own node. The wallet
  * already supports a "custom RPC" ingress (see `setCustomEndpoint` in the network

--- a/web/packages/web-wallet/src/lib/payment-request.ts
+++ b/web/packages/web-wallet/src/lib/payment-request.ts
@@ -10,7 +10,7 @@
  *
  * Link format (#470):
  *
- *   https://wallet.botho.io/pay#<base64url(JSON)>
+ *   https://botho.io/pay#<base64url(JSON)>
  *
  * where the JSON is `{ to, amount?, memo? }`:
  *   - `to`     the requester's public address (tbotho://… / botho://…).
@@ -98,7 +98,7 @@ export function buildPaymentRequestFragment(req: PaymentRequest): string {
 /**
  * Build the full shareable payment-request URL.
  *
- * @param origin e.g. `https://wallet.botho.io` (trailing slash tolerated)
+ * @param origin e.g. `https://botho.io` (trailing slash tolerated)
  * @param req    the payment request
  */
 export function buildPaymentRequestLink(origin: string, req: PaymentRequest): string {

--- a/web/packages/web-wallet/wrangler.toml
+++ b/web/packages/web-wallet/wrangler.toml
@@ -2,7 +2,7 @@
 #
 # Deploy with:
 #   pnpm --filter @botho/web-wallet deploy
-# which runs `wrangler pages deploy dist --project-name=botho-wallet`.
+# which runs `wrangler pages deploy dist --project-name=botho`.
 #
 # Requires CLOUDFLARE_API_TOKEN with the "Cloudflare Pages: Edit" permission.
 name = "botho"


### PR DESCRIPTION
## Summary

`wallet.botho.io` was retired and the site consolidated to a single `botho.io` Cloudflare Pages project (#725). This sweeps the dead domain out of doc comments, READMEs, and config comments, and corrects the stale `--project-name=botho-wallet` deploy comment to `--project-name=botho` (which is what the actual `deploy` script in `package.json` already runs). Also folds in #676: the `BOTHO_LIVE_URL` default in the opt-in live-smoke config/spec + README default now point at `botho.io`.

These are comments/docs + one opt-in test default — no product logic changes. The Rust `botho-wallet/` CLI crate is intentionally untouched (it is current and unrelated to the retired Pages project).

## Changes

- `web/packages/web-wallet/wrangler.toml` — deploy comment `--project-name=botho-wallet` → `--project-name=botho` (now matches the `deploy` script).
- `web/packages/web-wallet/public/_headers` — header comment `wallet.botho.io` → `botho.io`.
- `web/packages/web-wallet/SECURITY.md` — 4 doc references → `botho.io`.
- `web/packages/core/src/wallet/claim-link.ts` — doc-comment example host + `@param origin` example → `botho.io`.
- `web/packages/web-wallet/src/lib/payment-request.ts` — doc-comment example host + `@param origin` example → `botho.io`.
- `web/packages/web-wallet/src/lib/custom-rpc-link.ts` — doc-comment example host → `botho.io`.
- `web/README.md` — live-smoke prose host + `BOTHO_LIVE_URL` default in the table → `botho.io` (#676).
- `web/e2e/playwright.live.config.ts` — comments + `BOTHO_LIVE_URL` default → `botho.io` (#676).
- `web/e2e/tests/live/smoke.spec.ts` — comments, `describe` title, + `BOTHO_LIVE_URL` default → `botho.io` (sibling of the live config; #676).

## Deliberately left unchanged (out of scope / would be a logic change)

Noted here for the reviewer rather than swept, per the issue's "when in doubt, leave it and note it" guidance:

- **Runtime origin fallbacks** in `web-wallet` source (`src/contexts/wallet.tsx`, `src/components/OutstandingLinks.tsx`, `src/components/RequestModal.tsx`) still default to `'https://wallet.botho.io'` when `window.location.origin` is unavailable. These are runtime logic (they shape produced share links), not comments/docs, and the issue explicitly scoped to "no logic changes." Candidate follow-up.
- **Test fixtures** that pass `'https://wallet.botho.io'` as an arbitrary origin string (`claim-link.test.ts`, `payment-request.test.ts`, `claim.test.tsx`, `network-deep-link.test.tsx`, `node-status.test.ts`, `wasm-signer/.../claim-link-live-node.test.ts`). The literal value is irrelevant to the assertions; changing it is churn with no behavior benefit.
- **`baas-worker` package** (`README.md`, `wrangler.toml` `ALLOWED_ORIGINS`, `status.ts`/`index.ts` comments, tests). Not in the issue's candidate list; `ALLOWED_ORIGINS` is load-bearing CORS config. Candidate follow-up.
- **Architecture comments** describing the retired split-subdomain layout (`src/App.tsx`, `src/pages/wallet.tsx`). Rewording these requires understanding surrounding routing logic; left to avoid scope creep.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No dead-domain example refs remain (in candidate files) | ✅ | `grep wallet.botho.io` returns nothing across all 9 changed files |
| Rust `botho-wallet` crate refs untouched | ✅ | No Rust/Cargo/`botho-wallet/` files in the diff; only `web/**` docs+comments |
| `--project-name=botho-wallet` Pages comment corrected | ✅ | Now `--project-name=botho`, matching the `deploy` script in `package.json` |
| Builds/tests still pass | ✅ | See Test Plan |

## Test Plan

- `pnpm --filter @botho/web-wallet build` — passes (`tsc` typecheck + `vite build`, 2486 modules, PWA generated).
- `pnpm --filter @botho/core typecheck` and `pnpm --filter @botho/web-wallet typecheck` — both clean.
- `vitest run` on `claim-link.test.ts` + `payment-request.test.ts` — 46 tests pass.

Closes #732
Closes #676