### PR TITLE
docs(security): add operator-bundle verify script + self-hosting runbook

### DIFF
--- a/docs/operations/reproducible-builds.md
+++ b/docs/operations/reproducible-builds.md
@@ -213,6 +213,17 @@ For high-security deployments:
 3. Verify GPG signatures when available
 4. Audit the build script before running
 
+## Web Operator Bundle
+
+The node binaries above are not the only artifact operators verify. The
+**operator dashboard** (`/operator`) is a browser bundle that imports the
+operator signing key, so operators can verify and self-host it using the same
+build-then-compare-hashes discipline. See
+[`self-hosted-operator-dashboard.md`](./self-hosted-operator-dashboard.md) for
+the web-bundle procedure (`web/scripts/verify-operator-bundle.sh`) and
+[`../security/quorum-write-path.md`](../security/quorum-write-path.md) §8.3.1 for
+why it matters.
+
 ## Resources
 
 - [Reproducible Builds](https://reproducible-builds.org/) - Standards and best practices

--- a/docs/operations/self-hosted-operator-dashboard.md
+++ b/docs/operations/self-hosted-operator-dashboard.md
@@ -1,0 +1,202 @@
+# Self-Hosting the Operator Dashboard
+
+This runbook explains how a quorum operator can **build, verify, and self-host**
+the Botho operator dashboard (`/operator`) instead of trusting the shared
+Cloudflare Pages deploy at `botho.io` / `wallet.botho.io`.
+
+It is the operator-facing companion to
+[`docs/security/quorum-write-path.md`](../security/quorum-write-path.md) §8.3.1
+(bundle-integrity hardening) and parallels the node-binary procedure in
+[`reproducible-builds.md`](./reproducible-builds.md).
+
+## Why this exists
+
+The operator dashboard imports your operator Ed25519 signing key into the
+browser (encrypted under a mandatory passphrase, session-only, never sent to any
+host) and signs quorum-curation envelopes client-side. The serious residual risk
+(§8.3) is a **malicious bundle**: a compromised host could serve JavaScript that
+prompts you to sign attacker-chosen bytes.
+
+Two independent mitigations reduce this to near-zero for a careful operator:
+
+1. **Verify the bundle** you are about to run against a maintainer-published
+   hash, *before* you import your key. A tampered bundle produces a different
+   hash and is caught.
+2. **Self-host** that verified bundle from infrastructure you control, so the
+   shared Pages host is no longer in your trust path at all.
+
+This runbook covers both. Doing (1) alone already closes most of the risk; (2)
+removes the host entirely and is recommended for mainnet.
+
+## Prerequisites
+
+- Git
+- Node.js + [pnpm](https://pnpm.io/) (the repo uses pnpm workspaces under `web/`)
+- A trusted machine to build on
+- The maintainer-published bundle hash for the release you intend to run
+  (see [Where to find the published hash](#where-to-find-the-published-hash))
+
+## Step 1: Clone and check out a pinned commit
+
+Never build from a moving branch. Check out the exact tag/commit whose bundle
+hash the maintainer published.
+
+```bash
+git clone https://github.com/botho-project/botho.git
+cd botho
+git checkout <tag-or-commit>   # e.g. v0.3.2
+git rev-parse HEAD             # record this — it's what you're trusting
+```
+
+## Step 2: Build the bundle
+
+```bash
+cd web
+pnpm install --frozen-lockfile
+
+# Build the operator dashboard bundle (the whole SPA; /operator is one route).
+# Include the in-browser signer wasm so the signing path actually works:
+pnpm --filter @botho/web-wallet build:all
+```
+
+The build output lands in `web/packages/web-wallet/dist/`.
+
+> `build:all` runs `build:wasm` then `build`. If you only need to *inspect*
+> the bundle hash and not sign, plain `pnpm --filter @botho/web-wallet build`
+> is enough — but self-hosting for real use requires the wasm signer, so
+> prefer `build:all`.
+
+## Step 3: Verify the bundle hash
+
+Compute the aggregate bundle hash and compare it to the maintainer-published
+value **before you trust the bundle with your key**:
+
+```bash
+# From the repo root (or web/):
+web/scripts/verify-operator-bundle.sh --expected sha256-<published-value>
+```
+
+Or via the package script:
+
+```bash
+pnpm --filter @botho/web-wallet verify:operator-bundle -- --expected sha256-<published-value>
+```
+
+The script hashes every file in `dist/` (excluding source maps), then computes a
+single SHA-256 over the sorted per-file checksum list. On a match it prints
+`MATCH` and exits 0; on a mismatch it prints `MISMATCH`, tells you **not** to
+import your key, and exits 2.
+
+To see the full per-file listing (useful for auditing exactly what is in the
+bundle):
+
+```bash
+web/scripts/verify-operator-bundle.sh --manifest
+```
+
+### Reproducibility
+
+The bundle hash is deterministic: building the same pinned commit in two clean
+checkouts on the same toolchain produces the identical aggregate hash. If your
+hash does not match the published value:
+
+1. Confirm `git rev-parse HEAD` matches the published commit.
+2. Confirm `git status` is clean (no local modifications).
+3. Confirm you ran `pnpm install --frozen-lockfile` (lockfile-pinned deps).
+4. Re-run the build in a fresh `dist/` (`rm -rf web/packages/web-wallet/dist`).
+
+If it still differs, **do not proceed** — treat it as a potentially tampered
+source tree or a toolchain drift and report it.
+
+## Step 4: Serve the verified bundle
+
+Serve `web/packages/web-wallet/dist/` as static files from infrastructure you
+control. Any static file server works; the dashboard is a client-side SPA that
+talks to a node's read RPC / `operator_submitAction` endpoint over the network.
+
+Two examples:
+
+```bash
+# Option A: local-only preview (quickest — binds localhost)
+cd web
+pnpm --filter @botho/web-wallet preview   # serves dist/ on http://localhost:4173
+
+# Option B: any static file server you trust, on infra you control
+#   (nginx, caddy, `python3 -m http.server`, an internal Pages/Netlify you own, …)
+#   Point it at web/packages/web-wallet/dist/ and serve index.html as the SPA
+#   fallback for client-side routes like /operator.
+```
+
+Because the SPA uses client-side routing, configure your server to serve
+`index.html` for unknown paths (SPA fallback) so `/operator` resolves.
+
+> **RPC reachability.** The bundle reaches a node's RPC directly. For local
+> `pnpm preview`, the Vite preview proxy forwards `/rpc` to a seed node (see
+> `vite.config.ts`); for a custom static host you must ensure the browser can
+> reach your node's RPC (same-origin proxy or CORS), exactly as the shared
+> deploy does.
+
+## Step 5: Handle PWA auto-update (important)
+
+The SPA registers a service worker with `registerType: 'autoUpdate'`
+(`vite.config.ts`). On the shared deploy this silently fetches and activates a
+**newer** bundle after each deploy — which would defeat the whole point of
+pinning a verified bundle.
+
+When self-hosting, keep the served `dist/` **fixed**: serve one verified build
+and do not roll a newer one behind the same origin. With no newer bundle
+available, the service worker has nothing to pull, so your verified bundle stays
+in force. The service-worker files (`sw.js`, `workbox-*.js`) are themselves part
+of the verified trust set — `verify-operator-bundle.sh` hashes them — so a
+tampered service worker changes the aggregate hash and is caught by Step 3.
+
+If you *intentionally* upgrade to a newer release:
+
+1. Repeat Steps 1–3 at the new pinned commit against the new published hash.
+2. Replace the served `dist/` only after the new bundle verifies.
+3. Clear the old service worker / hard-refresh so the new bundle takes control.
+
+## Step 6: Confirm the dashboard works
+
+Load your self-hosted URL, open `/operator`, and confirm:
+
+- The **Actions** tab loads and lets you import your operator key (under a
+  passphrase).
+- The **dry-run preview** renders the canonical envelope before any signature
+  (this is the §8.3 mitigation — always read it and confirm the bytes are what
+  you intend before signing).
+- A dry-run against your real node returns the expected verdict.
+
+Only import your operator key into a bundle whose hash you verified in Step 3.
+
+## Where to find the published hash
+
+Maintainers publish the operator bundle hash for a release alongside the release
+artifacts (the same channel as `SHA256SUMS.txt` for node binaries — see
+[`reproducible-builds.md`](./reproducible-builds.md)). To publish one yourself as
+a maintainer:
+
+```bash
+git checkout <tag>
+cd web && pnpm install --frozen-lockfile && pnpm --filter @botho/web-wallet build:all
+web/scripts/verify-operator-bundle.sh     # prints: operator bundle hash: sha256-<...>
+```
+
+Publish that `sha256-<...>` value next to the release for the pinned commit.
+
+## What this does and does not remove from the trust path
+
+**Removed** by verify + self-host:
+
+- Trust in the shared Cloudflare Pages host serving an honest bundle.
+- Silent bundle replacement via PWA auto-update (when you serve a fixed build).
+
+**Still trusted** (out of scope for this runbook):
+
+- The pinned source commit and its dependency lockfile.
+- Your build machine and the toolchain on it.
+- The node you submit actions to (its gate + audit log — see §4, §6).
+
+Whether the in-browser key path is the right posture for mainnet at all —
+versus an air-gapped signer or hardware key — is a separate security-review
+decision tracked as a §8.3 follow-up, not something this runbook settles.

--- a/docs/security/quorum-write-path.md
+++ b/docs/security/quorum-write-path.md
@@ -387,7 +387,7 @@ part of the same future-review gate as mode/threshold actions (§3).
 |---|---|---|---|
 | 8.1 | **Stolen read token** | View operator-only reads: per-peer gate classification (a targeting map), quorum configs, audit log, dry-run verdicts — until TTL (≤7d) or secret rotation | Change anything: the token is verify-only HMAC on the read path; `operator_submitAction` never accepts it |
 | 8.2 | **Captured envelope** (network vantage) | Learn one intended config change (TLS makes even this unlikely) | Replay (nonce), retarget (targetNode), outlive 5 min (expiry), or modify (signature) — §5 |
-| 8.3 | **Compromised dashboard host** (Cloudflare Pages) | Serve a malicious bundle: steal read tokens; prompt the operator to sign attacker-chosen envelopes (the serious risk) | Sign anything itself (no key on the host). Mitigations: the dashboard shows the canonical envelope before signing; malicious signed actions are still gate-checked (no fork), audit-logged (attributable), and bounded by the v1 action set (worst case = liveness harassment, recoverable via §7). Residual risk accepted for testnet; mainnet hardening (SRI, self-hosting the operator page) tracked in #709. |
+| 8.3 | **Compromised dashboard host** (Cloudflare Pages) | Serve a malicious bundle: steal read tokens; prompt the operator to sign attacker-chosen envelopes (the serious risk) | Sign anything itself (no key on the host). Mitigations: the dashboard shows the canonical envelope before signing; malicious signed actions are still gate-checked (no fork), audit-logged (attributable), and bounded by the v1 action set (worst case = liveness harassment, recoverable via §7). Residual risk accepted for testnet; mainnet hardening (SRI, self-hosting the operator page) tracked in #709/#757 — see §8.3.1 for the decided approach and `docs/operations/self-hosted-operator-dashboard.md` for the operator procedure. |
 | 8.4 | **Compromised node** (root) | Ignore/rewrite its own config, forge its own audit log, lie in RPC responses — that node is lost regardless of this design | Sign actions against OTHER nodes (no private key material anywhere on nodes — the design's core invariant); other nodes' gates and logs are unaffected |
 | 8.5 | **Malicious insider with the operator key** | Everything the write path allows: liveness harassment within the v1 action set, degenerate-posture edits down to membership 2 (self-acknowledged, attributable) | Fork the fleet (gate, §7.1); drive any node to a self-externalizing solo quorum (membership-1 hard floor, §3); flip mode/threshold (not in v1); enroll new keys or erase fleet-wide audit trail (key list and logs are SSH-domain). Recovery: revoke via §2; SSH ladder §7. |
 
@@ -399,6 +399,61 @@ gate-accepted edit could still make a node diverge (solo self-
 externalization). The SSH superpower remains, unchanged, as the recovery
 root. The new surface strictly dominates the status quo for safety while
 adding operator convenience.
+
+### 8.3.1 Addendum — 8.3 mainnet hardening: bundle integrity (SRI vs. self-hosting)
+
+8.3 accepts, for testnet, the residual risk that a compromised Pages host
+serves a malicious dashboard *bundle* that prompts the operator to sign
+attacker-chosen bytes. This addendum records the mainnet-hardening approach
+decided in #757 (follow-up to #709), so the choice and its trade-offs are not
+re-litigated at mainnet time.
+
+**Why "SRI on the operator page" is not a drop-in fix.** `/operator` is not a
+standalone deploy — it is one route inside the shared Vite SPA
+(`web/packages/web-wallet`), served from a single Cloudflare Pages project
+(`project-name=botho`) to `botho.io`/`wallet.botho.io` from one `dist/` build.
+Browser Subresource Integrity (`<script integrity="sha384-…">`) pins hashes of
+**sub-resources referenced by an HTML document the consumer controls**; it
+cannot pin the top-level, same-origin HTML document itself. So there are two
+distinct ways to close 8.3, with different cost/guarantee profiles:
+
+| Approach | Guarantee | Cost | Status |
+|---|---|---|---|
+| **(a) Split-build + true SRI** — give `/operator` its own Vite build / Pages target whose `index.html` pins `integrity=` hashes for its own JS/CSS chunks. | Browser *enforces* integrity: a tampered chunk fails to load, no operator action required. | High — a second build artifact + deploy target + CI job kept in sync with the shared `@botho/features`/`@botho/core` packages; touches Vite config, Pages topology, and the App router. | **Deferred to follow-up** (assessed **L**). Filed as a separate issue; see PR for #757. |
+| **(b) Whole-bundle hash pin + out-of-band verify** — a maintainer publishes an aggregate hash of the built `dist/` tree; the operator verifies their bundle against it **before importing their key**, and/or self-hosts that exact bundle. | Operator-enforced: integrity depends on the operator running the check. No browser enforcement, but no host-topology change. | Low — one verify script + a runbook. Composes directly with self-hosting. | **Shipped in #757.** `web/scripts/verify-operator-bundle.sh` + `docs/operations/self-hosted-operator-dashboard.md`. |
+
+**Interaction with self-hosting.** Approach (b) is the natural companion to the
+second §9 hardening item ("self-hosting the operator page"): an operator who
+builds the bundle from a pinned tag, verifies its aggregate hash against a
+maintainer-published value, and serves that `dist/` from infrastructure they
+control has removed the Pages host from the trust path entirely — without
+waiting on the split-build. (a) remains desirable on top of (b) for the
+non-self-hosting operator, because it moves enforcement from "operator
+remembers to run the check" to "the browser refuses the bad bundle." See
+`docs/operations/self-hosted-operator-dashboard.md` for the operator-facing
+procedure.
+
+**PWA auto-update caveat.** The SPA registers a service worker with
+`registerType: 'autoUpdate'` (`vite.config.ts`), which auto-fetches and
+activates a new bundle after a deploy. Under either approach this means a
+verified/pinned bundle can be silently replaced by a later one. The
+self-hosting runbook documents the required mitigation: serve a fixed,
+already-verified `dist/` (no rolling deploy behind it), so there is no newer
+bundle for the service worker to pull; and re-verify the hash after any
+intentional update before trusting a new signing session. Note that the
+service-worker files (`sw.js`, `workbox-*.js`) are **inside** the verified
+trust set — `verify-operator-bundle.sh` hashes them along with the app chunks —
+so a tampered service worker changes the aggregate hash and is caught.
+
+**Not closed by this addendum (human/operator follow-ups):**
+
+- The **§8.3 threat-model re-review** (checklist item 3 in #757 / §9) — deciding
+  whether an in-browser key path is the right mainnet posture at all, versus an
+  air-gapped signer or hardware key — is a security-reviewer judgement, not a
+  code change.
+- An operator **actually standing up** their own hosting for the bundle is an
+  infrastructure action outside this repo; the repo's job (done here) is to make
+  self-hosting *possible, scripted, and documented*.
 
 ## 9. Review checklist (for the #708 reviewer)
 
@@ -417,4 +472,8 @@ adding operator convenience.
 - [ ] Audit log records authenticated outcomes only; pre-signature failures
       are rate-limited tracing + a counter (round-1 finding 3).
 - [ ] 8.3's residual risk (malicious bundle prompting the operator) is
-      acceptable for testnet, and the mainnet hardening list is filed.
+      acceptable for testnet, and the mainnet hardening list is filed. The
+      decided mainnet approach and its trade-offs are recorded in §8.3.1;
+      the whole-bundle verify path (`web/scripts/verify-operator-bundle.sh` +
+      `docs/operations/self-hosted-operator-dashboard.md`) is in place, and the
+      split-build/true-SRI option is deferred to a tracked follow-up.

--- a/web/packages/web-wallet/package.json
+++ b/web/packages/web-wallet/package.json
@@ -10,6 +10,7 @@
     "build:all": "pnpm build:wasm && pnpm build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "verify:operator-bundle": "../../scripts/verify-operator-bundle.sh --dist dist",
     "deploy": "pnpm build && wrangler pages deploy dist --project-name=botho",
     "deploy:all": "pnpm build:all && wrangler pages deploy dist --project-name=botho"
   },

--- a/web/scripts/verify-operator-bundle.sh
+++ b/web/scripts/verify-operator-bundle.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Verify the operator dashboard bundle
+#
+# The operator dashboard (`/operator`, see docs/security/quorum-write-path.md)
+# imports the operator Ed25519 key into the browser and signs quorum-curation
+# envelopes client-side. §8.3 of that doc identifies the serious residual risk:
+# a malicious dashboard *bundle* could prompt the operator to sign
+# attacker-chosen bytes. This script lets an operator (or an independent
+# verifier) confirm that the bundle they are about to trust is bit-for-bit the
+# one a maintainer published a hash for, before they ever import their key.
+#
+# Because `/operator` is one route inside the shared Vite SPA
+# (web/packages/web-wallet), the unit of trust is the *whole* built `dist/`
+# tree, not a single chunk. This script computes:
+#
+#   1. Per-file SHA-256 checksums for every asset in `dist/` (SHA256SUMS-style),
+#      excluding non-deterministic build artifacts (source maps, the PWA
+#      service-worker manifest revision, etc.), and
+#   2. A single aggregate "bundle hash" = SHA-256 over the sorted per-file
+#      checksum list. This one value is what a maintainer publishes and an
+#      operator compares.
+#
+# This parallels scripts/build-release.sh + SHA256SUMS.txt for the node
+# binaries (docs/operations/reproducible-builds.md), extended to the web bundle.
+#
+# Usage:
+#   web/scripts/verify-operator-bundle.sh [--dist DIR] [--expected HASH] [--manifest]
+#
+# Options:
+#   --dist DIR        Path to the built bundle (default: dist next to this repo's
+#                     web-wallet package, i.e. web/packages/web-wallet/dist)
+#   --expected HASH   Compare the computed aggregate bundle hash against HASH and
+#                     exit non-zero on mismatch. Without this flag the script
+#                     just prints the hash (publish mode).
+#   --manifest        Also print the full per-file SHA256SUMS listing to stdout.
+#
+# Exit codes:
+#   0  hash computed (and matched --expected, if given)
+#   1  usage / environment error (no dist dir, etc.)
+#   2  hash mismatch against --expected
+#
+# Example (maintainer, publishing):
+#   pnpm --filter @botho/web-wallet build
+#   web/scripts/verify-operator-bundle.sh
+#   # -> prints: operator bundle hash: sha256-<...>
+#
+# Example (operator, verifying a build they made from a pinned tag):
+#   web/scripts/verify-operator-bundle.sh --expected sha256-<published-value>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# web/scripts -> web/packages/web-wallet
+DEFAULT_DIST="$(cd "$SCRIPT_DIR/../packages/web-wallet" && pwd)/dist"
+
+DIST_DIR="$DEFAULT_DIST"
+EXPECTED=""
+PRINT_MANIFEST=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dist)
+            DIST_DIR="$2"
+            shift 2
+            ;;
+        --expected)
+            EXPECTED="$2"
+            shift 2
+            ;;
+        --manifest)
+            PRINT_MANIFEST=1
+            shift
+            ;;
+        --)
+            # Bare separator (e.g. inserted by `pnpm run … -- <args>`); skip it.
+            shift
+            ;;
+        -h|--help)
+            grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -d "$DIST_DIR" ]]; then
+    echo "error: dist directory not found: $DIST_DIR" >&2
+    echo "       build it first: pnpm --filter @botho/web-wallet build" >&2
+    exit 1
+fi
+
+# Portable SHA-256: coreutils sha256sum on Linux, shasum on macOS.
+sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$@"
+    else
+        shasum -a 256 "$@"
+    fi
+}
+
+# Files excluded from the trust set because they are not part of the executable
+# bundle the browser runs, or are not deterministic across environments:
+#   *.map              source maps — debugging aid, not shipped to the browser
+#                      runtime as executable code; large and toolchain-sensitive.
+# The service-worker manifest (sw.js / workbox-*.js) IS included: it controls
+# what the PWA caches and executes, so it is part of the trust boundary. See the
+# self-hosting runbook for how to pin the deployment against auto-update.
+EXCLUDE_REGEX='\.map$'
+
+# Compute per-file checksums with paths RELATIVE to dist so the manifest is
+# stable regardless of where the checkout lives. Sort by path for determinism.
+MANIFEST="$(
+    cd "$DIST_DIR"
+    # -type f, prune the excluded patterns, hash each, strip the leading "./".
+    find . -type f | LC_ALL=C sort | grep -Ev "$EXCLUDE_REGEX" | while IFS= read -r f; do
+        rel="${f#./}"
+        line="$(sha256 "$f")"
+        # Replace the (possibly "./"-prefixed) path with the normalized rel path
+        # while keeping the hash column, so the manifest is host-independent.
+        hash="${line%% *}"
+        printf '%s  %s\n' "$hash" "$rel"
+    done
+)"
+
+if [[ -z "$MANIFEST" ]]; then
+    echo "error: no files hashed under $DIST_DIR (empty build?)" >&2
+    exit 1
+fi
+
+# Aggregate bundle hash = SHA-256 over the sorted manifest text.
+AGG="$(printf '%s\n' "$MANIFEST" | sha256 | awk '{print $1}')"
+BUNDLE_HASH="sha256-$AGG"
+
+if [[ "$PRINT_MANIFEST" -eq 1 ]]; then
+    echo "=== per-file SHA256SUMS ($DIST_DIR) ==="
+    printf '%s\n' "$MANIFEST"
+    echo "==="
+fi
+
+echo "operator bundle hash: $BUNDLE_HASH"
+echo "  dist:  $DIST_DIR"
+echo "  files: $(printf '%s\n' "$MANIFEST" | wc -l | tr -d ' ')"
+
+if [[ -n "$EXPECTED" ]]; then
+    if [[ "$BUNDLE_HASH" == "$EXPECTED" ]]; then
+        echo "MATCH: bundle hash matches expected value."
+        exit 0
+    else
+        echo "MISMATCH: bundle hash does NOT match expected value!" >&2
+        echo "  expected: $EXPECTED" >&2
+        echo "  actual:   $BUNDLE_HASH" >&2
+        echo "  Do NOT import your operator key into this bundle." >&2
+        exit 2
+    fi
+fi


### PR DESCRIPTION
## Summary

Implements the Builder-sized (**M**) slice of the §8.3 mainnet-hardening list
for the quorum operator dashboard: a way for a quorum operator to **verify and
self-host** the `/operator` bundle instead of trusting the shared Cloudflare
Pages deploy. This closes §8.3's malicious-bundle risk for a careful operator
without changing deploy topology.

Per the curator's recommended scope, this PR delivers the doc + verify-script +
threat-model addendum (option **b**). The larger split-build / true
browser-enforced SRI (option **a**, assessed **L**) is **deferred to a
follow-up**, filed as **#772**, and referenced from the §8.3.1 addendum.

## Changes

- **`web/scripts/verify-operator-bundle.sh`** (new): hashes the built `dist/`
  tree (excluding source maps) into a single deterministic aggregate
  `sha256-…` bundle hash and compares it against a maintainer-published value
  (`--expected`), refusing on mismatch (exit 2). `--manifest` prints the full
  per-file SHA256SUMS listing. Parallels `scripts/build-release.sh` +
  `SHA256SUMS.txt` for node binaries. Service-worker files (`sw.js`,
  `workbox-*.js`) are inside the hashed trust set.
- **`web/packages/web-wallet/package.json`**: `verify:operator-bundle` script.
- **`docs/operations/self-hosted-operator-dashboard.md`** (new): operator
  runbook — clone at a pinned tag, build, verify hash, serve `dist/`, handle
  the PWA `autoUpdate` service worker.
- **`docs/security/quorum-write-path.md`** §8.3.1 (new addendum): records the
  decided approach with a trade-off table (option a vs b), the PWA auto-update
  caveat, and the human-only follow-ups. §8.3 table row + §9 checklist updated
  to point at it.
- **`docs/operations/reproducible-builds.md`**: cross-link to the web procedure.

## Acceptance Criteria Verification

| Criterion (from curator scope) | Status | Verification |
|---|---|---|
| Document chosen approach as §8.3 addendum with trade-off analysis | ✅ | New §8.3.1 with option a/b table, PWA caveat, follow-up notes |
| Build/verify script hashing the built bundle vs a published value | ✅ | `verify-operator-bundle.sh`; tested `--expected` MATCH (exit 0) + MISMATCH (exit 2) against a real build |
| Reproducibility check (same commit → same hash) | ✅ | Two clean `pnpm --filter @botho/web-wallet build` runs both produced `sha256-782fb3ed…` |
| Operator-facing self-hosting runbook under `docs/operations/` | ✅ | New `self-hosted-operator-dashboard.md`, modeled on `reproducible-builds.md` |
| §8.3 threat-model re-review | ➡️ follow-up | Human/security-reviewer action; called out in §8.3.1 as not code-closable |
| Split-build for true browser-enforced SRI | ➡️ #772 | Assessed L; deferred per curator, filed as #772, referenced in §8.3.1 |
| package.json verify script entry | ✅ | `verify:operator-bundle`; `pnpm … -- --expected …` passthrough tested (MATCH) |

## Test Plan

Ran against a real production build in the worktree:

- `pnpm install --frozen-lockfile && pnpm --filter @botho/web-wallet build` — succeeds (2492 modules, `dist/` produced).
- `web/scripts/verify-operator-bundle.sh --manifest` → 16 files hashed, `.map` excluded, `sw.js`/`workbox-*.js` included; aggregate `sha256-782fb3ed6e5d81344529d993d3a364dc3df9fd112654dd58f9b9bd42641122ac`.
- `--expected` MATCH → exit 0; bogus `--expected` → `MISMATCH` + "do NOT import your key" + exit 2.
- Clean rebuild (`rm -rf dist` then rebuild) → identical aggregate hash (reproducible).
- `pnpm --filter @botho/web-wallet verify:operator-bundle -- --expected <hash>` → MATCH (script tolerates the `--` pnpm inserts).
- `bash -n` syntax check, `--help`, and missing-dir error path (exit 1) all pass.
- `pnpm --filter @botho/web-wallet typecheck` → clean (package.json edit).

## Notes / deviations

- **Not fully closable by code alone** (called out explicitly per curator): the
  §8.3 threat-model re-review is a security-reviewer action, and an operator
  *actually* standing up their own hosting is infrastructure outside this repo.
  This PR makes self-hosting possible, scripted, and documented — it does not
  claim the §9 checklist items are fully satisfied by code.
- Reverted an unrelated `web/pnpm-workspace.yaml` change that `pnpm install`
  auto-wrote (`allowBuilds` prompts) — out of scope.

Closes #757