### PR TITLE
docs: mark v0.x protocol specs as historical snapshots, point spec index at implemented 4.1.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,8 +63,7 @@ Welcome to the Botho documentation. Botho is a privacy-preserving, mined cryptoc
 ### Protocol Specification
 | Document | Description |
 |----------|-------------|
-| [Specification](specification/README.md) | Formal protocol specification |
-| [Protocol v0.1.0](specification/protocol-v0.1.0.md) | Complete protocol reference |
+| [Specification](specification/README.md) | Protocol specification index — historical snapshots + current-protocol pointers |
 
 ### Architecture Deep Dives
 | Document | Description |

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -1,17 +1,47 @@
 # Botho Protocol Specification
 
-This directory contains the formal specification of the Botho protocol.
+This directory contains protocol specification documents for Botho.
 
-## Documents
+## Current protocol
+
+The implemented wire protocol version is **4.1.0** (minimum supported peer
+version: **4.0.0**), as defined by `PROTOCOL_VERSION` and
+`MIN_SUPPORTED_PROTOCOL_VERSION` in
+[`botho/src/network/discovery.rs`](../../botho/src/network/discovery.rs).
+
+**No consolidated specification document exists yet for the current
+protocol.** The v0.x documents below are historical snapshots of an early
+design; the protocol has since gone through several breaking revisions. A
+current consolidated spec snapshot is future work. Until it exists, the
+authoritative sources are the code and the concept docs.
+
+### Major deltas since the v0.2.0 snapshot
+
+| Area | Change | Authoritative source |
+|------|--------|---------------------|
+| Proof of work | RandomX (CPU-egalitarian) replaced the earlier PoW design (#443) | [`botho/src/pow.rs`](../../botho/src/pow.rs) |
+| Monetary unit | Single-unit picocredit migration; nanoBTH fee/display tier retired (#694) | [`transaction/types/src/constants.rs`](../../transaction/types/src/constants.rs) |
+| Emission schedule | ~611M BTH total over 5 yearly halvings (#351) | [`botho/src/monetary.rs`](../../botho/src/monetary.rs) |
+| Difficulty | M5 time-based difficulty controller (#554) | [`botho/src/block.rs`](../../botho/src/block.rs) |
+| Fees & lottery | 80/20 fee split; cluster-weighted lottery selection | [`botho/src/consensus/lottery.rs`](../../botho/src/consensus/lottery.rs), [`cluster-tax/src/lottery.rs`](../../cluster-tax/src/lottery.rs) |
+| Demurrage | Cluster-tax demurrage on idle balances | [`cluster-tax/src/demurrage.rs`](../../cluster-tax/src/demurrage.rs) |
+| Block timing | Dynamic block timing (3-40s range) | [`botho/src/block.rs`](../../botho/src/block.rs) |
+| Prose documentation | Concept-level descriptions of the current design | [`docs/concepts/`](../concepts/README.md) |
+
+## Historical documents
 
 | Version | Status | Date | Description |
 |---------|--------|------|-------------|
-| [v0.2.0](protocol-v0.2.0.md) | Draft | 2025-01-03 | Current specification (LION removed) |
-| [v0.1.0](protocol-v0.1.0.md) | Superseded | 2024-12-31 | Initial specification (includes deprecated LION) |
+| [v0.2.0](protocol-v0.2.0.md) | Historical snapshot | 2025-01-03 | Early draft spec (LION removed); does **not** describe the current wire protocol |
+| [v0.1.0](protocol-v0.1.0.md) | Historical snapshot | 2024-12-31 | Initial spec (includes deprecated LION); does **not** describe the current wire protocol |
+
+These documents are preserved for design history. **Do not implement against
+them.** A third-party implementer or auditor should treat the code paths in
+the table above as normative.
 
 ## Overview
 
-The Botho protocol specification provides complete documentation for:
+The v0.x specification snapshots covered:
 
 - **Transaction Format**: Minting and Private transaction structures
 - **Consensus (SCP)**: Stellar Consensus Protocol implementation
@@ -23,13 +53,17 @@ The Botho protocol specification provides complete documentation for:
 
 ## Purpose
 
-This specification enables:
+A complete, current specification would enable:
 
 1. **Interoperability**: Third-party wallet and node implementations
 2. **Security Audits**: Complete protocol documentation for auditors
 3. **Academic Review**: Peer review of cryptographic constructions
 4. **Developer Onboarding**: Comprehensive protocol reference
 5. **Compliance**: Regulatory documentation requirements
+
+Until a current snapshot is produced, these needs are served by the code
+references in the [Current protocol](#current-protocol) section and the
+[concept docs](../concepts/README.md).
 
 ## Versioning
 

--- a/docs/specification/protocol-v0.1.0.md
+++ b/docs/specification/protocol-v0.1.0.md
@@ -1,10 +1,10 @@
 # Botho Protocol Specification
 
 **Version**: 0.1.0
-**Status**: Draft
+**Status**: Historical snapshot
 **Last Updated**: 2024-12-31
 
-> **⚠️ SUPERSEDED**: This specification has been replaced by [v0.2.0](protocol-v0.2.0.md). LION (PQ-Private) transactions described here have been **deprecated**. The current protocol uses only two transaction types: Minting (ML-DSA signatures) and Private (CLSAG ring signatures). See [ADR-0001](../decisions/0001-deprecate-lion-ring-signatures.md) for the deprecation decision.
+> **⚠️ HISTORICAL SNAPSHOT (SUPERSEDED)**: This specification was superseded by [v0.2.0](protocol-v0.2.0.md), which is itself a historical snapshot — **neither document describes the current wire protocol** (implemented version 4.1.0). See the [specification index](README.md) for the current protocol version and pointers to authoritative sources. LION (PQ-Private) transactions described here have been **deprecated**; the protocol uses only two transaction types: Minting (ML-DSA signatures) and Private (CLSAG ring signatures). See [ADR-0001](../decisions/0001-deprecate-lion-ring-signatures.md) for the deprecation decision.
 
 ## Abstract
 

--- a/docs/specification/protocol-v0.2.0.md
+++ b/docs/specification/protocol-v0.2.0.md
@@ -1,8 +1,18 @@
 # Botho Protocol Specification
 
 **Version**: 0.2.0
-**Status**: Draft
+**Status**: Historical snapshot
 **Last Updated**: 2025-01-03
+
+> **⚠️ HISTORICAL SNAPSHOT**: This document does **not** describe the current
+> wire protocol (implemented version 4.1.0, defined in
+> [`botho/src/network/discovery.rs`](../../botho/src/network/discovery.rs)).
+> It predates — at minimum — RandomX proof of work, the picocredit single-unit
+> migration, the current emission schedule, time-based difficulty, the 80/20
+> fee split with cluster-weighted lottery, demurrage, and dynamic block
+> timing. Do not implement against it. See the
+> [specification index](README.md) for the current protocol version and
+> pointers to authoritative sources.
 
 ## Abstract
 


### PR DESCRIPTION
## Summary

The spec index (`docs/specification/README.md`) called the `protocol-v0.2.0.md` draft the "Current specification", and `docs/README.md` linked `protocol-v0.1.0.md` as the "Complete protocol reference" — while the implemented wire protocol is `PROTOCOL_VERSION = "4.1.0"` (min-supported 4.0.0) in `botho/src/network/discovery.rs`. This implements option (a) from the issue: honest reclassification plus pointers to authoritative sources, without attempting a new consolidated spec (noted as future work).

## Changes

- `docs/specification/README.md`: added a **Current protocol** section stating implemented version 4.1.0 (min-supported 4.0.0) with a source pointer to `botho/src/network/discovery.rs`; added a delta table for the major changes since the v0.2.0 snapshot — RandomX PoW (#443), picocredit single-unit migration (#694), ~611M / 5-halving emission (#351), M5 time-based difficulty (#554), 80/20 fee split + cluster-weighted lottery, demurrage, dynamic block timing (3-40s) — each with authoritative code paths, plus `docs/concepts/` for prose; reclassified both v0.x documents as **Historical snapshot** with an explicit "do not implement against these" warning; noted a consolidated current spec snapshot is future work; softened the Purpose section accordingly
- `docs/specification/protocol-v0.2.0.md`: Status changed Draft → Historical snapshot; added a warning banner listing what it predates and pointing to the spec index
- `docs/specification/protocol-v0.1.0.md`: aligned the existing SUPERSEDED banner to historical-snapshot wording, clarifying that v0.2.0 is also a snapshot and neither describes the current wire protocol; Status changed Draft → Historical snapshot
- `docs/README.md`: removed the "Protocol v0.1.0 — Complete protocol reference" row; the Specification row now reads "Protocol specification index — historical snapshots + current-protocol pointers"

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Spec index states implemented protocol version | ✅ | "Current protocol" section states 4.1.0 / min-supported 4.0.0, sourced from `botho/src/network/discovery.rs` (`PROTOCOL_VERSION` at line 109) |
| Both v0.x docs marked historical snapshots | ✅ | Status fields + banners updated in both files; index table reclassified |
| Major deltas enumerated with authoritative pointers | ✅ | Delta table covers RandomX, picocredits, emission, difficulty, fee split/lottery, demurrage, block timing; all referenced files verified to exist |
| `docs/README.md` link stops overselling stale spec | ✅ | v0.1.0 "Complete protocol reference" row removed; index row reworded |
| Root `README.md` checked for spec links | ✅ | Grepped for `protocol-v0`/`specification` — no direct spec-version link exists, left unchanged |
| No code changes; v0.x spec bodies not rewritten | ✅ | Diff touches only 4 markdown files; spec bodies untouched apart from Status/banner headers |

## Test Plan

- Verified every relative link target added in this PR resolves on disk (13/13 files exist, including `../decisions/0001-deprecate-lion-ring-signatures.md` and `../concepts/README.md`)
- Confirmed `PROTOCOL_VERSION = "4.1.0"` and `MIN_SUPPORTED_PROTOCOL_VERSION = "4.0.0"` in `botho/src/network/discovery.rs`
- Branch based on latest `origin/main` (afde19e9, includes PR #763's 3-40s block-timing docs — delta table uses the reconciled 3-40s range)

Closes #762