### PR TITLE
feat(web-wallet): translate wallet/pay/claim/contacts pages (en/es)

### DIFF
--- a/web/packages/web-wallet/src/lib/i18n.ts
+++ b/web/packages/web-wallet/src/lib/i18n.ts
@@ -2,9 +2,10 @@
  * i18next initialization for the web-wallet SPA (issue #764, phase 1).
  *
  * Phase 1 scope: framework setup + the marketing landing page translated into
- * one additional language (Spanish). Only the `landing` namespace is wired up
- * here; wallet/pay/claim/docs surfaces are deliberately out of scope and land
- * in later phases.
+ * one additional language (Spanish). Phase 2 (issue #777) added the
+ * transactional surfaces — the `wallet`, `pay`, `claim`, and `contacts`
+ * namespaces. `docs` and metadata/OG surfaces remain out of scope and land in
+ * later phases.
  *
  * Locale is driven by a URL path prefix (`/es/...`) rather than a subdomain, so
  * the existing `botho.io` / `wallet.botho.io` host-switch logic in `App.tsx`
@@ -21,6 +22,14 @@ import { initReactI18next } from 'react-i18next'
 
 import enLanding from '../locales/en/landing.json'
 import esLanding from '../locales/es/landing.json'
+import enWallet from '../locales/en/wallet.json'
+import esWallet from '../locales/es/wallet.json'
+import enPay from '../locales/en/pay.json'
+import esPay from '../locales/es/pay.json'
+import enClaim from '../locales/en/claim.json'
+import esClaim from '../locales/es/claim.json'
+import enContacts from '../locales/en/contacts.json'
+import esContacts from '../locales/es/contacts.json'
 
 /**
  * The set of locales the app knows how to render. `en` MUST stay first — it is
@@ -65,8 +74,20 @@ export function storeLocale(locale: SupportedLocale): void {
 }
 
 const resources = {
-  en: { landing: enLanding },
-  es: { landing: esLanding },
+  en: {
+    landing: enLanding,
+    wallet: enWallet,
+    pay: enPay,
+    claim: enClaim,
+    contacts: enContacts,
+  },
+  es: {
+    landing: esLanding,
+    wallet: esWallet,
+    pay: esPay,
+    claim: esClaim,
+    contacts: esContacts,
+  },
 } as const
 
 // Initialize once. Guard against double-init under React StrictMode / HMR.
@@ -77,7 +98,7 @@ if (!i18n.isInitialized) {
     fallbackLng: DEFAULT_LOCALE,
     supportedLngs: SUPPORTED_LOCALES as unknown as string[],
     defaultNS: 'landing',
-    ns: ['landing'],
+    ns: ['landing', 'wallet', 'pay', 'claim', 'contacts'],
     interpolation: {
       // React already escapes interpolated values.
       escapeValue: false,

--- a/web/packages/web-wallet/src/locales/en/claim.json
+++ b/web/packages/web-wallet/src/locales/en/claim.json
@@ -1,0 +1,48 @@
+{
+  "header": {
+    "walletName": "Botho Wallet"
+  },
+  "title": "Claim Your BTH",
+  "loading": {
+    "checking": "Checking your claim link…",
+    "reading": "Reading your claim link…"
+  },
+  "ready": {
+    "prompt": "Someone sent you a claim link.",
+    "reveal": "Reveal & check this link",
+    "privacyNote": "We only contact the network once you tap above — your link stays private until then."
+  },
+  "errors": {
+    "notValidGeneric": "This claim link is not valid.",
+    "noLink": "No claim link found. The link should look like .../claim#…",
+    "scanFailed": "Failed to scan the link.",
+    "invalidDestination": "Enter a valid destination address (tbotho://… or botho://…).",
+    "newWalletPassword": "Set a password for your new wallet before claiming.",
+    "confirmOverwrite": "Confirm replacing the wallet already stored on this device before claiming.",
+    "claimFailed": "Claim failed."
+  },
+  "waiting": "Waiting for the sender's payment to confirm on-chain. This page will update automatically — it can take a minute or two.",
+  "alreadyClaimed": "This link has already been claimed.",
+  "claimable": {
+    "youveBeenSent": "You've been sent",
+    "feeCovered": "Network fee of {{fee}} BTH covered by the sender.",
+    "sendToLabel": "Send to address",
+    "addressPlaceholder": "tbotho://1/…",
+    "createWallet": "Don't have a wallet? Create one",
+    "recoveryPhraseTitle": "Your new recovery phrase",
+    "recoveryPhraseNote": "Write this down and keep it safe — it is the ONLY way to recover this wallet. We'll save it encrypted in this browser when you claim.",
+    "passwordPrompt": "Set a password — your wallet is encrypted on this device with it.",
+    "overwriteWarningStrong": "This device already has a wallet{{suffix}}.",
+    "overwriteWarning": "Claiming with this NEW wallet replaces the stored one and deletes its seed — any funds in it are lost unless you have its recovery phrase backed up.",
+    "claiming": "Claiming…",
+    "claim": "Claim {{amount}} BTH",
+    "bearerWarning": "This is a bearer link — anyone with it can claim. Claim promptly so no one else does first."
+  },
+  "claimed": {
+    "amount": "Claimed {{amount}} BTH",
+    "onTheirWay": "The funds are on their way to your address.",
+    "viewTransaction": "View transaction",
+    "deleteMessageNote": "For your privacy, delete the message that contained this link from your chat. It's already claimed and can't be used again, but removing it keeps the secret out of your message history and backups.",
+    "goToWallet": "Go to my wallet"
+  }
+}

--- a/web/packages/web-wallet/src/locales/en/contacts.json
+++ b/web/packages/web-wallet/src/locales/en/contacts.json
@@ -1,0 +1,61 @@
+{
+  "header": {
+    "walletName": "Botho Wallet"
+  },
+  "title": "Contacts",
+  "add": "Add",
+  "addDisabledPlaintext": "Add a password to your wallet to save contacts",
+  "addDisabledLocked": "Unlock your wallet to save contacts",
+  "sort": {
+    "name": "Name",
+    "lastTx": "Recent",
+    "txCount": "Most paid"
+  },
+  "plaintextHint": {
+    "title": "Contacts require a password-protected wallet",
+    "body": "Your wallet has no password, so contacts can't be saved — they're encrypted on this device and never stored in cleartext. Add a password to start saving contacts.",
+    "cta": "Set a password"
+  },
+  "lockedHint": {
+    "title": "Wallet is locked",
+    "body": "Unlock your wallet to view and save contacts. They're encrypted on this device and unavailable while locked.",
+    "cta": "Go to wallet to unlock"
+  },
+  "searchPlaceholder": "Search by name or address…",
+  "empty": {
+    "none": "No contacts yet. Addresses you pay will appear here, ready to label.",
+    "noMatch": "No contacts match your search."
+  },
+  "row": {
+    "unnamed": "Unnamed — tap to label",
+    "timesPaid": "{{count}}× paid",
+    "editTitle": "Edit contact",
+    "labelTitle": "Tap to label this address",
+    "editButtonTitle": "Edit"
+  },
+  "editor": {
+    "addTitle": "Add contact",
+    "editTitle": "Edit contact",
+    "close": "Close",
+    "nameLabel": "Name",
+    "namePlaceholder": "e.g. Alice",
+    "addressLabel": "Address",
+    "addressPlaceholder": "tbotho://1/…",
+    "addressFixed": "The address can't be changed for an existing contact.",
+    "notesLabel": "Notes",
+    "notesOptional": "(optional)",
+    "notesPlaceholder": "Anything to remember about this contact…",
+    "saveAdd": "Add contact",
+    "saveEdit": "Save changes",
+    "deleteConfirmPrompt": "Remove this contact? This only deletes the local label, not any payments.",
+    "delete": "Delete",
+    "cancel": "Cancel",
+    "deleteContact": "Delete contact"
+  },
+  "errors": {
+    "enterAddress": "Enter an address.",
+    "invalidAddress": "That does not look like a valid Botho address.",
+    "saveFailed": "Could not save contact.",
+    "deleteFailed": "Could not delete contact."
+  }
+}

--- a/web/packages/web-wallet/src/locales/en/pay.json
+++ b/web/packages/web-wallet/src/locales/en/pay.json
@@ -1,0 +1,67 @@
+{
+  "header": {
+    "walletName": "Botho Wallet"
+  },
+  "title": "Send a Payment",
+  "parsing": "Reading the payment request…",
+  "errors": {
+    "notValidGeneric": "This payment-request link is not valid.",
+    "noRequest": "No payment request found. The link should look like .../pay#…",
+    "invalidRecipient": "This payment-request link has an invalid recipient address.",
+    "amountPositive": "Amount must be greater than 0.",
+    "amountInvalid": "Enter a valid amount.",
+    "paymentFailed": "Payment failed."
+  },
+  "confirm": {
+    "youArePaying": "You're paying",
+    "aBothoAddress": "a Botho address",
+    "selfPay": "This request is for your own address — you'd be paying yourself.",
+    "knownNamed": "You've paid {{name}} before — they're in your contacts.",
+    "knownUnnamed": "You've paid this address before — it's in your contacts.",
+    "unknownStrong": "You have not paid this address before.",
+    "unknown": "Double-check the full address above — payment-request links are attacker-controllable and payments can't be reversed.",
+    "noteLabel": "Note from the requester",
+    "noteFromBotho": "(not from Botho)",
+    "amountLabel": "Amount (BTH)",
+    "max": "Max: {{amount}} BTH",
+    "amountPlaceholder": "0.00",
+    "noAmountSpecified": "The requester didn't specify an amount — enter how much to send.",
+    "largePrefillStrong": "{{amount}} BTH",
+    "largePrefillPrefix": "This link is requesting a large amount (",
+    "largePrefillSuffix": "). I've verified the amount and recipient and want to send it.",
+    "sending": "Sending…",
+    "pay": "Pay {{amount}}",
+    "payNoAmount": "Pay"
+  },
+  "success": {
+    "paymentSent": "Payment sent",
+    "sentTo": "Sent {{amount}} BTH to {{recipient}}.",
+    "theRequester": "the requester",
+    "viewTransaction": "View transaction",
+    "savedToContacts": "Saved to your contacts.",
+    "savePrompt": "Save this address as a contact?",
+    "namePlaceholder": "Name (optional)",
+    "saveAsContact": "Save as contact",
+    "saveError": "Could not save contact.",
+    "goToWallet": "Go to my wallet"
+  },
+  "gate": {
+    "unlockPrompt": "Unlock your wallet to pay this request.",
+    "needWalletPrompt": "You need a wallet to pay this request.",
+    "createNew": "Create New",
+    "importExisting": "Import Existing",
+    "passwordPlaceholder": "Enter password",
+    "unlock": "Unlock",
+    "unlockFailed": "Unlock failed.",
+    "revealPrompt": "Click to reveal",
+    "confirmedPhrase": "I've written down my recovery phrase and stored it safely.",
+    "setPasswordPrompt": "Set a password — your wallet is encrypted on this device with it.",
+    "overwriteStrong": "This device already has a wallet{{suffix}}.",
+    "overwriteWarning": "Continuing replaces it and deletes its stored seed — any funds in it are lost unless you have its recovery phrase backed up.",
+    "createContinue": "Create & Continue",
+    "createFailed": "Could not create wallet.",
+    "seedPlaceholder": "Enter your 12 or 24 word recovery phrase…",
+    "importContinue": "Import & Continue",
+    "importFailed": "Import failed."
+  }
+}

--- a/web/packages/web-wallet/src/locales/en/wallet.json
+++ b/web/packages/web-wallet/src/locales/en/wallet.json
@@ -1,0 +1,86 @@
+{
+  "header": {
+    "walletNameLong": "Botho Wallet",
+    "walletNameShort": "Wallet"
+  },
+  "createView": {
+    "title": "Create New Wallet",
+    "subtitle": "Write down your recovery phrase and store it safely.",
+    "clickToReveal": "Click to reveal",
+    "confirmPhrase": "I have written down my recovery phrase and stored it in a safe place.",
+    "setPassword": "Set a password",
+    "passwordNote": "Your wallet is encrypted on this device with this password. There is no way to recover it if you forget it — keep your recovery phrase safe as a backup.",
+    "createButton": "Create Wallet"
+  },
+  "importView": {
+    "title": "Import Wallet",
+    "subtitle": "Enter your 12 or 24 word recovery phrase to restore your wallet.",
+    "recoveryPhraseLabel": "Recovery Phrase",
+    "placeholder": "Enter your recovery phrase, separating each word with a space...",
+    "wordCountOne": "{{count}} word",
+    "wordCountOther": "{{count}} words",
+    "expectedWords": "Expected 12 or 24 words",
+    "setPassword": "Set a password",
+    "passwordNote": "Your wallet is encrypted on this device with this password.",
+    "importFailed": "Import failed",
+    "importing": "Importing...",
+    "importButton": "Import Wallet"
+  },
+  "autoLock": {
+    "minute": "1 minute",
+    "fiveMinutes": "5 minutes",
+    "fifteenMinutes": "15 minutes",
+    "thirtyMinutes": "30 minutes",
+    "hour": "1 hour",
+    "off": "Off (never)"
+  },
+  "settingsModal": {
+    "title": "Settings",
+    "subtitle": "Security and wallet controls.",
+    "autoLockLabel": "Auto-lock after inactivity",
+    "autoLockEnabled": "Lock the wallet automatically when idle. Activity resets the timer.",
+    "autoLockDisabled": "Set a password to enable auto-lock.",
+    "lockWallet": "Lock wallet",
+    "lockWalletTitle": "Lock wallet",
+    "enableLockingTitle": "Set a password to enable locking",
+    "enableLockingLink": "Set a password to enable locking",
+    "resetWallet": "Reset wallet",
+    "close": "Close"
+  },
+  "dashboard": {
+    "send": "Send",
+    "receive": "Receive",
+    "sendViaLink": "Send via Link",
+    "request": "Request",
+    "contacts": "Contacts",
+    "lockWalletTitle": "Lock wallet",
+    "enableLockingTitle": "Set a password to enable locking",
+    "settingsTitle": "Settings",
+    "protectedTitle": "Wallet is password-protected",
+    "protectedBody": "Your seed, contacts, and claim links are encrypted on this device.",
+    "unprotectedTitle": "Wallet has no password",
+    "unprotectedBody": "Set a password to encrypt your wallet and enable claim links.",
+    "changePassword": "Change password",
+    "setPassword": "Set a password",
+    "recentTransactions": "Recent Transactions",
+    "transactionFailed": "Transaction failed"
+  },
+  "resetModal": {
+    "title": "Reset Wallet",
+    "body": "This will remove your wallet from this device. Make sure you have your recovery phrase saved before continuing.",
+    "confirm": "Reset & Start Over",
+    "cancel": "Cancel"
+  },
+  "unlockView": {
+    "title": "Unlock Wallet",
+    "subtitle": "Enter your password to access your wallet.",
+    "passwordPlaceholder": "Enter password",
+    "unlockFailed": "Unlock failed",
+    "unlocking": "Unlocking...",
+    "unlock": "Unlock"
+  },
+  "setup": {
+    "createNew": "Create New",
+    "importExisting": "Import Existing"
+  }
+}

--- a/web/packages/web-wallet/src/locales/es/claim.json
+++ b/web/packages/web-wallet/src/locales/es/claim.json
@@ -1,0 +1,48 @@
+{
+  "header": {
+    "walletName": "Monedero Botho"
+  },
+  "title": "Reclama tus BTH",
+  "loading": {
+    "checking": "Comprobando tu enlace de reclamación…",
+    "reading": "Leyendo tu enlace de reclamación…"
+  },
+  "ready": {
+    "prompt": "Alguien te ha enviado un enlace de reclamación.",
+    "reveal": "Revelar y comprobar este enlace",
+    "privacyNote": "Solo contactamos con la red cuando tocas el botón de arriba: tu enlace permanece privado hasta entonces."
+  },
+  "errors": {
+    "notValidGeneric": "Este enlace de reclamación no es válido.",
+    "noLink": "No se encontró ningún enlace de reclamación. El enlace debería verse como .../claim#…",
+    "scanFailed": "No se pudo escanear el enlace.",
+    "invalidDestination": "Introduce una dirección de destino válida (tbotho://… o botho://…).",
+    "newWalletPassword": "Establece una contraseña para tu nuevo monedero antes de reclamar.",
+    "confirmOverwrite": "Confirma que quieres reemplazar el monedero ya almacenado en este dispositivo antes de reclamar.",
+    "claimFailed": "La reclamación falló."
+  },
+  "waiting": "Esperando a que el pago del remitente se confirme en la cadena. Esta página se actualizará automáticamente: puede tardar uno o dos minutos.",
+  "alreadyClaimed": "Este enlace ya ha sido reclamado.",
+  "claimable": {
+    "youveBeenSent": "Te han enviado",
+    "feeCovered": "Comisión de red de {{fee}} BTH cubierta por el remitente.",
+    "sendToLabel": "Enviar a la dirección",
+    "addressPlaceholder": "tbotho://1/…",
+    "createWallet": "¿No tienes monedero? Crea uno",
+    "recoveryPhraseTitle": "Tu nueva frase de recuperación",
+    "recoveryPhraseNote": "Anótala y guárdala en un lugar seguro: es la ÚNICA forma de recuperar este monedero. La guardaremos cifrada en este navegador cuando reclames.",
+    "passwordPrompt": "Establece una contraseña: tu monedero se cifra en este dispositivo con ella.",
+    "overwriteWarningStrong": "Este dispositivo ya tiene un monedero{{suffix}}.",
+    "overwriteWarning": "Reclamar con este NUEVO monedero reemplaza el almacenado y borra su semilla: cualquier fondo que contenga se perderá salvo que tengas su frase de recuperación respaldada.",
+    "claiming": "Reclamando…",
+    "claim": "Reclamar {{amount}} BTH",
+    "bearerWarning": "Este es un enlace al portador: cualquiera que lo tenga puede reclamarlo. Reclámalo pronto para que nadie lo haga antes."
+  },
+  "claimed": {
+    "amount": "Reclamados {{amount}} BTH",
+    "onTheirWay": "Los fondos van de camino a tu dirección.",
+    "viewTransaction": "Ver transacción",
+    "deleteMessageNote": "Por tu privacidad, elimina de tu chat el mensaje que contenía este enlace. Ya está reclamado y no se puede volver a usar, pero eliminarlo mantiene el secreto fuera de tu historial de mensajes y copias de seguridad.",
+    "goToWallet": "Ir a mi monedero"
+  }
+}

--- a/web/packages/web-wallet/src/locales/es/contacts.json
+++ b/web/packages/web-wallet/src/locales/es/contacts.json
@@ -1,0 +1,61 @@
+{
+  "header": {
+    "walletName": "Monedero Botho"
+  },
+  "title": "Contactos",
+  "add": "Añadir",
+  "addDisabledPlaintext": "Añade una contraseña a tu monedero para guardar contactos",
+  "addDisabledLocked": "Desbloquea tu monedero para guardar contactos",
+  "sort": {
+    "name": "Nombre",
+    "lastTx": "Recientes",
+    "txCount": "Más pagados"
+  },
+  "plaintextHint": {
+    "title": "Los contactos requieren un monedero protegido con contraseña",
+    "body": "Tu monedero no tiene contraseña, así que los contactos no se pueden guardar: se cifran en este dispositivo y nunca se almacenan en texto plano. Añade una contraseña para empezar a guardar contactos.",
+    "cta": "Establecer una contraseña"
+  },
+  "lockedHint": {
+    "title": "El monedero está bloqueado",
+    "body": "Desbloquea tu monedero para ver y guardar contactos. Están cifrados en este dispositivo y no están disponibles mientras está bloqueado.",
+    "cta": "Ir al monedero para desbloquear"
+  },
+  "searchPlaceholder": "Buscar por nombre o dirección…",
+  "empty": {
+    "none": "Aún no hay contactos. Las direcciones a las que pagues aparecerán aquí, listas para etiquetar.",
+    "noMatch": "Ningún contacto coincide con tu búsqueda."
+  },
+  "row": {
+    "unnamed": "Sin nombre: toca para etiquetar",
+    "timesPaid": "{{count}}× pagado",
+    "editTitle": "Editar contacto",
+    "labelTitle": "Toca para etiquetar esta dirección",
+    "editButtonTitle": "Editar"
+  },
+  "editor": {
+    "addTitle": "Añadir contacto",
+    "editTitle": "Editar contacto",
+    "close": "Cerrar",
+    "nameLabel": "Nombre",
+    "namePlaceholder": "p. ej. Alicia",
+    "addressLabel": "Dirección",
+    "addressPlaceholder": "tbotho://1/…",
+    "addressFixed": "La dirección no se puede cambiar en un contacto existente.",
+    "notesLabel": "Notas",
+    "notesOptional": "(opcional)",
+    "notesPlaceholder": "Cualquier cosa que quieras recordar sobre este contacto…",
+    "saveAdd": "Añadir contacto",
+    "saveEdit": "Guardar cambios",
+    "deleteConfirmPrompt": "¿Eliminar este contacto? Esto solo borra la etiqueta local, no los pagos.",
+    "delete": "Eliminar",
+    "cancel": "Cancelar",
+    "deleteContact": "Eliminar contacto"
+  },
+  "errors": {
+    "enterAddress": "Introduce una dirección.",
+    "invalidAddress": "Eso no parece una dirección de Botho válida.",
+    "saveFailed": "No se pudo guardar el contacto.",
+    "deleteFailed": "No se pudo eliminar el contacto."
+  }
+}

--- a/web/packages/web-wallet/src/locales/es/pay.json
+++ b/web/packages/web-wallet/src/locales/es/pay.json
@@ -1,0 +1,67 @@
+{
+  "header": {
+    "walletName": "Monedero Botho"
+  },
+  "title": "Enviar un pago",
+  "parsing": "Leyendo la solicitud de pago…",
+  "errors": {
+    "notValidGeneric": "Este enlace de solicitud de pago no es válido.",
+    "noRequest": "No se encontró ninguna solicitud de pago. El enlace debería verse como .../pay#…",
+    "invalidRecipient": "Este enlace de solicitud de pago tiene una dirección de destinatario no válida.",
+    "amountPositive": "El importe debe ser mayor que 0.",
+    "amountInvalid": "Introduce un importe válido.",
+    "paymentFailed": "El pago falló."
+  },
+  "confirm": {
+    "youArePaying": "Estás pagando a",
+    "aBothoAddress": "una dirección de Botho",
+    "selfPay": "Esta solicitud es para tu propia dirección: te estarías pagando a ti mismo.",
+    "knownNamed": "Ya has pagado a {{name}} antes: está en tus contactos.",
+    "knownUnnamed": "Ya has pagado a esta dirección antes: está en tus contactos.",
+    "unknownStrong": "No has pagado a esta dirección antes.",
+    "unknown": "Verifica bien la dirección completa de arriba: los enlaces de solicitud de pago pueden estar controlados por atacantes y los pagos no se pueden revertir.",
+    "noteLabel": "Nota del solicitante",
+    "noteFromBotho": "(no de Botho)",
+    "amountLabel": "Importe (BTH)",
+    "max": "Máx.: {{amount}} BTH",
+    "amountPlaceholder": "0.00",
+    "noAmountSpecified": "El solicitante no especificó un importe: introduce cuánto enviar.",
+    "largePrefillStrong": "{{amount}} BTH",
+    "largePrefillPrefix": "Este enlace solicita un importe elevado (",
+    "largePrefillSuffix": "). He verificado el importe y el destinatario y quiero enviarlo.",
+    "sending": "Enviando…",
+    "pay": "Pagar {{amount}}",
+    "payNoAmount": "Pagar"
+  },
+  "success": {
+    "paymentSent": "Pago enviado",
+    "sentTo": "Se enviaron {{amount}} BTH a {{recipient}}.",
+    "theRequester": "el solicitante",
+    "viewTransaction": "Ver transacción",
+    "savedToContacts": "Guardado en tus contactos.",
+    "savePrompt": "¿Guardar esta dirección como contacto?",
+    "namePlaceholder": "Nombre (opcional)",
+    "saveAsContact": "Guardar como contacto",
+    "saveError": "No se pudo guardar el contacto.",
+    "goToWallet": "Ir a mi monedero"
+  },
+  "gate": {
+    "unlockPrompt": "Desbloquea tu monedero para pagar esta solicitud.",
+    "needWalletPrompt": "Necesitas un monedero para pagar esta solicitud.",
+    "createNew": "Crear nuevo",
+    "importExisting": "Importar existente",
+    "passwordPlaceholder": "Introduce la contraseña",
+    "unlock": "Desbloquear",
+    "unlockFailed": "El desbloqueo falló.",
+    "revealPrompt": "Haz clic para revelar",
+    "confirmedPhrase": "He anotado mi frase de recuperación y la he guardado de forma segura.",
+    "setPasswordPrompt": "Establece una contraseña: tu monedero se cifra en este dispositivo con ella.",
+    "overwriteStrong": "Este dispositivo ya tiene un monedero{{suffix}}.",
+    "overwriteWarning": "Si continúas, lo reemplazas y borras su semilla almacenada: cualquier fondo que contenga se perderá salvo que tengas su frase de recuperación respaldada.",
+    "createContinue": "Crear y continuar",
+    "createFailed": "No se pudo crear el monedero.",
+    "seedPlaceholder": "Introduce tu frase de recuperación de 12 o 24 palabras…",
+    "importContinue": "Importar y continuar",
+    "importFailed": "La importación falló."
+  }
+}

--- a/web/packages/web-wallet/src/locales/es/wallet.json
+++ b/web/packages/web-wallet/src/locales/es/wallet.json
@@ -1,0 +1,86 @@
+{
+  "header": {
+    "walletNameLong": "Monedero Botho",
+    "walletNameShort": "Monedero"
+  },
+  "createView": {
+    "title": "Crear nuevo monedero",
+    "subtitle": "Anota tu frase de recuperación y guárdala de forma segura.",
+    "clickToReveal": "Haz clic para revelar",
+    "confirmPhrase": "He anotado mi frase de recuperación y la he guardado en un lugar seguro.",
+    "setPassword": "Establece una contraseña",
+    "passwordNote": "Tu monedero se cifra en este dispositivo con esta contraseña. No hay forma de recuperarlo si la olvidas: guarda tu frase de recuperación como copia de seguridad.",
+    "createButton": "Crear monedero"
+  },
+  "importView": {
+    "title": "Importar monedero",
+    "subtitle": "Introduce tu frase de recuperación de 12 o 24 palabras para restaurar tu monedero.",
+    "recoveryPhraseLabel": "Frase de recuperación",
+    "placeholder": "Introduce tu frase de recuperación, separando cada palabra con un espacio...",
+    "wordCountOne": "{{count}} palabra",
+    "wordCountOther": "{{count}} palabras",
+    "expectedWords": "Se esperan 12 o 24 palabras",
+    "setPassword": "Establece una contraseña",
+    "passwordNote": "Tu monedero se cifra en este dispositivo con esta contraseña.",
+    "importFailed": "La importación falló",
+    "importing": "Importando...",
+    "importButton": "Importar monedero"
+  },
+  "autoLock": {
+    "minute": "1 minuto",
+    "fiveMinutes": "5 minutos",
+    "fifteenMinutes": "15 minutos",
+    "thirtyMinutes": "30 minutos",
+    "hour": "1 hora",
+    "off": "Desactivado (nunca)"
+  },
+  "settingsModal": {
+    "title": "Ajustes",
+    "subtitle": "Controles de seguridad y del monedero.",
+    "autoLockLabel": "Bloqueo automático tras inactividad",
+    "autoLockEnabled": "Bloquea el monedero automáticamente cuando está inactivo. La actividad reinicia el temporizador.",
+    "autoLockDisabled": "Establece una contraseña para activar el bloqueo automático.",
+    "lockWallet": "Bloquear monedero",
+    "lockWalletTitle": "Bloquear monedero",
+    "enableLockingTitle": "Establece una contraseña para activar el bloqueo",
+    "enableLockingLink": "Establece una contraseña para activar el bloqueo",
+    "resetWallet": "Restablecer monedero",
+    "close": "Cerrar"
+  },
+  "dashboard": {
+    "send": "Enviar",
+    "receive": "Recibir",
+    "sendViaLink": "Enviar por enlace",
+    "request": "Solicitar",
+    "contacts": "Contactos",
+    "lockWalletTitle": "Bloquear monedero",
+    "enableLockingTitle": "Establece una contraseña para activar el bloqueo",
+    "settingsTitle": "Ajustes",
+    "protectedTitle": "El monedero está protegido con contraseña",
+    "protectedBody": "Tu semilla, contactos y enlaces de reclamación están cifrados en este dispositivo.",
+    "unprotectedTitle": "El monedero no tiene contraseña",
+    "unprotectedBody": "Establece una contraseña para cifrar tu monedero y activar los enlaces de reclamación.",
+    "changePassword": "Cambiar contraseña",
+    "setPassword": "Establecer una contraseña",
+    "recentTransactions": "Transacciones recientes",
+    "transactionFailed": "La transacción falló"
+  },
+  "resetModal": {
+    "title": "Restablecer monedero",
+    "body": "Esto eliminará tu monedero de este dispositivo. Asegúrate de tener guardada tu frase de recuperación antes de continuar.",
+    "confirm": "Restablecer y empezar de nuevo",
+    "cancel": "Cancelar"
+  },
+  "unlockView": {
+    "title": "Desbloquear monedero",
+    "subtitle": "Introduce tu contraseña para acceder a tu monedero.",
+    "passwordPlaceholder": "Introduce la contraseña",
+    "unlockFailed": "El desbloqueo falló",
+    "unlocking": "Desbloqueando...",
+    "unlock": "Desbloquear"
+  },
+  "setup": {
+    "createNew": "Crear nuevo",
+    "importExisting": "Importar existente"
+  }
+}

--- a/web/packages/web-wallet/src/pages/claim.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/claim.i18n.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Locale-rendering coverage for the claim page (issue #777, i18n phase 2).
+ * With no claim-link fragment the page lands in the deterministic "invalid"
+ * state; we assert its page-owned copy renders in the active locale under both
+ * the default and `/es`-prefixed paths.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('../lib/claim-link-ops', () => ({
+  scanEphemeral: vi.fn(),
+  sweepEphemeral: vi.fn(),
+}))
+vi.mock('../contexts/wallet', () => ({
+  useAdapter: () => ({ onNewBlock: () => () => {} }),
+}))
+vi.mock('../contexts/network', () => ({
+  useNetwork: () => ({ network: { explorerUrl: null } }),
+}))
+
+// Imported AFTER the mocks are registered.
+import { ClaimPage } from './claim'
+import i18n from '../lib/i18n'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+function renderAt(path: string) {
+  window.location.hash = ''
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <ClaimPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('ClaimPage i18n', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    return i18n.changeLanguage('en')
+  })
+
+  afterEach(() => cleanup())
+
+  it('renders English page copy by default', () => {
+    renderAt('/claim')
+    expect(screen.getByRole('heading', { name: 'Claim Your BTH' })).toBeTruthy()
+    expect(
+      screen.getByText('No claim link found. The link should look like .../claim#…'),
+    ).toBeTruthy()
+  })
+
+  it('renders Spanish page copy when the active locale is es', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/claim')
+    expect(screen.getByRole('heading', { name: 'Reclama tus BTH' })).toBeTruthy()
+    expect(
+      screen.getByText(
+        'No se encontró ningún enlace de reclamación. El enlace debería verse como .../claim#…',
+      ),
+    ).toBeTruthy()
+    // English source string must NOT leak through untranslated.
+    expect(screen.queryByRole('heading', { name: 'Claim Your BTH' })).toBeNull()
+  })
+})

--- a/web/packages/web-wallet/src/pages/claim.tsx
+++ b/web/packages/web-wallet/src/pages/claim.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { Button, Card, Input, Logo } from '@botho/ui'
 import {
@@ -61,6 +62,7 @@ type ClaimState =
   | 'claimed'
 
 export function ClaimPage() {
+  const { t } = useTranslation('claim')
   const adapter = useAdapter()
   const { network } = useNetwork()
 
@@ -108,7 +110,7 @@ export function ClaimPage() {
   useEffect(() => {
     if (!initialHash || initialHash === '#') {
       setState('invalid')
-      setError('No claim link found. The link should look like .../claim#…')
+      setError(t('errors.noLink'))
       return
     }
     try {
@@ -124,9 +126,9 @@ export function ClaimPage() {
       setState('ready')
     } catch (err) {
       setState('invalid')
-      setError(err instanceof Error ? err.message : 'This claim link is not valid.')
+      setError(err instanceof Error ? err.message : t('errors.notValidGeneric'))
     }
-  }, [initialHash])
+  }, [initialHash, t])
 
   // Explicit user action that begins the first network call (the scan). Keeping
   // the scan behind this gate is what makes a preview/unfurl fetch a no-op.
@@ -151,10 +153,10 @@ export function ClaimPage() {
         setState((prev) => (prev === 'claimable' ? 'already-claimed' : 'waiting'))
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to scan the link.')
+      setError(err instanceof Error ? err.message : t('errors.scanFailed'))
       setState('invalid')
     }
-  }, [adapter, secret])
+  }, [adapter, secret, t])
 
   // 2. Scan once the secret is parsed, and re-scan on each new block while we
   //    are still waiting for the funding to confirm.
@@ -183,15 +185,15 @@ export function ClaimPage() {
     if (!secret) return
     const dest = destination.trim()
     if (!isValidAddress(dest)) {
-      setError('Enter a valid destination address (tbotho://… or botho://…).')
+      setError(t('errors.invalidDestination'))
       return
     }
     if (persistingNewWallet && !newWalletPasswordValid) {
-      setError('Set a password for your new wallet before claiming.')
+      setError(t('errors.newWalletPassword'))
       return
     }
     if (overwriteBlocked) {
-      setError('Confirm replacing the wallet already stored on this device before claiming.')
+      setError(t('errors.confirmOverwrite'))
       return
     }
     setError(null)
@@ -209,7 +211,7 @@ export function ClaimPage() {
       setState('claimed')
     } catch (err) {
       sweepingRef.current = false
-      const msg = err instanceof Error ? err.message : 'Claim failed.'
+      const msg = err instanceof Error ? err.message : t('errors.claimFailed')
       // A double-spend / empty-set error means someone else claimed first.
       if (/already claimed|empty|double|nothing to claim|spent|insufficient/i.test(msg)) {
         setState('already-claimed')
@@ -230,7 +232,7 @@ export function ClaimPage() {
           <Link to="/" className="flex items-center gap-2 sm:gap-3">
             <ArrowLeft size={18} className="text-ghost" />
             <Logo size="sm" showText={false} />
-            <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">Botho Wallet</span>
+            <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">{t('header.walletName')}</span>
           </Link>
         </div>
       </header>
@@ -242,14 +244,14 @@ export function ClaimPage() {
               <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-pulse/10 flex items-center justify-center mx-auto mb-3 sm:mb-4">
                 <Gift className="text-pulse" size={28} />
               </div>
-              <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">Claim Your BTH</h2>
+              <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">{t('title')}</h2>
             </div>
 
             {(state === 'parsing' || state === 'scanning') && (
               <div className="flex flex-col items-center gap-3 py-6 text-ghost">
                 <Loader2 size={28} className="animate-spin text-pulse" />
                 <p className="text-sm">
-                  {state === 'scanning' ? 'Checking your claim link…' : 'Reading your claim link…'}
+                  {state === 'scanning' ? t('loading.checking') : t('loading.reading')}
                 </p>
               </div>
             )}
@@ -257,7 +259,7 @@ export function ClaimPage() {
             {state === 'ready' && (
               <div className="space-y-4">
                 <div className="text-center">
-                  <p className="text-sm text-ghost">Someone sent you a claim link.</p>
+                  <p className="text-sm text-ghost">{t('ready.prompt')}</p>
                   {secret?.amountHint !== undefined && (
                     <p className="font-display text-2xl font-bold text-pulse mt-1">
                       ~{formatBTH(secret.amountHint)} BTH
@@ -266,11 +268,10 @@ export function ClaimPage() {
                 </div>
                 <Button onClick={handleReveal} className="w-full justify-center">
                   <Gift size={16} className="mr-2" />
-                  Reveal &amp; check this link
+                  {t('ready.reveal')}
                 </Button>
                 <p className="text-xs text-ghost text-center">
-                  We only contact the network once you tap above — your link stays private until
-                  then.
+                  {t('ready.privacyNote')}
                 </p>
               </div>
             )}
@@ -278,7 +279,7 @@ export function ClaimPage() {
             {state === 'invalid' && (
               <div className="flex items-start gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
                 <AlertCircle size={16} className="shrink-0 mt-0.5" />
-                <span>{error ?? 'This claim link is not valid.'}</span>
+                <span>{error ?? t('errors.notValidGeneric')}</span>
               </div>
             )}
 
@@ -286,8 +287,7 @@ export function ClaimPage() {
               <div className="flex flex-col items-center gap-3 py-4 text-center">
                 <Clock size={28} className="text-amber-400" />
                 <p className="text-sm text-ghost">
-                  Waiting for the sender&apos;s payment to confirm on-chain. This page will
-                  update automatically — it can take a minute or two.
+                  {t('waiting')}
                 </p>
                 <Loader2 size={18} className="animate-spin text-pulse" />
               </div>
@@ -296,25 +296,25 @@ export function ClaimPage() {
             {state === 'already-claimed' && (
               <div className="flex items-start gap-2 p-3 rounded-lg bg-steel/40 border border-steel text-light text-sm">
                 <Check size={16} className="shrink-0 mt-0.5 text-ghost" />
-                <span>This link has already been claimed.</span>
+                <span>{t('alreadyClaimed')}</span>
               </div>
             )}
 
             {(state === 'claimable' || state === 'sweeping') && scan && (
               <div className="space-y-4">
                 <div className="text-center">
-                  <p className="text-sm text-ghost">You&apos;ve been sent</p>
+                  <p className="text-sm text-ghost">{t('claimable.youveBeenSent')}</p>
                   <p className="font-display text-3xl font-bold text-pulse">{formatBTH(scan.net)} BTH</p>
                   <p className="text-xs text-ghost mt-1">
-                    Network fee of {formatBTH(scan.fee)} BTH covered by the sender.
+                    {t('claimable.feeCovered', { fee: formatBTH(scan.fee) })}
                   </p>
                 </div>
 
                 <div>
-                  <label className="block text-sm text-ghost mb-1.5">Send to address</label>
+                  <label className="block text-sm text-ghost mb-1.5">{t('claimable.sendToLabel')}</label>
                   <Input
                     type="text"
-                    placeholder="tbotho://1/…"
+                    placeholder={t('claimable.addressPlaceholder')}
                     value={destination}
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                       setDestination(e.target.value)
@@ -329,25 +329,24 @@ export function ClaimPage() {
                     disabled={state === 'sweeping'}
                     className="text-xs text-pulse hover:underline mt-2"
                   >
-                    Don&apos;t have a wallet? Create one
+                    {t('claimable.createWallet')}
                   </button>
                 </div>
 
                 {showNewWallet && createdMnemonic && (
                   <div className="p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 space-y-2">
                     <div className="flex items-center gap-2 text-amber-300 text-sm font-medium">
-                      <Eye size={15} /> Your new recovery phrase
+                      <Eye size={15} /> {t('claimable.recoveryPhraseTitle')}
                     </div>
                     <p className="font-mono text-xs leading-relaxed text-amber-100/90 break-words">
                       {createdMnemonic}
                     </p>
                     <p className="text-xs text-amber-200/80">
-                      Write this down and keep it safe — it is the ONLY way to recover this
-                      wallet. We&apos;ll save it encrypted in this browser when you claim.
+                      {t('claimable.recoveryPhraseNote')}
                     </p>
                     <div className="pt-1">
                       <p className="text-xs text-amber-200/80 mb-2">
-                        Set a password — your wallet is encrypted on this device with it.
+                        {t('claimable.passwordPrompt')}
                       </p>
                       <PasswordFields
                         password={newWalletPassword}
@@ -366,15 +365,13 @@ export function ClaimPage() {
                         />
                         <span className="text-xs text-danger">
                           <strong className="font-semibold">
-                            This device already has a wallet
-                            {existingWallet.address
-                              ? ` (${shortenAddress(existingWallet.address)})`
-                              : ''}
-                            .
+                            {t('claimable.overwriteWarningStrong', {
+                              suffix: existingWallet.address
+                                ? ` (${shortenAddress(existingWallet.address)})`
+                                : '',
+                            })}
                           </strong>{' '}
-                          Claiming with this NEW wallet replaces the stored one and
-                          deletes its seed — any funds in it are lost unless you
-                          have its recovery phrase backed up.
+                          {t('claimable.overwriteWarning')}
                         </span>
                       </label>
                     )}
@@ -399,17 +396,16 @@ export function ClaimPage() {
                   className="w-full justify-center"
                 >
                   {state === 'sweeping' ? (
-                    <><Loader2 size={16} className="mr-2 animate-spin" />Claiming…</>
+                    <><Loader2 size={16} className="mr-2 animate-spin" />{t('claimable.claiming')}</>
                   ) : (
-                    <>Claim {formatBTH(scan.net)} BTH</>
+                    <>{t('claimable.claim', { amount: formatBTH(scan.net) })}</>
                   )}
                 </Button>
 
                 <div className="flex items-start gap-2 text-xs text-ghost">
                   <ShieldAlert size={14} className="shrink-0 mt-0.5" />
                   <span>
-                    This is a bearer link — anyone with it can claim. Claim promptly so no
-                    one else does first.
+                    {t('claimable.bearerWarning')}
                   </span>
                 </div>
               </div>
@@ -422,9 +418,9 @@ export function ClaimPage() {
                     <Check className="text-success" size={26} />
                   </div>
                   <p className="text-lg font-semibold text-light">
-                    Claimed {scan ? formatBTH(scan.net) : ''} BTH
+                    {t('claimed.amount', { amount: scan ? formatBTH(scan.net) : '' })}
                   </p>
-                  <p className="text-sm text-ghost">The funds are on their way to your address.</p>
+                  <p className="text-sm text-ghost">{t('claimed.onTheirWay')}</p>
                   {explorerTxUrl && (
                     <a
                       href={explorerTxUrl}
@@ -432,7 +428,7 @@ export function ClaimPage() {
                       rel="noopener noreferrer"
                       className="inline-flex items-center gap-1 text-xs text-ghost hover:text-light"
                     >
-                      View transaction <ExternalLink size={12} />
+                      {t('claimed.viewTransaction')} <ExternalLink size={12} />
                     </a>
                   )}
                 </div>
@@ -443,14 +439,12 @@ export function ClaimPage() {
                 <div className="flex items-start gap-2 p-3 rounded-lg bg-steel/40 border border-steel text-xs text-ghost">
                   <ShieldAlert size={14} className="shrink-0 mt-0.5 text-amber-400" />
                   <span>
-                    For your privacy, delete the message that contained this link from your chat.
-                    It&apos;s already claimed and can&apos;t be used again, but removing it keeps the
-                    secret out of your message history and backups.
+                    {t('claimed.deleteMessageNote')}
                   </span>
                 </div>
 
                 <Link to="/wallet">
-                  <Button className="w-full justify-center">Go to my wallet</Button>
+                  <Button className="w-full justify-center">{t('claimed.goToWallet')}</Button>
                 </Link>
               </div>
             )}

--- a/web/packages/web-wallet/src/pages/contacts.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/contacts.i18n.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Locale-rendering coverage for the contacts page (issue #777, i18n phase 2).
+ * Renders the page under both the default (`/contacts`) and `/es`-prefixed
+ * (`/es/contacts`) paths and asserts the page-owned copy renders in the active
+ * locale. Copy owned by shared `@botho/ui` components is out of scope.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const useWalletMock = vi.fn()
+vi.mock('../contexts/wallet', () => ({
+  useWallet: () => useWalletMock(),
+}))
+
+// Imported AFTER the mock is registered.
+import { ContactsPage } from './contacts'
+import i18n from '../lib/i18n'
+
+const ASYNC_NOOP = async () => {}
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+function baseWallet(overrides: Record<string, unknown> = {}) {
+  return {
+    contacts: [],
+    addContact: vi.fn(ASYNC_NOOP),
+    updateContact: vi.fn(ASYNC_NOOP),
+    deleteContact: vi.fn(ASYNC_NOOP),
+    hasWallet: true,
+    isEncrypted: true,
+    isLocked: false,
+    setPassword: vi.fn(ASYNC_NOOP),
+    changePassword: vi.fn(ASYNC_NOOP),
+    ...overrides,
+  }
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <ContactsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('ContactsPage i18n', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useWalletMock.mockReset()
+    useWalletMock.mockReturnValue(baseWallet())
+    return i18n.changeLanguage('en')
+  })
+
+  afterEach(() => cleanup())
+
+  it('renders English page copy by default', () => {
+    renderAt('/contacts')
+    expect(screen.getByRole('heading', { name: 'Contacts' })).toBeTruthy()
+    expect(screen.getByPlaceholderText('Search by name or address…')).toBeTruthy()
+    expect(
+      screen.getByText('No contacts yet. Addresses you pay will appear here, ready to label.'),
+    ).toBeTruthy()
+  })
+
+  it('renders Spanish page copy when the active locale is es', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/contacts')
+    expect(screen.getByRole('heading', { name: 'Contactos' })).toBeTruthy()
+    expect(screen.getByPlaceholderText('Buscar por nombre o dirección…')).toBeTruthy()
+    // English source string must NOT leak through untranslated.
+    expect(screen.queryByRole('heading', { name: 'Contacts' })).toBeNull()
+  })
+})

--- a/web/packages/web-wallet/src/pages/contacts.tsx
+++ b/web/packages/web-wallet/src/pages/contacts.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { Button, Card, Input, Logo, ModalOverlay } from '@botho/ui'
 import { isValidAddress } from '@botho/core'
@@ -21,11 +22,8 @@ import { PasswordSettingsModal } from '../components/PasswordSettingsModal'
 
 type SortBy = 'name' | 'lastTx' | 'txCount'
 
-const SORT_LABELS: Record<SortBy, string> = {
-  name: 'Name',
-  lastTx: 'Recent',
-  txCount: 'Most paid',
-}
+/** Sort options in display order. Labels are resolved via i18n at render time. */
+const SORT_ORDER: SortBy[] = ['name', 'lastTx', 'txCount']
 
 /** Truncate an address for compact display. */
 function shortAddress(address: string, len = 10): string {
@@ -74,6 +72,7 @@ function arrange(contacts: Contact[], sortBy: SortBy, query: string): Contact[] 
  * entries (auto-created on send) show as "Unnamed — tap to label".
  */
 export function ContactsPage() {
+  const { t } = useTranslation('contacts')
   const {
     contacts,
     addContact,
@@ -119,7 +118,7 @@ export function ContactsPage() {
             <ArrowLeft size={18} className="text-ghost" />
             <Logo size="sm" showText={false} />
             <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">
-              Botho Wallet
+              {t('header.walletName')}
             </span>
           </Link>
         </div>
@@ -130,7 +129,7 @@ export function ContactsPage() {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Users className="text-pulse" size={22} />
-              <h1 className="font-display text-xl sm:text-2xl font-bold">Contacts</h1>
+              <h1 className="font-display text-xl sm:text-2xl font-bold">{t('title')}</h1>
             </div>
             <Button
               onClick={() => setAdding(true)}
@@ -139,11 +138,11 @@ export function ContactsPage() {
                 canPersistContacts
                   ? undefined
                   : plaintextWallet
-                    ? 'Add a password to your wallet to save contacts'
-                    : 'Unlock your wallet to save contacts'
+                    ? t('addDisabledPlaintext')
+                    : t('addDisabledLocked')
               }
             >
-              <Plus size={16} className="mr-2" />Add
+              <Plus size={16} className="mr-2" />{t('add')}
             </Button>
           </div>
 
@@ -156,15 +155,13 @@ export function ContactsPage() {
                 <Lock size={18} className="text-pulse shrink-0 mt-0.5" />
                 <div className="space-y-2">
                   <p className="text-sm text-light">
-                    Contacts require a password-protected wallet
+                    {t('plaintextHint.title')}
                   </p>
                   <p className="text-xs text-ghost">
-                    Your wallet has no password, so contacts can&apos;t be saved —
-                    they&apos;re encrypted on this device and never stored in
-                    cleartext. Add a password to start saving contacts.
+                    {t('plaintextHint.body')}
                   </p>
                   <Button size="sm" onClick={() => setShowPasswordModal(true)}>
-                    Set a password
+                    {t('plaintextHint.cta')}
                   </Button>
                 </div>
               </div>
@@ -176,13 +173,12 @@ export function ContactsPage() {
               <div className="flex items-start gap-3">
                 <Lock size={18} className="text-pulse shrink-0 mt-0.5" />
                 <div className="space-y-2">
-                  <p className="text-sm text-light">Wallet is locked</p>
+                  <p className="text-sm text-light">{t('lockedHint.title')}</p>
                   <p className="text-xs text-ghost">
-                    Unlock your wallet to view and save contacts. They&apos;re
-                    encrypted on this device and unavailable while locked.
+                    {t('lockedHint.body')}
                   </p>
                   <Link to="/wallet">
-                    <Button size="sm">Go to wallet to unlock</Button>
+                    <Button size="sm">{t('lockedHint.cta')}</Button>
                   </Link>
                 </div>
               </div>
@@ -197,7 +193,7 @@ export function ContactsPage() {
             />
             <Input
               type="text"
-              placeholder="Search by name or address…"
+              placeholder={t('searchPlaceholder')}
               value={query}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setQuery(e.target.value)
@@ -208,7 +204,7 @@ export function ContactsPage() {
 
           {/* Sort toggle */}
           <div className="flex rounded-lg bg-abyss border border-steel p-1">
-            {(Object.keys(SORT_LABELS) as SortBy[]).map((key) => (
+            {SORT_ORDER.map((key) => (
               <button
                 key={key}
                 onClick={() => setSortBy(key)}
@@ -218,7 +214,7 @@ export function ContactsPage() {
                     : 'text-ghost hover:text-light'
                 }`}
               >
-                {SORT_LABELS[key]}
+                {t(`sort.${key}`)}
               </button>
             ))}
           </div>
@@ -227,8 +223,8 @@ export function ContactsPage() {
           {arranged.length === 0 ? (
             <Card className="p-6 text-center text-ghost text-sm">
               {contacts.length === 0
-                ? 'No contacts yet. Addresses you pay will appear here, ready to label.'
-                : 'No contacts match your search.'}
+                ? t('empty.none')
+                : t('empty.noMatch')}
             </Card>
           ) : (
             <div className="space-y-2">
@@ -292,6 +288,7 @@ function ContactRow({
   editable?: boolean
   onEdit: () => void
 }) {
+  const { t } = useTranslation('contacts')
   const named = contact.name.trim().length > 0
   return (
     <Card className="p-3 sm:p-4 flex items-center justify-between gap-3">
@@ -302,8 +299,8 @@ function ContactRow({
         title={
           editable
             ? named
-              ? 'Edit contact'
-              : 'Tap to label this address'
+              ? t('row.editTitle')
+              : t('row.labelTitle')
             : undefined
         }
       >
@@ -313,11 +310,11 @@ function ContactRow({
               named ? 'text-light' : 'text-ghost italic'
             }`}
           >
-            {named ? contact.name : 'Unnamed — tap to label'}
+            {named ? contact.name : t('row.unnamed')}
           </span>
           {contact.txCount > 0 && (
             <span className="shrink-0 text-[11px] text-ghost bg-abyss border border-steel rounded-full px-2 py-0.5">
-              {contact.txCount}× paid
+              {t('row.timesPaid', { count: contact.txCount })}
             </span>
           )}
         </div>
@@ -328,7 +325,7 @@ function ContactRow({
           <p className="text-xs text-ghost/80 mt-1 truncate">{contact.notes}</p>
         )}
       </button>
-      <Button variant="ghost" size="sm" onClick={onEdit} disabled={!editable} title="Edit">
+      <Button variant="ghost" size="sm" onClick={onEdit} disabled={!editable} title={t('row.editButtonTitle')}>
         {named ? <Pencil size={16} /> : <Tag size={16} />}
       </Button>
     </Card>
@@ -348,6 +345,7 @@ function ContactEditor({
   onSave: (data: { name: string; address: string; notes?: string }) => Promise<void>
   onDelete?: () => Promise<void>
 }) {
+  const { t } = useTranslation('contacts')
   const [name, setName] = useState(contact?.name ?? '')
   const [address, setAddress] = useState(contact?.address ?? '')
   const [notes, setNotes] = useState(contact?.notes ?? '')
@@ -362,11 +360,11 @@ function ContactEditor({
   const handleSave = async () => {
     setError(null)
     if (!address.trim()) {
-      setError('Enter an address.')
+      setError(t('errors.enterAddress'))
       return
     }
     if (!isValidAddress(address.trim())) {
-      setError('That does not look like a valid Botho address.')
+      setError(t('errors.invalidAddress'))
       return
     }
     setBusy(true)
@@ -378,7 +376,7 @@ function ContactEditor({
       })
       onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not save contact.')
+      setError(err instanceof Error ? err.message : t('errors.saveFailed'))
     } finally {
       setBusy(false)
     }
@@ -391,7 +389,7 @@ function ContactEditor({
       await onDelete()
       onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not delete contact.')
+      setError(err instanceof Error ? err.message : t('errors.deleteFailed'))
       setBusy(false)
     }
   }
@@ -407,19 +405,19 @@ function ContactEditor({
       <Card className="w-full sm:max-w-md p-5 sm:p-6 rounded-t-2xl sm:rounded-2xl max-h-[92vh] overflow-y-auto">
         <div className="flex items-center justify-between mb-5">
           <h3 className="font-display text-lg font-semibold">
-            {mode === 'add' ? 'Add contact' : 'Edit contact'}
+            {mode === 'add' ? t('editor.addTitle') : t('editor.editTitle')}
           </h3>
-          <button onClick={onClose} className="text-ghost hover:text-light" aria-label="Close">
+          <button onClick={onClose} className="text-ghost hover:text-light" aria-label={t('editor.close')}>
             <X size={20} />
           </button>
         </div>
 
         <div className="space-y-4">
           <div>
-            <label className="block text-sm text-ghost mb-1.5">Name</label>
+            <label className="block text-sm text-ghost mb-1.5">{t('editor.nameLabel')}</label>
             <Input
               type="text"
-              placeholder="e.g. Alice"
+              placeholder={t('editor.namePlaceholder')}
               value={name}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 setName(e.target.value)
@@ -430,10 +428,10 @@ function ContactEditor({
           </div>
 
           <div>
-            <label className="block text-sm text-ghost mb-1.5">Address</label>
+            <label className="block text-sm text-ghost mb-1.5">{t('editor.addressLabel')}</label>
             <Input
               type="text"
-              placeholder="tbotho://1/…"
+              placeholder={t('editor.addressPlaceholder')}
               value={address}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 setAddress(e.target.value)
@@ -444,14 +442,14 @@ function ContactEditor({
             />
             {!addressEditable && (
               <p className="text-xs text-ghost/70 mt-1">
-                The address can&apos;t be changed for an existing contact.
+                {t('editor.addressFixed')}
               </p>
             )}
           </div>
 
           <div>
             <label className="block text-sm text-ghost mb-1.5">
-              Notes <span className="text-ghost/70">(optional)</span>
+              {t('editor.notesLabel')} <span className="text-ghost/70">{t('editor.notesOptional')}</span>
             </label>
             <textarea
               value={notes}
@@ -459,7 +457,7 @@ function ContactEditor({
                 setNotes(e.target.value)
                 setError(null)
               }}
-              placeholder="Anything to remember about this contact…"
+              placeholder={t('editor.notesPlaceholder')}
               rows={3}
               className="w-full p-3 rounded-lg bg-abyss border border-steel text-sm leading-relaxed resize-none focus:outline-none focus:ring-2 focus:ring-pulse/50 focus:border-pulse placeholder:text-ghost/50"
             />
@@ -474,15 +472,14 @@ function ContactEditor({
 
           <Button onClick={handleSave} disabled={busy} className="w-full justify-center">
             <Check size={16} className="mr-2" />
-            {mode === 'add' ? 'Add contact' : 'Save changes'}
+            {mode === 'add' ? t('editor.saveAdd') : t('editor.saveEdit')}
           </Button>
 
           {mode === 'edit' && onDelete && (
             confirmDelete ? (
               <div className="space-y-2">
                 <p className="text-xs text-ghost text-center">
-                  Remove this contact? This only deletes the local label, not any
-                  payments.
+                  {t('editor.deleteConfirmPrompt')}
                 </p>
                 <div className="flex gap-2">
                   <Button
@@ -491,14 +488,14 @@ function ContactEditor({
                     disabled={busy}
                     className="flex-1 justify-center"
                   >
-                    <Trash2 size={16} className="mr-2" />Delete
+                    <Trash2 size={16} className="mr-2" />{t('editor.delete')}
                   </Button>
                   <Button
                     variant="secondary"
                     onClick={() => setConfirmDelete(false)}
                     className="flex-1 justify-center"
                   >
-                    Cancel
+                    {t('editor.cancel')}
                   </Button>
                 </div>
               </div>
@@ -508,7 +505,7 @@ function ContactEditor({
                 onClick={() => setConfirmDelete(true)}
                 className="w-full justify-center text-danger"
               >
-                <Trash2 size={16} className="mr-2" />Delete contact
+                <Trash2 size={16} className="mr-2" />{t('editor.deleteContact')}
               </Button>
             )
           )}

--- a/web/packages/web-wallet/src/pages/pay.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/pay.i18n.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Locale-rendering coverage for the pay page (issue #777, i18n phase 2).
+ * With no payment-request fragment the page lands in the deterministic
+ * "invalid" state; we assert its page-owned copy renders in the active locale
+ * under both the default and `/es`-prefixed paths.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const useWalletMock = vi.fn()
+vi.mock('../contexts/wallet', () => ({
+  useWallet: () => useWalletMock(),
+}))
+vi.mock('../contexts/network', () => ({
+  useNetwork: () => ({ network: { explorerUrl: 'https://explorer.test' } }),
+}))
+
+// Imported AFTER the mocks are registered.
+import { PayPage } from './pay'
+import i18n from '../lib/i18n'
+
+const ASYNC_NOOP = async () => {}
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+function baseWallet(overrides: Record<string, unknown> = {}) {
+  return {
+    hasWallet: true,
+    isLocked: false,
+    address: null,
+    contacts: [],
+    addContact: vi.fn(ASYNC_NOOP),
+    send: vi.fn(async () => 'deadbeef'),
+    refreshBalance: vi.fn(ASYNC_NOOP),
+    refreshTransactions: vi.fn(ASYNC_NOOP),
+    createWallet: vi.fn(ASYNC_NOOP),
+    importWallet: vi.fn(ASYNC_NOOP),
+    unlockWallet: vi.fn(ASYNC_NOOP),
+    balance: null,
+    ...overrides,
+  }
+}
+
+function renderAt(path: string) {
+  window.location.hash = ''
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <PayPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('PayPage i18n', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useWalletMock.mockReset()
+    useWalletMock.mockReturnValue(baseWallet())
+    return i18n.changeLanguage('en')
+  })
+
+  afterEach(() => cleanup())
+
+  it('renders English page copy by default', () => {
+    renderAt('/pay')
+    expect(screen.getByRole('heading', { name: 'Send a Payment' })).toBeTruthy()
+    expect(
+      screen.getByText('No payment request found. The link should look like .../pay#…'),
+    ).toBeTruthy()
+  })
+
+  it('renders Spanish page copy when the active locale is es', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/pay')
+    expect(screen.getByRole('heading', { name: 'Enviar un pago' })).toBeTruthy()
+    expect(
+      screen.getByText(
+        'No se encontró ninguna solicitud de pago. El enlace debería verse como .../pay#…',
+      ),
+    ).toBeTruthy()
+    // English source string must NOT leak through untranslated.
+    expect(screen.queryByRole('heading', { name: 'Send a Payment' })).toBeNull()
+  })
+})

--- a/web/packages/web-wallet/src/pages/pay.tsx
+++ b/web/packages/web-wallet/src/pages/pay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { Button, Card, Input, Logo } from '@botho/ui'
 import {
@@ -57,6 +58,7 @@ type ParseState = 'parsing' | 'invalid' | 'ready'
 type SetupMode = 'unlock' | 'create' | 'import'
 
 export function PayPage() {
+  const { t } = useTranslation('pay')
   const {
     hasWallet,
     isLocked,
@@ -92,7 +94,7 @@ export function PayPage() {
   useEffect(() => {
     if (!initialHash || initialHash === '#') {
       setParseState('invalid')
-      setParseError('No payment request found. The link should look like .../pay#…')
+      setParseError(t('errors.noRequest'))
       return
     }
     try {
@@ -106,9 +108,9 @@ export function PayPage() {
       setParseState('ready')
     } catch (err) {
       setParseState('invalid')
-      setParseError(err instanceof Error ? err.message : 'This payment-request link is not valid.')
+      setParseError(err instanceof Error ? err.message : t('errors.notValidGeneric'))
     }
-  }, [initialHash])
+  }, [initialHash, t])
 
   const explorerBase = network.explorerUrl
 
@@ -120,7 +122,7 @@ export function PayPage() {
             <ArrowLeft size={18} className="text-ghost" />
             <Logo size="sm" showText={false} />
             <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">
-              Botho Wallet
+              {t('header.walletName')}
             </span>
           </Link>
         </div>
@@ -133,20 +135,20 @@ export function PayPage() {
               <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-pulse/10 flex items-center justify-center mx-auto mb-3 sm:mb-4">
                 <Send className="text-pulse" size={26} />
               </div>
-              <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">Send a Payment</h2>
+              <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">{t('title')}</h2>
             </div>
 
             {parseState === 'parsing' && (
               <div className="flex flex-col items-center gap-3 py-6 text-ghost">
                 <Loader2 size={28} className="animate-spin text-pulse" />
-                <p className="text-sm">Reading the payment request…</p>
+                <p className="text-sm">{t('parsing')}</p>
               </div>
             )}
 
             {parseState === 'invalid' && (
               <div className="flex items-start gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
                 <AlertCircle size={16} className="shrink-0 mt-0.5" />
-                <span>{parseError ?? 'This payment-request link is not valid.'}</span>
+                <span>{parseError ?? t('errors.notValidGeneric')}</span>
               </div>
             )}
 
@@ -207,6 +209,7 @@ function PayConfirm({
   refreshTransactions: () => Promise<void>
   explorerBase?: string
 }) {
+  const { t } = useTranslation('pay')
   const [amountStr, setAmountStr] = useState(
     request.amount !== undefined ? formatBTH(request.amount, { separators: false }) : '',
   )
@@ -243,9 +246,9 @@ function PayConfirm({
   if (amountStr.trim()) {
     try {
       amount = parseBTH(amountStr)
-      if (amount <= 0n) amountError = 'Amount must be greater than 0.'
+      if (amount <= 0n) amountError = t('errors.amountPositive')
     } catch {
-      amountError = 'Enter a valid amount.'
+      amountError = t('errors.amountInvalid')
     }
   }
 
@@ -267,7 +270,7 @@ function PayConfirm({
       setTxHash(hash)
       await Promise.allSettled([refreshBalance(), refreshTransactions()])
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Payment failed.')
+      setError(err instanceof Error ? err.message : t('errors.paymentFailed'))
     } finally {
       setIsSending(false)
     }
@@ -280,7 +283,7 @@ function PayConfirm({
       await addContact(saveName.trim(), request.to)
       setSavedContact(true)
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : 'Could not save contact.')
+      setSaveError(err instanceof Error ? err.message : t('success.saveError'))
     } finally {
       setSavingContact(false)
     }
@@ -297,9 +300,12 @@ function PayConfirm({
           <div className="w-12 h-12 rounded-full bg-success/10 flex items-center justify-center">
             <Check className="text-success" size={26} />
           </div>
-          <p className="text-lg font-semibold text-light">Payment sent</p>
+          <p className="text-lg font-semibold text-light">{t('success.paymentSent')}</p>
           <p className="text-sm text-ghost">
-            Sent {formatBTH(amount)} BTH to {contactName ?? 'the requester'}.
+            {t('success.sentTo', {
+              amount: formatBTH(amount),
+              recipient: contactName ?? t('success.theRequester'),
+            })}
           </p>
           {explorerTxUrl && (
             <a
@@ -308,7 +314,7 @@ function PayConfirm({
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 text-xs text-ghost hover:text-light"
             >
-              View transaction <ExternalLink size={12} />
+              {t('success.viewTransaction')} <ExternalLink size={12} />
             </a>
           )}
         </div>
@@ -317,17 +323,17 @@ function PayConfirm({
           (savedContact ? (
             <div className="flex items-center gap-2 p-3 rounded-lg bg-success/10 border border-success/20 text-success text-xs">
               <UserCheck size={15} className="shrink-0" />
-              <span>Saved to your contacts.</span>
+              <span>{t('success.savedToContacts')}</span>
             </div>
           ) : (
             <div className="space-y-2 p-3 rounded-lg bg-abyss border border-steel">
               <p className="text-xs text-ghost flex items-center gap-1.5">
                 <UserPlus size={14} className="text-pulse" />
-                Save this address as a contact?
+                {t('success.savePrompt')}
               </p>
               <Input
                 type="text"
-                placeholder="Name (optional)"
+                placeholder={t('success.namePlaceholder')}
                 value={saveName}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                   setSaveName(e.target.value)
@@ -342,13 +348,13 @@ function PayConfirm({
                 className="w-full justify-center"
               >
                 {savingContact ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}
-                Save as contact
+                {t('success.saveAsContact')}
               </Button>
             </div>
           ))}
 
         <Link to="/wallet">
-          <Button className="w-full justify-center">Go to my wallet</Button>
+          <Button className="w-full justify-center">{t('success.goToWallet')}</Button>
         </Link>
       </div>
     )
@@ -358,7 +364,7 @@ function PayConfirm({
     return (
       <div className="flex items-start gap-2 p-3 rounded-lg bg-danger/10 border border-danger/20 text-danger text-sm">
         <AlertCircle size={16} className="shrink-0 mt-0.5" />
-        <span>This payment-request link has an invalid recipient address.</span>
+        <span>{t('errors.invalidRecipient')}</span>
       </div>
     )
   }
@@ -366,9 +372,9 @@ function PayConfirm({
   return (
     <div className="space-y-4">
       <div className="text-center">
-        <p className="text-sm text-ghost">You&apos;re paying</p>
+        <p className="text-sm text-ghost">{t('confirm.youArePaying')}</p>
         <p className="font-display text-lg font-semibold text-light break-words">
-          {contactName ?? 'a Botho address'}
+          {contactName ?? t('confirm.aBothoAddress')}
         </p>
         <p className="text-xs text-ghost mt-1 font-mono break-all">{request.to}</p>
       </div>
@@ -376,7 +382,7 @@ function PayConfirm({
       {isSelfPay && (
         <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 text-amber-200/90 text-xs">
           <ShieldAlert size={15} className="text-amber-400 shrink-0 mt-0.5" />
-          <span>This request is for your own address — you&apos;d be paying yourself.</span>
+          <span>{t('confirm.selfPay')}</span>
         </div>
       )}
 
@@ -391,8 +397,8 @@ function PayConfirm({
             <UserCheck size={15} className="shrink-0 mt-0.5" />
             <span>
               {contactName
-                ? `You've paid ${contactName} before — they're in your contacts.`
-                : "You've paid this address before — it's in your contacts."}
+                ? t('confirm.knownNamed', { name: contactName })
+                : t('confirm.knownUnnamed')}
             </span>
           </div>
         ) : (
@@ -400,10 +406,9 @@ function PayConfirm({
             <ShieldQuestion size={15} className="text-amber-400 shrink-0 mt-0.5" />
             <span>
               <strong className="font-semibold text-amber-100">
-                You have not paid this address before.
+                {t('confirm.unknownStrong')}
               </strong>{' '}
-              Double-check the full address above — payment-request links are
-              attacker-controllable and payments can&apos;t be reversed.
+              {t('confirm.unknown')}
             </span>
           </div>
         ))}
@@ -411,8 +416,8 @@ function PayConfirm({
       {request.memo && (
         <div>
           <label className="block text-sm text-ghost mb-1.5">
-            Note from the requester{' '}
-            <span className="text-ghost/60">(not from Botho)</span>
+            {t('confirm.noteLabel')}{' '}
+            <span className="text-ghost/60">{t('confirm.noteFromBotho')}</span>
           </label>
           <div className="px-3 py-2 rounded-lg bg-abyss border border-steel text-sm text-light break-words">
             {request.memo}
@@ -422,21 +427,21 @@ function PayConfirm({
 
       <div>
         <div className="flex items-center justify-between mb-1.5">
-          <label className="block text-sm text-ghost">Amount (BTH)</label>
+          <label className="block text-sm text-ghost">{t('confirm.amountLabel')}</label>
           {balance && (
             <button
               type="button"
               onClick={() => setAmountStr(formatBTH(balance.available, { separators: false }))}
               className="text-xs text-pulse hover:underline"
             >
-              Max: {formatBTH(balance.available)} BTH
+              {t('confirm.max', { amount: formatBTH(balance.available) })}
             </button>
           )}
         </div>
         <Input
           type="text"
           inputMode="decimal"
-          placeholder="0.00"
+          placeholder={t('confirm.amountPlaceholder')}
           value={amountStr}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             setAmountStr(e.target.value)
@@ -447,7 +452,7 @@ function PayConfirm({
         />
         {request.amount === undefined && (
           <p className="text-xs text-ghost mt-1">
-            The requester didn&apos;t specify an amount — enter how much to send.
+            {t('confirm.noAmountSpecified')}
           </p>
         )}
 
@@ -464,11 +469,11 @@ function PayConfirm({
               className="mt-0.5 w-4 h-4 accent-pulse shrink-0"
             />
             <span className="text-xs text-amber-200/90">
-              This link is requesting a large amount (
+              {t('confirm.largePrefillPrefix')}
               <strong className="font-semibold text-amber-100">
-                {formatBTH(prefilledAmount!)} BTH
+                {t('confirm.largePrefillStrong', { amount: formatBTH(prefilledAmount!) })}
               </strong>
-              ). I&apos;ve verified the amount and recipient and want to send it.
+              {t('confirm.largePrefillSuffix')}
             </span>
           </label>
         )}
@@ -492,12 +497,12 @@ function PayConfirm({
         {isSending ? (
           <>
             <Loader2 size={16} className="mr-2 animate-spin" />
-            Sending…
+            {t('confirm.sending')}
           </>
         ) : (
           <>
             <Send size={16} className="mr-2" />
-            Pay {amount > 0n ? `${formatBTH(amount)} BTH` : ''}
+            {amount > 0n ? t('confirm.pay', { amount: `${formatBTH(amount)} BTH` }) : t('confirm.payNoAmount')}
           </>
         )}
       </Button>
@@ -521,6 +526,7 @@ function WalletGate({
   onImport: (seedPhrase: string, password?: string) => Promise<void>
   onUnlock: (password: string) => Promise<void>
 }) {
+  const { t } = useTranslation('pay')
   const [mode, setMode] = useState<SetupMode>(isLocked ? 'unlock' : 'create')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -565,7 +571,7 @@ function WalletGate({
     try {
       await onUnlock(password)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unlock failed.')
+      setError(err instanceof Error ? err.message : t('gate.unlockFailed'))
     } finally {
       setBusy(false)
     }
@@ -578,7 +584,7 @@ function WalletGate({
     try {
       await onCreate(newMnemonic, newPassword)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not create wallet.')
+      setError(err instanceof Error ? err.message : t('gate.createFailed'))
     } finally {
       setBusy(false)
     }
@@ -591,7 +597,7 @@ function WalletGate({
     try {
       await onImport(seedPhrase, newPassword)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Import failed.')
+      setError(err instanceof Error ? err.message : t('gate.importFailed'))
     } finally {
       setBusy(false)
     }
@@ -603,8 +609,8 @@ function WalletGate({
     <div className="space-y-4">
       <p className="text-sm text-ghost text-center">
         {isLocked
-          ? 'Unlock your wallet to pay this request.'
-          : 'You need a wallet to pay this request.'}
+          ? t('gate.unlockPrompt')
+          : t('gate.needWalletPrompt')}
       </p>
 
       {!isLocked && (
@@ -618,7 +624,7 @@ function WalletGate({
               mode === 'create' ? 'bg-steel text-light' : 'text-ghost hover:text-light'
             }`}
           >
-            Create New
+            {t('gate.createNew')}
           </button>
           <button
             onClick={() => {
@@ -629,7 +635,7 @@ function WalletGate({
               mode === 'import' ? 'bg-steel text-light' : 'text-ghost hover:text-light'
             }`}
           >
-            Import Existing
+            {t('gate.importExisting')}
           </button>
         </div>
       )}
@@ -641,7 +647,7 @@ function WalletGate({
           </div>
           <Input
             type="password"
-            placeholder="Enter password"
+            placeholder={t('gate.passwordPlaceholder')}
             value={password}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               setPassword(e.target.value)
@@ -654,7 +660,7 @@ function WalletGate({
           />
           <Button onClick={handleUnlock} disabled={!password || busy} className="w-full justify-center">
             {busy ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}
-            Unlock
+            {t('gate.unlock')}
           </Button>
         </div>
       )}
@@ -675,7 +681,7 @@ function WalletGate({
                 className="absolute inset-0 flex items-center justify-center gap-2 text-ghost hover:text-light"
               >
                 <Eye size={18} />
-                <span className="text-sm">Click to reveal</span>
+                <span className="text-sm">{t('gate.revealPrompt')}</span>
               </button>
             )}
           </div>
@@ -687,12 +693,12 @@ function WalletGate({
               className="mt-1 w-4 h-4 accent-pulse"
             />
             <span className="text-xs text-ghost">
-              I&apos;ve written down my recovery phrase and stored it safely.
+              {t('gate.confirmedPhrase')}
             </span>
           </label>
           <div>
             <p className="text-xs text-ghost mb-2">
-              Set a password — your wallet is encrypted on this device with it.
+              {t('gate.setPasswordPrompt')}
             </p>
             <PasswordFields
               password={newPassword}
@@ -711,11 +717,11 @@ function WalletGate({
               />
               <span className="text-xs text-danger">
                 <strong className="font-semibold">
-                  This device already has a wallet
-                  {existingWallet.address ? ` (${shortenAddress(existingWallet.address)})` : ''}.
+                  {t('gate.overwriteStrong', {
+                    suffix: existingWallet.address ? ` (${shortenAddress(existingWallet.address)})` : '',
+                  })}
                 </strong>{' '}
-                Continuing replaces it and deletes its stored seed — any funds in
-                it are lost unless you have its recovery phrase backed up.
+                {t('gate.overwriteWarning')}
               </span>
             </label>
           )}
@@ -725,7 +731,7 @@ function WalletGate({
             className="w-full justify-center"
           >
             {busy ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}
-            Create &amp; Continue
+            {t('gate.createContinue')}
           </Button>
         </div>
       )}
@@ -738,13 +744,13 @@ function WalletGate({
               setSeedPhrase(e.target.value)
               setError(null)
             }}
-            placeholder="Enter your 12 or 24 word recovery phrase…"
+            placeholder={t('gate.seedPlaceholder')}
             rows={3}
             className="w-full p-3 rounded-lg bg-abyss border border-steel font-mono text-xs leading-relaxed resize-none focus:outline-none focus:ring-2 focus:ring-pulse/50 focus:border-pulse placeholder:text-ghost/50"
           />
           <div>
             <p className="text-xs text-ghost mb-2">
-              Set a password — your wallet is encrypted on this device with it.
+              {t('gate.setPasswordPrompt')}
             </p>
             <PasswordFields
               password={newPassword}
@@ -763,11 +769,11 @@ function WalletGate({
               />
               <span className="text-xs text-danger">
                 <strong className="font-semibold">
-                  This device already has a wallet
-                  {existingWallet.address ? ` (${shortenAddress(existingWallet.address)})` : ''}.
+                  {t('gate.overwriteStrong', {
+                    suffix: existingWallet.address ? ` (${shortenAddress(existingWallet.address)})` : '',
+                  })}
                 </strong>{' '}
-                Continuing replaces it and deletes its stored seed — any funds in
-                it are lost unless you have its recovery phrase backed up.
+                {t('gate.overwriteWarning')}
               </span>
             </label>
           )}
@@ -777,7 +783,7 @@ function WalletGate({
             className="w-full justify-center"
           >
             {busy ? <Loader2 size={16} className="mr-2 animate-spin" /> : null}
-            Import &amp; Continue
+            {t('gate.importContinue')}
           </Button>
         </div>
       )}

--- a/web/packages/web-wallet/src/pages/wallet.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.i18n.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Locale-rendering coverage for the wallet page (issue #777, i18n phase 2).
+ * With no wallet present the page renders the create/import setup view; we
+ * assert its page-owned copy renders in the active locale under both the
+ * default and `/es`-prefixed paths.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const useWalletMock = vi.fn()
+vi.mock('../contexts/wallet', () => ({
+  useWallet: () => useWalletMock(),
+}))
+vi.mock('../contexts/network', () => ({
+  useNetwork: () => ({ hasFaucet: false }),
+}))
+// NetworkSelector renders the network context UI (shared chrome) — stub it so
+// this page-copy test stays focused on wallet-owned strings.
+vi.mock('../components/NetworkSelector', () => ({
+  NetworkSelector: () => null,
+}))
+vi.mock('../components/CustomRpcTrustGate', () => ({
+  CustomRpcTrustGate: () => null,
+  CustomNodeBanner: () => null,
+}))
+
+// Imported AFTER the mocks are registered.
+import { WalletPage } from './wallet'
+import i18n from '../lib/i18n'
+
+const ASYNC_NOOP = async () => {}
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+function noWallet(overrides: Record<string, unknown> = {}) {
+  return {
+    hasWallet: false,
+    isLocked: false,
+    isConnecting: false,
+    address: null,
+    createWallet: vi.fn(ASYNC_NOOP),
+    importWallet: vi.fn(ASYNC_NOOP),
+    unlockWallet: vi.fn(ASYNC_NOOP),
+    ...overrides,
+  }
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <WalletPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('WalletPage i18n', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useWalletMock.mockReset()
+    useWalletMock.mockReturnValue(noWallet())
+    return i18n.changeLanguage('en')
+  })
+
+  afterEach(() => cleanup())
+
+  it('renders English setup copy by default', () => {
+    renderAt('/wallet')
+    expect(screen.getByRole('heading', { name: 'Create New Wallet' })).toBeTruthy()
+    expect(
+      screen.getByText('Write down your recovery phrase and store it safely.'),
+    ).toBeTruthy()
+  })
+
+  it('renders Spanish setup copy when the active locale is es', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/wallet')
+    expect(screen.getByRole('heading', { name: 'Crear nuevo monedero' })).toBeTruthy()
+    expect(
+      screen.getByText('Anota tu frase de recuperación y guárdala de forma segura.'),
+    ).toBeTruthy()
+    // English source string must NOT leak through untranslated.
+    expect(screen.queryByRole('heading', { name: 'Create New Wallet' })).toBeNull()
+  })
+})

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { Button, Card, Input, Logo, ModalOverlay } from '@botho/ui'
 import { createMnemonic12 } from '@botho/core'
@@ -17,6 +18,7 @@ import { PasswordFields, PasswordSettingsModal, isPasswordValid } from '../compo
 import { Send, Link2, Download, RefreshCw, ArrowLeft, Shield, Eye, KeyRound, AlertCircle, Lock, Settings, Trash2, Users, QrCode, Clock } from 'lucide-react'
 
 function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?: string) => void }) {
+  const { t } = useTranslation('wallet')
   const [showMnemonic, setShowMnemonic] = useState(false)
   const [confirmed, setConfirmed] = useState(false)
   const [password, setPassword] = useState('')
@@ -39,8 +41,8 @@ function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?
           <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-pulse/10 flex items-center justify-center mx-auto mb-3 sm:mb-4">
             <Shield className="text-pulse" size={28} />
           </div>
-          <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">Create New Wallet</h2>
-          <p className="text-ghost text-sm sm:text-base">Write down your recovery phrase and store it safely.</p>
+          <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">{t('createView.title')}</h2>
+          <p className="text-ghost text-sm sm:text-base">{t('createView.subtitle')}</p>
         </div>
 
         <div className="relative mb-5 sm:mb-6">
@@ -53,7 +55,7 @@ function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?
               className="absolute inset-0 flex items-center justify-center gap-2 text-ghost hover:text-light transition-colors"
             >
               <Eye size={20} />
-              <span className="text-sm">Click to reveal</span>
+              <span className="text-sm">{t('createView.clickToReveal')}</span>
             </button>
           )}
         </div>
@@ -61,7 +63,7 @@ function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?
         <label className="flex items-start gap-3 mb-4 cursor-pointer">
           <input type="checkbox" checked={confirmed} onChange={(e) => setConfirmed(e.target.checked)} className="mt-1 w-4 h-4 accent-pulse" />
           <span className="text-sm text-ghost">
-            I have written down my recovery phrase and stored it in a safe place.
+            {t('createView.confirmPhrase')}
             <span className="text-danger ml-1">*</span>
           </span>
         </label>
@@ -70,10 +72,9 @@ function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?
           <div className="flex items-start gap-3 mb-3">
             <Lock size={16} className="text-pulse mt-0.5 shrink-0" />
             <div>
-              <span className="text-sm text-light">Set a password</span>
+              <span className="text-sm text-light">{t('createView.setPassword')}</span>
               <p className="text-xs text-ghost mt-1">
-                Your wallet is encrypted on this device with this password. There is no way to
-                recover it if you forget it — keep your recovery phrase safe as a backup.
+                {t('createView.passwordNote')}
               </p>
             </div>
           </div>
@@ -86,7 +87,7 @@ function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?
         </div>
 
         <Button onClick={handleCreate} disabled={!confirmed || !showMnemonic || !passwordValid} className="w-full">
-          Create Wallet
+          {t('createView.createButton')}
         </Button>
       </Card>
     </div>
@@ -94,6 +95,7 @@ function CreateWalletView({ onCreate }: { onCreate: (mnemonic: string, password?
 }
 
 function ImportWalletView({ onImport }: { onImport: (mnemonic: string, password?: string) => Promise<void> }) {
+  const { t } = useTranslation('wallet')
   const [seedPhrase, setSeedPhrase] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isImporting, setIsImporting] = useState(false)
@@ -110,7 +112,7 @@ function ImportWalletView({ onImport }: { onImport: (mnemonic: string, password?
     try {
       await onImport(seedPhrase, password)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Import failed')
+      setError(err instanceof Error ? err.message : t('importView.importFailed'))
     } finally {
       setIsImporting(false)
     }
@@ -123,29 +125,31 @@ function ImportWalletView({ onImport }: { onImport: (mnemonic: string, password?
           <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-pulse/10 flex items-center justify-center mx-auto mb-3 sm:mb-4">
             <KeyRound className="text-pulse" size={28} />
           </div>
-          <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">Import Wallet</h2>
-          <p className="text-ghost text-sm sm:text-base">Enter your 12 or 24 word recovery phrase to restore your wallet.</p>
+          <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">{t('importView.title')}</h2>
+          <p className="text-ghost text-sm sm:text-base">{t('importView.subtitle')}</p>
         </div>
 
         <div className="space-y-4">
           <div>
-            <label className="block text-sm text-ghost mb-2">Recovery Phrase</label>
+            <label className="block text-sm text-ghost mb-2">{t('importView.recoveryPhraseLabel')}</label>
             <textarea
               value={seedPhrase}
               onChange={(e) => {
                 setSeedPhrase(e.target.value)
                 setError(null)
               }}
-              placeholder="Enter your recovery phrase, separating each word with a space..."
+              placeholder={t('importView.placeholder')}
               rows={4}
               className="w-full p-3 sm:p-4 rounded-lg bg-abyss border border-steel font-mono text-xs sm:text-sm leading-relaxed resize-none focus:outline-none focus:ring-2 focus:ring-pulse/50 focus:border-pulse placeholder:text-ghost/50"
             />
             <div className="flex justify-between items-center mt-2">
               <span className="text-xs text-ghost">
-                {wordCount} {wordCount === 1 ? 'word' : 'words'}
+                {wordCount === 1
+                  ? t('importView.wordCountOne', { count: wordCount })
+                  : t('importView.wordCountOther', { count: wordCount })}
               </span>
               {wordCount > 0 && wordCount !== 12 && wordCount !== 24 && (
-                <span className="text-xs text-warning">Expected 12 or 24 words</span>
+                <span className="text-xs text-warning">{t('importView.expectedWords')}</span>
               )}
             </div>
           </div>
@@ -154,9 +158,9 @@ function ImportWalletView({ onImport }: { onImport: (mnemonic: string, password?
             <div className="flex items-start gap-3 mb-3">
               <Lock size={16} className="text-pulse mt-0.5 shrink-0" />
               <div>
-                <span className="text-sm text-light">Set a password</span>
+                <span className="text-sm text-light">{t('importView.setPassword')}</span>
                 <p className="text-xs text-ghost mt-1">
-                  Your wallet is encrypted on this device with this password.
+                  {t('importView.passwordNote')}
                 </p>
               </div>
             </div>
@@ -181,9 +185,9 @@ function ImportWalletView({ onImport }: { onImport: (mnemonic: string, password?
             className="w-full"
           >
             {isImporting ? (
-              <><RefreshCw size={16} className="mr-2 animate-spin" />Importing...</>
+              <><RefreshCw size={16} className="mr-2 animate-spin" />{t('importView.importing')}</>
             ) : (
-              'Import Wallet'
+              t('importView.importButton')
             )}
           </Button>
         </div>
@@ -192,14 +196,17 @@ function ImportWalletView({ onImport }: { onImport: (mnemonic: string, password?
   )
 }
 
-/** Auto-lock timeout options for the settings control (#490). 0 = Off/Never. */
-const AUTO_LOCK_OPTIONS: Array<{ minutes: number; label: string }> = [
-  { minutes: 1, label: '1 minute' },
-  { minutes: 5, label: '5 minutes' },
-  { minutes: 15, label: '15 minutes' },
-  { minutes: 30, label: '30 minutes' },
-  { minutes: 60, label: '1 hour' },
-  { minutes: 0, label: 'Off (never)' },
+/**
+ * Auto-lock timeout options for the settings control (#490). 0 = Off/Never.
+ * Labels are resolved via i18n (`wallet.autoLock.*`) at render time.
+ */
+const AUTO_LOCK_OPTIONS: Array<{ minutes: number; labelKey: string }> = [
+  { minutes: 1, labelKey: 'autoLock.minute' },
+  { minutes: 5, labelKey: 'autoLock.fiveMinutes' },
+  { minutes: 15, labelKey: 'autoLock.fifteenMinutes' },
+  { minutes: 30, labelKey: 'autoLock.thirtyMinutes' },
+  { minutes: 60, labelKey: 'autoLock.hour' },
+  { minutes: 0, labelKey: 'autoLock.off' },
 ]
 
 /**
@@ -225,6 +232,7 @@ function SettingsModal({
   onReset: () => void
   onClose: () => void
 }) {
+  const { t } = useTranslation('wallet')
   return (
     // Shared dismissal policy (#655): backdrop click / Escape close, same as
     // the explicit Close button.
@@ -237,8 +245,8 @@ function SettingsModal({
           <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-pulse/10 flex items-center justify-center mx-auto mb-3 sm:mb-4">
             <Settings className="text-pulse" size={28} />
           </div>
-          <h3 className="font-display text-lg sm:text-xl font-semibold mb-2">Settings</h3>
-          <p className="text-ghost text-sm">Security and wallet controls.</p>
+          <h3 className="font-display text-lg sm:text-xl font-semibold mb-2">{t('settingsModal.title')}</h3>
+          <p className="text-ghost text-sm">{t('settingsModal.subtitle')}</p>
         </div>
 
         <div className="space-y-5">
@@ -246,7 +254,7 @@ function SettingsModal({
           <div>
             <div className="flex items-center gap-2 mb-2">
               <Clock size={16} className="text-pulse shrink-0" />
-              <span className="text-sm font-medium text-light">Auto-lock after inactivity</span>
+              <span className="text-sm font-medium text-light">{t('settingsModal.autoLockLabel')}</span>
             </div>
             <select
               value={autoLockMinutes}
@@ -256,14 +264,14 @@ function SettingsModal({
             >
               {AUTO_LOCK_OPTIONS.map((opt) => (
                 <option key={opt.minutes} value={opt.minutes}>
-                  {opt.label}
+                  {t(opt.labelKey)}
                 </option>
               ))}
             </select>
             <p className="text-xs text-ghost mt-1">
               {isEncrypted
-                ? 'Lock the wallet automatically when idle. Activity resets the timer.'
-                : 'Set a password to enable auto-lock.'}
+                ? t('settingsModal.autoLockEnabled')
+                : t('settingsModal.autoLockDisabled')}
             </p>
           </div>
 
@@ -274,10 +282,10 @@ function SettingsModal({
               onClick={onLock}
               disabled={!isEncrypted}
               className="w-full justify-center"
-              title={isEncrypted ? 'Lock wallet' : 'Set a password to enable locking'}
+              title={isEncrypted ? t('settingsModal.lockWalletTitle') : t('settingsModal.enableLockingTitle')}
             >
               <Lock size={16} className="mr-2" />
-              Lock wallet
+              {t('settingsModal.lockWallet')}
             </Button>
             {!isEncrypted && (
               <button
@@ -285,7 +293,7 @@ function SettingsModal({
                 onClick={onSetPassword}
                 className="text-xs text-pulse hover:underline mt-2"
               >
-                Set a password to enable locking
+                {t('settingsModal.enableLockingLink')}
               </button>
             )}
           </div>
@@ -294,12 +302,12 @@ function SettingsModal({
           <div className="border-t border-steel pt-4">
             <Button variant="danger" onClick={onReset} className="w-full justify-center">
               <Trash2 size={16} className="mr-2" />
-              Reset wallet
+              {t('settingsModal.resetWallet')}
             </Button>
           </div>
 
           <Button variant="ghost" onClick={onClose} className="w-full justify-center">
-            Close
+            {t('settingsModal.close')}
           </Button>
         </div>
       </Card>
@@ -308,6 +316,7 @@ function SettingsModal({
 }
 
 function WalletDashboard() {
+  const { t } = useTranslation('wallet')
   const { address, balance, transactions, isConnecting, isConnected, refreshBalance, refreshTransactions, resetWallet, send, estimateFee, contacts, searchContacts, isEncrypted, setPassword, changePassword, lockWallet, autoLockMinutes, setAutoLockMinutes } = useWallet()
 
   // Resolve a counterparty address to a saved contact name for the transaction
@@ -349,7 +358,7 @@ function WalletDashboard() {
       await Promise.allSettled([refreshBalance(), refreshTransactions()])
       return { success: true, txHash }
     } catch (err) {
-      return { success: false, error: err instanceof Error ? err.message : 'Transaction failed' }
+      return { success: false, error: err instanceof Error ? err.message : t('dashboard.transactionFailed') }
     } finally {
       setIsSending(false)
     }
@@ -366,20 +375,20 @@ function WalletDashboard() {
   const actionButtons = (
     <>
       <Button onClick={() => setSendOpen(true)}>
-        <Send size={16} className="mr-2" />Send
+        <Send size={16} className="mr-2" />{t('dashboard.send')}
       </Button>
       <Button variant="secondary" onClick={() => setReceiveOpen(true)}>
-        <QrCode size={16} className="mr-2" />Receive
+        <QrCode size={16} className="mr-2" />{t('dashboard.receive')}
       </Button>
       <Button variant="secondary" onClick={() => setSendLinkOpen(true)}>
-        <Link2 size={16} className="mr-2" />Send via Link
+        <Link2 size={16} className="mr-2" />{t('dashboard.sendViaLink')}
       </Button>
       <Button variant="secondary" onClick={() => setRequestOpen(true)}>
-        <Download size={16} className="mr-2" />Request
+        <Download size={16} className="mr-2" />{t('dashboard.request')}
       </Button>
       <Link to="/contacts">
         <Button variant="secondary">
-          <Users size={16} className="mr-2" />Contacts
+          <Users size={16} className="mr-2" />{t('dashboard.contacts')}
         </Button>
       </Link>
       <Button variant="ghost" size="sm" onClick={refreshBalance} disabled={isConnecting}>
@@ -390,11 +399,11 @@ function WalletDashboard() {
         size="sm"
         onClick={lockWallet}
         disabled={!isEncrypted}
-        title={isEncrypted ? 'Lock wallet' : 'Set a password to enable locking'}
+        title={isEncrypted ? t('dashboard.lockWalletTitle') : t('dashboard.enableLockingTitle')}
       >
         <Lock size={16} />
       </Button>
-      <Button variant="ghost" size="sm" onClick={() => setShowSettings(true)} title="Settings">
+      <Button variant="ghost" size="sm" onClick={() => setShowSettings(true)} title={t('dashboard.settingsTitle')}>
         <Settings size={16} />
       </Button>
     </>
@@ -427,12 +436,12 @@ function WalletDashboard() {
             <Shield size={18} className={isEncrypted ? 'text-success mt-0.5 shrink-0' : 'text-warning mt-0.5 shrink-0'} />
             <div>
               <p className="text-sm font-medium text-light">
-                {isEncrypted ? 'Wallet is password-protected' : 'Wallet has no password'}
+                {isEncrypted ? t('dashboard.protectedTitle') : t('dashboard.unprotectedTitle')}
               </p>
               <p className="text-xs text-ghost mt-1">
                 {isEncrypted
-                  ? 'Your seed, contacts, and claim links are encrypted on this device.'
-                  : 'Set a password to encrypt your wallet and enable claim links.'}
+                  ? t('dashboard.protectedBody')
+                  : t('dashboard.unprotectedBody')}
               </p>
             </div>
           </div>
@@ -442,7 +451,7 @@ function WalletDashboard() {
             onClick={() => setShowPasswordModal(true)}
           >
             <KeyRound size={16} className="mr-2" />
-            {isEncrypted ? 'Change password' : 'Set a password'}
+            {isEncrypted ? t('dashboard.changePassword') : t('dashboard.setPassword')}
           </Button>
         </div>
       </Card>
@@ -451,7 +460,7 @@ function WalletDashboard() {
 
       <TransactionList
         transactions={transactions}
-        title="Recent Transactions"
+        title={t('dashboard.recentTransactions')}
         showChevron={false}
         resolveName={resolveName}
       />
@@ -520,15 +529,15 @@ function WalletDashboard() {
               <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-danger/10 flex items-center justify-center mx-auto mb-3 sm:mb-4">
                 <Trash2 className="text-danger" size={28} />
               </div>
-              <h3 className="font-display text-lg sm:text-xl font-semibold mb-2">Reset Wallet</h3>
-              <p className="text-ghost text-sm">This will remove your wallet from this device. Make sure you have your recovery phrase saved before continuing.</p>
+              <h3 className="font-display text-lg sm:text-xl font-semibold mb-2">{t('resetModal.title')}</h3>
+              <p className="text-ghost text-sm">{t('resetModal.body')}</p>
             </div>
             <div className="space-y-3">
               <Button variant="danger" onClick={handleReset} className="w-full justify-center">
-                Reset & Start Over
+                {t('resetModal.confirm')}
               </Button>
               <Button variant="secondary" onClick={() => setShowResetConfirm(false)} className="w-full justify-center">
-                Cancel
+                {t('resetModal.cancel')}
               </Button>
             </div>
           </Card>
@@ -539,6 +548,7 @@ function WalletDashboard() {
 }
 
 function UnlockWalletView({ onUnlock, address }: { onUnlock: (password: string) => Promise<void>; address: string | null }) {
+  const { t } = useTranslation('wallet')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isUnlocking, setIsUnlocking] = useState(false)
@@ -549,7 +559,7 @@ function UnlockWalletView({ onUnlock, address }: { onUnlock: (password: string) 
     try {
       await onUnlock(password)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Unlock failed')
+      setError(err instanceof Error ? err.message : t('unlockView.unlockFailed'))
     } finally {
       setIsUnlocking(false)
     }
@@ -568,8 +578,8 @@ function UnlockWalletView({ onUnlock, address }: { onUnlock: (password: string) 
           <div className="w-14 h-14 sm:w-16 sm:h-16 rounded-full bg-pulse/10 flex items-center justify-center mx-auto mb-3 sm:mb-4">
             <Lock className="text-pulse" size={28} />
           </div>
-          <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">Unlock Wallet</h2>
-          <p className="text-ghost text-sm sm:text-base">Enter your password to access your wallet.</p>
+          <h2 className="font-display text-xl sm:text-2xl font-bold mb-2">{t('unlockView.title')}</h2>
+          <p className="text-ghost text-sm sm:text-base">{t('unlockView.subtitle')}</p>
           {address && (
             <p className="text-xs text-ghost mt-2 font-mono truncate px-4">{address}</p>
           )}
@@ -578,7 +588,7 @@ function UnlockWalletView({ onUnlock, address }: { onUnlock: (password: string) 
         <div className="space-y-4">
           <Input
             type="password"
-            placeholder="Enter password"
+            placeholder={t('unlockView.passwordPlaceholder')}
             value={password}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
               setPassword(e.target.value)
@@ -601,9 +611,9 @@ function UnlockWalletView({ onUnlock, address }: { onUnlock: (password: string) 
             className="w-full"
           >
             {isUnlocking ? (
-              <><RefreshCw size={16} className="mr-2 animate-spin" />Unlocking...</>
+              <><RefreshCw size={16} className="mr-2 animate-spin" />{t('unlockView.unlocking')}</>
             ) : (
-              'Unlock'
+              t('unlockView.unlock')
             )}
           </Button>
         </div>
@@ -615,6 +625,7 @@ function UnlockWalletView({ onUnlock, address }: { onUnlock: (password: string) 
 type WalletMode = 'create' | 'import'
 
 function WalletSetup({ onCreate, onImport }: { onCreate: (mnemonic: string, password?: string) => void; onImport: (mnemonic: string, password?: string) => Promise<void> }) {
+  const { t } = useTranslation('wallet')
   const [mode, setMode] = useState<WalletMode>('create')
 
   return (
@@ -629,7 +640,7 @@ function WalletSetup({ onCreate, onImport }: { onCreate: (mnemonic: string, pass
                 : 'text-ghost hover:text-light'
             }`}
           >
-            Create New
+            {t('setup.createNew')}
           </button>
           <button
             onClick={() => setMode('import')}
@@ -639,7 +650,7 @@ function WalletSetup({ onCreate, onImport }: { onCreate: (mnemonic: string, pass
                 : 'text-ghost hover:text-light'
             }`}
           >
-            Import Existing
+            {t('setup.importExisting')}
           </button>
         </div>
       </div>
@@ -654,6 +665,7 @@ function WalletSetup({ onCreate, onImport }: { onCreate: (mnemonic: string, pass
 }
 
 export function WalletPage() {
+  const { t } = useTranslation('wallet')
   const { hasWallet: walletExists, isLocked, isConnecting, address, createWallet, importWallet, unlockWallet } = useWallet()
 
   const handleCreate = async (mnemonic: string, password?: string) => {
@@ -703,8 +715,8 @@ export function WalletPage() {
           <Link to={homeHref} className="flex items-center gap-2 sm:gap-3">
             <ArrowLeft size={18} className="text-ghost" />
             <Logo size="sm" showText={false} />
-            <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">Botho Wallet</span>
-            <span className="font-display text-base font-semibold sm:hidden">Wallet</span>
+            <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">{t('header.walletNameLong')}</span>
+            <span className="font-display text-base font-semibold sm:hidden">{t('header.walletNameShort')}</span>
           </Link>
           <NetworkSelector />
         </div>

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ['./vitest.setup.ts'],
     include: ['packages/**/*.test.ts', 'packages/**/*.test.tsx'],
     environmentMatchGlobs: [
       // Use jsdom for React component tests

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,0 +1,20 @@
+/**
+ * Global vitest setup.
+ *
+ * Initializes the web-wallet i18next instance (side-effect import) so any
+ * component test that renders a page calling `useTranslation()` resolves real
+ * translations instead of bare keys. Page tests default to the `en` locale, so
+ * existing assertions against English copy keep passing without per-file
+ * boilerplate (issue #777, i18n phase 2). Tests that need Spanish call
+ * `i18n.changeLanguage('es')` explicitly.
+ *
+ * The import is wrapped so it is a no-op in the non-jsdom (node) test
+ * environment where the React/i18n stack is not needed.
+ */
+import { beforeAll } from 'vitest'
+
+beforeAll(async () => {
+  if (typeof document !== 'undefined') {
+    await import('./packages/web-wallet/src/lib/i18n')
+  }
+})


### PR DESCRIPTION
## Summary

Phase 2 of the web i18n rollout (issue #777). Extracts page-owned copy from the four highest-traffic transactional wallet surfaces — wallet, pay, claim, contacts — into dedicated i18next namespaces and translates them to Spanish, reusing the phase-1 framework shipped in #774 (react-i18next + `/es` URL-prefix routing + statically bundled JSON namespaces). `/es/wallet`, `/es/pay`, `/es/claim`, `/es/contacts` now render fully localized copy; the unprefixed English routes are unchanged.

## Changes

- **`lib/i18n.ts`**: register `wallet`, `pay`, `claim`, `contacts` namespaces (static JSON imports, extend `resources` and the `ns` array; `defaultNS` stays `landing`).
- **8 new locale files** (`locales/{en,es}/{wallet,pay,claim,contacts}.json`): English extracted verbatim from the pages, Spanish translated in the informal *tú* register to match the existing `es/landing.json`.
- **4 page files**: each calls `useTranslation(<ns>)` (subcomponents get their own hook). Extracted visible text **plus** `placeholder=`, `aria-label=`, `title=` attributes and inline error/toast strings. Interpolation used for dynamic bits (amounts, contact names, the `(address)` overwrite-warning suffix).
- **`wallet.tsx`**: deliberately kept to a mechanical, minimal-diff pass (in-place `t()` swaps, no structural refactor) to minimize rebase pain against the in-flight checkout/node-hosting work on this file. Diff is 142 lines changed — well under the 300-line scope-guard threshold.
- **4 new `*.i18n.test.tsx`**: render each page at the default (`/wallet`) and `/es`-prefixed (`/es/wallet`) paths and assert per-locale page copy, following the `landing.test.tsx` pattern.
- **`vitest.setup.ts` + `vitest.config.ts` (setupFiles)**: initialize the i18n instance globally in jsdom tests. Required because the existing `pay.test.tsx` / `claim.test.tsx` / `contacts.test.tsx` now render pages that call `useTranslation()`; without an initialized i18n those tests would see bare keys instead of English copy. Defaulting to `en` keeps every existing English assertion green with zero per-file edits.

### Out of scope (untouched, per the curator plan)
- Shared `@botho/ui` / `@botho/features` component copy (`BalanceCard`, `TransactionList`, `SendModal`, etc.).
- `docs.tsx` (phase 3), metadata/OG/`Accept-Language` (phase 4), and `node.tsx` / `explorer.tsx` / `network.tsx` / `operator.tsx`.

## Open question (non-blocking)

`LocaleSwitcher` is **not** wired into the wallet/pay/claim/contacts headers in this PR. These four pages have their own distinct header layouts (and `wallet.tsx` was explicitly to be kept minimal-diff), so adding the switcher was left out to avoid touching shared header structure and inflating the `wallet.tsx` diff. Language is still selectable from the landing page and persists via `localStorage` + the `/es` URL prefix. Wiring the switcher into these headers is a good small follow-up if desired.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New `wallet`/`pay`/`claim`/`contacts` namespaces registered in `i18n.ts` | ✅ | `resources` + `ns` extended; typecheck passes |
| One namespace per page via `useTranslation(<ns>)` | ✅ | Each page + its subcomponents call the matching hook |
| English extracted verbatim; Spanish added | ✅ | `en/*.json` mirror source strings; `es/*.json` translated (tú register) |
| Placeholders / aria-labels / errors covered, not just headings | ✅ | e.g. `searchPlaceholder`, `editor.close` aria-label, all inline `setError` strings |
| Shared component copy excluded | ✅ | No edits under `@botho/ui` / `@botho/features` |
| `wallet.tsx` minimal-diff, no structural refactor | ✅ | 142 lines changed, in-place swaps only |
| Per-page locale tests at default + `/es` paths | ✅ | 4 new `*.i18n.test.tsx`, 2 cases each |
| No regressions in existing suites | ✅ | `pnpm check:ci` green: 740 passed / 10 skipped |
| Default-locale routes unchanged | ✅ | English assertions in existing tests + e2e-referenced paths untouched |

## Test Plan

- `pnpm check:ci` (typecheck all 8 projects + `pnpm test:run` + wrangler dry-run) — **passing**: 73 test files, 740 tests passed, 10 skipped, 0 failed.
- New i18n tests assert Spanish copy renders under `/es` and that the English source string does **not** leak through untranslated.

Closes #777