### PR TITLE
fix(web-wallet): point retired wallet.botho.io origin fallback at botho.io

### DIFF
--- a/web/packages/web-wallet/src/components/OutstandingLinks.tsx
+++ b/web/packages/web-wallet/src/components/OutstandingLinks.tsx
@@ -61,7 +61,7 @@ export function OutstandingLinks() {
     const origin =
       typeof window !== 'undefined' && window.location?.origin
         ? window.location.origin
-        : 'https://wallet.botho.io'
+        : 'https://botho.io'
     const url = buildClaimLink(origin, ephMnemonic, amount)
     try {
       await navigator.clipboard.writeText(url)

--- a/web/packages/web-wallet/src/components/RequestModal.tsx
+++ b/web/packages/web-wallet/src/components/RequestModal.tsx
@@ -71,7 +71,7 @@ export function RequestModal({ isOpen, onClose }: { isOpen: boolean; onClose: ()
     const origin =
       typeof window !== 'undefined' && window.location?.origin
         ? window.location.origin
-        : 'https://wallet.botho.io'
+        : 'https://botho.io'
     try {
       url = buildPaymentRequestLink(
         origin,

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -1201,7 +1201,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     const origin =
       typeof window !== 'undefined' && window.location?.origin
         ? window.location.origin
-        : 'https://wallet.botho.io'
+        : 'https://botho.io'
     const url = buildClaimLink(origin, ephMnemonic, amount)
 
     // Refresh the sender's balance opportunistically.


### PR DESCRIPTION
## Summary
Three web-wallet files hardcoded `'https://wallet.botho.io'` as a last-resort origin fallback (used only when `window.location.origin` is unavailable). Since wallet.botho.io was retired and the site consolidated to the single `botho.io` Pages project (#725), that fallback produced dead claim/payment links in the fallback path. This repoints the fallback string at the canonical `https://botho.io`. The primary `window.location.origin` path is unchanged.

Follow-up from the #732 docs sweep (PR #739), which deliberately left runtime logic out of scope.

## Changes
- `src/contexts/wallet.tsx` (claim-link build): fallback `'https://wallet.botho.io'` -> `'https://botho.io'`
- `src/components/OutstandingLinks.tsx` (`handleCopy` claim-link): fallback `'https://wallet.botho.io'` -> `'https://botho.io'`
- `src/components/RequestModal.tsx` (payment-request link): fallback `'https://wallet.botho.io'` -> `'https://botho.io'`

No test fixtures/assertions needed updating: the remaining `wallet.botho.io` references in tests are explicit function inputs (`buildClaimLink`/`buildPaymentRequestLink` called with an origin argument) or `window.location` mocks that exercise the primary path — none assert the fallback branch. The Rust `botho-wallet/` crate was not touched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| No `wallet.botho.io` remains as a runtime fallback in the three files | ✅ | `grep` of the three files shows only `'https://botho.io'` at the fallback lines |
| Primary `window.location.origin` behavior unchanged | ✅ | Only the fallback string literal changed; the ternary primary branch is untouched |
| `pnpm --filter @botho/web-wallet build` + typecheck passes | ✅ | tsc + vite build succeeded (2486 modules, built in 5.18s) |
| Affected vitest pass | ✅ | 6 files / 64 tests green (wallet, ReceiveModal, payment-request, claim-link-ops, claim, network-deep-link) |
| Rust `botho-wallet/` crate not touched | ✅ | Diff limited to three web-wallet `.tsx` files |

## Test Plan
- `cd web && pnpm --filter @botho/web-wallet build` — typecheck + vite build pass
- `vitest run` on the six affected files — 64/64 pass

Closes #740