### PR TITLE
feat(web): operator action composer with in-browser key vault, dry-run preview, and audit view

### DIFF
--- a/web/packages/features/package.json
+++ b/web/packages/features/package.json
@@ -25,6 +25,8 @@
   "dependencies": {
     "@botho/core": "workspace:*",
     "@botho/ui": "workspace:*",
+    "@noble/curves": "^1.8.1",
+    "@noble/hashes": "^2.0.1",
     "lucide-react": "^0.562.0",
     "motion": "^12.23.26"
   },

--- a/web/packages/features/src/operator/action-envelope.test.ts
+++ b/web/packages/features/src/operator/action-envelope.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest'
+import { ed25519 } from '@noble/curves/ed25519.js'
+import {
+  buildDryRun,
+  buildEnvelopeFields,
+  buildRealApply,
+  canonicalizeEnvelope,
+  blake2b256Hex,
+  DOMAIN_SEPARATOR,
+  signerKeyIdFromPublicKey,
+  signingMessage,
+  verifyEnvelopeSignature,
+  type ComposeActionRequest,
+  type EnvelopeFields,
+} from './action-envelope'
+import fixtures from './fixtures/operator-action-fixtures.json'
+
+/**
+ * CROSS-LANGUAGE CANONICALIZATION FIXTURE TEST (issue #751, the #1 failure
+ * mode). The fixture values are produced by the NODE's Rust code
+ * (`botho/src/operator_action.rs`) for the deterministic key seed [1u8; 32].
+ *
+ * If the browser's canonical byte string, Ed25519 signature, signerKeyId, or
+ * envelopeHash drift from these, the node's parse-after-verify signature check
+ * fails. These asserts guarantee byte-for-byte agreement with the node.
+ */
+
+const SEED = hexToBytes(fixtures.signingKeySeed)
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+function bytesToHex(b: Uint8Array): string {
+  return [...b].map((x) => x.toString(16).padStart(2, '0')).join('')
+}
+
+/** A SignFn bound to the fixture seed key (matches the Rust signer). */
+const fixtureSign = (msg: Uint8Array) => ed25519.sign(msg, SEED)
+
+describe('cross-language canonicalization fixture (matches the node)', () => {
+  it('derives the node public key + signerKeyId from the seed', () => {
+    const pk = ed25519.getPublicKey(SEED)
+    expect(bytesToHex(pk)).toBe(fixtures.publicKeyHex)
+    expect(signerKeyIdFromPublicKey(pk)).toBe(fixtures.signerKeyId)
+  })
+
+  it('uses the same domain separator as the node', () => {
+    expect(DOMAIN_SEPARATOR).toBe(fixtures.domainSeparator)
+  })
+
+  for (const fx of fixtures.envelopes) {
+    describe(fx.name, () => {
+      const fields = fx.fields as unknown as EnvelopeFields
+
+      it('produces the EXACT canonical byte string the node produced', () => {
+        expect(canonicalizeEnvelope(fields)).toBe(fx.canonical)
+      })
+
+      it('produces the EXACT Ed25519 signature the node accepts', () => {
+        const sig = bytesToHex(fixtureSign(signingMessage(fx.canonical)))
+        expect(sig).toBe(fx.signature)
+      })
+
+      it('the fixture signature verifies against the node public key', () => {
+        const pk = ed25519.getPublicKey(SEED)
+        expect(verifyEnvelopeSignature(fx.canonical, fx.signature, pk)).toBe(true)
+      })
+
+      if ('envelopeHash' in fx && fx.envelopeHash) {
+        it('produces the EXACT envelopeHash the node stores (§6)', () => {
+          expect(blake2b256Hex(new TextEncoder().encode(fx.canonical))).toBe(fx.envelopeHash)
+        })
+      }
+    })
+  }
+})
+
+describe('canonicalization rules', () => {
+  it('sorts keys lexicographically with acknowledgeDegenerate first', () => {
+    const fields: EnvelopeFields = {
+      v: 1,
+      action: 'quorum.unpin_member',
+      params: { peerId: 'P' },
+      targetNode: 'T',
+      signerKeyId: 'S',
+      nonce: 'N',
+      issuedAt: 1,
+      expiresAt: 2,
+      dryRun: false,
+      acknowledgeDegenerate: true,
+    }
+    const c = canonicalizeEnvelope(fields)
+    expect(c.startsWith('{"acknowledgeDegenerate":true,"action":')).toBe(true)
+    // Keys appear in sorted order, no whitespace.
+    expect(c).not.toContain(' ')
+    expect(c.endsWith('"v":1}')).toBe(true)
+  })
+
+  it('omits acknowledgeDegenerate entirely when not set (matches optional node field)', () => {
+    const fields: EnvelopeFields = {
+      v: 1,
+      action: 'quorum.pin_member',
+      params: { peerId: 'P' },
+      targetNode: 'T',
+      signerKeyId: 'S',
+      nonce: 'N',
+      issuedAt: 1,
+      expiresAt: 2,
+      dryRun: false,
+    }
+    expect(canonicalizeEnvelope(fields)).not.toContain('acknowledgeDegenerate')
+  })
+
+  it('rejects non-integer numbers (the node rejects floats)', () => {
+    const fields = {
+      v: 1,
+      action: 'quorum.set_max_auto_members',
+      params: { value: 8.5 },
+      targetNode: 'T',
+      signerKeyId: 'S',
+      nonce: 'N',
+      issuedAt: 1,
+      expiresAt: 2,
+      dryRun: false,
+    } as unknown as EnvelopeFields
+    expect(() => canonicalizeEnvelope(fields)).toThrow(/integers only/)
+  })
+})
+
+describe('finding 1: dry-run and real apply are separately signed with fresh nonces', () => {
+  const req: ComposeActionRequest = {
+    action: 'quorum.set_max_auto_members',
+    params: { value: 8 },
+    targetNode: '12D3KooWTest',
+    signerKeyId: 'abcd',
+  }
+
+  it('buildDryRun sets dryRun:true, buildRealApply sets dryRun:false', () => {
+    const dry = buildDryRun(req, fixtureSign)
+    const apply = buildRealApply(req, fixtureSign)
+    expect(dry.fields.dryRun).toBe(true)
+    expect(apply.fields.dryRun).toBe(false)
+  })
+
+  it('the real apply has a DIFFERENT nonce and DIFFERENT signed bytes than the dry-run', () => {
+    const dry = buildDryRun(req, fixtureSign)
+    const apply = buildRealApply(req, fixtureSign)
+    expect(apply.fields.nonce).not.toBe(dry.fields.nonce)
+    expect(apply.canonical).not.toBe(dry.canonical)
+    expect(apply.signature).not.toBe(dry.signature)
+  })
+
+  it('two apply builds never reuse a nonce (fresh 128-bit each time)', () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 50; i++) {
+      const a = buildRealApply(req, fixtureSign)
+      expect(seen.has(a.fields.nonce)).toBe(false)
+      expect(a.fields.nonce).toHaveLength(32)
+      seen.add(a.fields.nonce)
+    }
+  })
+
+  it('issuedAt/expiresAt are <= 300s apart', () => {
+    const a = buildEnvelopeFields(req, false)
+    expect(a.expiresAt - a.issuedAt).toBeLessThanOrEqual(300)
+    expect(a.expiresAt).toBeGreaterThan(a.issuedAt)
+  })
+})
+
+describe('compose validation (pre-sign, mirrors node shape checks)', () => {
+  it('requires a targetNode', () => {
+    expect(() =>
+      buildEnvelopeFields(
+        { action: 'quorum.pin_member', params: { peerId: 'P' }, targetNode: '', signerKeyId: 'S' },
+        true,
+      ),
+    ).toThrow(/targetNode/)
+  })
+
+  it('requires a peerId for pin/unpin', () => {
+    expect(() =>
+      buildEnvelopeFields(
+        {
+          action: 'quorum.pin_member',
+          params: { peerId: '' },
+          targetNode: 'T',
+          signerKeyId: 'S',
+        },
+        true,
+      ),
+    ).toThrow(/peerId/)
+  })
+
+  it('rejects a max_auto_members value over the ceiling', () => {
+    expect(() =>
+      buildEnvelopeFields(
+        {
+          action: 'quorum.set_max_auto_members',
+          params: { value: 65 },
+          targetNode: 'T',
+          signerKeyId: 'S',
+        },
+        true,
+      ),
+    ).toThrow(/0\.\.=64/)
+  })
+})

--- a/web/packages/features/src/operator/action-envelope.ts
+++ b/web/packages/features/src/operator/action-envelope.ts
@@ -1,0 +1,379 @@
+/**
+ * Operator-signed quorum-curation action envelope — the BROWSER side of the
+ * write path (#751, P4.4e of the #709 proposal). This is the security core: it
+ * MUST byte-for-byte reproduce the node's Rust canonicalization
+ * (`botho/src/operator_action.rs`) or the node's parse-after-verify signature
+ * check fails (`docs/security/quorum-write-path.md` §3, §4; finding 1).
+ *
+ * ## Cross-language canonicalization contract (the #1 failure mode)
+ *
+ * The node signs and verifies over `DOMAIN_SEPARATOR || canonical_bytes`, where
+ * `canonical_bytes` is the EXACT UTF-8 JSON string with:
+ *   - keys sorted lexicographically at the top level (and `params` keys sorted
+ *     too — every object is emitted sorted),
+ *   - integers only (no floats, no `1.0`),
+ *   - NO insignificant whitespace.
+ *
+ * The node NEVER re-serializes a parsed object: it verifies over the received
+ * bytes and only then parses them. So the browser is the sole producer of the
+ * canonical bytes — this module owns that production and never lets the caller
+ * hand-edit the signed string. `action-envelope.test.ts` asserts byte-equality
+ * against a committed fixture the Rust code produced (`fixtures/`), which is how
+ * we guarantee the two languages agree.
+ *
+ * ## Finding 1 — dryRun is a SIGNED field
+ *
+ * A dry-run preview and the real apply are DIFFERENT signed byte strings (the
+ * `dryRun` value AND a fresh nonce differ). The UI can never "flip a flag" on
+ * already-signed bytes; it must sign a fresh envelope. {@link buildRealApply}
+ * enforces the fresh nonce.
+ *
+ * No key material is exposed here: signing takes a {@link SignFn} the vault
+ * provides (the raw secret never leaves the vault module).
+ */
+
+import { blake2b } from '@noble/hashes/blake2.js'
+import { ed25519 } from '@noble/curves/ed25519.js'
+
+/**
+ * Domain separator prepended to the canonical bytes before signing / verifying
+ * (§3). Prevents cross-protocol signature reuse. MUST equal the node's
+ * `DOMAIN_SEPARATOR` (`botho/src/operator_action.rs`).
+ */
+export const DOMAIN_SEPARATOR = 'botho-operator-action-v1'
+
+/** The only envelope version v1 verifiers accept (§3). */
+export const ENVELOPE_VERSION = 1
+
+/** Max envelope lifetime in seconds (`expiresAt - issuedAt <= 300`, §3/§4). */
+export const MAX_ENVELOPE_LIFETIME_SECS = 300
+
+/** Default lifetime the composer uses when building an envelope. */
+export const DEFAULT_ENVELOPE_LIFETIME_SECS = 120
+
+/** Upper bound on `max_auto_members` (§4 step 7; mirrors the node ceiling). */
+export const MAX_AUTO_MEMBERS_CEILING = 64
+
+/**
+ * The v1 action allowlist (§3). This is a security invariant on the node
+ * (mode/threshold are deliberately excluded to bound a compromised-dashboard
+ * attack to recoverable liveness, §8.3); the composer only ever offers these.
+ */
+export type OperatorActionName =
+  | 'quorum.pin_member'
+  | 'quorum.unpin_member'
+  | 'quorum.set_max_auto_members'
+
+/** The `params` object for each v1 action (matches the node's `parse_action`). */
+export type OperatorActionParams =
+  | { peerId: string }
+  | { value: number }
+
+/**
+ * The logical fields of a signed action envelope. This is the operator's
+ * INTENT; {@link canonicalizeEnvelope} renders it to the exact signed bytes.
+ */
+export interface EnvelopeFields {
+  /** Envelope version — always {@link ENVELOPE_VERSION}. */
+  v: number
+  /** The v1 action name. */
+  action: OperatorActionName
+  /** The action params object. */
+  params: OperatorActionParams
+  /** The target node's base58 PeerId (must equal that node's own PeerId). */
+  targetNode: string
+  /** The signer fingerprint (blake2b-256(pubkey)[..8] hex). */
+  signerKeyId: string
+  /** Fresh 128-bit nonce, lowercase hex (32 chars). */
+  nonce: string
+  /** Unix seconds the envelope was issued. */
+  issuedAt: number
+  /** Unix seconds the envelope expires (`<= issuedAt + 300`). */
+  expiresAt: number
+  /** Whether this is a dry-run preview (SIGNED field, finding 1). */
+  dryRun: boolean
+  /**
+   * Only set (to `true`) when the operator acknowledges a resulting
+   * degenerate (<4-node) quorum. Absent otherwise, matching the node's
+   * optional field. Never emit `false` — absence and `false` must both mean
+   * "not acknowledged" and the node treats absence as `false`.
+   */
+  acknowledgeDegenerate?: true
+}
+
+/** A fully-produced signed envelope: the exact bytes + detached signature. */
+export interface SignedActionEnvelope {
+  /** The canonical JSON string, verbatim, as signed (the node verifies THIS). */
+  canonical: string
+  /** Detached Ed25519 signature over `DOMAIN_SEPARATOR || canonical`, hex. */
+  signature: string
+  /** blake2b-256(canonical) hex — the node's `envelopeHash` (§6). */
+  envelopeHash: string
+  /** The logical fields, for display / diffing (NOT what is signed). */
+  fields: EnvelopeFields
+}
+
+/** A signing function: sign 32-... arbitrary bytes, return the 64-byte sig. */
+export type SignFn = (message: Uint8Array) => Uint8Array
+
+// ---------------------------------------------------------------------------
+// hex helpers (self-contained; mirrors vault.ts style)
+// ---------------------------------------------------------------------------
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = ''
+  for (const b of bytes) out += b.toString(16).padStart(2, '0')
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Canonical JSON (MUST byte-match the node)
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize one JSON value in the node's canonical form: object keys sorted
+ * lexicographically (by UTF-16 code unit, which matches Rust's `BTreeMap`
+ * ordering for the ASCII field names used here), integers only, no whitespace.
+ *
+ * Throws on any non-integer number or non-finite value — the node rejects
+ * floats (`serde_json` `as_u64` returns None for `5.0`), so producing one here
+ * would guarantee a signature the node cannot accept. Fail loud at sign time.
+ */
+function canonicalizeValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      throw new Error(
+        `canonical envelope requires integers only; got non-integer ${value}`,
+      )
+    }
+    // Number.isInteger already excludes NaN/Infinity. Emit the plain decimal.
+    return String(value)
+  }
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalizeValue).join(',')}]`
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    const keys = Object.keys(obj).sort()
+    const parts = keys.map((k) => `${JSON.stringify(k)}:${canonicalizeValue(obj[k])}`)
+    return `{${parts.join(',')}}`
+  }
+  throw new Error(`cannot canonicalize value of type ${typeof value}`)
+}
+
+/**
+ * Render {@link EnvelopeFields} to the canonical signed byte string.
+ *
+ * We build a plain object with exactly the node's known-key set and let
+ * {@link canonicalizeValue} sort + serialize it. `acknowledgeDegenerate` is
+ * included ONLY when truthy (matching the node's optional field). This is the
+ * ONE place the signed bytes are produced; nothing else constructs them.
+ */
+export function canonicalizeEnvelope(fields: EnvelopeFields): string {
+  const obj: Record<string, unknown> = {
+    v: fields.v,
+    action: fields.action,
+    params: fields.params,
+    targetNode: fields.targetNode,
+    signerKeyId: fields.signerKeyId,
+    nonce: fields.nonce,
+    issuedAt: fields.issuedAt,
+    expiresAt: fields.expiresAt,
+    dryRun: fields.dryRun,
+  }
+  if (fields.acknowledgeDegenerate === true) {
+    obj.acknowledgeDegenerate = true
+  }
+  return canonicalizeValue(obj)
+}
+
+/** blake2b-256 hex of arbitrary bytes — the node's `blake2b_256_hex` (§6). */
+export function blake2b256Hex(bytes: Uint8Array): string {
+  return bytesToHex(blake2b(bytes, { dkLen: 32 }))
+}
+
+/**
+ * Compute the signer fingerprint (`signerKeyId`): blake2b-256(pubkey) truncated
+ * to the first 8 bytes, lowercase hex. MUST match the node's `fingerprint_hex`
+ * (`botho/src/operator_key.rs`, `FINGERPRINT_BYTES = 8`).
+ */
+export function signerKeyIdFromPublicKey(publicKey: Uint8Array): string {
+  return bytesToHex(blake2b(publicKey, { dkLen: 32 }).slice(0, 8))
+}
+
+/** The exact bytes that get signed: `DOMAIN_SEPARATOR || canonical`. */
+export function signingMessage(canonical: string): Uint8Array {
+  const domain = new TextEncoder().encode(DOMAIN_SEPARATOR)
+  const body = new TextEncoder().encode(canonical)
+  const out = new Uint8Array(domain.length + body.length)
+  out.set(domain, 0)
+  out.set(body, domain.length)
+  return out
+}
+
+/**
+ * Verify a detached signature over an envelope's canonical bytes with the
+ * domain separator, against a public key. Used by tests and as a defensive
+ * self-check before submitting (a bad self-signature means something is wrong
+ * locally — never send it).
+ */
+export function verifyEnvelopeSignature(
+  canonical: string,
+  signatureHex: string,
+  publicKey: Uint8Array,
+): boolean {
+  try {
+    const sig = hexToBytesStrict(signatureHex)
+    return ed25519.verify(sig, signingMessage(canonical), publicKey)
+  } catch {
+    return false
+  }
+}
+
+function hexToBytesStrict(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error('Invalid hex string')
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    const b = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+    if (Number.isNaN(b)) throw new Error('Invalid hex string')
+    out[i] = b
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Nonce + envelope construction
+// ---------------------------------------------------------------------------
+
+/** A fresh 128-bit nonce, lowercase hex (32 chars). */
+export function freshNonce(): string {
+  return bytesToHex(crypto.getRandomValues(new Uint8Array(16)))
+}
+
+/** Current Unix seconds. */
+function nowSecs(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+/** The composer's request (before nonce/time/dryRun are stamped on). */
+export interface ComposeActionRequest {
+  action: OperatorActionName
+  params: OperatorActionParams
+  /** The node's base58 PeerId (resolved live from `node_getStatus`). */
+  targetNode: string
+  /** The signer fingerprint. */
+  signerKeyId: string
+  /** Set `true` when the operator acknowledges a degenerate result. */
+  acknowledgeDegenerate?: boolean
+  /** Envelope lifetime; defaults to {@link DEFAULT_ENVELOPE_LIFETIME_SECS}. */
+  lifetimeSecs?: number
+}
+
+/**
+ * Validate a compose request's payload (mirrors the node's shape checks so the
+ * operator sees an error BEFORE signing, not after a node rejection). Throws
+ * with a human message on the first problem.
+ */
+export function validateComposeRequest(req: ComposeActionRequest): void {
+  if (!req.targetNode || req.targetNode.trim() === '') {
+    throw new Error('targetNode (a node PeerId) is required')
+  }
+  if (!req.signerKeyId || req.signerKeyId.trim() === '') {
+    throw new Error('signerKeyId is required (import the operator key first)')
+  }
+  switch (req.action) {
+    case 'quorum.pin_member':
+    case 'quorum.unpin_member': {
+      const p = req.params as { peerId?: unknown }
+      if (typeof p.peerId !== 'string' || p.peerId.trim() === '') {
+        throw new Error('a peerId is required for pin/unpin')
+      }
+      break
+    }
+    case 'quorum.set_max_auto_members': {
+      const p = req.params as { value?: unknown }
+      if (typeof p.value !== 'number' || !Number.isInteger(p.value)) {
+        throw new Error('value must be an integer for set_max_auto_members')
+      }
+      if (p.value < 0 || p.value > MAX_AUTO_MEMBERS_CEILING) {
+        throw new Error(`value must be in 0..=${MAX_AUTO_MEMBERS_CEILING}`)
+      }
+      break
+    }
+    default:
+      throw new Error(`unsupported action ${String(req.action)}`)
+  }
+}
+
+/**
+ * Build the envelope fields for a request, stamping a fresh nonce + issuedAt /
+ * expiresAt and the given `dryRun`. Every call produces a DISTINCT nonce, so a
+ * dry-run and its real apply are always different signed strings (finding 1).
+ */
+export function buildEnvelopeFields(
+  req: ComposeActionRequest,
+  dryRun: boolean,
+  now: number = nowSecs(),
+): EnvelopeFields {
+  validateComposeRequest(req)
+  const lifetime = Math.min(
+    req.lifetimeSecs ?? DEFAULT_ENVELOPE_LIFETIME_SECS,
+    MAX_ENVELOPE_LIFETIME_SECS,
+  )
+  const fields: EnvelopeFields = {
+    v: ENVELOPE_VERSION,
+    action: req.action,
+    params: req.params,
+    targetNode: req.targetNode,
+    signerKeyId: req.signerKeyId,
+    nonce: freshNonce(),
+    issuedAt: now,
+    expiresAt: now + lifetime,
+    dryRun,
+  }
+  if (req.acknowledgeDegenerate === true) {
+    fields.acknowledgeDegenerate = true
+  }
+  return fields
+}
+
+/**
+ * Canonicalize + sign an envelope. The signature is over
+ * `DOMAIN_SEPARATOR || canonical`. Signing is delegated to {@link SignFn} so
+ * the raw secret never enters this module.
+ */
+export function signEnvelope(fields: EnvelopeFields, sign: SignFn): SignedActionEnvelope {
+  const canonical = canonicalizeEnvelope(fields)
+  const signature = bytesToHex(sign(signingMessage(canonical)))
+  return {
+    canonical,
+    signature,
+    envelopeHash: blake2b256Hex(new TextEncoder().encode(canonical)),
+    fields,
+  }
+}
+
+/** Compose + sign a `dryRun: true` preview envelope. */
+export function buildDryRun(
+  req: ComposeActionRequest,
+  sign: SignFn,
+  now?: number,
+): SignedActionEnvelope {
+  return signEnvelope(buildEnvelopeFields(req, true, now), sign)
+}
+
+/**
+ * Compose + sign the REAL `dryRun: false` apply envelope with a FRESH nonce
+ * (finding 1: the UI can never reuse the dry-run bytes — this produces a new
+ * envelope with its own nonce and its own signature).
+ */
+export function buildRealApply(
+  req: ComposeActionRequest,
+  sign: SignFn,
+  now?: number,
+): SignedActionEnvelope {
+  return signEnvelope(buildEnvelopeFields(req, false, now), sign)
+}

--- a/web/packages/features/src/operator/action-submit.test.ts
+++ b/web/packages/features/src/operator/action-submit.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  isAppliedResult,
+  isRefusedResult,
+  parseOutcome,
+  submitAction,
+  submitToFleet,
+  type FleetSubmitItem,
+} from './action-submit'
+import type { SignedActionEnvelope } from './action-envelope'
+import type { FleetNode } from '../network/types'
+
+const node = (id: string): FleetNode => ({
+  id,
+  name: `Node ${id}`,
+  rpcEndpoint: `https://${id}.test/rpc`,
+})
+
+const signed: SignedActionEnvelope = {
+  canonical: '{"v":1}',
+  signature: 'ab'.repeat(32),
+  envelopeHash: 'cd'.repeat(32),
+  fields: {} as SignedActionEnvelope['fields'],
+}
+
+/** A node applied-outcome result body (matches the node's success shape). */
+const appliedBody = {
+  outcome: 'applied',
+  dryRun: false,
+  signerKeyId: 'c5e21ab1c9f6022d',
+  action: 'quorum.pin_member',
+  message: 'operator action applied',
+  auditTag: 'applied',
+  authenticated: true,
+  resultingQuorum: { mode: 'recommended', members: ['P'], maxAutoMembers: 8 },
+  gate: {
+    intersectionRefused: false,
+    curatedMembers: 1,
+    autoMembers: 3,
+    suppressedPeers: 0,
+    maxAutoMembers: 8,
+    faultTolerant: true,
+    degenerate: false,
+  },
+}
+
+/** A gate-refused outcome (returned as an RPC error whose data is the outcome). */
+const refusedBody = {
+  outcome: 'gate_refused',
+  dryRun: false,
+  signerKeyId: 'c5e21ab1c9f6022d',
+  action: 'quorum.pin_member',
+  message: 'gate refused',
+  auditTag: 'gate_refused',
+  authenticated: true,
+  gate: {
+    intersectionRefused: true,
+    curatedMembers: 0,
+    autoMembers: 0,
+    suppressedPeers: 0,
+    maxAutoMembers: 8,
+    faultTolerant: false,
+    degenerate: true,
+  },
+}
+
+function mockFetchOnce(response: unknown, ok = true, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => response,
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('parseOutcome (truthful outcome parsing, anti-#541)', () => {
+  it('parses an applied outcome', () => {
+    const o = parseOutcome(appliedBody)
+    expect(o?.outcome).toBe('applied')
+    expect(o?.authenticated).toBe(true)
+    expect(o?.gate?.faultTolerant).toBe(true)
+  })
+
+  it('returns null for an unrecognized shape (never fabricates applied)', () => {
+    expect(parseOutcome({ foo: 'bar' })).toBeNull()
+    expect(parseOutcome(null)).toBeNull()
+    expect(parseOutcome('applied')).toBeNull()
+  })
+})
+
+describe('submitAction (single node)', () => {
+  it('maps a success result to an applied outcome', async () => {
+    vi.stubGlobal('fetch', mockFetchOnce({ result: appliedBody, id: 1 }))
+    const r = await submitAction(node('a'), signed)
+    expect(r.status).toBe('ok')
+    expect(isAppliedResult(r)).toBe(true)
+  })
+
+  it('maps an RPC error whose data is the outcome to a refusal (NOT unreachable)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchOnce({ error: { code: -32024, message: 'gate refused', data: refusedBody }, id: 1 }),
+    )
+    const r = await submitAction(node('a'), signed)
+    expect(r.status).toBe('ok')
+    expect(isRefusedResult(r)).toBe(true)
+    expect(isAppliedResult(r)).toBe(false)
+  })
+
+  it('maps OPERATOR_NOT_ENABLED to not-enabled', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchOnce({ error: { code: -32020, message: 'not configured' }, id: 1 }),
+    )
+    const r = await submitAction(node('a'), signed)
+    expect(r.status).toBe('not-enabled')
+  })
+
+  it('maps a transport failure to unreachable (NOT a refusal, NOT applied)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+    const r = await submitAction(node('a'), signed)
+    expect(r.status).toBe('unreachable')
+    expect(isAppliedResult(r)).toBe(false)
+    expect(isRefusedResult(r)).toBe(false)
+  })
+
+  it('does NOT treat a dry-run applied outcome as a real apply', async () => {
+    vi.stubGlobal('fetch', mockFetchOnce({ result: { ...appliedBody, dryRun: true }, id: 1 }))
+    const r = await submitAction(node('a'), signed)
+    expect(r.status).toBe('ok')
+    expect(isAppliedResult(r)).toBe(false) // dryRun applied is a preview, not applied
+  })
+
+  it('sends EXACTLY {envelope, signature} — no sibling params (finding 1)', async () => {
+    const fetchMock = mockFetchOnce({ result: appliedBody, id: 1 })
+    vi.stubGlobal('fetch', fetchMock)
+    await submitAction(node('a'), signed)
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(Object.keys(body.params).sort()).toEqual(['envelope', 'signature'])
+    expect(body.params).not.toHaveProperty('dryRun')
+    expect(body.method).toBe('operator_submitAction')
+  })
+})
+
+describe('submitToFleet (partial failure is first-class, §7.3)', () => {
+  it('classifies a mixed fleet: some applied, some refused, some unreachable', async () => {
+    // Per-node fetch behavior keyed by endpoint.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (url.includes('a.test')) {
+          return Promise.resolve({ ok: true, status: 200, json: async () => ({ result: appliedBody }) })
+        }
+        if (url.includes('b.test')) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ error: { code: -32024, data: refusedBody } }),
+          })
+        }
+        return Promise.reject(new Error('down'))
+      }),
+    )
+    const items: FleetSubmitItem[] = [
+      { node: node('a'), signed },
+      { node: node('b'), signed },
+      { node: node('c'), signed },
+    ]
+    const outcome = await submitToFleet(items)
+    expect(outcome.appliedNodeIds).toEqual(['a'])
+    expect(outcome.refusedNodeIds).toEqual(['b'])
+    expect(outcome.inconclusiveNodeIds).toEqual(['c'])
+    expect(outcome.partial).toBe(true)
+    expect(outcome.allApplied).toBe(false)
+  })
+
+  it('allApplied is true only when every node applied', async () => {
+    vi.stubGlobal('fetch', mockFetchOnce({ result: appliedBody }))
+    const outcome = await submitToFleet([
+      { node: node('a'), signed },
+      { node: node('b'), signed },
+    ])
+    expect(outcome.allApplied).toBe(true)
+    expect(outcome.partial).toBe(false)
+  })
+})

--- a/web/packages/features/src/operator/action-submit.ts
+++ b/web/packages/features/src/operator/action-submit.ts
@@ -1,0 +1,300 @@
+/**
+ * `operator_submitAction` RPC client (#751) — submits a signed envelope to ONE
+ * node and parses the node's structured outcome (§6, anti-#541).
+ *
+ * TRUTHFUL OUTCOMES: applied / refused state comes EXCLUSIVELY from the node's
+ * response snapshot. This module never infers "applied" — it maps the node's
+ * `OperatorActionOutcome` (`botho/src/operator_action.rs`) 1:1. A refusal is a
+ * JSON-RPC error whose `data` carries the same outcome shape; a transport
+ * failure is a distinct `unreachable` result (NOT a refusal, NOT a success).
+ *
+ * Fleet submit (`submitToFleet`) fans one envelope-per-node out concurrently
+ * and reports per-node outcomes, so "some nodes refused" is a first-class
+ * partial-failure result (§7.3) rather than a single boolean.
+ */
+
+import type { FleetNode } from '../network/types'
+import type { SignedActionEnvelope } from './action-envelope'
+
+/** Node RPC error codes for the operator write surface (`botho/src/rpc/mod.rs`). */
+const OPERATOR_NOT_ENABLED = -32020
+const OPERATOR_ACTION_REJECTED = -32024
+
+/** The terminal outcome class the node reports (`OutcomeClass`, snake_case). */
+export type OutcomeClass = 'applied' | 'gate_refused' | 'verify_refused'
+
+/** A compact quorum posture the node returns (`QuorumPosture`, §6). */
+export interface QuorumPosture {
+  mode: string
+  members: string[]
+  maxAutoMembers: number
+}
+
+/** The gate verdict the node returns (`GateVerdict`, §6). */
+export interface GateVerdict {
+  intersectionRefused: boolean
+  curatedMembers: number
+  autoMembers: number
+  suppressedPeers: number
+  maxAutoMembers: number
+  faultTolerant: boolean
+  degenerate: boolean
+}
+
+/**
+ * The node's structured action outcome (`OperatorActionOutcome`, camelCase on
+ * the wire). Every field is exactly what the node reported — the dashboard
+ * renders from THIS, never from inference.
+ */
+export interface OperatorActionOutcome {
+  outcome: OutcomeClass
+  dryRun: boolean
+  signerKeyId?: string
+  action?: string
+  message: string
+  auditTag: string
+  authenticated: boolean
+  prevQuorum?: QuorumPosture
+  resultingQuorum?: QuorumPosture
+  gate?: GateVerdict
+}
+
+/**
+ * The result of submitting to ONE node. Distinguishes:
+ *   - `ok`: the node returned a structured outcome (applied OR refused — check
+ *     `outcome.outcome`). This is the ONLY source of applied/refused truth.
+ *   - `not-enabled`: the node has no operator write surface configured.
+ *   - `unreachable`: transport/HTTP/parse failure — NOT a refusal, NOT applied.
+ */
+export type SubmitResult =
+  | { status: 'ok'; outcome: OperatorActionOutcome }
+  | { status: 'not-enabled'; message: string }
+  | { status: 'unreachable'; message: string }
+
+/** True when a result is a node-confirmed APPLIED (real, not dry-run) outcome. */
+export function isAppliedResult(r: SubmitResult): boolean {
+  return r.status === 'ok' && r.outcome.outcome === 'applied' && !r.outcome.dryRun
+}
+
+/** True when a result is a node-confirmed refusal (gate or verify). */
+export function isRefusedResult(r: SubmitResult): boolean {
+  return (
+    r.status === 'ok' &&
+    (r.outcome.outcome === 'gate_refused' || r.outcome.outcome === 'verify_refused')
+  )
+}
+
+function parseQuorumPosture(v: unknown): QuorumPosture | undefined {
+  if (!v || typeof v !== 'object') return undefined
+  const o = v as Record<string, unknown>
+  const members = Array.isArray(o.members)
+    ? o.members.filter((x): x is string => typeof x === 'string')
+    : []
+  return {
+    mode: typeof o.mode === 'string' ? o.mode : 'unknown',
+    members,
+    maxAutoMembers: typeof o.maxAutoMembers === 'number' ? o.maxAutoMembers : 0,
+  }
+}
+
+function parseGate(v: unknown): GateVerdict | undefined {
+  if (!v || typeof v !== 'object') return undefined
+  const o = v as Record<string, unknown>
+  const num = (x: unknown): number => (typeof x === 'number' ? x : 0)
+  const bool = (x: unknown): boolean => x === true
+  return {
+    intersectionRefused: bool(o.intersectionRefused),
+    curatedMembers: num(o.curatedMembers),
+    autoMembers: num(o.autoMembers),
+    suppressedPeers: num(o.suppressedPeers),
+    maxAutoMembers: num(o.maxAutoMembers),
+    faultTolerant: bool(o.faultTolerant),
+    degenerate: bool(o.degenerate),
+  }
+}
+
+/**
+ * Parse a node outcome object (from a success `result` or an error `data`) into
+ * a typed {@link OperatorActionOutcome}. Returns `null` if the shape is
+ * unrecognizable (which the caller treats as `unreachable`, never as applied).
+ */
+export function parseOutcome(v: unknown): OperatorActionOutcome | null {
+  if (!v || typeof v !== 'object') return null
+  const o = v as Record<string, unknown>
+  const cls = o.outcome
+  if (cls !== 'applied' && cls !== 'gate_refused' && cls !== 'verify_refused') {
+    return null
+  }
+  return {
+    outcome: cls,
+    dryRun: o.dryRun === true,
+    signerKeyId: typeof o.signerKeyId === 'string' ? o.signerKeyId : undefined,
+    action: typeof o.action === 'string' ? o.action : undefined,
+    message: typeof o.message === 'string' ? o.message : '',
+    auditTag: typeof o.auditTag === 'string' ? o.auditTag : '',
+    authenticated: o.authenticated === true,
+    prevQuorum: parseQuorumPosture(o.prevQuorum),
+    resultingQuorum: parseQuorumPosture(o.resultingQuorum),
+    gate: parseGate(o.gate),
+  }
+}
+
+/**
+ * Submit a signed envelope to ONE node's `operator_submitAction`. The RPC takes
+ * EXACTLY the `{ envelope, signature }` argument (finding 1: no sibling param
+ * such as `dryRun` is sent — `dryRun` lives INSIDE the signed envelope). The
+ * outcome is read exclusively from the node's response.
+ */
+export async function submitAction(
+  node: FleetNode,
+  signed: SignedActionEnvelope,
+  timeoutMs = 8000,
+): Promise<SubmitResult> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(node.rpcEndpoint, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'operator_submitAction',
+        // EXACTLY these two fields — nothing else influences processing.
+        params: { envelope: signed.canonical, signature: signed.signature },
+        id: 1,
+      }),
+    })
+    if (!response.ok) {
+      return { status: 'unreachable', message: `HTTP ${response.status}` }
+    }
+    const json = (await response.json()) as {
+      result?: unknown
+      error?: { code?: number; message?: string; data?: unknown }
+    }
+
+    if (json.error) {
+      // A refusal is an error whose `data` carries the structured outcome.
+      if (json.error.code === OPERATOR_NOT_ENABLED) {
+        return {
+          status: 'not-enabled',
+          message: json.error.message ?? 'operator actions not configured',
+        }
+      }
+      const outcome = parseOutcome(json.error.data)
+      if (outcome) return { status: 'ok', outcome }
+      if (json.error.code === OPERATOR_ACTION_REJECTED) {
+        // Rejected but no parseable outcome payload — surface the message.
+        return { status: 'unreachable', message: json.error.message ?? 'rejected' }
+      }
+      return { status: 'unreachable', message: json.error.message ?? 'rpc error' }
+    }
+
+    const outcome = parseOutcome(json.result)
+    if (!outcome) return { status: 'unreachable', message: 'unrecognized node response' }
+    return { status: 'ok', outcome }
+  } catch (e) {
+    return { status: 'unreachable', message: e instanceof Error ? e.message : 'network error' }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+/**
+ * Resolve a node's own base58 PeerId from `node_getStatus` (the `peerId`
+ * field), which is EXACTLY the value the node's `targetNode` binding check
+ * compares against (`botho/src/rpc/mod.rs`). The composer uses this to address
+ * each envelope automatically — the operator never types a PeerId, so a
+ * fleet-wide action produces one correctly-targeted envelope per node.
+ *
+ * Returns `null` on any failure (transport / missing field) — the caller must
+ * NOT sign an envelope for a node whose PeerId it could not confirm.
+ */
+export async function fetchNodePeerId(
+  node: FleetNode,
+  timeoutMs = 5000,
+): Promise<string | null> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(node.rpcEndpoint, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'node_getStatus', params: {}, id: 1 }),
+    })
+    if (!response.ok) return null
+    const json = (await response.json()) as { result?: { peerId?: unknown } }
+    const peerId = json.result?.peerId
+    return typeof peerId === 'string' && peerId.length > 0 ? peerId : null
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+/** One node's slot in a fleet submit: the node + its per-node signed envelope. */
+export interface FleetSubmitItem {
+  node: FleetNode
+  signed: SignedActionEnvelope
+}
+
+/** Per-node result of a fleet submit. */
+export interface FleetSubmitEntry {
+  nodeId: string
+  nodeName: string
+  result: SubmitResult
+}
+
+/**
+ * A fleet submit outcome (§7.3): per-node results PLUS the aggregate partial-
+ * failure classification. "Some nodes refused" is a first-class state, not a
+ * boolean — the UI must show exactly which nodes did what.
+ */
+export interface FleetSubmitOutcome {
+  entries: FleetSubmitEntry[]
+  /** Nodes that confirmed APPLIED (real apply). */
+  appliedNodeIds: string[]
+  /** Nodes that REFUSED (gate or verify). */
+  refusedNodeIds: string[]
+  /** Nodes that were unreachable / not-enabled (no verdict). */
+  inconclusiveNodeIds: string[]
+  /** True when every node applied. */
+  allApplied: boolean
+  /** True when at least one node applied AND at least one did not — partial. */
+  partial: boolean
+}
+
+/**
+ * Submit a per-node signed envelope to each node concurrently and classify the
+ * aggregate. Each node gets its OWN envelope (its own `targetNode` PeerId + its
+ * own fresh nonce) — the composer builds N envelopes for a fleet action.
+ */
+export async function submitToFleet(items: FleetSubmitItem[]): Promise<FleetSubmitOutcome> {
+  const entries: FleetSubmitEntry[] = await Promise.all(
+    items.map(async ({ node, signed }) => ({
+      nodeId: node.id,
+      nodeName: node.name,
+      result: await submitAction(node, signed),
+    })),
+  )
+
+  const appliedNodeIds = entries.filter((e) => isAppliedResult(e.result)).map((e) => e.nodeId)
+  const refusedNodeIds = entries.filter((e) => isRefusedResult(e.result)).map((e) => e.nodeId)
+  const inconclusiveNodeIds = entries
+    .filter((e) => !isAppliedResult(e.result) && !isRefusedResult(e.result))
+    .map((e) => e.nodeId)
+
+  const allApplied = entries.length > 0 && appliedNodeIds.length === entries.length
+  const partial = appliedNodeIds.length > 0 && appliedNodeIds.length < entries.length
+
+  return {
+    entries,
+    appliedNodeIds,
+    refusedNodeIds,
+    inconclusiveNodeIds,
+    allApplied,
+    partial,
+  }
+}

--- a/web/packages/features/src/operator/audit.test.ts
+++ b/web/packages/features/src/operator/audit.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchAuditLog } from './audit'
+import type { FleetNode } from '../network/types'
+
+const node: FleetNode = { id: 'a', name: 'Node A', rpcEndpoint: 'https://a.test/rpc' }
+
+const storedEntry = {
+  ts: 1_800_000_000,
+  signerKeyId: 'c5e21ab1c9f6022d',
+  envelopeHash: 'deadbeef'.repeat(8),
+  action: 'quorum.pin_member',
+  params: { peerId: '12D3KooWfake' },
+  dryRun: false,
+  outcome: 'applied',
+  prevQuorum: { mode: 'recommended', members: [], maxAutoMembers: 8 },
+  newQuorum: { mode: 'recommended', members: ['12D3KooWfake'], maxAutoMembers: 8 },
+  gate: { intersectionRefused: false },
+}
+
+function mockFetch(response: unknown, ok = true, status = 200) {
+  return vi.fn().mockResolvedValue({ ok, status, json: async () => response })
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('fetchAuditLog (renders stored entries only, anti-#541)', () => {
+  it('returns the node stored entries verbatim', async () => {
+    vi.stubGlobal('fetch', mockFetch({ result: { entries: [storedEntry], count: 1 } }))
+    const r = await fetchAuditLog(node, 'tok')
+    expect(r.status).toBe('ok')
+    if (r.status === 'ok') {
+      expect(r.data).toHaveLength(1)
+      expect(r.data[0].outcome).toBe('applied')
+      expect(r.data[0].newQuorum).toEqual(storedEntry.newQuorum)
+    }
+  })
+
+  it('returns an empty list when the node has no entries (not a fabricated one)', async () => {
+    vi.stubGlobal('fetch', mockFetch({ result: { entries: [], count: 0 } }))
+    const r = await fetchAuditLog(node, 'tok')
+    expect(r.status).toBe('ok')
+    if (r.status === 'ok') expect(r.data).toEqual([])
+  })
+
+  it('maps not-enabled / unauthorized / unreachable distinctly', async () => {
+    vi.stubGlobal('fetch', mockFetch({ error: { code: -32020 } }))
+    expect((await fetchAuditLog(node, 'tok')).status).toBe('not-enabled')
+
+    vi.stubGlobal('fetch', mockFetch({ error: { code: -32021 } }))
+    expect((await fetchAuditLog(node, 'bad')).status).toBe('unauthorized')
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('down')))
+    expect((await fetchAuditLog(node, 'tok')).status).toBe('unreachable')
+  })
+
+  it('drops malformed entries rather than surfacing garbage', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({ result: { entries: [storedEntry, { nonsense: true }, null] } }),
+    )
+    const r = await fetchAuditLog(node, 'tok')
+    expect(r.status).toBe('ok')
+    if (r.status === 'ok') expect(r.data).toHaveLength(1)
+  })
+})

--- a/web/packages/features/src/operator/audit.ts
+++ b/web/packages/features/src/operator/audit.ts
@@ -1,0 +1,114 @@
+/**
+ * `operator_getAuditLog` RPC client (#751) — fetches the node's persisted audit
+ * entries (#750's `OperatorAuditEntry` shape, §6). The dashboard's audit view
+ * renders EXCLUSIVELY from these stored entries (anti-#541) — it never
+ * fabricates or infers history.
+ *
+ * The read is token-gated (the same operator read token as
+ * `operator_getQuorumInfo`); the token is opaque to the client and verified
+ * only by the node.
+ */
+
+import type { FleetNode } from '../network/types'
+import type { OperatorFetchResult } from './types'
+
+const OPERATOR_NOT_ENABLED = -32020
+const OPERATOR_TOKEN_REJECTED = -32021
+
+/**
+ * One persisted audit entry, mirroring the node's `OperatorAuditEntry` (#750,
+ * §6 wire shape). Every field is exactly what the node stored — the view
+ * renders these verbatim.
+ */
+export interface AuditEntry {
+  /** Unix seconds the action was processed. */
+  ts: number
+  /** Fingerprint of the signing key. */
+  signerKeyId: string
+  /** blake2b-256 hex of the canonical signed envelope bytes. */
+  envelopeHash: string
+  /** The attempted action (`quorum.pin_member`, ...). */
+  action: string
+  /** The attempted action params. */
+  params: unknown
+  /** Whether the action was a dry run. */
+  dryRun: boolean
+  /** `applied` | `gate_refused` | `verify_refused:<reason>`. */
+  outcome: string
+  /** Quorum posture BEFORE the edit (present when known). */
+  prevQuorum?: unknown
+  /** Quorum posture AFTER — present ONLY for `applied` (refusals have no new state). */
+  newQuorum?: unknown
+  /** Gate snapshot for the evaluation (absent for pre-gate refusals). */
+  gate?: unknown
+}
+
+/** Parse one raw audit entry, keeping only the node-reported fields. */
+function parseEntry(v: unknown): AuditEntry | null {
+  if (!v || typeof v !== 'object') return null
+  const o = v as Record<string, unknown>
+  if (typeof o.action !== 'string' || typeof o.outcome !== 'string') return null
+  return {
+    ts: typeof o.ts === 'number' ? o.ts : 0,
+    signerKeyId: typeof o.signerKeyId === 'string' ? o.signerKeyId : '',
+    envelopeHash: typeof o.envelopeHash === 'string' ? o.envelopeHash : '',
+    action: o.action,
+    params: o.params,
+    dryRun: o.dryRun === true,
+    outcome: o.outcome,
+    // Use `in` so an explicitly-null field stays distinct from an absent one.
+    prevQuorum: 'prevQuorum' in o ? o.prevQuorum : undefined,
+    newQuorum: 'newQuorum' in o ? o.newQuorum : undefined,
+    gate: 'gate' in o ? o.gate : undefined,
+  }
+}
+
+/**
+ * Fetch one node's audit log (token-gated). Returns the node's stored entries
+ * (newest first, as the node serves them) or a degraded state. Never fabricates
+ * entries.
+ */
+export async function fetchAuditLog(
+  node: FleetNode,
+  token: string | null,
+  limit = 200,
+  timeoutMs = 8000,
+): Promise<OperatorFetchResult<AuditEntry[]>> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(node.rpcEndpoint, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'operator_getAuditLog',
+        params: { token: token ?? '', limit },
+        id: 1,
+      }),
+    })
+    if (!response.ok) return { status: 'unreachable' }
+    const json = (await response.json()) as {
+      result?: { entries?: unknown }
+      error?: { code?: number }
+    }
+    if (json.error) {
+      if (json.error.code === OPERATOR_NOT_ENABLED) return { status: 'not-enabled' }
+      if (json.error.code === OPERATOR_TOKEN_REJECTED) return { status: 'unauthorized' }
+      return { status: 'unreachable' }
+    }
+    const raw = json.result?.entries
+    if (!Array.isArray(raw)) return { status: 'unreachable' }
+    const entries: AuditEntry[] = []
+    for (const r of raw) {
+      const e = parseEntry(r)
+      if (e) entries.push(e)
+    }
+    return { status: 'ok', data: entries }
+  } catch {
+    return { status: 'unreachable' }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}

--- a/web/packages/features/src/operator/components/action-composer.test.tsx
+++ b/web/packages/features/src/operator/components/action-composer.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The composer's contract (#751, §3/§4/§6/§8.3):
+ *  - disabled until an operator key is imported;
+ *  - a MANDATORY dry-run preview shows the node's verdict AND the canonical
+ *    envelope BEFORE any real apply (§4, §8.3);
+ *  - the real apply is a SEPARATELY SIGNED dryRun:false envelope with a FRESH
+ *    nonce — the UI cannot reuse the dry-run bytes (finding 1);
+ *  - applied/refused state comes exclusively from the node response (anti-#541);
+ *  - fleet per-node refusal is a first-class partial-failure outcome (§7.3).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ActionComposer } from './action-composer'
+import { importOperatorKey } from '../key-vault'
+import type { SessionSigner } from '../key-vault'
+import type { FleetNode } from '../../network/types'
+import fixtures from '../fixtures/operator-action-fixtures.json'
+
+const NODES: FleetNode[] = [
+  { id: 'a', name: 'Node A', rpcEndpoint: 'https://a.test/rpc' },
+  { id: 'b', name: 'Node B', rpcEndpoint: 'https://b.test/rpc' },
+]
+
+const PEER_A = '12D3KooWA1111111111111111111111111111111111111111111'
+const PEER_B = '12D3KooWB2222222222222222222222222222222222222222222'
+
+function outcomeBody(outcome: string, dryRun: boolean) {
+  return {
+    outcome,
+    dryRun,
+    signerKeyId: fixtures.signerKeyId,
+    action: 'quorum.set_max_auto_members',
+    message: outcome,
+    auditTag: outcome,
+    authenticated: true,
+    resultingQuorum: { mode: 'recommended', members: [], maxAutoMembers: 8 },
+    gate: {
+      intersectionRefused: outcome !== 'applied',
+      curatedMembers: 0,
+      autoMembers: 3,
+      suppressedPeers: 0,
+      maxAutoMembers: 8,
+      faultTolerant: true,
+      degenerate: false,
+    },
+  }
+}
+
+/**
+ * Wire a fetch mock that:
+ *  - answers node_getStatus with each node's PeerId,
+ *  - records every operator_submitAction body so tests can assert on the
+ *    signed envelopes (dryRun flag + nonce), and returns a scripted outcome.
+ */
+function wireFetch(submitOutcome: (url: string, dryRun: boolean) => unknown) {
+  const submitBodies: { url: string; params: { envelope: string; signature: string } }[] = []
+  const fetchMock = vi.fn().mockImplementation((url: string, init: { body: string }) => {
+    const req = JSON.parse(init.body)
+    if (req.method === 'node_getStatus') {
+      const peerId = url.includes('a.test') ? PEER_A : PEER_B
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ result: { peerId } }) })
+    }
+    // operator_submitAction
+    const params = req.params as { envelope: string; signature: string }
+    submitBodies.push({ url, params })
+    const parsed = JSON.parse(params.envelope) as { dryRun: boolean }
+    const body = submitOutcome(url, parsed.dryRun)
+    return Promise.resolve({ ok: true, status: 200, json: async () => body })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return submitBodies
+}
+
+async function makeSigner(): Promise<SessionSigner> {
+  return importOperatorKey(fixtures.signingKeySeed, 'test-passphrase')
+}
+
+/** Fill the compose form for a set_max_auto_members action on both nodes. */
+function fillMaxAuto() {
+  fireEvent.change(screen.getByLabelText('Action'), {
+    target: { value: 'quorum.set_max_auto_members' },
+  })
+  fireEvent.change(screen.getByLabelText(/maxAutoMembers/), { target: { value: '8' } })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('ActionComposer', () => {
+  it('is disabled until a key is imported', () => {
+    render(<ActionComposer nodes={NODES} signer={null} />)
+    expect(screen.getByText(/Import the operator signing key/)).toBeTruthy()
+  })
+
+  it('dry-run preview shows the canonical envelope AND the node verdict before apply', async () => {
+    wireFetch((_url, dryRun) => ({ result: outcomeBody('applied', dryRun) }))
+    const signer = await makeSigner()
+    render(<ActionComposer nodes={NODES} signer={signer} />)
+    fillMaxAuto()
+    fireEvent.click(screen.getByText('Dry-run preview'))
+
+    // The canonical envelope for each node is displayed (§8.3).
+    await waitFor(() => expect(screen.getByTestId('canonical-a')).toBeTruthy())
+    const canonicalA = screen.getByTestId('canonical-a').textContent ?? ''
+    expect(canonicalA).toContain('"dryRun":true')
+    expect(canonicalA).toContain(`"targetNode":"${PEER_A}"`)
+    // The node's verdict is shown before any real apply.
+    expect(screen.getAllByText('would apply').length).toBeGreaterThan(0)
+    // The apply button exists but nothing has been applied yet.
+    expect(screen.getByText(/Sign & apply/)).toBeTruthy()
+    expect(screen.queryByTestId('apply-result')).toBeNull()
+  })
+
+  it('the real apply is a separately-signed dryRun:false envelope with a FRESH nonce (finding 1)', async () => {
+    const bodies = wireFetch((_url, dryRun) => ({ result: outcomeBody('applied', dryRun) }))
+    const signer = await makeSigner()
+    render(<ActionComposer nodes={NODES} signer={signer} />)
+    fillMaxAuto()
+    fireEvent.click(screen.getByText('Dry-run preview'))
+    await waitFor(() => expect(screen.getByTestId('canonical-a')).toBeTruthy())
+
+    fireEvent.click(screen.getByText(/Sign & apply/))
+    await waitFor(() => expect(screen.getByTestId('apply-result')).toBeTruthy())
+
+    // Two dry-run envelopes (one per node) + two apply envelopes were submitted.
+    const dryRuns = bodies.filter((b) => JSON.parse(b.params.envelope).dryRun === true)
+    const applies = bodies.filter((b) => JSON.parse(b.params.envelope).dryRun === false)
+    expect(dryRuns).toHaveLength(2)
+    expect(applies).toHaveLength(2)
+
+    // For node A: the apply envelope is DIFFERENT bytes, DIFFERENT signature,
+    // and a DIFFERENT nonce than the dry-run — the UI never flipped a flag.
+    const dryA = dryRuns.find((b) => b.url.includes('a.test'))!
+    const applyA = applies.find((b) => b.url.includes('a.test'))!
+    expect(applyA.params.envelope).not.toBe(dryA.params.envelope)
+    expect(applyA.params.signature).not.toBe(dryA.params.signature)
+    const dryNonce = JSON.parse(dryA.params.envelope).nonce
+    const applyNonce = JSON.parse(applyA.params.envelope).nonce
+    expect(applyNonce).not.toBe(dryNonce)
+  })
+
+  it('renders applied EXCLUSIVELY from the node response (anti-#541)', async () => {
+    wireFetch((_url, dryRun) => ({ result: outcomeBody('applied', dryRun) }))
+    const signer = await makeSigner()
+    render(<ActionComposer nodes={NODES} signer={signer} />)
+    fillMaxAuto()
+    fireEvent.click(screen.getByText('Dry-run preview'))
+    await waitFor(() => expect(screen.getByTestId('canonical-a')).toBeTruthy())
+    fireEvent.click(screen.getByText(/Sign & apply/))
+    await waitFor(() => expect(screen.getByTestId('apply-result')).toBeTruthy())
+    // Both nodes report applied.
+    expect(screen.getAllByText('applied').length).toBe(2)
+  })
+
+  it('fleet per-node refusal is a first-class partial-failure outcome (§7.3)', async () => {
+    // Node A applies; node B refuses (gate_refused).
+    wireFetch((url, dryRun) => {
+      if (url.includes('b.test')) {
+        return { error: { code: -32024, data: outcomeBody('gate_refused', dryRun) } }
+      }
+      return { result: outcomeBody('applied', dryRun) }
+    })
+    const signer = await makeSigner()
+    render(<ActionComposer nodes={NODES} signer={signer} />)
+    fillMaxAuto()
+    fireEvent.click(screen.getByText('Dry-run preview'))
+    await waitFor(() => expect(screen.getByTestId('canonical-a')).toBeTruthy())
+    fireEvent.click(screen.getByText(/Sign & apply/))
+    await waitFor(() => expect(screen.getByTestId('apply-result')).toBeTruthy())
+
+    // The partial-failure banner is shown.
+    expect(screen.getByTestId('partial-failure')).toBeTruthy()
+    expect(screen.getByText('applied')).toBeTruthy()
+    expect(screen.getByText('gate_refused')).toBeTruthy()
+  })
+})

--- a/web/packages/features/src/operator/components/action-composer.tsx
+++ b/web/packages/features/src/operator/components/action-composer.tsx
@@ -1,0 +1,528 @@
+import { useMemo, useState } from 'react'
+import { AlertTriangle, CheckCircle2, Eye, KeyRound, ShieldAlert, XCircle } from 'lucide-react'
+import { Card, CardContent } from '@botho/ui'
+import type { FleetNode } from '../../network/types'
+import {
+  buildDryRun,
+  buildRealApply,
+  MAX_AUTO_MEMBERS_CEILING,
+  type ComposeActionRequest,
+  type OperatorActionName,
+  type SignedActionEnvelope,
+} from '../action-envelope'
+import {
+  fetchNodePeerId,
+  submitToFleet,
+  type FleetSubmitItem,
+  type FleetSubmitOutcome,
+  type SubmitResult,
+} from '../action-submit'
+import type { SessionSigner } from '../key-vault'
+
+/**
+ * The action composer (#751, §3/§4/§6/§8.3): compose a v1 quorum-curation
+ * action, sign a MANDATORY dry-run, review the node's verdict + the canonical
+ * envelope, then sign a SEPARATE real-apply envelope (fresh nonce, finding 1).
+ * Applied/refused state comes exclusively from the node's response (anti-#541).
+ *
+ * State machine:
+ *   compose → (sign dryRun, submit) → preview → (sign fresh apply, submit) → result
+ * The operator sees the canonical bytes at BOTH the preview and the apply
+ * confirmation, before any signature is sent (§8.3 mitigation).
+ */
+
+type Phase = 'compose' | 'previewing' | 'preview' | 'applying' | 'result'
+
+export interface ActionComposerProps {
+  nodes: FleetNode[]
+  /** The unlocked session signer; null ⇒ the composer is disabled. */
+  signer: SessionSigner | null
+  className?: string
+}
+
+interface PreviewState {
+  /** The per-node signed dry-run envelopes (for display) + node results. */
+  entries: { node: FleetNode; signed: SignedActionEnvelope; result: SubmitResult }[]
+  /** The compose request captured at preview time (reused to build the apply). */
+  request: Omit<ComposeActionRequest, 'targetNode'>
+  /** Resolved targetNode per node id at preview time. */
+  targetNodeById: Record<string, string>
+}
+
+export function ActionComposer({ nodes, signer, className }: ActionComposerProps) {
+  const [action, setAction] = useState<OperatorActionName>('quorum.pin_member')
+  const [peerId, setPeerId] = useState('')
+  const [maxAuto, setMaxAuto] = useState('8')
+  const [ack, setAck] = useState(false)
+  const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>(nodes.map((n) => n.id))
+  const [phase, setPhase] = useState<Phase>('compose')
+  const [error, setError] = useState<string | null>(null)
+  const [preview, setPreview] = useState<PreviewState | null>(null)
+  const [result, setResult] = useState<FleetSubmitOutcome | null>(null)
+
+  const disabled = signer === null
+
+  const selectedNodes = useMemo(
+    () => nodes.filter((n) => selectedNodeIds.includes(n.id)),
+    [nodes, selectedNodeIds],
+  )
+
+  function buildRequestBase(): Omit<ComposeActionRequest, 'targetNode'> {
+    const params =
+      action === 'quorum.set_max_auto_members'
+        ? { value: Number.parseInt(maxAuto, 10) }
+        : { peerId: peerId.trim() }
+    return {
+      action,
+      params,
+      signerKeyId: signer!.signerKeyId,
+      acknowledgeDegenerate: ack ? true : undefined,
+    }
+  }
+
+  /**
+   * Step 1: sign a dryRun:true envelope PER node (resolving each node's PeerId
+   * live), submit, and show the operator the node's verdict + the canonical
+   * bytes before any real apply.
+   */
+  async function onPreview() {
+    setError(null)
+    if (!signer) {
+      setError('Import the operator key first.')
+      return
+    }
+    if (selectedNodes.length === 0) {
+      setError('Select at least one target node.')
+      return
+    }
+    setPhase('previewing')
+    try {
+      const base = buildRequestBase()
+      const targetNodeById: Record<string, string> = {}
+      const entries: PreviewState['entries'] = []
+      for (const node of selectedNodes) {
+        const target = await fetchNodePeerId(node)
+        if (!target) {
+          entries.push({
+            node,
+            // Cannot sign for a node whose PeerId is unconfirmed.
+            signed: {
+              canonical: '',
+              signature: '',
+              envelopeHash: '',
+              fields: {} as SignedActionEnvelope['fields'],
+            },
+            result: { status: 'unreachable', message: 'could not resolve node PeerId' },
+          })
+          continue
+        }
+        targetNodeById[node.id] = target
+        const signed = buildDryRun({ ...base, targetNode: target }, signer.sign)
+        const result = (await submitToFleet([{ node, signed }])).entries[0].result
+        entries.push({ node, signed, result })
+      }
+      setPreview({ entries, request: base, targetNodeById })
+      setPhase('preview')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'preview failed')
+      setPhase('compose')
+    }
+  }
+
+  /**
+   * Step 2: sign a SEPARATE dryRun:false envelope with a FRESH nonce per node
+   * (finding 1 — the UI never reuses the dry-run bytes), submit, and render the
+   * node-confirmed outcome.
+   */
+  async function onApply() {
+    if (!signer || !preview) return
+    setPhase('applying')
+    setError(null)
+    try {
+      const items: FleetSubmitItem[] = []
+      for (const { node } of preview.entries) {
+        const target = preview.targetNodeById[node.id]
+        if (!target) continue // node we could not target at preview time
+        const signed = buildRealApply({ ...preview.request, targetNode: target }, signer.sign)
+        items.push({ node, signed })
+      }
+      const outcome = await submitToFleet(items)
+      setResult(outcome)
+      setPhase('result')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'apply failed')
+      setPhase('preview')
+    }
+  }
+
+  function reset() {
+    setPreview(null)
+    setResult(null)
+    setError(null)
+    setPhase('compose')
+  }
+
+  if (disabled) {
+    return (
+      <Card className={className}>
+        <CardContent className="flex items-center gap-3 py-6 text-ghost">
+          <KeyRound className="h-5 w-5 shrink-0" />
+          <span>Import the operator signing key to compose actions.</span>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className={`space-y-4 ${className ?? ''}`} data-testid="action-composer">
+      {error && (
+        <div
+          role="alert"
+          className="flex items-center gap-2 rounded border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-300"
+        >
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {(phase === 'compose' || phase === 'previewing') && (
+        <ComposeForm
+          action={action}
+          setAction={setAction}
+          peerId={peerId}
+          setPeerId={setPeerId}
+          maxAuto={maxAuto}
+          setMaxAuto={setMaxAuto}
+          ack={ack}
+          setAck={setAck}
+          nodes={nodes}
+          selectedNodeIds={selectedNodeIds}
+          setSelectedNodeIds={setSelectedNodeIds}
+          busy={phase === 'previewing'}
+          onPreview={onPreview}
+        />
+      )}
+
+      {(phase === 'preview' || phase === 'applying') && preview && (
+        <PreviewPanel
+          preview={preview}
+          busy={phase === 'applying'}
+          onApply={onApply}
+          onCancel={reset}
+        />
+      )}
+
+      {phase === 'result' && result && <ResultPanel result={result} onDone={reset} />}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Compose form
+// ---------------------------------------------------------------------------
+
+interface ComposeFormProps {
+  action: OperatorActionName
+  setAction: (a: OperatorActionName) => void
+  peerId: string
+  setPeerId: (s: string) => void
+  maxAuto: string
+  setMaxAuto: (s: string) => void
+  ack: boolean
+  setAck: (b: boolean) => void
+  nodes: FleetNode[]
+  selectedNodeIds: string[]
+  setSelectedNodeIds: (ids: string[]) => void
+  busy: boolean
+  onPreview: () => void
+}
+
+function ComposeForm(props: ComposeFormProps) {
+  const isPeerAction = props.action !== 'quorum.set_max_auto_members'
+  const toggleNode = (id: string) => {
+    props.setSelectedNodeIds(
+      props.selectedNodeIds.includes(id)
+        ? props.selectedNodeIds.filter((x) => x !== id)
+        : [...props.selectedNodeIds, id],
+    )
+  }
+  return (
+    <Card>
+      <CardContent className="space-y-4 py-5">
+        <div className="space-y-1">
+          <label htmlFor="op-action" className="text-sm text-ghost">
+            Action
+          </label>
+          <select
+            id="op-action"
+            value={props.action}
+            onChange={(e) => props.setAction(e.target.value as OperatorActionName)}
+            className="w-full rounded border border-steel bg-abyss px-3 py-2 text-sm text-light"
+          >
+            <option value="quorum.pin_member">quorum.pin_member</option>
+            <option value="quorum.unpin_member">quorum.unpin_member</option>
+            <option value="quorum.set_max_auto_members">quorum.set_max_auto_members</option>
+          </select>
+        </div>
+
+        {isPeerAction ? (
+          <div className="space-y-1">
+            <label htmlFor="op-peer" className="text-sm text-ghost">
+              Member PeerId (base58)
+            </label>
+            <input
+              id="op-peer"
+              value={props.peerId}
+              onChange={(e) => props.setPeerId(e.target.value)}
+              placeholder="12D3Koo..."
+              className="w-full rounded border border-steel bg-abyss px-3 py-2 font-mono text-sm text-light"
+            />
+          </div>
+        ) : (
+          <div className="space-y-1">
+            <label htmlFor="op-max" className="text-sm text-ghost">
+              maxAutoMembers (0..{MAX_AUTO_MEMBERS_CEILING})
+            </label>
+            <input
+              id="op-max"
+              type="number"
+              min={0}
+              max={MAX_AUTO_MEMBERS_CEILING}
+              value={props.maxAuto}
+              onChange={(e) => props.setMaxAuto(e.target.value)}
+              className="w-full rounded border border-steel bg-abyss px-3 py-2 text-sm text-light"
+            />
+          </div>
+        )}
+
+        <label className="flex items-center gap-2 text-sm text-ghost">
+          <input
+            type="checkbox"
+            checked={props.ack}
+            onChange={(e) => props.setAck(e.target.checked)}
+          />
+          acknowledgeDegenerate (required only to shrink below the 4-node BFT floor)
+        </label>
+
+        <div className="space-y-1">
+          <span className="text-sm text-ghost">Target nodes (one signed envelope per node)</span>
+          <div className="flex flex-wrap gap-2">
+            {props.nodes.map((n) => (
+              <label
+                key={n.id}
+                className="flex items-center gap-1.5 rounded border border-steel px-2 py-1 text-xs text-light"
+              >
+                <input
+                  type="checkbox"
+                  checked={props.selectedNodeIds.includes(n.id)}
+                  onChange={() => toggleNode(n.id)}
+                />
+                {n.name}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={props.onPreview}
+          disabled={props.busy}
+          className="flex items-center gap-2 rounded bg-[--color-slate] px-4 py-2 text-sm font-medium text-light disabled:opacity-50"
+        >
+          <Eye className="h-4 w-4" />
+          {props.busy ? 'Signing dry-run…' : 'Dry-run preview'}
+        </button>
+      </CardContent>
+    </Card>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Preview panel — shows canonical bytes + node verdict before real apply
+// ---------------------------------------------------------------------------
+
+function PreviewPanel({
+  preview,
+  busy,
+  onApply,
+  onCancel,
+}: {
+  preview: PreviewState
+  busy: boolean
+  onApply: () => void
+  onCancel: () => void
+}) {
+  const anyTargetable = preview.entries.some((e) => e.signed.canonical !== '')
+  return (
+    <Card>
+      <CardContent className="space-y-4 py-5">
+        <div className="flex items-center gap-2 text-sm font-medium text-light">
+          <Eye className="h-4 w-4" />
+          Dry-run preview — review before signing the real apply
+        </div>
+        <p className="text-xs text-ghost">
+          The real apply is a SEPARATELY SIGNED envelope with a fresh nonce. Review the exact
+          canonical bytes below (what you will sign) and each node&apos;s verdict.
+        </p>
+
+        {preview.entries.map(({ node, signed, result }) => (
+          <div key={node.id} className="space-y-2 rounded border border-steel p-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-light">{node.name}</span>
+              <VerdictBadge result={result} />
+            </div>
+            {signed.canonical ? (
+              <pre
+                data-testid={`canonical-${node.id}`}
+                className="overflow-x-auto rounded bg-abyss p-2 font-mono text-[11px] text-ghost"
+              >
+                {signed.canonical}
+              </pre>
+            ) : (
+              <span className="text-xs text-red-300">
+                Not targetable: {result.status === 'unreachable' ? result.message : result.status}
+              </span>
+            )}
+            {result.status === 'ok' && <QuorumPreview result={result} />}
+          </div>
+        ))}
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onApply}
+            disabled={busy || !anyTargetable}
+            className="flex items-center gap-2 rounded bg-emerald-600/80 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+          >
+            <CheckCircle2 className="h-4 w-4" />
+            {busy ? 'Signing apply…' : 'Sign & apply (fresh signature)'}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="rounded border border-steel px-4 py-2 text-sm text-ghost disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function QuorumPreview({ result }: { result: Extract<SubmitResult, { status: 'ok' }> }) {
+  const q = result.outcome.resultingQuorum
+  const g = result.outcome.gate
+  return (
+    <div className="text-xs text-ghost">
+      {q && (
+        <div>
+          Resulting quorum: mode {q.mode}, {q.members.length} curated member(s), cap{' '}
+          {q.maxAutoMembers}
+        </div>
+      )}
+      {g && (
+        <div className="flex items-center gap-1">
+          {g.degenerate && <ShieldAlert className="h-3 w-3 text-amber-400" />}
+          {g.intersectionRefused ? 'intersection REFUSED' : 'intersection ok'} · fault-tolerant:{' '}
+          {String(g.faultTolerant)}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function VerdictBadge({ result }: { result: SubmitResult }) {
+  if (result.status !== 'ok') {
+    return (
+      <span className="rounded bg-steel/40 px-2 py-0.5 text-[11px] text-ghost">
+        {result.status}
+      </span>
+    )
+  }
+  const cls = result.outcome.outcome
+  if (cls === 'applied') {
+    return (
+      <span className="rounded bg-emerald-600/30 px-2 py-0.5 text-[11px] text-emerald-300">
+        would apply
+      </span>
+    )
+  }
+  return (
+    <span className="rounded bg-red-500/20 px-2 py-0.5 text-[11px] text-red-300">
+      {result.outcome.auditTag}
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Result panel — node-confirmed apply outcomes ONLY (anti-#541)
+// ---------------------------------------------------------------------------
+
+function ResultPanel({ result, onDone }: { result: FleetSubmitOutcome; onDone: () => void }) {
+  return (
+    <Card>
+      <CardContent className="space-y-3 py-5" data-testid="apply-result">
+        <div className="text-sm font-medium text-light">Apply result (from node responses)</div>
+
+        {result.partial && (
+          <div
+            role="alert"
+            data-testid="partial-failure"
+            className="flex items-center gap-2 rounded border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-300"
+          >
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            Partial failure: {result.appliedNodeIds.length} node(s) applied,{' '}
+            {result.refusedNodeIds.length} refused, {result.inconclusiveNodeIds.length} inconclusive.
+          </div>
+        )}
+
+        {result.entries.map((e) => (
+          <div
+            key={e.nodeId}
+            className="flex items-center justify-between rounded border border-steel px-3 py-2"
+          >
+            <span className="text-sm text-light">{e.nodeName}</span>
+            <ResultBadge result={e.result} />
+          </div>
+        ))}
+
+        <button
+          type="button"
+          onClick={onDone}
+          className="rounded border border-steel px-4 py-2 text-sm text-ghost"
+        >
+          Compose another
+        </button>
+      </CardContent>
+    </Card>
+  )
+}
+
+function ResultBadge({ result }: { result: SubmitResult }) {
+  if (result.status !== 'ok') {
+    return (
+      <span className="flex items-center gap-1 text-xs text-ghost">
+        <XCircle className="h-3.5 w-3.5" />
+        {result.status}
+        {result.status !== 'not-enabled' ? '' : ''}
+      </span>
+    )
+  }
+  const cls = result.outcome.outcome
+  if (cls === 'applied' && !result.outcome.dryRun) {
+    return (
+      <span className="flex items-center gap-1 text-xs text-emerald-300">
+        <CheckCircle2 className="h-3.5 w-3.5" />
+        applied
+      </span>
+    )
+  }
+  return (
+    <span className="flex items-center gap-1 text-xs text-red-300">
+      <XCircle className="h-3.5 w-3.5" />
+      {result.outcome.auditTag}
+    </span>
+  )
+}

--- a/web/packages/features/src/operator/components/audit-log-view.test.tsx
+++ b/web/packages/features/src/operator/components/audit-log-view.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The audit view's contract (#751, §6, anti-#541): it renders EXCLUSIVELY the
+ * node's stored entries. An empty list shows "no actions", a failed fetch shows
+ * an explicit unavailable state — never a fabricated success.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { AuditLogView } from './audit-log-view'
+import type { AuditEntry } from '../audit'
+
+afterEach(cleanup)
+
+const applied: AuditEntry = {
+  ts: 1_800_000_000,
+  signerKeyId: 'c5e21ab1c9f6022d',
+  envelopeHash: 'deadbeef'.repeat(8),
+  action: 'quorum.pin_member',
+  params: { peerId: '12D3KooWfake' },
+  dryRun: false,
+  outcome: 'applied',
+  newQuorum: { mode: 'recommended', members: ['12D3KooWfake'], maxAutoMembers: 8 },
+}
+
+const refused: AuditEntry = {
+  ts: 1_800_000_100,
+  signerKeyId: 'c5e21ab1c9f6022d',
+  envelopeHash: 'cafe'.repeat(16),
+  action: 'quorum.unpin_member',
+  params: { peerId: '12D3KooWfake' },
+  dryRun: false,
+  outcome: 'gate_refused',
+}
+
+describe('AuditLogView', () => {
+  it('renders stored entries with their node-reported outcomes', () => {
+    render(<AuditLogView entries={[refused, applied]} />)
+    expect(screen.getByTestId('audit-log-view')).toBeTruthy()
+    expect(screen.getByText('applied')).toBeTruthy()
+    expect(screen.getByText('gate_refused')).toBeTruthy()
+    expect(screen.getByText('quorum.pin_member')).toBeTruthy()
+  })
+
+  it('shows an explicit empty state when there are no entries', () => {
+    render(<AuditLogView entries={[]} />)
+    expect(screen.getByText(/No operator actions recorded/)).toBeTruthy()
+    expect(screen.queryByTestId('audit-log-view')).toBeNull()
+  })
+
+  it('shows an explicit unavailable state on fetch failure (never fabricated entries)', () => {
+    render(<AuditLogView entries={[]} unavailable />)
+    expect(screen.getByText(/Audit log unavailable/)).toBeTruthy()
+    expect(screen.queryByTestId('audit-log-view')).toBeNull()
+  })
+
+  it('does NOT show a dry-run entry as applied', () => {
+    render(<AuditLogView entries={[{ ...applied, dryRun: true }]} />)
+    // The applied badge is only for real applies; a dry-run renders its outcome tag.
+    expect(screen.queryByText('applied')).toBeNull()
+  })
+})

--- a/web/packages/features/src/operator/components/audit-log-view.tsx
+++ b/web/packages/features/src/operator/components/audit-log-view.tsx
@@ -1,0 +1,109 @@
+import { CheckCircle2, FileClock, XCircle } from 'lucide-react'
+import { Card, CardContent } from '@botho/ui'
+import type { AuditEntry } from '../audit'
+
+/**
+ * Audit-log view (#751, §6, anti-#541): renders EXCLUSIVELY the node's stored
+ * audit entries (#750's `OperatorAuditEntry`). It never fabricates, infers, or
+ * optimistically shows an outcome — an empty list is an empty list, and a
+ * failed fetch renders an explicit unavailable state, not a blank success.
+ */
+
+export interface AuditLogViewProps {
+  /** The node's stored entries (newest first, as the node serves them). */
+  entries: AuditEntry[]
+  /** True when the audit fetch failed / is unauthorized — show, don't fake. */
+  unavailable?: boolean
+  className?: string
+}
+
+export function AuditLogView({ entries, unavailable, className }: AuditLogViewProps) {
+  if (unavailable) {
+    return (
+      <Card className={className}>
+        <CardContent className="flex items-center gap-3 py-6 text-ghost">
+          <FileClock className="h-5 w-5 shrink-0" />
+          Audit log unavailable (unreachable or unauthorized). No entries are shown rather than
+          fabricated ones.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (entries.length === 0) {
+    return (
+      <Card className={className}>
+        <CardContent className="flex items-center gap-3 py-6 text-ghost">
+          <FileClock className="h-5 w-5 shrink-0" />
+          No operator actions recorded on this node yet.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className={`space-y-2 ${className ?? ''}`} data-testid="audit-log-view">
+      {entries.map((e, i) => (
+        <AuditRow key={`${e.envelopeHash}-${e.ts}-${i}`} entry={e} />
+      ))}
+    </div>
+  )
+}
+
+function AuditRow({ entry }: { entry: AuditEntry }) {
+  const applied = entry.outcome === 'applied'
+  const when = entry.ts ? new Date(entry.ts * 1000).toISOString() : 'unknown time'
+  return (
+    <Card>
+      <CardContent className="space-y-1 py-3">
+        <div className="flex items-center justify-between">
+          <span className="font-mono text-sm text-light">{entry.action}</span>
+          <OutcomeBadge outcome={entry.outcome} applied={applied} dryRun={entry.dryRun} />
+        </div>
+        <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-ghost">
+          <span>{when}</span>
+          <span>signer {entry.signerKeyId || '—'}</span>
+          {entry.dryRun && <span className="text-amber-400">dry-run</span>}
+          <span className="font-mono">env {entry.envelopeHash.slice(0, 12)}…</span>
+        </div>
+        <pre className="overflow-x-auto rounded bg-abyss p-1.5 font-mono text-[11px] text-ghost">
+          {JSON.stringify(entry.params)}
+        </pre>
+      </CardContent>
+    </Card>
+  )
+}
+
+function OutcomeBadge({
+  outcome,
+  applied,
+  dryRun,
+}: {
+  outcome: string
+  applied: boolean
+  dryRun: boolean
+}) {
+  if (applied && !dryRun) {
+    return (
+      <span className="flex items-center gap-1 text-xs text-emerald-300">
+        <CheckCircle2 className="h-3.5 w-3.5" />
+        applied
+      </span>
+    )
+  }
+  if (applied && dryRun) {
+    // A dry-run that the gate WOULD accept: never shown as "applied" (nothing
+    // was installed). Label it as a preview so it is unmistakable (anti-#541).
+    return (
+      <span className="flex items-center gap-1 text-xs text-amber-300">
+        dry-run (would apply)
+      </span>
+    )
+  }
+  return (
+    <span className="flex items-center gap-1 text-xs text-red-300">
+      <XCircle className="h-3.5 w-3.5" />
+      {outcome}
+    </span>
+  )
+}

--- a/web/packages/features/src/operator/fixtures/operator-action-fixtures.json
+++ b/web/packages/features/src/operator/fixtures/operator-action-fixtures.json
@@ -1,0 +1,75 @@
+{
+  "_comment": [
+    "CROSS-LANGUAGE CANONICALIZATION FIXTURE (issue #751).",
+    "These values are produced by the NODE's Rust operator-action code",
+    "(botho/src/operator_action.rs) for the deterministic signing key",
+    "SigningKey::from_bytes(&[1u8; 32]). The browser composer MUST reproduce the",
+    "EXACT canonical byte string, the EXACT Ed25519 signature over",
+    "'botho-operator-action-v1' || canonical_bytes, the EXACT signerKeyId",
+    "(blake2b-256(pubkey)[..8] hex), and the EXACT envelopeHash",
+    "(blake2b-256(canonical_bytes) hex). If any of these drift, the node's",
+    "parse-after-verify signature check fails — the #1 failure mode for this",
+    "feature. action-envelope.test.ts asserts byte-equality against every entry.",
+    "To regenerate: temporarily print these from a Rust test in operator_action.rs",
+    "using the existing build_signed/sign_str test helpers (seed [1;32])."
+  ],
+  "domainSeparator": "botho-operator-action-v1",
+  "signingKeySeed": "0101010101010101010101010101010101010101010101010101010101010101",
+  "publicKeyHex": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c",
+  "signerKeyId": "c5e21ab1c9f6022d",
+  "targetNode": "12D3KooWL3hwtanTFomj8bT4KQEHukZW7QxNMqtopYFKae2cJ7Nr",
+  "memberPeerId": "12D3KooWJWoaqZhDaoEFshF7Rh1bpY9ohihFhzcW6d69Lr2NASuq",
+  "envelopes": [
+    {
+      "name": "pin_member dryRun",
+      "fields": {
+        "v": 1,
+        "action": "quorum.pin_member",
+        "params": { "peerId": "12D3KooWJWoaqZhDaoEFshF7Rh1bpY9ohihFhzcW6d69Lr2NASuq" },
+        "targetNode": "12D3KooWL3hwtanTFomj8bT4KQEHukZW7QxNMqtopYFKae2cJ7Nr",
+        "signerKeyId": "c5e21ab1c9f6022d",
+        "nonce": "00112233445566778899aabbccddeeff",
+        "issuedAt": 1800000000,
+        "expiresAt": 1800000100,
+        "dryRun": true
+      },
+      "canonical": "{\"action\":\"quorum.pin_member\",\"dryRun\":true,\"expiresAt\":1800000100,\"issuedAt\":1800000000,\"nonce\":\"00112233445566778899aabbccddeeff\",\"params\":{\"peerId\":\"12D3KooWJWoaqZhDaoEFshF7Rh1bpY9ohihFhzcW6d69Lr2NASuq\"},\"signerKeyId\":\"c5e21ab1c9f6022d\",\"targetNode\":\"12D3KooWL3hwtanTFomj8bT4KQEHukZW7QxNMqtopYFKae2cJ7Nr\",\"v\":1}",
+      "signature": "0243ef32149904b90f38933e5d604413883ee70cf63958367fad3cec416135fee352c84022ac306be38f2abbcb17a1e7656311e112f2b4b2ab005915a8cdb006",
+      "envelopeHash": "3d0bba6b7353a6ccb9d1b71fe86b89a4e43c55faafef1c567cc7ace62554b5b5"
+    },
+    {
+      "name": "set_max_auto_members apply",
+      "fields": {
+        "v": 1,
+        "action": "quorum.set_max_auto_members",
+        "params": { "value": 8 },
+        "targetNode": "12D3KooWL3hwtanTFomj8bT4KQEHukZW7QxNMqtopYFKae2cJ7Nr",
+        "signerKeyId": "c5e21ab1c9f6022d",
+        "nonce": "aabbccddeeff00112233445566778899",
+        "issuedAt": 1800000000,
+        "expiresAt": 1800000100,
+        "dryRun": false
+      },
+      "canonical": "{\"action\":\"quorum.set_max_auto_members\",\"dryRun\":false,\"expiresAt\":1800000100,\"issuedAt\":1800000000,\"nonce\":\"aabbccddeeff00112233445566778899\",\"params\":{\"value\":8},\"signerKeyId\":\"c5e21ab1c9f6022d\",\"targetNode\":\"12D3KooWL3hwtanTFomj8bT4KQEHukZW7QxNMqtopYFKae2cJ7Nr\",\"v\":1}",
+      "signature": "33db378de0a4d6c4ab57d479c10d99bb273349865c7e8620edd48c2a23b276b9eb344184b6dac6b8426c930892f9665e4bc2fb192d62fa471f35920034a8560f",
+      "envelopeHash": "8a36b680bef590fec0cfff0c3fa2548e1483b47a9ec1952e986b506a70ec4597"
+    },
+    {
+      "name": "unpin_member acknowledgeDegenerate",
+      "fields": {
+        "v": 1,
+        "action": "quorum.unpin_member",
+        "params": { "peerId": "12D3KooWJWoaqZhDaoEFshF7Rh1bpY9ohihFhzcW6d69Lr2NASuq" },
+        "targetNode": "12D3KooWL3hwtanTFomj8bT4KQEHukZW7QxNMqtopYFKae2cJ7Nr",
+        "signerKeyId": "c5e21ab1c9f6022d",
+        "nonce": "0102030405060708090a0b0c0d0e0f10",
+        "issuedAt": 1800000000,
+        "expiresAt": 1800000100,
+        "dryRun": false,
+        "acknowledgeDegenerate": true
+      },
+      "canonical": "{\"acknowledgeDegenerate\":true,\"action\":\"quorum.unpin_member\",\"dryRun\":false,\"expiresAt\":1800000100,\"issuedAt\":1800000000,\"nonce\":\"0102030405060708090a0b0c0d0e0f10\",\"params\":{\"peerId\":\"12D3KooWJWoaqZhDaoEFshF7Rh1bpY9ohihFhzcW6d69Lr2NASuq\"},\"signerKeyId\":\"c5e21ab1c9f6022d\",\"targetNode\":\"12D3KooWL3hwtanTFomj8bT4KQEHukZW7QxNMqtopYFKae2cJ7Nr\",\"v\":1}",
+      "signature": "598e83d2933b0dc2ab81bd37fc099bafb94c2ff182e6bd40b53013ac335c4ae0b873bb30b4067d120a260dd8aaa0ec0b9a7c5761acecabddc507b1af8122eb0a"
+    }
+  ]
+}

--- a/web/packages/features/src/operator/hooks.ts
+++ b/web/packages/features/src/operator/hooks.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import type { FleetNode } from '../network/types'
 import { fetchOperatorQuorumInfo, fetchTrustStatuses } from './quorum'
+import { fetchAuditLog, type AuditEntry } from './audit'
 import type { NodeTrustStatus, OperatorFetchResult, OperatorQuorumInfo } from './types'
 
 /**
@@ -119,4 +120,48 @@ export function useOperatorQuorumInfo(
   }
 
   return { info, mode }
+}
+
+export interface UseOperatorAuditLogResult {
+  /** Per-node audit fetch result; missing key = first poll in flight. */
+  logs: Record<string, OperatorFetchResult<AuditEntry[]>>
+}
+
+/**
+ * Poll every node's persisted audit log (#750/#751, §6) using the operator read
+ * `token`. Entries come EXCLUSIVELY from the node (anti-#541). When `token` is
+ * falsy the hook does nothing (the audit view then shows an unavailable state).
+ *
+ * Callers must pass a referentially-stable `nodes` array — it is an effect
+ * dependency.
+ */
+export function useOperatorAuditLog(
+  nodes: FleetNode[],
+  token: string | null,
+  { pollMs = 30_000 }: UseTrustStatusOptions = {},
+): UseOperatorAuditLogResult {
+  const [logs, setLogs] = useState<Record<string, OperatorFetchResult<AuditEntry[]>>>({})
+
+  useEffect(() => {
+    if (!token) {
+      setLogs({})
+      return
+    }
+    let cancelled = false
+    const poll = async () => {
+      const results = await Promise.all(
+        nodes.map(async (n) => [n.id, await fetchAuditLog(n, token)] as const),
+      )
+      if (cancelled) return
+      setLogs(Object.fromEntries(results))
+    }
+    poll()
+    const id = setInterval(poll, pollMs)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [nodes, token, pollMs])
+
+  return { logs }
 }

--- a/web/packages/features/src/operator/index.ts
+++ b/web/packages/features/src/operator/index.ts
@@ -2,8 +2,14 @@ export * from './types'
 export * from './quorum'
 export * from './hooks'
 export * from './token'
+export * from './action-envelope'
+export * from './action-submit'
+export * from './audit'
+export * from './key-vault'
 export { TrustNodeCard, type TrustNodeCardProps } from './components/trust-node-card'
 export {
   TrustDashboard,
   type TrustDashboardProps,
 } from './components/trust-dashboard'
+export { ActionComposer, type ActionComposerProps } from './components/action-composer'
+export { AuditLogView, type AuditLogViewProps } from './components/audit-log-view'

--- a/web/packages/features/src/operator/key-vault.test.ts
+++ b/web/packages/features/src/operator/key-vault.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { ed25519 } from '@noble/curves/ed25519.js'
+import { importOperatorKey, unlockOperatorKey } from './key-vault'
+import { signingMessage, verifyEnvelopeSignature } from './action-envelope'
+import fixtures from './fixtures/operator-action-fixtures.json'
+
+const SEED_HEX = fixtures.signingKeySeed
+
+function bytesToHex(b: Uint8Array): string {
+  return [...b].map((x) => x.toString(16).padStart(2, '0')).join('')
+}
+
+describe('operator key vault (§2, #474/#475 no-plaintext-by-default)', () => {
+  it('imports a valid Ed25519 secret under a passphrase and derives the node signerKeyId', async () => {
+    const signer = await importOperatorKey(SEED_HEX, 'correct horse battery staple')
+    expect(signer.signerKeyId).toBe(fixtures.signerKeyId)
+    expect(signer.publicKeyHex).toBe(fixtures.publicKeyHex)
+    expect(signer.isUnlocked).toBe(true)
+  })
+
+  it('REFUSES an empty passphrase (no plaintext-by-default)', async () => {
+    await expect(importOperatorKey(SEED_HEX, '')).rejects.toThrow(/passphrase is required/)
+    await expect(importOperatorKey(SEED_HEX, '   ')).rejects.toThrow(/passphrase is required/)
+  })
+
+  it('REFUSES a malformed secret key', async () => {
+    await expect(importOperatorKey('not-hex', 'pw')).rejects.toThrow(/hex/)
+    await expect(importOperatorKey('ab', 'pw')).rejects.toThrow(/64 lowercase hex/)
+  })
+
+  it('the vault blob is encrypted at rest — the raw secret does NOT appear in it', async () => {
+    const signer = await importOperatorKey(SEED_HEX, 'pw-123')
+    expect(signer.vaultBlob).not.toContain(SEED_HEX)
+    // Blob is a versioned vault blob (starts with the "bv" magic in hex: 6276).
+    expect(signer.vaultBlob.startsWith('6276')).toBe(true)
+  })
+
+  it('the session signer signs bytes the node would accept', async () => {
+    const signer = await importOperatorKey(SEED_HEX, 'pw')
+    const canonical = fixtures.envelopes[0].canonical
+    const sig = signer.sign(signingMessage(canonical))
+    const pk = ed25519.getPublicKey(new Uint8Array([...SEED_HEX.matchAll(/../g)].map((m) => parseInt(m[0], 16))))
+    expect(verifyEnvelopeSignature(canonical, bytesToHex(sig), pk)).toBe(true)
+    // And it matches the committed node fixture signature exactly.
+    expect(bytesToHex(sig)).toBe(fixtures.envelopes[0].signature)
+  })
+
+  it('wipe() locks the signer so it can no longer sign', async () => {
+    const signer = await importOperatorKey(SEED_HEX, 'pw')
+    signer.wipe()
+    expect(signer.isUnlocked).toBe(false)
+    expect(() => signer.sign(new Uint8Array([1, 2, 3]))).toThrow(/locked/)
+  })
+
+  it('unlockOperatorKey re-derives the signer from the vault blob + passphrase', async () => {
+    const first = await importOperatorKey(SEED_HEX, 'pw-abc')
+    const reopened = await unlockOperatorKey(first.vaultBlob, 'pw-abc')
+    expect(reopened.signerKeyId).toBe(first.signerKeyId)
+    expect(reopened.publicKeyHex).toBe(first.publicKeyHex)
+  })
+
+  it('unlockOperatorKey rejects the wrong passphrase (AES-GCM auth failure)', async () => {
+    const first = await importOperatorKey(SEED_HEX, 'right-pw')
+    await expect(unlockOperatorKey(first.vaultBlob, 'wrong-pw')).rejects.toThrow()
+  })
+})

--- a/web/packages/features/src/operator/key-vault.ts
+++ b/web/packages/features/src/operator/key-vault.ts
@@ -1,0 +1,175 @@
+/**
+ * Operator signing-key vault (#751, §2) — imports the operator Ed25519 key into
+ * the browser ENCRYPTED under a mandatory passphrase, held in memory for the
+ * session only.
+ *
+ * ## No plaintext-by-default (the #474/#475 lesson)
+ *
+ * The raw secret is NEVER stored in the clear and NEVER sent to a server (the
+ * Pages host serves static assets and never sees the key, §2/§8.3). We reuse
+ * the wallet's audited vault (`@botho/core` `VaultKey`: AES-256-GCM + PBKDF2)
+ * to wrap the secret at rest, and expose signing through a {@link SessionSigner}
+ * that keeps the decrypted secret in a closure for the session and can wipe it.
+ *
+ * A passphrase is MANDATORY: {@link importOperatorKey} refuses an empty /
+ * whitespace-only passphrase, exactly as the node's `OperatorKeyFile::generate`
+ * does. There is no unencrypted path.
+ *
+ * ## What the operator imports
+ *
+ * The node's `botho operator keygen` writes a JSON key file whose `ciphertext`
+ * is the operator's own at-rest form. For the dashboard the operator provides
+ * the 32-byte Ed25519 secret scalar as lowercase hex (64 chars) — the same
+ * scalar `SigningKey::to_bytes()` produces. We derive the public key (and the
+ * `signerKeyId` fingerprint) from it so the composer can address the node.
+ */
+
+import { VaultKey } from '@botho/core/wallet'
+import { ed25519 } from '@noble/curves/ed25519.js'
+import type { SignFn } from './action-envelope'
+import { signerKeyIdFromPublicKey } from './action-envelope'
+
+/** Length of the Ed25519 secret scalar in hex characters (32 bytes). */
+const SECRET_HEX_LEN = 64
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = ''
+  for (const b of bytes) out += b.toString(16).padStart(2, '0')
+  return out
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.trim().toLowerCase()
+  if (clean.length % 2 !== 0) throw new Error('secret key hex has odd length')
+  const out = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    const b = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+    if (Number.isNaN(b)) throw new Error('secret key is not valid hex')
+    out[i] = b
+  }
+  return out
+}
+
+/**
+ * An in-memory, session-held operator signer. The decrypted secret lives only
+ * inside this object for the tab's lifetime; {@link wipe} zeroes it. The public
+ * key + fingerprint are safe to expose (they identify the signer to the node).
+ */
+export class SessionSigner {
+  private secret: Uint8Array | null
+
+  private constructor(
+    secret: Uint8Array,
+    readonly publicKey: Uint8Array,
+    readonly signerKeyId: string,
+    /** The AES-256-GCM + PBKDF2 vault blob (encrypted secret) for re-derive. */
+    readonly vaultBlob: string,
+  ) {
+    this.secret = secret
+  }
+
+  /** True while the secret is still held (not wiped). */
+  get isUnlocked(): boolean {
+    return this.secret !== null
+  }
+
+  /** The operator public key as lowercase hex (for display). */
+  get publicKeyHex(): string {
+    return bytesToHex(this.publicKey)
+  }
+
+  /**
+   * A {@link SignFn} bound to this signer. Throws if the secret has been wiped.
+   * The composer calls this to sign `DOMAIN_SEPARATOR || canonical`; the raw
+   * secret never leaves this closure.
+   */
+  get sign(): SignFn {
+    return (message: Uint8Array): Uint8Array => {
+      if (this.secret === null) {
+        throw new Error('operator signer is locked — re-import the key')
+      }
+      return ed25519.sign(message, this.secret)
+    }
+  }
+
+  /**
+   * Zero and drop the in-memory secret. After this the signer is locked and
+   * signing throws. Call on sign-out / tab-hide. The vault blob remains so the
+   * operator can re-derive with their passphrase if desired.
+   */
+  wipe(): void {
+    if (this.secret) {
+      this.secret.fill(0)
+      this.secret = null
+    }
+  }
+
+  /** @internal — build a signer from a decrypted secret. */
+  static async fromSecret(secret: Uint8Array, vaultBlob: string): Promise<SessionSigner> {
+    const publicKey = ed25519.getPublicKey(secret)
+    const signerKeyId = signerKeyIdFromPublicKey(publicKey)
+    return new SessionSigner(secret, publicKey, signerKeyId, vaultBlob)
+  }
+}
+
+/**
+ * Import an operator Ed25519 secret key (32-byte scalar, lowercase hex) under a
+ * MANDATORY passphrase. The secret is wrapped in a `VaultKey` blob (AES-256-GCM
+ * + PBKDF2, reusing `@botho/core`) and a {@link SessionSigner} holding the
+ * decrypted secret is returned for the session.
+ *
+ * Refuses:
+ *   - an empty / whitespace-only passphrase (no plaintext-by-default, §2),
+ *   - a secret that is not exactly 64 lowercase hex chars.
+ */
+export async function importOperatorKey(
+  secretKeyHex: string,
+  passphrase: string,
+): Promise<SessionSigner> {
+  if (passphrase.trim() === '') {
+    throw new Error(
+      'a passphrase is required to encrypt the operator key in the browser — ' +
+        'refusing to hold an unencrypted key (empty passphrase rejected)',
+    )
+  }
+  const clean = secretKeyHex.trim().toLowerCase()
+  if (clean.length !== SECRET_HEX_LEN || !/^[0-9a-f]+$/.test(clean)) {
+    throw new Error(
+      `operator secret key must be ${SECRET_HEX_LEN} lowercase hex characters ` +
+        '(the 32-byte Ed25519 secret scalar)',
+    )
+  }
+  const secret = hexToBytes(clean)
+  // Validate it is a usable Ed25519 secret by deriving the public key.
+  try {
+    ed25519.getPublicKey(secret)
+  } catch {
+    throw new Error('the provided bytes are not a valid Ed25519 secret key')
+  }
+
+  // Wrap the secret at rest under the passphrase (AES-256-GCM + PBKDF2). The
+  // resulting blob could be persisted to sessionStorage by the caller if they
+  // choose; the raw secret is never persisted in the clear.
+  const vaultKey = await VaultKey.fromPassword(passphrase)
+  const vaultBlob = await vaultKey.encryptString(clean)
+
+  return SessionSigner.fromSecret(secret, vaultBlob)
+}
+
+/**
+ * Re-derive a session signer from a previously-produced vault blob + passphrase
+ * (e.g. after a page reload where the operator kept the encrypted blob in
+ * sessionStorage). Throws on wrong passphrase (AES-GCM auth failure).
+ */
+export async function unlockOperatorKey(
+  vaultBlob: string,
+  passphrase: string,
+): Promise<SessionSigner> {
+  if (passphrase.trim() === '') {
+    throw new Error('a passphrase is required to unlock the operator key')
+  }
+  const vaultKey = await VaultKey.fromPasswordAndBlob(passphrase, vaultBlob)
+  const secretHex = await vaultKey.decryptString(vaultBlob)
+  const secret = hexToBytes(secretHex)
+  return SessionSigner.fromSecret(secret, vaultBlob)
+}

--- a/web/packages/web-wallet/src/pages/operator.tsx
+++ b/web/packages/web-wallet/src/pages/operator.tsx
@@ -2,15 +2,20 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Logo } from '@botho/ui'
 import {
+  ActionComposer,
+  AuditLogView,
   captureOperatorToken,
+  importOperatorKey,
   NetworkDashboard,
   TrustDashboard,
   useFleetHistory,
   useFleetStatus,
+  useOperatorAuditLog,
   useOperatorQuorumInfo,
   useTrustStatus,
+  type SessionSigner,
 } from '@botho/features'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, KeyRound } from 'lucide-react'
 import { FLEET, METRICS_API_BASE } from '../config/fleet'
 
 /**
@@ -25,13 +30,17 @@ import { FLEET, METRICS_API_BASE } from '../config/fleet'
  *
  * Each tab mounts its own polling hook, so only the visible tab polls.
  */
-type OperatorTab = 'fleet' | 'trust'
+type OperatorTab = 'fleet' | 'trust' | 'actions' | 'audit'
 
 export function OperatorPage() {
   const [tab, setTab] = useState<OperatorTab>('fleet')
   // Lift any magic-link read token out of the URL fragment into sessionStorage
   // on mount (#707), then strip it from the address bar. Null ⇒ public view.
   const [token] = useState<string | null>(() => captureOperatorToken())
+  // The operator signing key is imported into an in-memory, session-only vault
+  // (#751, §2). It NEVER touches the server (the Pages host serves static
+  // assets only) and is held here for the composer's lifetime.
+  const [signer, setSigner] = useState<SessionSigner | null>(null)
 
   return (
     <div className="min-h-screen">
@@ -71,9 +80,18 @@ export function OperatorPage() {
             <TabButton active={tab === 'trust'} onClick={() => setTab('trust')}>
               Trust
             </TabButton>
+            <TabButton active={tab === 'actions'} onClick={() => setTab('actions')}>
+              Actions
+            </TabButton>
+            <TabButton active={tab === 'audit'} onClick={() => setTab('audit')}>
+              Audit
+            </TabButton>
           </div>
 
-          {tab === 'fleet' ? <FleetTab /> : <TrustTab token={token} />}
+          {tab === 'fleet' && <FleetTab />}
+          {tab === 'trust' && <TrustTab token={token} />}
+          {tab === 'actions' && <ActionsTab signer={signer} setSigner={setSigner} />}
+          {tab === 'audit' && <AuditTab token={token} />}
         </div>
       </main>
     </div>
@@ -137,5 +155,149 @@ function TrustTab({ token }: { token: string | null }) {
       operatorInfo={token ? info : undefined}
       operatorMode={mode}
     />
+  )
+}
+
+/**
+ * Actions tab (#751): import the operator signing key into an in-memory,
+ * passphrase-encrypted session vault (§2), then compose signed quorum-curation
+ * actions with a mandatory dry-run preview (§4). The key never leaves the
+ * browser (§8.3).
+ *
+ * MAINNET HARDENING (§8.3, §9): for testnet the residual risk of a malicious
+ * Pages bundle prompting the operator for a signature is ACCEPTED. Before
+ * mainnet the operator page must ship with Subresource Integrity (SRI) and/or
+ * be self-hosted so the operator controls the exact bundle they run. Tracked as
+ * follow-up issue #757 (the mainnet-hardening list from §9).
+ */
+function ActionsTab({
+  signer,
+  setSigner,
+}: {
+  signer: SessionSigner | null
+  setSigner: (s: SessionSigner | null) => void
+}) {
+  return (
+    <div className="space-y-4">
+      <KeyImportPanel signer={signer} setSigner={setSigner} />
+      <ActionComposer nodes={FLEET} signer={signer} />
+    </div>
+  )
+}
+
+function KeyImportPanel({
+  signer,
+  setSigner,
+}: {
+  signer: SessionSigner | null
+  setSigner: (s: SessionSigner | null) => void
+}) {
+  const [secret, setSecret] = useState('')
+  const [pass, setPass] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  async function onImport() {
+    setError(null)
+    setBusy(true)
+    try {
+      const s = await importOperatorKey(secret, pass)
+      setSigner(s)
+      // Clear the raw secret + passphrase from the form inputs immediately.
+      setSecret('')
+      setPass('')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'import failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function onLock() {
+    signer?.wipe()
+    setSigner(null)
+  }
+
+  if (signer) {
+    return (
+      <div className="flex items-center justify-between rounded border border-steel bg-abyss/50 px-4 py-3">
+        <div className="flex items-center gap-2 text-sm text-light">
+          <KeyRound className="h-4 w-4 text-emerald-400" />
+          Operator key loaded · signerKeyId <span className="font-mono">{signer.signerKeyId}</span>
+        </div>
+        <button
+          type="button"
+          onClick={onLock}
+          className="rounded border border-steel px-3 py-1.5 text-xs text-ghost"
+        >
+          Lock / forget key
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3 rounded border border-steel bg-abyss/50 p-4">
+      <div className="flex items-center gap-2 text-sm font-medium text-light">
+        <KeyRound className="h-4 w-4" />
+        Import operator signing key (encrypted in-browser, session only)
+      </div>
+      {error && (
+        <div role="alert" className="text-xs text-red-300">
+          {error}
+        </div>
+      )}
+      <input
+        aria-label="operator secret key hex"
+        value={secret}
+        onChange={(e) => setSecret(e.target.value)}
+        placeholder="Ed25519 secret scalar (64 hex chars)"
+        className="w-full rounded border border-steel bg-abyss px-3 py-2 font-mono text-sm text-light"
+      />
+      <input
+        aria-label="operator key passphrase"
+        type="password"
+        value={pass}
+        onChange={(e) => setPass(e.target.value)}
+        placeholder="Passphrase (required — encrypts the key in memory)"
+        className="w-full rounded border border-steel bg-abyss px-3 py-2 text-sm text-light"
+      />
+      <button
+        type="button"
+        onClick={onImport}
+        disabled={busy}
+        className="rounded bg-[--color-slate] px-4 py-2 text-sm font-medium text-light disabled:opacity-50"
+      >
+        {busy ? 'Encrypting…' : 'Import key'}
+      </button>
+      <p className="text-xs text-ghost">
+        The key is encrypted (AES-256-GCM + PBKDF2) and held in memory for this tab only. It is
+        never sent to a server. Mainnet hardening (SRI / self-hosting the operator page) is tracked
+        as a follow-up.
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Audit tab (#751, §6): renders each node's persisted audit log EXCLUSIVELY
+ * from the node's stored entries (#750; anti-#541).
+ */
+function AuditTab({ token }: { token: string | null }) {
+  const { logs } = useOperatorAuditLog(FLEET, token)
+  return (
+    <div className="space-y-6">
+      {FLEET.map((node) => {
+        const result = logs[node.id]
+        const entries = result?.status === 'ok' ? result.data : []
+        const unavailable = !token || (result !== undefined && result.status !== 'ok')
+        return (
+          <div key={node.id} className="space-y-2">
+            <h3 className="text-sm font-medium text-light">{node.name}</h3>
+            <AuditLogView entries={entries} unavailable={unavailable} />
+          </div>
+        )
+      })}
+    </div>
   )
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -158,6 +158,12 @@ importers:
       '@botho/ui':
         specifier: workspace:*
         version: link:../ui
+      '@noble/curves':
+        specifier: ^1.8.1
+        version: 1.9.7
+      '@noble/hashes':
+        specifier: ^2.0.1
+        version: 2.0.1
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.3)


### PR DESCRIPTION
## Summary

Implements the Pages-hosted operator write surface (#751, P4.4e of #709): client-side key import/vault, the signed-action composer, a mandatory dry-run preview, and the audit-log view. No server-side signing — the Pages host serves static assets and never sees the key (§2, §8.3). Built against the merged node RPC: #748 (`operator_submitAction`) and #750 (extended audit entry shape).

## Changes

- **Key vault (`key-vault.ts`, §2):** imports the operator Ed25519 secret (32-byte scalar hex) under a **mandatory** passphrase, wrapping it with `@botho/core` `VaultKey` (AES-256-GCM + PBKDF2). A `SessionSigner` holds the decrypted secret in a closure for the session and can `wipe()` it. No plaintext-by-default (#474/#475). The raw secret never reaches a server.
- **Envelope core (`action-envelope.ts`, §3):** produces the canonical JSON (keys sorted lexicographically, integers only, no whitespace) and signs `"botho-operator-action-v1" || canonical` with Ed25519 (`@noble/curves`). Fresh 128-bit nonce; `issuedAt`/`expiresAt` ≤ 300s. `signerKeyId` = blake2b-256(pubkey)[..8] hex; `envelopeHash` = blake2b-256(canonical).
- **Submit client (`action-submit.ts`, §6/§7.3):** sends EXACTLY `{envelope, signature}` (finding 1 — no sibling `dryRun`). Parses the node's `OperatorActionOutcome`; per-node `targetNode` is resolved live from `node_getStatus`. `submitToFleet` classifies applied / refused / inconclusive and flags **partial failure**.
- **Audit client + view (`audit.ts`, `audit-log-view.tsx`, §6):** renders EXCLUSIVELY the node's stored entries (#750 shape). Empty list and fetch failure are explicit states, never a fabricated success (anti-#541).
- **Composer (`action-composer.tsx`, §4/§8.3):** compose → sign `dryRun:true` → show the node verdict **and the canonical bytes** → sign a **separate** `dryRun:false` envelope with a **fresh nonce** → render node-confirmed outcomes.
- **Page wiring:** `/operator` gains Actions + Audit tabs.
- **Mainnet hardening (§8.3/§9):** SRI / self-hosting tracked as **#757** (linked in a code note in `operator.tsx`).

### Cross-language canonicalization (the #1 failure mode)

The browser canonical bytes must byte-match the node's Rust canonicalization or the node's parse-after-verify signature check fails. Guaranteed by a committed fixture (`fixtures/operator-action-fixtures.json`) produced by the node's Rust code for the deterministic key seed `[1u8; 32]`. `action-envelope.test.ts` asserts, per fixture envelope, byte-equality of the canonical string, the Ed25519 signature, the `signerKeyId`, and the `envelopeHash` against the node's values (verified: JS output is identical to Rust for all three action kinds).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Operator key imports encrypted under mandatory passphrase; no plaintext-at-rest; memory-only | ✅ | `key-vault.test.ts`: refuses empty passphrase; vault blob does not contain the raw secret; `wipe()` locks signing |
| Composer builds canonical envelope matching the node (fixture verifies node-side) | ✅ | `action-envelope.test.ts` asserts byte-equality vs the committed Rust fixture (canonical + sig + hash + signerKeyId) |
| Dry-run preview shows the node gate verdict before the real apply | ✅ | `action-composer.test.tsx` "dry-run preview shows the canonical envelope AND the node verdict before apply" |
| Real apply separately signed dryRun:false with fresh nonce (UI can't reuse dry-run bytes) | ✅ | `action-composer.test.tsx` finding-1 test: apply envelope has different bytes/signature/nonce than the dry-run |
| Canonical envelope displayed before any signature (§8.3) | ✅ | Preview panel renders `canonical-<nodeId>` `<pre>`; test asserts its content before apply |
| Never renders applied except from node response (anti-#541) | ✅ | `action-submit.test.ts`: unrecognized/transport → not applied; dry-run applied ≠ real apply. `audit.test.ts`: empty/failed → explicit state |
| Audit view renders stored entries only | ✅ | `audit-log-view.test.tsx`: empty + unavailable explicit states; entries render node outcomes verbatim |
| Fleet per-node refusal is a first-class partial-failure outcome | ✅ | `action-submit.test.ts` mixed-fleet test; `action-composer.test.tsx` partial-failure banner |
| Mainnet hardening list filed and linked | ✅ | #757 filed; linked in `operator.tsx` code note |

## Test Plan

- `pnpm -r typecheck` — green (all 8 packages, incl. web-wallet).
- `pnpm test:run` — 710 passed / 10 skipped; 54 new operator tests pass.
- `pnpm install --frozen-lockfile` — green (lockfile adds only `@noble/curves`/`@noble/hashes` to `@botho/features`, already present in `@botho/core`).
- Cross-language fixture confirmed by generating values from the node's Rust test helpers (seed `[1;32]`) and asserting JS reproduces them exactly.

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)