### PR TITLE
feat(web-wallet): localize docs page via per-locale markdown files (en/es)

### DIFF
--- a/web/packages/web-wallet/src/docs-content/en/api.md
+++ b/web/packages/web-wallet/src/docs-content/en/api.md
@@ -1,0 +1,203 @@
+## JSON-RPC API
+
+Botho nodes expose a JSON-RPC 2.0 API on port **7101** (mainnet) or **17101** (testnet) by default; override with `rpc_port` in the config. All requests use the standard JSON-RPC 2.0 format.
+
+### Request Format
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "METHOD_NAME",
+  "params": { ... },
+  "id": 1
+}
+```
+
+---
+
+## Node Methods
+
+### node_getStatus
+
+Get node status and sync information.
+
+**Response (selected fields):**
+- `version` - Node software version
+- `network` - Network name (e.g., "botho-testnet")
+- `uptimeSeconds` - Node uptime in seconds
+- `syncStatus` / `syncProgress` / `synced` - Live sync state
+- `chainHeight` - Current blockchain height
+- `tipHash` - Hash of the latest block
+- `peerCount` / `scpPeerCount` - Connected peers / SCP-participating peers
+- `mempoolSize` - Transactions in mempool
+- `mintingActive` - Whether minting is enabled
+- `quorumFaultTolerant` / `quorumDegenerate` - BFT posture (fault tolerance requires ≥ 4 participating nodes)
+
+The full response also includes build info, SCP slot progress, quorum-gate state, and miner-health fields for monitoring.
+
+---
+
+## Chain Methods
+
+### getChainInfo
+
+Get blockchain information.
+
+**Response:**
+- `height` - Current block height
+- `tipHash` - Hash of the tip block
+- `difficulty` - Current mining difficulty
+- `totalMined` - Total coins mined (picocredits, as a string)
+- `totalFeesBurned` - Cumulative burned fees (picocredits, as a string)
+- `circulatingSupply` - totalMined minus burns (picocredits, as a string)
+- `mempoolSize` - Number of pending transactions
+- `mempoolFees` - Total fees in mempool
+
+### getBlockByHeight
+
+Get a block by its height.
+
+**Parameters:**
+- `height` (number) - Block height
+
+**Response:**
+- `height` - Block height
+- `hash` - Block hash
+- `prevHash` - Previous block hash
+- `timestamp` - Block timestamp
+- `difficulty` - Block difficulty
+- `nonce` - Mining nonce
+- `txCount` - Number of transactions
+- `mintingReward` - Minting reward amount
+
+### getMempoolInfo
+
+Get mempool statistics.
+
+**Response:**
+- `size` - Number of transactions
+- `totalFees` - Total fees from all transactions
+- `txHashes` - Array of transaction hashes (up to 100)
+
+### estimateFee (alias: tx_estimateFee)
+
+Estimate transaction fee.
+
+**Parameters:**
+- `amount` (number) - Transaction amount
+- `memos` (number) - Number of encrypted memo fields
+
+**Response:**
+- `minimumFee` - Minimum required fee
+- `clusterFactor` - Progressive multiplier, scaled ×1000 (1000 = 1x, 6000 = 6x)
+- `clusterFactorDisplay` - Human-readable factor (e.g., "1.25x")
+- `clusterWealth` - Cluster wealth the factor was derived from
+- `recommendedFee` - Recommended fee for normal priority
+- `highPriorityFee` - Fee for high priority confirmation
+
+---
+
+## Wallet Methods
+
+### chain_getOutputs
+
+Get transaction outputs for wallet sync.
+
+**Parameters:**
+- `start_height` (number) - Starting block height
+- `end_height` (number) - Ending block height (max 100 blocks per request)
+
+**Response:** Array of blocks, each containing:
+- `height` - Block height
+- `outputs` - Array of outputs with `txHash`, `outputIndex`, `targetKey`, `publicKey`, `amountCommitment`
+
+### wallet_getBalance
+
+Get wallet balance (requires local wallet).
+
+**Response:**
+- `confirmed` - Confirmed balance
+- `pending` - Pending balance
+- `total` - Total balance
+- `utxoCount` - Number of unspent outputs
+
+### wallet_getAddress
+
+Get wallet keys and address info.
+
+**Response:**
+- `viewKey` - Public view key (hex)
+- `spendKey` - Public spend key (hex)
+- `hasWallet` - Whether node has a wallet configured
+
+---
+
+## Transaction Methods
+
+### tx_submit / sendRawTransaction
+
+Submit a signed transaction.
+
+**Parameters:**
+- `tx_hex` (string) - Hex-encoded serialized transaction
+
+**Response:**
+- `txHash` - Transaction hash
+
+---
+
+## Minting Methods
+
+### minting_getStatus
+
+Get minting status.
+
+**Response:**
+- `active` - Whether minting is enabled
+- `threads` - Number of minting threads
+- `hashrate` - Current hashrate
+- `totalHashes` - Total hashes computed
+- `blocksFound` - Blocks mined by this node
+- `currentDifficulty` - Current network difficulty
+- `uptimeSeconds` - Minting uptime
+
+---
+
+## Network Methods
+
+### network_getInfo
+
+Get network connection information.
+
+**Response:**
+- `peerCount` - Total peer count
+- `inboundCount` - Inbound connections
+- `outboundCount` - Outbound connections
+- `bytesSent` - Total bytes sent
+- `bytesReceived` - Total bytes received
+- `uptimeSeconds` - Connection uptime
+
+### network_getPeers
+
+Get list of connected peers.
+
+**Response:**
+- `peers` - Array of peer information
+
+---
+
+## Other Methods
+
+The API surface is larger than this page. Notable additional methods:
+
+| Method | Purpose |
+|--------|---------|
+| `getBlockByHash` | Fetch a block by hash instead of height |
+| `getSupplyInfo` | Emission and supply details |
+| `tx_get` / `tx_getStatus` | Look up a transaction / its confirmation status |
+| `address_validate` | Check whether an address string is well-formed |
+| `fee_getRate` | Current dynamic fee rate |
+| `cluster_getWealth` / `cluster_getAllWealth` | Cluster wealth queries (powers the explorer views) |
+| `chain_areKeyImagesSpent` | Check key images for double-spend detection |
+| `faucet_getStatus` / `faucet_request` | Testnet faucet |
+| `operator_*` | Operator trust surface (disabled unless configured; see the operator runbooks) |

--- a/web/packages/web-wallet/src/docs-content/en/cluster-tags.md
+++ b/web/packages/web-wallet/src/docs-content/en/cluster-tags.md
@@ -1,0 +1,179 @@
+## Cluster Tags
+
+Cluster tags are Botho's novel mechanism for tracking coin provenance without compromising privacy. They enable **Sybil-resistant progressive fees**, **lottery-based redistribution**, and **privacy-preserving ring signatures**.
+
+### The Problem: Wealth Taxation Without Identity
+
+Traditional progressive taxation requires identity. In cryptocurrency:
+
+- **Amount-based fees** fail instantly — split 1M into 1000×1K and pay lower rates
+- **Account-based taxation** is impossible — anyone can create unlimited addresses
+- **Transaction counting** doesn't work — bots can create artificial activity
+
+**The core challenge:** How do you tax wealth concentration when you can't identify who owns what?
+
+### The Solution: Provenance Tracking
+
+Instead of tracking *who* owns coins, we track *where* they came from. Every coin carries a memory of its origin.
+
+**Key insight:** Splitting coins doesn't change where they came from.
+
+### How Cluster Tags Work
+
+**1. Clusters Are Born at Minting**
+
+Each block reward creates a unique "cluster" — an identity for coins minted by a specific minter. The minting reward carries a 100% tag for that cluster.
+
+```
+Block 1000: Minter A receives 50 BTH
+  → Tag: {cluster_A: 100%}
+
+Block 1001: Minter B receives 50 BTH
+  → Tag: {cluster_B: 100%}
+```
+
+**2. Tags Inherit on Transfer**
+
+When coins move, the recipient's UTXO inherits the sender's tags:
+
+```
+Minter A → Merchant → Customer
+  100%   →   95%    →   90%   (A's cluster factor)
+```
+
+**3. Tags Blend on Combination**
+
+When multiple inputs are spent together, output tags are a value-weighted average:
+
+```
+Input 1: 70 BTH {cluster_A: 100%}
+Input 2: 30 BTH {cluster_B: 100%}
+─────────────────────────────────
+Output: 100 BTH {cluster_A: 70%, cluster_B: 30%}
+```
+
+**4. Tags Decay Over Time**
+
+Each transaction hop decays the tag by 5%, spreading attribution across the economy. But decay only applies if the UTXO is at least 720 blocks old (one to a few hours, depending on the load-adaptive block time), preventing wash trading attacks.
+
+### Why Splitting Doesn't Work
+
+This is what makes cluster tags special:
+
+```
+Whale splits 1,000,000 BTH into 1000 × 1000 BTH
+
+Before: 1 UTXO with {whale_cluster: 100%}
+After:  1000 UTXOs, each with {whale_cluster: 100%}
+
+Fee rate: unchanged (based on cluster wealth, not UTXO count)
+```
+
+The "source wealth" of a cluster is the total value minted by that minter — splitting doesn't reduce it.
+
+### Progressive Fee Curve
+
+The cluster factor determines how much you pay. It follows a smooth sigmoid curve in the *logarithm* of cluster wealth, with its midpoint at 100,000 BTH:
+
+| Cluster Wealth | Fee Multiplier |
+|----------------|----------------|
+| Small clusters (≤ ~1K BTH) | ~1x (base rate) |
+| Mid-size clusters (~100K BTH) | ~3.5x (curve midpoint) |
+| Whale clusters (≥ ~10M BTH) | ~6x (saturates) |
+
+The multiplier applies to a size-based fee (`per-byte rate × transaction size`), so the same transfer costs a whale cluster up to 6× what it costs well-circulated coins — and no amount of splitting changes that.
+
+### Lottery-Based Redistribution
+
+80% of all transaction fees are redistributed to eligible UTXOs via a lottery. 20% are burned.
+
+**How it works:**
+
+1. Each transaction pays a fee based on cluster factor
+2. 80% of the fee is split among 4 winners drawn with verifiable randomness
+3. 20% is permanently burned (deflationary)
+
+**How winners are selected (cluster-weighted):**
+
+A UTXO's winning weight is its **value divided by its cluster factor**. This is the only progressive weighting that is split-invariant:
+
+- Weights are value-based, so splitting a position into many UTXOs never increases total weight
+- The tilt comes from cluster provenance, which inherits through splits
+- Well-circulated (low-factor) coins win proportionally more; whale-cluster coins win less
+
+To participate, a UTXO must be at least 720 blocks old and worth at least 1 µBTH.
+
+### Ring Signatures and Tag Privacy
+
+Cluster tags work seamlessly with CLSAG ring signatures:
+
+**The challenge:** Ring signatures hide which input is real among 20 ring members. How do we calculate the correct fee?
+
+**The solution:** Centroid-based validation
+
+1. All ring members' tags are publicly known
+2. The fee derives from the value-weighted *centroid* of the ring's tags, with floors that stop cheap background decoys from dragging the factor down
+3. The claimed output tags must be at least 70% similar (cosine similarity) to the ring centroid, or the transaction is rejected
+
+This prevents fee evasion — you can't cherry-pick low-factor decoys to cut your fee, because implausible ring compositions fail validation.
+
+### Decay Mechanism Details
+
+To prevent wash trading (sending to yourself repeatedly to decay tags):
+
+**Age-Based Gating:**
+- Decay only applies to UTXOs at least 720 blocks old
+- New outputs from rapid self-transfers don't decay
+- The age gate naturally caps decay at ~12 events per day
+
+**Natural rate limiting:**
+
+| Attack | Result |
+|--------|--------|
+| 100 rapid self-transfers | 0% decay (all outputs too young) |
+| Patient attack (1 day) | ~46% max decay (only ~12 eligible hops) |
+| Patient attack (1 week) | ~99% decay — but you've paid ~84 transaction fees |
+| Holding without transacting | 0% decay |
+
+### Privacy Considerations
+
+**Phase 1 (Current):** Tags are public on UTXOs. This enables direct fee verification but reveals some provenance information.
+
+**Phase 2 (Planned):** Tags will be hidden using Pedersen commitments with zero-knowledge proofs. Validators verify correct fees without seeing actual tag values.
+
+### Economic Incentives
+
+The cluster tag system creates aligned incentives:
+
+| Behavior | Effect on Tags | Incentive |
+|----------|----------------|-----------|
+| **Circulate coins** | Tags decay and blend | Lower fees, higher lottery weight |
+| **Hoard wealth** | Tags remain concentrated | Higher fees, lower lottery weight, demurrage |
+| **Split into many UTXOs** | Tags unchanged | No benefit — fees and lottery weight are provenance- and value-based |
+
+### Technical Parameters
+
+| Parameter | Value | Purpose |
+|-----------|-------|---------|
+| Decay rate | 5% per eligible hop | Gradual tag diffusion |
+| Min UTXO age (decay + lottery) | 720 blocks | Wash trading prevention |
+| Min UTXO value (lottery) | 1 µBTH | Dust exclusion |
+| Cluster factor range | 1x–6x (midpoint 3.5x at 100K BTH) | Progressive fees |
+| Ring size | 20 | Privacy set for tag propagation |
+| Lottery winners | 4 per drawing | Redistribution granularity |
+| Burn rate | 20% of fees | Deflationary pressure |
+| Pool rate | 80% of fees | Redistribution amount |
+| Demurrage | 2%/yr at max factor (see Tokenomics) | Reaches idle concentrated wealth |
+
+### Summary
+
+Cluster tags solve the "Sybil-resistant progressive taxation" problem that plagues cryptocurrency:
+
+1. **Track provenance, not identity** — Coins remember their origin
+2. **Resist splitting attacks** — Cluster wealth is fixed at minting
+3. **Enable progressive fees** — Wealthy clusters pay more
+4. **Power fair redistribution** — Lottery weight tilts toward well-circulated coins
+5. **Preserve privacy** — Works with ring signatures
+6. **Encourage circulation** — Tags decay through commerce
+
+This makes Botho the first cryptocurrency with a credible mechanism for wealth-based fees that can't be trivially evaded.

--- a/web/packages/web-wallet/src/docs-content/en/consensus.md
+++ b/web/packages/web-wallet/src/docs-content/en/consensus.md
@@ -1,0 +1,73 @@
+## Stellar Consensus Protocol
+
+Botho uses the **Stellar Consensus Protocol (SCP)** for distributed consensus. SCP is a federated Byzantine agreement protocol that provides fast finality, energy efficiency, and flexible trust—without sacrificing decentralization.
+
+### Why Not Proof-of-Work Consensus?
+
+Proof-of-work (PoW) consensus, as used in Bitcoin, has significant drawbacks:
+
+- **Energy waste** - PoW deliberately consumes massive amounts of electricity as a security mechanism
+- **Slow finality** - Bitcoin transactions aren't truly final for an hour or more
+- **Centralization pressure** - Mining economies of scale push toward industrial operations
+- **51% attacks** - If an attacker controls majority hashpower, they can rewrite history
+
+**Botho still uses proof-of-work — but only for coin issuance, never for consensus.** Blocks are minted through CPU-egalitarian RandomX mining, which decides *who earns the block reward*. Whether that block is *accepted* is decided entirely by SCP. This decoupling means an attacker with majority hashpower can out-earn everyone else, but cannot rewrite history or censor transactions — and because hashpower buys no security, there is no arms-race pressure toward Bitcoin-scale energy consumption.
+
+### Why Not Proof-of-Stake?
+
+Proof-of-stake (PoS) improves on energy usage but introduces its own issues:
+
+- **Nothing-at-stake** - Validators can cheaply vote on multiple chain forks
+- **Wealth concentration** - The rich get richer through staking rewards
+- **Long-range attacks** - Old keys can potentially rewrite history
+- **Complexity** - PoS systems require intricate slashing and validator selection logic
+
+### How SCP Works
+
+SCP takes a fundamentally different approach based on **federated voting**:
+
+**Quorum Slices:** Each node in the network defines its own "quorum slice"—a set of other nodes it trusts. A node will only accept a statement as final when its quorum slice agrees.
+
+**Quorum Intersection:** The network is secure as long as all quorum slices share some nodes in common. This ensures that two conflicting statements cannot both achieve consensus.
+
+**Federated Voting:** Consensus proceeds through a series of voting rounds:
+
+1. **Nominate** - Nodes propose candidate values for the next block
+2. **Prepare** - Nodes vote to prepare a specific value
+3. **Commit** - Nodes vote to commit the prepared value
+4. **Externalize** - Once committed, the value is final
+
+**Key Insight:** Unlike PoW where you trust "the longest chain," in SCP you explicitly choose which nodes to trust. This makes the trust model transparent and auditable.
+
+### Properties of SCP
+
+**Decentralized Control:** No central authority determines consensus. Each node independently chooses its quorum slice based on its own assessment of trustworthiness.
+
+**Low Latency:** Transactions reach finality in seconds (typically 3-5 seconds under normal conditions), compared to minutes or hours for PoW systems.
+
+**Flexible Trust:** Participants can choose different quorum configurations based on their needs. Some may trust established institutions; others may trust a set of technical experts.
+
+**Asymptotic Security:** As the network grows and quorum slices become more interconnected, the system becomes more resilient against Byzantine failures.
+
+**Energy Efficiency:** SCP nodes only need to exchange messages and verify signatures—no computational puzzles, no energy waste.
+
+### Safety vs. Liveness
+
+SCP prioritizes **safety** over **liveness**:
+
+- **Safety:** The network will never confirm conflicting transactions
+- **Liveness:** The network should eventually make progress
+
+If the quorum structure is disrupted (too many nodes go offline), SCP will halt rather than risk confirming conflicting transactions. This is the correct trade-off for a monetary system—it's better to pause than to have funds stolen.
+
+### Quorum Configuration in Botho
+
+The Botho network starts with a bootstrap quorum centered on the foundation's seed nodes. Over time, as more independent nodes join, the quorum structure will become increasingly decentralized.
+
+Node operators can customize their quorum slice to trust:
+- The foundation's seed nodes (default)
+- Other known community nodes
+- Nodes run by exchanges or businesses they trust
+- Any combination of the above
+
+The health of the network depends on sufficient quorum intersection. The Botho explorer shows real-time quorum topology to help operators make informed decisions.

--- a/web/packages/web-wallet/src/docs-content/en/getting-started.md
+++ b/web/packages/web-wallet/src/docs-content/en/getting-started.md
@@ -1,0 +1,77 @@
+## Getting Started with Botho
+
+Botho is a privacy-focused cryptocurrency designed for the post-quantum era. It combines **stealth addresses** for transaction privacy with the **Stellar Consensus Protocol (SCP)** for fast, energy-efficient consensus. Unlike proof-of-work cryptocurrencies, Botho achieves finality in seconds while maintaining strong privacy guarantees.
+
+### What Makes Botho Different?
+
+Traditional cryptocurrencies like Bitcoin have transparent blockchains where anyone can trace the flow of funds between addresses. Even "privacy coins" often rely on cryptographic assumptions that may be broken by future quantum computers.
+
+Botho takes a different approach:
+
+- **Stealth addresses** ensure that each payment you receive goes to a unique one-time address, making it impossible to link your transactions together by watching the blockchain
+- **Post-quantum cryptography** protects your privacy against adversaries with quantum computers
+- **Federated Byzantine Agreement** provides fast finality — consensus safety never depends on hashpower
+- **Egalitarian issuance** distributes new coins through RandomX CPU mining that is deliberately decoupled from consensus: mining earns rewards but buys no say over which transactions confirm
+- **Progressive economics** — fees scale 1×–6× with wealth concentration, 80% of every fee is redistributed by lottery, and 20% is burned
+
+### Creating a Wallet
+
+Getting started with Botho takes just a few steps:
+
+1. **Visit the Wallet page** - Click "Launch Wallet" from the homepage or navigate directly to the wallet
+2. **Choose "Create New Wallet"** - You can also import an existing wallet if you have a recovery phrase
+3. **Secure your recovery phrase** - You'll be shown a 24-word mnemonic phrase. Write this down on paper and store it in a safe place. This phrase is the **only way** to recover your funds if you lose access to your device
+4. **Optional: Set a password** - Add an encryption password for additional security. You'll need this password each time you open the wallet in this browser
+
+**Important:** Never share your recovery phrase with anyone. Anyone with these words can access your funds. Never store it digitally (no screenshots, no cloud storage, no password managers).
+
+### Understanding Your Wallet Address
+
+Your wallet address looks like this: `botho://1/4nuKn2U5qsRk3vD...` (about 90 characters total)
+
+This address format includes:
+- **Protocol identifier** (`botho://` on mainnet, `tbotho://` on testnet) - Different prefixes prevent accidental cross-network sends
+- **Address version** (`1/` for classical addresses, `1q/` for quantum-safe addresses)
+- **Public keys** - Your view key and spend key, encoded together in base58
+
+Quantum-safe addresses (`1q/`) additionally embed ML-KEM and ML-DSA public keys, which makes them much longer (~4,400 characters) — better suited to QR codes and files than manual copying.
+
+You can safely share this address with anyone who wants to send you funds. Thanks to stealth addresses, each incoming transaction will be sent to a unique derived address that only you can spend from.
+
+### Receiving Your First Payment
+
+When someone sends you BTH:
+
+1. They use your public address to derive a unique one-time address
+2. The transaction is broadcast to the network and included in a block
+3. Your wallet scans new blocks and detects payments addressed to you
+4. The funds appear in your balance, usually within one block — block time adapts to network load, from 3 seconds under very heavy traffic up to 40 seconds when the network is idle
+
+### Sending Payments
+
+To send BTH to someone else:
+
+1. Click the **Send** button in your wallet
+2. Enter the recipient's Botho address
+3. Enter the amount to send
+4. Review the transaction details including the fee
+5. Confirm the transaction
+
+Transactions are final once confirmed—there are no chargebacks or reversals in Botho.
+
+### Transaction Fees
+
+Every Botho transaction requires a small fee. These fees serve three purposes:
+
+1. **Spam prevention** - Fees make it expensive to flood the network with junk transactions
+2. **Progressive taxation** - Fees scale 1× to 6× based on cluster wealth, discouraging concentration without enabling Sybil attacks
+3. **Redistribution and deflation** - 80% of every fee is redistributed to holders through a lottery; the remaining 20% is permanently burned
+
+Fees are size-based, not amount-based: `fee = per-byte rate × transaction size × cluster factor (1×–6×) × output penalty`. See the Cluster Tags and Tokenomics sections for details.
+
+### Security Best Practices
+
+- **Back up your recovery phrase** on paper, stored in a secure location
+- **Use a password** to encrypt your wallet in the browser
+- **Consider running your own node** for maximum privacy
+- **Verify addresses carefully** before sending funds—transactions cannot be reversed

--- a/web/packages/web-wallet/src/docs-content/en/network.md
+++ b/web/packages/web-wallet/src/docs-content/en/network.md
@@ -1,0 +1,108 @@
+## Network Information
+
+This page provides technical details about the Botho network, including connection information, network parameters, and security model.
+
+### Network Status
+
+The Botho network is currently in **testnet** phase. This means:
+
+- Coins have no monetary value
+- The network may be reset during development
+- Features are still being tested and refined
+- Bug reports and feedback are welcome
+
+Production mainnet launch will be announced when the network is stable.
+
+### Connecting to the Network
+
+**Seed Discovery:**
+
+Bootstrap peers are discovered via DNS TXT records rather than a hardcoded list:
+
+| Network | DNS Seed Domain |
+|---------|-----------------|
+| Mainnet | seeds.botho.io |
+| Testnet | seeds.testnet.botho.io |
+
+When your node starts, it resolves the seed domain to learn about bootstrap peers (you can also pin explicit `bootstrap_peers` in the config). After initial discovery, your node maintains connections to multiple peers for redundancy.
+
+**Peer Discovery:**
+
+Botho uses libp2p for networking, which supports multiple discovery mechanisms:
+
+- **Bootstrap nodes** - Known seed nodes for initial connection
+- **mDNS** - Local network discovery for development
+- **Kademlia DHT** - Distributed peer discovery
+- **Gossipsub** - Topic-based message propagation
+
+### Network Parameters
+
+**Block Production:**
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| Block time | 3–40 seconds (load-adaptive) | Fast blocks under heavy traffic (3 s only at 20+ tx/s), slow blocks when idle |
+| Max block size | 20 MB | Maximum serialized block size |
+| Max transactions per block | 5,000 | Transaction count limit |
+
+**Transaction Limits:**
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| Max inputs | 16 | Maximum inputs per transaction |
+| Max outputs | 16 | Maximum outputs per transaction |
+| Ring size | 20 | Number of members in CLSAG ring signature |
+| Max tx size | 100 KB | Maximum serialized transaction size |
+
+**Fees:**
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| Fee formula | per-byte rate × size × cluster factor × output penalty | Size-based, wealth-progressive |
+| Cluster factor | 1x–6x | Progressive multiplier from coin provenance |
+| Output penalty | quadratic, capped at 100x | Anti-UTXO-farming |
+| Fee destination | 80% lottery / 20% burned | Redistribution plus deflationary pressure |
+
+### Port Reference
+
+Defaults differ by network (mainnet / testnet); all are configurable:
+
+| Port (mainnet / testnet) | Protocol | Purpose |
+|--------------------------|----------|---------|
+| 7100 / 17100 | TCP | P2P gossip (libp2p) |
+| 7101 / 17101 | HTTP + WebSocket | JSON-RPC API and real-time updates |
+| 9090 / 19090 | HTTP | Prometheus metrics |
+
+### Network Security
+
+**Sybil Resistance:**
+
+The network resists Sybil attacks through:
+- Quorum-based consensus (SCP)
+- Reputation scoring for peers
+- Resource requirements for block minting
+
+**Eclipse Protection:**
+
+Nodes protect against eclipse attacks by:
+- Maintaining diverse peer connections
+- Preferring peers with established history
+- Regular peer rotation
+- Multiple independent peer discovery methods
+
+### Getting Involved
+
+**For Developers:**
+- Source code: [github.com/botho-project/botho](https://github.com/botho-project/botho)
+- Report bugs via GitHub issues
+- Contributions welcome (see CONTRIBUTING.md)
+
+**For Node Operators:**
+- Run a node to strengthen the network
+- Enable minting if you have reliable uptime
+- Monitor your node's quorum intersection
+
+**For Users:**
+- Test the wallet and report issues
+- Provide feedback on user experience
+- Help with documentation and translations

--- a/web/packages/web-wallet/src/docs-content/en/privacy-progressivity.md
+++ b/web/packages/web-wallet/src/docs-content/en/privacy-progressivity.md
@@ -1,0 +1,216 @@
+## How Botho Achieves Both Privacy and Progressivity
+
+This is Botho's most surprising achievement: **privacy and progressive economics working together, not against each other.**
+
+The conventional wisdom says these goals are incompatible. To tax the wealthy more, you need to know who's wealthy. But knowing who's wealthy means tracking identity and balances—the opposite of privacy.
+
+Botho proves this trade-off is false. Here's how.
+
+### The Apparent Impossibility
+
+Consider what "progressive taxation" traditionally requires:
+
+1. **Identify the taxpayer** — Link transactions to a person
+2. **Track their wealth** — Know how much they own
+3. **Apply graduated rates** — Charge more to those with more
+
+Every step violates privacy. If you know Alice has 1M coins, you've already destroyed her financial privacy.
+
+This creates what seems like a fundamental conflict:
+
+| Goal | Requires |
+|------|----------|
+| **Privacy** | Hide who owns what |
+| **Progressivity** | Know who owns what |
+
+Most projects accept this trade-off, choosing either:
+- **Full privacy** (Monero, Zcash): No progressive fees possible
+- **Full transparency** (Bitcoin, Ethereum): Progressive fees possible but no privacy
+
+Botho takes a third path.
+
+### The Key Insight: Provenance, Not Identity
+
+The breakthrough is realizing that progressive taxation doesn't *require* knowing identity or total wealth. It requires **correlating fees with economic behavior**.
+
+Instead of asking "Who owns this coin and how rich are they?" Botho asks:
+
+> "Where did this coin come from, and how much has it circulated?"
+
+This question has a surprising property: **it's answerable on-chain without linking to identity.**
+
+### What We Track: Minting Proximity
+
+Every coin in Botho carries a "cluster tag" — a memory of which minting event created it. This is not tracking the *owner*, but the *origin*.
+
+| Coin State | Tags | Fee Level |
+|------------|------|-----------|
+| Freshly minted | `{cluster_A: 100%}` | High |
+| Well-traded | `{cluster_A: 5%, cluster_B: 15%, ...}` | Low |
+
+The key properties:
+
+| Property | Effect |
+|----------|--------|
+| **Concentrated tags** | Recently minted, not yet circulated → High fees |
+| **Diversified tags** | Traded through many hands → Low fees |
+| **Splitting-resistant** | Splitting preserves tag concentration |
+| **Decay-resistant** | Only real commerce reduces tags |
+
+### Why This Is Progressive
+
+Here's where it gets interesting. **Minting proximity correlates with wealth concentration** in predictable ways:
+
+**New minters tend to be wealthy.** Earning block rewards requires hardware, electricity, and reliable uptime. Even with CPU-egalitarian RandomX mining, fresh coins disproportionately go to those with existing resources.
+
+**Active traders tend to be merchants.** Small businesses and regular users transact frequently, causing their coins to mix with coins from many sources.
+
+**Hoarders keep concentrated tags.** If you mine coins and hold them without trading, your tags never decay. You keep paying high fees.
+
+**Commerce diversifies naturally.** Every legitimate transaction mixes your tags with your counterparty's tags. Economic activity automatically reduces your fee rate.
+
+This creates a **behavioral correlation**:
+
+| Behavior Pattern | Tag State | Fee Level |
+|------------------|-----------|-----------|
+| Mine and hold (wealthy behavior) | Concentrated | High |
+| Active commerce (merchant behavior) | Diversified | Low |
+| Regular user spending | Mixed | Medium→Low |
+| Whale accumulating | Concentrated | High |
+
+We don't need to know *who* you are. We just observe *how your coins behave*.
+
+### What Remains Private
+
+This is crucial: **cluster tags reveal provenance, not identity.**
+
+| Information | Status |
+|-------------|--------|
+| Who owns a UTXO | **Private** (ring signatures) |
+| Who received a payment | **Private** (stealth addresses) |
+| Amount transferred | **Private** (confidential transactions) |
+| Your total balance | **Private** (no account linkage) |
+| Which UTXO you spent | **Private** (ring signatures) |
+| Where coins originated | Public (cluster tags) |
+| How diversified tags are | Public (enables fee calculation) |
+
+You reveal *something*—the coin's history—but not *who you are* or *what you own*.
+
+### The Ring Signature Integration
+
+Ring signatures and cluster tags work together seamlessly:
+
+**How ring signatures work:** When you spend, you prove "I own ONE of these 20 UTXOs" without revealing which one. This provides sender privacy.
+
+**The challenge:** If we don't know which UTXO you're spending, how do we calculate the correct fee?
+
+**The solution: Centroid-based validation.**
+
+1. All 20 ring members' tags are publicly visible
+2. The fee derives from the **value-weighted centroid** of the ring's tags, with floors so cheap background decoys can't drag the factor down
+3. The output tags you claim must be at least 70% similar to that centroid, or validators reject the transaction
+
+```
+Ring members' tags → value-weighted centroid → cluster factor
+Claimed output tags: must be ≥ 70% similar to the centroid
+```
+
+This means **privacy doesn't enable fee evasion.** A large real input dominates its own ring's centroid, so cherry-picking low-factor decoys produces an implausible ring that fails validation instead of a discount.
+
+### The Lottery Redistribution
+
+Fees flow back to the community through a cluster-tilted lottery:
+
+**80% of all fees** are redistributed to eligible UTXOs. **20% are burned** (deflationary).
+
+**How selection works:**
+
+```
+weight = value ÷ cluster factor
+
+Well-circulated UTXO (factor 1x):  full weight per BTH
+Whale-cluster UTXO (factor 6x):    1/6 the weight per BTH
+```
+
+**Well-circulated coins win up to 6× more per BTH than concentrated wealth.** This is progressive redistribution without knowing anyone's identity — and because weight is value-based, splitting a position into many UTXOs never increases its total weight.
+
+**Eligibility gates** prevent gaming: a UTXO must be at least 720 blocks old and worth at least 1 µBTH to participate.
+
+### Attack Resistance
+
+We've tested these mechanisms extensively:
+
+**Splitting Attack:**
+```
+Attacker: Split 1M BTH into 1000 × 1K BTH
+Result: Each piece still has {whale_cluster: 100%}
+Fee reduction: 0% (cluster factor unchanged)
+Verdict: Attack defeated
+```
+
+**Sybil Attack (Multiple Accounts):**
+```
+Attacker: Create 100 sybil addresses, send 10K to each
+Result: Each sybil's UTXO inherits whale tags
+Fee reduction: Minimal (tags propagate)
+Verdict: Attack defeated
+```
+
+**Parking Attack (Split and Wait):**
+```
+Attacker: Split into 100 UTXOs, wait for lottery winnings
+Result: Weight is value-based — splitting gains NO weight
+        Cluster factor inherits — the tilt still works against you
+        Quadratic output fees make the split itself cost up to 100×
+Verdict: Attack defeated
+```
+
+**Wash Trading (Self-transfers):**
+```
+Attacker: Send to self rapidly to decay tags
+Result: Age-gating requires 720 blocks per decay
+        At most ~12 decays per day ≈ 46% daily decay
+        1 week of wash trading: ~99% decay
+        Cost: ~84 transaction fees (each feeding the lottery)
+Verdict: Expensive, slow, detectable
+```
+
+### The Complete Picture
+
+Botho achieves privacy + progressivity through layered design:
+
+| Layer | Privacy Feature | Progressive Feature |
+|-------|-----------------|---------------------|
+| **Sender** | Ring signatures (1-of-20) | Centroid-validated tag propagation |
+| **Recipient** | Stealth addresses | — |
+| **Amount** | Pedersen commitments | — |
+| **Fee rate** | — | Cluster factor curve (1-6×) |
+| **Holding cost** | — | Demurrage on idle wealthy-cluster coins |
+| **Redistribution** | Verifiable random drawing | Cluster-tilted weights (value ÷ factor) |
+
+Each layer contributes to both goals without conflict.
+
+### Why This Matters
+
+This isn't just a technical achievement—it changes what's possible:
+
+**For users:** You get financial privacy AND a fair economic system. No trade-off required.
+
+**For merchants:** Low fees reward economic activity. The more you trade, the lower your rates.
+
+**For the network:** Wealth naturally flows from concentrated to distributed holdings. Self-custody is rewarded over custodial services.
+
+**For the ecosystem:** We've proven that "privacy vs. fairness" is a false dichotomy. Other projects can adopt these techniques.
+
+### Summary
+
+Botho's privacy + progressivity mechanism works because:
+
+1. **We track provenance, not identity** — Where coins came from, not who owns them
+2. **Provenance correlates with wealth behavior** — Fresh minters are wealthy, active traders are merchants
+3. **Ring signatures preserve privacy** — Centroid validation prevents gaming
+4. **Cluster-tilted lottery is progressive** — Well-circulated coins win more per BTH
+5. **Value-based weights and quadratic output fees deter attacks** — Parking and splitting don't pay off
+6. **Commerce is rewarded** — Tags decay through legitimate trade; idle concentrated wealth pays demurrage
+
+The result: **The first cryptocurrency where you can be private AND contribute fairly to the network, where the wealthy pay more without anyone knowing who they are.**

--- a/web/packages/web-wallet/src/docs-content/en/privacy.md
+++ b/web/packages/web-wallet/src/docs-content/en/privacy.md
@@ -1,0 +1,90 @@
+## Privacy Features
+
+Privacy is not just a feature in Botho—it's a fundamental design principle. Every aspect of the protocol is designed to protect your financial privacy while maintaining the auditability properties needed for a sound monetary system.
+
+### Why Privacy Matters
+
+Financial privacy is essential for:
+
+- **Personal security** - Public wealth makes you a target for criminals
+- **Business confidentiality** - Competitors shouldn't see your supplier payments or revenue
+- **Fungibility** - Money should be interchangeable; tainted coins create a two-tier system
+- **Human dignity** - Your financial life is nobody's business but your own
+- **Censorship resistance** - When all transactions look identical, there's no basis for blocking particular payments. Bitcoin works hard to solve this problem with various techniques, but privacy-by-default solves it elegantly: validators cannot discriminate because they cannot distinguish
+
+### Stealth Addresses
+
+Stealth addresses are the foundation of Botho's privacy model. Here's how they work:
+
+**The Problem:** In Bitcoin, if you publish an address to receive donations, anyone can see every donation you've ever received by looking at that address on the blockchain.
+
+**The Solution:** In Botho, your public address is not where funds are actually sent. Instead, each sender uses your public address to mathematically derive a unique one-time address. Only you can detect and spend from these derived addresses.
+
+**Technical Details:**
+
+1. Your wallet has a **view keypair** and a **spend keypair**
+2. The sender generates a random value and combines it with your public keys
+3. This produces a one-time address that appears random to everyone else
+4. Your wallet uses your private view key to scan for payments addressed to you
+5. To spend, you use your private spend key to sign the transaction
+
+The result: Even if you publish your address publicly, no one watching the blockchain can determine how many payments you've received, when you received them, or how much they were for.
+
+### Ring Signatures (Private Transactions)
+
+When you send a **Private transaction**, Botho uses **CLSAG ring signatures** to hide which specific coins you're spending. Your transaction references 20 possible inputs (a "ring"), and the signature proves you own one of them without revealing which one.
+
+CLSAG (Concise Linkable Spontaneous Anonymous Group) is an efficient ring signature scheme that provides strong sender privacy with compact signatures (~700 bytes per input).
+
+This breaks the transaction graph that would otherwise allow tracing funds through the blockchain. An observer sees that *someone* in the ring spent *some* coins, but cannot determine which participant or which specific coins.
+
+> **Note:** All value transfers use ring signatures. Minting transactions (block rewards) use ML-DSA signatures since the minter is public.
+
+### Confidential Amounts
+
+In all **Private transactions** (which includes all value transfers), amounts are hidden using **Pedersen commitments** with **Bulletproofs** range proofs. These cryptographic constructs allow the network to verify that transactions balance (inputs equal outputs plus fees) without revealing the actual amounts.
+
+Validators can confirm:
+- No new money is created from thin air
+- The sender has sufficient funds
+- The fee is at least the minimum required
+- All amounts are positive (via Bulletproofs)
+
+But they cannot determine:
+- How much is being transferred
+- The sender's total balance
+- The recipient's total balance
+
+> **Note:** Minting transactions (block rewards) have public amounts for supply auditability, but recipients are still hidden via stealth addresses.
+
+### Post-Quantum Cryptography
+
+Quantum computers pose a future threat to the cryptographic algorithms that secure most cryptocurrencies today. Botho uses a **hybrid post-quantum architecture** that protects the most critical data while keeping transactions efficient.
+
+**Algorithms Used:**
+
+- **ML-KEM-768** (FIPS 203) - Post-quantum stealth addresses (recipient privacy is permanent)
+- **ML-DSA-65** (FIPS 204) - Post-quantum signatures for minting transactions
+- **CLSAG** - Classical ring signatures for private transactions (sender privacy is ephemeral)
+- **Pedersen + Bulletproofs** - Information-theoretic amount hiding (quantum-safe)
+
+**Why This Architecture?**
+
+Recipient identity is recorded on-chain forever—a quantum attacker in 2045 could link recipients from 2025 transactions. ML-KEM protects against this "harvest now, decrypt later" threat. Sender privacy, however, is ephemeral—its value degrades over time as economic context becomes historical. Using classical CLSAG keeps transactions small (~4 KB vs ~65 KB for post-quantum alternatives).
+
+**Transaction Types:**
+
+| Type | Recipient | Amount | Sender | Use Case |
+|------|-----------|--------|--------|----------|
+| Minting | Hidden (ML-KEM) | Public | Known (ML-DSA) | Block rewards |
+| Private | Hidden (ML-KEM) | Hidden | Hidden (CLSAG ring=20) | All transfers (~4 KB) |
+
+Recipients and amounts are protected against quantum computers. Sender privacy uses efficient classical signatures.
+
+### Privacy Best Practices
+
+To maximize your privacy when using Botho:
+
+1. **Run your own node** - This prevents revealing your addresses to third-party servers
+2. **Use a new address for each context** - While stealth addresses protect received funds, using separate addresses for work vs personal adds another layer
+3. **Be mindful of metadata** - Privacy on-chain doesn't help if you reveal information off-chain

--- a/web/packages/web-wallet/src/docs-content/en/running-node.md
+++ b/web/packages/web-wallet/src/docs-content/en/running-node.md
@@ -1,0 +1,157 @@
+## Running a Botho Node
+
+Running your own Botho node gives you the highest level of privacy and helps strengthen the network. When you run a node, your wallet connects directly to the blockchain without relying on third-party servers.
+
+### Why Run a Node?
+
+**Privacy:** When you use a light wallet or web wallet, you're trusting a server not to log your addresses or transactions. Running your own node means your wallet activity stays on your machine.
+
+**Verification:** Your node independently validates every transaction and block. You don't have to trust anyone's claims about the state of the network.
+
+**Network health:** More nodes make the network more resilient. Your node relays transactions and blocks, helping the network function.
+
+**Minting advantage:** Running your own node gives you lower latency in the minting competition. Nodes that receive new blocks faster can begin working on the next block sooner, increasing their chances of earning minting rewards.
+
+**Participation:** If you want to mint new blocks or participate in consensus, you need a full node.
+
+### System Requirements
+
+**Minimum Requirements:**
+- 2 CPU cores
+- 4 GB RAM
+- 50 GB SSD storage
+- 10 Mbps internet connection
+
+**Recommended:**
+- 4+ CPU cores
+- 8 GB RAM
+- 100 GB NVMe SSD
+- 100 Mbps internet connection
+
+The blockchain is currently small, but storage requirements will grow over time.
+
+### Installation
+
+**From Source (Recommended):**
+
+```bash
+# Install Rust if you haven't already
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Clone the repository
+git clone https://github.com/botho-project/botho.git
+cd botho
+
+# Build in release mode
+cargo build --release
+
+# The binary is at ./target/release/botho
+```
+
+**First-Time Setup:**
+
+```bash
+# Initialize a new wallet and configuration
+./target/release/botho init
+
+# This will:
+# - Generate a 24-word recovery phrase
+# - Create your config and wallet under ~/.botho/
+
+# Variants:
+#   botho init --recover   # restore a wallet from an existing mnemonic
+#   botho init --relay     # relay/seed node config with no wallet
+```
+
+**IMPORTANT:** Write down your recovery phrase and store it securely!
+
+### Running the Node
+
+**Basic operation:**
+
+```bash
+# Start the node and sync with the network
+./target/release/botho run
+```
+
+**With minting enabled:**
+
+```bash
+# Start the node and participate in block production
+./target/release/botho run --mint
+```
+
+### CLI Commands Reference
+
+**Wallet Commands:**
+
+| Command | Description |
+|---------|-------------|
+| `botho init` | Create a new wallet with a 24-word mnemonic |
+| `botho balance` | Show your current wallet balance |
+| `botho address` | Display your receiving address (`--save` writes it to a file) |
+| `botho send <address> <amount>` | Send BTH (amount in BTH; `--quantum` for post-quantum crypto, `--memo` to attach an encrypted note) |
+
+All sends use CLSAG ring signatures — sender privacy is on by default, not a flag.
+
+**Node Commands:**
+
+| Command | Description |
+|---------|-------------|
+| `botho run` | Start the node and sync with the network |
+| `botho run --mint` | Start with minting enabled (`--mint-threads N` to limit CPU use) |
+| `botho status` | Show node sync status and peer count |
+| `botho snapshot` | Manage UTXO snapshots for fast initial sync |
+
+### Configuration
+
+The configuration file lives under `~/.botho/`. All ports have network-specific defaults, so a minimal config works out of the box:
+
+```toml
+# "mainnet" or "testnet"
+network_type = "testnet"
+
+[network]
+# Defaults: gossip 7100 (mainnet) / 17100 (testnet)
+#           RPC    7101 (mainnet) / 17101 (testnet)
+#           metrics 9090 (mainnet) / 19090 (testnet), 0 disables
+# gossip_port = 17100
+# rpc_port = 17101
+# metrics_port = 19090
+
+# Optional explicit bootstrap peers (multiaddr format).
+# If unset, peers are discovered via DNS seed TXT records
+# (seeds.botho.io / seeds.testnet.botho.io).
+# bootstrap_peers = ["/dns4/eu.seed.botho.io/tcp/7100/p2p/<peer-id>"]
+
+[minting]
+enabled = false
+threads = 0   # 0 = use all CPU cores
+```
+
+### Firewall Configuration
+
+If you want your node to accept incoming connections (recommended):
+
+```bash
+# Allow P2P gossip traffic (17100 on testnet, 7100 on mainnet)
+sudo ufw allow 17100/tcp
+
+# Optional: Allow RPC access (only if needed externally)
+# sudo ufw allow 17101/tcp
+```
+
+### Troubleshooting
+
+**Node won't sync:**
+- Check your internet connection
+- Verify firewall allows outbound connections on the gossip port
+- As a last resort, clear the chain database under `~/.botho/` and resync (testnet only — this rescans from genesis)
+
+**High memory usage:**
+- Reduce minting threads (RandomX keeps a large in-memory dataset)
+- Consider adding swap space if RAM is limited
+
+**Can't connect to peers:**
+- Ensure your gossip port (17100 testnet / 7100 mainnet) is open for incoming connections
+- Check if you're behind a strict NAT

--- a/web/packages/web-wallet/src/docs-content/en/tokenomics.md
+++ b/web/packages/web-wallet/src/docs-content/en/tokenomics.md
@@ -1,0 +1,144 @@
+## Tokenomics
+
+Botho (BTH) uses a two-phase emission model designed for long-term sustainability: an initial distribution phase with halvings, followed by perpetual tail emission targeting stable inflation.
+
+### Overview
+
+| Parameter | Value |
+|-----------|-------|
+| Token symbol | BTH |
+| Smallest unit | picocredit (10⁻¹² BTH) |
+| Pre-mine | None (100% mined) |
+| Phase 1 supply | ~611 million BTH |
+| Block time | 3–40 seconds (load-adaptive; 5 s monetary baseline) |
+
+### Unit System
+
+BTH uses 12-decimal precision. The picocredit is the single base unit — every amount on the wire (balances, fees, cluster wealth) is denominated in picocredits, and formatting into BTH happens only in the display layer:
+
+- **1 picocredit** = 0.000000000001 BTH (smallest unit)
+- **1 microBTH (µBTH)** = 1,000,000 picocredits = 0.000001 BTH
+- **1 milliBTH (mBTH)** = 1,000,000,000 picocredits = 0.001 BTH
+- **1 BTH** = 1,000,000,000,000 picocredits
+
+---
+
+## Emission Schedule
+
+All monetary math assumes the 5-second high-load block time (actual blocks range 3–40 s, dropping to 3 s only at very high load, 20+ tx/s). When the network is idle and blocks slow down (up to 40 s), emission stretches proportionally — a natural dampener: a busy network emits at the full schedule, an idle one emits less.
+
+### Phase 1: Halving Period (~5 years at full load)
+
+The minting reward starts at 50 BTH and halves every **6,307,200 blocks** (one year of 5-second blocks). After five halving epochs, Phase 1 has distributed **611,010,000 BTH**:
+
+| Epoch | Minting Reward | Cumulative Supply |
+|-------|----------------|-------------------|
+| 1 | 50 BTH | ~315.4M BTH |
+| 2 | 25 BTH | ~473.0M BTH |
+| 3 | 12.5 BTH | ~552.0M BTH |
+| 4 | 6.25 BTH | ~591.3M BTH |
+| 5 | 3.125 BTH | ~611.0M BTH |
+
+(This is the canonical schedule ratified in issue #351, locked by regression tests in the node.)
+
+### Phase 2: Tail Emission
+
+After Phase 1, Botho transitions to perpetual tail emission targeting **2% annual net inflation** (gross emission minus fee burns), with difficulty adjusting to hit the target.
+
+**Why tail emission?**
+
+- **Security budget** - Ensures minters always have incentive to secure the network
+- **Lost coin replacement** - Compensates for coins lost to forgotten keys
+- **Predictable monetary policy** - 2% is below typical fiat inflation
+
+At the ~611M BTH Phase-1 supply and full load, 2% works out to roughly **2 BTH per block**, growing slowly with supply.
+
+---
+
+## Fee Structure
+
+### Transaction Fees
+
+Every fee is split two ways: **80% is redistributed** to holders through the cluster-tilted lottery, and **20% is burned**, creating deflationary pressure that offsets tail emission.
+
+```
+fee = per-byte rate × transaction size × cluster factor × output penalty + memo fees
+```
+
+| Parameter | Value |
+|-----------|-------|
+| Fee basis | Transaction size (bytes), not amount |
+| Cluster factor | 1x–6x progressive multiplier |
+| Output penalty | Quadratic in output count, capped at 100x |
+| Memo fee | Flat per encrypted memo |
+| Fee destination | 80% lottery pool / 20% burned |
+| Priority | Higher fees = faster confirmation |
+
+### Cluster-Based Progressive Fees
+
+Botho implements a novel **progressive fee system** that taxes wealth concentration without enabling Sybil attacks.
+
+**The core innovation:** Instead of taxing based on transaction amount (easily gamed by splitting), fees are based on coin *provenance* — where coins originally came from.
+
+| Parameter | Value |
+|-----------|-------|
+| Cluster factor range | 1x to 6x multiplier |
+| Curve shape | Sigmoid in log(cluster wealth), midpoint 3.5x at 100K BTH |
+| Tag decay | 5% per eligible hop |
+
+**Why it's Sybil-resistant:** Splitting coins doesn't change their origin. A whale's coins carry the same cluster tag whether held in 1 UTXO or 1000.
+
+### Demurrage
+
+Transaction fees are a consumption tax — they can't touch wealth that never moves. Demurrage closes that gap: a **holding charge on wealthy-cluster coins, paid when they are eventually spent**.
+
+| Parameter | Value |
+|-----------|-------|
+| Rate | 2% per year at the maximum (6x) cluster factor |
+| Scaling | Proportional to (factor − 1) — factor-1 coins pay **zero** |
+| Bootstrap | Disabled during the first halving epoch |
+| Proceeds | Flow into the lottery redistribution pool |
+
+Everyday coins never pay demurrage; it binds only concentrated, idle wealth. Churning doesn't escape it — spending pays the accrued charge first, so the total paid over any holding period is the same no matter how often you self-transfer (and each transfer adds fees on top).
+
+> **See the [Cluster Tags](#cluster-tags) section** for a complete explanation of how provenance tracking, progressive fees, lottery redistribution, and ring signature privacy work together.
+
+---
+
+## Supply Projections
+
+### Long-Term Growth
+
+At sustained full load (5-second blocks; slower when the network is idle):
+
+| Epoch | Approximate Supply | Annual Inflation |
+|-------|-------------------|------------------|
+| 1 | ~315M BTH | High (initial) |
+| 3 | ~552M BTH | ~17% |
+| 5 | ~611M BTH | ~3% |
+| Tail (perpetual) | +2%/year net of burns | 2% |
+
+---
+
+## Economic Design Philosophy
+
+### Why No Pre-mine?
+
+- **Fair distribution** - Everyone starts equal; early minters take on risk
+- **Credibility** - No insider advantage or founder enrichment
+- **Decentralization** - No concentrated holdings from day one
+
+### Why Split Fees 80/20?
+
+- **Redistribution** - 80% flows back to holders via the cluster-tilted lottery, favoring well-circulated coins
+- **Deflationary pressure** - The 20% burn offsets tail emission
+- **Predictable** - Net inflation = gross emission − burns
+
+### Why Progressive Cluster Fees?
+
+- **Reduce concentration** — Wealthy clusters pay more
+- **Sybil-resistant** — Can't avoid by splitting accounts
+- **Encourage circulation** — Moving coins diffuses tags, reducing fees
+- **Privacy-compatible** — Works with ring signatures and stealth addresses
+
+> **Deep dive:** See the [Cluster Tags](#cluster-tags) documentation for the complete technical explanation.

--- a/web/packages/web-wallet/src/docs-content/es/api.md
+++ b/web/packages/web-wallet/src/docs-content/es/api.md
@@ -1,0 +1,203 @@
+## API JSON-RPC
+
+Los nodos de Botho exponen una API JSON-RPC 2.0 en el puerto **7101** (mainnet) o **17101** (testnet) por defecto; se puede cambiar con `rpc_port` en la configuración. Todas las solicitudes usan el formato estándar JSON-RPC 2.0.
+
+### Formato de la solicitud
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "METHOD_NAME",
+  "params": { ... },
+  "id": 1
+}
+```
+
+---
+
+## Métodos del nodo
+
+### node_getStatus
+
+Obtiene el estado del nodo y la información de sincronización.
+
+**Respuesta (campos seleccionados):**
+- `version` - Versión del software del nodo
+- `network` - Nombre de la red (p. ej., "botho-testnet")
+- `uptimeSeconds` - Tiempo de actividad del nodo en segundos
+- `syncStatus` / `syncProgress` / `synced` - Estado de sincronización en vivo
+- `chainHeight` - Altura actual de la cadena de bloques
+- `tipHash` - Hash del último bloque
+- `peerCount` / `scpPeerCount` - Pares conectados / pares que participan en SCP
+- `mempoolSize` - Transacciones en el mempool
+- `mintingActive` - Si la acuñación está habilitada
+- `quorumFaultTolerant` / `quorumDegenerate` - Postura BFT (la tolerancia a fallos requiere ≥ 4 nodos participantes)
+
+La respuesta completa también incluye información de compilación, el progreso de las ranuras de SCP, el estado de la puerta de quórum y campos de salud del minero para monitoreo.
+
+---
+
+## Métodos de la cadena
+
+### getChainInfo
+
+Obtiene información de la cadena de bloques.
+
+**Respuesta:**
+- `height` - Altura de bloque actual
+- `tipHash` - Hash del bloque de la punta
+- `difficulty` - Dificultad de minería actual
+- `totalMined` - Total de monedas minadas (en picocréditos, como cadena)
+- `totalFeesBurned` - Comisiones quemadas acumuladas (en picocréditos, como cadena)
+- `circulatingSupply` - totalMined menos las quemas (en picocréditos, como cadena)
+- `mempoolSize` - Número de transacciones pendientes
+- `mempoolFees` - Total de comisiones en el mempool
+
+### getBlockByHeight
+
+Obtiene un bloque por su altura.
+
+**Parámetros:**
+- `height` (número) - Altura de bloque
+
+**Respuesta:**
+- `height` - Altura de bloque
+- `hash` - Hash del bloque
+- `prevHash` - Hash del bloque anterior
+- `timestamp` - Marca de tiempo del bloque
+- `difficulty` - Dificultad del bloque
+- `nonce` - Nonce de minería
+- `txCount` - Número de transacciones
+- `mintingReward` - Importe de la recompensa de acuñación
+
+### getMempoolInfo
+
+Obtiene estadísticas del mempool.
+
+**Respuesta:**
+- `size` - Número de transacciones
+- `totalFees` - Total de comisiones de todas las transacciones
+- `txHashes` - Array de hashes de transacción (hasta 100)
+
+### estimateFee (alias: tx_estimateFee)
+
+Estima la comisión de una transacción.
+
+**Parámetros:**
+- `amount` (número) - Importe de la transacción
+- `memos` (número) - Número de campos de memo cifrados
+
+**Respuesta:**
+- `minimumFee` - Comisión mínima requerida
+- `clusterFactor` - Multiplicador progresivo, escalado ×1000 (1000 = 1x, 6000 = 6x)
+- `clusterFactorDisplay` - Factor legible para humanos (p. ej., "1.25x")
+- `clusterWealth` - Riqueza del clúster de la que se derivó el factor
+- `recommendedFee` - Comisión recomendada para prioridad normal
+- `highPriorityFee` - Comisión para confirmación de alta prioridad
+
+---
+
+## Métodos del monedero
+
+### chain_getOutputs
+
+Obtiene las salidas de transacción para la sincronización del monedero.
+
+**Parámetros:**
+- `start_height` (número) - Altura de bloque inicial
+- `end_height` (número) - Altura de bloque final (máximo 100 bloques por solicitud)
+
+**Respuesta:** Array de bloques, cada uno con:
+- `height` - Altura de bloque
+- `outputs` - Array de salidas con `txHash`, `outputIndex`, `targetKey`, `publicKey`, `amountCommitment`
+
+### wallet_getBalance
+
+Obtiene el saldo del monedero (requiere un monedero local).
+
+**Respuesta:**
+- `confirmed` - Saldo confirmado
+- `pending` - Saldo pendiente
+- `total` - Saldo total
+- `utxoCount` - Número de salidas no gastadas
+
+### wallet_getAddress
+
+Obtiene las claves del monedero y la información de la dirección.
+
+**Respuesta:**
+- `viewKey` - Clave pública de visualización (hex)
+- `spendKey` - Clave pública de gasto (hex)
+- `hasWallet` - Si el nodo tiene un monedero configurado
+
+---
+
+## Métodos de transacción
+
+### tx_submit / sendRawTransaction
+
+Envía una transacción firmada.
+
+**Parámetros:**
+- `tx_hex` (cadena) - Transacción serializada codificada en hex
+
+**Respuesta:**
+- `txHash` - Hash de la transacción
+
+---
+
+## Métodos de acuñación
+
+### minting_getStatus
+
+Obtiene el estado de la acuñación.
+
+**Respuesta:**
+- `active` - Si la acuñación está habilitada
+- `threads` - Número de hilos de acuñación
+- `hashrate` - Tasa de hash actual
+- `totalHashes` - Total de hashes calculados
+- `blocksFound` - Bloques minados por este nodo
+- `currentDifficulty` - Dificultad actual de la red
+- `uptimeSeconds` - Tiempo de actividad de la acuñación
+
+---
+
+## Métodos de red
+
+### network_getInfo
+
+Obtiene información de la conexión de red.
+
+**Respuesta:**
+- `peerCount` - Número total de pares
+- `inboundCount` - Conexiones entrantes
+- `outboundCount` - Conexiones salientes
+- `bytesSent` - Total de bytes enviados
+- `bytesReceived` - Total de bytes recibidos
+- `uptimeSeconds` - Tiempo de actividad de la conexión
+
+### network_getPeers
+
+Obtiene la lista de pares conectados.
+
+**Respuesta:**
+- `peers` - Array con la información de los pares
+
+---
+
+## Otros métodos
+
+La superficie de la API es mayor que esta página. Métodos adicionales destacados:
+
+| Método | Propósito |
+|--------|---------|
+| `getBlockByHash` | Obtener un bloque por hash en lugar de por altura |
+| `getSupplyInfo` | Detalles de emisión y oferta |
+| `tx_get` / `tx_getStatus` | Consultar una transacción / su estado de confirmación |
+| `address_validate` | Comprobar si una cadena de dirección está bien formada |
+| `fee_getRate` | Tarifa de comisión dinámica actual |
+| `cluster_getWealth` / `cluster_getAllWealth` | Consultas de riqueza de clúster (alimentan las vistas del explorador) |
+| `chain_areKeyImagesSpent` | Comprobar imágenes de clave para la detección de doble gasto |
+| `faucet_getStatus` / `faucet_request` | Grifo (faucet) de testnet |
+| `operator_*` | Superficie de confianza del operador (deshabilitada salvo que se configure; ver los runbooks del operador) |

--- a/web/packages/web-wallet/src/docs-content/es/cluster-tags.md
+++ b/web/packages/web-wallet/src/docs-content/es/cluster-tags.md
@@ -1,0 +1,179 @@
+## Etiquetas de clúster
+
+Las etiquetas de clúster son el mecanismo novedoso de Botho para rastrear la procedencia de las monedas sin comprometer la privacidad. Habilitan **comisiones progresivas resistentes a Sybil**, **redistribución basada en lotería** y **firmas de anillo que preservan la privacidad**.
+
+### El problema: gravar la riqueza sin identidad
+
+La tributación progresiva tradicional requiere identidad. En criptomonedas:
+
+- Las **comisiones basadas en el importe** fallan al instante: divide 1M en 1000×1K y paga tarifas más bajas
+- La **tributación basada en cuentas** es imposible: cualquiera puede crear direcciones ilimitadas
+- El **recuento de transacciones** no funciona: los bots pueden generar actividad artificial
+
+**El reto central:** ¿Cómo gravar la concentración de riqueza cuando no puedes identificar quién posee qué?
+
+### La solución: rastreo de procedencia
+
+En lugar de rastrear *quién* posee las monedas, rastreamos *de dónde* vienen. Cada moneda lleva un recuerdo de su origen.
+
+**Idea clave:** Dividir monedas no cambia de dónde vinieron.
+
+### Cómo funcionan las etiquetas de clúster
+
+**1. Los clústeres nacen en la acuñación**
+
+Cada recompensa de bloque crea un "clúster" único: una identidad para las monedas acuñadas por un acuñador concreto. La recompensa de acuñación lleva una etiqueta del 100 % para ese clúster.
+
+```
+Bloque 1000: el acuñador A recibe 50 BTH
+  → Etiqueta: {cluster_A: 100%}
+
+Bloque 1001: el acuñador B recibe 50 BTH
+  → Etiqueta: {cluster_B: 100%}
+```
+
+**2. Las etiquetas se heredan al transferir**
+
+Cuando las monedas se mueven, el UTXO del destinatario hereda las etiquetas del remitente:
+
+```
+Acuñador A → Comercio → Cliente
+   100%   →   95%    →   90%   (factor de clúster de A)
+```
+
+**3. Las etiquetas se mezclan al combinar**
+
+Cuando se gastan varias entradas juntas, las etiquetas de salida son un promedio ponderado por valor:
+
+```
+Entrada 1: 70 BTH {cluster_A: 100%}
+Entrada 2: 30 BTH {cluster_B: 100%}
+─────────────────────────────────
+Salida: 100 BTH {cluster_A: 70%, cluster_B: 30%}
+```
+
+**4. Las etiquetas decaen con el tiempo**
+
+Cada salto de transacción reduce la etiqueta un 5 %, repartiendo la atribución por toda la economía. Pero el decaimiento solo se aplica si el UTXO tiene al menos 720 bloques de antigüedad (de una a unas pocas horas, según el tiempo de bloque adaptativo a la carga), lo que previene ataques de wash trading.
+
+### Por qué dividir no funciona
+
+Esto es lo que hace especiales a las etiquetas de clúster:
+
+```
+Una ballena divide 1 000 000 BTH en 1000 × 1000 BTH
+
+Antes: 1 UTXO con {whale_cluster: 100%}
+Después: 1000 UTXO, cada uno con {whale_cluster: 100%}
+
+Tarifa de comisión: sin cambios (basada en la riqueza del clúster, no en el número de UTXO)
+```
+
+La "riqueza de origen" de un clúster es el valor total acuñado por ese acuñador: dividir no lo reduce.
+
+### Curva de comisión progresiva
+
+El factor de clúster determina cuánto pagas. Sigue una curva sigmoidal suave en el *logaritmo* de la riqueza del clúster, con su punto medio en 100 000 BTH:
+
+| Riqueza del clúster | Multiplicador de comisión |
+|----------------|----------------|
+| Clústeres pequeños (≤ ~1K BTH) | ~1x (tarifa base) |
+| Clústeres medianos (~100K BTH) | ~3.5x (punto medio de la curva) |
+| Clústeres ballena (≥ ~10M BTH) | ~6x (se satura) |
+
+El multiplicador se aplica a una comisión basada en el tamaño (`tarifa por byte × tamaño de la transacción`), de modo que la misma transferencia cuesta a un clúster ballena hasta 6× lo que cuesta a monedas bien circuladas, y ninguna cantidad de división cambia eso.
+
+### Redistribución basada en lotería
+
+El 80 % de todas las comisiones de transacción se redistribuye a los UTXO elegibles mediante una lotería. El 20 % se quema.
+
+**Cómo funciona:**
+
+1. Cada transacción paga una comisión basada en el factor de clúster
+2. El 80 % de la comisión se reparte entre 4 ganadores elegidos con aleatoriedad verificable
+3. El 20 % se quema permanentemente (deflacionario)
+
+**Cómo se seleccionan los ganadores (ponderado por clúster):**
+
+El peso ganador de un UTXO es su **valor dividido por su factor de clúster**. Esta es la única ponderación progresiva que es invariante a la división:
+
+- Los pesos se basan en el valor, así que dividir una posición en muchos UTXO nunca aumenta el peso total
+- El sesgo proviene de la procedencia del clúster, que se hereda a través de las divisiones
+- Las monedas bien circuladas (factor bajo) ganan proporcionalmente más; las monedas de clúster ballena ganan menos
+
+Para participar, un UTXO debe tener al menos 720 bloques de antigüedad y valer al menos 1 µBTH.
+
+### Firmas de anillo y privacidad de las etiquetas
+
+Las etiquetas de clúster funcionan sin problemas con las firmas de anillo CLSAG:
+
+**El reto:** Las firmas de anillo ocultan qué entrada es la real entre 20 miembros del anillo. ¿Cómo calculamos la comisión correcta?
+
+**La solución:** validación basada en el centroide
+
+1. Las etiquetas de todos los miembros del anillo son públicamente conocidas
+2. La comisión se deriva del *centroide* ponderado por valor de las etiquetas del anillo, con suelos que impiden que los señuelos baratos de fondo arrastren el factor hacia abajo
+3. Las etiquetas de salida reclamadas deben tener al menos un 70 % de similitud (similitud coseno) con el centroide del anillo, o la transacción se rechaza
+
+Esto previene la evasión de comisiones: no puedes seleccionar a dedo señuelos de factor bajo para reducir tu comisión, porque las composiciones de anillo inverosímiles no pasan la validación.
+
+### Detalles del mecanismo de decaimiento
+
+Para prevenir el wash trading (enviarte fondos a ti mismo repetidamente para decaer las etiquetas):
+
+**Restricción por antigüedad:**
+- El decaimiento solo se aplica a UTXO con al menos 720 bloques de antigüedad
+- Las salidas nuevas de autotransferencias rápidas no decaen
+- La restricción de antigüedad limita de forma natural el decaimiento a ~12 eventos por día
+
+**Limitación de tasa natural:**
+
+| Ataque | Resultado |
+|--------|--------|
+| 100 autotransferencias rápidas | 0 % de decaimiento (todas las salidas demasiado nuevas) |
+| Ataque paciente (1 día) | ~46 % de decaimiento máximo (solo ~12 saltos elegibles) |
+| Ataque paciente (1 semana) | ~99 % de decaimiento, pero has pagado ~84 comisiones de transacción |
+| Retener sin transaccionar | 0 % de decaimiento |
+
+### Consideraciones de privacidad
+
+**Fase 1 (actual):** Las etiquetas son públicas en los UTXO. Esto permite la verificación directa de comisiones pero revela cierta información de procedencia.
+
+**Fase 2 (planificada):** Las etiquetas se ocultarán mediante compromisos de Pedersen con pruebas de conocimiento cero. Los validadores verifican las comisiones correctas sin ver los valores reales de las etiquetas.
+
+### Incentivos económicos
+
+El sistema de etiquetas de clúster crea incentivos alineados:
+
+| Comportamiento | Efecto en las etiquetas | Incentivo |
+|----------|----------------|-----------|
+| **Circular monedas** | Las etiquetas decaen y se mezclan | Comisiones más bajas, mayor peso en la lotería |
+| **Acumular riqueza** | Las etiquetas permanecen concentradas | Comisiones más altas, menor peso en la lotería, demurrage |
+| **Dividir en muchos UTXO** | Etiquetas sin cambios | Sin beneficio: las comisiones y el peso en la lotería se basan en la procedencia y el valor |
+
+### Parámetros técnicos
+
+| Parámetro | Valor | Propósito |
+|-----------|-------|---------|
+| Tasa de decaimiento | 5 % por salto elegible | Difusión gradual de etiquetas |
+| Antigüedad mínima del UTXO (decaimiento + lotería) | 720 bloques | Prevención de wash trading |
+| Valor mínimo del UTXO (lotería) | 1 µBTH | Exclusión de polvo (dust) |
+| Rango del factor de clúster | 1x–6x (punto medio 3.5x en 100K BTH) | Comisiones progresivas |
+| Tamaño del anillo | 20 | Conjunto de privacidad para la propagación de etiquetas |
+| Ganadores de la lotería | 4 por sorteo | Granularidad de la redistribución |
+| Tasa de quema | 20 % de las comisiones | Presión deflacionaria |
+| Tasa del fondo | 80 % de las comisiones | Cantidad de redistribución |
+| Demurrage | 2 %/año al factor máximo (ver Tokenómica) | Alcanza la riqueza concentrada e inactiva |
+
+### Resumen
+
+Las etiquetas de clúster resuelven el problema de la "tributación progresiva resistente a Sybil" que aqueja a las criptomonedas:
+
+1. **Rastrean procedencia, no identidad**: las monedas recuerdan su origen
+2. **Resisten los ataques de división**: la riqueza del clúster se fija en la acuñación
+3. **Habilitan comisiones progresivas**: los clústeres ricos pagan más
+4. **Impulsan una redistribución justa**: el peso en la lotería se inclina hacia las monedas bien circuladas
+5. **Preservan la privacidad**: funcionan con firmas de anillo
+6. **Fomentan la circulación**: las etiquetas decaen a través del comercio
+
+Esto convierte a Botho en la primera criptomoneda con un mecanismo creíble para comisiones basadas en la riqueza que no se pueden evadir de forma trivial.

--- a/web/packages/web-wallet/src/docs-content/es/consensus.md
+++ b/web/packages/web-wallet/src/docs-content/es/consensus.md
@@ -1,0 +1,73 @@
+## Protocolo de Consenso Stellar
+
+Botho usa el **Protocolo de Consenso Stellar (SCP)** para el consenso distribuido. SCP es un protocolo de acuerdo bizantino federado que proporciona firmeza rápida, eficiencia energética y confianza flexible, sin sacrificar la descentralización.
+
+### ¿Por qué no consenso por prueba de trabajo?
+
+El consenso por prueba de trabajo (PoW), como se usa en Bitcoin, tiene inconvenientes importantes:
+
+- **Desperdicio de energía**: la PoW consume deliberadamente enormes cantidades de electricidad como mecanismo de seguridad
+- **Firmeza lenta**: las transacciones de Bitcoin no son realmente definitivas hasta pasada una hora o más
+- **Presión de centralización**: las economías de escala de la minería empujan hacia operaciones industriales
+- **Ataques del 51 %**: si un atacante controla la mayoría del poder de cómputo, puede reescribir la historia
+
+**Botho aún usa prueba de trabajo, pero solo para la emisión de monedas, nunca para el consenso.** Los bloques se acuñan mediante minería RandomX igualitaria en CPU, que decide *quién gana la recompensa de bloque*. Que ese bloque sea *aceptado* lo decide enteramente SCP. Este desacoplamiento significa que un atacante con la mayoría del poder de cómputo puede ganar más que los demás, pero no puede reescribir la historia ni censurar transacciones; y como el poder de cómputo no compra seguridad, no hay presión de carrera armamentística hacia un consumo energético a escala de Bitcoin.
+
+### ¿Por qué no prueba de participación?
+
+La prueba de participación (PoS) mejora el uso de energía pero introduce sus propios problemas:
+
+- **Nada en juego (nothing-at-stake)**: los validadores pueden votar de forma barata en múltiples bifurcaciones de la cadena
+- **Concentración de riqueza**: los ricos se hacen más ricos con las recompensas de staking
+- **Ataques de largo alcance**: las claves antiguas pueden potencialmente reescribir la historia
+- **Complejidad**: los sistemas PoS requieren una intrincada lógica de slashing y selección de validadores
+
+### Cómo funciona SCP
+
+SCP adopta un enfoque fundamentalmente distinto basado en la **votación federada**:
+
+**Rebanadas de quórum:** Cada nodo de la red define su propia "rebanada de quórum": un conjunto de otros nodos en los que confía. Un nodo solo aceptará una afirmación como definitiva cuando su rebanada de quórum esté de acuerdo.
+
+**Intersección de quórum:** La red es segura mientras todas las rebanadas de quórum compartan algunos nodos en común. Esto garantiza que dos afirmaciones en conflicto no puedan alcanzar ambas el consenso.
+
+**Votación federada:** El consenso avanza a través de una serie de rondas de votación:
+
+1. **Nominar**: los nodos proponen valores candidatos para el siguiente bloque
+2. **Preparar**: los nodos votan para preparar un valor específico
+3. **Confirmar**: los nodos votan para confirmar el valor preparado
+4. **Externalizar**: una vez confirmado, el valor es definitivo
+
+**Idea clave:** A diferencia de la PoW, donde confías en "la cadena más larga", en SCP eliges explícitamente en qué nodos confiar. Esto hace que el modelo de confianza sea transparente y auditable.
+
+### Propiedades de SCP
+
+**Control descentralizado:** Ninguna autoridad central determina el consenso. Cada nodo elige de forma independiente su rebanada de quórum según su propia evaluación de fiabilidad.
+
+**Baja latencia:** Las transacciones alcanzan la firmeza en segundos (normalmente de 3 a 5 segundos en condiciones normales), frente a los minutos u horas de los sistemas PoW.
+
+**Confianza flexible:** Los participantes pueden elegir distintas configuraciones de quórum según sus necesidades. Algunos pueden confiar en instituciones consolidadas; otros pueden confiar en un conjunto de expertos técnicos.
+
+**Seguridad asintótica:** A medida que la red crece y las rebanadas de quórum se interconectan más, el sistema se vuelve más resiliente ante fallos bizantinos.
+
+**Eficiencia energética:** Los nodos SCP solo necesitan intercambiar mensajes y verificar firmas: sin rompecabezas computacionales, sin desperdicio de energía.
+
+### Seguridad frente a vivacidad
+
+SCP prioriza la **seguridad** sobre la **vivacidad**:
+
+- **Seguridad:** La red nunca confirmará transacciones en conflicto
+- **Vivacidad:** La red debería, con el tiempo, avanzar
+
+Si la estructura de quórum se ve interrumpida (demasiados nodos se desconectan), SCP se detendrá en lugar de arriesgarse a confirmar transacciones en conflicto. Este es el compromiso correcto para un sistema monetario: es mejor pausar que permitir el robo de fondos.
+
+### Configuración de quórum en Botho
+
+La red Botho comienza con un quórum de arranque centrado en los nodos semilla de la fundación. Con el tiempo, a medida que se unen más nodos independientes, la estructura de quórum se volverá cada vez más descentralizada.
+
+Los operadores de nodos pueden personalizar su rebanada de quórum para confiar en:
+- Los nodos semilla de la fundación (por defecto)
+- Otros nodos conocidos de la comunidad
+- Nodos operados por casas de cambio o negocios en los que confíen
+- Cualquier combinación de lo anterior
+
+La salud de la red depende de una intersección de quórum suficiente. El explorador de Botho muestra la topología de quórum en tiempo real para ayudar a los operadores a tomar decisiones informadas.

--- a/web/packages/web-wallet/src/docs-content/es/getting-started.md
+++ b/web/packages/web-wallet/src/docs-content/es/getting-started.md
@@ -1,0 +1,77 @@
+## Primeros pasos con Botho
+
+Botho es una criptomoneda centrada en la privacidad, diseñada para la era poscuántica. Combina **direcciones sigilosas** para la privacidad de las transacciones con el **Protocolo de Consenso Stellar (SCP)** para lograr un consenso rápido y eficiente en energía. A diferencia de las criptomonedas de prueba de trabajo, Botho alcanza la firmeza en segundos manteniendo sólidas garantías de privacidad.
+
+### ¿Qué hace diferente a Botho?
+
+Las criptomonedas tradicionales como Bitcoin tienen cadenas de bloques transparentes en las que cualquiera puede rastrear el flujo de fondos entre direcciones. Incluso las llamadas "monedas de privacidad" a menudo dependen de supuestos criptográficos que los futuros ordenadores cuánticos podrían romper.
+
+Botho adopta un enfoque distinto:
+
+- Las **direcciones sigilosas** garantizan que cada pago que recibes vaya a una dirección única de un solo uso, lo que hace imposible vincular tus transacciones entre sí observando la cadena de bloques
+- La **criptografía poscuántica** protege tu privacidad frente a adversarios con ordenadores cuánticos
+- El **Acuerdo Bizantino Federado** proporciona firmeza rápida: la seguridad del consenso nunca depende del poder de cómputo (hashpower)
+- La **emisión igualitaria** distribuye monedas nuevas mediante minería de CPU con RandomX, deliberadamente desacoplada del consenso: minar genera recompensas pero no otorga voz sobre qué transacciones se confirman
+- La **economía progresiva**: las comisiones escalan de 1× a 6× según la concentración de riqueza, el 80 % de cada comisión se redistribuye por lotería y el 20 % se quema
+
+### Crear un monedero
+
+Empezar con Botho solo requiere unos pocos pasos:
+
+1. **Visita la página del Monedero**: haz clic en "Abrir monedero" desde la página de inicio o navega directamente al monedero
+2. **Elige "Crear nuevo monedero"**: también puedes importar un monedero existente si tienes una frase de recuperación
+3. **Protege tu frase de recuperación**: se te mostrará una frase mnemónica de 24 palabras. Anótala en papel y guárdala en un lugar seguro. Esta frase es la **única forma** de recuperar tus fondos si pierdes el acceso a tu dispositivo
+4. **Opcional: Define una contraseña**: añade una contraseña de cifrado para mayor seguridad. Necesitarás esta contraseña cada vez que abras el monedero en este navegador
+
+**Importante:** Nunca compartas tu frase de recuperación con nadie. Cualquiera que tenga estas palabras puede acceder a tus fondos. Nunca la guardes de forma digital (sin capturas de pantalla, sin almacenamiento en la nube, sin gestores de contraseñas).
+
+### Entender la dirección de tu monedero
+
+La dirección de tu monedero se parece a esto: `botho://1/4nuKn2U5qsRk3vD...` (unos 90 caracteres en total)
+
+Este formato de dirección incluye:
+- **Identificador de protocolo** (`botho://` en mainnet, `tbotho://` en testnet): los distintos prefijos evitan envíos accidentales entre redes
+- **Versión de dirección** (`1/` para direcciones clásicas, `1q/` para direcciones a prueba de cuántica)
+- **Claves públicas**: tu clave de visualización y tu clave de gasto, codificadas juntas en base58
+
+Las direcciones a prueba de cuántica (`1q/`) incorporan además claves públicas ML-KEM y ML-DSA, lo que las hace mucho más largas (~4 400 caracteres); son más adecuadas para códigos QR y archivos que para copiarlas a mano.
+
+Puedes compartir esta dirección con total tranquilidad con cualquiera que quiera enviarte fondos. Gracias a las direcciones sigilosas, cada transacción entrante se enviará a una dirección derivada única que solo tú puedes gastar.
+
+### Recibir tu primer pago
+
+Cuando alguien te envía BTH:
+
+1. Usa tu dirección pública para derivar una dirección única de un solo uso
+2. La transacción se difunde a la red y se incluye en un bloque
+3. Tu monedero escanea los bloques nuevos y detecta los pagos dirigidos a ti
+4. Los fondos aparecen en tu saldo, normalmente en un bloque: el tiempo de bloque se adapta a la carga de la red, desde 3 segundos con tráfico muy alto hasta 40 segundos cuando la red está inactiva
+
+### Enviar pagos
+
+Para enviar BTH a otra persona:
+
+1. Haz clic en el botón **Enviar** de tu monedero
+2. Introduce la dirección Botho del destinatario
+3. Introduce el importe a enviar
+4. Revisa los detalles de la transacción, incluida la comisión
+5. Confirma la transacción
+
+Las transacciones son definitivas una vez confirmadas: en Botho no hay contracargos ni reversiones.
+
+### Comisiones de transacción
+
+Cada transacción de Botho requiere una pequeña comisión. Estas comisiones cumplen tres propósitos:
+
+1. **Prevención de spam**: las comisiones encarecen inundar la red con transacciones basura
+2. **Tributación progresiva**: las comisiones escalan de 1× a 6× según la riqueza del clúster, desincentivando la concentración sin habilitar ataques Sybil
+3. **Redistribución y deflación**: el 80 % de cada comisión se redistribuye a los poseedores mediante una lotería; el 20 % restante se quema permanentemente
+
+Las comisiones se basan en el tamaño, no en el importe: `fee = tarifa por byte × tamaño de la transacción × factor de clúster (1×–6×) × penalización por salida`. Consulta las secciones Etiquetas de clúster y Tokenómica para más detalles.
+
+### Buenas prácticas de seguridad
+
+- **Haz una copia de tu frase de recuperación** en papel, guardada en un lugar seguro
+- **Usa una contraseña** para cifrar tu monedero en el navegador
+- **Considera ejecutar tu propio nodo** para lograr la máxima privacidad
+- **Verifica las direcciones con cuidado** antes de enviar fondos: las transacciones no se pueden revertir

--- a/web/packages/web-wallet/src/docs-content/es/network.md
+++ b/web/packages/web-wallet/src/docs-content/es/network.md
@@ -1,0 +1,108 @@
+## Información de la red
+
+Esta página ofrece detalles técnicos sobre la red Botho, incluida la información de conexión, los parámetros de red y el modelo de seguridad.
+
+### Estado de la red
+
+La red Botho se encuentra actualmente en fase de **testnet**. Esto significa que:
+
+- Las monedas no tienen valor monetario
+- La red puede reiniciarse durante el desarrollo
+- Las funciones aún se están probando y refinando
+- Se agradecen los informes de errores y los comentarios
+
+El lanzamiento de la mainnet de producción se anunciará cuando la red sea estable.
+
+### Conectarse a la red
+
+**Descubrimiento de semillas:**
+
+Los pares de arranque se descubren mediante registros TXT de DNS en lugar de una lista codificada:
+
+| Red | Dominio semilla de DNS |
+|---------|-----------------|
+| Mainnet | seeds.botho.io |
+| Testnet | seeds.testnet.botho.io |
+
+Cuando tu nodo arranca, resuelve el dominio semilla para conocer los pares de arranque (también puedes fijar `bootstrap_peers` explícitos en la configuración). Tras el descubrimiento inicial, tu nodo mantiene conexiones con múltiples pares para lograr redundancia.
+
+**Descubrimiento de pares:**
+
+Botho usa libp2p para la red, que admite múltiples mecanismos de descubrimiento:
+
+- **Nodos de arranque**: nodos semilla conocidos para la conexión inicial
+- **mDNS**: descubrimiento en la red local para desarrollo
+- **DHT Kademlia**: descubrimiento distribuido de pares
+- **Gossipsub**: propagación de mensajes basada en temas
+
+### Parámetros de red
+
+**Producción de bloques:**
+
+| Parámetro | Valor | Descripción |
+|-----------|-------|-------------|
+| Tiempo de bloque | 3–40 segundos (adaptativo a la carga) | Bloques rápidos con tráfico alto (3 s solo con 20+ tx/s), bloques lentos cuando está inactiva |
+| Tamaño máximo de bloque | 20 MB | Tamaño máximo del bloque serializado |
+| Máximo de transacciones por bloque | 5000 | Límite de recuento de transacciones |
+
+**Límites de transacción:**
+
+| Parámetro | Valor | Descripción |
+|-----------|-------|-------------|
+| Máximo de entradas | 16 | Máximo de entradas por transacción |
+| Máximo de salidas | 16 | Máximo de salidas por transacción |
+| Tamaño del anillo | 20 | Número de miembros en la firma de anillo CLSAG |
+| Tamaño máximo de tx | 100 KB | Tamaño máximo de la transacción serializada |
+
+**Comisiones:**
+
+| Parámetro | Valor | Descripción |
+|-----------|-------|-------------|
+| Fórmula de comisión | tarifa por byte × tamaño × factor de clúster × penalización por salida | Basada en el tamaño, progresiva según la riqueza |
+| Factor de clúster | 1x–6x | Multiplicador progresivo según la procedencia de la moneda |
+| Penalización por salida | cuadrática, limitada a 100x | Anti-farming de UTXO |
+| Destino de la comisión | 80 % lotería / 20 % quemado | Redistribución más presión deflacionaria |
+
+### Referencia de puertos
+
+Los valores por defecto difieren según la red (mainnet / testnet); todos son configurables:
+
+| Puerto (mainnet / testnet) | Protocolo | Propósito |
+|--------------------------|----------|---------|
+| 7100 / 17100 | TCP | Gossip P2P (libp2p) |
+| 7101 / 17101 | HTTP + WebSocket | API JSON-RPC y actualizaciones en tiempo real |
+| 9090 / 19090 | HTTP | Métricas Prometheus |
+
+### Seguridad de la red
+
+**Resistencia a Sybil:**
+
+La red resiste los ataques Sybil mediante:
+- Consenso basado en quórum (SCP)
+- Puntuación de reputación de los pares
+- Requisitos de recursos para la acuñación de bloques
+
+**Protección contra eclipse:**
+
+Los nodos se protegen contra ataques de eclipse mediante:
+- El mantenimiento de conexiones diversas con los pares
+- La preferencia por pares con un historial establecido
+- La rotación regular de pares
+- Múltiples métodos independientes de descubrimiento de pares
+
+### Cómo participar
+
+**Para desarrolladores:**
+- Código fuente: [github.com/botho-project/botho](https://github.com/botho-project/botho)
+- Informa de errores mediante los issues de GitHub
+- Se agradecen las contribuciones (ver CONTRIBUTING.md)
+
+**Para operadores de nodos:**
+- Ejecuta un nodo para fortalecer la red
+- Habilita la acuñación si tienes un tiempo de actividad fiable
+- Monitorea la intersección de quórum de tu nodo
+
+**Para usuarios:**
+- Prueba el monedero e informa de los problemas
+- Aporta comentarios sobre la experiencia de usuario
+- Ayuda con la documentación y las traducciones

--- a/web/packages/web-wallet/src/docs-content/es/privacy-progressivity.md
+++ b/web/packages/web-wallet/src/docs-content/es/privacy-progressivity.md
@@ -1,0 +1,216 @@
+## Cómo Botho logra a la vez privacidad y progresividad
+
+Este es el logro más sorprendente de Botho: **la privacidad y la economía progresiva funcionando juntas, no en conflicto.**
+
+La sabiduría convencional dice que estos objetivos son incompatibles. Para gravar más a los ricos, necesitas saber quién es rico. Pero saber quién es rico significa rastrear identidad y saldos, lo contrario de la privacidad.
+
+Botho demuestra que esa disyuntiva es falsa. Así lo hace.
+
+### La aparente imposibilidad
+
+Considera lo que la "tributación progresiva" requiere tradicionalmente:
+
+1. **Identificar al contribuyente**: vincular las transacciones a una persona
+2. **Rastrear su riqueza**: saber cuánto posee
+3. **Aplicar tarifas graduadas**: cobrar más a quienes tienen más
+
+Cada paso viola la privacidad. Si sabes que Alice tiene 1M de monedas, ya has destruido su privacidad financiera.
+
+Esto crea lo que parece un conflicto fundamental:
+
+| Objetivo | Requiere |
+|------|----------|
+| **Privacidad** | Ocultar quién posee qué |
+| **Progresividad** | Saber quién posee qué |
+
+La mayoría de los proyectos aceptan esta disyuntiva y eligen entre:
+- **Privacidad total** (Monero, Zcash): sin comisiones progresivas posibles
+- **Transparencia total** (Bitcoin, Ethereum): comisiones progresivas posibles pero sin privacidad
+
+Botho toma una tercera vía.
+
+### La idea clave: procedencia, no identidad
+
+El avance está en darse cuenta de que la tributación progresiva no *requiere* conocer la identidad ni la riqueza total. Requiere **correlacionar las comisiones con el comportamiento económico**.
+
+En lugar de preguntar "¿Quién posee esta moneda y cuán rico es?", Botho pregunta:
+
+> "¿De dónde vino esta moneda y cuánto ha circulado?"
+
+Esta pregunta tiene una propiedad sorprendente: **es respondible en la cadena sin vincularla a una identidad.**
+
+### Qué rastreamos: la proximidad a la acuñación
+
+Cada moneda en Botho lleva una "etiqueta de clúster", un recuerdo de qué evento de acuñación la creó. Esto no rastrea al *propietario*, sino el *origen*.
+
+| Estado de la moneda | Etiquetas | Nivel de comisión |
+|------------|------|-----------|
+| Recién acuñada | `{cluster_A: 100%}` | Alto |
+| Bien negociada | `{cluster_A: 5%, cluster_B: 15%, ...}` | Bajo |
+
+Las propiedades clave:
+
+| Propiedad | Efecto |
+|----------|--------|
+| **Etiquetas concentradas** | Recién acuñada, aún sin circular → Comisiones altas |
+| **Etiquetas diversificadas** | Negociada por muchas manos → Comisiones bajas |
+| **Resistente a la división** | Dividir preserva la concentración de etiquetas |
+| **Resistente al decaimiento** | Solo el comercio real reduce las etiquetas |
+
+### Por qué esto es progresivo
+
+Aquí es donde se pone interesante. **La proximidad a la acuñación se correlaciona con la concentración de riqueza** de formas predecibles:
+
+**Los nuevos acuñadores tienden a ser ricos.** Ganar recompensas de bloque requiere hardware, electricidad y tiempo de actividad fiable. Incluso con la minería RandomX igualitaria en CPU, las monedas nuevas van desproporcionadamente a quienes ya tienen recursos.
+
+**Los negociantes activos tienden a ser comerciantes.** Los pequeños negocios y los usuarios habituales transaccionan con frecuencia, lo que hace que sus monedas se mezclen con monedas de muchas fuentes.
+
+**Los acaparadores mantienen etiquetas concentradas.** Si minas monedas y las retienes sin negociar, tus etiquetas nunca decaen. Sigues pagando comisiones altas.
+
+**El comercio diversifica de forma natural.** Cada transacción legítima mezcla tus etiquetas con las de tu contraparte. La actividad económica reduce automáticamente tu tarifa de comisión.
+
+Esto crea una **correlación de comportamiento**:
+
+| Patrón de comportamiento | Estado de las etiquetas | Nivel de comisión |
+|------------------|-----------|-----------|
+| Minar y retener (comportamiento de rico) | Concentrado | Alto |
+| Comercio activo (comportamiento de comerciante) | Diversificado | Bajo |
+| Gasto de usuario habitual | Mixto | Medio→Bajo |
+| Ballena acumulando | Concentrado | Alto |
+
+No necesitamos saber *quién* eres. Simplemente observamos *cómo se comportan tus monedas*.
+
+### Qué permanece privado
+
+Esto es crucial: **las etiquetas de clúster revelan procedencia, no identidad.**
+
+| Información | Estado |
+|-------------|--------|
+| Quién posee un UTXO | **Privado** (firmas de anillo) |
+| Quién recibió un pago | **Privado** (direcciones sigilosas) |
+| Importe transferido | **Privado** (transacciones confidenciales) |
+| Tu saldo total | **Privado** (sin vinculación de cuentas) |
+| Qué UTXO gastaste | **Privado** (firmas de anillo) |
+| De dónde se originaron las monedas | Público (etiquetas de clúster) |
+| Cuán diversificadas están las etiquetas | Público (permite el cálculo de comisiones) |
+
+Revelas *algo* —la historia de la moneda— pero no *quién eres* ni *qué posees*.
+
+### La integración con las firmas de anillo
+
+Las firmas de anillo y las etiquetas de clúster funcionan juntas sin problemas:
+
+**Cómo funcionan las firmas de anillo:** Cuando gastas, demuestras "poseo UNO de estos 20 UTXO" sin revelar cuál. Esto proporciona privacidad del remitente.
+
+**El reto:** Si no sabemos qué UTXO estás gastando, ¿cómo calculamos la comisión correcta?
+
+**La solución: validación basada en el centroide.**
+
+1. Las etiquetas de los 20 miembros del anillo son visibles públicamente
+2. La comisión se deriva del **centroide ponderado por valor** de las etiquetas del anillo, con suelos para que los señuelos baratos de fondo no puedan arrastrar el factor hacia abajo
+3. Las etiquetas de salida que reclamas deben tener al menos un 70 % de similitud con ese centroide, o los validadores rechazan la transacción
+
+```
+Etiquetas de los miembros del anillo → centroide ponderado por valor → factor de clúster
+Etiquetas de salida reclamadas: deben ser ≥ 70 % similares al centroide
+```
+
+Esto significa que **la privacidad no habilita la evasión de comisiones.** Una entrada real grande domina el centroide de su propio anillo, así que seleccionar a dedo señuelos de factor bajo produce un anillo inverosímil que falla la validación en lugar de un descuento.
+
+### La redistribución por lotería
+
+Las comisiones regresan a la comunidad a través de una lotería inclinada por clúster:
+
+**El 80 % de todas las comisiones** se redistribuye a los UTXO elegibles. **El 20 % se quema** (deflacionario).
+
+**Cómo funciona la selección:**
+
+```
+peso = valor ÷ factor de clúster
+
+UTXO bien circulado (factor 1x):  peso completo por BTH
+UTXO de clúster ballena (factor 6x):    1/6 del peso por BTH
+```
+
+**Las monedas bien circuladas ganan hasta 6× más por BTH que la riqueza concentrada.** Esta es redistribución progresiva sin conocer la identidad de nadie, y como el peso se basa en el valor, dividir una posición en muchos UTXO nunca aumenta su peso total.
+
+**Las restricciones de elegibilidad** previenen el abuso: un UTXO debe tener al menos 720 bloques de antigüedad y valer al menos 1 µBTH para participar.
+
+### Resistencia a ataques
+
+Hemos probado estos mecanismos exhaustivamente:
+
+**Ataque de división:**
+```
+Atacante: divide 1M BTH en 1000 × 1K BTH
+Resultado: cada pieza aún tiene {whale_cluster: 100%}
+Reducción de comisión: 0 % (factor de clúster sin cambios)
+Veredicto: ataque derrotado
+```
+
+**Ataque Sybil (múltiples cuentas):**
+```
+Atacante: crea 100 direcciones sybil, envía 10K a cada una
+Resultado: el UTXO de cada sybil hereda las etiquetas de la ballena
+Reducción de comisión: mínima (las etiquetas se propagan)
+Veredicto: ataque derrotado
+```
+
+**Ataque de aparcamiento (dividir y esperar):**
+```
+Atacante: divide en 100 UTXO, espera las ganancias de la lotería
+Resultado: el peso se basa en el valor: dividir NO gana peso
+        El factor de clúster se hereda: el sesgo sigue en tu contra
+        Las comisiones cuadráticas por salida hacen que la división cueste hasta 100×
+Veredicto: ataque derrotado
+```
+
+**Wash trading (autotransferencias):**
+```
+Atacante: envía a sí mismo rápidamente para decaer las etiquetas
+Resultado: la restricción de antigüedad requiere 720 bloques por decaimiento
+        Como máximo ~12 decaimientos por día ≈ 46 % de decaimiento diario
+        1 semana de wash trading: ~99 % de decaimiento
+        Coste: ~84 comisiones de transacción (cada una alimentando la lotería)
+Veredicto: caro, lento, detectable
+```
+
+### El panorama completo
+
+Botho logra privacidad + progresividad mediante un diseño por capas:
+
+| Capa | Función de privacidad | Función progresiva |
+|-------|-----------------|---------------------|
+| **Remitente** | Firmas de anillo (1 de 20) | Propagación de etiquetas validada por centroide |
+| **Destinatario** | Direcciones sigilosas | — |
+| **Importe** | Compromisos de Pedersen | — |
+| **Tarifa de comisión** | — | Curva del factor de clúster (1-6×) |
+| **Coste de retención** | — | Demurrage sobre monedas inactivas de clúster rico |
+| **Redistribución** | Sorteo aleatorio verificable | Pesos inclinados por clúster (valor ÷ factor) |
+
+Cada capa contribuye a ambos objetivos sin conflicto.
+
+### Por qué esto importa
+
+Esto no es solo un logro técnico: cambia lo que es posible:
+
+**Para los usuarios:** Obtienes privacidad financiera Y un sistema económico justo. Sin disyuntiva.
+
+**Para los comerciantes:** Las comisiones bajas premian la actividad económica. Cuanto más negocias, más bajas son tus tarifas.
+
+**Para la red:** La riqueza fluye de forma natural desde las tenencias concentradas hacia las distribuidas. La autocustodia se premia por encima de los servicios de custodia.
+
+**Para el ecosistema:** Hemos demostrado que "privacidad frente a equidad" es una falsa dicotomía. Otros proyectos pueden adoptar estas técnicas.
+
+### Resumen
+
+El mecanismo de privacidad + progresividad de Botho funciona porque:
+
+1. **Rastreamos procedencia, no identidad**: de dónde vinieron las monedas, no quién las posee
+2. **La procedencia se correlaciona con el comportamiento de riqueza**: los acuñadores nuevos son ricos, los negociantes activos son comerciantes
+3. **Las firmas de anillo preservan la privacidad**: la validación por centroide previene el abuso
+4. **La lotería inclinada por clúster es progresiva**: las monedas bien circuladas ganan más por BTH
+5. **Los pesos basados en el valor y las comisiones cuadráticas por salida disuaden los ataques**: aparcar y dividir no compensan
+6. **El comercio se premia**: las etiquetas decaen mediante el comercio legítimo; la riqueza concentrada e inactiva paga demurrage
+
+El resultado: **La primera criptomoneda donde puedes ser privado Y contribuir con equidad a la red, donde los ricos pagan más sin que nadie sepa quiénes son.**

--- a/web/packages/web-wallet/src/docs-content/es/privacy.md
+++ b/web/packages/web-wallet/src/docs-content/es/privacy.md
@@ -1,0 +1,90 @@
+## Funciones de privacidad
+
+La privacidad no es solo una función en Botho: es un principio de diseño fundamental. Cada aspecto del protocolo está diseñado para proteger tu privacidad financiera manteniendo a la vez las propiedades de auditabilidad que necesita un sistema monetario sólido.
+
+### Por qué importa la privacidad
+
+La privacidad financiera es esencial para:
+
+- **Seguridad personal**: la riqueza pública te convierte en objetivo de delincuentes
+- **Confidencialidad de negocio**: los competidores no deberían ver tus pagos a proveedores ni tus ingresos
+- **Fungibilidad**: el dinero debe ser intercambiable; las monedas "manchadas" crean un sistema de dos niveles
+- **Dignidad humana**: tu vida financiera no es asunto de nadie más que tuyo
+- **Resistencia a la censura**: cuando todas las transacciones parecen idénticas, no hay base para bloquear pagos concretos. Bitcoin se esfuerza por resolver este problema con diversas técnicas, pero la privacidad por defecto lo resuelve con elegancia: los validadores no pueden discriminar porque no pueden distinguir
+
+### Direcciones sigilosas
+
+Las direcciones sigilosas son la base del modelo de privacidad de Botho. Así funcionan:
+
+**El problema:** En Bitcoin, si publicas una dirección para recibir donaciones, cualquiera puede ver todas las donaciones que has recibido consultando esa dirección en la cadena de bloques.
+
+**La solución:** En Botho, tu dirección pública no es donde realmente se envían los fondos. En su lugar, cada remitente usa tu dirección pública para derivar matemáticamente una dirección única de un solo uso. Solo tú puedes detectar y gastar desde esas direcciones derivadas.
+
+**Detalles técnicos:**
+
+1. Tu monedero tiene un **par de claves de visualización** y un **par de claves de gasto**
+2. El remitente genera un valor aleatorio y lo combina con tus claves públicas
+3. Esto produce una dirección de un solo uso que parece aleatoria para todos los demás
+4. Tu monedero usa tu clave privada de visualización para buscar los pagos dirigidos a ti
+5. Para gastar, usas tu clave privada de gasto para firmar la transacción
+
+El resultado: aunque publiques tu dirección públicamente, nadie que observe la cadena de bloques puede determinar cuántos pagos has recibido, cuándo los recibiste ni por cuánto fueron.
+
+### Firmas de anillo (transacciones privadas)
+
+Cuando envías una **transacción privada**, Botho usa **firmas de anillo CLSAG** para ocultar qué monedas concretas estás gastando. Tu transacción hace referencia a 20 posibles entradas (un "anillo"), y la firma demuestra que posees una de ellas sin revelar cuál.
+
+CLSAG (Concise Linkable Spontaneous Anonymous Group) es un esquema eficiente de firma de anillo que ofrece una sólida privacidad del remitente con firmas compactas (~700 bytes por entrada).
+
+Esto rompe el grafo de transacciones que de otro modo permitiría rastrear fondos a través de la cadena de bloques. Un observador ve que *alguien* del anillo gastó *algunas* monedas, pero no puede determinar qué participante ni qué monedas concretas.
+
+> **Nota:** Todas las transferencias de valor usan firmas de anillo. Las transacciones de acuñación (recompensas de bloque) usan firmas ML-DSA, ya que el acuñador es público.
+
+### Importes confidenciales
+
+En todas las **transacciones privadas** (que incluyen todas las transferencias de valor), los importes se ocultan mediante **compromisos de Pedersen** con pruebas de rango **Bulletproofs**. Estas construcciones criptográficas permiten a la red verificar que las transacciones cuadran (las entradas igualan a las salidas más las comisiones) sin revelar los importes reales.
+
+Los validadores pueden confirmar:
+- Que no se crea dinero de la nada
+- Que el remitente tiene fondos suficientes
+- Que la comisión es al menos el mínimo requerido
+- Que todos los importes son positivos (mediante Bulletproofs)
+
+Pero no pueden determinar:
+- Cuánto se está transfiriendo
+- El saldo total del remitente
+- El saldo total del destinatario
+
+> **Nota:** Las transacciones de acuñación (recompensas de bloque) tienen importes públicos para la auditabilidad de la oferta, pero los destinatarios siguen ocultos mediante direcciones sigilosas.
+
+### Criptografía poscuántica
+
+Los ordenadores cuánticos suponen una amenaza futura para los algoritmos criptográficos que hoy protegen la mayoría de las criptomonedas. Botho usa una **arquitectura poscuántica híbrida** que protege los datos más críticos manteniendo las transacciones eficientes.
+
+**Algoritmos utilizados:**
+
+- **ML-KEM-768** (FIPS 203): direcciones sigilosas poscuánticas (la privacidad del destinatario es permanente)
+- **ML-DSA-65** (FIPS 204): firmas poscuánticas para las transacciones de acuñación
+- **CLSAG**: firmas de anillo clásicas para las transacciones privadas (la privacidad del remitente es efímera)
+- **Pedersen + Bulletproofs**: ocultación de importes con seguridad de teoría de la información (a prueba de cuántica)
+
+**¿Por qué esta arquitectura?**
+
+La identidad del destinatario queda registrada en la cadena para siempre: un atacante cuántico en 2045 podría vincular destinatarios a partir de transacciones de 2025. ML-KEM protege frente a esta amenaza de "recolectar ahora, descifrar después". La privacidad del remitente, en cambio, es efímera: su valor se degrada con el tiempo a medida que el contexto económico se vuelve histórico. Usar CLSAG clásico mantiene las transacciones pequeñas (~4 KB frente a ~65 KB de las alternativas poscuánticas).
+
+**Tipos de transacción:**
+
+| Tipo | Destinatario | Importe | Remitente | Caso de uso |
+|------|-----------|--------|--------|----------|
+| Acuñación | Oculto (ML-KEM) | Público | Conocido (ML-DSA) | Recompensas de bloque |
+| Privada | Oculto (ML-KEM) | Oculto | Oculto (anillo CLSAG=20) | Todas las transferencias (~4 KB) |
+
+Los destinatarios y los importes están protegidos frente a los ordenadores cuánticos. La privacidad del remitente usa firmas clásicas eficientes.
+
+### Buenas prácticas de privacidad
+
+Para maximizar tu privacidad al usar Botho:
+
+1. **Ejecuta tu propio nodo**: así evitas revelar tus direcciones a servidores de terceros
+2. **Usa una dirección nueva para cada contexto**: aunque las direcciones sigilosas protegen los fondos recibidos, usar direcciones separadas para trabajo y para uso personal añade otra capa
+3. **Ten cuidado con los metadatos**: la privacidad en la cadena no sirve de nada si revelas información fuera de la cadena

--- a/web/packages/web-wallet/src/docs-content/es/running-node.md
+++ b/web/packages/web-wallet/src/docs-content/es/running-node.md
@@ -1,0 +1,157 @@
+## Ejecutar un nodo Botho
+
+Ejecutar tu propio nodo Botho te ofrece el máximo nivel de privacidad y ayuda a fortalecer la red. Cuando ejecutas un nodo, tu monedero se conecta directamente a la cadena de bloques sin depender de servidores de terceros.
+
+### ¿Por qué ejecutar un nodo?
+
+**Privacidad:** Cuando usas un monedero ligero o un monedero web, estás confiando en que un servidor no registre tus direcciones ni tus transacciones. Ejecutar tu propio nodo hace que la actividad de tu monedero se quede en tu máquina.
+
+**Verificación:** Tu nodo valida de forma independiente cada transacción y cada bloque. No tienes que confiar en las afirmaciones de nadie sobre el estado de la red.
+
+**Salud de la red:** Más nodos hacen la red más resiliente. Tu nodo retransmite transacciones y bloques, ayudando a que la red funcione.
+
+**Ventaja de acuñación:** Ejecutar tu propio nodo te da menor latencia en la competición de acuñación. Los nodos que reciben nuevos bloques más rápido pueden empezar a trabajar antes en el siguiente bloque, aumentando sus posibilidades de ganar recompensas de acuñación.
+
+**Participación:** Si quieres acuñar nuevos bloques o participar en el consenso, necesitas un nodo completo.
+
+### Requisitos del sistema
+
+**Requisitos mínimos:**
+- 2 núcleos de CPU
+- 4 GB de RAM
+- 50 GB de almacenamiento SSD
+- Conexión a internet de 10 Mbps
+
+**Recomendado:**
+- 4+ núcleos de CPU
+- 8 GB de RAM
+- 100 GB de SSD NVMe
+- Conexión a internet de 100 Mbps
+
+La cadena de bloques es actualmente pequeña, pero los requisitos de almacenamiento crecerán con el tiempo.
+
+### Instalación
+
+**Desde el código fuente (recomendado):**
+
+```bash
+# Instala Rust si aún no lo tienes
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Clona el repositorio
+git clone https://github.com/botho-project/botho.git
+cd botho
+
+# Compila en modo release
+cargo build --release
+
+# El binario está en ./target/release/botho
+```
+
+**Configuración inicial:**
+
+```bash
+# Inicializa un monedero y una configuración nuevos
+./target/release/botho init
+
+# Esto hará lo siguiente:
+# - Generar una frase de recuperación de 24 palabras
+# - Crear tu configuración y tu monedero en ~/.botho/
+
+# Variantes:
+#   botho init --recover   # restaura un monedero desde un mnemónico existente
+#   botho init --relay     # configuración de nodo relay/semilla sin monedero
+```
+
+**IMPORTANTE:** ¡Anota tu frase de recuperación y guárdala de forma segura!
+
+### Ejecutar el nodo
+
+**Operación básica:**
+
+```bash
+# Inicia el nodo y sincroniza con la red
+./target/release/botho run
+```
+
+**Con acuñación habilitada:**
+
+```bash
+# Inicia el nodo y participa en la producción de bloques
+./target/release/botho run --mint
+```
+
+### Referencia de comandos de la CLI
+
+**Comandos del monedero:**
+
+| Comando | Descripción |
+|---------|-------------|
+| `botho init` | Crea un nuevo monedero con un mnemónico de 24 palabras |
+| `botho balance` | Muestra el saldo actual de tu monedero |
+| `botho address` | Muestra tu dirección de recepción (`--save` la escribe en un archivo) |
+| `botho send <address> <amount>` | Envía BTH (importe en BTH; `--quantum` para criptografía poscuántica, `--memo` para adjuntar una nota cifrada) |
+
+Todos los envíos usan firmas de anillo CLSAG: la privacidad del remitente está activa por defecto, no es un flag.
+
+**Comandos del nodo:**
+
+| Comando | Descripción |
+|---------|-------------|
+| `botho run` | Inicia el nodo y sincroniza con la red |
+| `botho run --mint` | Inicia con la acuñación habilitada (`--mint-threads N` para limitar el uso de CPU) |
+| `botho status` | Muestra el estado de sincronización del nodo y el número de pares |
+| `botho snapshot` | Gestiona las instantáneas de UTXO para una sincronización inicial rápida |
+
+### Configuración
+
+El archivo de configuración se encuentra en `~/.botho/`. Todos los puertos tienen valores por defecto específicos de la red, así que una configuración mínima funciona sin más:
+
+```toml
+# "mainnet" o "testnet"
+network_type = "testnet"
+
+[network]
+# Por defecto: gossip 7100 (mainnet) / 17100 (testnet)
+#              RPC    7101 (mainnet) / 17101 (testnet)
+#              metrics 9090 (mainnet) / 19090 (testnet), 0 lo desactiva
+# gossip_port = 17100
+# rpc_port = 17101
+# metrics_port = 19090
+
+# Pares de arranque explícitos opcionales (formato multiaddr).
+# Si no se define, los pares se descubren mediante registros TXT de DNS
+# (seeds.botho.io / seeds.testnet.botho.io).
+# bootstrap_peers = ["/dns4/eu.seed.botho.io/tcp/7100/p2p/<peer-id>"]
+
+[minting]
+enabled = false
+threads = 0   # 0 = usar todos los núcleos de CPU
+```
+
+### Configuración del cortafuegos
+
+Si quieres que tu nodo acepte conexiones entrantes (recomendado):
+
+```bash
+# Permite el tráfico de gossip P2P (17100 en testnet, 7100 en mainnet)
+sudo ufw allow 17100/tcp
+
+# Opcional: permite el acceso RPC (solo si se necesita externamente)
+# sudo ufw allow 17101/tcp
+```
+
+### Resolución de problemas
+
+**El nodo no sincroniza:**
+- Comprueba tu conexión a internet
+- Verifica que el cortafuegos permita conexiones salientes en el puerto de gossip
+- Como último recurso, borra la base de datos de la cadena en `~/.botho/` y vuelve a sincronizar (solo en testnet: esto reescanea desde el génesis)
+
+**Uso elevado de memoria:**
+- Reduce los hilos de acuñación (RandomX mantiene un gran conjunto de datos en memoria)
+- Considera añadir espacio de intercambio (swap) si la RAM es limitada
+
+**No se puede conectar con los pares:**
+- Asegúrate de que tu puerto de gossip (17100 testnet / 7100 mainnet) esté abierto para conexiones entrantes
+- Comprueba si estás detrás de un NAT estricto

--- a/web/packages/web-wallet/src/docs-content/es/tokenomics.md
+++ b/web/packages/web-wallet/src/docs-content/es/tokenomics.md
@@ -1,0 +1,144 @@
+## Tokenómica
+
+Botho (BTH) usa un modelo de emisión en dos fases diseñado para la sostenibilidad a largo plazo: una fase inicial de distribución con halvings, seguida de una emisión de cola perpetua orientada a una inflación estable.
+
+### Visión general
+
+| Parámetro | Valor |
+|-----------|-------|
+| Símbolo del token | BTH |
+| Unidad más pequeña | picocrédito (10⁻¹² BTH) |
+| Preminado | Ninguno (100 % minado) |
+| Oferta de la Fase 1 | ~611 millones de BTH |
+| Tiempo de bloque | 3–40 segundos (adaptativo a la carga; 5 s de referencia monetaria) |
+
+### Sistema de unidades
+
+BTH usa una precisión de 12 decimales. El picocrédito es la única unidad base: cada importe en la red (saldos, comisiones, riqueza de clúster) se denomina en picocréditos, y el formateo a BTH ocurre solo en la capa de presentación:
+
+- **1 picocrédito** = 0.000000000001 BTH (unidad más pequeña)
+- **1 microBTH (µBTH)** = 1 000 000 picocréditos = 0.000001 BTH
+- **1 miliBTH (mBTH)** = 1 000 000 000 picocréditos = 0.001 BTH
+- **1 BTH** = 1 000 000 000 000 picocréditos
+
+---
+
+## Calendario de emisión
+
+Todos los cálculos monetarios asumen el tiempo de bloque de 5 segundos con carga alta (los bloques reales van de 3 a 40 s, bajando a 3 s solo con carga muy alta, 20+ tx/s). Cuando la red está inactiva y los bloques se ralentizan (hasta 40 s), la emisión se estira proporcionalmente: un amortiguador natural: una red ocupada emite según el calendario completo, una inactiva emite menos.
+
+### Fase 1: periodo de halving (~5 años a plena carga)
+
+La recompensa de acuñación comienza en 50 BTH y se reduce a la mitad cada **6 307 200 bloques** (un año de bloques de 5 segundos). Tras cinco épocas de halving, la Fase 1 ha distribuido **611 010 000 BTH**:
+
+| Época | Recompensa de acuñación | Oferta acumulada |
+|-------|----------------|-------------------|
+| 1 | 50 BTH | ~315.4M BTH |
+| 2 | 25 BTH | ~473.0M BTH |
+| 3 | 12.5 BTH | ~552.0M BTH |
+| 4 | 6.25 BTH | ~591.3M BTH |
+| 5 | 3.125 BTH | ~611.0M BTH |
+
+(Este es el calendario canónico ratificado en el issue #351, fijado por pruebas de regresión en el nodo.)
+
+### Fase 2: emisión de cola
+
+Tras la Fase 1, Botho pasa a una emisión de cola perpetua orientada a una **inflación neta anual del 2 %** (emisión bruta menos las quemas de comisiones), con la dificultad ajustándose para alcanzar el objetivo.
+
+**¿Por qué emisión de cola?**
+
+- **Presupuesto de seguridad**: garantiza que los acuñadores siempre tengan incentivo para asegurar la red
+- **Reemplazo de monedas perdidas**: compensa las monedas perdidas por claves olvidadas
+- **Política monetaria predecible**: el 2 % está por debajo de la inflación fiat típica
+
+Con la oferta de ~611M de BTH de la Fase 1 y a plena carga, el 2 % equivale a aproximadamente **2 BTH por bloque**, creciendo lentamente con la oferta.
+
+---
+
+## Estructura de comisiones
+
+### Comisiones de transacción
+
+Cada comisión se divide en dos: el **80 % se redistribuye** a los poseedores mediante la lotería inclinada por clúster, y el **20 % se quema**, creando una presión deflacionaria que compensa la emisión de cola.
+
+```
+fee = tarifa por byte × tamaño de la transacción × factor de clúster × penalización por salida + comisiones de memo
+```
+
+| Parámetro | Valor |
+|-----------|-------|
+| Base de la comisión | Tamaño de la transacción (bytes), no el importe |
+| Factor de clúster | Multiplicador progresivo 1x–6x |
+| Penalización por salida | Cuadrática en el número de salidas, limitada a 100x |
+| Comisión por memo | Plana por cada memo cifrado |
+| Destino de la comisión | 80 % al fondo de lotería / 20 % quemado |
+| Prioridad | Comisiones más altas = confirmación más rápida |
+
+### Comisiones progresivas basadas en clúster
+
+Botho implementa un novedoso **sistema de comisiones progresivas** que grava la concentración de riqueza sin habilitar ataques Sybil.
+
+**La innovación central:** En lugar de gravar según el importe de la transacción (fácil de manipular dividiendo), las comisiones se basan en la *procedencia* de la moneda: de dónde vinieron originalmente las monedas.
+
+| Parámetro | Valor |
+|-----------|-------|
+| Rango del factor de clúster | multiplicador de 1x a 6x |
+| Forma de la curva | Sigmoide en log(riqueza del clúster), punto medio 3.5x en 100K BTH |
+| Decaimiento de etiquetas | 5 % por salto elegible |
+
+**Por qué es resistente a Sybil:** Dividir monedas no cambia su origen. Las monedas de una ballena llevan la misma etiqueta de clúster tanto si se guardan en 1 UTXO como en 1000.
+
+### Demurrage
+
+Las comisiones de transacción son un impuesto al consumo: no pueden tocar la riqueza que nunca se mueve. El demurrage cierra esa brecha: un **cargo por retención sobre las monedas de clúster rico, pagado cuando finalmente se gastan**.
+
+| Parámetro | Valor |
+|-----------|-------|
+| Tasa | 2 % anual al factor de clúster máximo (6x) |
+| Escalado | Proporcional a (factor − 1): las monedas de factor 1 pagan **cero** |
+| Arranque | Deshabilitado durante la primera época de halving |
+| Ingresos | Fluyen al fondo de redistribución por lotería |
+
+Las monedas de uso cotidiano nunca pagan demurrage; solo afecta a la riqueza concentrada e inactiva. Mover las monedas no lo evita: gastar paga primero el cargo acumulado, así que el total pagado durante cualquier periodo de retención es el mismo sin importar cuántas veces te autotransfieras (y cada transferencia añade comisiones por encima).
+
+> **Consulta la sección [Etiquetas de clúster](#cluster-tags)** para una explicación completa de cómo el rastreo de procedencia, las comisiones progresivas, la redistribución por lotería y la privacidad de las firmas de anillo funcionan juntos.
+
+---
+
+## Proyecciones de oferta
+
+### Crecimiento a largo plazo
+
+A plena carga sostenida (bloques de 5 segundos; más lentos cuando la red está inactiva):
+
+| Época | Oferta aproximada | Inflación anual |
+|-------|-------------------|------------------|
+| 1 | ~315M BTH | Alta (inicial) |
+| 3 | ~552M BTH | ~17 % |
+| 5 | ~611M BTH | ~3 % |
+| Cola (perpetua) | +2 %/año neto de quemas | 2 % |
+
+---
+
+## Filosofía del diseño económico
+
+### ¿Por qué no hay preminado?
+
+- **Distribución justa**: todos empiezan iguales; los primeros acuñadores asumen riesgo
+- **Credibilidad**: sin ventaja para iniciados ni enriquecimiento del fundador
+- **Descentralización**: sin tenencias concentradas desde el primer día
+
+### ¿Por qué dividir las comisiones 80/20?
+
+- **Redistribución**: el 80 % regresa a los poseedores mediante la lotería inclinada por clúster, favoreciendo a las monedas bien circuladas
+- **Presión deflacionaria**: la quema del 20 % compensa la emisión de cola
+- **Predecible**: inflación neta = emisión bruta − quemas
+
+### ¿Por qué comisiones progresivas por clúster?
+
+- **Reducir la concentración**: los clústeres ricos pagan más
+- **Resistentes a Sybil**: no se pueden evitar dividiendo cuentas
+- **Fomentan la circulación**: mover monedas difunde las etiquetas, reduciendo las comisiones
+- **Compatibles con la privacidad**: funcionan con firmas de anillo y direcciones sigilosas
+
+> **En profundidad:** Consulta la documentación de [Etiquetas de clúster](#cluster-tags) para la explicación técnica completa.

--- a/web/packages/web-wallet/src/docs-content/index.ts
+++ b/web/packages/web-wallet/src/docs-content/index.ts
@@ -1,0 +1,136 @@
+/**
+ * Docs content registry (issue #778, i18n phase 3).
+ *
+ * The docs page body (~1500 lines of markdown across 9 sections) is far too
+ * large to extract key-by-key into a JSON `t()` namespace the way phases 1–2
+ * handled the landing/wallet/pay/claim/contacts copy. Instead each section's
+ * markdown lives in its own per-locale `.md` file under `docs-content/<locale>/`,
+ * imported here with Vite's `?raw` suffix so the content is statically bundled
+ * (consistent with `i18n.ts`'s deliberate no-lazy-load / no-flash-of-English
+ * decision) and stays plain markdown — easy to diff, review and translate.
+ *
+ * `id`, `icon` and ordering are locale-INVARIANT and live in `SECTION_META`
+ * below. The `id` slug is URL-addressable (`/docs#<id>`, the legacy
+ * `/docs/<id>` redirect, and internal `[...](#<id>)` cross-links all key off it)
+ * and MUST NOT be translated — see `docs-deep-link.test.tsx` (#656 guard).
+ * `icon` is a non-serializable `lucide-react` component reference, so it cannot
+ * live in a JSON/markdown resource. Only the section TITLE (a short nav label /
+ * H1, stored in the `docs` i18n namespace) and the markdown BODY (these files)
+ * are locale-dependent.
+ *
+ * Content selection falls back to English when a locale is missing a section
+ * file, mirroring `i18n.ts`'s `fallbackLng: DEFAULT_LOCALE` behavior.
+ */
+import type { LucideIcon } from 'lucide-react'
+import {
+  Book,
+  Shield,
+  Tag,
+  Scale,
+  Zap,
+  Terminal,
+  Code,
+  Globe,
+  Coins,
+} from 'lucide-react'
+
+import { DEFAULT_LOCALE, type SupportedLocale } from '../lib/i18n'
+
+// --- English markdown bodies -------------------------------------------------
+import enGettingStarted from './en/getting-started.md?raw'
+import enPrivacy from './en/privacy.md?raw'
+import enClusterTags from './en/cluster-tags.md?raw'
+import enPrivacyProgressivity from './en/privacy-progressivity.md?raw'
+import enConsensus from './en/consensus.md?raw'
+import enRunningNode from './en/running-node.md?raw'
+import enApi from './en/api.md?raw'
+import enNetwork from './en/network.md?raw'
+import enTokenomics from './en/tokenomics.md?raw'
+
+// --- Spanish markdown bodies -------------------------------------------------
+import esGettingStarted from './es/getting-started.md?raw'
+import esPrivacy from './es/privacy.md?raw'
+import esClusterTags from './es/cluster-tags.md?raw'
+import esPrivacyProgressivity from './es/privacy-progressivity.md?raw'
+import esConsensus from './es/consensus.md?raw'
+import esRunningNode from './es/running-node.md?raw'
+import esApi from './es/api.md?raw'
+import esNetwork from './es/network.md?raw'
+import esTokenomics from './es/tokenomics.md?raw'
+
+/** A documentation section id — a stable, English, URL-addressable slug. */
+export type DocSectionId =
+  | 'getting-started'
+  | 'privacy'
+  | 'cluster-tags'
+  | 'privacy-progressivity'
+  | 'consensus'
+  | 'running-node'
+  | 'api'
+  | 'network'
+  | 'tokenomics'
+
+export interface DocSectionMeta {
+  /** Stable URL slug — NEVER localized (routing + cross-links depend on it). */
+  id: DocSectionId
+  /** Non-serializable lucide-react icon reference — locale-invariant. */
+  icon: LucideIcon
+}
+
+/**
+ * Locale-invariant section metadata, in render order. Adding/removing a section
+ * here must be mirrored by matching `<locale>/<id>.md` files and a `sections.<id>`
+ * title entry in every `locales/<locale>/docs.json`.
+ */
+export const SECTION_META: readonly DocSectionMeta[] = [
+  { id: 'getting-started', icon: Book },
+  { id: 'privacy', icon: Shield },
+  { id: 'cluster-tags', icon: Tag },
+  { id: 'privacy-progressivity', icon: Scale },
+  { id: 'consensus', icon: Zap },
+  { id: 'running-node', icon: Terminal },
+  { id: 'api', icon: Code },
+  { id: 'network', icon: Globe },
+  { id: 'tokenomics', icon: Coins },
+]
+
+type ContentMap = Record<DocSectionId, string>
+
+const CONTENT_BY_LOCALE: Record<SupportedLocale, ContentMap> = {
+  en: {
+    'getting-started': enGettingStarted,
+    privacy: enPrivacy,
+    'cluster-tags': enClusterTags,
+    'privacy-progressivity': enPrivacyProgressivity,
+    consensus: enConsensus,
+    'running-node': enRunningNode,
+    api: enApi,
+    network: enNetwork,
+    tokenomics: enTokenomics,
+  },
+  es: {
+    'getting-started': esGettingStarted,
+    privacy: esPrivacy,
+    'cluster-tags': esClusterTags,
+    'privacy-progressivity': esPrivacyProgressivity,
+    consensus: esConsensus,
+    'running-node': esRunningNode,
+    api: esApi,
+    network: esNetwork,
+    tokenomics: esTokenomics,
+  },
+}
+
+/**
+ * Return the markdown body for `id` in `locale`, falling back to the default
+ * locale's content when the requested locale is missing that section (mirrors
+ * i18next's `fallbackLng`). Falls back further to an empty string only if the
+ * id is somehow unknown, so a bad lookup renders blank rather than crashing.
+ */
+export function getSectionContent(id: DocSectionId, locale: SupportedLocale): string {
+  const localized = CONTENT_BY_LOCALE[locale]?.[id]
+  if (localized != null && localized.trim() !== '') {
+    return localized
+  }
+  return CONTENT_BY_LOCALE[DEFAULT_LOCALE][id] ?? ''
+}

--- a/web/packages/web-wallet/src/lib/i18n.ts
+++ b/web/packages/web-wallet/src/lib/i18n.ts
@@ -4,8 +4,11 @@
  * Phase 1 scope: framework setup + the marketing landing page translated into
  * one additional language (Spanish). Phase 2 (issue #777) added the
  * transactional surfaces — the `wallet`, `pay`, `claim`, and `contacts`
- * namespaces. `docs` and metadata/OG surfaces remain out of scope and land in
- * later phases.
+ * namespaces. Phase 3 (issue #778) added the `docs` namespace: section titles /
+ * nav labels live here as JSON keys, while the large markdown bodies live in
+ * per-locale `.md` files under `../docs-content/` (imported with Vite `?raw`)
+ * rather than as escaped JSON strings. Metadata/OG surfaces remain out of scope
+ * and land in a later phase.
  *
  * Locale is driven by a URL path prefix (`/es/...`) rather than a subdomain, so
  * the existing `botho.io` / `wallet.botho.io` host-switch logic in `App.tsx`
@@ -30,6 +33,8 @@ import enClaim from '../locales/en/claim.json'
 import esClaim from '../locales/es/claim.json'
 import enContacts from '../locales/en/contacts.json'
 import esContacts from '../locales/es/contacts.json'
+import enDocs from '../locales/en/docs.json'
+import esDocs from '../locales/es/docs.json'
 
 /**
  * The set of locales the app knows how to render. `en` MUST stay first — it is
@@ -80,6 +85,7 @@ const resources = {
     pay: enPay,
     claim: enClaim,
     contacts: enContacts,
+    docs: enDocs,
   },
   es: {
     landing: esLanding,
@@ -87,6 +93,7 @@ const resources = {
     pay: esPay,
     claim: esClaim,
     contacts: esContacts,
+    docs: esDocs,
   },
 } as const
 
@@ -98,7 +105,7 @@ if (!i18n.isInitialized) {
     fallbackLng: DEFAULT_LOCALE,
     supportedLngs: SUPPORTED_LOCALES as unknown as string[],
     defaultNS: 'landing',
-    ns: ['landing', 'wallet', 'pay', 'claim', 'contacts'],
+    ns: ['landing', 'wallet', 'pay', 'claim', 'contacts', 'docs'],
     interpolation: {
       // React already escapes interpolated values.
       escapeValue: false,

--- a/web/packages/web-wallet/src/locales/en/docs.json
+++ b/web/packages/web-wallet/src/locales/en/docs.json
@@ -1,0 +1,19 @@
+{
+  "brand": "Botho",
+  "brandDocs": "Botho Docs",
+  "backToHome": "Back to home",
+  "openMenu": "Open menu",
+  "closeMenu": "Close menu",
+  "notFound": "Section “{{segment}}” not found — showing Getting Started.",
+  "sections": {
+    "getting-started": "Getting Started",
+    "privacy": "Privacy Features",
+    "cluster-tags": "Cluster Tags",
+    "privacy-progressivity": "Privacy + Progressivity",
+    "consensus": "Consensus",
+    "running-node": "Running a Node",
+    "api": "API Reference",
+    "network": "Network",
+    "tokenomics": "Tokenomics"
+  }
+}

--- a/web/packages/web-wallet/src/locales/es/docs.json
+++ b/web/packages/web-wallet/src/locales/es/docs.json
@@ -1,0 +1,19 @@
+{
+  "brand": "Botho",
+  "brandDocs": "Botho Docs",
+  "backToHome": "Volver al inicio",
+  "openMenu": "Abrir menú",
+  "closeMenu": "Cerrar menú",
+  "notFound": "Sección «{{segment}}» no encontrada — mostrando Primeros pasos.",
+  "sections": {
+    "getting-started": "Primeros pasos",
+    "privacy": "Funciones de privacidad",
+    "cluster-tags": "Etiquetas de clúster",
+    "privacy-progressivity": "Privacidad + Progresividad",
+    "consensus": "Consenso",
+    "running-node": "Ejecutar un nodo",
+    "api": "Referencia de la API",
+    "network": "Red",
+    "tokenomics": "Tokenómica"
+  }
+}

--- a/web/packages/web-wallet/src/pages/docs.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/docs.i18n.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Locale-rendering coverage for the docs page (issue #778, i18n phase 3).
+ *
+ * The docs body lives in per-locale markdown files (`docs-content/<locale>/*.md`)
+ * imported with Vite `?raw`, while section titles live in the `docs` i18n
+ * namespace. Section `id` slugs and the `#hash` scheme are locale-INVARIANT —
+ * the English-only behavior is guarded separately by `docs-deep-link.test.tsx`.
+ * Here we assert the SPANISH surface: `/es/docs` renders translated titles and
+ * markdown, cross-locale content does not leak English, and a mid-session
+ * language switch re-renders the active section in the new language.
+ */
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { DocsPage } from './docs'
+import i18n from '../lib/i18n'
+
+/** Mirrors the `/docs` + `/es/docs` route pairs registered via LocaleRoutes. */
+function renderDocs(initialEntries: string[]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/docs" element={<DocsPage />} />
+        <Route path="/docs/*" element={<DocsPage />} />
+        <Route path="/es/docs" element={<DocsPage />} />
+        <Route path="/es/docs/*" element={<DocsPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function activeHeading(): string | null {
+  return screen.getByRole('heading', { level: 1 }).textContent
+}
+
+describe('DocsPage i18n (es)', () => {
+  beforeEach(() => i18n.changeLanguage('en'))
+  afterEach(() => {
+    cleanup()
+    return i18n.changeLanguage('en')
+  })
+
+  it('renders Spanish section titles and markdown under /es/docs', async () => {
+    await i18n.changeLanguage('es')
+    renderDocs(['/es/docs'])
+
+    // Default section (getting-started) H1 uses the localized title.
+    expect(activeHeading()).toBe('Primeros pasos')
+    // Body markdown comes from docs-content/es/getting-started.md.
+    expect(screen.getByText(/Botho es una criptomoneda centrada en la privacidad/)).toBeTruthy()
+    // English source copy must NOT leak through untranslated.
+    expect(screen.queryByText(/Botho is a privacy-focused cryptocurrency/)).toBeNull()
+  })
+
+  it('renders a Spanish deep-linked section (/es/docs#cluster-tags)', async () => {
+    await i18n.changeLanguage('es')
+    renderDocs(['/es/docs#cluster-tags'])
+
+    expect(activeHeading()).toBe('Etiquetas de clúster')
+    expect(screen.getByText(/Las etiquetas de clúster son el mecanismo novedoso de Botho/)).toBeTruthy()
+  })
+
+  it('nav labels are localized while the hrefs keep the invariant slug', async () => {
+    await i18n.changeLanguage('es')
+    renderDocs(['/es/docs'])
+
+    // Localized nav label (desktop + mobile => at least one match).
+    const consensusLinks = screen.getAllByRole('link', { name: 'Consenso' })
+    expect(consensusLinks.length).toBeGreaterThan(0)
+    // The href keeps the locale prefix + the English slug (locale-invariant id).
+    expect(consensusLinks[0].getAttribute('href')).toBe('/es/docs#consensus')
+  })
+
+  it('re-renders the active section in the new language on a mid-session switch', async () => {
+    await i18n.changeLanguage('es')
+    renderDocs(['/es/docs#consensus'])
+    expect(activeHeading()).toBe('Consenso')
+    expect(
+      screen.getByText(/SCP es un protocolo de acuerdo bizantino federado/),
+    ).toBeTruthy()
+
+    // Switching to English re-renders the same section under the English route.
+    cleanup()
+    await i18n.changeLanguage('en')
+    renderDocs(['/docs#consensus'])
+    await waitFor(() => expect(activeHeading()).toBe('Consensus'))
+    expect(
+      screen.getByText(/SCP is a federated Byzantine agreement protocol/),
+    ).toBeTruthy()
+  })
+
+  it('renders the not-found hint in Spanish for an unknown /es/docs segment', async () => {
+    await i18n.changeLanguage('es')
+    renderDocs(['/es/docs/protocol'])
+    // Getting Started title in Spanish, plus a Spanish not-found hint.
+    expect(activeHeading()).toBe('Primeros pasos')
+    const hint = screen.getByText(/no encontrada — mostrando Primeros pasos/)
+    expect(hint.textContent).toContain('protocol')
+  })
+})

--- a/web/packages/web-wallet/src/pages/docs.tsx
+++ b/web/packages/web-wallet/src/pages/docs.tsx
@@ -1,1340 +1,46 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { Logo } from '@botho/ui'
-import {
-  AlertTriangle,
-  ArrowLeft,
-  Book,
-  Code,
-  Shield,
-  Zap,
-  Globe,
-  Terminal,
-  Menu,
-  X,
-  Coins,
-  Tag,
-  Scale,
-} from 'lucide-react'
+import { AlertTriangle, ArrowLeft, Menu, X } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
-const sections = [
-  {
-    id: 'getting-started',
-    title: 'Getting Started',
-    icon: Book,
-    content: `
-## Getting Started with Botho
+import { LocaleSwitcher } from '../components/LocaleSwitcher'
+import { DEFAULT_LOCALE, isSupportedLocale } from '../lib/i18n'
+import { SECTION_META, getSectionContent, type DocSectionId } from '../docs-content'
 
-Botho is a privacy-focused cryptocurrency designed for the post-quantum era. It combines **stealth addresses** for transaction privacy with the **Stellar Consensus Protocol (SCP)** for fast, energy-efficient consensus. Unlike proof-of-work cryptocurrencies, Botho achieves finality in seconds while maintaining strong privacy guarantees.
-
-### What Makes Botho Different?
-
-Traditional cryptocurrencies like Bitcoin have transparent blockchains where anyone can trace the flow of funds between addresses. Even "privacy coins" often rely on cryptographic assumptions that may be broken by future quantum computers.
-
-Botho takes a different approach:
-
-- **Stealth addresses** ensure that each payment you receive goes to a unique one-time address, making it impossible to link your transactions together by watching the blockchain
-- **Post-quantum cryptography** protects your privacy against adversaries with quantum computers
-- **Federated Byzantine Agreement** provides fast finality — consensus safety never depends on hashpower
-- **Egalitarian issuance** distributes new coins through RandomX CPU mining that is deliberately decoupled from consensus: mining earns rewards but buys no say over which transactions confirm
-- **Progressive economics** — fees scale 1×–6× with wealth concentration, 80% of every fee is redistributed by lottery, and 20% is burned
-
-### Creating a Wallet
-
-Getting started with Botho takes just a few steps:
-
-1. **Visit the Wallet page** - Click "Launch Wallet" from the homepage or navigate directly to the wallet
-2. **Choose "Create New Wallet"** - You can also import an existing wallet if you have a recovery phrase
-3. **Secure your recovery phrase** - You'll be shown a 24-word mnemonic phrase. Write this down on paper and store it in a safe place. This phrase is the **only way** to recover your funds if you lose access to your device
-4. **Optional: Set a password** - Add an encryption password for additional security. You'll need this password each time you open the wallet in this browser
-
-**Important:** Never share your recovery phrase with anyone. Anyone with these words can access your funds. Never store it digitally (no screenshots, no cloud storage, no password managers).
-
-### Understanding Your Wallet Address
-
-Your wallet address looks like this: \`botho://1/4nuKn2U5qsRk3vD...\` (about 90 characters total)
-
-This address format includes:
-- **Protocol identifier** (\`botho://\` on mainnet, \`tbotho://\` on testnet) - Different prefixes prevent accidental cross-network sends
-- **Address version** (\`1/\` for classical addresses, \`1q/\` for quantum-safe addresses)
-- **Public keys** - Your view key and spend key, encoded together in base58
-
-Quantum-safe addresses (\`1q/\`) additionally embed ML-KEM and ML-DSA public keys, which makes them much longer (~4,400 characters) — better suited to QR codes and files than manual copying.
-
-You can safely share this address with anyone who wants to send you funds. Thanks to stealth addresses, each incoming transaction will be sent to a unique derived address that only you can spend from.
-
-### Receiving Your First Payment
-
-When someone sends you BTH:
-
-1. They use your public address to derive a unique one-time address
-2. The transaction is broadcast to the network and included in a block
-3. Your wallet scans new blocks and detects payments addressed to you
-4. The funds appear in your balance, usually within one block — block time adapts to network load, from 3 seconds under very heavy traffic up to 40 seconds when the network is idle
-
-### Sending Payments
-
-To send BTH to someone else:
-
-1. Click the **Send** button in your wallet
-2. Enter the recipient's Botho address
-3. Enter the amount to send
-4. Review the transaction details including the fee
-5. Confirm the transaction
-
-Transactions are final once confirmed—there are no chargebacks or reversals in Botho.
-
-### Transaction Fees
-
-Every Botho transaction requires a small fee. These fees serve three purposes:
-
-1. **Spam prevention** - Fees make it expensive to flood the network with junk transactions
-2. **Progressive taxation** - Fees scale 1× to 6× based on cluster wealth, discouraging concentration without enabling Sybil attacks
-3. **Redistribution and deflation** - 80% of every fee is redistributed to holders through a lottery; the remaining 20% is permanently burned
-
-Fees are size-based, not amount-based: \`fee = per-byte rate × transaction size × cluster factor (1×–6×) × output penalty\`. See the Cluster Tags and Tokenomics sections for details.
-
-### Security Best Practices
-
-- **Back up your recovery phrase** on paper, stored in a secure location
-- **Use a password** to encrypt your wallet in the browser
-- **Consider running your own node** for maximum privacy
-- **Verify addresses carefully** before sending funds—transactions cannot be reversed
-    `,
-  },
-  {
-    id: 'privacy',
-    title: 'Privacy Features',
-    icon: Shield,
-    content: `
-## Privacy Features
-
-Privacy is not just a feature in Botho—it's a fundamental design principle. Every aspect of the protocol is designed to protect your financial privacy while maintaining the auditability properties needed for a sound monetary system.
-
-### Why Privacy Matters
-
-Financial privacy is essential for:
-
-- **Personal security** - Public wealth makes you a target for criminals
-- **Business confidentiality** - Competitors shouldn't see your supplier payments or revenue
-- **Fungibility** - Money should be interchangeable; tainted coins create a two-tier system
-- **Human dignity** - Your financial life is nobody's business but your own
-- **Censorship resistance** - When all transactions look identical, there's no basis for blocking particular payments. Bitcoin works hard to solve this problem with various techniques, but privacy-by-default solves it elegantly: validators cannot discriminate because they cannot distinguish
-
-### Stealth Addresses
-
-Stealth addresses are the foundation of Botho's privacy model. Here's how they work:
-
-**The Problem:** In Bitcoin, if you publish an address to receive donations, anyone can see every donation you've ever received by looking at that address on the blockchain.
-
-**The Solution:** In Botho, your public address is not where funds are actually sent. Instead, each sender uses your public address to mathematically derive a unique one-time address. Only you can detect and spend from these derived addresses.
-
-**Technical Details:**
-
-1. Your wallet has a **view keypair** and a **spend keypair**
-2. The sender generates a random value and combines it with your public keys
-3. This produces a one-time address that appears random to everyone else
-4. Your wallet uses your private view key to scan for payments addressed to you
-5. To spend, you use your private spend key to sign the transaction
-
-The result: Even if you publish your address publicly, no one watching the blockchain can determine how many payments you've received, when you received them, or how much they were for.
-
-### Ring Signatures (Private Transactions)
-
-When you send a **Private transaction**, Botho uses **CLSAG ring signatures** to hide which specific coins you're spending. Your transaction references 20 possible inputs (a "ring"), and the signature proves you own one of them without revealing which one.
-
-CLSAG (Concise Linkable Spontaneous Anonymous Group) is an efficient ring signature scheme that provides strong sender privacy with compact signatures (~700 bytes per input).
-
-This breaks the transaction graph that would otherwise allow tracing funds through the blockchain. An observer sees that *someone* in the ring spent *some* coins, but cannot determine which participant or which specific coins.
-
-> **Note:** All value transfers use ring signatures. Minting transactions (block rewards) use ML-DSA signatures since the minter is public.
-
-### Confidential Amounts
-
-In all **Private transactions** (which includes all value transfers), amounts are hidden using **Pedersen commitments** with **Bulletproofs** range proofs. These cryptographic constructs allow the network to verify that transactions balance (inputs equal outputs plus fees) without revealing the actual amounts.
-
-Validators can confirm:
-- No new money is created from thin air
-- The sender has sufficient funds
-- The fee is at least the minimum required
-- All amounts are positive (via Bulletproofs)
-
-But they cannot determine:
-- How much is being transferred
-- The sender's total balance
-- The recipient's total balance
-
-> **Note:** Minting transactions (block rewards) have public amounts for supply auditability, but recipients are still hidden via stealth addresses.
-
-### Post-Quantum Cryptography
-
-Quantum computers pose a future threat to the cryptographic algorithms that secure most cryptocurrencies today. Botho uses a **hybrid post-quantum architecture** that protects the most critical data while keeping transactions efficient.
-
-**Algorithms Used:**
-
-- **ML-KEM-768** (FIPS 203) - Post-quantum stealth addresses (recipient privacy is permanent)
-- **ML-DSA-65** (FIPS 204) - Post-quantum signatures for minting transactions
-- **CLSAG** - Classical ring signatures for private transactions (sender privacy is ephemeral)
-- **Pedersen + Bulletproofs** - Information-theoretic amount hiding (quantum-safe)
-
-**Why This Architecture?**
-
-Recipient identity is recorded on-chain forever—a quantum attacker in 2045 could link recipients from 2025 transactions. ML-KEM protects against this "harvest now, decrypt later" threat. Sender privacy, however, is ephemeral—its value degrades over time as economic context becomes historical. Using classical CLSAG keeps transactions small (~4 KB vs ~65 KB for post-quantum alternatives).
-
-**Transaction Types:**
-
-| Type | Recipient | Amount | Sender | Use Case |
-|------|-----------|--------|--------|----------|
-| Minting | Hidden (ML-KEM) | Public | Known (ML-DSA) | Block rewards |
-| Private | Hidden (ML-KEM) | Hidden | Hidden (CLSAG ring=20) | All transfers (~4 KB) |
-
-Recipients and amounts are protected against quantum computers. Sender privacy uses efficient classical signatures.
-
-### Privacy Best Practices
-
-To maximize your privacy when using Botho:
-
-1. **Run your own node** - This prevents revealing your addresses to third-party servers
-2. **Use a new address for each context** - While stealth addresses protect received funds, using separate addresses for work vs personal adds another layer
-3. **Be mindful of metadata** - Privacy on-chain doesn't help if you reveal information off-chain
-    `,
-  },
-  {
-    id: 'cluster-tags',
-    title: 'Cluster Tags',
-    icon: Tag,
-    content: `
-## Cluster Tags
-
-Cluster tags are Botho's novel mechanism for tracking coin provenance without compromising privacy. They enable **Sybil-resistant progressive fees**, **lottery-based redistribution**, and **privacy-preserving ring signatures**.
-
-### The Problem: Wealth Taxation Without Identity
-
-Traditional progressive taxation requires identity. In cryptocurrency:
-
-- **Amount-based fees** fail instantly — split 1M into 1000×1K and pay lower rates
-- **Account-based taxation** is impossible — anyone can create unlimited addresses
-- **Transaction counting** doesn't work — bots can create artificial activity
-
-**The core challenge:** How do you tax wealth concentration when you can't identify who owns what?
-
-### The Solution: Provenance Tracking
-
-Instead of tracking *who* owns coins, we track *where* they came from. Every coin carries a memory of its origin.
-
-**Key insight:** Splitting coins doesn't change where they came from.
-
-### How Cluster Tags Work
-
-**1. Clusters Are Born at Minting**
-
-Each block reward creates a unique "cluster" — an identity for coins minted by a specific minter. The minting reward carries a 100% tag for that cluster.
-
-\`\`\`
-Block 1000: Minter A receives 50 BTH
-  → Tag: {cluster_A: 100%}
-
-Block 1001: Minter B receives 50 BTH
-  → Tag: {cluster_B: 100%}
-\`\`\`
-
-**2. Tags Inherit on Transfer**
-
-When coins move, the recipient's UTXO inherits the sender's tags:
-
-\`\`\`
-Minter A → Merchant → Customer
-  100%   →   95%    →   90%   (A's cluster factor)
-\`\`\`
-
-**3. Tags Blend on Combination**
-
-When multiple inputs are spent together, output tags are a value-weighted average:
-
-\`\`\`
-Input 1: 70 BTH {cluster_A: 100%}
-Input 2: 30 BTH {cluster_B: 100%}
-─────────────────────────────────
-Output: 100 BTH {cluster_A: 70%, cluster_B: 30%}
-\`\`\`
-
-**4. Tags Decay Over Time**
-
-Each transaction hop decays the tag by 5%, spreading attribution across the economy. But decay only applies if the UTXO is at least 720 blocks old (one to a few hours, depending on the load-adaptive block time), preventing wash trading attacks.
-
-### Why Splitting Doesn't Work
-
-This is what makes cluster tags special:
-
-\`\`\`
-Whale splits 1,000,000 BTH into 1000 × 1000 BTH
-
-Before: 1 UTXO with {whale_cluster: 100%}
-After:  1000 UTXOs, each with {whale_cluster: 100%}
-
-Fee rate: unchanged (based on cluster wealth, not UTXO count)
-\`\`\`
-
-The "source wealth" of a cluster is the total value minted by that minter — splitting doesn't reduce it.
-
-### Progressive Fee Curve
-
-The cluster factor determines how much you pay. It follows a smooth sigmoid curve in the *logarithm* of cluster wealth, with its midpoint at 100,000 BTH:
-
-| Cluster Wealth | Fee Multiplier |
-|----------------|----------------|
-| Small clusters (≤ ~1K BTH) | ~1x (base rate) |
-| Mid-size clusters (~100K BTH) | ~3.5x (curve midpoint) |
-| Whale clusters (≥ ~10M BTH) | ~6x (saturates) |
-
-The multiplier applies to a size-based fee (\`per-byte rate × transaction size\`), so the same transfer costs a whale cluster up to 6× what it costs well-circulated coins — and no amount of splitting changes that.
-
-### Lottery-Based Redistribution
-
-80% of all transaction fees are redistributed to eligible UTXOs via a lottery. 20% are burned.
-
-**How it works:**
-
-1. Each transaction pays a fee based on cluster factor
-2. 80% of the fee is split among 4 winners drawn with verifiable randomness
-3. 20% is permanently burned (deflationary)
-
-**How winners are selected (cluster-weighted):**
-
-A UTXO's winning weight is its **value divided by its cluster factor**. This is the only progressive weighting that is split-invariant:
-
-- Weights are value-based, so splitting a position into many UTXOs never increases total weight
-- The tilt comes from cluster provenance, which inherits through splits
-- Well-circulated (low-factor) coins win proportionally more; whale-cluster coins win less
-
-To participate, a UTXO must be at least 720 blocks old and worth at least 1 µBTH.
-
-### Ring Signatures and Tag Privacy
-
-Cluster tags work seamlessly with CLSAG ring signatures:
-
-**The challenge:** Ring signatures hide which input is real among 20 ring members. How do we calculate the correct fee?
-
-**The solution:** Centroid-based validation
-
-1. All ring members' tags are publicly known
-2. The fee derives from the value-weighted *centroid* of the ring's tags, with floors that stop cheap background decoys from dragging the factor down
-3. The claimed output tags must be at least 70% similar (cosine similarity) to the ring centroid, or the transaction is rejected
-
-This prevents fee evasion — you can't cherry-pick low-factor decoys to cut your fee, because implausible ring compositions fail validation.
-
-### Decay Mechanism Details
-
-To prevent wash trading (sending to yourself repeatedly to decay tags):
-
-**Age-Based Gating:**
-- Decay only applies to UTXOs at least 720 blocks old
-- New outputs from rapid self-transfers don't decay
-- The age gate naturally caps decay at ~12 events per day
-
-**Natural rate limiting:**
-
-| Attack | Result |
-|--------|--------|
-| 100 rapid self-transfers | 0% decay (all outputs too young) |
-| Patient attack (1 day) | ~46% max decay (only ~12 eligible hops) |
-| Patient attack (1 week) | ~99% decay — but you've paid ~84 transaction fees |
-| Holding without transacting | 0% decay |
-
-### Privacy Considerations
-
-**Phase 1 (Current):** Tags are public on UTXOs. This enables direct fee verification but reveals some provenance information.
-
-**Phase 2 (Planned):** Tags will be hidden using Pedersen commitments with zero-knowledge proofs. Validators verify correct fees without seeing actual tag values.
-
-### Economic Incentives
-
-The cluster tag system creates aligned incentives:
-
-| Behavior | Effect on Tags | Incentive |
-|----------|----------------|-----------|
-| **Circulate coins** | Tags decay and blend | Lower fees, higher lottery weight |
-| **Hoard wealth** | Tags remain concentrated | Higher fees, lower lottery weight, demurrage |
-| **Split into many UTXOs** | Tags unchanged | No benefit — fees and lottery weight are provenance- and value-based |
-
-### Technical Parameters
-
-| Parameter | Value | Purpose |
-|-----------|-------|---------|
-| Decay rate | 5% per eligible hop | Gradual tag diffusion |
-| Min UTXO age (decay + lottery) | 720 blocks | Wash trading prevention |
-| Min UTXO value (lottery) | 1 µBTH | Dust exclusion |
-| Cluster factor range | 1x–6x (midpoint 3.5x at 100K BTH) | Progressive fees |
-| Ring size | 20 | Privacy set for tag propagation |
-| Lottery winners | 4 per drawing | Redistribution granularity |
-| Burn rate | 20% of fees | Deflationary pressure |
-| Pool rate | 80% of fees | Redistribution amount |
-| Demurrage | 2%/yr at max factor (see Tokenomics) | Reaches idle concentrated wealth |
-
-### Summary
-
-Cluster tags solve the "Sybil-resistant progressive taxation" problem that plagues cryptocurrency:
-
-1. **Track provenance, not identity** — Coins remember their origin
-2. **Resist splitting attacks** — Cluster wealth is fixed at minting
-3. **Enable progressive fees** — Wealthy clusters pay more
-4. **Power fair redistribution** — Lottery weight tilts toward well-circulated coins
-5. **Preserve privacy** — Works with ring signatures
-6. **Encourage circulation** — Tags decay through commerce
-
-This makes Botho the first cryptocurrency with a credible mechanism for wealth-based fees that can't be trivially evaded.
-    `,
-  },
-  {
-    id: 'privacy-progressivity',
-    title: 'Privacy + Progressivity',
-    icon: Scale,
-    content: `
-## How Botho Achieves Both Privacy and Progressivity
-
-This is Botho's most surprising achievement: **privacy and progressive economics working together, not against each other.**
-
-The conventional wisdom says these goals are incompatible. To tax the wealthy more, you need to know who's wealthy. But knowing who's wealthy means tracking identity and balances—the opposite of privacy.
-
-Botho proves this trade-off is false. Here's how.
-
-### The Apparent Impossibility
-
-Consider what "progressive taxation" traditionally requires:
-
-1. **Identify the taxpayer** — Link transactions to a person
-2. **Track their wealth** — Know how much they own
-3. **Apply graduated rates** — Charge more to those with more
-
-Every step violates privacy. If you know Alice has 1M coins, you've already destroyed her financial privacy.
-
-This creates what seems like a fundamental conflict:
-
-| Goal | Requires |
-|------|----------|
-| **Privacy** | Hide who owns what |
-| **Progressivity** | Know who owns what |
-
-Most projects accept this trade-off, choosing either:
-- **Full privacy** (Monero, Zcash): No progressive fees possible
-- **Full transparency** (Bitcoin, Ethereum): Progressive fees possible but no privacy
-
-Botho takes a third path.
-
-### The Key Insight: Provenance, Not Identity
-
-The breakthrough is realizing that progressive taxation doesn't *require* knowing identity or total wealth. It requires **correlating fees with economic behavior**.
-
-Instead of asking "Who owns this coin and how rich are they?" Botho asks:
-
-> "Where did this coin come from, and how much has it circulated?"
-
-This question has a surprising property: **it's answerable on-chain without linking to identity.**
-
-### What We Track: Minting Proximity
-
-Every coin in Botho carries a "cluster tag" — a memory of which minting event created it. This is not tracking the *owner*, but the *origin*.
-
-| Coin State | Tags | Fee Level |
-|------------|------|-----------|
-| Freshly minted | \`{cluster_A: 100%}\` | High |
-| Well-traded | \`{cluster_A: 5%, cluster_B: 15%, ...}\` | Low |
-
-The key properties:
-
-| Property | Effect |
-|----------|--------|
-| **Concentrated tags** | Recently minted, not yet circulated → High fees |
-| **Diversified tags** | Traded through many hands → Low fees |
-| **Splitting-resistant** | Splitting preserves tag concentration |
-| **Decay-resistant** | Only real commerce reduces tags |
-
-### Why This Is Progressive
-
-Here's where it gets interesting. **Minting proximity correlates with wealth concentration** in predictable ways:
-
-**New minters tend to be wealthy.** Earning block rewards requires hardware, electricity, and reliable uptime. Even with CPU-egalitarian RandomX mining, fresh coins disproportionately go to those with existing resources.
-
-**Active traders tend to be merchants.** Small businesses and regular users transact frequently, causing their coins to mix with coins from many sources.
-
-**Hoarders keep concentrated tags.** If you mine coins and hold them without trading, your tags never decay. You keep paying high fees.
-
-**Commerce diversifies naturally.** Every legitimate transaction mixes your tags with your counterparty's tags. Economic activity automatically reduces your fee rate.
-
-This creates a **behavioral correlation**:
-
-| Behavior Pattern | Tag State | Fee Level |
-|------------------|-----------|-----------|
-| Mine and hold (wealthy behavior) | Concentrated | High |
-| Active commerce (merchant behavior) | Diversified | Low |
-| Regular user spending | Mixed | Medium→Low |
-| Whale accumulating | Concentrated | High |
-
-We don't need to know *who* you are. We just observe *how your coins behave*.
-
-### What Remains Private
-
-This is crucial: **cluster tags reveal provenance, not identity.**
-
-| Information | Status |
-|-------------|--------|
-| Who owns a UTXO | **Private** (ring signatures) |
-| Who received a payment | **Private** (stealth addresses) |
-| Amount transferred | **Private** (confidential transactions) |
-| Your total balance | **Private** (no account linkage) |
-| Which UTXO you spent | **Private** (ring signatures) |
-| Where coins originated | Public (cluster tags) |
-| How diversified tags are | Public (enables fee calculation) |
-
-You reveal *something*—the coin's history—but not *who you are* or *what you own*.
-
-### The Ring Signature Integration
-
-Ring signatures and cluster tags work together seamlessly:
-
-**How ring signatures work:** When you spend, you prove "I own ONE of these 20 UTXOs" without revealing which one. This provides sender privacy.
-
-**The challenge:** If we don't know which UTXO you're spending, how do we calculate the correct fee?
-
-**The solution: Centroid-based validation.**
-
-1. All 20 ring members' tags are publicly visible
-2. The fee derives from the **value-weighted centroid** of the ring's tags, with floors so cheap background decoys can't drag the factor down
-3. The output tags you claim must be at least 70% similar to that centroid, or validators reject the transaction
-
-\`\`\`
-Ring members' tags → value-weighted centroid → cluster factor
-Claimed output tags: must be ≥ 70% similar to the centroid
-\`\`\`
-
-This means **privacy doesn't enable fee evasion.** A large real input dominates its own ring's centroid, so cherry-picking low-factor decoys produces an implausible ring that fails validation instead of a discount.
-
-### The Lottery Redistribution
-
-Fees flow back to the community through a cluster-tilted lottery:
-
-**80% of all fees** are redistributed to eligible UTXOs. **20% are burned** (deflationary).
-
-**How selection works:**
-
-\`\`\`
-weight = value ÷ cluster factor
-
-Well-circulated UTXO (factor 1x):  full weight per BTH
-Whale-cluster UTXO (factor 6x):    1/6 the weight per BTH
-\`\`\`
-
-**Well-circulated coins win up to 6× more per BTH than concentrated wealth.** This is progressive redistribution without knowing anyone's identity — and because weight is value-based, splitting a position into many UTXOs never increases its total weight.
-
-**Eligibility gates** prevent gaming: a UTXO must be at least 720 blocks old and worth at least 1 µBTH to participate.
-
-### Attack Resistance
-
-We've tested these mechanisms extensively:
-
-**Splitting Attack:**
-\`\`\`
-Attacker: Split 1M BTH into 1000 × 1K BTH
-Result: Each piece still has {whale_cluster: 100%}
-Fee reduction: 0% (cluster factor unchanged)
-Verdict: Attack defeated
-\`\`\`
-
-**Sybil Attack (Multiple Accounts):**
-\`\`\`
-Attacker: Create 100 sybil addresses, send 10K to each
-Result: Each sybil's UTXO inherits whale tags
-Fee reduction: Minimal (tags propagate)
-Verdict: Attack defeated
-\`\`\`
-
-**Parking Attack (Split and Wait):**
-\`\`\`
-Attacker: Split into 100 UTXOs, wait for lottery winnings
-Result: Weight is value-based — splitting gains NO weight
-        Cluster factor inherits — the tilt still works against you
-        Quadratic output fees make the split itself cost up to 100×
-Verdict: Attack defeated
-\`\`\`
-
-**Wash Trading (Self-transfers):**
-\`\`\`
-Attacker: Send to self rapidly to decay tags
-Result: Age-gating requires 720 blocks per decay
-        At most ~12 decays per day ≈ 46% daily decay
-        1 week of wash trading: ~99% decay
-        Cost: ~84 transaction fees (each feeding the lottery)
-Verdict: Expensive, slow, detectable
-\`\`\`
-
-### The Complete Picture
-
-Botho achieves privacy + progressivity through layered design:
-
-| Layer | Privacy Feature | Progressive Feature |
-|-------|-----------------|---------------------|
-| **Sender** | Ring signatures (1-of-20) | Centroid-validated tag propagation |
-| **Recipient** | Stealth addresses | — |
-| **Amount** | Pedersen commitments | — |
-| **Fee rate** | — | Cluster factor curve (1-6×) |
-| **Holding cost** | — | Demurrage on idle wealthy-cluster coins |
-| **Redistribution** | Verifiable random drawing | Cluster-tilted weights (value ÷ factor) |
-
-Each layer contributes to both goals without conflict.
-
-### Why This Matters
-
-This isn't just a technical achievement—it changes what's possible:
-
-**For users:** You get financial privacy AND a fair economic system. No trade-off required.
-
-**For merchants:** Low fees reward economic activity. The more you trade, the lower your rates.
-
-**For the network:** Wealth naturally flows from concentrated to distributed holdings. Self-custody is rewarded over custodial services.
-
-**For the ecosystem:** We've proven that "privacy vs. fairness" is a false dichotomy. Other projects can adopt these techniques.
-
-### Summary
-
-Botho's privacy + progressivity mechanism works because:
-
-1. **We track provenance, not identity** — Where coins came from, not who owns them
-2. **Provenance correlates with wealth behavior** — Fresh minters are wealthy, active traders are merchants
-3. **Ring signatures preserve privacy** — Centroid validation prevents gaming
-4. **Cluster-tilted lottery is progressive** — Well-circulated coins win more per BTH
-5. **Value-based weights and quadratic output fees deter attacks** — Parking and splitting don't pay off
-6. **Commerce is rewarded** — Tags decay through legitimate trade; idle concentrated wealth pays demurrage
-
-The result: **The first cryptocurrency where you can be private AND contribute fairly to the network, where the wealthy pay more without anyone knowing who they are.**
-    `,
-  },
-  {
-    id: 'consensus',
-    title: 'Consensus',
-    icon: Zap,
-    content: `
-## Stellar Consensus Protocol
-
-Botho uses the **Stellar Consensus Protocol (SCP)** for distributed consensus. SCP is a federated Byzantine agreement protocol that provides fast finality, energy efficiency, and flexible trust—without sacrificing decentralization.
-
-### Why Not Proof-of-Work Consensus?
-
-Proof-of-work (PoW) consensus, as used in Bitcoin, has significant drawbacks:
-
-- **Energy waste** - PoW deliberately consumes massive amounts of electricity as a security mechanism
-- **Slow finality** - Bitcoin transactions aren't truly final for an hour or more
-- **Centralization pressure** - Mining economies of scale push toward industrial operations
-- **51% attacks** - If an attacker controls majority hashpower, they can rewrite history
-
-**Botho still uses proof-of-work — but only for coin issuance, never for consensus.** Blocks are minted through CPU-egalitarian RandomX mining, which decides *who earns the block reward*. Whether that block is *accepted* is decided entirely by SCP. This decoupling means an attacker with majority hashpower can out-earn everyone else, but cannot rewrite history or censor transactions — and because hashpower buys no security, there is no arms-race pressure toward Bitcoin-scale energy consumption.
-
-### Why Not Proof-of-Stake?
-
-Proof-of-stake (PoS) improves on energy usage but introduces its own issues:
-
-- **Nothing-at-stake** - Validators can cheaply vote on multiple chain forks
-- **Wealth concentration** - The rich get richer through staking rewards
-- **Long-range attacks** - Old keys can potentially rewrite history
-- **Complexity** - PoS systems require intricate slashing and validator selection logic
-
-### How SCP Works
-
-SCP takes a fundamentally different approach based on **federated voting**:
-
-**Quorum Slices:** Each node in the network defines its own "quorum slice"—a set of other nodes it trusts. A node will only accept a statement as final when its quorum slice agrees.
-
-**Quorum Intersection:** The network is secure as long as all quorum slices share some nodes in common. This ensures that two conflicting statements cannot both achieve consensus.
-
-**Federated Voting:** Consensus proceeds through a series of voting rounds:
-
-1. **Nominate** - Nodes propose candidate values for the next block
-2. **Prepare** - Nodes vote to prepare a specific value
-3. **Commit** - Nodes vote to commit the prepared value
-4. **Externalize** - Once committed, the value is final
-
-**Key Insight:** Unlike PoW where you trust "the longest chain," in SCP you explicitly choose which nodes to trust. This makes the trust model transparent and auditable.
-
-### Properties of SCP
-
-**Decentralized Control:** No central authority determines consensus. Each node independently chooses its quorum slice based on its own assessment of trustworthiness.
-
-**Low Latency:** Transactions reach finality in seconds (typically 3-5 seconds under normal conditions), compared to minutes or hours for PoW systems.
-
-**Flexible Trust:** Participants can choose different quorum configurations based on their needs. Some may trust established institutions; others may trust a set of technical experts.
-
-**Asymptotic Security:** As the network grows and quorum slices become more interconnected, the system becomes more resilient against Byzantine failures.
-
-**Energy Efficiency:** SCP nodes only need to exchange messages and verify signatures—no computational puzzles, no energy waste.
-
-### Safety vs. Liveness
-
-SCP prioritizes **safety** over **liveness**:
-
-- **Safety:** The network will never confirm conflicting transactions
-- **Liveness:** The network should eventually make progress
-
-If the quorum structure is disrupted (too many nodes go offline), SCP will halt rather than risk confirming conflicting transactions. This is the correct trade-off for a monetary system—it's better to pause than to have funds stolen.
-
-### Quorum Configuration in Botho
-
-The Botho network starts with a bootstrap quorum centered on the foundation's seed nodes. Over time, as more independent nodes join, the quorum structure will become increasingly decentralized.
-
-Node operators can customize their quorum slice to trust:
-- The foundation's seed nodes (default)
-- Other known community nodes
-- Nodes run by exchanges or businesses they trust
-- Any combination of the above
-
-The health of the network depends on sufficient quorum intersection. The Botho explorer shows real-time quorum topology to help operators make informed decisions.
-    `,
-  },
-  {
-    id: 'running-node',
-    title: 'Running a Node',
-    icon: Terminal,
-    content: `
-## Running a Botho Node
-
-Running your own Botho node gives you the highest level of privacy and helps strengthen the network. When you run a node, your wallet connects directly to the blockchain without relying on third-party servers.
-
-### Why Run a Node?
-
-**Privacy:** When you use a light wallet or web wallet, you're trusting a server not to log your addresses or transactions. Running your own node means your wallet activity stays on your machine.
-
-**Verification:** Your node independently validates every transaction and block. You don't have to trust anyone's claims about the state of the network.
-
-**Network health:** More nodes make the network more resilient. Your node relays transactions and blocks, helping the network function.
-
-**Minting advantage:** Running your own node gives you lower latency in the minting competition. Nodes that receive new blocks faster can begin working on the next block sooner, increasing their chances of earning minting rewards.
-
-**Participation:** If you want to mint new blocks or participate in consensus, you need a full node.
-
-### System Requirements
-
-**Minimum Requirements:**
-- 2 CPU cores
-- 4 GB RAM
-- 50 GB SSD storage
-- 10 Mbps internet connection
-
-**Recommended:**
-- 4+ CPU cores
-- 8 GB RAM
-- 100 GB NVMe SSD
-- 100 Mbps internet connection
-
-The blockchain is currently small, but storage requirements will grow over time.
-
-### Installation
-
-**From Source (Recommended):**
-
-\`\`\`bash
-# Install Rust if you haven't already
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-# Clone the repository
-git clone https://github.com/botho-project/botho.git
-cd botho
-
-# Build in release mode
-cargo build --release
-
-# The binary is at ./target/release/botho
-\`\`\`
-
-**First-Time Setup:**
-
-\`\`\`bash
-# Initialize a new wallet and configuration
-./target/release/botho init
-
-# This will:
-# - Generate a 24-word recovery phrase
-# - Create your config and wallet under ~/.botho/
-
-# Variants:
-#   botho init --recover   # restore a wallet from an existing mnemonic
-#   botho init --relay     # relay/seed node config with no wallet
-\`\`\`
-
-**IMPORTANT:** Write down your recovery phrase and store it securely!
-
-### Running the Node
-
-**Basic operation:**
-
-\`\`\`bash
-# Start the node and sync with the network
-./target/release/botho run
-\`\`\`
-
-**With minting enabled:**
-
-\`\`\`bash
-# Start the node and participate in block production
-./target/release/botho run --mint
-\`\`\`
-
-### CLI Commands Reference
-
-**Wallet Commands:**
-
-| Command | Description |
-|---------|-------------|
-| \`botho init\` | Create a new wallet with a 24-word mnemonic |
-| \`botho balance\` | Show your current wallet balance |
-| \`botho address\` | Display your receiving address (\`--save\` writes it to a file) |
-| \`botho send <address> <amount>\` | Send BTH (amount in BTH; \`--quantum\` for post-quantum crypto, \`--memo\` to attach an encrypted note) |
-
-All sends use CLSAG ring signatures — sender privacy is on by default, not a flag.
-
-**Node Commands:**
-
-| Command | Description |
-|---------|-------------|
-| \`botho run\` | Start the node and sync with the network |
-| \`botho run --mint\` | Start with minting enabled (\`--mint-threads N\` to limit CPU use) |
-| \`botho status\` | Show node sync status and peer count |
-| \`botho snapshot\` | Manage UTXO snapshots for fast initial sync |
-
-### Configuration
-
-The configuration file lives under \`~/.botho/\`. All ports have network-specific defaults, so a minimal config works out of the box:
-
-\`\`\`toml
-# "mainnet" or "testnet"
-network_type = "testnet"
-
-[network]
-# Defaults: gossip 7100 (mainnet) / 17100 (testnet)
-#           RPC    7101 (mainnet) / 17101 (testnet)
-#           metrics 9090 (mainnet) / 19090 (testnet), 0 disables
-# gossip_port = 17100
-# rpc_port = 17101
-# metrics_port = 19090
-
-# Optional explicit bootstrap peers (multiaddr format).
-# If unset, peers are discovered via DNS seed TXT records
-# (seeds.botho.io / seeds.testnet.botho.io).
-# bootstrap_peers = ["/dns4/eu.seed.botho.io/tcp/7100/p2p/<peer-id>"]
-
-[minting]
-enabled = false
-threads = 0   # 0 = use all CPU cores
-\`\`\`
-
-### Firewall Configuration
-
-If you want your node to accept incoming connections (recommended):
-
-\`\`\`bash
-# Allow P2P gossip traffic (17100 on testnet, 7100 on mainnet)
-sudo ufw allow 17100/tcp
-
-# Optional: Allow RPC access (only if needed externally)
-# sudo ufw allow 17101/tcp
-\`\`\`
-
-### Troubleshooting
-
-**Node won't sync:**
-- Check your internet connection
-- Verify firewall allows outbound connections on the gossip port
-- As a last resort, clear the chain database under \`~/.botho/\` and resync (testnet only — this rescans from genesis)
-
-**High memory usage:**
-- Reduce minting threads (RandomX keeps a large in-memory dataset)
-- Consider adding swap space if RAM is limited
-
-**Can't connect to peers:**
-- Ensure your gossip port (17100 testnet / 7100 mainnet) is open for incoming connections
-- Check if you're behind a strict NAT
-    `,
-  },
-  {
-    id: 'api',
-    title: 'API Reference',
-    icon: Code,
-    content: `
-## JSON-RPC API
-
-Botho nodes expose a JSON-RPC 2.0 API on port **7101** (mainnet) or **17101** (testnet) by default; override with \`rpc_port\` in the config. All requests use the standard JSON-RPC 2.0 format.
-
-### Request Format
-
-\`\`\`json
-{
-  "jsonrpc": "2.0",
-  "method": "METHOD_NAME",
-  "params": { ... },
-  "id": 1
-}
-\`\`\`
-
----
-
-## Node Methods
-
-### node_getStatus
-
-Get node status and sync information.
-
-**Response (selected fields):**
-- \`version\` - Node software version
-- \`network\` - Network name (e.g., "botho-testnet")
-- \`uptimeSeconds\` - Node uptime in seconds
-- \`syncStatus\` / \`syncProgress\` / \`synced\` - Live sync state
-- \`chainHeight\` - Current blockchain height
-- \`tipHash\` - Hash of the latest block
-- \`peerCount\` / \`scpPeerCount\` - Connected peers / SCP-participating peers
-- \`mempoolSize\` - Transactions in mempool
-- \`mintingActive\` - Whether minting is enabled
-- \`quorumFaultTolerant\` / \`quorumDegenerate\` - BFT posture (fault tolerance requires ≥ 4 participating nodes)
-
-The full response also includes build info, SCP slot progress, quorum-gate state, and miner-health fields for monitoring.
-
----
-
-## Chain Methods
-
-### getChainInfo
-
-Get blockchain information.
-
-**Response:**
-- \`height\` - Current block height
-- \`tipHash\` - Hash of the tip block
-- \`difficulty\` - Current mining difficulty
-- \`totalMined\` - Total coins mined (picocredits, as a string)
-- \`totalFeesBurned\` - Cumulative burned fees (picocredits, as a string)
-- \`circulatingSupply\` - totalMined minus burns (picocredits, as a string)
-- \`mempoolSize\` - Number of pending transactions
-- \`mempoolFees\` - Total fees in mempool
-
-### getBlockByHeight
-
-Get a block by its height.
-
-**Parameters:**
-- \`height\` (number) - Block height
-
-**Response:**
-- \`height\` - Block height
-- \`hash\` - Block hash
-- \`prevHash\` - Previous block hash
-- \`timestamp\` - Block timestamp
-- \`difficulty\` - Block difficulty
-- \`nonce\` - Mining nonce
-- \`txCount\` - Number of transactions
-- \`mintingReward\` - Minting reward amount
-
-### getMempoolInfo
-
-Get mempool statistics.
-
-**Response:**
-- \`size\` - Number of transactions
-- \`totalFees\` - Total fees from all transactions
-- \`txHashes\` - Array of transaction hashes (up to 100)
-
-### estimateFee (alias: tx_estimateFee)
-
-Estimate transaction fee.
-
-**Parameters:**
-- \`amount\` (number) - Transaction amount
-- \`memos\` (number) - Number of encrypted memo fields
-
-**Response:**
-- \`minimumFee\` - Minimum required fee
-- \`clusterFactor\` - Progressive multiplier, scaled ×1000 (1000 = 1x, 6000 = 6x)
-- \`clusterFactorDisplay\` - Human-readable factor (e.g., "1.25x")
-- \`clusterWealth\` - Cluster wealth the factor was derived from
-- \`recommendedFee\` - Recommended fee for normal priority
-- \`highPriorityFee\` - Fee for high priority confirmation
-
----
-
-## Wallet Methods
-
-### chain_getOutputs
-
-Get transaction outputs for wallet sync.
-
-**Parameters:**
-- \`start_height\` (number) - Starting block height
-- \`end_height\` (number) - Ending block height (max 100 blocks per request)
-
-**Response:** Array of blocks, each containing:
-- \`height\` - Block height
-- \`outputs\` - Array of outputs with \`txHash\`, \`outputIndex\`, \`targetKey\`, \`publicKey\`, \`amountCommitment\`
-
-### wallet_getBalance
-
-Get wallet balance (requires local wallet).
-
-**Response:**
-- \`confirmed\` - Confirmed balance
-- \`pending\` - Pending balance
-- \`total\` - Total balance
-- \`utxoCount\` - Number of unspent outputs
-
-### wallet_getAddress
-
-Get wallet keys and address info.
-
-**Response:**
-- \`viewKey\` - Public view key (hex)
-- \`spendKey\` - Public spend key (hex)
-- \`hasWallet\` - Whether node has a wallet configured
-
----
-
-## Transaction Methods
-
-### tx_submit / sendRawTransaction
-
-Submit a signed transaction.
-
-**Parameters:**
-- \`tx_hex\` (string) - Hex-encoded serialized transaction
-
-**Response:**
-- \`txHash\` - Transaction hash
-
----
-
-## Minting Methods
-
-### minting_getStatus
-
-Get minting status.
-
-**Response:**
-- \`active\` - Whether minting is enabled
-- \`threads\` - Number of minting threads
-- \`hashrate\` - Current hashrate
-- \`totalHashes\` - Total hashes computed
-- \`blocksFound\` - Blocks mined by this node
-- \`currentDifficulty\` - Current network difficulty
-- \`uptimeSeconds\` - Minting uptime
-
----
-
-## Network Methods
-
-### network_getInfo
-
-Get network connection information.
-
-**Response:**
-- \`peerCount\` - Total peer count
-- \`inboundCount\` - Inbound connections
-- \`outboundCount\` - Outbound connections
-- \`bytesSent\` - Total bytes sent
-- \`bytesReceived\` - Total bytes received
-- \`uptimeSeconds\` - Connection uptime
-
-### network_getPeers
-
-Get list of connected peers.
-
-**Response:**
-- \`peers\` - Array of peer information
-
----
-
-## Other Methods
-
-The API surface is larger than this page. Notable additional methods:
-
-| Method | Purpose |
-|--------|---------|
-| \`getBlockByHash\` | Fetch a block by hash instead of height |
-| \`getSupplyInfo\` | Emission and supply details |
-| \`tx_get\` / \`tx_getStatus\` | Look up a transaction / its confirmation status |
-| \`address_validate\` | Check whether an address string is well-formed |
-| \`fee_getRate\` | Current dynamic fee rate |
-| \`cluster_getWealth\` / \`cluster_getAllWealth\` | Cluster wealth queries (powers the explorer views) |
-| \`chain_areKeyImagesSpent\` | Check key images for double-spend detection |
-| \`faucet_getStatus\` / \`faucet_request\` | Testnet faucet |
-| \`operator_*\` | Operator trust surface (disabled unless configured; see the operator runbooks) |
-    `,
-  },
-  {
-    id: 'network',
-    title: 'Network',
-    icon: Globe,
-    content: `
-## Network Information
-
-This page provides technical details about the Botho network, including connection information, network parameters, and security model.
-
-### Network Status
-
-The Botho network is currently in **testnet** phase. This means:
-
-- Coins have no monetary value
-- The network may be reset during development
-- Features are still being tested and refined
-- Bug reports and feedback are welcome
-
-Production mainnet launch will be announced when the network is stable.
-
-### Connecting to the Network
-
-**Seed Discovery:**
-
-Bootstrap peers are discovered via DNS TXT records rather than a hardcoded list:
-
-| Network | DNS Seed Domain |
-|---------|-----------------|
-| Mainnet | seeds.botho.io |
-| Testnet | seeds.testnet.botho.io |
-
-When your node starts, it resolves the seed domain to learn about bootstrap peers (you can also pin explicit \`bootstrap_peers\` in the config). After initial discovery, your node maintains connections to multiple peers for redundancy.
-
-**Peer Discovery:**
-
-Botho uses libp2p for networking, which supports multiple discovery mechanisms:
-
-- **Bootstrap nodes** - Known seed nodes for initial connection
-- **mDNS** - Local network discovery for development
-- **Kademlia DHT** - Distributed peer discovery
-- **Gossipsub** - Topic-based message propagation
-
-### Network Parameters
-
-**Block Production:**
-
-| Parameter | Value | Description |
-|-----------|-------|-------------|
-| Block time | 3–40 seconds (load-adaptive) | Fast blocks under heavy traffic (3 s only at 20+ tx/s), slow blocks when idle |
-| Max block size | 20 MB | Maximum serialized block size |
-| Max transactions per block | 5,000 | Transaction count limit |
-
-**Transaction Limits:**
-
-| Parameter | Value | Description |
-|-----------|-------|-------------|
-| Max inputs | 16 | Maximum inputs per transaction |
-| Max outputs | 16 | Maximum outputs per transaction |
-| Ring size | 20 | Number of members in CLSAG ring signature |
-| Max tx size | 100 KB | Maximum serialized transaction size |
-
-**Fees:**
-
-| Parameter | Value | Description |
-|-----------|-------|-------------|
-| Fee formula | per-byte rate × size × cluster factor × output penalty | Size-based, wealth-progressive |
-| Cluster factor | 1x–6x | Progressive multiplier from coin provenance |
-| Output penalty | quadratic, capped at 100x | Anti-UTXO-farming |
-| Fee destination | 80% lottery / 20% burned | Redistribution plus deflationary pressure |
-
-### Port Reference
-
-Defaults differ by network (mainnet / testnet); all are configurable:
-
-| Port (mainnet / testnet) | Protocol | Purpose |
-|--------------------------|----------|---------|
-| 7100 / 17100 | TCP | P2P gossip (libp2p) |
-| 7101 / 17101 | HTTP + WebSocket | JSON-RPC API and real-time updates |
-| 9090 / 19090 | HTTP | Prometheus metrics |
-
-### Network Security
-
-**Sybil Resistance:**
-
-The network resists Sybil attacks through:
-- Quorum-based consensus (SCP)
-- Reputation scoring for peers
-- Resource requirements for block minting
-
-**Eclipse Protection:**
-
-Nodes protect against eclipse attacks by:
-- Maintaining diverse peer connections
-- Preferring peers with established history
-- Regular peer rotation
-- Multiple independent peer discovery methods
-
-### Getting Involved
-
-**For Developers:**
-- Source code: [github.com/botho-project/botho](https://github.com/botho-project/botho)
-- Report bugs via GitHub issues
-- Contributions welcome (see CONTRIBUTING.md)
-
-**For Node Operators:**
-- Run a node to strengthen the network
-- Enable minting if you have reliable uptime
-- Monitor your node's quorum intersection
-
-**For Users:**
-- Test the wallet and report issues
-- Provide feedback on user experience
-- Help with documentation and translations
-    `,
-  },
-  {
-    id: 'tokenomics',
-    title: 'Tokenomics',
-    icon: Coins,
-    content: `
-## Tokenomics
-
-Botho (BTH) uses a two-phase emission model designed for long-term sustainability: an initial distribution phase with halvings, followed by perpetual tail emission targeting stable inflation.
-
-### Overview
-
-| Parameter | Value |
-|-----------|-------|
-| Token symbol | BTH |
-| Smallest unit | picocredit (10⁻¹² BTH) |
-| Pre-mine | None (100% mined) |
-| Phase 1 supply | ~611 million BTH |
-| Block time | 3–40 seconds (load-adaptive; 5 s monetary baseline) |
-
-### Unit System
-
-BTH uses 12-decimal precision. The picocredit is the single base unit — every amount on the wire (balances, fees, cluster wealth) is denominated in picocredits, and formatting into BTH happens only in the display layer:
-
-- **1 picocredit** = 0.000000000001 BTH (smallest unit)
-- **1 microBTH (µBTH)** = 1,000,000 picocredits = 0.000001 BTH
-- **1 milliBTH (mBTH)** = 1,000,000,000 picocredits = 0.001 BTH
-- **1 BTH** = 1,000,000,000,000 picocredits
-
----
-
-## Emission Schedule
-
-All monetary math assumes the 5-second high-load block time (actual blocks range 3–40 s, dropping to 3 s only at very high load, 20+ tx/s). When the network is idle and blocks slow down (up to 40 s), emission stretches proportionally — a natural dampener: a busy network emits at the full schedule, an idle one emits less.
-
-### Phase 1: Halving Period (~5 years at full load)
-
-The minting reward starts at 50 BTH and halves every **6,307,200 blocks** (one year of 5-second blocks). After five halving epochs, Phase 1 has distributed **611,010,000 BTH**:
-
-| Epoch | Minting Reward | Cumulative Supply |
-|-------|----------------|-------------------|
-| 1 | 50 BTH | ~315.4M BTH |
-| 2 | 25 BTH | ~473.0M BTH |
-| 3 | 12.5 BTH | ~552.0M BTH |
-| 4 | 6.25 BTH | ~591.3M BTH |
-| 5 | 3.125 BTH | ~611.0M BTH |
-
-(This is the canonical schedule ratified in issue #351, locked by regression tests in the node.)
-
-### Phase 2: Tail Emission
-
-After Phase 1, Botho transitions to perpetual tail emission targeting **2% annual net inflation** (gross emission minus fee burns), with difficulty adjusting to hit the target.
-
-**Why tail emission?**
-
-- **Security budget** - Ensures minters always have incentive to secure the network
-- **Lost coin replacement** - Compensates for coins lost to forgotten keys
-- **Predictable monetary policy** - 2% is below typical fiat inflation
-
-At the ~611M BTH Phase-1 supply and full load, 2% works out to roughly **2 BTH per block**, growing slowly with supply.
-
----
-
-## Fee Structure
-
-### Transaction Fees
-
-Every fee is split two ways: **80% is redistributed** to holders through the cluster-tilted lottery, and **20% is burned**, creating deflationary pressure that offsets tail emission.
-
-\`\`\`
-fee = per-byte rate × transaction size × cluster factor × output penalty + memo fees
-\`\`\`
-
-| Parameter | Value |
-|-----------|-------|
-| Fee basis | Transaction size (bytes), not amount |
-| Cluster factor | 1x–6x progressive multiplier |
-| Output penalty | Quadratic in output count, capped at 100x |
-| Memo fee | Flat per encrypted memo |
-| Fee destination | 80% lottery pool / 20% burned |
-| Priority | Higher fees = faster confirmation |
-
-### Cluster-Based Progressive Fees
-
-Botho implements a novel **progressive fee system** that taxes wealth concentration without enabling Sybil attacks.
-
-**The core innovation:** Instead of taxing based on transaction amount (easily gamed by splitting), fees are based on coin *provenance* — where coins originally came from.
-
-| Parameter | Value |
-|-----------|-------|
-| Cluster factor range | 1x to 6x multiplier |
-| Curve shape | Sigmoid in log(cluster wealth), midpoint 3.5x at 100K BTH |
-| Tag decay | 5% per eligible hop |
-
-**Why it's Sybil-resistant:** Splitting coins doesn't change their origin. A whale's coins carry the same cluster tag whether held in 1 UTXO or 1000.
-
-### Demurrage
-
-Transaction fees are a consumption tax — they can't touch wealth that never moves. Demurrage closes that gap: a **holding charge on wealthy-cluster coins, paid when they are eventually spent**.
-
-| Parameter | Value |
-|-----------|-------|
-| Rate | 2% per year at the maximum (6x) cluster factor |
-| Scaling | Proportional to (factor − 1) — factor-1 coins pay **zero** |
-| Bootstrap | Disabled during the first halving epoch |
-| Proceeds | Flow into the lottery redistribution pool |
-
-Everyday coins never pay demurrage; it binds only concentrated, idle wealth. Churning doesn't escape it — spending pays the accrued charge first, so the total paid over any holding period is the same no matter how often you self-transfer (and each transfer adds fees on top).
-
-> **See the [Cluster Tags](#cluster-tags) section** for a complete explanation of how provenance tracking, progressive fees, lottery redistribution, and ring signature privacy work together.
-
----
-
-## Supply Projections
-
-### Long-Term Growth
-
-At sustained full load (5-second blocks; slower when the network is idle):
-
-| Epoch | Approximate Supply | Annual Inflation |
-|-------|-------------------|------------------|
-| 1 | ~315M BTH | High (initial) |
-| 3 | ~552M BTH | ~17% |
-| 5 | ~611M BTH | ~3% |
-| Tail (perpetual) | +2%/year net of burns | 2% |
-
----
-
-## Economic Design Philosophy
-
-### Why No Pre-mine?
-
-- **Fair distribution** - Everyone starts equal; early minters take on risk
-- **Credibility** - No insider advantage or founder enrichment
-- **Decentralization** - No concentrated holdings from day one
-
-### Why Split Fees 80/20?
-
-- **Redistribution** - 80% flows back to holders via the cluster-tilted lottery, favoring well-circulated coins
-- **Deflationary pressure** - The 20% burn offsets tail emission
-- **Predictable** - Net inflation = gross emission − burns
-
-### Why Progressive Cluster Fees?
-
-- **Reduce concentration** — Wealthy clusters pay more
-- **Sybil-resistant** — Can't avoid by splitting accounts
-- **Encourage circulation** — Moving coins diffuses tags, reducing fees
-- **Privacy-compatible** — Works with ring signatures and stealth addresses
-
-> **Deep dive:** See the [Cluster Tags](#cluster-tags) documentation for the complete technical explanation.
-    `,
-  },
-]
 
 export function DocsPage() {
   const location = useLocation()
   const navigate = useNavigate()
+  const { t, i18n } = useTranslation('docs')
+
+  // Active locale for content selection + locale-preserving links. Derived from
+  // the URL prefix (LocaleRoutes strips `/es` before matching, but `useLocation`
+  // in this child still reports the real, prefixed pathname) with i18n.language
+  // as the fallback. `id` slugs and the `#hash` scheme are locale-INVARIANT, so
+  // only the markdown BODY and the nav/H1 TITLE change with the locale.
+  const localeSegment = location.pathname.split('/')[1]
+  const activeLocale = isSupportedLocale(localeSegment) ? localeSegment : DEFAULT_LOCALE
+  // Non-default locales keep their `/es` prefix on generated links so hash
+  // navigation and the path→hash redirect stay within the active language.
+  const localePrefix = activeLocale === DEFAULT_LOCALE ? '' : `/${activeLocale}`
+
+  // Build the render-order section list by zipping the locale-invariant meta
+  // (id + icon) with the active-locale title and markdown body.
+  const sections = useMemo(
+    () =>
+      SECTION_META.map((meta) => ({
+        id: meta.id,
+        icon: meta.icon,
+        title: t(`sections.${meta.id}`),
+        content: getSectionContent(meta.id, activeLocale),
+      })),
+    // i18n.language re-triggers when the active language changes mid-session.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [t, activeLocale, i18n.language],
+  )
 
   // Path-style deep links (`/docs/<section>`) land here via the `/docs/*`
   // catchall route in App.tsx. The hash form (`/docs#<section>`) is the
@@ -1347,16 +53,17 @@ export function DocsPage() {
   const normalizedSegment = pathSegment.toLowerCase()
   // A hash always wins over a path segment (e.g. /docs/consensus#privacy).
   const hasHash = location.hash.slice(1) !== ''
-  const segmentIsKnown = normalizedSegment !== '' && sections.some((s) => s.id === normalizedSegment)
+  const segmentIsKnown =
+    normalizedSegment !== '' && SECTION_META.some((s) => s.id === normalizedSegment)
   const shouldRedirect = segmentIsKnown && !hasHash
 
   useEffect(() => {
     if (shouldRedirect) {
-      navigate(`/docs#${normalizedSegment}`, { replace: true })
+      navigate(`${localePrefix}/docs#${normalizedSegment}`, { replace: true })
     }
-  }, [shouldRedirect, normalizedSegment, navigate])
+  }, [shouldRedirect, normalizedSegment, navigate, localePrefix])
 
-  const hash = location.hash.slice(1) || 'getting-started'
+  const hash = (location.hash.slice(1) || 'getting-started') as DocSectionId
   const currentSection = sections.find((s) => s.id === hash) || sections[0]
   const notFoundSegment = !hasHash && pathSegment !== '' && !segmentIsKnown ? pathSegment : null
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
@@ -1370,17 +77,20 @@ export function DocsPage() {
       {/* Mobile header */}
       <header className="md:hidden sticky top-0 z-50 bg-abyss/95 backdrop-blur border-b border-steel">
         <div className="flex items-center justify-between px-4 py-3">
-          <Link to="/" className="flex items-center gap-2">
+          <Link to={localePrefix || '/'} className="flex items-center gap-2">
             <Logo size="sm" showText={false} />
-            <span className="font-display text-base font-semibold">Botho</span>
+            <span className="font-display text-base font-semibold">{t('brand')}</span>
           </Link>
-          <button
-            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            className="p-2 -mr-2 text-ghost hover:text-light transition-colors"
-            aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
-          >
-            {mobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
-          </button>
+          <div className="flex items-center gap-2">
+            <LocaleSwitcher />
+            <button
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              className="p-2 -mr-2 text-ghost hover:text-light transition-colors"
+              aria-label={mobileMenuOpen ? t('closeMenu') : t('openMenu')}
+            >
+              {mobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+            </button>
+          </div>
         </div>
       </header>
 
@@ -1401,9 +111,13 @@ export function DocsPage() {
         `}
       >
         <div className="p-4 border-b border-steel flex items-center justify-between">
-          <Link to="/" className="flex items-center gap-2" onClick={handleNavClick}>
+          <Link
+            to={localePrefix || '/'}
+            className="flex items-center gap-2"
+            onClick={handleNavClick}
+          >
             <Logo size="sm" showText={false} />
-            <span className="font-display text-base font-semibold">Botho Docs</span>
+            <span className="font-display text-base font-semibold">{t('brandDocs')}</span>
           </Link>
           <button
             onClick={() => setMobileMenuOpen(false)}
@@ -1416,7 +130,7 @@ export function DocsPage() {
           {sections.map((section) => (
             <Link
               key={section.id}
-              to={`/docs#${section.id}`}
+              to={`${localePrefix}/docs#${section.id}`}
               onClick={handleNavClick}
               className={`flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors ${
                 currentSection.id === section.id
@@ -1431,12 +145,12 @@ export function DocsPage() {
         </nav>
         <div className="p-4 border-t border-steel mt-auto">
           <Link
-            to="/"
+            to={localePrefix || '/'}
             onClick={handleNavClick}
             className="flex items-center gap-2 text-ghost hover:text-light transition-colors text-sm"
           >
             <ArrowLeft size={16} />
-            Back to home
+            {t('backToHome')}
           </Link>
         </div>
       </aside>
@@ -1444,15 +158,18 @@ export function DocsPage() {
       {/* Desktop sidebar */}
       <aside className="hidden md:block w-64 border-r border-steel bg-abyss/50 fixed top-0 bottom-0 left-0 overflow-y-auto">
         <div className="p-6">
-          <Link to="/" className="flex items-center gap-3 mb-8">
-            <Logo size="md" showText={false} />
-            <span className="font-display text-lg font-semibold">Botho</span>
-          </Link>
+          <div className="flex items-center justify-between mb-8">
+            <Link to={localePrefix || '/'} className="flex items-center gap-3">
+              <Logo size="md" showText={false} />
+              <span className="font-display text-lg font-semibold">{t('brand')}</span>
+            </Link>
+            <LocaleSwitcher />
+          </div>
           <nav className="space-y-1">
             {sections.map((section) => (
               <Link
                 key={section.id}
-                to={`/docs#${section.id}`}
+                to={`${localePrefix}/docs#${section.id}`}
                 className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
                   currentSection.id === section.id
                     ? 'bg-pulse/10 text-pulse'
@@ -1467,11 +184,11 @@ export function DocsPage() {
         </div>
         <div className="p-6 border-t border-steel">
           <Link
-            to="/"
+            to={localePrefix || '/'}
             className="flex items-center gap-2 text-ghost hover:text-light transition-colors text-sm"
           >
             <ArrowLeft size={16} />
-            Back to home
+            {t('backToHome')}
           </Link>
         </div>
       </aside>
@@ -1485,9 +202,7 @@ export function DocsPage() {
               className="mb-6 flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-200/90 text-sm"
             >
               <AlertTriangle size={16} className="shrink-0 mt-0.5 text-amber-400" />
-              <span>
-                Section &ldquo;{notFoundSegment}&rdquo; not found — showing Getting Started.
-              </span>
+              <span>{t('notFound', { segment: notFoundSegment })}</span>
             </div>
           )}
           <div className="flex items-center gap-3 mb-6 md:mb-8">


### PR DESCRIPTION
## Summary

Phase 3 of the web i18n rollout (#764). `docs.tsx` embedded ~1500 lines of English markdown as inline template literals — far too large to extract key-by-key like phases 1–2. This PR moves the content to per-section, per-locale markdown files and adds full Spanish translations, following the curator's recommended Option A (static `?raw` imports, no lazy-load).

## Changes

- **New `docs-content/<locale>/<id>.md`** (9 sections × 2 locales = 18 files) holding the markdown bodies as plain markdown (best diff/review ergonomics; code fences, GFM tables, blockquotes round-trip natively).
- **New `docs-content/index.ts`** — locale-invariant `SECTION_META` (id + lucide-react icon, the non-serializable bits), static `?raw` imports, and `getSectionContent(id, locale)` with an English fallback mirroring i18next's `fallbackLng`.
- **New `docs` i18n namespace** (`locales/{en,es}/docs.json`) for the short section titles / nav labels + chrome strings (back-to-home, menu aria labels, not-found hint), registered in `i18n.ts` alongside the phase-1/2 namespaces.
- **`docs.tsx` rewritten** to zip `SECTION_META` with the active-locale title (`t('sections.<id>')`) and body; `LocaleSwitcher` added to the mobile + desktop headers; generated nav/redirect URLs now carry the active `/es` prefix so hash navigation stays within the current language. The `section.id` slug scheme, `#hash` routing, and the `/docs/<id>` → `/docs#<id>` redirect are unchanged and locale-invariant.
- **Full Spanish translation** of all 9 sections (informal *tú*, technical register consistent with the existing `es` locale files). Code blocks, JSON-RPC method/field names, CLI commands, config keys, URLs, and protocol terms (SCP, RandomX, CLSAG, Bulletproofs, ML-KEM/ML-DSA, picocredits) kept untranslated; surrounding prose and code comments translated. Internal `[...](#cluster-tags)` cross-links keep the invariant slug.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| English render byte-equivalent (no `id`/routing changes) | ✅ | `docs-deep-link.test.tsx` (#656 guard) passes **unmodified** — 18/18 |
| markdown-per-locale strategy (Option A, `?raw`, no lazy-load) | ✅ | `docs-content/<locale>/*.md` + static imports in `docs-content/index.ts` |
| `section.id` slugs locale-invariant | ✅ | slugs live in `SECTION_META`; only title + body are locale-dependent |
| lucide-react icons stay in TS | ✅ | `icon` kept in `SECTION_META`, never serialized |
| Spanish `/es/docs` renders translated titles + body | ✅ | new `docs.i18n.test.tsx` — 5/5 |
| LocaleSwitcher wired into docs headers | ✅ | added to mobile + desktop headers |
| full web check green | ✅ | `pnpm check:ci` from `web/`: 745 passed / 10 skipped, typecheck clean, wrangler dry-run ok |

## Test Plan

- `pnpm --filter @botho/web-wallet exec vitest run src/pages/docs-deep-link.test.tsx src/pages/docs.i18n.test.tsx` → 23/23 pass.
- `pnpm check:ci` (from `web/`) → typecheck + 745 tests + wrangler dry-run all green.
- `pnpm --filter @botho/web-wallet build` → succeeds in ~2.2s. Bundle impact is proportionate: docs markdown roughly doubles (~52 KB EN + ~61 KB ES raw, both bundled into `main-*.js`, gzip-compressed); consistent with the no-lazy-load precedent — no measurable regression to build time.

## Deviations from the curator plan

- **Title storage**: chose the `docs.json` namespace (curator left this open). Titles are short and the namespace also cleanly holds the chrome strings (back-to-home, menu aria labels, not-found hint), avoiding a parallel TS title map.
- **Locale-preserving links**: additionally made the docs nav/redirect/home links carry the active `/es` prefix (a small win beyond the strict scope) so a Spanish visitor stays in Spanish when clicking a section — the section-id keying itself is untouched.

Closes #778