### PR TITLE
feat(web-wallet): edge locale negotiation + localized OG/Twitter/hreflang metadata

### DIFF
--- a/web/packages/web-wallet/functions/_middleware.ts
+++ b/web/packages/web-wallet/functions/_middleware.ts
@@ -1,0 +1,143 @@
+/**
+ * Cloudflare Pages Function middleware (issue #779) — the thin runtime adapter
+ * over the pure logic in `lib/locale-negotiation.ts`. It runs on every request
+ * to the `botho` Pages project and does two things for HTML document
+ * navigations only:
+ *
+ *   Part A — localize the OG/Twitter/description meta + inject hreflang/canonical
+ *            alternates into the served `index.html`, per the resolved locale.
+ *   Part B — first-visit Accept-Language negotiation: 302-redirect a fresh
+ *            visitor whose browser prefers a supported non-default locale to the
+ *            locale-prefixed equivalent path, once (guarded by a cookie).
+ *
+ * Everything decision-shaped lives in the pure module and is unit-tested; this
+ * file only reads headers, calls `next()`, and stitches the decision onto a
+ * real `Response`. Non-document requests (assets, /rpc, /api, manifest, service
+ * worker, the operator entry) pass straight through untouched.
+ *
+ * Caching: negotiated / rewritten HTML responses carry `Vary: Accept-Language,
+ * Cookie` and `Cache-Control: private, no-store` so a shared cache can never
+ * serve one visitor's locale-specific document or redirect to another visitor.
+ */
+import {
+  LOCALE_COOKIE_NAME,
+  localizeDocumentHtml,
+  negotiateLocaleRedirect,
+  parseLocaleFromPath,
+} from './lib/locale-negotiation'
+
+// Minimal shape of the Cloudflare Pages Functions context we use. Declared
+// locally (rather than depending on `@cloudflare/workers-types`) to keep this
+// package's devDependencies unchanged — the fields below are stable public API.
+interface PagesContext {
+  request: Request
+  next: () => Promise<Response>
+}
+
+/** Cookie attributes: 1-year, site-wide, lax — a preference marker, not a secret. */
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
+function localeCookie(locale: string): string {
+  return (
+    `${LOCALE_COOKIE_NAME}=${locale}; Path=/; Max-Age=${COOKIE_MAX_AGE}; ` +
+    'SameSite=Lax; Secure'
+  )
+}
+
+/**
+ * Does this request look like a top-level HTML document navigation we should
+ * localize / negotiate? We deliberately gate on the `Accept` header and path so
+ * asset/API/manifest/service-worker requests pass straight through.
+ */
+function isDocumentRequest(request: Request, pathname: string): boolean {
+  // Never touch the SRI-pinned operator entry or its assets (#772).
+  if (pathname === '/operator' || pathname === '/operator.html' || pathname.startsWith('/operator/')) {
+    return false
+  }
+  // Skip well-known non-document roots.
+  if (
+    pathname.startsWith('/rpc') ||
+    pathname.startsWith('/api') ||
+    pathname.startsWith('/pkg/') ||
+    pathname.startsWith('/assets/') ||
+    pathname === '/manifest.webmanifest' ||
+    pathname === '/sw.js' ||
+    pathname === '/registerSW.js'
+  ) {
+    return false
+  }
+  // Skip anything with a file extension (favicon.ico, *.png, *.svg, *.pdf, ...).
+  const lastSegment = pathname.slice(pathname.lastIndexOf('/') + 1)
+  if (lastSegment.includes('.')) {
+    return false
+  }
+  // Only treat requests that accept HTML as document navigations.
+  const accept = request.headers.get('Accept') ?? ''
+  return accept.includes('text/html') || accept === '' || accept.includes('*/*')
+}
+
+export const onRequest = async (context: PagesContext): Promise<Response> => {
+  const { request, next } = context
+  const url = new URL(request.url)
+  const pathname = url.pathname
+
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return next()
+  }
+  if (!isDocumentRequest(request, pathname)) {
+    return next()
+  }
+
+  const headers = request.headers
+  const decision = negotiateLocaleRedirect({
+    pathname,
+    acceptLanguage: headers.get('Accept-Language'),
+    cookie: headers.get('Cookie'),
+    userAgent: headers.get('User-Agent'),
+  })
+
+  // Part B: first-visit redirect.
+  if (decision.kind === 'redirect') {
+    const location = url.origin + decision.location + url.search
+    const res = new Response(null, {
+      status: 302,
+      headers: {
+        Location: location,
+        'Set-Cookie': localeCookie(decision.cookieLocale),
+        // A preference redirect must never be cached and shared across visitors.
+        'Cache-Control': 'private, no-store',
+        Vary: 'Accept-Language, Cookie',
+      },
+    })
+    return res
+  }
+
+  // Fetch the underlying static asset (index.html for SPA routes).
+  const response = await next()
+
+  // Only rewrite HTML documents; pass everything else (e.g. the SW fallback
+  // serving a non-HTML asset) through untouched.
+  const contentType = response.headers.get('Content-Type') ?? ''
+  if (!contentType.includes('text/html')) {
+    return response
+  }
+
+  const { locale } = parseLocaleFromPath(pathname)
+  const originalHtml = await response.text()
+  const localized = localizeDocumentHtml(originalHtml, locale, pathname)
+
+  const newHeaders = new Headers(response.headers)
+  // Locale-specific document: keep shared caches from cross-serving it, and make
+  // sure any cache keys on the negotiating inputs.
+  newHeaders.set('Cache-Control', 'private, no-store')
+  newHeaders.append('Vary', 'Accept-Language')
+  newHeaders.append('Vary', 'Cookie')
+  if (decision.kind === 'pass' && decision.setCookieLocale) {
+    newHeaders.append('Set-Cookie', localeCookie(decision.setCookieLocale))
+  }
+
+  return new Response(localized, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: newHeaders,
+  })
+}

--- a/web/packages/web-wallet/functions/lib/locale-negotiation.test.ts
+++ b/web/packages/web-wallet/functions/lib/locale-negotiation.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Unit tests for the pure edge locale-negotiation core (issue #779). These
+ * exercise the decision logic and the HTML rewrite WITHOUT any Cloudflare
+ * runtime, mirroring the "pure testable core, I/O at the edges" pattern of
+ * `baas-worker/src/checkout.test.ts`.
+ */
+import { describe, it, expect } from 'vitest'
+
+import {
+  BOT_UA_SUBSTRINGS,
+  buildLocalePath,
+  isBotUserAgent,
+  LOCALE_COOKIE_NAME,
+  LOCALE_METADATA,
+  localizeDocumentHtml,
+  negotiateLocaleRedirect,
+  parseAcceptLanguage,
+  parseLocaleFromPath,
+  readCookie,
+  SITE_ORIGIN,
+  SUPPORTED_LOCALES,
+} from './locale-negotiation'
+
+describe('parseAcceptLanguage', () => {
+  it('returns the highest-q supported locale', () => {
+    expect(parseAcceptLanguage('es')).toBe('es')
+    expect(parseAcceptLanguage('en-US,en;q=0.9')).toBe('en')
+  })
+
+  it('ignores region subtags (es-MX matches es)', () => {
+    expect(parseAcceptLanguage('es-MX')).toBe('es')
+    expect(parseAcceptLanguage('en-GB,en;q=0.8')).toBe('en')
+  })
+
+  it('picks the highest-weighted SUPPORTED locale, skipping unsupported ones', () => {
+    // fr is unsupported and highest-weighted; es is the best supported match.
+    expect(parseAcceptLanguage('fr;q=0.9,es;q=0.5')).toBe('es')
+    expect(parseAcceptLanguage('de,fr;q=0.7,es;q=0.3')).toBe('es')
+  })
+
+  it('honours q-value ordering over header order', () => {
+    expect(parseAcceptLanguage('en;q=0.4,es;q=0.9')).toBe('es')
+    expect(parseAcceptLanguage('es;q=0.2,en;q=0.9')).toBe('en')
+  })
+
+  it('treats a bare wildcard as the default locale', () => {
+    expect(parseAcceptLanguage('*')).toBe('en')
+  })
+
+  it('returns undefined for absent / empty / unsupported-only / unparseable headers', () => {
+    expect(parseAcceptLanguage(undefined)).toBeUndefined()
+    expect(parseAcceptLanguage(null)).toBeUndefined()
+    expect(parseAcceptLanguage('')).toBeUndefined()
+    expect(parseAcceptLanguage('fr,de;q=0.8')).toBeUndefined()
+    expect(parseAcceptLanguage(';;;')).toBeUndefined()
+  })
+
+  it('drops q=0 entries', () => {
+    expect(parseAcceptLanguage('es;q=0,en;q=0.5')).toBe('en')
+    expect(parseAcceptLanguage('es;q=0')).toBeUndefined()
+  })
+})
+
+describe('isBotUserAgent', () => {
+  it('matches known crawler / unfurl UAs (case-insensitive)', () => {
+    expect(isBotUserAgent('facebookexternalhit/1.1')).toBe(true)
+    expect(isBotUserAgent('Twitterbot/1.0')).toBe(true)
+    expect(isBotUserAgent('Slackbot-LinkExpanding 1.0')).toBe(true)
+    expect(isBotUserAgent('TelegramBot (like TwitterBot)')).toBe(true)
+    expect(isBotUserAgent('Discordbot/2.0')).toBe(true)
+    expect(isBotUserAgent('Mozilla/5.0 (compatible; Googlebot/2.1)')).toBe(true)
+    expect(isBotUserAgent('Mozilla/5.0 (compatible; bingbot/2.0)')).toBe(true)
+    expect(isBotUserAgent('WhatsApp/2.19')).toBe(true)
+  })
+
+  it('does not match ordinary browser UAs', () => {
+    expect(
+      isBotUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+      ),
+    ).toBe(false)
+    expect(isBotUserAgent('')).toBe(false)
+    expect(isBotUserAgent(null)).toBe(false)
+    expect(isBotUserAgent(undefined)).toBe(false)
+  })
+
+  it('has a non-empty denylist', () => {
+    expect(BOT_UA_SUBSTRINGS.length).toBeGreaterThan(5)
+  })
+})
+
+describe('readCookie', () => {
+  it('extracts a named cookie value', () => {
+    expect(readCookie('a=1; botho_locale=es; b=2', 'botho_locale')).toBe('es')
+    expect(readCookie('botho_locale=en', 'botho_locale')).toBe('en')
+  })
+
+  it('returns undefined when absent', () => {
+    expect(readCookie('a=1; b=2', 'botho_locale')).toBeUndefined()
+    expect(readCookie('', 'botho_locale')).toBeUndefined()
+    expect(readCookie(null, 'botho_locale')).toBeUndefined()
+  })
+})
+
+describe('parseLocaleFromPath', () => {
+  it('extracts an explicit non-default prefix', () => {
+    expect(parseLocaleFromPath('/es/wallet')).toEqual({ locale: 'es', rest: '/wallet' })
+    expect(parseLocaleFromPath('/es')).toEqual({ locale: 'es', rest: '/' })
+  })
+
+  it('defaults to en for unprefixed / unsupported prefixes', () => {
+    expect(parseLocaleFromPath('/wallet')).toEqual({ locale: 'en', rest: '/wallet' })
+    expect(parseLocaleFromPath('/xx/wallet')).toEqual({ locale: 'en', rest: '/xx/wallet' })
+    expect(parseLocaleFromPath('/')).toEqual({ locale: 'en', rest: '/' })
+  })
+})
+
+describe('buildLocalePath', () => {
+  it('leaves the default locale unprefixed and prefixes others', () => {
+    expect(buildLocalePath('en', '/wallet')).toBe('/wallet')
+    expect(buildLocalePath('es', '/wallet')).toBe('/es/wallet')
+    expect(buildLocalePath('es', '/')).toBe('/es')
+  })
+})
+
+describe('negotiateLocaleRedirect', () => {
+  const browserUA =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
+
+  it('redirects a first-visit es browser on a default path to the /es equivalent', () => {
+    const d = negotiateLocaleRedirect({
+      pathname: '/wallet',
+      acceptLanguage: 'es-ES,es;q=0.9',
+      cookie: null,
+      userAgent: browserUA,
+    })
+    expect(d).toEqual({ kind: 'redirect', location: '/es/wallet', cookieLocale: 'es' })
+  })
+
+  it('redirects the root path first-visit es browser to /es', () => {
+    const d = negotiateLocaleRedirect({
+      pathname: '/',
+      acceptLanguage: 'es',
+      cookie: null,
+      userAgent: browserUA,
+    })
+    expect(d).toEqual({ kind: 'redirect', location: '/es', cookieLocale: 'es' })
+  })
+
+  it('does NOT redirect a first-visit en browser (passes, stamps default cookie)', () => {
+    const d = negotiateLocaleRedirect({
+      pathname: '/wallet',
+      acceptLanguage: 'en-US,en;q=0.9',
+      cookie: null,
+      userAgent: browserUA,
+    })
+    expect(d).toEqual({ kind: 'pass', setCookieLocale: 'en' })
+  })
+
+  it('does NOT redirect when the cookie is already set, even if Accept-Language differs', () => {
+    const d = negotiateLocaleRedirect({
+      pathname: '/wallet',
+      acceptLanguage: 'es',
+      cookie: `${LOCALE_COOKIE_NAME}=en`,
+      userAgent: browserUA,
+    })
+    expect(d).toEqual({ kind: 'pass' })
+  })
+
+  it('never redirects known crawler/bot UAs regardless of Accept-Language', () => {
+    for (const ua of ['facebookexternalhit/1.1', 'Twitterbot/1.0', 'Googlebot/2.1', 'Slackbot 1.0']) {
+      const d = negotiateLocaleRedirect({
+        pathname: '/wallet',
+        acceptLanguage: 'es-ES,es;q=1.0',
+        cookie: null,
+        userAgent: ua,
+      })
+      expect(d).toEqual({ kind: 'pass' })
+    }
+  })
+
+  it('never redirects a path that already carries a locale prefix (stamps that locale)', () => {
+    const d = negotiateLocaleRedirect({
+      pathname: '/es/wallet',
+      acceptLanguage: 'en-US,en;q=0.9',
+      cookie: null,
+      userAgent: browserUA,
+    })
+    expect(d).toEqual({ kind: 'pass', setCookieLocale: 'es' })
+  })
+
+  it('does not redirect when Accept-Language is absent (privacy browsers)', () => {
+    const d = negotiateLocaleRedirect({
+      pathname: '/wallet',
+      acceptLanguage: null,
+      cookie: null,
+      userAgent: browserUA,
+    })
+    expect(d).toEqual({ kind: 'pass', setCookieLocale: 'en' })
+  })
+
+  it('does not redirect when the best supported match is the default locale', () => {
+    const d = negotiateLocaleRedirect({
+      pathname: '/',
+      acceptLanguage: 'fr;q=0.9,en;q=0.5', // fr unsupported → en wins
+      cookie: null,
+      userAgent: browserUA,
+    })
+    expect(d).toEqual({ kind: 'pass', setCookieLocale: 'en' })
+  })
+})
+
+describe('localizeDocumentHtml', () => {
+  // A representative slice of index.html with the exact tag format the rewrite
+  // targets (property/name first, then content).
+  const baseHtml = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="description" content="Botho - Private Currency for the Quantum Era" />
+    <meta property="og:site_name" content="Botho" />
+    <meta property="og:title" content="Botho - Private Currency for the Quantum Era" />
+    <meta property="og:description" content="Instant SCP finality. Quantum-safe recipient addresses. Progressive economics that reward circulation over hoarding." />
+    <meta property="og:url" content="https://botho.io/" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Botho - Private Currency for the Quantum Era" />
+    <meta name="twitter:description" content="Instant SCP finality. Quantum-safe recipient addresses. Progressive economics that reward circulation over hoarding." />
+    <title>Botho</title>
+  </head>
+  <body><div id="root"></div></body>
+</html>`
+
+  it('localizes og/twitter/description meta to Spanish for an es path', () => {
+    const out = localizeDocumentHtml(baseHtml, 'es', '/es/wallet')
+    expect(out).toContain(
+      `<meta property="og:title" content="${LOCALE_METADATA.es.title}" />`,
+    )
+    expect(out).toContain(
+      `<meta name="twitter:title" content="${LOCALE_METADATA.es.title}" />`,
+    )
+    expect(out).toContain(
+      `<meta property="og:description" content="${LOCALE_METADATA.es.description}" />`,
+    )
+    expect(out).toContain(
+      `<meta name="twitter:description" content="${LOCALE_METADATA.es.description}" />`,
+    )
+    expect(out).toContain(
+      `<meta name="description" content="${LOCALE_METADATA.es.description}" />`,
+    )
+    // No English title/description survives.
+    expect(out).not.toContain('Private Currency for the Quantum Era')
+  })
+
+  it('sets og:url and canonical to the requested locale-prefixed URL', () => {
+    const out = localizeDocumentHtml(baseHtml, 'es', '/es/wallet')
+    expect(out).toContain(
+      `<meta property="og:url" content="${SITE_ORIGIN}/es/wallet" />`,
+    )
+    expect(out).toContain(`<link rel="canonical" href="${SITE_ORIGIN}/es/wallet" />`)
+    // The hardcoded "https://botho.io/" og:url must be gone.
+    expect(out).not.toContain('content="https://botho.io/"')
+  })
+
+  it('sets <html lang> to the resolved locale', () => {
+    expect(localizeDocumentHtml(baseHtml, 'es', '/es')).toContain('<html lang="es">')
+    expect(localizeDocumentHtml(baseHtml, 'en', '/')).toContain('<html lang="en">')
+  })
+
+  it('injects hreflang alternates for every supported locale plus x-default', () => {
+    const out = localizeDocumentHtml(baseHtml, 'es', '/es/wallet')
+    expect(out).toContain(
+      `<link rel="alternate" hreflang="en" href="${SITE_ORIGIN}/wallet" />`,
+    )
+    expect(out).toContain(
+      `<link rel="alternate" hreflang="es" href="${SITE_ORIGIN}/es/wallet" />`,
+    )
+    expect(out).toContain(
+      `<link rel="alternate" hreflang="x-default" href="${SITE_ORIGIN}/wallet" />`,
+    )
+    // One alternate per supported locale + x-default.
+    const count = (out.match(/rel="alternate"/g) ?? []).length
+    expect(count).toBe(SUPPORTED_LOCALES.length + 1)
+  })
+
+  it('leaves English metadata content unchanged (no regression) for the default locale', () => {
+    const out = localizeDocumentHtml(baseHtml, 'en', '/wallet')
+    expect(out).toContain(
+      `<meta property="og:title" content="${LOCALE_METADATA.en.title}" />`,
+    )
+    expect(out).toContain(
+      `<meta property="og:description" content="${LOCALE_METADATA.en.description}" />`,
+    )
+    // og:url is corrected from the hardcoded root to the real requested path.
+    expect(out).toContain(
+      `<meta property="og:url" content="${SITE_ORIGIN}/wallet" />`,
+    )
+  })
+
+  it('escapes HTML-significant characters in injected attribute values', () => {
+    // Root path for es → the canonical/hreflang for root must be well-formed.
+    const out = localizeDocumentHtml(baseHtml, 'es', '/es')
+    expect(out).toContain(`<link rel="canonical" href="${SITE_ORIGIN}/es" />`)
+    expect(out).toContain(
+      `<link rel="alternate" hreflang="x-default" href="${SITE_ORIGIN}/" />`,
+    )
+  })
+})

--- a/web/packages/web-wallet/functions/lib/locale-negotiation.ts
+++ b/web/packages/web-wallet/functions/lib/locale-negotiation.ts
@@ -1,0 +1,364 @@
+/**
+ * Pure, unit-testable core of the Cloudflare Pages edge locale layer (issue
+ * #779). Two responsibilities, both expressed as side-effect-free functions so
+ * they can be tested with vitest exactly like `baas-worker/src/checkout.ts`:
+ *
+ *  1. `negotiateLocaleRedirect(...)` — decide whether a first-visit navigation
+ *     should be redirected to its `Accept-Language`-matched locale prefix.
+ *  2. `localizeDocumentHtml(...)` — rewrite the static `index.html`'s OG/Twitter
+ *     meta + inject `hreflang` alternates for the resolved locale of a request.
+ *
+ * The Cloudflare-specific glue (reading the real `Request`, calling
+ * `context.next()`, attaching headers to the real `Response`) lives in the thin
+ * adapter `functions/_middleware.ts`; NOTHING in this file imports Cloudflare
+ * runtime types — inputs are plain strings so the logic is trivially testable.
+ *
+ * The supported-locale list and default are imported from the SPA's leaf
+ * constants module (`../../src/lib/locales`) rather than duplicated, so the edge
+ * layer and the client-side router can never drift (#779 Affected Files).
+ */
+import {
+  DEFAULT_LOCALE,
+  isSupportedLocale,
+  SUPPORTED_LOCALES,
+  type SupportedLocale,
+} from '../../src/lib/locales'
+
+export { SUPPORTED_LOCALES, DEFAULT_LOCALE, type SupportedLocale }
+
+/** Canonical site origin used for absolute `og:url` / `hreflang` values. */
+export const SITE_ORIGIN = 'https://botho.io'
+
+/**
+ * Per-locale document metadata used to rewrite the (English-baked) `index.html`
+ * OG/Twitter tags. Keep the copy in sync with the landing hero
+ * (`locales/<locale>/landing.json`) and with the English baseline in
+ * `index.html` — the `en` entry MUST match `index.html` verbatim so the
+ * default-locale response is byte-identical to the un-rewritten document.
+ */
+export interface LocaleMetadata {
+  /** `<meta name="description">` + og/twitter description. */
+  description: string
+  /** og:title / twitter:title. */
+  title: string
+  /** `document.title` (the browser tab). */
+  htmlTitle: string
+}
+
+export const LOCALE_METADATA: Record<SupportedLocale, LocaleMetadata> = {
+  en: {
+    title: 'Botho - Private Currency for the Quantum Era',
+    description:
+      'Instant SCP finality. Quantum-safe recipient addresses. Progressive economics that reward circulation over hoarding.',
+    htmlTitle: 'Botho',
+  },
+  es: {
+    title: 'Botho - Moneda Privada para la Era Cuántica',
+    description:
+      'Finalidad SCP instantánea. Direcciones de destinatario resistentes a la computación cuántica. Economía progresiva que premia la circulación sobre el acaparamiento.',
+    htmlTitle: 'Botho',
+  },
+}
+
+/**
+ * Best-effort denylist of User-Agent substrings for link-preview unfurlers and
+ * search-engine crawlers. Matched case-insensitively. Crawlers MUST NEVER be
+ * redirected (#779): a redirect breaks OG/Twitter unfurls (most preview bots do
+ * not follow redirects) and can look like cloaking to search engines. This is a
+ * heuristic, not an exhaustive list — treat as one of several skip signals.
+ */
+export const BOT_UA_SUBSTRINGS: readonly string[] = [
+  'bot',
+  'crawl',
+  'spider',
+  'slurp',
+  'facebookexternalhit',
+  'facebookcatalog',
+  'slackbot',
+  'telegrambot',
+  'discordbot',
+  'whatsapp',
+  'twitterbot',
+  'linkedinbot',
+  'pinterest',
+  'redditbot',
+  'embedly',
+  'quora link preview',
+  'google-inspectiontool',
+  'chrome-lighthouse',
+  'headlesschrome',
+]
+
+/** True when `userAgent` looks like a crawler / link-preview bot. */
+export function isBotUserAgent(userAgent: string | null | undefined): boolean {
+  if (!userAgent) return false
+  const ua = userAgent.toLowerCase()
+  return BOT_UA_SUBSTRINGS.some((needle) => ua.includes(needle))
+}
+
+/**
+ * Parse an `Accept-Language` header and return the highest-q-weighted locale
+ * that we actually support, or `undefined` if none match (or the header is
+ * absent / unparseable). Only base language tags are compared (e.g. `es-MX`
+ * matches `es`); region subtags are ignored since we key on base language.
+ *
+ * A ~q-value parser is sufficient for the tiny supported set — no dependency.
+ * `q` defaults to 1.0 when omitted, and entries are stably ordered by descending
+ * q so equal-weight ties preserve header order (matching browser precedence).
+ */
+export function parseAcceptLanguage(
+  header: string | null | undefined,
+): SupportedLocale | undefined {
+  if (!header) return undefined
+
+  const entries: { tag: string; q: number }[] = []
+  for (const part of header.split(',')) {
+    const [rawTag, ...params] = part.trim().split(';')
+    const tag = rawTag.trim().toLowerCase()
+    if (!tag) continue
+    let q = 1
+    for (const param of params) {
+      const [k, v] = param.split('=').map((s) => s.trim())
+      if (k === 'q') {
+        const parsed = Number.parseFloat(v)
+        if (Number.isFinite(parsed)) q = parsed
+      }
+    }
+    // A wildcard `*` means "any language"; only honour it as the default locale.
+    entries.push({ tag, q })
+  }
+
+  // Stable sort by descending q (Array#sort is stable in modern engines, and we
+  // additionally track original index to be explicit about tie-breaking).
+  const ordered = entries
+    .map((e, i) => ({ ...e, i }))
+    .filter((e) => e.q > 0)
+    .sort((a, b) => (b.q === a.q ? a.i - b.i : b.q - a.q))
+
+  for (const { tag } of ordered) {
+    if (tag === '*') return DEFAULT_LOCALE
+    const base = tag.split('-')[0]
+    if (isSupportedLocale(base)) return base
+  }
+  return undefined
+}
+
+/**
+ * Read a single cookie value from a `Cookie` request-header string, or
+ * `undefined` when absent. Whitespace-tolerant; does not decode values (our
+ * locale cookie values are plain ASCII locale codes).
+ */
+export function readCookie(
+  cookieHeader: string | null | undefined,
+  name: string,
+): string | undefined {
+  if (!cookieHeader) return undefined
+  for (const pair of cookieHeader.split(';')) {
+    const eq = pair.indexOf('=')
+    if (eq === -1) continue
+    if (pair.slice(0, eq).trim() === name) {
+      return pair.slice(eq + 1).trim()
+    }
+  }
+  return undefined
+}
+
+/** Cookie set once per visitor to mark "locale already negotiated / chosen". */
+export const LOCALE_COOKIE_NAME = 'botho_locale'
+
+/**
+ * Split a pathname into its (optional) leading locale segment and the rest.
+ * Mirrors `src/lib/locale-path.ts#parseLocalePath` semantics (an unsupported or
+ * absent prefix resolves to the default locale with the path unchanged) but is
+ * re-implemented here so the Pages Function does not import the SPA's routing
+ * module (which is bundled for the browser, not the edge).
+ */
+export function parseLocaleFromPath(pathname: string): {
+  locale: SupportedLocale
+  rest: string
+} {
+  const segments = pathname.split('/')
+  const first = segments[1]
+  if (isSupportedLocale(first) && first !== DEFAULT_LOCALE) {
+    const rest = '/' + segments.slice(2).join('/')
+    return { locale: first, rest: rest === '/' ? '/' : rest.replace(/\/$/, '') || '/' }
+  }
+  return { locale: DEFAULT_LOCALE, rest: pathname || '/' }
+}
+
+/** Build a locale-prefixed pathname (default locale is unprefixed). */
+export function buildLocalePath(locale: SupportedLocale, rest: string): string {
+  const normalizedRest = rest.startsWith('/') ? rest : `/${rest}`
+  if (locale === DEFAULT_LOCALE) return normalizedRest
+  if (normalizedRest === '/') return `/${locale}`
+  return `/${locale}${normalizedRest}`
+}
+
+/** Inputs to the redirect decision — plain primitives, no runtime types. */
+export interface NegotiationInput {
+  /** Request path (no query string), e.g. `/wallet`. */
+  pathname: string
+  /** Raw `Accept-Language` header value (or null/undefined if absent). */
+  acceptLanguage: string | null | undefined
+  /** Raw `Cookie` header value (or null/undefined). */
+  cookie: string | null | undefined
+  /** Raw `User-Agent` header value (or null/undefined). */
+  userAgent: string | null | undefined
+}
+
+export type NegotiationDecision =
+  | {
+      /** Redirect the visitor to `location` (302) and set the seen-cookie. */
+      kind: 'redirect'
+      location: string
+      /** Locale the cookie should be stamped with. */
+      cookieLocale: SupportedLocale
+    }
+  | {
+      /**
+       * No redirect — pass the request through. `setCookieLocale` is set when we
+       * should still stamp the first-visit cookie on the pass-through response
+       * (marks the visitor "seen" so we don't re-evaluate on every navigation);
+       * `undefined` means don't touch cookies (bot / already-cookied / asset).
+       */
+      kind: 'pass'
+      setCookieLocale?: SupportedLocale
+    }
+
+/**
+ * Decide whether a first-visit HTML navigation should be redirected to its
+ * `Accept-Language`-matched locale prefix. Pure: given the request primitives,
+ * returns a `redirect` or `pass` decision. See the acceptance criteria in #779.
+ *
+ * Order of checks (each is a "never redirect" gate except the last):
+ *  1. Bot/crawler UA           → pass, no cookie (unfurl/SEO must see canonical URL)
+ *  2. Cookie already set       → pass, respect the prior explicit/negotiated choice
+ *  3. Path already has an       → pass, but stamp the cookie for that locale
+ *     explicit locale prefix         (visiting /es/* is itself a choice)
+ *  4. Accept-Language resolves  → REDIRECT (302) to the prefixed equivalent
+ *     to a non-default locale        and stamp the cookie
+ *  5. otherwise (default match, → pass, stamp default cookie
+ *     no/absent header, etc.)
+ */
+export function negotiateLocaleRedirect(input: NegotiationInput): NegotiationDecision {
+  const { pathname, acceptLanguage, cookie, userAgent } = input
+
+  // 1. Never redirect crawlers / link-preview bots.
+  if (isBotUserAgent(userAgent)) {
+    return { kind: 'pass' }
+  }
+
+  // 2. Respect a prior choice recorded in the cookie — no redirect, no re-stamp.
+  if (readCookie(cookie, LOCALE_COOKIE_NAME) !== undefined) {
+    return { kind: 'pass' }
+  }
+
+  const { locale: pathLocale } = parseLocaleFromPath(pathname)
+
+  // 3. An explicit locale prefix in the URL is itself a choice: never redirect
+  //    away from it, but stamp the cookie so subsequent visits are stable.
+  if (pathLocale !== DEFAULT_LOCALE) {
+    return { kind: 'pass', setCookieLocale: pathLocale }
+  }
+
+  // 4. First visit to an unprefixed (default-locale) path: negotiate.
+  const preferred = parseAcceptLanguage(acceptLanguage)
+  if (preferred && preferred !== DEFAULT_LOCALE) {
+    const { rest } = parseLocaleFromPath(pathname)
+    return {
+      kind: 'redirect',
+      location: buildLocalePath(preferred, rest),
+      cookieLocale: preferred,
+    }
+  }
+
+  // 5. Default locale is the right answer (matched, absent, or unsupported
+  //    header) — pass through, but stamp the cookie so we stop re-negotiating.
+  return { kind: 'pass', setCookieLocale: DEFAULT_LOCALE }
+}
+
+/** Escape a string for safe insertion into a double-quoted HTML attribute. */
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/**
+ * Rewrite the static `index.html` document for `locale` at request `pathname`:
+ *  - localize og:title / twitter:title / og:description / twitter:description /
+ *    the plain `<meta name="description">` and `<title>` to the locale's copy,
+ *  - set og:url to the actual requested (locale-prefixed) absolute URL rather
+ *    than the hardcoded `https://botho.io/`,
+ *  - inject `<link rel="alternate" hreflang="...">` alternates (en / es /
+ *    x-default) pointing at the sibling URLs for the current page, and a
+ *    self-referential `<link rel="canonical">`.
+ *
+ * Pure string transform (no DOM, no I/O) so it is unit-testable and cheap at the
+ * edge. The English (default-locale) case is returned effectively unchanged
+ * except for the injected hreflang/canonical block and the corrected og:url,
+ * satisfying the "no metadata regression" acceptance criterion.
+ */
+export function localizeDocumentHtml(
+  html: string,
+  locale: SupportedLocale,
+  pathname: string,
+): string {
+  const meta = LOCALE_METADATA[locale]
+  const { rest } = parseLocaleFromPath(pathname)
+
+  const canonicalPath = buildLocalePath(locale, rest)
+  const canonicalUrl = `${SITE_ORIGIN}${canonicalPath === '/' ? '/' : canonicalPath}`
+
+  let out = html
+
+  // Rewrite meta *content* by matching each tag's stable attribute selector.
+  const setMetaContent = (
+    selectorAttr: 'property' | 'name',
+    selectorValue: string,
+    content: string,
+  ): void => {
+    const re = new RegExp(
+      `(<meta\\s+${selectorAttr}="${selectorValue}"\\s+content=")([^"]*)(")`,
+      'i',
+    )
+    out = out.replace(re, `$1${escapeAttr(content)}$3`)
+  }
+
+  setMetaContent('name', 'description', meta.description)
+  setMetaContent('property', 'og:title', meta.title)
+  setMetaContent('property', 'og:description', meta.description)
+  setMetaContent('property', 'og:url', canonicalUrl)
+  setMetaContent('name', 'twitter:title', meta.title)
+  setMetaContent('name', 'twitter:description', meta.description)
+
+  // Localize the <html lang="..."> attribute.
+  out = out.replace(/(<html\s+lang=")[^"]*(")/i, `$1${locale}$2`)
+
+  // Localize the document <title>.
+  out = out.replace(/<title>[^<]*<\/title>/i, `<title>${escapeAttr(meta.htmlTitle)}</title>`)
+
+  // Build the hreflang alternates + canonical block for the current page.
+  const alternates = SUPPORTED_LOCALES.map((loc) => {
+    const p = buildLocalePath(loc, rest)
+    const href = `${SITE_ORIGIN}${p === '/' ? '/' : p}`
+    return `    <link rel="alternate" hreflang="${loc}" href="${escapeAttr(href)}" />`
+  })
+  const xDefaultPath = buildLocalePath(DEFAULT_LOCALE, rest)
+  const xDefaultHref = `${SITE_ORIGIN}${xDefaultPath === '/' ? '/' : xDefaultPath}`
+  alternates.push(
+    `    <link rel="alternate" hreflang="x-default" href="${escapeAttr(xDefaultHref)}" />`,
+  )
+  const linkBlock =
+    `    <link rel="canonical" href="${escapeAttr(canonicalUrl)}" />\n` +
+    alternates.join('\n') +
+    '\n'
+
+  // Insert the link block just before </head> (idempotent-ish: only added once
+  // per response since we operate on the freshly-fetched static document).
+  out = out.replace(/(\s*)<\/head>/i, `\n${linkBlock}$1</head>`)
+
+  return out
+}

--- a/web/packages/web-wallet/src/lib/i18n.ts
+++ b/web/packages/web-wallet/src/lib/i18n.ts
@@ -23,6 +23,13 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 
+import {
+  DEFAULT_LOCALE,
+  isSupportedLocale,
+  SUPPORTED_LOCALES,
+  type SupportedLocale,
+} from './locales'
+
 import enLanding from '../locales/en/landing.json'
 import esLanding from '../locales/es/landing.json'
 import enWallet from '../locales/en/wallet.json'
@@ -37,24 +44,20 @@ import enDocs from '../locales/en/docs.json'
 import esDocs from '../locales/es/docs.json'
 
 /**
- * The set of locales the app knows how to render. `en` MUST stay first — it is
- * the default and the unprefixed locale. Add a new entry here (plus its
- * resource bundles) to light up an additional language.
+ * Locale constants live in the dependency-free `./locales` leaf module so build
+ * targets that must not import the i18next runtime (the edge Pages Function,
+ * #779) can share them. Re-exported here so existing `./i18n` importers are
+ * unchanged.
  */
-export const SUPPORTED_LOCALES = ['en', 'es'] as const
-
-export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
-
-/** The default locale, served without a URL prefix. */
-export const DEFAULT_LOCALE: SupportedLocale = 'en'
+export {
+  SUPPORTED_LOCALES,
+  DEFAULT_LOCALE,
+  isSupportedLocale,
+  type SupportedLocale,
+}
 
 /** localStorage key used to persist the visitor's explicit locale choice. */
 export const LOCALE_STORAGE_KEY = 'botho:locale'
-
-/** Type guard: is `value` one of the locales we actually support? */
-export function isSupportedLocale(value: string | undefined | null): value is SupportedLocale {
-  return value != null && (SUPPORTED_LOCALES as readonly string[]).includes(value)
-}
 
 /**
  * Read a previously persisted locale choice from localStorage, falling back to

--- a/web/packages/web-wallet/src/lib/locales.ts
+++ b/web/packages/web-wallet/src/lib/locales.ts
@@ -1,0 +1,29 @@
+/**
+ * Dependency-free locale constants — the single source of truth for the set of
+ * locales the app supports and which one is the (unprefixed) default.
+ *
+ * This module intentionally has NO imports (no i18next, no JSON resource
+ * bundles). It is split out of `i18n.ts` (which re-exports everything here so
+ * existing importers are unchanged) so that build targets which must NOT pull in
+ * the whole i18next runtime — notably the Cloudflare Pages Function under
+ * `functions/` that does edge Accept-Language negotiation (issue #779) — can
+ * import the locale list from here and stay in lockstep with the SPA without
+ * duplicating the list. Add a new locale HERE (and its resource bundles in
+ * `i18n.ts`) to light up an additional language everywhere at once.
+ */
+
+/**
+ * The set of locales the app knows how to render. `en` MUST stay first — it is
+ * the default and the unprefixed locale.
+ */
+export const SUPPORTED_LOCALES = ['en', 'es'] as const
+
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
+
+/** The default locale, served without a URL prefix. */
+export const DEFAULT_LOCALE: SupportedLocale = 'en'
+
+/** Type guard: is `value` one of the locales we actually support? */
+export function isSupportedLocale(value: string | undefined | null): value is SupportedLocale {
+  return value != null && (SUPPORTED_LOCALES as readonly string[]).includes(value)
+}

--- a/web/packages/web-wallet/tsconfig.json
+++ b/web/packages/web-wallet/tsconfig.json
@@ -8,5 +8,5 @@
     // Locale resource bundles (issue #764) are imported as typed JSON modules.
     "resolveJsonModule": true
   },
-  "include": ["src"]
+  "include": ["src", "functions"]
 }


### PR DESCRIPTION
## Summary

Phase 4 of the i18n rollout (#779). Adds a Cloudflare Pages Function for the `botho` Pages project (net-new `functions/` — the site had none) that, for HTML document navigations only, (A) localizes OG/Twitter/description metadata + injects `hreflang`/`canonical` per locale, and (B) does first-visit `Accept-Language` edge negotiation. All decision logic lives in a pure, unit-tested module (`functions/lib/locale-negotiation.ts`), mirroring the `baas-worker/src/checkout.ts` "pure core, I/O at the edges" pattern; `_middleware.ts` is a thin adapter.

## Changes

- **NEW `functions/lib/locale-negotiation.ts`** — pure core: `parseAcceptLanguage` (q-value parser, no dep), `isBotUserAgent` (crawler/unfurl denylist), `readCookie`, `parseLocaleFromPath`/`buildLocalePath`, `negotiateLocaleRedirect` (the redirect decision), and `localizeDocumentHtml` (per-locale meta + hreflang rewrite).
- **NEW `functions/_middleware.ts`** — thin runtime adapter: gates on document requests, calls the pure core, stitches the decision onto a real `Response` (302 + cookie, or HTML rewrite), passes assets/`/rpc`/`/api`/manifest/SW/operator through untouched.
- **NEW `functions/lib/locale-negotiation.test.ts`** — 29 vitest unit tests.
- **NEW `src/lib/locales.ts`** — dependency-free leaf module with `SUPPORTED_LOCALES`/`DEFAULT_LOCALE`/`isSupportedLocale`; `src/lib/i18n.ts` now re-exports from it so the edge Function shares the exact same locale list without importing the i18next runtime (no drift). Public API of `./i18n` is unchanged.
- **`tsconfig.json`** — include `functions` so the Pages Function is typechecked by `pnpm typecheck`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `/es/*` returns Spanish og/twitter title+description; og:url = requested URL | ✅ | `curl /es/wallet` via `wrangler pages dev`: Spanish copy, `og:url=https://botho.io/es/wallet` |
| Default (en, unprefixed) metadata unchanged | ✅ | `curl /wallet`: English copy preserved; og:url corrected to `/wallet` |
| `hreflang` (en/es/x-default) present on locale-aware responses | ✅ | curl output shows all three `<link rel="alternate">` + `rel="canonical"` |
| First-visit `Accept-Language: es` on default path → 302 to `/es` equiv | ✅ | `curl -H "Accept-Language: es" /wallet` → `302 Location: /es/wallet` |
| Cookie set → never redirected regardless of Accept-Language | ✅ | `curl -H "Cookie: botho_locale=en" -H "Accept-Language: es"` → 200 |
| Known crawler/bot UA never redirected (messenger + search bot tested) | ✅ | `facebookexternalhit` and `Googlebot` both → 200, no redirect |
| Already-`/es/*` path never redirected | ✅ | `curl /es/wallet` (en Accept-Language) → 200 |
| Non-HTML requests (assets, manifest, /rpc, SW) unaffected | ✅ | `favicon.png` + `manifest.webmanifest` pass through, no rewrite/cookie |
| Negotiation logic is a pure, unit-testable function | ✅ | `negotiateLocaleRedirect` / `localizeDocumentHtml` — 29 tests |
| Cache-Control/Vary set so shared caches can't cross-serve | ✅ | negotiated responses carry `Cache-Control: private, no-store` + `Vary: Accept-Language, Cookie` |
| PWA manifest scope explicitly resolved | ✅ | Scoped English-only (documented limitation below) |

## Test Plan

- **Unit**: `vitest run` on `functions/lib/locale-negotiation.test.ts` — 29 passing, covering q-value parsing (highest-weighted *supported* locale), absent/empty/unsupported/wildcard headers, `q=0` drop, bot UA exemption (Facebook/Twitter/Slack/Telegram/Discord/Google/Bing/WhatsApp), cookie suppression, locale-prefixed path suppression, no-Accept-Language fallback, and the full HTML rewrite (Spanish meta, og:url, `<html lang>`, hreflang count, English no-regression, attribute escaping).
- **Full suite**: `pnpm check:ci` green — 774 tests pass, typecheck clean across all packages, baas-worker wrangler dry-run OK.
- **End-to-end edge**: `pnpm build` then `wrangler pages dev dist`; curl'd every acceptance case above against the live Pages dev server (Pages Functions do not run under `vite preview`/Playwright, so this is the authoritative edge verification). All behaved as specified.

## Known limitation (deferred)

PWA manifest localization is intentionally **English-only** for this pass. A static `manifest.webmanifest` is fetched once per `<link rel="manifest">` URL, so per-locale install names would require per-locale manifest URLs + rewriting the `<link>` href — low value for the small PWA-install traffic slice. Flagged as a follow-up rather than blocking the higher-value OG/Twitter + negotiation work, per the issue's decomposition guidance.

## Deviations from the curator's plan

- Chose **Option 1** (Pages Function response rewrite) over per-locale static builds, as recommended.
- Added `src/lib/locales.ts` leaf module (touching `i18n.ts` via re-export, both listed affected files) to genuinely eliminate locale-list drift rather than duplicating the list with a comment.
- Reverted an unrelated `pnpm install` side-effect to `web/pnpm-workspace.yaml` (allowBuilds scaffold) to keep scope clean.

Closes #779