### PR TITLE
feat(web): split operator dashboard into its own SRI-pinned build entry

### DIFF
--- a/docs/operations/self-hosted-operator-dashboard.md
+++ b/docs/operations/self-hosted-operator-dashboard.md
@@ -17,16 +17,25 @@ host) and signs quorum-curation envelopes client-side. The serious residual risk
 (§8.3) is a **malicious bundle**: a compromised host could serve JavaScript that
 prompts you to sign attacker-chosen bytes.
 
-Two independent mitigations reduce this to near-zero for a careful operator:
+Three mitigations reduce this to near-zero for a careful operator:
 
-1. **Verify the bundle** you are about to run against a maintainer-published
+1. **Browser-enforced SRI (option (a), #772), on by default.** `/operator` is
+   its own build entry (`operator.html`) whose HTML pins `integrity="sha384-…"`
+   hashes for every JS/CSS chunk it loads. Any tampered chunk fails the browser's
+   own integrity check and never executes — no operator action required. This
+   protects the operator entry's *sub-resources* even on the shared Pages deploy.
+   Its one residual gap: the browser does not integrity-check the top-level
+   `operator.html` document itself (SRI never does), so mitigations 2–3 remain
+   worthwhile.
+2. **Verify the bundle** you are about to run against a maintainer-published
    hash, *before* you import your key. A tampered bundle produces a different
-   hash and is caught.
-2. **Self-host** that verified bundle from infrastructure you control, so the
+   hash and is caught. This covers the top-level document that SRI cannot.
+3. **Self-host** that verified bundle from infrastructure you control, so the
    shared Pages host is no longer in your trust path at all.
 
-This runbook covers both. Doing (1) alone already closes most of the risk; (2)
-removes the host entirely and is recommended for mainnet.
+This runbook covers (2) and (3); (1) is automatic. Doing (2) alone already
+closes most of the risk on top of (1); (3) removes the host entirely and is
+recommended for mainnet.
 
 ## Prerequisites
 
@@ -54,12 +63,17 @@ git rev-parse HEAD             # record this — it's what you're trusting
 cd web
 pnpm install --frozen-lockfile
 
-# Build the operator dashboard bundle (the whole SPA; /operator is one route).
+# Build the operator dashboard bundle. The build is multi-page: the marketing/
+# wallet SPA is `dist/index.html`, and the operator dashboard is its own entry,
+# `dist/operator.html`, whose referenced chunks carry SRI integrity hashes.
 # Include the in-browser signer wasm so the signing path actually works:
 pnpm --filter @botho/web-wallet build:all
 ```
 
-The build output lands in `web/packages/web-wallet/dist/`.
+The build output lands in `web/packages/web-wallet/dist/`. Two HTML entry
+documents are emitted: `dist/index.html` (main SPA) and `dist/operator.html`
+(the standalone, SRI-pinned operator dashboard — this is what `/operator`
+serves).
 
 > `build:all` runs `build:wasm` then `build`. If you only need to *inspect*
 > the bundle hash and not sign, plain `pnpm --filter @botho/web-wallet build`
@@ -94,6 +108,23 @@ bundle):
 web/scripts/verify-operator-bundle.sh --manifest
 ```
 
+### Confirm the operator entry's browser-enforced SRI (option (a))
+
+Independently of the aggregate hash, you can confirm the operator entry pins a
+correct `sha384` integrity hash on each chunk it references — the scriptable
+equivalent of the check the browser performs on load:
+
+```bash
+web/scripts/verify-operator-bundle.sh --verify-sri
+# or: pnpm --filter @botho/web-wallet verify:operator-sri
+```
+
+It parses `dist/operator.html`, recomputes the `sha384` of each referenced chunk
+from disk, and exits 3 if any reference is missing an `integrity` attribute or
+the hash does not match. This is what protects you on the *shared* deploy even
+without self-hosting: a compromised host that swaps a chunk cannot match the
+pinned hash, and the browser refuses to run it.
+
 ### Reproducibility
 
 The bundle hash is deterministic: building the same pinned commit in two clean
@@ -123,12 +154,26 @@ pnpm --filter @botho/web-wallet preview   # serves dist/ on http://localhost:417
 
 # Option B: any static file server you trust, on infra you control
 #   (nginx, caddy, `python3 -m http.server`, an internal Pages/Netlify you own, …)
-#   Point it at web/packages/web-wallet/dist/ and serve index.html as the SPA
-#   fallback for client-side routes like /operator.
+#   Point it at web/packages/web-wallet/dist/. See the routing note below for
+#   how to map /operator to operator.html and everything else to index.html.
 ```
 
-Because the SPA uses client-side routing, configure your server to serve
-`index.html` for unknown paths (SPA fallback) so `/operator` resolves.
+Because the build is now multi-page, configure your server's client-side-routing
+fallback carefully:
+
+- `/operator` (and any `/<locale>/operator`, e.g. `/es/operator`) must serve
+  **`operator.html`** — the standalone, SRI-pinned operator document.
+- All other unknown paths serve **`index.html`** — the main SPA fallback.
+
+Serving `index.html` for `/operator` would load the un-SRI-pinned main SPA route
+instead of the split operator entry, silently discarding the browser-enforced
+integrity. Example nginx:
+
+```nginx
+location = /operator      { try_files /operator.html =404; }
+location ~ ^/[a-z]{2}/operator$ { try_files /operator.html =404; }
+location /                { try_files $uri /index.html; }
+```
 
 > **RPC reachability.** The bundle reaches a node's RPC directly. For local
 > `pnpm preview`, the Vite preview proxy forwards `/rpc` to a seed node (see
@@ -138,10 +183,18 @@ Because the SPA uses client-side routing, configure your server to serve
 
 ## Step 5: Handle PWA auto-update (important)
 
-The SPA registers a service worker with `registerType: 'autoUpdate'`
+The main SPA registers a service worker with `registerType: 'autoUpdate'`
 (`vite.config.ts`). On the shared deploy this silently fetches and activates a
 **newer** bundle after each deploy — which would defeat the whole point of
 pinning a verified bundle.
+
+> **Note (option (a), #772):** the operator entry is deliberately kept *out* of
+> the service worker. `operator-main.tsx` does not register the SW, and
+> `operator.html` is excluded from the Workbox precache
+> (`globIgnores: ['operator.html']`), so the operator document is always fetched
+> fresh over the network and cannot be silently swapped from the SW cache. The
+> guidance below still matters for the *rest* of the bundle and for the chunks
+> the operator entry loads.
 
 When self-hosting, keep the served `dist/` **fixed**: serve one verified build
 and do not roll a newer one behind the same origin. With no newer bundle
@@ -186,9 +239,15 @@ Publish that `sha256-<...>` value next to the release for the pinned commit.
 
 ## What this does and does not remove from the trust path
 
+**Removed** by browser-enforced SRI (automatic, even on the shared deploy):
+
+- Silent tampering of the operator entry's JS/CSS **chunks** — the browser
+  refuses any chunk whose bytes don't match the pinned `sha384` hash.
+
 **Removed** by verify + self-host:
 
-- Trust in the shared Cloudflare Pages host serving an honest bundle.
+- Trust in the shared Cloudflare Pages host serving an honest top-level
+  `operator.html` document (the one thing SRI cannot pin).
 - Silent bundle replacement via PWA auto-update (when you serve a fixed build).
 
 **Still trusted** (out of scope for this runbook):

--- a/docs/security/quorum-write-path.md
+++ b/docs/security/quorum-write-path.md
@@ -419,24 +419,58 @@ distinct ways to close 8.3, with different cost/guarantee profiles:
 
 | Approach | Guarantee | Cost | Status |
 |---|---|---|---|
-| **(a) Split-build + true SRI** — give `/operator` its own Vite build / Pages target whose `index.html` pins `integrity=` hashes for its own JS/CSS chunks. | Browser *enforces* integrity: a tampered chunk fails to load, no operator action required. | High — a second build artifact + deploy target + CI job kept in sync with the shared `@botho/features`/`@botho/core` packages; touches Vite config, Pages topology, and the App router. | **Deferred to follow-up** (assessed **L**). Filed as a separate issue; see PR for #757. |
+| **(a) Split-build + true SRI** — give `/operator` its own Vite build entry whose HTML document pins `integrity=` hashes for its own JS/CSS chunks. | Browser *enforces* integrity: a tampered chunk fails to load, no operator action required. | High — a second build entry + an SRI-injection plugin + PWA precache exclusion, kept in sync with the shared `@botho/features`/`@botho/core` packages; touches Vite config and adds a standalone operator app shell. | **Shipped in #772.** Multi-page Vite build (`operator.html` -> `operator-main.tsx`) within `web/packages/web-wallet` on the same Pages project; `sriHashPlugin` pins `sha384` integrity on the operator entry's chunks; a build-time test (`operator-sri.test.ts`) and `verify-operator-bundle.sh --verify-sri` enforce it. |
 | **(b) Whole-bundle hash pin + out-of-band verify** — a maintainer publishes an aggregate hash of the built `dist/` tree; the operator verifies their bundle against it **before importing their key**, and/or self-hosts that exact bundle. | Operator-enforced: integrity depends on the operator running the check. No browser enforcement, but no host-topology change. | Low — one verify script + a runbook. Composes directly with self-hosting. | **Shipped in #757.** `web/scripts/verify-operator-bundle.sh` + `docs/operations/self-hosted-operator-dashboard.md`. |
 
 **Interaction with self-hosting.** Approach (b) is the natural companion to the
 second §9 hardening item ("self-hosting the operator page"): an operator who
 builds the bundle from a pinned tag, verifies its aggregate hash against a
 maintainer-published value, and serves that `dist/` from infrastructure they
-control has removed the Pages host from the trust path entirely — without
-waiting on the split-build. (a) remains desirable on top of (b) for the
-non-self-hosting operator, because it moves enforcement from "operator
-remembers to run the check" to "the browser refuses the bad bundle." See
-`docs/operations/self-hosted-operator-dashboard.md` for the operator-facing
+control has removed the Pages host from the trust path entirely. (a) now sits
+**on top of** (b) for the non-self-hosting operator: it moves enforcement from
+"operator remembers to run the check" to "the browser refuses the bad chunk."
+See `docs/operations/self-hosted-operator-dashboard.md` for the operator-facing
 procedure.
+
+**What (a) landed (#772), and its residual gap.** The operator dashboard is now
+its own Vite build entry — `web/packages/web-wallet/operator.html` bootstraps
+`operator-main.tsx` -> `OperatorApp.tsx`, a slimmed router mounting only the
+`/operator` route (with the same `parseLocalePath` locale handling as the main
+SPA). It is emitted into the *same* Cloudflare Pages project (`dist/operator.html`
+alongside `dist/index.html`), so the `/operator` URL is unchanged and no DNS/
+Pages-topology change was needed. A build-time plugin (`sriHashPlugin` in
+`vite.config.ts`, modeled on the existing `wasmSignerPkgPlugin`) injects
+`integrity="sha384-…"` + `crossorigin` onto every `<script>`, `<link
+rel="stylesheet">`, and `<link rel="modulepreload">` in the emitted
+`operator.html` that references a local chunk. `operator-sri.test.ts` runs a
+real build and asserts, byte-for-byte, that every operator asset reference is
+pinned and every pinned hash matches the file on disk; `verify-operator-bundle.sh
+--verify-sri` performs the same check against a built `dist/` as a scriptable
+stand-in for the browser's own integrity enforcement.
+
+The **residual trust gap** is inherent to SRI and unchanged from the analysis
+above: browsers do **not** SRI-check a top-level, same-origin navigation, so the
+operator *document itself* (`operator.html`) is still trusted-on-load. The
+security gain from (a) is therefore specifically narrower than "the host can't
+lie": a compromised Pages host can still serve a bad `operator.html`, but it can
+**no longer silently swap the JS/CSS chunks that document references** without
+the browser refusing to execute them. That forces any attacker payload into the
+one HTML file that is smallest and easiest to diff/monitor, rather than hiding
+in any of N chunk files. Closing the top-level-document gap entirely still
+requires (b) — verifying the whole bundle out-of-band and/or self-hosting.
 
 **PWA auto-update caveat.** The SPA registers a service worker with
 `registerType: 'autoUpdate'` (`vite.config.ts`), which auto-fetches and
-activates a new bundle after a deploy. Under either approach this means a
-verified/pinned bundle can be silently replaced by a later one. The
+activates a new bundle after a deploy. SRI only pins *sub-resources*, not the
+top-level document, so an auto-updated SW that could serve `operator.html` from
+cache would defeat (a) (it could hand back a document pinning attacker-chosen
+hashes). The (a) mitigation, landed in #772: the operator entry does **not**
+register the service worker (`operator-main.tsx` omits the `registerSW` call),
+and `operator.html` is excluded from the Workbox precache manifest
+(`globIgnores: ['operator.html']` in `vite.config.ts`) with a
+`navigateFallbackDenylist` entry for `/operator`. The browser therefore always
+fetches the operator document fresh over the network, and the `integrity=`
+attributes on that fresh document protect its sub-resources. For (b), the
 self-hosting runbook documents the required mitigation: serve a fixed,
 already-verified `dist/` (no rolling deploy behind it), so there is no newer
 bundle for the service worker to pull; and re-verify the hash after any
@@ -475,5 +509,8 @@ so a tampered service worker changes the aggregate hash and is caught.
       acceptable for testnet, and the mainnet hardening list is filed. The
       decided mainnet approach and its trade-offs are recorded in §8.3.1;
       the whole-bundle verify path (`web/scripts/verify-operator-bundle.sh` +
-      `docs/operations/self-hosted-operator-dashboard.md`) is in place, and the
-      split-build/true-SRI option is deferred to a tracked follow-up.
+      `docs/operations/self-hosted-operator-dashboard.md`) is in place (option
+      (b), #757), and the split-build/browser-enforced-SRI option (a) has landed
+      (#772): the operator entry is its own SRI-pinned Vite build target,
+      excluded from the PWA service worker, with a build-time integrity test and
+      a `--verify-sri` script mode.

--- a/web/packages/web-wallet/operator.html
+++ b/web/packages/web-wallet/operator.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="description" content="Botho Operator Dashboard" />
+
+    <!-- Do NOT advertise this document to link-preview crawlers or search
+         indexes: the operator dashboard is an operational surface, not a
+         marketing page. -->
+    <meta name="robots" content="noindex, nofollow" />
+
+    <meta name="theme-color" content="#06b6d4" />
+
+    <!-- Favicon and Icons -->
+    <link rel="icon" type="image/png" href="/favicon.png" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="mask-icon" href="/mask-icon.svg" color="#06b6d4" />
+
+    <title>Botho Operator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!--
+      Standalone entry for the operator dashboard (#772, §8.3.1 option (a)).
+
+      The operator dashboard is split into its own Vite build target so this
+      document references ONLY its own hashed JS/CSS chunks. A build-time plugin
+      (`sriHashPlugin` in vite.config.ts) pins `integrity="sha384-…"` on the
+      emitted <script>/<link> tags below so the browser refuses a tampered chunk
+      with no operator action required.
+
+      This entry deliberately does NOT register the PWA service worker (see
+      operator-main.tsx): the operator document must always be fetched fresh
+      over the network so an auto-updated SW cannot silently swap it.
+    -->
+    <script type="module" src="/src/operator-main.tsx"></script>
+  </body>
+</html>

--- a/web/packages/web-wallet/package.json
+++ b/web/packages/web-wallet/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "verify:operator-bundle": "../../scripts/verify-operator-bundle.sh --dist dist",
+    "verify:operator-sri": "../../scripts/verify-operator-bundle.sh --verify-sri --dist dist",
     "deploy": "pnpm build && wrangler pages deploy dist --project-name=botho",
     "deploy:all": "pnpm build:all && wrangler pages deploy dist --project-name=botho"
   },

--- a/web/packages/web-wallet/src/OperatorApp.test.tsx
+++ b/web/packages/web-wallet/src/OperatorApp.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Standalone operator-entry shell (#772, §8.3.1 option (a)). The split operator
+ * build boots `OperatorApp` instead of the full SPA `App`; this asserts it
+ * mounts the operator dashboard at `/operator` and at a locale-prefixed
+ * `/:locale/operator`, matching the `LocaleRoutes` contract of the main SPA.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import OperatorApp from './OperatorApp'
+
+// jsdom lacks localStorage; provide a minimal mock for i18n persistence.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+beforeEach(() => {
+  localStorageMock.clear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+function renderAt(path: string) {
+  window.history.pushState({}, '', path)
+  return render(<OperatorApp />)
+}
+
+// `getByRole` throws if the element is absent, so its mere resolution is the
+// assertion; this project does not wire up jest-dom matchers.
+const fleetTab = () => screen.getByRole('tab', { name: /fleet/i })
+
+describe('OperatorApp standalone shell', () => {
+  it('mounts the operator dashboard at /operator', async () => {
+    renderAt('/operator')
+    // The operator header renders the tablist with a Fleet tab.
+    await waitFor(() => fleetTab())
+    expect(document.documentElement.lang).toBe('en')
+  })
+
+  it('mounts the operator dashboard under a non-default locale prefix (/es/operator)', async () => {
+    renderAt('/es/operator')
+    await waitFor(() => fleetTab())
+    // Locale side effects mirror the main SPA's LocaleRoutes.
+    await waitFor(() => expect(document.documentElement.lang).toBe('es'))
+  })
+
+  it('redirects an unknown in-document path to /operator', async () => {
+    renderAt('/somewhere-else')
+    await waitFor(() => fleetTab())
+    expect(window.location.pathname).toBe('/operator')
+  })
+})

--- a/web/packages/web-wallet/src/OperatorApp.tsx
+++ b/web/packages/web-wallet/src/OperatorApp.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from 'react'
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+} from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { OperatorPage } from './pages/operator'
+import { parseLocalePath } from './lib/locale-path'
+import { DEFAULT_LOCALE, storeLocale } from './lib/i18n'
+
+/**
+ * Standalone operator-dashboard shell (#772, §8.3.1 option (a)).
+ *
+ * The operator dashboard is served from its own Vite build entry
+ * (`operator.html` -> `operator-main.tsx`) so its HTML document references only
+ * its own hashed chunks and can pin `integrity=` (SRI) on them. This shell is
+ * the operator analogue of `App.tsx`, trimmed to just the routes the operator
+ * document needs.
+ *
+ * Only `/operator` is a real route here. It is reached at `/operator` and, for
+ * a non-default locale, at `/:locale/operator` (e.g. `/es/operator`) — the same
+ * locale-stripping contract `App.tsx` uses for the main SPA, reusing
+ * `parseLocalePath`. Any other path redirects to `/operator` so a stray
+ * navigation within this document lands somewhere valid rather than a blank
+ * screen; cross-surface links inside the page (to `/`, `/network`, `/explorer`)
+ * are full-document navigations back into the main SPA and are unaffected.
+ */
+function OperatorRoutes() {
+  return (
+    <Routes>
+      <Route path="/operator" element={<OperatorPage />} />
+      {/* Any other path within the operator document falls back to /operator. */}
+      <Route path="*" element={<Navigate to="/operator" replace />} />
+    </Routes>
+  )
+}
+
+/**
+ * Locale-routing shell for the operator entry, mirroring `LocaleRoutes` in
+ * `App.tsx`: strip any leading supported-locale segment before matching, and
+ * keep i18next's active language, the persisted choice, and `<html lang>` in
+ * sync with the URL.
+ */
+function OperatorLocaleRoutes() {
+  const { i18n } = useTranslation()
+  const location = useLocation()
+  const { locale, rest } = parseLocalePath(location.pathname)
+
+  useEffect(() => {
+    if (i18n.language !== locale) {
+      void i18n.changeLanguage(locale)
+    }
+    storeLocale(locale)
+    if (typeof document !== 'undefined') {
+      document.documentElement.lang = locale
+    }
+  }, [i18n, locale])
+
+  if (locale === DEFAULT_LOCALE) {
+    return <OperatorRoutes />
+  }
+
+  const strippedLocation = { ...location, pathname: rest }
+  return (
+    <Routes location={strippedLocation}>
+      <Route path="/*" element={<OperatorRoutes />} />
+    </Routes>
+  )
+}
+
+function OperatorApp() {
+  return (
+    <BrowserRouter>
+      <OperatorLocaleRoutes />
+    </BrowserRouter>
+  )
+}
+
+export default OperatorApp

--- a/web/packages/web-wallet/src/operator-main.tsx
+++ b/web/packages/web-wallet/src/operator-main.tsx
@@ -1,0 +1,29 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import OperatorApp from './OperatorApp'
+// Initialize i18next before the app renders (issue #764), matching main.tsx so
+// `useTranslation()` works synchronously on first paint.
+import './lib/i18n'
+import '@botho/ui/styles/theme.css'
+
+// NOTE (#772, §8.3.1 option (a)): this entry deliberately does NOT register the
+// PWA service worker.
+//
+// The main SPA registers a `registerType: 'autoUpdate'` service worker in
+// `main.tsx`, which auto-fetches and activates a new bundle after a deploy. SRI
+// only pins *sub-resources* referenced by a document — it cannot protect the
+// top-level HTML document itself. If the operator document were under SW
+// control, an auto-updated worker could silently swap `operator.html` (and thus
+// the integrity hashes it pins), defeating the whole point of the split.
+//
+// By not registering the SW here, and by excluding `operator.html` + its chunks
+// from the Workbox precache glob in `vite.config.ts`, the browser always fetches
+// `/operator` fresh over the network. The `integrity=` attributes injected onto
+// this document's <script>/<link> tags then guarantee the referenced chunks are
+// byte-for-byte the published ones or the browser refuses to execute them.
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <OperatorApp />
+  </StrictMode>,
+)

--- a/web/packages/web-wallet/src/operator-sri.test.ts
+++ b/web/packages/web-wallet/src/operator-sri.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Build-time Subresource Integrity (SRI) contract for the operator dashboard
+ * entry (#772, §8.3.1 option (a)).
+ *
+ * The operator dashboard is split into its own Vite build target (`operator.html`
+ * -> `operator-main.tsx`) so its emitted HTML document references only its own
+ * hashed chunks and pins `integrity="sha384-…"` on each `<script>`/`<link>` tag
+ * (`sriHashPlugin` in `vite.config.ts`). Browser-enforced SRI is the entire
+ * point of the split: a tampered chunk on the host fails to load with no
+ * operator action required.
+ *
+ * This test runs a real production build in-process (fast — a few seconds) into
+ * a temp dir, then asserts, byte-for-byte against the files on disk, that:
+ *   1. every local (root-relative) <script src>/<link rel=stylesheet|modulepreload href>
+ *      reference in `operator.html` carries an `integrity="sha384-…"` attribute, and
+ *   2. each pinned hash equals the sha384 of the referenced emitted asset.
+ *
+ * If the SRI plugin regresses (missing attribute, stale/incorrect hash), this
+ * test fails, which fails `pnpm test:run` / CI.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { build } from 'vite'
+import { createHash } from 'node:crypto'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+const sri = (bytes: Buffer): string =>
+  'sha384-' + createHash('sha384').update(bytes).digest('base64')
+
+/** Extract same-origin, root-relative script/style/modulepreload refs + any integrity. */
+function collectAssetTags(
+  html: string,
+): { attr: string; ref: string; integrity: string | null }[] {
+  const out: { attr: string; ref: string; integrity: string | null }[] = []
+  const tagRe = /<(script|link)\b[^>]*>/gi
+  let match: RegExpExecArray | null
+  while ((match = tagRe.exec(html)) !== null) {
+    const tag = match[0]
+    const isScript = /^<script/i.test(tag)
+    const isStyle = /^<link/i.test(tag) && /rel\s*=\s*["']stylesheet["']/i.test(tag)
+    const isPreload =
+      /^<link/i.test(tag) && /rel\s*=\s*["']modulepreload["']/i.test(tag)
+    if (!isScript && !isStyle && !isPreload) continue
+    const attr = isScript ? 'src' : 'href'
+    const refM = tag.match(new RegExp(`\\b${attr}\\s*=\\s*["']([^"']+)["']`, 'i'))
+    if (!refM) continue
+    const ref = refM[1]
+    // Only local (root-relative) asset chunks are integrity-checkable here.
+    if (!ref.startsWith('/assets/')) continue
+    const intM = tag.match(/\bintegrity\s*=\s*["']([^"']+)["']/i)
+    out.push({ attr, ref, integrity: intM ? intM[1] : null })
+  }
+  return out
+}
+
+describe('operator entry Subresource Integrity', () => {
+  let dist: string
+
+  beforeAll(async () => {
+    dist = mkdtempSync(path.join(tmpdir(), 'operator-sri-'))
+    await build({
+      root: PKG_ROOT,
+      logLevel: 'silent',
+      build: {
+        outDir: dist,
+        emptyOutDir: true,
+        // Source maps are irrelevant to the SRI contract and slow the build.
+        sourcemap: false,
+      },
+    })
+  }, 120_000)
+
+  afterAll(() => {
+    if (dist) rmSync(dist, { recursive: true, force: true })
+  })
+
+  it('pins a matching sha384 integrity hash on every operator asset reference', () => {
+    const html = readFileSync(path.join(dist, 'operator.html'), 'utf8')
+    const tags = collectAssetTags(html)
+
+    // Sanity: the operator entry must reference at least its own JS entry chunk
+    // and its CSS — a zero-reference document would trivially "pass".
+    expect(tags.length).toBeGreaterThanOrEqual(2)
+
+    for (const { attr, ref, integrity } of tags) {
+      expect(
+        integrity,
+        `operator.html ${attr}="${ref}" is missing an integrity attribute`,
+      ).not.toBeNull()
+
+      const onDisk = readFileSync(path.join(dist, ref.replace(/^\//, '')))
+      expect(
+        integrity,
+        `operator.html ${attr}="${ref}" integrity does not match the file on disk`,
+      ).toBe(sri(onDisk))
+    }
+  })
+
+  it('does not pin integrity on the main SPA entry (index.html stays SW-managed)', () => {
+    // The main SPA is under PWA/auto-update service-worker control; pinning SRI
+    // on a document the SW may replace would be self-defeating (§8.3.1). Assert
+    // the split is targeted: index.html carries no integrity attributes.
+    const html = readFileSync(path.join(dist, 'index.html'), 'utf8')
+    expect(html).not.toMatch(/\bintegrity\s*=/i)
+  })
+})

--- a/web/packages/web-wallet/vite.config.ts
+++ b/web/packages/web-wallet/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
 import path from 'path'
+import { createHash } from 'node:crypto'
 import { cpSync, existsSync, readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 
@@ -75,11 +76,111 @@ function wasmSignerPkgPlugin(): Plugin {
   }
 }
 
+// HTML entry files (relative to the package root) whose emitted document should
+// have Subresource Integrity (SRI) hashes injected onto every referenced
+// <script>/<link rel="stylesheet"> tag. Only the operator dashboard entry is
+// SRI-pinned (#772, §8.3.1 option (a)): its browser-enforced integrity is the
+// whole point of splitting it into its own build target. The main SPA entry
+// (index.html) is intentionally left unpinned — it is under PWA/auto-update
+// service-worker control, where injected integrity hashes on a document the SW
+// may replace would be self-defeating.
+const SRI_ENTRY_HTML = new Set(['operator.html'])
+
+/**
+ * Inject Subresource Integrity (`integrity="sha384-…"` + `crossorigin`) onto the
+ * `<script src>` and `<link rel="stylesheet" href>` tags of the operator entry's
+ * emitted HTML document (#772, §8.3.1 option (a)).
+ *
+ * Runs in Rollup's `generateBundle` (build only), after the entry's chunks and
+ * CSS have been emitted, so every referenced asset is present in the bundle and
+ * its final (hashed) filename is known. For each same-origin, root-relative
+ * asset reference in a targeted HTML file we compute the sha384 of the emitted
+ * asset's exact bytes and rewrite the tag to pin it. A tampered chunk on the
+ * host then fails the browser's integrity check and is never executed — no
+ * operator action required.
+ *
+ * Modeled on the post-build file-manipulation pattern `wasmSignerPkgPlugin`
+ * already uses in this file; hand-rolled (no new dependency) for one hash fn.
+ */
+function sriHashPlugin(): Plugin {
+  const sri = (bytes: string | Uint8Array): string =>
+    'sha384-' + createHash('sha384').update(bytes).digest('base64')
+
+  return {
+    name: 'botho-operator-sri',
+    apply: 'build',
+    enforce: 'post',
+    generateBundle(_options, bundle) {
+      // Index emitted assets/chunks by their root-absolute path (`/assets/x.js`)
+      // so we can resolve an HTML `src`/`href` to the emitted bytes.
+      const byPath = new Map<string, string | Uint8Array>()
+      for (const [fileName, output] of Object.entries(bundle)) {
+        const bytes =
+          output.type === 'chunk'
+            ? output.code
+            : typeof output.source === 'string'
+              ? output.source
+              : output.source
+        byPath.set('/' + fileName, bytes)
+      }
+
+      for (const [fileName, output] of Object.entries(bundle)) {
+        if (output.type !== 'asset') continue
+        if (!SRI_ENTRY_HTML.has(fileName)) continue
+        const html =
+          typeof output.source === 'string'
+            ? output.source
+            : Buffer.from(output.source).toString('utf8')
+
+        // Rewrite <script src="…">, <link rel="stylesheet" href="…"> and
+        // <link rel="modulepreload" href="…">, adding integrity (+ crossorigin
+        // where absent) for each root-relative asset we can resolve. The browser
+        // enforces integrity on all three, including modulepreloaded chunks the
+        // operator entry statically imports (e.g. the shared framework chunk).
+        const rewritten = html.replace(
+          /<(script|link)\b[^>]*>/gi,
+          (tag: string) => {
+            const isScript = /^<script/i.test(tag)
+            const isStyle =
+              /^<link/i.test(tag) && /rel\s*=\s*["']stylesheet["']/i.test(tag)
+            const isModulePreload =
+              /^<link/i.test(tag) && /rel\s*=\s*["']modulepreload["']/i.test(tag)
+            if (!isScript && !isStyle && !isModulePreload) return tag
+            if (/\bintegrity\s*=/i.test(tag)) return tag // already pinned
+
+            const attr = isScript ? 'src' : 'href'
+            const m = tag.match(new RegExp(`\\b${attr}\\s*=\\s*["']([^"']+)["']`, 'i'))
+            if (!m) return tag
+            const ref = m[1]
+            const bytes = byPath.get(ref)
+            if (bytes === undefined) return tag // external / unresolved — skip
+
+            const integrity = sri(bytes)
+            const closeIdx = tag.lastIndexOf('>')
+            const selfClosing = tag[closeIdx - 1] === '/'
+            const insertAt = selfClosing ? closeIdx - 1 : closeIdx
+            // Vite already emits a bare `crossorigin` on its own tags; only add
+            // one when the tag lacks it, to avoid a duplicate attribute.
+            const needsCrossorigin = !/\bcrossorigin\b/i.test(tag)
+            const injected =
+              ` integrity="${integrity}"` +
+              (needsCrossorigin ? ' crossorigin="anonymous"' : '')
+            return tag.slice(0, insertAt) + injected + tag.slice(insertAt)
+          },
+        )
+
+        output.source = rewritten
+      }
+    },
+  }
+}
+
 export default defineConfig({
   plugins: [
     react(),
     tailwindcss(),
     wasmSignerPkgPlugin(),
+    sriHashPlugin(),
     VitePWA({
       registerType: 'autoUpdate',
       // We register the service worker ourselves via the `virtual:pwa-register`
@@ -121,7 +222,16 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
-        navigateFallbackDenylist: [/\.pdf$/],
+        // Keep the operator dashboard document out of the precache manifest
+        // (#772, §8.3.1 option (a)). The SW must never cache or serve
+        // `operator.html`, so the browser always fetches the operator entry
+        // fresh over the network — an auto-updated SW then cannot silently swap
+        // the top-level document that pins the SRI hashes. The referenced JS/CSS
+        // chunks are still integrity-checked by the browser on that fresh fetch.
+        globIgnores: ['operator.html'],
+        // Never let the SPA's navigation fallback hijack /operator: it must
+        // resolve to the standalone operator document, not the main app shell.
+        navigateFallbackDenylist: [/\.pdf$/, /^\/operator(\/|$)/, /\/operator\.html$/],
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
@@ -175,5 +285,16 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     sourcemap: true,
+    rollupOptions: {
+      // Multi-page build (#772, §8.3.1 option (a)): the main SPA (index.html)
+      // and the standalone operator dashboard (operator.html) are two entry
+      // documents in the same Cloudflare Pages project. Vite emits a distinct
+      // entry chunk graph per entry; the operator document references only its
+      // own chunks, which `sriHashPlugin` then integrity-pins.
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        operator: path.resolve(__dirname, 'operator.html'),
+      },
+    },
   },
 })

--- a/web/scripts/verify-operator-bundle.sh
+++ b/web/scripts/verify-operator-bundle.sh
@@ -9,9 +9,22 @@
 # verifier) confirm that the bundle they are about to trust is bit-for-bit the
 # one a maintainer published a hash for, before they ever import their key.
 #
-# Because `/operator` is one route inside the shared Vite SPA
-# (web/packages/web-wallet), the unit of trust is the *whole* built `dist/`
-# tree, not a single chunk. This script computes:
+# Two complementary layers of trust, both covered by this script:
+#
+#   * Whole-bundle hash (option (b), #757). The built `dist/` tree is hashed into
+#     one aggregate value a maintainer publishes and an operator compares before
+#     importing their key. This is operator-enforced (you must remember to run
+#     it) and is the natural companion to self-hosting the exact `dist/`.
+#
+#   * Operator-entry Subresource Integrity (option (a), #772). The operator
+#     dashboard is now its own Vite build entry (`operator.html`) whose emitted
+#     HTML pins `integrity="sha384-…"` on each JS/CSS chunk it references, so the
+#     BROWSER refuses a tampered chunk with no operator action required. The
+#     `--verify-sri` mode below re-derives each pinned hash from the file on disk
+#     and fails on any missing/mismatched attribute — the scriptable equivalent
+#     of the browser's own check.
+#
+# The whole-bundle hash computes:
 #
 #   1. Per-file SHA-256 checksums for every asset in `dist/` (SHA256SUMS-style),
 #      excluding non-deterministic build artifacts (source maps, the PWA
@@ -25,6 +38,7 @@
 #
 # Usage:
 #   web/scripts/verify-operator-bundle.sh [--dist DIR] [--expected HASH] [--manifest]
+#   web/scripts/verify-operator-bundle.sh --verify-sri [--dist DIR]
 #
 # Options:
 #   --dist DIR        Path to the built bundle (default: dist next to this repo's
@@ -33,11 +47,18 @@
 #                     exit non-zero on mismatch. Without this flag the script
 #                     just prints the hash (publish mode).
 #   --manifest        Also print the full per-file SHA256SUMS listing to stdout.
+#   --verify-sri      Verify the operator entry's browser-enforced SRI: parse
+#                     dist/operator.html, and for every root-relative <script>/
+#                     <link> reference confirm it has an integrity="sha384-…"
+#                     attribute whose hash matches the file on disk. Exits 3 on
+#                     any missing or mismatched attribute. Runs instead of the
+#                     aggregate-hash computation.
 #
 # Exit codes:
-#   0  hash computed (and matched --expected, if given)
+#   0  hash computed (and matched --expected, if given) / SRI verified
 #   1  usage / environment error (no dist dir, etc.)
 #   2  hash mismatch against --expected
+#   3  operator-entry SRI verification failed (--verify-sri)
 #
 # Example (maintainer, publishing):
 #   pnpm --filter @botho/web-wallet build
@@ -46,6 +67,9 @@
 #
 # Example (operator, verifying a build they made from a pinned tag):
 #   web/scripts/verify-operator-bundle.sh --expected sha256-<published-value>
+#
+# Example (confirm the operator entry's browser-enforced SRI is intact):
+#   web/scripts/verify-operator-bundle.sh --verify-sri
 
 set -euo pipefail
 
@@ -56,6 +80,7 @@ DEFAULT_DIST="$(cd "$SCRIPT_DIR/../packages/web-wallet" && pwd)/dist"
 DIST_DIR="$DEFAULT_DIST"
 EXPECTED=""
 PRINT_MANIFEST=0
+VERIFY_SRI=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -69,6 +94,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --manifest)
             PRINT_MANIFEST=1
+            shift
+            ;;
+        --verify-sri)
+            VERIFY_SRI=1
             shift
             ;;
         --)
@@ -100,6 +129,100 @@ sha256() {
         shasum -a 256 "$@"
     fi
 }
+
+# sha384 of a file, as base64 (the encoding SRI uses in `sha384-<base64>`).
+sha384_b64() {
+    # shasum prints hex; convert hex -> raw -> base64. Portable across macOS
+    # (shasum) and Linux (sha384sum).
+    if command -v sha384sum >/dev/null 2>&1; then
+        sha384sum "$1" | awk '{print $1}' | xxd -r -p | base64 | tr -d '\n'
+    else
+        shasum -a 384 "$1" | awk '{print $1}' | xxd -r -p | base64 | tr -d '\n'
+    fi
+}
+
+# --verify-sri: browser-enforced integrity check for the operator entry (#772,
+# §8.3.1 option (a)). Parse dist/operator.html and confirm every root-relative
+# <script src>/<link href> reference carries an integrity="sha384-…" attribute
+# whose hash matches the file on disk — the scriptable equivalent of the check a
+# browser performs on load. Exits 3 on any missing/mismatched attribute.
+if [[ "$VERIFY_SRI" -eq 1 ]]; then
+    OPERATOR_HTML="$DIST_DIR/operator.html"
+    if [[ ! -f "$OPERATOR_HTML" ]]; then
+        echo "error: operator entry not found: $OPERATOR_HTML" >&2
+        echo "       build it first: pnpm --filter @botho/web-wallet build" >&2
+        exit 1
+    fi
+
+    echo "operator entry SRI verification"
+    echo "  html:  $OPERATOR_HTML"
+
+    fail=0
+    checked=0
+    # Explicit error handling below (grep returns non-zero on no-match, which we
+    # treat as "attribute absent"), so relax `set -e`/pipefail for this block.
+    set +e
+    set +o pipefail
+    # Extract every <script …>/<link …> tag onto its own line, then inspect the
+    # ones that reference a root-relative /assets/ chunk.
+    tags="$(tr '\n' ' ' < "$OPERATOR_HTML" | grep -oE '<(script|link)\b[^>]*>')"
+    while IFS= read -r tag; do
+        [[ -z "$tag" ]] && continue
+        # Only script/stylesheet/modulepreload tags carry executable sub-resources.
+        is_script=0; is_asset_link=0
+        [[ "$tag" =~ ^\<script ]] && is_script=1
+        if [[ "$tag" =~ ^\<link ]] && \
+           { [[ "$tag" =~ rel=\"stylesheet\" ]] || [[ "$tag" =~ rel=\"modulepreload\" ]]; }; then
+            is_asset_link=1
+        fi
+        [[ "$is_script" -eq 0 && "$is_asset_link" -eq 0 ]] && continue
+
+        if [[ "$is_script" -eq 1 ]]; then
+            ref="$(printf '%s' "$tag" | grep -oE 'src="[^"]+"' | head -1 | sed 's/^src="//;s/"$//')"
+        else
+            ref="$(printf '%s' "$tag" | grep -oE 'href="[^"]+"' | head -1 | sed 's/^href="//;s/"$//')"
+        fi
+        # Only local, root-relative chunk references are integrity-checkable.
+        [[ "$ref" == /assets/* ]] || continue
+
+        integrity="$(printf '%s' "$tag" | grep -oE 'integrity="sha384-[^"]+"' | head -1 | sed 's/^integrity="sha384-//;s/"$//')"
+        if [[ -z "$integrity" ]]; then
+            echo "  MISSING integrity: $ref" >&2
+            fail=1
+            continue
+        fi
+
+        file="$DIST_DIR/${ref#/}"
+        if [[ ! -f "$file" ]]; then
+            echo "  MISSING file for pinned ref: $ref" >&2
+            fail=1
+            continue
+        fi
+        actual="$(sha384_b64 "$file")"
+        if [[ "$actual" != "$integrity" ]]; then
+            echo "  MISMATCH: $ref" >&2
+            echo "    pinned:   sha384-$integrity" >&2
+            echo "    on disk:  sha384-$actual" >&2
+            fail=1
+            continue
+        fi
+        checked=$((checked + 1))
+        echo "  OK: $ref"
+    done <<< "$tags"
+
+    if [[ "$checked" -eq 0 && "$fail" -eq 0 ]]; then
+        echo "error: no integrity-pinned asset references found in operator.html" >&2
+        echo "       (expected the SRI plugin to pin the operator entry chunks)" >&2
+        exit 3
+    fi
+    if [[ "$fail" -ne 0 ]]; then
+        echo "FAIL: operator entry SRI verification failed." >&2
+        echo "  Do NOT import your operator key into this bundle." >&2
+        exit 3
+    fi
+    echo "MATCH: all $checked operator asset references have a correct sha384 integrity hash."
+    exit 0
+fi
 
 # Files excluded from the trust set because they are not part of the executable
 # bundle the browser runs, or are not deterministic across environments:


### PR DESCRIPTION
## Summary

Lands **option (a)** of the operator-dashboard mainnet hardening (`docs/security/quorum-write-path.md` §8.3.1, follow-up to #757): browser-enforced Subresource Integrity for the operator dashboard. `/operator` was one route inside the shared Vite SPA, so its JS/CSS chunks could not carry `integrity=` hashes (SRI pins the sub-resources of a document the consumer controls, not a client-side route). This splits it into its own Vite build entry whose emitted HTML pins `sha384` hashes on each chunk it loads, so a tampered chunk on the host fails to load with **no operator action required**.

Implemented as **Option 1** from the curator's plan: a second entry point (`operator.html` -> `operator-main.tsx`) as a multi-page build **within** `web/packages/web-wallet`, deployed to the **same** Cloudflare Pages project — the `/operator` URL is unchanged, no new package or Pages/DNS topology.

## Changes

- **New operator entry**: `operator.html` (own document, `noindex`), `src/operator-main.tsx` (bootstrap that deliberately does **not** register the PWA service worker), `src/OperatorApp.tsx` (slim router: only `/operator` + `/:locale/operator`, reusing `parseLocalePath` — the i18n `AppRoutes`/`LocaleRoutes` shell from #774 is intentionally kept out of the operator entry).
- **`vite.config.ts`**: multi-page `rollupOptions.input` (`main` + `operator`); a hand-rolled `sriHashPlugin` (`generateBundle`, `enforce: 'post'`, modeled on the existing `wasmSignerPkgPlugin`) that injects `integrity="sha384-…"` + `crossorigin` onto every `<script>`/`<link rel="stylesheet">`/`<link rel="modulepreload">` in `operator.html` referencing a local chunk; PWA `globIgnores: ['operator.html']` + a `/operator` `navigateFallbackDenylist` entry so the SW never caches/serves the operator document.
- **Tests**: `operator-sri.test.ts` runs a real production build and asserts every operator asset reference is pinned and each hash matches the file byte-for-byte (and that `index.html` stays unpinned); `OperatorApp.test.tsx` asserts the shell mounts at `/operator`, `/es/operator`, and redirects unknown in-document paths.
- **`verify-operator-bundle.sh`**: new `--verify-sri` mode (exit 3 on any missing/mismatched attribute) — the scriptable equivalent of the browser's own SRI check; plus a `verify:operator-sri` package script. The existing whole-bundle hash mode (option (b), #757) is unchanged and still covers the new output.
- **Docs**: §8.3.1 marks option (a) landed and documents the residual top-level-document trust gap (SRI never pins the navigated document); the self-hosted runbook covers the multi-page layout, the `/operator -> operator.html` server routing rule, and `--verify-sri`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `/operator` (+ `/:locale/operator`) served by a distinct build entry referencing its own hashed chunks | ✅ | `dist/operator.html` boots `operator-*.js`; `OperatorApp.test.tsx` renders `/operator` and `/es/operator` |
| Every script/link tag in operator HTML has a matching `sha384` integrity hash | ✅ | `operator-sri.test.ts` (build + byte-for-byte compare); manual `shasum -a 384` matches all 3 refs |
| Build-time test fails on missing/mismatched integrity | ✅ | `operator-sri.test.ts` in `pnpm test:run`; tamper test → `--verify-sri` exits 3 |
| Operator entry excluded from PWA precache/auto-update | ✅ | `operator-main.tsx` omits `registerSW`; `globIgnores: ['operator.html']`; verified `operator.html` absent from `sw.js` precache manifest |
| `verify-operator-bundle.sh` still covers operator output after split | ✅ | whole-bundle hash unchanged; new `--verify-sri` mode verifies the operator entry specifically |
| §8.3.1 updated to mark option (a) landed + residual gap | ✅ | table status → "Shipped in #772"; new landed-addendum + residual-gap paragraphs |
| Existing `/operator` links / magic-link tokens keep working | ✅ | same Pages project, same `/operator` URL, `captureOperatorToken()` path unchanged (no redirect needed) |

## Test Plan

- `pnpm -r typecheck` — clean across all 8 web workspaces.
- `pnpm test:run` — **732 passed / 10 skipped (76 files)**, including the 2 new test files.
- `pnpm --filter @botho/web-wallet build` — emits `dist/index.html` (main, unpinned) + `dist/operator.html` (operator, SRI-pinned); `operator.html` absent from `sw.js` precache manifest.
- `web/scripts/verify-operator-bundle.sh --verify-sri` — `MATCH: all 3 operator asset references have a correct sha384 integrity hash`.
- **SRI tamper evidence**: appended a byte to a copy of `dist/assets/operator-*.js`; `--verify-sri` reported `MISMATCH` (pinned vs. on-disk sha384) and exited 3. This is exactly the comparison a browser performs on load — a mismatch means the browser refuses to execute the chunk. (A headless real-browser check was not run; the scripted integrity-attribute check is the acceptable substitute per the issue.)

Closes #772