### PR TITLE
fix: reconcile block-time floor constants (dead MIN_BLOCK_TIME=5 vs live 3s floor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ Unlike Bitcoin's probabilistic finality (wait 6 blocks = 60 minutes to be "sure"
 | Parameter | Value |
 |:--|:--|
 | Slot interval | 20 seconds (SCP consensus cycle) |
-| Dynamic block time | 5-40 seconds (adapts to network load) |
+| Dynamic block time | 3-40 seconds (adapts to network load; 3s only at very high load, 20+ tx/s) |
 | Monetary baseline | 5 seconds (for emission calculations) |
 | Difficulty adjustment | Every block, from observed block time (0.5x–2x per step) |
 | Phase 1 supply | ~611 million BTH (~5 years of halvings) |
 | Tail emission | Supply-dependent, ~1.9 BTH/block at the ~611M tail-onset supply (2% net annual inflation) |
 | Native unit | BTH (12 decimal places; 1 BTH = 10¹² picocredits) |
 
-Block timing adapts to network activity: busy networks produce faster blocks (5s), idle networks produce slower blocks (40s). This creates natural inflation dampening—less activity means less emission.
+Block timing adapts to network activity: busy networks produce faster blocks (5s under high load, down to 3s at very high load), idle networks produce slower blocks (40s). This creates natural inflation dampening—less activity means less emission.
 
 ## Philosophy in Practice
 

--- a/botho/src/block.rs
+++ b/botho/src/block.rs
@@ -692,8 +692,15 @@ fn calculate_tail_reward_u128(
 pub mod dynamic_timing {
     use super::Block;
 
-    /// Minimum block time (consensus floor - SCP needs time to complete)
-    pub const MIN_BLOCK_TIME: u64 = 5;
+    // Superseded (issue #761): this constant was never consumed anywhere and
+    // contradicted the live 3 s floor. The single authority for the minimum
+    // block time is `crate::consensus::ConsensusConfig::MIN_BLOCK_TIME_SECS`
+    // (= 3), which matches the fastest tier of `BLOCK_TIME_LEVELS` below (a
+    // compile-time assertion at the bottom of this module keeps them in sync).
+    // Kept commented-out rather than deleted per CLAUDE.md code preservation.
+    //
+    // /// Minimum block time (consensus floor - SCP needs time to complete)
+    // pub const MIN_BLOCK_TIME: u64 = 5;
 
     /// Maximum block time (efficiency ceiling when idle)
     pub const MAX_BLOCK_TIME: u64 = 40;
@@ -716,6 +723,23 @@ pub mod dynamic_timing {
         (0.2, 20), // Low load: 0.2+ tx/s → 20s blocks
         (0.0, 40), // Idle: <0.2 tx/s → 40s blocks
     ];
+
+    /// Compile-time assertion: the consensus floor
+    /// (`ConsensusConfig::MIN_BLOCK_TIME_SECS`) must equal the fastest tier of
+    /// `BLOCK_TIME_LEVELS` so the two can never drift apart again (issue
+    /// #761). Only the u64 block-time component matters here; the f64 tx-rate
+    /// thresholds are irrelevant to the floor.
+    const _: () = assert!(
+        crate::consensus::ConsensusConfig::MIN_BLOCK_TIME_SECS == BLOCK_TIME_LEVELS[0].1,
+        "ConsensusConfig::MIN_BLOCK_TIME_SECS must match the fastest BLOCK_TIME_LEVELS tier"
+    );
+
+    /// Compile-time assertion: `MAX_BLOCK_TIME` must equal the slowest (idle)
+    /// tier of `BLOCK_TIME_LEVELS`.
+    const _: () = assert!(
+        MAX_BLOCK_TIME == BLOCK_TIME_LEVELS[BLOCK_TIME_LEVELS.len() - 1].1,
+        "MAX_BLOCK_TIME must match the slowest BLOCK_TIME_LEVELS tier"
+    );
 
     /// Compute the target block time based on recent transaction load.
     ///

--- a/botho/src/monetary.rs
+++ b/botho/src/monetary.rs
@@ -35,18 +35,20 @@ use bth_cluster_tax::MonetaryPolicy;
 ///
 /// # Block Time Assumption
 ///
-/// All monetary calculations assume **5 second blocks** (the minimum block time
-/// under high load). When actual block times are slower (up to 40s when idle),
+/// All monetary calculations assume **5 second blocks** (the high-load tier of
+/// dynamic timing; actual blocks range 3-40s, with 3s only at very high load,
+/// 20+ tx/s). When actual block times are slower (up to 40s when idle),
 /// effective inflation and halving pace will be proportionally lower.
 ///
 /// This creates a natural inflation dampener: busy network = full inflation,
 /// idle network = reduced inflation.
 ///
-/// | Actual Block Time | Effective Inflation | Halving Period |
-/// |-------------------|--------------------:|---------------:|
-/// | 5s (high load)    | 2.0%/year           | 1 year         |
-/// | 20s (normal)      | 0.5%/year           | 4 years        |
-/// | 40s (idle)        | 0.25%/year          | 8 years        |
+/// | Actual Block Time  | Effective Inflation | Halving Period |
+/// |--------------------|--------------------:|---------------:|
+/// | 3s (very high load)| ~3.3%/year          | ~0.6 years     |
+/// | 5s (high load)     | 2.0%/year           | 1 year         |
+/// | 20s (normal)       | 0.5%/year           | 4 years        |
+/// | 40s (idle)         | 0.25%/year          | 8 years        |
 ///
 /// # Canonical Emission Schedule (decided 2026-06-15, issue #351)
 ///
@@ -76,7 +78,7 @@ pub fn mainnet_policy() -> MonetaryPolicy {
         tail_inflation_bps: 200,
 
         // Block time: 5 seconds assumed for monetary calculations
-        // Actual block time varies 5-40s based on network load (see dynamic_timing)
+        // Actual block time varies 3-40s based on network load (see dynamic_timing)
         target_block_time_secs: ASSUMED_BLOCK_TIME,
         min_block_time_secs: 3,  // Absolute floor (consensus needs time)
         max_block_time_secs: 60, // Absolute ceiling

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -266,7 +266,7 @@ max_block_time_secs: 60,      // Absolute ceiling
 halving_interval: 6_307_200,  // ~1 year at 5s blocks
 ```
 
-### 2. Dynamic Block Timing (5-40s actual)
+### 2. Dynamic Block Timing (3-40s actual)
 
 **Location**: `botho/src/block.rs` → `dynamic_timing` module
 
@@ -295,7 +295,7 @@ These systems are **complementary**, not competing:
 │                              ▼                                   │
 │                     ┌────────────────┐                          │
 │                     │ Actual blocks  │                          │
-│                     │ 5-40s dynamic  │                          │
+│                     │ 3-40s dynamic  │                          │
 │                     └────────────────┘                          │
 │                              │                                   │
 │                              ▼                                   │

--- a/docs/concepts/comparison.md
+++ b/docs/concepts/comparison.md
@@ -183,7 +183,7 @@ Secret Network focuses on programmable privacy (smart contracts). Botho focuses 
 | Aspect | Botho | Bitcoin | Monero | Zcash |
 |--------|-------|---------|--------|-------|
 | Mechanism | SCP consensus + RandomX PoW (issuance only) | PoW (SHA-256) | PoW (RandomX) | PoW (Equihash) |
-| Block time | 5-40 sec (dynamic) | 600 sec | 120 sec | 75 sec |
+| Block time | 3-40 sec (dynamic) | 600 sec | 120 sec | 75 sec |
 | Finality | Immediate | Probabilistic | Probabilistic | Probabilistic |
 | Fault tolerance | Byzantine | Crash | Crash | Crash |
 

--- a/docs/concepts/monetary-policy.md
+++ b/docs/concepts/monetary-policy.md
@@ -28,7 +28,7 @@ Botho's monetary policy achieves predictable inflation through the interaction o
 
 The key insight is that **block production and emission are decoupled**:
 
-- **Block production**: Controlled by SCP consensus (20-second slots, 5-40s dynamic based on load)
+- **Block production**: Controlled by SCP consensus (20-second slots, 3-40s dynamic based on load)
 - **Emission rate**: Controlled by mining difficulty (how many blocks include minting rewards)
 
 This separation allows precise monetary targeting without affecting transaction throughput.
@@ -42,7 +42,8 @@ This separation allows precise monetary targeting without affecting transaction 
 > - 5 halvings total before tail emission (~5 years at 5s blocks)
 > - See `monetary.rs::mainnet_policy()` for the authoritative implementation
 >
-> **Adaptive Inflation**: Since actual block times vary (5-40s based on network load),
+> **Adaptive Inflation**: Since actual block times vary (3-40s based on network load;
+> 3s only at very high load, 20+ tx/s),
 > effective inflation scales with network activity:
 >
 > | Block Time | Effective Inflation | Halving Period |

--- a/docs/concepts/tokenomics.md
+++ b/docs/concepts/tokenomics.md
@@ -11,7 +11,7 @@ Botho (BTH) uses a two-phase emission model designed for long-term sustainabilit
 | Display unit | BTH (formatted from picocredits at the UI edge) |
 | Pre-mine | None (100% mined) |
 | Phase 1 supply | ~611 million BTH (~5 years of halvings) |
-| Block time | 5-40 seconds (dynamic based on load); 5s baseline for monetary calculations |
+| Block time | 3-40 seconds (dynamic based on load; 3s only at 20+ tx/s); 5s baseline for monetary calculations |
 | Consensus | SCP (Stellar Consensus Protocol) |
 
 ## Unit System
@@ -333,7 +333,7 @@ Two properties worth noting:
 | Pre-mine | None | None | None | ~72M ETH |
 | Fee destination | 80% redistributed (lottery), 20% burned | To minters | To minters | Partially burned |
 | Progressive fees | Yes (cluster-based) | No | No | No |
-| Block time | 5-40s (dynamic; 5s baseline) | 600s | 120s | 12s |
+| Block time | 3-40s (dynamic; 5s baseline) | 600s | 120s | 12s |
 
 ## Technical References
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -646,7 +646,7 @@ where Δ depends on network conditions and fee priority
 **Achieved via:**
 - Gossipsub message propagation
 - Fee-priority mempool ordering
-- Dynamic block timing (5-40s based on load)
+- Dynamic block timing (3-40s based on load)
 
 ### 6. Economic Redistribution Integrity
 

--- a/web/packages/web-wallet/src/pages/docs.tsx
+++ b/web/packages/web-wallet/src/pages/docs.tsx
@@ -72,7 +72,7 @@ When someone sends you BTH:
 1. They use your public address to derive a unique one-time address
 2. The transaction is broadcast to the network and included in a block
 3. Your wallet scans new blocks and detects payments addressed to you
-4. The funds appear in your balance, usually within one block — block time adapts to network load, from 5 seconds under heavy traffic up to 40 seconds when the network is idle
+4. The funds appear in your balance, usually within one block — block time adapts to network load, from 3 seconds under very heavy traffic up to 40 seconds when the network is idle
 
 ### Sending Payments
 
@@ -1112,7 +1112,7 @@ Botho uses libp2p for networking, which supports multiple discovery mechanisms:
 
 | Parameter | Value | Description |
 |-----------|-------|-------------|
-| Block time | 5–40 seconds (load-adaptive) | Fast blocks under heavy traffic, slow blocks when idle |
+| Block time | 3–40 seconds (load-adaptive) | Fast blocks under heavy traffic (3 s only at 20+ tx/s), slow blocks when idle |
 | Max block size | 20 MB | Maximum serialized block size |
 | Max transactions per block | 5,000 | Transaction count limit |
 
@@ -1196,7 +1196,7 @@ Botho (BTH) uses a two-phase emission model designed for long-term sustainabilit
 | Smallest unit | picocredit (10⁻¹² BTH) |
 | Pre-mine | None (100% mined) |
 | Phase 1 supply | ~611 million BTH |
-| Block time | 5–40 seconds (load-adaptive) |
+| Block time | 3–40 seconds (load-adaptive; 5 s monetary baseline) |
 
 ### Unit System
 
@@ -1211,7 +1211,7 @@ BTH uses 12-decimal precision. The picocredit is the single base unit — every 
 
 ## Emission Schedule
 
-All monetary math assumes the 5-second full-load block time. When the network is idle and blocks slow down (up to 40 s), emission stretches proportionally — a natural dampener: a busy network emits at the full schedule, an idle one emits less.
+All monetary math assumes the 5-second high-load block time (actual blocks range 3–40 s, dropping to 3 s only at very high load, 20+ tx/s). When the network is idle and blocks slow down (up to 40 s), emission stretches proportionally — a natural dampener: a busy network emits at the full schedule, an idle one emits less.
 
 ### Phase 1: Halving Period (~5 years at full load)
 


### PR DESCRIPTION
Closes #761

## Summary

Three sources disagreed about the minimum block time; the loser was a dead constant that kept propagating a stale "5-40s" range into user-facing docs.

### Code changes (`botho/src/block.rs`, `botho/src/monetary.rs`)

- **Commented out** `dynamic_timing::MIN_BLOCK_TIME = 5` (per CLAUDE.md code-preservation policy) — it had zero consumers and contradicted both the 3s tier of `BLOCK_TIME_LEVELS` and `ConsensusConfig::MIN_BLOCK_TIME_SECS = 3`. The supersession note points at `ConsensusConfig::MIN_BLOCK_TIME_SECS` as the single authority.
- **Added compile-time asserts** tying `ConsensusConfig::MIN_BLOCK_TIME_SECS` to the fastest `BLOCK_TIME_LEVELS` tier (and `MAX_BLOCK_TIME` to the slowest tier) so the constants can never drift apart again. Asserts compare the u64 block-time components only; f64 thresholds are irrelevant.
- **monetary.rs doc comments**: "5-40s" → "3-40s", clarified 3s occurs only at very high load (20+ tx/s), added a 3s row to the effective-inflation table. The 5s monetary baseline language is unchanged (it is correct).

### Doc sweep (5-40s → 3-40s)

- `README.md` (block parameters table + timing paragraph)
- `docs/concepts/architecture.md`, `comparison.md`, `monetary-policy.md`, `tokenomics.md`
- `docs/security/threat-model.md`
- `web/packages/web-wallet/src/pages/docs.tsx` (4 occurrences)

`docs/FAQ.md` has no block-time mentions. `docs/minting.md` already used the correct 3-40s framing (used as reference). Historical records (CHANGELOG, audit archives, PLAN, whitepaper TODO checklist) intentionally left untouched; the whitepaper source itself is already clean.

## Testing

- `cargo build -p botho` — passes (const asserts compile, proving the constants match)
- `cargo test -p botho --lib dynamic_timing` — 2/2 pass
- `pnpm --filter @botho/web-wallet exec tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)