### PR TITLE
docs(web): fix stale LocaleSync comment references to LocaleRoutes

### DIFF
--- a/web/packages/web-wallet/src/components/LocaleSwitcher.tsx
+++ b/web/packages/web-wallet/src/components/LocaleSwitcher.tsx
@@ -4,7 +4,7 @@
  * Toggles the active locale by re-mapping the current URL to the target
  * locale's prefix (default locale = no prefix) and persisting the explicit
  * choice to localStorage. The actual `i18n.changeLanguage` + `<html lang>`
- * update is driven off the URL by `LocaleSync`, so navigation is the single
+ * update is driven off the URL by `LocaleRoutes`, so navigation is the single
  * source of truth for the active language.
  */
 import { useLocation, useNavigate } from 'react-router-dom'

--- a/web/packages/web-wallet/src/pages/landing.test.tsx
+++ b/web/packages/web-wallet/src/pages/landing.test.tsx
@@ -79,7 +79,7 @@ describe('LandingPage i18n', () => {
 
     // MemoryRouter navigation drives the i18n change via the app shell in prod;
     // here we assert the switcher persisted the choice and, after changing the
-    // language directly (what LocaleSync does off the URL), Spanish renders.
+    // language directly (what LocaleRoutes does off the URL), Spanish renders.
     expect(localStorage.getItem('botho:locale')).toBe('es')
   })
 


### PR DESCRIPTION
## Summary
Two code comments referenced a `LocaleSync` component that does not exist. The actual locale-sync shell in `App.tsx` is named `LocaleRoutes`. This corrects both comment references. Cosmetic only — no behavior change.

## Changes
- `web/packages/web-wallet/src/components/LocaleSwitcher.tsx:7` — JSDoc comment now says `LocaleRoutes` instead of `LocaleSync`
- `web/packages/web-wallet/src/pages/landing.test.tsx:82` — inline comment now says `LocaleRoutes` instead of `LocaleSync`

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `LocaleSwitcher.tsx:7` comment says `LocaleRoutes` | ✅ | See diff |
| `landing.test.tsx:82` comment says `LocaleRoutes` | ✅ | See diff |
| No other `LocaleSync` occurrences under `web/` | ✅ | `git grep -n LocaleSync -- 'web/*'` returns empty on this branch |
| No behavior change — only comment text edited | ✅ | Diff is 2 lines, both inside comments; no code/identifier/assertion touched |

## Test Plan
Both edits are inside comments only (a JSDoc block comment and an inline `//` comment); no executable code, imports, or test assertions reference `LocaleSync` as an identifier, so no runtime behavior changes. Verified via `git diff` that the change is limited to comment text. Re-verified against current `origin/main` (post PR #781 merge) that these were the only two stale references repo-wide.

Closes #775