### PR TITLE
fix(web): landing header overflow, nav wrap, locale switcher, /en orphan (#797)

### DIFF
--- a/web/packages/web-wallet/functions/_middleware.ts
+++ b/web/packages/web-wallet/functions/_middleware.ts
@@ -24,6 +24,7 @@ import {
   localizeDocumentHtml,
   negotiateLocaleRedirect,
   parseLocaleFromPath,
+  stripEnPrefixRedirect,
 } from './lib/locale-negotiation'
 
 // Minimal shape of the Cloudflare Pages Functions context we use. Declared
@@ -85,6 +86,24 @@ export const onRequest = async (context: PagesContext): Promise<Response> => {
   }
   if (!isDocumentRequest(request, pathname)) {
     return next()
+  }
+
+  // `/en` and `/en/*` are orphan URLs (English is the unprefixed default) that
+  // otherwise render a blank SPA page (#797). Permanently 301 them to the
+  // unprefixed equivalent, preserving the query string. This runs BEFORE
+  // Accept-Language negotiation so a first-time es visitor hitting `/en` lands on
+  // `/` (and, if applicable, is then negotiated onward) rather than `/es/en`.
+  const enTarget = stripEnPrefixRedirect(pathname)
+  if (enTarget !== undefined) {
+    return new Response(null, {
+      status: 301,
+      headers: {
+        Location: url.origin + enTarget + url.search,
+        // Path-shape correction is safe to cache, but keep it Vary-clean so it
+        // does not poison the negotiated/localized document cache keys.
+        'Cache-Control': 'public, max-age=3600',
+      },
+    })
   }
 
   const headers = request.headers

--- a/web/packages/web-wallet/functions/lib/locale-negotiation.test.ts
+++ b/web/packages/web-wallet/functions/lib/locale-negotiation.test.ts
@@ -18,6 +18,7 @@ import {
   parseLocaleFromPath,
   readCookie,
   SITE_ORIGIN,
+  stripEnPrefixRedirect,
   SUPPORTED_LOCALES,
 } from './locale-negotiation'
 
@@ -120,6 +121,53 @@ describe('buildLocalePath', () => {
     expect(buildLocalePath('en', '/wallet')).toBe('/wallet')
     expect(buildLocalePath('es', '/wallet')).toBe('/es/wallet')
     expect(buildLocalePath('es', '/')).toBe('/es')
+  })
+})
+
+describe('stripEnPrefixRedirect', () => {
+  it('maps the bare /en orphan (with or without trailing slash) to the root', () => {
+    expect(stripEnPrefixRedirect('/en')).toBe('/')
+    expect(stripEnPrefixRedirect('/en/')).toBe('/')
+  })
+
+  it('strips the /en prefix from deeper paths', () => {
+    expect(stripEnPrefixRedirect('/en/wallet')).toBe('/wallet')
+    expect(stripEnPrefixRedirect('/en/explorer/tx/abc')).toBe('/explorer/tx/abc')
+    expect(stripEnPrefixRedirect('/en/node/status')).toBe('/node/status')
+  })
+
+  it('returns undefined for paths that are NOT /en orphans', () => {
+    expect(stripEnPrefixRedirect('/')).toBeUndefined()
+    expect(stripEnPrefixRedirect('/wallet')).toBeUndefined()
+    expect(stripEnPrefixRedirect('/es')).toBeUndefined()
+    expect(stripEnPrefixRedirect('/es/wallet')).toBeUndefined()
+    // Lookalike segments that merely START with "en" must be left alone.
+    expect(stripEnPrefixRedirect('/enterprise')).toBeUndefined()
+    expect(stripEnPrefixRedirect('/env')).toBeUndefined()
+  })
+
+  it('runs independently of Accept-Language negotiation (the 301 wins, not /es/en)', () => {
+    // Regression guard for the compounding bug: negotiateLocaleRedirect would
+    // send a first-visit es browser on `/en` to `/es/en` (since `/en` is not an
+    // explicit locale prefix). The middleware must therefore apply the /en 301
+    // FIRST — this test documents that the pure strip helper resolves `/en` to
+    // the unprefixed root, and that negotiation of `/en` (were it ever reached)
+    // is exactly the pathology we avoid by ordering the strip ahead of it.
+    expect(stripEnPrefixRedirect('/en')).toBe('/')
+    const wouldCompound = negotiateLocaleRedirect({
+      pathname: '/en',
+      acceptLanguage: 'es-ES,es;q=0.9',
+      cookie: null,
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+    })
+    // Confirms the pathology exists at the negotiation layer (hence the ordering
+    // requirement): unguarded, `/en` negotiates onward to the orphan `/es/en`.
+    expect(wouldCompound).toEqual({
+      kind: 'redirect',
+      location: '/es/en',
+      cookieLocale: 'es',
+    })
   })
 })
 

--- a/web/packages/web-wallet/functions/lib/locale-negotiation.ts
+++ b/web/packages/web-wallet/functions/lib/locale-negotiation.ts
@@ -194,6 +194,39 @@ export function buildLocalePath(locale: SupportedLocale, rest: string): string {
   return `/${locale}${normalizedRest}`
 }
 
+/**
+ * `/en` is an orphan namespace: English is the *unprefixed* default locale, so a
+ * literal `/en` or `/en/*` path is not a locale prefix (see `parseLocaleFromPath`
+ * and its `locale-path.ts` twin — both deliberately leave `/en` un-stripped) and
+ * matches no client route → a blank SPA page (#797, item 4). These paths only
+ * arrive via stale bookmarks / external links, never from the switcher (which
+ * emits unprefixed paths for `en`).
+ *
+ * Detect such a path and return the canonical unprefixed equivalent so the edge
+ * can 301 it (a permanent URL-shape correction, not a preference negotiation):
+ *
+ *   `/en`            -> `/`
+ *   `/en/`           -> `/`
+ *   `/en/wallet`     -> `/wallet`
+ *   `/en/explorer/x` -> `/explorer/x`
+ *
+ * Returns `undefined` for any path that is NOT an `/en` orphan (including `/`,
+ * `/wallet`, `/es/...`, and lookalikes like `/enterprise`). The query string is
+ * NOT handled here — the caller preserves it — so this stays a pure path->path
+ * function. This check MUST run before Accept-Language negotiation so a first
+ * visit to `/en` is corrected to `/` (and only then, if applicable, negotiated
+ * to `/es`) rather than compounded into `/es/en`.
+ */
+export function stripEnPrefixRedirect(pathname: string): string | undefined {
+  if (pathname === '/en' || pathname === '/en/') return '/'
+  if (pathname.startsWith('/en/')) {
+    // Drop the leading `/en`, keeping the rest (already starts with `/`).
+    const rest = pathname.slice('/en'.length)
+    return rest || '/'
+  }
+  return undefined
+}
+
 /** Inputs to the redirect decision — plain primitives, no runtime types. */
 export interface NegotiationInput {
   /** Request path (no query string), e.g. `/wallet`. */

--- a/web/packages/web-wallet/src/App.test.tsx
+++ b/web/packages/web-wallet/src/App.test.tsx
@@ -68,4 +68,22 @@ describe('App locale routing', () => {
     expect(await screen.findByText('Quantum Era')).toBeTruthy()
     expect(document.documentElement.lang).toBe('en')
   })
+
+  it('redirects the /en orphan to the unprefixed English landing page (not blank)', async () => {
+    // `/en` matches no locale prefix (en is the unprefixed default) and no route,
+    // so without the catch-all it would render blank (#797, item 4c). The client
+    // redirect must land on `/` and show the English landing hero.
+    window.history.pushState({}, '', '/en')
+    render(<App />)
+    expect(await screen.findByText('Quantum Era')).toBeTruthy()
+    await waitFor(() => expect(window.location.pathname).toBe('/'))
+    expect(document.documentElement.lang).toBe('en')
+  })
+
+  it('strips the /en prefix from a deeper orphan path (/en/wallet -> /wallet)', async () => {
+    window.history.pushState({}, '', '/en/wallet')
+    render(<App />)
+    await waitFor(() => expect(window.location.pathname).toBe('/wallet'))
+    expect(document.documentElement.lang).toBe('en')
+  })
 })

--- a/web/packages/web-wallet/src/App.tsx
+++ b/web/packages/web-wallet/src/App.tsx
@@ -82,8 +82,27 @@ function AppRoutes() {
       <Route path="/node/success" element={<NodeSuccessPage />} />
       {/* Node status page reached via magic link (#458 §4 / #507). */}
       <Route path="/node/status" element={<NodeStatusPage />} />
+      {/*
+        `/en` is an orphan namespace — English is the unprefixed default, so
+        `/en` / `/en/*` match no route above and render blank (#797). The edge
+        301s these on a fresh load; this is client-side defense-in-depth for any
+        in-app navigation that constructs an `/en` URL without a full reload.
+      */}
+      <Route path="/en" element={<Navigate to="/" replace />} />
+      <Route path="/en/*" element={<EnPrefixRedirect />} />
     </Routes>
   )
+}
+
+/**
+ * Redirect a stale `/en/<rest>` URL to its unprefixed `/<rest>` equivalent,
+ * preserving the query string and hash. English is the unprefixed default, so
+ * `/en/wallet` is an orphan alias for `/wallet` (#797, item 4c).
+ */
+function EnPrefixRedirect() {
+  const location = useLocation()
+  const rest = location.pathname.slice('/en'.length) || '/'
+  return <Navigate to={`${rest}${location.search}${location.hash}`} replace />
 }
 
 /**

--- a/web/packages/web-wallet/src/pages/landing.test.tsx
+++ b/web/packages/web-wallet/src/pages/landing.test.tsx
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 import { LandingPage } from './landing'
 import i18n from '../lib/i18n'
 
@@ -81,6 +81,82 @@ describe('LandingPage i18n', () => {
     // here we assert the switcher persisted the choice and, after changing the
     // language directly (what LocaleRoutes does off the URL), Spanish renders.
     expect(localStorage.getItem('botho:locale')).toBe('es')
+  })
+
+  it('locale switcher label reflects Spanish on a direct /es load', async () => {
+    // Acceptance criterion (item 3): the switcher's displayed language must equal
+    // the actually-rendered language. `activeLocale` is derived purely from the
+    // URL, so `/es` → the <select value> is "es" (renders "Español"), matching
+    // the Spanish page content — no desync (#797).
+    await i18n.changeLanguage('es')
+    render(
+      <MemoryRouter initialEntries={['/es']}>
+        <LandingPage />
+      </MemoryRouter>,
+    )
+    const select = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+    expect(select.value).toBe('es')
+    // The selected <option>'s visible label is the Spanish endonym.
+    const selected = select.options[select.selectedIndex]
+    expect(selected.textContent).toBe('Español')
+  })
+
+  it('locale switcher label reflects English on a direct /en (orphan) load', () => {
+    // Even the orphan `/en` path parses to the default (en) locale, so the
+    // switcher must read "English" — never a stale "Español". This is the
+    // item-3/item-4 shared-root-cause regression guard: with well-formed URLs the
+    // label can never desync from the rendered language (#797).
+    render(
+      <MemoryRouter initialEntries={['/en']}>
+        <LandingPage />
+      </MemoryRouter>,
+    )
+    const select = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+    expect(select.value).toBe('en')
+    const selected = select.options[select.selectedIndex]
+    expect(selected.textContent).toBe('English')
+  })
+
+  it('locale switcher label reflects English on the unprefixed root (edge-redirect landing)', () => {
+    // Simulates a first-visit landing on the default-locale root after edge
+    // negotiation: the switcher reads "English" to match the rendered content.
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <LandingPage />
+      </MemoryRouter>,
+    )
+    const select = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+    expect(select.value).toBe('en')
+  })
+
+  it('locale switcher navigates to the sibling locale path on an in-session switch', () => {
+    // es→en round-trip through the switcher control emits the UNPREFIXED path for
+    // en (never `/en/...`), and vice versa — the mechanism that keeps the label
+    // and the URL in agreement (#797, item 3 confirmed-correct).
+    let seen = ''
+    function LocationProbe() {
+      seen = useLocation().pathname
+      return null
+    }
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/es/wallet']}>
+        <LandingPage />
+        <LocationProbe />
+      </MemoryRouter>,
+    )
+    const select = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+    // Reflects the /es URL.
+    expect(select.value).toBe('es')
+    // Switch es → en: must land on the unprefixed /wallet, not /en/wallet.
+    fireEvent.change(select, { target: { value: 'en' } })
+    expect(seen).toBe('/wallet')
+    expect(localStorage.getItem('botho:locale')).toBe('en')
+    rerender(
+      <MemoryRouter initialEntries={['/es/wallet']}>
+        <LandingPage />
+        <LocationProbe />
+      </MemoryRouter>,
+    )
   })
 
   it('exposes a language control labelled for assistive tech', () => {

--- a/web/packages/web-wallet/src/pages/landing.tsx
+++ b/web/packages/web-wallet/src/pages/landing.tsx
@@ -32,19 +32,27 @@ export function LandingPage() {
           </Link>
 
           {/* Desktop nav */}
-          <nav className="hidden md:flex items-center gap-8">
-            <Link to="/explorer" className="text-ghost hover:text-light transition-colors flex items-center gap-2">
+          {/*
+            Collapse to the hamburger at `lg:` (1024px) rather than `md:` (768px):
+            the six nav items + switcher + CTA leave no slack in the `max-w-6xl`
+            row, so ES's longer labels ("Alojar un nodo", "Informe técnico")
+            overflow/crush in the 768–1024px band where EN still just fits (#797).
+            `whitespace-nowrap` on every link/CTA additionally forbids two-line
+            wrapping (precedent: node.tsx:118).
+          */}
+          <nav className="hidden lg:flex items-center gap-8">
+            <Link to="/explorer" className="text-ghost hover:text-light transition-colors flex items-center gap-2 whitespace-nowrap">
               <Blocks size={18} />
               {t('nav.explorer')}
             </Link>
-            <Link to="/network" className="text-ghost hover:text-light transition-colors flex items-center gap-2">
+            <Link to="/network" className="text-ghost hover:text-light transition-colors flex items-center gap-2 whitespace-nowrap">
               <Activity size={18} />
               {t('nav.network')}
             </Link>
-            <Link to="/docs" className="text-ghost hover:text-light transition-colors">
+            <Link to="/docs" className="text-ghost hover:text-light transition-colors whitespace-nowrap">
               {t('nav.docs')}
             </Link>
-            <Link to="/node" className="text-ghost hover:text-light transition-colors flex items-center gap-2">
+            <Link to="/node" className="text-ghost hover:text-light transition-colors flex items-center gap-2 whitespace-nowrap">
               <Server size={18} />
               {t('nav.hostNode')}
             </Link>
@@ -52,7 +60,7 @@ export function LandingPage() {
               href="/botho-whitepaper.pdf"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-ghost hover:text-light transition-colors flex items-center gap-2"
+              className="text-ghost hover:text-light transition-colors flex items-center gap-2 whitespace-nowrap"
             >
               <FileText size={18} />
               {t('nav.whitepaper')}
@@ -61,21 +69,21 @@ export function LandingPage() {
               href="https://github.com/botho-project/botho"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-ghost hover:text-light transition-colors flex items-center gap-2"
+              className="text-ghost hover:text-light transition-colors flex items-center gap-2 whitespace-nowrap"
             >
               <Github size={18} />
               {t('nav.github')}
             </a>
-            <LocaleSwitcher />
+            <LocaleSwitcher className="whitespace-nowrap" />
             <Link to="/wallet">
-              <Button>{t('nav.launchWallet')}</Button>
+              <Button className="whitespace-nowrap">{t('nav.launchWallet')}</Button>
             </Link>
           </nav>
 
           {/* Mobile menu button */}
           <button
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            className="md:hidden p-2 -mr-2 text-ghost hover:text-light transition-colors"
+            className="lg:hidden p-2 -mr-2 text-ghost hover:text-light transition-colors"
             aria-label={mobileMenuOpen ? t('nav.closeMenu') : t('nav.openMenu')}
           >
             {mobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
@@ -84,7 +92,7 @@ export function LandingPage() {
 
         {/* Mobile menu */}
         {mobileMenuOpen && (
-          <div className="md:hidden border-t border-steel bg-abyss/95 backdrop-blur-md">
+          <div className="lg:hidden border-t border-steel bg-abyss/95 backdrop-blur-md">
             <nav className="px-4 py-4 space-y-1">
               <Link
                 to="/explorer"
@@ -134,7 +142,7 @@ export function LandingPage() {
               </div>
               <div className="pt-2">
                 <Link to="/wallet" onClick={() => setMobileMenuOpen(false)}>
-                  <Button className="w-full justify-center">{t('nav.launchWallet')}</Button>
+                  <Button className="w-full justify-center whitespace-nowrap">{t('nav.launchWallet')}</Button>
                 </Link>
               </div>
             </nav>


### PR DESCRIPTION
Fixes the four user-reported production bugs on botho.io `/es` and `/en` (issue #797). Ships to botho.io on merge.

## Changes

### 1. Header crowding (item 1)
`landing.tsx` collapsed to the hamburger at a single fixed `md:` (768px) breakpoint tuned to English label widths. Six nav items + switcher + CTA leave no slack in the `max-w-6xl` row, so Spanish's longer labels overflow/crush in the 768–1024px band. Raised the collapse breakpoint to `lg:` (1024px): `hidden md:flex` → `hidden lg:flex`, `md:hidden` → `lg:hidden` (both nav and mobile-menu wrapper). Per the curator's recommended simplest-robust option; a measurement-based progressive-disclosure nav is out of scope for this bug fix.

### 2. Nav label line-wrap (item 2)
Added `whitespace-nowrap` to every desktop nav `<Link>`/`<a>`, the `LocaleSwitcher` trigger, and the "Abrir monedero" CTA `<Button>` (plus the mobile CTA). Precedent: `node.tsx:118`.

### 3. Locale switcher wrong language (item 3)
Confirmed **no independent defect** (matches the curator's root-cause finding): `LocaleSwitcher` derives its label purely from the URL via `parseLocalePath`, which is correct for every well-formed URL. The only demonstrated desync path was a prior mis-navigation into a `/en` orphan URL — fixed by item 4. Added regression tests asserting the switcher label equals the rendered language for `/`, `/es`, `/en`, and after an in-session es↔en switch.

### 4. `/en` blank page (item 4)
English is the unprefixed default, so `/en` / `/en/*` match no route → blank SPA. Fixed in three layers per the curator spec:
- **Edge** — new pure `stripEnPrefixRedirect(pathname)` in `locale-negotiation.ts`; `_middleware.ts` 301s `/en`/`/en/*` to the unprefixed equivalent, preserving the query string. Runs **before** Accept-Language negotiation so a first-visit `es` browser hitting `/en` lands on `/` (then negotiates onward) instead of compounding into `/es/en`.
- **Client** — `<Route path="/en">` / `<Route path="/en/*">` redirects in `AppRoutes`, defense-in-depth for in-app navigations that construct an `/en` URL without a full reload.
- **Tests** — `locale-negotiation.test.ts` (strip helper + ordering-vs-negotiation guard), `App.test.tsx` (`/en` → `/`, `/en/wallet` → `/wallet`).

`parseLocalePath`'s documented `/en` semantics are unchanged (existing `locale-path.test.ts` case still passes).

## Verification

- **Full web vitest suite:** 797 passed / 10 skipped, 0 failed.
- **Typecheck:** clean across all 8 workspace projects.
- **`pnpm check:ci` step 3** (baas-worker `wrangler deploy --dry-run`): passes.
- **`wrangler pages dev` + curl matrix** against the built `dist/` with the Pages Function:

| Request | Headers | Result |
|---|---|---|
| `/en` | browser UA, no cookie | 301 → `/` |
| `/en/wallet` | browser UA | 301 → `/wallet` |
| `/en?foo=bar` | browser UA | 301 → `/?foo=bar` (query preserved) |
| `/en/wallet?x=1` | browser UA | 301 → `/wallet?x=1` |
| `/en` | `Accept-Language: es`, no cookie | **301 → `/`** (not 302 → `/es/en`) |
| `/en` | `Cookie: botho_locale=es` | 301 → `/` (wins over cookie short-circuit) |
| `/en` | `User-Agent: Googlebot` | 301 → `/` (crawlers never see blank) |
| `/enterprise` | browser UA | 200 (lookalike not redirected) |
| `/wallet` | browser UA | 200 (unaffected) |
| `/` | `Accept-Language: es`, no cookie | 302 → `/es` (normal negotiation intact) |

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)