### PR TITLE
feat(web): add LocaleSwitcher to transactional page headers

### DIFF
--- a/web/packages/web-wallet/src/pages/claim.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/claim.i18n.test.tsx
@@ -51,6 +51,21 @@ function renderAt(path: string) {
   )
 }
 
+// The LocaleSwitcher's <select> is uniquely identified by its locale-invariant
+// option endonyms ("English"/"Español"); this avoids depending on the active
+// locale's aria-label and tolerates other <select>s on the page.
+function localeSwitcherSelect(): HTMLSelectElement {
+  const match = screen
+    .getAllByRole('combobox')
+    .find((el) =>
+      Array.from((el as HTMLSelectElement).options).some(
+        (o) => o.textContent === 'Español',
+      ),
+    )
+  if (!match) throw new Error('LocaleSwitcher <select> not found')
+  return match as HTMLSelectElement
+}
+
 describe('ClaimPage i18n', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -78,5 +93,20 @@ describe('ClaimPage i18n', () => {
     ).toBeTruthy()
     // English source string must NOT leak through untranslated.
     expect(screen.queryByRole('heading', { name: 'Claim Your BTH' })).toBeNull()
+  })
+
+  it('renders the locale switcher with the active locale on a default load', () => {
+    renderAt('/claim')
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('en')
+    expect(select.options[select.selectedIndex].textContent).toBe('English')
+  })
+
+  it('renders the locale switcher label reflecting Spanish on a direct /es load', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/claim')
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('es')
+    expect(select.options[select.selectedIndex].textContent).toBe('Español')
   })
 })

--- a/web/packages/web-wallet/src/pages/claim.tsx
+++ b/web/packages/web-wallet/src/pages/claim.tsx
@@ -27,6 +27,7 @@ import {
 import { useAdapter } from '../contexts/wallet'
 import { useNetwork } from '../contexts/network'
 import { PasswordFields, isPasswordValid } from '../components/PasswordSettingsModal'
+import { LocaleSwitcher } from '../components/LocaleSwitcher'
 import { scanEphemeral, sweepEphemeral, type EphemeralScan } from '../lib/claim-link-ops'
 
 /**
@@ -234,6 +235,7 @@ export function ClaimPage() {
             <Logo size="sm" showText={false} />
             <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">{t('header.walletName')}</span>
           </Link>
+          <LocaleSwitcher className="whitespace-nowrap" />
         </div>
       </header>
 

--- a/web/packages/web-wallet/src/pages/contacts.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/contacts.i18n.test.tsx
@@ -61,6 +61,21 @@ function renderAt(path: string) {
   )
 }
 
+// The LocaleSwitcher's <select> is uniquely identified by its locale-invariant
+// option endonyms ("English"/"Español"); this avoids depending on the active
+// locale's aria-label and tolerates other <select>s on the page.
+function localeSwitcherSelect(): HTMLSelectElement {
+  const match = screen
+    .getAllByRole('combobox')
+    .find((el) =>
+      Array.from((el as HTMLSelectElement).options).some(
+        (o) => o.textContent === 'Español',
+      ),
+    )
+  if (!match) throw new Error('LocaleSwitcher <select> not found')
+  return match as HTMLSelectElement
+}
+
 describe('ContactsPage i18n', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -87,5 +102,20 @@ describe('ContactsPage i18n', () => {
     expect(screen.getByPlaceholderText('Buscar por nombre o dirección…')).toBeTruthy()
     // English source string must NOT leak through untranslated.
     expect(screen.queryByRole('heading', { name: 'Contacts' })).toBeNull()
+  })
+
+  it('renders the locale switcher with the active locale on a default load', () => {
+    renderAt('/contacts')
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('en')
+    expect(select.options[select.selectedIndex].textContent).toBe('English')
+  })
+
+  it('renders the locale switcher label reflecting Spanish on a direct /es load', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/contacts')
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('es')
+    expect(select.options[select.selectedIndex].textContent).toBe('Español')
   })
 })

--- a/web/packages/web-wallet/src/pages/contacts.tsx
+++ b/web/packages/web-wallet/src/pages/contacts.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react'
 import { useWallet } from '../contexts/wallet'
 import { PasswordSettingsModal } from '../components/PasswordSettingsModal'
+import { LocaleSwitcher } from '../components/LocaleSwitcher'
 
 type SortBy = 'name' | 'lastTx' | 'txCount'
 
@@ -121,6 +122,7 @@ export function ContactsPage() {
               {t('header.walletName')}
             </span>
           </Link>
+          <LocaleSwitcher className="whitespace-nowrap" />
         </div>
       </header>
 

--- a/web/packages/web-wallet/src/pages/node.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/node.i18n.test.tsx
@@ -38,6 +38,22 @@ function renderAt(path: string, element: React.ReactElement) {
   return render(<MemoryRouter initialEntries={[path]}>{element}</MemoryRouter>)
 }
 
+// The LocaleSwitcher's <select> is uniquely identified by its locale-invariant
+// option endonyms ("English"/"Español"). NodePage also renders a region
+// <select>, so this endonym match (not aria-label, which localizes to "Idioma"
+// under /es) disambiguates the switcher combobox from the region combobox.
+function localeSwitcherSelect(): HTMLSelectElement {
+  const match = screen
+    .getAllByRole('combobox')
+    .find((el) =>
+      Array.from((el as HTMLSelectElement).options).some(
+        (o) => o.textContent === 'Español',
+      ),
+    )
+  if (!match) throw new Error('LocaleSwitcher <select> not found')
+  return match as HTMLSelectElement
+}
+
 describe('node pages i18n', () => {
   beforeEach(() => {
     fetchNodeStatusMock.mockReset()
@@ -93,5 +109,35 @@ describe('node pages i18n', () => {
     renderAt('/es/node/status', <NodeStatusPage />)
     expect(await screen.findByText('En ejecución')).toBeTruthy()
     await waitFor(() => expect(screen.queryByText('Running')).toBeNull())
+  })
+
+  it('renders the locale switcher in the NodePage header with the active locale', () => {
+    renderAt('/node', <NodePage />)
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('en')
+    expect(select.options[select.selectedIndex].textContent).toBe('English')
+  })
+
+  it('renders the NodePage locale switcher label as Spanish on a direct /es load', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/node', <NodePage />)
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('es')
+    expect(select.options[select.selectedIndex].textContent).toBe('Español')
+  })
+
+  it('renders the locale switcher in the shared NodePageShell header (success page)', () => {
+    renderAt('/node/success', <NodeSuccessPage />)
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('en')
+    expect(select.options[select.selectedIndex].textContent).toBe('English')
+  })
+
+  it('renders the NodePageShell locale switcher as Spanish on a direct /es load', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/node/success', <NodeSuccessPage />)
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('es')
+    expect(select.options[select.selectedIndex].textContent).toBe('Español')
   })
 })

--- a/web/packages/web-wallet/src/pages/node.tsx
+++ b/web/packages/web-wallet/src/pages/node.tsx
@@ -28,6 +28,7 @@ import {
   tokenFromSearch,
   type NodeStatus,
 } from '../lib/node-status'
+import { LocaleSwitcher } from '../components/LocaleSwitcher'
 
 /**
  * P7.1 — "Host a node" surface (#458 §2, §4; issue #504).
@@ -92,10 +93,13 @@ export function NodePage() {
             <Logo size="md" showText={false} />
             <span className="font-display text-lg sm:text-xl font-semibold">Botho</span>
           </Link>
-          <Link to="/" className="text-ghost hover:text-light transition-colors flex items-center gap-2">
-            <ArrowLeft size={18} />
-            {t('checkout.back')}
-          </Link>
+          <div className="flex items-center gap-4">
+            <LocaleSwitcher className="whitespace-nowrap" />
+            <Link to="/" className="text-ghost hover:text-light transition-colors flex items-center gap-2">
+              <ArrowLeft size={18} />
+              {t('checkout.back')}
+            </Link>
+          </div>
         </div>
       </header>
 
@@ -237,6 +241,7 @@ function NodePageShell({ children }: { children: React.ReactNode }) {
             <Logo size="md" showText={false} />
             <span className="font-display text-lg sm:text-xl font-semibold">Botho</span>
           </Link>
+          <LocaleSwitcher className="whitespace-nowrap" />
         </div>
       </header>
       <main className="flex-1 flex items-center justify-center pt-28 px-4 sm:px-6">

--- a/web/packages/web-wallet/src/pages/pay.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/pay.i18n.test.tsx
@@ -68,6 +68,21 @@ function renderAt(path: string) {
   )
 }
 
+// The LocaleSwitcher's <select> is uniquely identified by its locale-invariant
+// option endonyms ("English"/"Español"); this avoids depending on the active
+// locale's aria-label and tolerates other <select>s on the page.
+function localeSwitcherSelect(): HTMLSelectElement {
+  const match = screen
+    .getAllByRole('combobox')
+    .find((el) =>
+      Array.from((el as HTMLSelectElement).options).some(
+        (o) => o.textContent === 'Español',
+      ),
+    )
+  if (!match) throw new Error('LocaleSwitcher <select> not found')
+  return match as HTMLSelectElement
+}
+
 describe('PayPage i18n', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -97,5 +112,20 @@ describe('PayPage i18n', () => {
     ).toBeTruthy()
     // English source string must NOT leak through untranslated.
     expect(screen.queryByRole('heading', { name: 'Send a Payment' })).toBeNull()
+  })
+
+  it('renders the locale switcher with the active locale on a default load', () => {
+    renderAt('/pay')
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('en')
+    expect(select.options[select.selectedIndex].textContent).toBe('English')
+  })
+
+  it('renders the locale switcher label reflecting Spanish on a direct /es load', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/pay')
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('es')
+    expect(select.options[select.selectedIndex].textContent).toBe('Español')
   })
 })

--- a/web/packages/web-wallet/src/pages/pay.tsx
+++ b/web/packages/web-wallet/src/pages/pay.tsx
@@ -29,6 +29,7 @@ import {
 import { useWallet } from '../contexts/wallet'
 import { useNetwork } from '../contexts/network'
 import { PasswordFields, isPasswordValid } from '../components/PasswordSettingsModal'
+import { LocaleSwitcher } from '../components/LocaleSwitcher'
 import { parsePaymentRequestFragment, type PaymentRequest } from '../lib/payment-request'
 
 /**
@@ -125,6 +126,7 @@ export function PayPage() {
               {t('header.walletName')}
             </span>
           </Link>
+          <LocaleSwitcher className="whitespace-nowrap" />
         </div>
       </header>
 

--- a/web/packages/web-wallet/src/pages/wallet.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.i18n.test.tsx
@@ -71,6 +71,21 @@ function renderAt(path: string) {
   )
 }
 
+// The LocaleSwitcher's <select> is uniquely identified by its locale-invariant
+// option endonyms ("English"/"Español"); this avoids depending on the active
+// locale's aria-label and tolerates other <select>s on the page.
+function localeSwitcherSelect(): HTMLSelectElement {
+  const match = screen
+    .getAllByRole('combobox')
+    .find((el) =>
+      Array.from((el as HTMLSelectElement).options).some(
+        (o) => o.textContent === 'Español',
+      ),
+    )
+  if (!match) throw new Error('LocaleSwitcher <select> not found')
+  return match as HTMLSelectElement
+}
+
 describe('WalletPage i18n', () => {
   beforeEach(() => {
     localStorage.clear()
@@ -98,5 +113,23 @@ describe('WalletPage i18n', () => {
     ).toBeTruthy()
     // English source string must NOT leak through untranslated.
     expect(screen.queryByRole('heading', { name: 'Create New Wallet' })).toBeNull()
+  })
+
+  it('renders the locale switcher with the active locale on a default load', () => {
+    renderAt('/wallet')
+    // Identify the locale switcher by its locale-invariant option endonyms
+    // ("English"/"Español"), so the assertion holds regardless of which locale's
+    // aria-label ("Language"/"Idioma") is active (PR #798 pattern, generalized).
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('en')
+    expect(select.options[select.selectedIndex].textContent).toBe('English')
+  })
+
+  it('renders the locale switcher label reflecting Spanish on a direct /es load', async () => {
+    await i18n.changeLanguage('es')
+    renderAt('/es/wallet')
+    const select = localeSwitcherSelect()
+    expect(select.value).toBe('es')
+    expect(select.options[select.selectedIndex].textContent).toBe('Español')
   })
 })

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -7,6 +7,7 @@ import { BalanceCard, TransactionList, SendModal, type SendFormData, type SendRe
 import { useWallet } from '../contexts/wallet'
 import { useNetwork } from '../contexts/network'
 import { NetworkSelector } from '../components/NetworkSelector'
+import { LocaleSwitcher } from '../components/LocaleSwitcher'
 import { FaucetButton } from '../components/FaucetButton'
 import { SendLinkModal } from '../components/SendLinkModal'
 import { RequestModal } from '../components/RequestModal'
@@ -777,7 +778,10 @@ export function WalletPage() {
             <span className="font-display text-base sm:text-lg font-semibold hidden sm:inline">{t('header.walletNameLong')}</span>
             <span className="font-display text-base font-semibold sm:hidden">{t('header.walletNameShort')}</span>
           </Link>
-          <NetworkSelector />
+          <div className="flex items-center gap-3">
+            <LocaleSwitcher className="whitespace-nowrap" />
+            <NetworkSelector />
+          </div>
         </div>
       </header>
       <main className="py-6 sm:py-8 md:py-12">


### PR DESCRIPTION
## Summary

Wires the in-app `LocaleSwitcher` into the header of the five transactional pages — wallet, pay, claim, contacts, and node — so a user landing on an `/es`-prefixed route (via a shared link or the edge Accept-Language redirect from PR #786) has an in-app affordance to switch locale without hand-editing the URL. Previously the switcher lived only on `landing.tsx` and `docs.tsx`. Deferred scope from PR #784; part 2 of #790.

## Changes

- **`wallet.tsx`** and **`node.tsx` `NodePage`** (already two-item `justify-between` rows): group the new `LocaleSwitcher` with the existing right-hand control (`NetworkSelector` / back-link) in a `flex items-center gap` span — becomes a three-item row.
- **`pay.tsx`**, **`claim.tsx`**, **`contacts.tsx`**, and **`node.tsx` `NodePageShell`** (previously one-item rows): `LocaleSwitcher` becomes the second `justify-between` item. `NodePageShell` covers both `NodeSuccessPage` and `NodeStatusPage`.
- Every usage passes `className="whitespace-nowrap"` (PR #798 precedent) to keep the globe+select from wrapping in a shared flex row.
- No new translation strings — `LocaleSwitcher` is self-contained.
- Extended all five `*.i18n.test.tsx` files with switcher presence + label-correctness assertions (combobox `value` equals the active locale, selected option endonym is `English`/`Español`) on both a default-path render and an `/es`-prefixed render, following the PR #798 `landing.test.tsx` pattern. Each test locates the switcher by its locale-invariant option endonyms rather than by the `aria-label` (which localizes to "Idioma" under `/es`) so the query survives sibling `<select>`s (the node region selector).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `LocaleSwitcher` renders in all five page headers (incl. both node headers) | ✅ | Edits + new tests assert presence on wallet/pay/claim/contacts/NodePage/NodePageShell |
| Switcher present/functional under `en` and `/es` routes | ✅ | Each test renders both default and `/es` paths; value matches locale |
| Selecting a locale navigates + persists via `storeLocale` | ✅ | Inherited unchanged from `LocaleSwitcher`; landing tests already cover the nav/persist mechanism (not regressed) |
| Displayed label reflects active locale on direct load | ✅ | New tests assert `select.value` and selected-option endonym per path |
| No layout regression / wrap | ✅ | `whitespace-nowrap` on every usage; two-item rows grouped in a flex span |
| `typecheck` + `lint` clean | ✅ | `pnpm --filter @botho/web-wallet typecheck` clean; full `check:ci` green |
| Full web-wallet suite passes, no regressions | ✅ | `pnpm check:ci`: 809 passed / 10 skipped |
| `wallet.tsx` diff kept mechanical/scoped to header | ✅ | Only the header `<div>` touched; no `NetworkSelector`/`NODE_REGIONS`/wallet logic changes |

## Test Plan

- `pnpm check:ci` from `web/`: `pnpm -r typecheck` clean, `vitest run` → **809 passed / 10 skipped** (26 in the five touched `*.i18n.test.tsx` files, up from 14), baas-worker `wrangler deploy --dry-run` succeeds.

Closes #794