### PR TITLE
test(network): allow print_stdout in fingerprint test module

### DIFF
--- a/botho/src/network/transport/fingerprint.rs
+++ b/botho/src/network/transport/fingerprint.rs
@@ -631,6 +631,9 @@ pub fn generate_synthetic_webrtc_pattern(packet_count: usize) -> TrafficPattern 
 }
 
 #[cfg(test)]
+// Test diagnostics printed to stdout (visible under `cargo test -- --nocapture`);
+// not part of production output. Mirrors the `commands` carve-out in lib.rs.
+#[allow(clippy::print_stdout)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Summary

`botho/src/lib.rs:8` declares `#![deny(clippy::print_stdout)]` crate-wide, which makes `cargo clippy -p botho --all-targets` fail on 8 pre-existing `println!` diagnostics inside `fingerprint.rs`'s `#[cfg(test)] mod tests`. (`--lib` alone passes because the calls are `#[cfg(test)]`-gated.) These are test-only printouts visible under `cargo test -- --nocapture`, not production output.

Following the crate's existing precedent — the `commands` module carve-out at `botho/src/lib.rs:33-34` — this adds `#[allow(clippy::print_stdout)]` on the `mod tests` block (Option A from the curator's enhancement). No `tracing` conversion, no wire/behavior change.

## Changes

- Add `#[allow(clippy::print_stdout)]` (with a rationale comment) to the `#[cfg(test)] mod tests` block in `botho/src/network/transport/fingerprint.rs`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `cargo clippy -p botho --all-targets` clean of `print_stdout` errors | ✅ | Before: `could not compile botho (lib test) due to 8 previous errors` at lines 730/734/745/763/764/768/772/776. After: clippy `Finished`, exit 0, no `print_stdout` errors |
| No behavior change to non-test / wire code | ✅ | Only added an attribute + comment; no code logic touched |
| Doc-comment `println!`s at lines 212/215 untouched | ✅ | Not modified (diff is confined to the `mod tests` declaration) |
| `cargo test -p botho --lib network::transport::fingerprint` passes | ✅ | 13 passed; 0 failed |

## Test Plan

- `cargo clippy -p botho --all-targets`: before showed 8 `print_stdout` errors in `fingerprint.rs`; after finishes cleanly (warnings only, no errors).
- `cargo test -p botho --lib network::transport::fingerprint`: 13 passed, 0 failed.

Closes #776