### PR TITLE
feat(web): localize node checkout, success, and status pages (en/es)

### DIFF
--- a/web/packages/web-wallet/src/lib/i18n.ts
+++ b/web/packages/web-wallet/src/lib/i18n.ts
@@ -42,6 +42,8 @@ import enContacts from '../locales/en/contacts.json'
 import esContacts from '../locales/es/contacts.json'
 import enDocs from '../locales/en/docs.json'
 import esDocs from '../locales/es/docs.json'
+import enNode from '../locales/en/node.json'
+import esNode from '../locales/es/node.json'
 
 /**
  * Locale constants live in the dependency-free `./locales` leaf module so build
@@ -89,6 +91,7 @@ const resources = {
     claim: enClaim,
     contacts: enContacts,
     docs: enDocs,
+    node: enNode,
   },
   es: {
     landing: esLanding,
@@ -97,6 +100,7 @@ const resources = {
     claim: esClaim,
     contacts: esContacts,
     docs: esDocs,
+    node: esNode,
   },
 } as const
 
@@ -108,7 +112,7 @@ if (!i18n.isInitialized) {
     fallbackLng: DEFAULT_LOCALE,
     supportedLngs: SUPPORTED_LOCALES as unknown as string[],
     defaultNS: 'landing',
-    ns: ['landing', 'wallet', 'pay', 'claim', 'contacts', 'docs'],
+    ns: ['landing', 'wallet', 'pay', 'claim', 'contacts', 'docs', 'node'],
     interpolation: {
       // React already escapes interpolated values.
       escapeValue: false,

--- a/web/packages/web-wallet/src/lib/node-checkout.ts
+++ b/web/packages/web-wallet/src/lib/node-checkout.ts
@@ -17,20 +17,25 @@
  * "coming soon": selectable so we can record demand (the choice is sent as
  * `preferredRegion` and lands in Stripe metadata), but the node itself
  * launches in the default region until that datacenter opens.
+ *
+ * `labelKey` names an i18n key under the `node` namespace (`region.*`) resolved
+ * at render time with `t()` — this lib module cannot call `useTranslation()` at
+ * module scope, so it carries the key and the page component translates it (the
+ * same indirection `AUTO_LOCK_OPTIONS` uses in `wallet.tsx`).
  */
-export const NODE_REGIONS: ReadonlyArray<{ id: string; label: string; available: boolean }> = [
-  { id: 'us-west-2', label: 'US West (Oregon) — us-west-2', available: true },
-  { id: 'us-east-1', label: 'US East (N. Virginia) — us-east-1', available: false },
-  { id: 'ca-central-1', label: 'Canada (Montréal) — ca-central-1', available: false },
-  { id: 'sa-east-1', label: 'South America (São Paulo) — sa-east-1', available: false },
-  { id: 'eu-central-1', label: 'Europe (Frankfurt) — eu-central-1', available: false },
-  { id: 'eu-west-2', label: 'Europe (London) — eu-west-2', available: false },
-  { id: 'af-south-1', label: 'Africa (Cape Town) — af-south-1', available: false },
-  { id: 'me-south-1', label: 'Middle East (Bahrain) — me-south-1', available: false },
-  { id: 'ap-south-1', label: 'Asia Pacific (Mumbai) — ap-south-1', available: false },
-  { id: 'ap-southeast-1', label: 'Asia Pacific (Singapore) — ap-southeast-1', available: false },
-  { id: 'ap-northeast-1', label: 'Asia Pacific (Tokyo) — ap-northeast-1', available: false },
-  { id: 'ap-southeast-2', label: 'Asia Pacific (Sydney) — ap-southeast-2', available: false },
+export const NODE_REGIONS: ReadonlyArray<{ id: string; labelKey: string; available: boolean }> = [
+  { id: 'us-west-2', labelKey: 'region.usWest2', available: true },
+  { id: 'us-east-1', labelKey: 'region.usEast1', available: false },
+  { id: 'ca-central-1', labelKey: 'region.caCentral1', available: false },
+  { id: 'sa-east-1', labelKey: 'region.saEast1', available: false },
+  { id: 'eu-central-1', labelKey: 'region.euCentral1', available: false },
+  { id: 'eu-west-2', labelKey: 'region.euWest2', available: false },
+  { id: 'af-south-1', labelKey: 'region.afSouth1', available: false },
+  { id: 'me-south-1', labelKey: 'region.meSouth1', available: false },
+  { id: 'ap-south-1', labelKey: 'region.apSouth1', available: false },
+  { id: 'ap-southeast-1', labelKey: 'region.apSoutheast1', available: false },
+  { id: 'ap-northeast-1', labelKey: 'region.apNortheast1', available: false },
+  { id: 'ap-southeast-2', labelKey: 'region.apSoutheast2', available: false },
 ]
 
 export const DEFAULT_NODE_REGION = NODE_REGIONS.find((r) => r.available)!.id

--- a/web/packages/web-wallet/src/locales/en/node.json
+++ b/web/packages/web-wallet/src/locales/en/node.json
@@ -1,0 +1,84 @@
+{
+  "region": {
+    "usWest2": "US West (Oregon) — us-west-2",
+    "usEast1": "US East (N. Virginia) — us-east-1",
+    "caCentral1": "Canada (Montréal) — ca-central-1",
+    "saEast1": "South America (São Paulo) — sa-east-1",
+    "euCentral1": "Europe (Frankfurt) — eu-central-1",
+    "euWest2": "Europe (London) — eu-west-2",
+    "afSouth1": "Africa (Cape Town) — af-south-1",
+    "meSouth1": "Middle East (Bahrain) — me-south-1",
+    "apSouth1": "Asia Pacific (Mumbai) — ap-south-1",
+    "apSoutheast1": "Asia Pacific (Singapore) — ap-southeast-1",
+    "apNortheast1": "Asia Pacific (Tokyo) — ap-northeast-1",
+    "apSoutheast2": "Asia Pacific (Sydney) — ap-southeast-2"
+  },
+  "checkout": {
+    "back": "Back",
+    "testnetBadge": "Testnet — billing runs in Stripe test mode",
+    "heroTitle": "Host a Node for Your Community",
+    "heroSubtitlePrefix": "We run an always-on Botho node for you — no servers to manage. You, and everyone you invite, transact from the app through your own private endpoint. ",
+    "heroPrice": "$50/month.",
+    "valueProp": {
+      "leadStrong": "Your node mines for you.",
+      "leadBody": " Out of the box it mines to the address you configure — helping secure the network, with any rewards going straight to your wallet. What you're buying is the managed hosting: the always-on node and the wallet experience. ",
+      "clarityStrong": "To be clear about value",
+      "clarityBody": ": testnet coins have zero real-world value, and mainnet coins float — mining rewards are not an income promise. Charges run in Stripe test mode while we validate the service."
+    },
+    "cards": {
+      "managedTitle": "Managed for you",
+      "managedDesc": "An always-on node in the cloud — no AWS, no SSH, no upkeep.",
+      "hubTitle": "Your community's hub",
+      "hubDesc": "A private endpoint you and everyone you invite transact through.",
+      "custodyTitle": "Non-custodial",
+      "custodyDesc": "Keys stay on every device. The node never holds anyone's funds."
+    },
+    "regionLabel": "Region",
+    "optgroupAvailable": "Available now",
+    "optgroupComingSoon": "Coming soon — tell us where you want to host",
+    "availableHint": "Your node will be provisioned here once you subscribe.",
+    "comingSoonHint": "This region isn't live yet. Your node launches in {{region}} for now, and your preference is recorded to help us prioritize new datacenters.",
+    "emailLabel": "Email",
+    "emailOptional": "(optional)",
+    "emailPlaceholder": "you@example.com",
+    "emailHint": "Pre-fills Stripe checkout and is where we'll send your node details. You can also enter it on the next screen.",
+    "submitting": "Redirecting to Stripe…",
+    "submit": "Subscribe — $50/mo",
+    "secureNote": "Secure checkout hosted by Stripe. Cancel anytime.",
+    "errorFallback": "Something went wrong starting checkout. Please try again."
+  },
+  "success": {
+    "title": "Subscription started",
+    "body": "Thanks! Your managed node is being provisioned. We'll email you a secure link to your node's status page — it shows your private RPC URL, the node's health, and a one-click link to open it in the wallet.",
+    "openWallet": "Open Wallet",
+    "backToHome": "Back to home"
+  },
+  "status": {
+    "title": "Your managed node",
+    "subtitle": "Botho-as-a-Service · testnet",
+    "loading": "Loading your node…",
+    "missingToken": "This status link is missing its access token.",
+    "loadError": "Could not load your node status.",
+    "portalError": "Could not open the billing portal.",
+    "tryAgain": "Try again",
+    "statusLabel": "Status",
+    "rpcLabel": "RPC endpoint",
+    "copyRpcAria": "Copy RPC URL",
+    "regionLabel": "Region",
+    "openInWallet": "Open in wallet",
+    "manageSubscription": "Manage subscription",
+    "state": {
+      "provisioning": "Provisioning",
+      "running": "Running",
+      "suspended": "Suspended",
+      "terminated": "Terminated"
+    },
+    "health": {
+      "notReporting": "Not yet reporting",
+      "unreachable": "Unreachable",
+      "online": "online",
+      "height": "height {{height}}",
+      "synced": "synced"
+    }
+  }
+}

--- a/web/packages/web-wallet/src/locales/es/node.json
+++ b/web/packages/web-wallet/src/locales/es/node.json
@@ -1,0 +1,84 @@
+{
+  "region": {
+    "usWest2": "Oeste de EE. UU. (Oregón) — us-west-2",
+    "usEast1": "Este de EE. UU. (Norte de Virginia) — us-east-1",
+    "caCentral1": "Canadá (Montreal) — ca-central-1",
+    "saEast1": "Sudamérica (São Paulo) — sa-east-1",
+    "euCentral1": "Europa (Fráncfort) — eu-central-1",
+    "euWest2": "Europa (Londres) — eu-west-2",
+    "afSouth1": "África (Ciudad del Cabo) — af-south-1",
+    "meSouth1": "Oriente Medio (Baréin) — me-south-1",
+    "apSouth1": "Asia-Pacífico (Bombay) — ap-south-1",
+    "apSoutheast1": "Asia-Pacífico (Singapur) — ap-southeast-1",
+    "apNortheast1": "Asia-Pacífico (Tokio) — ap-northeast-1",
+    "apSoutheast2": "Asia-Pacífico (Sídney) — ap-southeast-2"
+  },
+  "checkout": {
+    "back": "Atrás",
+    "testnetBadge": "Red de pruebas — la facturación funciona en modo de prueba de Stripe",
+    "heroTitle": "Aloja un nodo para tu comunidad",
+    "heroSubtitlePrefix": "Ejecutamos un nodo de Botho siempre activo por ti, sin servidores que gestionar. Tú, y todas las personas que invites, transáis desde la app a través de vuestro propio punto de acceso privado. ",
+    "heroPrice": "$50 al mes.",
+    "valueProp": {
+      "leadStrong": "Tu nodo mina para ti.",
+      "leadBody": " Desde el primer momento mina hacia la dirección que configures, ayudando a proteger la red, y cualquier recompensa va directa a tu monedero. Lo que compras es el alojamiento gestionado: el nodo siempre activo y la experiencia del monedero. ",
+      "clarityStrong": "Para ser claros sobre el valor",
+      "clarityBody": ": las monedas de la red de pruebas no tienen ningún valor real, y las de la red principal fluctúan; las recompensas de minería no son una promesa de ingresos. Los cargos funcionan en modo de prueba de Stripe mientras validamos el servicio."
+    },
+    "cards": {
+      "managedTitle": "Gestionado por nosotros",
+      "managedDesc": "Un nodo siempre activo en la nube: sin AWS, sin SSH, sin mantenimiento.",
+      "hubTitle": "El centro de tu comunidad",
+      "hubDesc": "Un punto de acceso privado por el que transáis tú y todas las personas que invites.",
+      "custodyTitle": "Sin custodia",
+      "custodyDesc": "Las claves permanecen en cada dispositivo. El nodo nunca guarda los fondos de nadie."
+    },
+    "regionLabel": "Región",
+    "optgroupAvailable": "Disponible ahora",
+    "optgroupComingSoon": "Próximamente — dinos dónde quieres alojar",
+    "availableHint": "Tu nodo se aprovisionará aquí en cuanto te suscribas.",
+    "comingSoonHint": "Esta región aún no está activa. Por ahora tu nodo se lanza en {{region}}, y guardamos tu preferencia para ayudarnos a priorizar nuevos centros de datos.",
+    "emailLabel": "Correo electrónico",
+    "emailOptional": "(opcional)",
+    "emailPlaceholder": "tu@ejemplo.com",
+    "emailHint": "Rellena de antemano el pago de Stripe y es donde te enviaremos los detalles de tu nodo. También puedes introducirlo en la siguiente pantalla.",
+    "submitting": "Redirigiendo a Stripe…",
+    "submit": "Suscríbete — $50/mes",
+    "secureNote": "Pago seguro alojado por Stripe. Cancela cuando quieras.",
+    "errorFallback": "Algo salió mal al iniciar el pago. Inténtalo de nuevo."
+  },
+  "success": {
+    "title": "Suscripción iniciada",
+    "body": "¡Gracias! Tu nodo gestionado se está aprovisionando. Te enviaremos por correo un enlace seguro a la página de estado de tu nodo, que muestra tu URL de RPC privada, la salud del nodo y un enlace de un clic para abrirlo en el monedero.",
+    "openWallet": "Abrir el monedero",
+    "backToHome": "Volver al inicio"
+  },
+  "status": {
+    "title": "Tu nodo gestionado",
+    "subtitle": "Botho como servicio · red de pruebas",
+    "loading": "Cargando tu nodo…",
+    "missingToken": "A este enlace de estado le falta su token de acceso.",
+    "loadError": "No se pudo cargar el estado de tu nodo.",
+    "portalError": "No se pudo abrir el portal de facturación.",
+    "tryAgain": "Inténtalo de nuevo",
+    "statusLabel": "Estado",
+    "rpcLabel": "Punto de acceso RPC",
+    "copyRpcAria": "Copiar URL de RPC",
+    "regionLabel": "Región",
+    "openInWallet": "Abrir en el monedero",
+    "manageSubscription": "Gestionar suscripción",
+    "state": {
+      "provisioning": "Aprovisionando",
+      "running": "En ejecución",
+      "suspended": "Suspendido",
+      "terminated": "Terminado"
+    },
+    "health": {
+      "notReporting": "Aún no informa",
+      "unreachable": "Inalcanzable",
+      "online": "en línea",
+      "height": "altura {{height}}",
+      "synced": "sincronizado"
+    }
+  }
+}

--- a/web/packages/web-wallet/src/pages/node.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/node.i18n.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Locale-rendering coverage for the node checkout / success / status pages
+ * (issue #793, i18n phase 5a). Asserts page-owned copy renders in the active
+ * locale under both the default and `/es`-prefixed paths, and that the
+ * `node-checkout` region catalog (`labelKey` → `t()`) and the status-page state
+ * badges / health summary switch language too.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { NodeStatus } from '../lib/node-status'
+
+const fetchNodeStatusMock = vi.fn()
+vi.mock('../lib/node-status', async () => {
+  const actual = await vi.importActual<typeof import('../lib/node-status')>('../lib/node-status')
+  return {
+    ...actual,
+    fetchNodeStatus: (token: string) => fetchNodeStatusMock(token),
+  }
+})
+
+// Imported AFTER the mocks are registered.
+import { NodePage, NodeSuccessPage, NodeStatusPage } from './node'
+import i18n from '../lib/i18n'
+
+const RUNNING_STATUS: NodeStatus = {
+  nodeId: 'node-1',
+  rpcUrl: 'https://rpc.example.test',
+  state: 'running',
+  region: 'us-west-2',
+  health: { status: 'online', chainHeight: 42, synced: true },
+  walletDeepLink: 'https://wallet.example.test/?rpc=...',
+}
+
+function renderAt(path: string, element: React.ReactElement) {
+  return render(<MemoryRouter initialEntries={[path]}>{element}</MemoryRouter>)
+}
+
+describe('node pages i18n', () => {
+  beforeEach(() => {
+    fetchNodeStatusMock.mockReset()
+    fetchNodeStatusMock.mockResolvedValue(RUNNING_STATUS)
+    // The status page reads its token from window.location.search.
+    window.history.replaceState({}, '', '/node/status?token=abc')
+    return i18n.changeLanguage('en')
+  })
+
+  afterEach(() => cleanup())
+
+  it('renders English checkout copy by default', () => {
+    renderAt('/node', <NodePage />)
+    expect(
+      screen.getByRole('heading', { name: 'Host a Node for Your Community' }),
+    ).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Subscribe/i })).toBeTruthy()
+    // Region catalog resolves through labelKey → t().
+    expect(screen.getByText('US West (Oregon) — us-west-2')).toBeTruthy()
+  })
+
+  it('renders Spanish checkout copy when the active locale is es', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/node', <NodePage />)
+    expect(screen.getByRole('heading', { name: 'Aloja un nodo para tu comunidad' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Suscríbete/i })).toBeTruthy()
+    expect(screen.getByText('Oeste de EE. UU. (Oregón) — us-west-2')).toBeTruthy()
+    // English source string must NOT leak through untranslated.
+    expect(
+      screen.queryByRole('heading', { name: 'Host a Node for Your Community' }),
+    ).toBeNull()
+  })
+
+  it('renders the success page in English by default', () => {
+    renderAt('/node/success', <NodeSuccessPage />)
+    expect(screen.getByRole('heading', { name: 'Subscription started' })).toBeTruthy()
+  })
+
+  it('renders the success page in Spanish under /es', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/node/success', <NodeSuccessPage />)
+    expect(screen.getByRole('heading', { name: 'Suscripción iniciada' })).toBeTruthy()
+    expect(screen.queryByRole('heading', { name: 'Subscription started' })).toBeNull()
+  })
+
+  it('renders the status page state badge in English by default', async () => {
+    renderAt('/node/status', <NodeStatusPage />)
+    expect(await screen.findByText('Running')).toBeTruthy()
+  })
+
+  it('renders the status page state badge in Spanish under /es', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/node/status', <NodeStatusPage />)
+    expect(await screen.findByText('En ejecución')).toBeTruthy()
+    await waitFor(() => expect(screen.queryByText('Running')).toBeNull())
+  })
+})

--- a/web/packages/web-wallet/src/pages/node.tsx
+++ b/web/packages/web-wallet/src/pages/node.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { Button, Card, Input, Logo } from '@botho/ui'
 import {
   Server,
@@ -50,6 +51,7 @@ import {
  * checkout, Stripe redirects to `/node/success` (the placeholder below).
  */
 export function NodePage() {
+  const { t } = useTranslation('node')
   const [region, setRegion] = useState<string>(DEFAULT_NODE_REGION)
   const [email, setEmail] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -71,13 +73,15 @@ export function NodePage() {
       window.location.assign(session.url)
     } catch (err) {
       const message =
-        err instanceof NodeCheckoutError
-          ? err.message
-          : 'Something went wrong starting checkout. Please try again.'
+        err instanceof NodeCheckoutError ? err.message : t('checkout.errorFallback')
       setError(message)
       setSubmitting(false)
     }
   }
+
+  const defaultRegionLabelKey = NODE_REGIONS.find(
+    (r) => r.id === DEFAULT_NODE_REGION,
+  )?.labelKey
 
   return (
     <div className="min-h-screen">
@@ -90,7 +94,7 @@ export function NodePage() {
           </Link>
           <Link to="/" className="text-ghost hover:text-light transition-colors flex items-center gap-2">
             <ArrowLeft size={18} />
-            Back
+            {t('checkout.back')}
           </Link>
         </div>
       </header>
@@ -101,19 +105,17 @@ export function NodePage() {
           <div className="text-center mb-10">
             <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-steel/50 border border-muted text-xs sm:text-sm text-ghost mb-6">
               <span className="w-2 h-2 rounded-full bg-warning" />
-              Testnet — billing runs in Stripe test mode
+              {t('checkout.testnetBadge')}
             </div>
             <div className="w-14 h-14 rounded-xl bg-pulse/10 flex items-center justify-center mx-auto mb-5">
               <Server className="text-pulse" size={28} />
             </div>
             <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold mb-4">
-              Host a Node for Your Community
+              {t('checkout.heroTitle')}
             </h1>
             <p className="text-base sm:text-lg text-ghost max-w-xl mx-auto">
-              We run an always-on Botho node for you — no servers to manage. You,
-              and everyone you invite, transact from the app through your own
-              private endpoint.{' '}
-              <span className="text-light whitespace-nowrap">$50/month.</span>
+              {t('checkout.heroSubtitlePrefix')}
+              <span className="text-light whitespace-nowrap">{t('checkout.heroPrice')}</span>
             </p>
           </div>
 
@@ -121,29 +123,24 @@ export function NodePage() {
           <div className="mb-8 p-4 rounded-xl bg-warning/10 border border-warning/30 flex gap-3">
             <AlertCircle className="text-warning shrink-0 mt-0.5" size={20} />
             <p className="text-sm text-ghost">
-              <span className="text-light font-medium">Your node mines for you.</span>{' '}
-              Out of the box it mines to the address you configure — helping secure
-              the network, with any rewards going straight to your wallet. What
-              you're buying is the managed hosting: the always-on node and the
-              wallet experience.{' '}
-              <span className="text-light">To be clear about value</span>: testnet
-              coins have zero real-world value, and mainnet coins float — mining
-              rewards are not an income promise. Charges run in Stripe test mode
-              while we validate the service.
+              <span className="text-light font-medium">{t('checkout.valueProp.leadStrong')}</span>
+              {t('checkout.valueProp.leadBody')}
+              <span className="text-light">{t('checkout.valueProp.clarityStrong')}</span>
+              {t('checkout.valueProp.clarityBody')}
             </p>
           </div>
 
           {/* What you get */}
           <div className="grid sm:grid-cols-3 gap-3 sm:gap-4 mb-8">
             {[
-              { icon: Cpu, title: 'Managed for you', desc: 'An always-on node in the cloud — no AWS, no SSH, no upkeep.' },
-              { icon: Globe, title: "Your community's hub", desc: 'A private endpoint you and everyone you invite transact through.' },
-              { icon: ShieldCheck, title: 'Non-custodial', desc: 'Keys stay on every device. The node never holds anyone\'s funds.' },
+              { icon: Cpu, titleKey: 'checkout.cards.managedTitle', descKey: 'checkout.cards.managedDesc' },
+              { icon: Globe, titleKey: 'checkout.cards.hubTitle', descKey: 'checkout.cards.hubDesc' },
+              { icon: ShieldCheck, titleKey: 'checkout.cards.custodyTitle', descKey: 'checkout.cards.custodyDesc' },
             ].map((f) => (
-              <div key={f.title} className="p-4 rounded-xl bg-slate/50 border border-steel">
+              <div key={f.titleKey} className="p-4 rounded-xl bg-slate/50 border border-steel">
                 <f.icon className="text-pulse mb-2" size={20} />
-                <div className="font-display font-semibold text-sm mb-1">{f.title}</div>
-                <div className="text-xs text-ghost">{f.desc}</div>
+                <div className="font-display font-semibold text-sm mb-1">{t(f.titleKey)}</div>
+                <div className="text-xs text-ghost">{t(f.descKey)}</div>
               </div>
             ))}
           </div>
@@ -151,7 +148,7 @@ export function NodePage() {
           {/* Checkout form */}
           <Card className="p-5 sm:p-6">
             <label className="block text-sm font-medium text-light mb-2" htmlFor="node-region">
-              Region
+              {t('checkout.regionLabel')}
             </label>
             <select
               id="node-region"
@@ -160,50 +157,45 @@ export function NodePage() {
               disabled={submitting}
               className="w-full mb-1 px-3 py-2.5 rounded-lg bg-void border border-steel text-light focus:outline-none focus:border-pulse disabled:opacity-50"
             >
-              <optgroup label="Available now">
+              <optgroup label={t('checkout.optgroupAvailable')}>
                 {NODE_REGIONS.filter((r) => r.available).map((r) => (
                   <option key={r.id} value={r.id}>
-                    {r.label}
+                    {t(r.labelKey)}
                   </option>
                 ))}
               </optgroup>
-              <optgroup label="Coming soon — tell us where you want to host">
+              <optgroup label={t('checkout.optgroupComingSoon')}>
                 {NODE_REGIONS.filter((r) => !r.available).map((r) => (
                   <option key={r.id} value={r.id}>
-                    {r.label}
+                    {t(r.labelKey)}
                   </option>
                 ))}
               </optgroup>
             </select>
             {isRegionAvailable(region) ? (
-              <p className="text-xs text-ghost mb-5">
-                Your node will be provisioned here once you subscribe.
-              </p>
+              <p className="text-xs text-ghost mb-5">{t('checkout.availableHint')}</p>
             ) : (
               <p className="text-xs text-warning mb-5">
-                This region isn't live yet. Your node launches in{' '}
-                {NODE_REGIONS.find((r) => r.id === DEFAULT_NODE_REGION)?.label} for
-                now, and your preference is recorded to help us prioritize new
-                datacenters.
+                {t('checkout.comingSoonHint', {
+                  region: defaultRegionLabelKey ? t(defaultRegionLabelKey) : '',
+                })}
               </p>
             )}
 
             <label className="block text-sm font-medium text-light mb-2" htmlFor="node-email">
-              Email <span className="text-ghost font-normal">(optional)</span>
+              {t('checkout.emailLabel')}{' '}
+              <span className="text-ghost font-normal">{t('checkout.emailOptional')}</span>
             </label>
             <Input
               id="node-email"
               type="email"
-              placeholder="you@example.com"
+              placeholder={t('checkout.emailPlaceholder')}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               disabled={submitting}
               className="mb-1"
             />
-            <p className="text-xs text-ghost mb-6">
-              Pre-fills Stripe checkout and is where we'll send your node details.
-              You can also enter it on the next screen.
-            </p>
+            <p className="text-xs text-ghost mb-6">{t('checkout.emailHint')}</p>
 
             {error && (
               <div className="mb-4 p-3 rounded-lg bg-error/10 border border-error/30 flex gap-2 text-sm text-error">
@@ -221,15 +213,13 @@ export function NodePage() {
               {submitting ? (
                 <>
                   <Loader2 className="animate-spin mr-2" size={18} />
-                  Redirecting to Stripe…
+                  {t('checkout.submitting')}
                 </>
               ) : (
-                'Subscribe — $50/mo'
+                t('checkout.submit')
               )}
             </Button>
-            <p className="text-xs text-center text-ghost mt-3">
-              Secure checkout hosted by Stripe. Cancel anytime.
-            </p>
+            <p className="text-xs text-center text-ghost mt-3">{t('checkout.secureNote')}</p>
           </Card>
         </div>
       </main>
@@ -263,6 +253,7 @@ function NodePageShell({ children }: { children: React.ReactNode }) {
  * user at the live status page once they have their magic link.
  */
 export function NodeSuccessPage() {
+  const { t } = useTranslation('node')
   return (
     <NodePageShell>
       <Card className="max-w-md w-full p-6 sm:p-8 text-center">
@@ -270,21 +261,17 @@ export function NodeSuccessPage() {
           <Check className="text-success" size={28} />
         </div>
         <h1 className="font-display text-2xl sm:text-3xl font-bold mb-3">
-          Subscription started
+          {t('success.title')}
         </h1>
-        <p className="text-sm sm:text-base text-ghost mb-6">
-          Thanks! Your managed node is being provisioned. We'll email you a secure
-          link to your node's status page — it shows your private RPC URL, the
-          node's health, and a one-click link to open it in the wallet.
-        </p>
+        <p className="text-sm sm:text-base text-ghost mb-6">{t('success.body')}</p>
         <div className="flex flex-col gap-3">
           <Link to="/wallet">
             <Button size="lg" className="w-full justify-center">
-              Open Wallet
+              {t('success.openWallet')}
             </Button>
           </Link>
           <Link to="/" className="text-sm text-ghost hover:text-light transition-colors">
-            Back to home
+            {t('success.backToHome')}
           </Link>
         </div>
       </Card>
@@ -292,24 +279,30 @@ export function NodeSuccessPage() {
   )
 }
 
+/** i18n translator bound to the `node` namespace (from `useTranslation('node')`). */
+type NodeT = ReturnType<typeof useTranslation<'node'>>['t']
+
 /** Colored dot + label for a node's lifecycle state. */
-function StateBadge({ state }: { state: NodeStatus['state'] }) {
-  const map: Record<NodeStatus['state'], { label: string; cls: string }> = {
-    provisioning: { label: 'Provisioning', cls: 'bg-warning/20 text-warning' },
-    running: { label: 'Running', cls: 'bg-success/20 text-success' },
-    suspended: { label: 'Suspended', cls: 'bg-warning/20 text-warning' },
-    terminated: { label: 'Terminated', cls: 'bg-danger/20 text-danger' },
+function StateBadge({ state, t }: { state: NodeStatus['state']; t: NodeT }) {
+  const map: Record<NodeStatus['state'], { labelKey: string; cls: string }> = {
+    provisioning: { labelKey: 'status.state.provisioning', cls: 'bg-warning/20 text-warning' },
+    running: { labelKey: 'status.state.running', cls: 'bg-success/20 text-success' },
+    suspended: { labelKey: 'status.state.suspended', cls: 'bg-warning/20 text-warning' },
+    terminated: { labelKey: 'status.state.terminated', cls: 'bg-danger/20 text-danger' },
   }
-  const { label, cls } = map[state]
-  return <span className={`px-2 py-0.5 rounded text-xs font-medium ${cls}`}>{label}</span>
+  const { labelKey, cls } = map[state]
+  return <span className={`px-2 py-0.5 rounded text-xs font-medium ${cls}`}>{t(labelKey)}</span>
 }
 
 /** One-line health summary from node_getStatus. */
-function healthSummary(health: NodeStatus['health']): string {
-  if (health.status === 'unknown') return 'Not yet reporting'
-  if (health.status === 'offline') return 'Unreachable'
-  const h = health.chainHeight != null ? `height ${health.chainHeight}` : 'online'
-  const sync = health.synced ? 'synced' : `${Math.round(health.syncProgress ?? 0)}%`
+function healthSummary(health: NodeStatus['health'], t: NodeT): string {
+  if (health.status === 'unknown') return t('status.health.notReporting')
+  if (health.status === 'offline') return t('status.health.unreachable')
+  const h =
+    health.chainHeight != null
+      ? t('status.health.height', { height: health.chainHeight })
+      : t('status.health.online')
+  const sync = health.synced ? t('status.health.synced') : `${Math.round(health.syncProgress ?? 0)}%`
   return `${h} · ${sync}`
 }
 
@@ -321,6 +314,7 @@ function healthSummary(health: NodeStatus['health']): string {
  * and a "Manage Subscription" button (Stripe Customer Portal).
  */
 export function NodeStatusPage() {
+  const { t } = useTranslation('node')
   const [status, setStatus] = useState<NodeStatus | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -332,7 +326,7 @@ export function NodeStatusPage() {
 
   const load = useCallback(async () => {
     if (!token) {
-      setError('This status link is missing its access token.')
+      setError(t('status.missingToken'))
       setLoading(false)
       return
     }
@@ -341,11 +335,11 @@ export function NodeStatusPage() {
     try {
       setStatus(await fetchNodeStatus(token))
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not load your node status.')
+      setError(err instanceof Error ? err.message : t('status.loadError'))
     } finally {
       setLoading(false)
     }
-  }, [token])
+  }, [token, t])
 
   useEffect(() => {
     void load()
@@ -369,7 +363,7 @@ export function NodeStatusPage() {
       const url = await createPortalUrl(token)
       window.location.assign(url)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not open the billing portal.')
+      setError(err instanceof Error ? err.message : t('status.portalError'))
       setPortalBusy(false)
     }
   }
@@ -382,15 +376,15 @@ export function NodeStatusPage() {
             <Server className="text-pulse" size={22} />
           </div>
           <div>
-            <h1 className="font-display text-xl sm:text-2xl font-bold">Your managed node</h1>
-            <p className="text-xs text-ghost">Botho-as-a-Service · testnet</p>
+            <h1 className="font-display text-xl sm:text-2xl font-bold">{t('status.title')}</h1>
+            <p className="text-xs text-ghost">{t('status.subtitle')}</p>
           </div>
         </div>
 
         {loading && (
           <div className="flex items-center gap-2 text-ghost py-8 justify-center">
             <Loader2 className="animate-spin" size={18} />
-            Loading your node…
+            {t('status.loading')}
           </div>
         )}
 
@@ -401,7 +395,7 @@ export function NodeStatusPage() {
               <p>{error}</p>
               {token && (
                 <button onClick={load} className="underline mt-2 text-light">
-                  Try again
+                  {t('status.tryAgain')}
                 </button>
               )}
             </div>
@@ -411,27 +405,27 @@ export function NodeStatusPage() {
         {!loading && status && (
           <div className="flex flex-col gap-5">
             <div className="flex items-center justify-between">
-              <span className="text-sm text-ghost">Status</span>
+              <span className="text-sm text-ghost">{t('status.statusLabel')}</span>
               <div className="flex items-center gap-2">
-                <StateBadge state={status.state} />
-                <span className="text-xs text-ghost">{healthSummary(status.health)}</span>
+                <StateBadge state={status.state} t={t} />
+                <span className="text-xs text-ghost">{healthSummary(status.health, t)}</span>
               </div>
             </div>
 
             <div>
-              <span className="text-sm text-ghost block mb-1.5">RPC endpoint</span>
+              <span className="text-sm text-ghost block mb-1.5">{t('status.rpcLabel')}</span>
               <div className="flex gap-2">
                 <code className="flex-1 px-3 py-2 rounded-lg bg-void border border-steel text-xs sm:text-sm text-light break-all">
                   {status.rpcUrl}
                 </code>
-                <Button size="sm" variant="ghost" onClick={handleCopy} aria-label="Copy RPC URL">
+                <Button size="sm" variant="ghost" onClick={handleCopy} aria-label={t('status.copyRpcAria')}>
                   {copied ? <Check size={16} className="text-success" /> : <Copy size={16} />}
                 </Button>
               </div>
             </div>
 
             <div className="flex items-center justify-between text-sm">
-              <span className="text-ghost">Region</span>
+              <span className="text-ghost">{t('status.regionLabel')}</span>
               <span className="text-light">{status.region}</span>
             </div>
 
@@ -441,7 +435,7 @@ export function NodeStatusPage() {
               <a href={status.walletDeepLink}>
                 <Button size="lg" className="w-full justify-center gap-2">
                   <ExternalLink size={18} />
-                  Open in wallet
+                  {t('status.openInWallet')}
                 </Button>
               </a>
               <Button
@@ -456,7 +450,7 @@ export function NodeStatusPage() {
                 ) : (
                   <CreditCard size={18} />
                 )}
-                Manage subscription
+                {t('status.manageSubscription')}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

The node hosting funnel (`/node`, `/node/success`, `/node/status`) rendered entirely in English regardless of locale — `/es/node` showed English copy. This wires `useTranslation('node')` into all three exported components in `node.tsx` and adds an `en`/`es` `node` namespace so the paid-hosting surface is fully localized. This is part 1 of #790 (decomposed during curation).

## Changes

- **New `node` namespace** (`src/locales/{en,es}/node.json`) covering: hero (badge/title/subtitle/price), the honest value-prop box, the 3 "what you get" cards, region select (label + both optgroup labels + both availability hints, with `{{region}}` interpolation for the coming-soon fallback), email field, submit button (idle + loading), error fallback, the full success page, and the status page (title/subtitle, 4 state-badge labels, health-summary strings, RPC/region row labels, action buttons).
- **`node-checkout.ts`**: `NODE_REGIONS` moves from hardcoded English `label` strings to i18n `labelKey`s (`region.*`), resolved with `t()` at render time — mirroring the `AUTO_LOCK_OPTIONS` `labelKey` pattern in `wallet.tsx` (a lib module cannot call `useTranslation()` at module scope). All 12 region labels are localized.
- **`node.tsx`**: `NodePage`, `NodeSuccessPage`, `NodeStatusPage` now consume `t()`. The `StateBadge` / `healthSummary` module-scope helpers take a `t` argument (typed `NodeT`) since they can't use the hook directly.
- **`i18n.ts`**: registered the `node` namespace (import + `resources.en/es` + `ns` array).
- **`node.i18n.test.tsx`** (new): renders all three pages under the default and `/es` locale, asserting hero title, submit button, a region label (labelKey→t path), the success heading, and a status-page state badge all switch language, and that English copy does not leak through in `es`.

English strings were extracted **byte-for-byte** from the existing source, so the e2e `checkout.spec.ts` default-locale assertions need zero changes. Spanish uses the informal *tú* register consistent with existing `es/*.json`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `useTranslation('node')` wired into all three components | ✅ | `NodePage`, `NodeSuccessPage`, `NodeStatusPage` all call it; `StateBadge`/`healthSummary` receive `t` |
| `NODE_REGIONS` uses `labelKey` (AUTO_LOCK_OPTIONS pattern), all callers updated | ✅ | `label` fully replaced with `labelKey`; `node.tsx` renders `t(r.labelKey)` at 3 sites |
| `en`/`es` `node.json` created with all required keys | ✅ | Hero, value-prop, cards, region select, email, submit, error, success, status, 12 regions |
| Namespace registered in `i18n.ts` | ✅ | Added to imports, `resources.en`, `resources.es`, and `ns` array |
| `node.i18n.test.tsx` added, mirrors phase-2 tests | ✅ | 6 tests across 3 pages × 2 locales — all pass |
| `node-checkout.test.ts` unchanged (only reads `.id`/`.available`) | ✅ | Confirmed by curator; 7 existing tests still green |
| `checkout.spec.ts` needs zero changes (byte-for-byte English) | ✅ | English copy extracted verbatim; default-locale regexes unchanged |
| Coming-soon region interpolates the localized default region name | ✅ | `comingSoonHint` uses `{{region}}` = `t(defaultRegionLabelKey)` |
| Spanish reads naturally (informal tú) | ✅ | Matches `es/wallet.json`/`es/pay.json` tone |

## Test Plan

`pnpm check:ci` in `web/` (worktree) — all green:
- `pnpm -r typecheck`: clean across all 8 packages
- `pnpm test:run`: **787 passed / 10 skipped** (incl. new `node.i18n.test.tsx` 6 tests + unchanged `node-checkout.test.ts` 7 tests)
- `wrangler deploy --dry-run`: succeeds

Closes #793