### PR TITLE
feat(mobile): platform-correct secure storage + first keychain tests

### DIFF
--- a/mobile/FRAMEWORK_DECISION.md
+++ b/mobile/FRAMEWORK_DECISION.md
@@ -103,6 +103,31 @@ let accessControl = SecAccessControlCreateWithFlags(
 - `.biometryCurrentSet`: Invalidate if biometrics change
 - Certificate pinning for RPC connections
 
+### Android-Specific Security
+
+`expo-secure-store` is cross-platform, so the same `keychain.ts` storage layer
+backs Android via the **Android Keystore** + `EncryptedSharedPreferences` — no
+separate native module or per-platform caller branching is needed.
+
+- **Android Keystore + `EncryptedSharedPreferences`**: the encrypted wallet blob
+  lives in `EncryptedSharedPreferences`, encrypted with a Keystore-held AES key.
+- **`requireAuthentication: true`** maps to `BiometricPrompt` + a Keystore key
+  created with `setUserAuthenticationRequired(true)` — the Android analog of the
+  iOS `SecAccessControl` biometry flags. It requires an enrolled biometric or
+  device credential (PIN/pattern/passcode); with none enrolled, `keychain.ts`
+  surfaces a typed `SecureStoreUnavailableError` (asks the user to set a screen
+  lock) instead of silently storing the wallet unauthenticated.
+- **No-cloud-backup**: Keystore-backed data is excluded from Android Auto Backup
+  by default — the security intent behind iOS's
+  `WHEN_UNLOCKED_THIS_DEVICE_ONLY`, achieved via a different platform mechanism.
+- **StrongBox / TEE hardware backing is device-dependent and NOT enforced**:
+  whether the key lands in a hardware-backed StrongBox / TEE keymaster vs. a
+  software keystore is a property of the device hardware. There is no public
+  `expo-secure-store` API to require StrongBox, so the app does not attempt to
+  condition behavior on it — this is a documented platform variance, not a
+  guarantee. The iOS-only `keychainAccessible` option is silently ignored by
+  `expo-secure-store` on Android.
+
 ## Rejected Alternatives
 
 ### Flutter

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -77,7 +77,31 @@ pnpm ios
 
 - `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`: No iCloud backup
 - Biometric protection (Face ID / Touch ID)
-- Hardware-backed encryption
+- Hardware-backed encryption (Secure Enclave where available)
+
+### Android Keystore
+
+The same `expo-secure-store`-backed storage layer (`app/src/native/keychain.ts`)
+runs on Android with no per-platform caller branching — parity with the iOS path:
+
+- **Android Keystore + `EncryptedSharedPreferences`**: the encrypted wallet blob
+  is stored in `EncryptedSharedPreferences`, encrypted with an Android
+  Keystore-held AES key. Analogous to iOS's `WHEN_UNLOCKED_THIS_DEVICE_ONLY`,
+  Keystore-backed data is excluded from Android Auto Backup by default, so the
+  wallet is not synced to the cloud.
+- **Biometric / device-credential protection**: `requireAuthentication: true`
+  routes reads/writes through Android's `BiometricPrompt` and creates the
+  Keystore key with `setUserAuthenticationRequired(true)`. This requires the
+  device to have a biometric or device credential (PIN/pattern/passcode)
+  enrolled — on a device with "Swipe"/"None" screen lock, `keychain.ts` throws a
+  typed `SecureStoreUnavailableError` prompting the user to set up a screen lock,
+  rather than silently downgrading to unauthenticated storage.
+- **Hardware backing is device-dependent**: whether the Keystore key lands in a
+  hardware-backed **StrongBox** / TEE keymaster vs. a software keystore depends
+  on the device's hardware. There is no public `expo-secure-store` API to *force*
+  StrongBox, so the app does **not** enforce it — this is a known platform
+  variance, not a guarantee. (Note: `keychainAccessible` in `SECURE_OPTIONS` is
+  iOS-only and is silently ignored by `expo-secure-store` on Android.)
 
 ### Network Security
 

--- a/mobile/app/package.json
+++ b/mobile/app/package.json
@@ -15,7 +15,7 @@
   "jest": {
     "preset": "jest-expo",
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|zustand))"
+      "node_modules/(?!\\.pnpm/)(?!((jest-)?react-native|@react-native(-community)?|@react-native/[^/]+|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|zustand))"
     ]
   },
   "dependencies": {
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@types/jest": "^29.5.14",
+    "babel-preset-expo": "~10.0.0",
     "@types/react": "~18.2.0",
     "eslint": "^8.0.0",
     "eslint-config-expo": "~7.0.0",

--- a/mobile/app/pnpm-lock.yaml
+++ b/mobile/app/pnpm-lock.yaml
@@ -51,9 +51,15 @@ importers:
       '@babel/core':
         specifier: ^7.20.0
         version: 7.29.7
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
       '@types/react':
         specifier: ~18.2.0
         version: 18.2.79
+      babel-preset-expo:
+        specifier: ~10.0.0
+        version: 10.0.2(@babel/core@7.29.7)
       eslint:
         specifier: ^8.0.0
         version: 8.57.1
@@ -1354,6 +1360,9 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/jsdom@20.0.1':
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
@@ -7223,6 +7232,11 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest@29.5.14':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
 
   '@types/jsdom@20.0.1':
     dependencies:

--- a/mobile/app/src/native/keychain.test.ts
+++ b/mobile/app/src/native/keychain.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Tests for the secure wallet storage layer (iOS Keychain / Android Keystore).
+ *
+ * These are the first tests `keychain.ts` has had on either platform (issue
+ * #791). They run headlessly against mocked `expo-secure-store` and
+ * `expo-local-authentication` — no device or emulator required — so they can
+ * live in a plain `pnpm test` step without any mobile CI infra.
+ *
+ * Coverage focus:
+ * - each exported function calls through to the mocked native modules with the
+ *   expected arguments (including the per-platform `SECURE_OPTIONS`);
+ * - the "no authenticator enrolled" fallback path (common on Android devices
+ *   with "Swipe"/"None" screen lock) surfaces a typed
+ *   `SecureStoreUnavailableError` rather than an uncaught rejection or a silent
+ *   downgrade to unauthenticated storage.
+ */
+
+import * as SecureStore from "expo-secure-store";
+import * as LocalAuthentication from "expo-local-authentication";
+
+import {
+  saveEncryptedWallet,
+  loadEncryptedWallet,
+  hasStoredWallet,
+  deleteWallet,
+  saveSyncHeight,
+  loadSyncHeight,
+  saveNodeUrl,
+  loadNodeUrl,
+  saveNodeList,
+  loadNodeList,
+  isBiometricAvailable,
+  isSecureStorageAvailable,
+  getBiometricType,
+  authenticateWithBiometrics,
+  SecureStoreUnavailableError,
+} from "./keychain";
+import type { ManagedNode } from "../config/nodes";
+
+// --- Mocks -----------------------------------------------------------------
+
+jest.mock("expo-secure-store", () => ({
+  // iOS keychain accessibility constant — a plain sentinel value here.
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: "WHEN_UNLOCKED_THIS_DEVICE_ONLY",
+  setItemAsync: jest.fn().mockResolvedValue(undefined),
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  deleteItemAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("expo-local-authentication", () => ({
+  AuthenticationType: {
+    FINGERPRINT: 1,
+    FACIAL_RECOGNITION: 2,
+  },
+  SecurityLevel: {
+    NONE: 0,
+    SECRET: 1,
+    BIOMETRIC: 2,
+    BIOMETRIC_STRONG: 3,
+  },
+  hasHardwareAsync: jest.fn().mockResolvedValue(true),
+  isEnrolledAsync: jest.fn().mockResolvedValue(true),
+  getEnrolledLevelAsync: jest.fn().mockResolvedValue(2),
+  supportedAuthenticationTypesAsync: jest.fn().mockResolvedValue([]),
+  authenticateAsync: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+const mockAuth = LocalAuthentication as jest.Mocked<typeof LocalAuthentication>;
+
+/** The exact options object keychain.ts uses for the authenticated blob. */
+const EXPECTED_SECURE_OPTIONS = {
+  keychainAccessible: "WHEN_UNLOCKED_THIS_DEVICE_ONLY",
+  requireAuthentication: true,
+  authenticationPrompt: "Authenticate to access your Botho wallet",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: a healthy device with a biometric enrolled.
+  mockAuth.hasHardwareAsync.mockResolvedValue(true);
+  mockAuth.isEnrolledAsync.mockResolvedValue(true);
+  mockAuth.getEnrolledLevelAsync.mockResolvedValue(
+    LocalAuthentication.SecurityLevel.BIOMETRIC
+  );
+  mockSecureStore.getItemAsync.mockResolvedValue(null);
+  mockSecureStore.setItemAsync.mockResolvedValue(undefined);
+  mockSecureStore.deleteItemAsync.mockResolvedValue(undefined);
+});
+
+// --- Authenticated wallet blob ---------------------------------------------
+
+describe("saveEncryptedWallet", () => {
+  it("writes the wallet with the authenticated SECURE_OPTIONS", async () => {
+    await saveEncryptedWallet("cipher-blob");
+
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledTimes(1);
+    const [key, value, options] = mockSecureStore.setItemAsync.mock.calls[0];
+    expect(key).toBe("botho_encrypted_wallet");
+    expect(options).toEqual(EXPECTED_SECURE_OPTIONS);
+
+    const stored = JSON.parse(value as string);
+    expect(stored.encryptedData).toBe("cipher-blob");
+    expect(typeof stored.createdAt).toBe("number");
+    expect(typeof stored.lastUnlock).toBe("number");
+  });
+
+  it("checks for an enrolled authenticator before writing", async () => {
+    await saveEncryptedWallet("cipher-blob");
+    // Either biometric enrollment or device-credential level is consulted.
+    expect(
+      mockAuth.isEnrolledAsync.mock.calls.length +
+        mockAuth.getEnrolledLevelAsync.mock.calls.length
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("loadEncryptedWallet", () => {
+  it("returns null when no wallet is stored", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce(null);
+    await expect(loadEncryptedWallet()).resolves.toBeNull();
+  });
+
+  it("reads with SECURE_OPTIONS and refreshes the unlock timestamp", async () => {
+    const stored = {
+      encryptedData: "cipher-blob",
+      createdAt: 1,
+      lastUnlock: 1,
+    };
+    mockSecureStore.getItemAsync.mockResolvedValueOnce(JSON.stringify(stored));
+
+    const wallet = await loadEncryptedWallet();
+
+    expect(wallet?.encryptedData).toBe("cipher-blob");
+    // Read used the authenticated options.
+    expect(mockSecureStore.getItemAsync).toHaveBeenCalledWith(
+      "botho_encrypted_wallet",
+      EXPECTED_SECURE_OPTIONS
+    );
+    // Unlock timestamp write-back happened.
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledTimes(1);
+    expect(wallet?.lastUnlock).toBeGreaterThanOrEqual(stored.createdAt);
+  });
+
+  it("still returns the wallet when the timestamp write-back fails", async () => {
+    const stored = {
+      encryptedData: "cipher-blob",
+      createdAt: 1,
+      lastUnlock: 1,
+    };
+    mockSecureStore.getItemAsync.mockResolvedValueOnce(JSON.stringify(stored));
+    mockSecureStore.setItemAsync.mockRejectedValueOnce(new Error("write boom"));
+
+    const wallet = await loadEncryptedWallet();
+    expect(wallet?.encryptedData).toBe("cipher-blob");
+  });
+
+  it("returns null on a generic read failure", async () => {
+    mockSecureStore.getItemAsync.mockRejectedValueOnce(
+      new Error("keystore corrupt")
+    );
+    await expect(loadEncryptedWallet()).resolves.toBeNull();
+  });
+});
+
+// --- Fallback: no authenticator enrolled -----------------------------------
+
+describe("no-authenticator-enrolled fallback", () => {
+  function makeDeviceWithNoLock() {
+    // Android "Swipe"/"None" security: no biometric, no device credential.
+    mockAuth.hasHardwareAsync.mockResolvedValue(false);
+    mockAuth.isEnrolledAsync.mockResolvedValue(false);
+    mockAuth.getEnrolledLevelAsync.mockResolvedValue(
+      LocalAuthentication.SecurityLevel.NONE
+    );
+  }
+
+  it("isSecureStorageAvailable is false with no lock configured", async () => {
+    makeDeviceWithNoLock();
+    await expect(isSecureStorageAvailable()).resolves.toBe(false);
+  });
+
+  it("isSecureStorageAvailable is true with a PIN but no biometric", async () => {
+    mockAuth.hasHardwareAsync.mockResolvedValue(false);
+    mockAuth.isEnrolledAsync.mockResolvedValue(false);
+    mockAuth.getEnrolledLevelAsync.mockResolvedValue(
+      LocalAuthentication.SecurityLevel.SECRET
+    );
+    await expect(isSecureStorageAvailable()).resolves.toBe(true);
+  });
+
+  it("saveEncryptedWallet throws SecureStoreUnavailableError and does not write", async () => {
+    makeDeviceWithNoLock();
+
+    await expect(saveEncryptedWallet("cipher-blob")).rejects.toBeInstanceOf(
+      SecureStoreUnavailableError
+    );
+    // Critically: we do NOT silently downgrade to an unauthenticated write.
+    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalled();
+  });
+
+  it("normalizes a native 'not enrolled' error to SecureStoreUnavailableError", async () => {
+    // Device reports a lock (passes the proactive check) but the native call
+    // still throws the platform 'no authentication enrolled' error.
+    mockSecureStore.setItemAsync.mockRejectedValueOnce(
+      new Error("Could not encrypt the value: no authentication is enrolled")
+    );
+
+    await expect(saveEncryptedWallet("cipher-blob")).rejects.toBeInstanceOf(
+      SecureStoreUnavailableError
+    );
+  });
+
+  it("loadEncryptedWallet re-throws SecureStoreUnavailableError from a native not-enrolled read", async () => {
+    mockSecureStore.getItemAsync.mockRejectedValueOnce(
+      new Error("No authentication is set up on this device")
+    );
+
+    await expect(loadEncryptedWallet()).rejects.toBeInstanceOf(
+      SecureStoreUnavailableError
+    );
+  });
+});
+
+// --- Existence / deletion --------------------------------------------------
+
+describe("hasStoredWallet", () => {
+  it("does an unauthenticated existence read (no SECURE_OPTIONS)", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce("{}");
+    await expect(hasStoredWallet()).resolves.toBe(true);
+    expect(mockSecureStore.getItemAsync).toHaveBeenCalledWith(
+      "botho_encrypted_wallet"
+    );
+  });
+
+  it("returns false when nothing is stored", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce(null);
+    await expect(hasStoredWallet()).resolves.toBe(false);
+  });
+
+  it("returns false (not throw) when the read errors", async () => {
+    mockSecureStore.getItemAsync.mockRejectedValueOnce(new Error("boom"));
+    await expect(hasStoredWallet()).resolves.toBe(false);
+  });
+});
+
+describe("deleteWallet", () => {
+  it("deletes the wallet and sync height keys", async () => {
+    await deleteWallet();
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "botho_encrypted_wallet"
+    );
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "botho_sync_height"
+    );
+  });
+});
+
+// --- Non-sensitive preferences (no auth gate) ------------------------------
+
+describe("sync height", () => {
+  it("saves the height as a string with no SECURE_OPTIONS", async () => {
+    await saveSyncHeight(42);
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      "botho_sync_height",
+      "42"
+    );
+  });
+
+  it("loads and parses the height", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce("128");
+    await expect(loadSyncHeight()).resolves.toBe(128);
+  });
+
+  it("defaults to 0 when unset", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce(null);
+    await expect(loadSyncHeight()).resolves.toBe(0);
+  });
+});
+
+describe("node URL", () => {
+  it("saves the node URL", async () => {
+    await saveNodeUrl("https://node.example.com");
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      "botho_node_url",
+      "https://node.example.com"
+    );
+  });
+
+  it("loads the node URL", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce("https://n.example");
+    await expect(loadNodeUrl()).resolves.toBe("https://n.example");
+  });
+});
+
+describe("node list", () => {
+  const nodes = [
+    { url: "https://a.example" },
+    { url: "https://b.example" },
+  ] as unknown as ManagedNode[];
+
+  it("saves the node list as JSON", async () => {
+    await saveNodeList(nodes);
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      "botho_node_list",
+      JSON.stringify(nodes)
+    );
+  });
+
+  it("loads and parses a stored node list", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce(JSON.stringify(nodes));
+    await expect(loadNodeList()).resolves.toEqual(nodes);
+  });
+
+  it("returns null on first run (nothing stored)", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce(null);
+    await expect(loadNodeList()).resolves.toBeNull();
+  });
+
+  it("returns null when the stored value is not an array", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce('{"not":"array"}');
+    await expect(loadNodeList()).resolves.toBeNull();
+  });
+
+  it("returns null on malformed JSON", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValueOnce("{ broken");
+    await expect(loadNodeList()).resolves.toBeNull();
+  });
+});
+
+// --- Biometric helpers -----------------------------------------------------
+
+describe("isBiometricAvailable", () => {
+  it("is true when hardware exists and a biometric is enrolled", async () => {
+    mockAuth.hasHardwareAsync.mockResolvedValue(true);
+    mockAuth.isEnrolledAsync.mockResolvedValue(true);
+    await expect(isBiometricAvailable()).resolves.toBe(true);
+  });
+
+  it("is false when there is no biometric hardware", async () => {
+    mockAuth.hasHardwareAsync.mockResolvedValue(false);
+    await expect(isBiometricAvailable()).resolves.toBe(false);
+    expect(mockAuth.isEnrolledAsync).not.toHaveBeenCalled();
+  });
+
+  it("is false when hardware exists but nothing is enrolled", async () => {
+    mockAuth.hasHardwareAsync.mockResolvedValue(true);
+    mockAuth.isEnrolledAsync.mockResolvedValue(false);
+    await expect(isBiometricAvailable()).resolves.toBe(false);
+  });
+});
+
+describe("getBiometricType", () => {
+  it("reports face when facial recognition is supported", async () => {
+    mockAuth.supportedAuthenticationTypesAsync.mockResolvedValue([
+      LocalAuthentication.AuthenticationType.FACIAL_RECOGNITION,
+    ]);
+    await expect(getBiometricType()).resolves.toBe("face");
+  });
+
+  it("reports fingerprint when fingerprint is supported", async () => {
+    mockAuth.supportedAuthenticationTypesAsync.mockResolvedValue([
+      LocalAuthentication.AuthenticationType.FINGERPRINT,
+    ]);
+    await expect(getBiometricType()).resolves.toBe("fingerprint");
+  });
+
+  it("reports null when nothing is supported", async () => {
+    mockAuth.supportedAuthenticationTypesAsync.mockResolvedValue([]);
+    await expect(getBiometricType()).resolves.toBeNull();
+  });
+});
+
+describe("authenticateWithBiometrics", () => {
+  it("passes the prompt through and returns success", async () => {
+    mockAuth.authenticateAsync.mockResolvedValue({ success: true });
+    await expect(authenticateWithBiometrics("Unlock")).resolves.toBe(true);
+    expect(mockAuth.authenticateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ promptMessage: "Unlock" })
+    );
+  });
+
+  it("returns false when authentication fails", async () => {
+    mockAuth.authenticateAsync.mockResolvedValue({
+      success: false,
+      error: "user_cancel",
+    });
+    await expect(authenticateWithBiometrics()).resolves.toBe(false);
+  });
+});

--- a/mobile/app/src/native/keychain.ts
+++ b/mobile/app/src/native/keychain.ts
@@ -1,9 +1,20 @@
 /**
- * iOS Keychain Integration
+ * Secure Wallet Storage (iOS Keychain + Android Keystore)
  *
- * Provides secure storage for encrypted wallet data using iOS Keychain
- * with biometric protection. Uses expo-secure-store under the hood with
- * additional configuration for maximum security.
+ * Provides secure storage for encrypted wallet data with biometric
+ * protection. Uses `expo-secure-store` under the hood, which is a
+ * cross-platform Expo module — NOT an iOS-only wrapper:
+ *
+ * - iOS: backed by the iOS Keychain (Security.framework), with
+ *   `SecAccessControl` biometry flags when `requireAuthentication` is set.
+ * - Android: backed by the Android Keystore + `EncryptedSharedPreferences`,
+ *   with `BiometricPrompt` gating when `requireAuthentication` is set (the
+ *   Keystore key is created with `setUserAuthenticationRequired(true)`).
+ *
+ * The same exported surface (`saveEncryptedWallet`, `loadEncryptedWallet`,
+ * etc.) therefore works on both platforms without per-platform branching in
+ * the callers (e.g. `walletStore.ts`). See the `SECURE_OPTIONS` doc comment
+ * below for which options are cross-platform vs. iOS-only.
  */
 
 import * as SecureStore from "expo-secure-store";
@@ -33,16 +44,60 @@ export interface StoredWallet {
 }
 
 /**
- * Keychain options for maximum security
+ * Secure-store options for the encrypted wallet blob.
  *
- * - kSecAttrAccessibleWhenUnlockedThisDeviceOnly: No iCloud backup
- * - requireAuthentication: Require biometric/passcode
+ * Per-platform behaviour of each field (important: some fields are silently
+ * ignored on Android, so the "maximum security" posture is NOT identical
+ * across platforms and must not be assumed to be):
+ *
+ * - `keychainAccessible` (**iOS-only**): `WHEN_UNLOCKED_THIS_DEVICE_ONLY` maps
+ *   to `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, which keeps the item out
+ *   of iCloud Keychain backup. `expo-secure-store` **ignores this field on
+ *   Android** — there is no Android accessibility constant. Android's own
+ *   equivalent (excluding Keystore-backed data from Auto Backup) is applied by
+ *   the platform by default, so the security intent still holds on Android,
+ *   just via a different mechanism, not via this option.
+ * - `requireAuthentication` (**cross-platform**): on iOS this sets
+ *   `SecAccessControl` biometry flags; on Android it routes the read/write
+ *   through `BiometricPrompt` and creates the Keystore key with
+ *   `setUserAuthenticationRequired(true)`. NOTE: on Android this **requires at
+ *   least one biometric or device credential to be enrolled** — otherwise
+ *   `expo-secure-store` throws at write time. See `SECURE_STORE_UNAVAILABLE`
+ *   below and `saveEncryptedWallet` / `loadEncryptedWallet` for how that is
+ *   handled.
+ * - `authenticationPrompt` (**cross-platform**): the message shown in the
+ *   biometric/credential prompt on both platforms.
+ *
+ * Whether the Keystore key material lands in hardware-backed StrongBox / TEE
+ * vs. a software keystore on Android is device-dependent and cannot be forced
+ * from JS (there is no public `expo-secure-store` API for it). This is
+ * documented in `mobile/README.md` and `mobile/FRAMEWORK_DECISION.md` rather
+ * than enforced in code.
  */
 const SECURE_OPTIONS: SecureStore.SecureStoreOptions = {
   keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
   requireAuthentication: true,
   authenticationPrompt: "Authenticate to access your Botho wallet",
 };
+
+/**
+ * Thrown when the secure store cannot satisfy the `requireAuthentication`
+ * contract because the device has no biometric or device-credential enrolled.
+ *
+ * This is most common on Android (many devices ship with "Swipe"/"None" screen
+ * lock), but can also occur on a fresh iOS simulator/device with no Face ID /
+ * Touch ID / passcode configured. Callers should surface an actionable message
+ * asking the user to set up a screen lock, rather than treating this as a
+ * generic storage failure.
+ */
+export class SecureStoreUnavailableError extends Error {
+  constructor(
+    message = "Secure storage requires a screen lock (biometric or device passcode/PIN). Please enable a screen lock in your device settings and try again."
+  ) {
+    super(message);
+    this.name = "SecureStoreUnavailableError";
+  }
+}
 
 /**
  * Check if biometric authentication is available
@@ -86,9 +141,86 @@ export async function authenticateWithBiometrics(
 }
 
 /**
- * Save encrypted wallet to Keychain
+ * Whether the device can satisfy `requireAuthentication`-gated secure storage.
  *
- * Requires biometric authentication to write.
+ * `requireAuthentication: true` needs an enrolled authenticator:
+ * - biometric (Face ID / Touch ID / fingerprint), OR
+ * - a device credential (PIN / pattern / passcode).
+ *
+ * `isBiometricAvailable()` only covers the biometric case, so we additionally
+ * treat `SECURITY_LEVEL >= SECRET` (a passcode/PIN is set) as sufficient — a
+ * device with a PIN but no fingerprint can still back `requireAuthentication`
+ * via device-credential fallback. This is what lets us give the user an
+ * actionable "set up a screen lock" message *before* the write throws.
+ */
+export async function isSecureStorageAvailable(): Promise<boolean> {
+  // A biometric enrollment is sufficient on both platforms.
+  if (await isBiometricAvailable()) return true;
+
+  // Otherwise, a device credential (PIN/pattern/passcode) is also sufficient
+  // for `requireAuthentication` via device-credential fallback.
+  const level = await LocalAuthentication.getEnrolledLevelAsync();
+  return level !== LocalAuthentication.SecurityLevel.NONE;
+}
+
+/**
+ * Fallback decision for `requireAuthentication`-gated storage on a device with
+ * no enrolled authenticator.
+ *
+ * Approach chosen (per issue #791 acceptance criteria — option "a" + "b"
+ * combined): we PROACTIVELY detect the missing-enrollment case via
+ * `isSecureStorageAvailable()` and throw a typed, actionable
+ * `SecureStoreUnavailableError` before ever calling `expo-secure-store`. We
+ * ALSO wrap the underlying call so that if the platform throws the native
+ * "no authentication enrolled" error anyway (races, platform quirks), it is
+ * normalized to the same typed error instead of leaking as an uncaught
+ * rejection. This keeps callers on a single, catchable failure mode on both
+ * iOS and Android.
+ *
+ * Rationale for erroring rather than silently downgrading to unauthenticated
+ * storage: the wallet blob is the most sensitive data in the app; storing it
+ * without `requireAuthentication` would be a silent security regression. It is
+ * better to require the user to set a screen lock than to weaken protection
+ * without their knowledge.
+ */
+async function setAuthenticatedItem(
+  key: string,
+  value: string
+): Promise<void> {
+  if (!(await isSecureStorageAvailable())) {
+    throw new SecureStoreUnavailableError();
+  }
+  try {
+    await SecureStore.setItemAsync(key, value, SECURE_OPTIONS);
+  } catch (error) {
+    if (isNoAuthEnrolledError(error)) {
+      throw new SecureStoreUnavailableError();
+    }
+    throw error;
+  }
+}
+
+/**
+ * Best-effort classifier for the native "no authentication enrolled" error.
+ *
+ * `expo-secure-store` surfaces this differently per platform/version, so we
+ * match on the well-known message fragments rather than a stable error code.
+ */
+function isNoAuthEnrolledError(error: unknown): boolean {
+  const message =
+    error instanceof Error ? error.message : String(error ?? "");
+  return (
+    /authentication/i.test(message) &&
+    /(not|no).*(enrolled|set up|available|configured)/i.test(message)
+  );
+}
+
+/**
+ * Save encrypted wallet to secure storage (iOS Keychain / Android Keystore).
+ *
+ * Requires biometric or device-credential authentication to write. Throws
+ * {@link SecureStoreUnavailableError} if the device has no screen lock
+ * configured (see the fallback decision on `setAuthenticatedItem`).
  */
 export async function saveEncryptedWallet(
   encryptedData: string
@@ -99,18 +231,17 @@ export async function saveEncryptedWallet(
     lastUnlock: Date.now(),
   };
 
-  await SecureStore.setItemAsync(
-    WALLET_KEY,
-    JSON.stringify(wallet),
-    SECURE_OPTIONS
-  );
+  await setAuthenticatedItem(WALLET_KEY, JSON.stringify(wallet));
 }
 
 /**
- * Load encrypted wallet from Keychain
+ * Load encrypted wallet from secure storage (iOS Keychain / Android Keystore).
  *
- * Requires biometric authentication to read.
- * Returns null if no wallet is stored.
+ * Requires biometric or device-credential authentication to read. Returns null
+ * if no wallet is stored. Re-throws {@link SecureStoreUnavailableError} so the
+ * caller can prompt the user to set up a screen lock (rather than silently
+ * treating "no lock configured" as "no wallet"); all other errors are logged
+ * and result in `null`.
  */
 export async function loadEncryptedWallet(): Promise<StoredWallet | null> {
   try {
@@ -119,17 +250,24 @@ export async function loadEncryptedWallet(): Promise<StoredWallet | null> {
 
     const wallet: StoredWallet = JSON.parse(data);
 
-    // Update last unlock time
+    // Update last unlock time (best-effort; failure here must not lose the
+    // successfully-read wallet).
     wallet.lastUnlock = Date.now();
-    await SecureStore.setItemAsync(
-      WALLET_KEY,
-      JSON.stringify(wallet),
-      SECURE_OPTIONS
-    );
+    try {
+      await setAuthenticatedItem(WALLET_KEY, JSON.stringify(wallet));
+    } catch (writeError) {
+      console.warn("Failed to update wallet unlock timestamp:", writeError);
+    }
 
     return wallet;
   } catch (error) {
-    console.error("Failed to load wallet from Keychain:", error);
+    if (error instanceof SecureStoreUnavailableError) {
+      throw error;
+    }
+    if (isNoAuthEnrolledError(error)) {
+      throw new SecureStoreUnavailableError();
+    }
+    console.error("Failed to load wallet from secure storage:", error);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

Brings the mobile wallet's secure key storage to documented Android parity with
iOS. The curator investigation confirmed the storage layer already runs on
Android (`keychain.ts` is built on cross-platform `expo-secure-store`, which
wraps Android Keystore + `EncryptedSharedPreferences`; the Android build target,
biometric permissions, and UniFFI Kotlin bindings are already committed). The
real gaps were narrow: per-platform option correctness, a missing-enrollment
fallback decision, docs, and the fact that `keychain.ts` had **zero** tests.

Scope is strictly the `keychain.ts` secure-storage layer. This PR does **not**
create the `BothoWallet` Expo native RN-bridge module (a separate,
platform-neutral gap tracked in `mobile/NATIVE_INTEGRATION.md`), and does **not**
implement #788's passkey-gated backup/sync feature.

## Changes

- **`keychain.ts` per-platform annotation**: rewrote the `SECURE_OPTIONS` doc
  comment to mark `keychainAccessible` as **iOS-only** (silently ignored by
  `expo-secure-store` on Android) and `requireAuthentication` /
  `authenticationPrompt` as cross-platform, so the old "maximum security"
  comment no longer over-claims for Android. Also generalized the file/function
  header comments from "iOS Keychain" to the cross-platform reality.
- **Missing-enrollment fallback** (`SecureStoreUnavailableError` +
  `isSecureStorageAvailable()`): proactively detect devices with no enrolled
  biometric **or** device credential (Android "Swipe"/"None" lock, or a fresh
  iOS device with no Face ID/passcode) before the authenticated write, throwing
  a typed, actionable error. Also normalize any native "not enrolled" error at
  the `SecureStore` call site to the same typed error, so callers see a single
  catchable failure mode instead of an uncaught rejection or a silent downgrade
  to unauthenticated storage. Rationale is documented in a code comment (the
  wallet blob is the app's most sensitive data; requiring a screen lock is
  preferable to weakening protection silently).
- **New `keychain.test.ts`**: first tests for this file, headless (mocked
  `expo-secure-store` + `expo-local-authentication`, no device/emulator).
  Covers the full exported surface across both platform option paths plus the
  no-authenticator fallback (58 assertions across the app's now-runnable suite).
- **Jest runnable under pnpm**: added `babel-preset-expo` as a direct
  devDependency (so the `jest-expo` babel transform can resolve it under pnpm's
  hoisting) and fixed `transformIgnorePatterns` to handle pnpm's nested
  `node_modules/.pnpm/<pkg>/node_modules/<pkg>` layout. Before this, **all four**
  app test suites (including the 3 pre-existing ones) failed to run at all.
- **Docs**: added an "Android Keystore" parity subsection to `mobile/README.md`
  and an "Android-Specific Security" subsection to `mobile/FRAMEWORK_DECISION.md`,
  both noting the device-dependent StrongBox/TEE variance is not enforced.
- **`app.json` Android permissions reviewed**: `USE_BIOMETRIC` + `USE_FINGERPRINT`
  (already present) are sufficient for `requireAuthentication`-gated
  `expo-secure-store`; `expo-secure-store` declares no additional Android
  permissions of its own. No manifest change needed (no gap found).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `SECURE_OPTIONS` documents iOS-only vs. cross-platform fields; no over-claim | ✅ | Rewritten doc comment on `SECURE_OPTIONS` in `keychain.ts` |
| Platform-aware fallback for no-enrollment, one approach, reasoning in comment | ✅ | `SecureStoreUnavailableError` + `isSecureStorageAvailable()` + `setAuthenticatedItem`; combined proactive-detect + native-error-normalize, rationale in code comment |
| README / FRAMEWORK_DECISION describe Android parity + StrongBox device-dependence | ✅ | New subsections in both docs |
| `app.json` Android permissions reviewed for completeness | ✅ | Confirmed `USE_BIOMETRIC`/`USE_FINGERPRINT` sufficient; expo-secure-store adds no perms; no gap → no edit |
| New `keychain.test.ts` covers full surface + no-enrollment fallback | ✅ | `keychain.test.ts` covers all 13 exported fns + fallback paths |
| `typecheck` and `test` both pass | ✅ | `pnpm typecheck` clean; `pnpm test` → 4 suites / 58 tests pass |
| PR states native module + #788 are out of scope | ✅ | See Summary |

## Test Plan

- `pnpm -C mobile/app typecheck` → passes (`tsc --noEmit`, no errors).
- `pnpm -C mobile/app test` → 4 suites, 58 tests pass headlessly (mocked native
  modules). The `console.error`/`console.warn` lines in output are expected from
  the deliberate negative-path tests.
- `pnpm -C mobile/app lint` → 0 errors (2 pre-existing warnings in `unlock.tsx`,
  untouched, out of scope).
- StrongBox-vs-software keystore placement is a hardware characteristic and is
  documented rather than asserted (unit tests / emulators can't verify it), per
  the issue's test plan.

Closes #791