### PR TITLE
feat(mobile): surface screen-lock guidance on unlock failure

### DIFF
--- a/mobile/app/app/unlock.test.ts
+++ b/mobile/app/app/unlock.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for `classifyUnlockError`, the pure error-classification helper used by
+ * the unlock screen's biometric-auth catch block (issue #801).
+ *
+ * PR #800 (issue #791) introduced a typed `SecureStoreUnavailableError` whose
+ * default message tells the user to enable a screen lock. This helper ensures
+ * that actionable message reaches the `Alert.alert` shown on the unlock screen,
+ * while all other errors keep the existing generic retry message.
+ *
+ * The helper is a side-effect-free function, so it is unit-tested here in plain
+ * jest without rendering the React Native component tree.
+ */
+
+import { classifyUnlockError } from "./unlock";
+import { SecureStoreUnavailableError } from "../src/native/keychain";
+
+describe("classifyUnlockError", () => {
+  it("surfaces the actionable message for SecureStoreUnavailableError", () => {
+    const err = new SecureStoreUnavailableError();
+    const { title, message } = classifyUnlockError(err);
+
+    expect(title).toBe("Error");
+    // Assert against the class's own default message (not a copied string) so
+    // this test never drifts from keychain.ts.
+    expect(message).toBe(new SecureStoreUnavailableError().message);
+  });
+
+  it("preserves a custom SecureStoreUnavailableError message", () => {
+    const err = new SecureStoreUnavailableError("custom guidance");
+    const { message } = classifyUnlockError(err);
+
+    expect(message).toBe("custom guidance");
+  });
+
+  it("returns the generic message for a plain Error", () => {
+    const { title, message } = classifyUnlockError(new Error("boom"));
+
+    expect(title).toBe("Error");
+    expect(message).toBe("Authentication failed. Please try again.");
+  });
+
+  it("returns the generic message for a non-Error thrown value", () => {
+    const { title, message } = classifyUnlockError("not an error object");
+
+    expect(title).toBe("Error");
+    expect(message).toBe("Authentication failed. Please try again.");
+  });
+});

--- a/mobile/app/app/unlock.tsx
+++ b/mobile/app/app/unlock.tsx
@@ -23,7 +23,27 @@ import {
   getBiometricType,
   authenticateWithBiometrics,
   loadEncryptedWallet,
+  SecureStoreUnavailableError,
 } from "../src/native/keychain";
+
+/**
+ * Maps a caught unlock error to the Alert.alert title/message pair to show the
+ * user. A {@link SecureStoreUnavailableError} carries actionable guidance
+ * (enable a screen lock in device settings), so its message is surfaced
+ * verbatim; all other errors fall back to the generic retry message.
+ *
+ * Exported as a pure, side-effect-free function so the branching logic can be
+ * unit-tested without rendering the component tree.
+ */
+export function classifyUnlockError(err: unknown): {
+  title: string;
+  message: string;
+} {
+  if (err instanceof SecureStoreUnavailableError) {
+    return { title: "Error", message: err.message };
+  }
+  return { title: "Error", message: "Authentication failed. Please try again." };
+}
 
 export default function UnlockScreen() {
   const router = useRouter();
@@ -98,7 +118,8 @@ export default function UnlockScreen() {
       router.replace("/");
     } catch (err) {
       console.error("Biometric auth error:", err);
-      Alert.alert("Error", "Authentication failed. Please try again.");
+      const { title, message } = classifyUnlockError(err);
+      Alert.alert(title, message);
     } finally {
       setIsAuthenticating(false);
     }


### PR DESCRIPTION
## Summary

PR #800 (issue #791) introduced a typed `SecureStoreUnavailableError` whose default message tells the user to enable a screen lock. Its sole live caller, `unlock.tsx`'s `handleBiometricAuth`, swallowed that guidance into a generic `Alert.alert("Error", "Authentication failed. Please try again.")`. This surfaces the actionable message so users on a device with no screen lock know what to do.

## Changes

- `mobile/app/app/unlock.tsx`: import `SecureStoreUnavailableError` from `../src/native/keychain`; add an exported pure helper `classifyUnlockError(err): { title, message }` that returns the error's own message for `SecureStoreUnavailableError` and the existing generic message otherwise; use it in the `handleBiometricAuth` catch block (replacing the hardcoded generic alert). `console.error` logging unchanged; the `!success` and mnemonic-unlock paths untouched.
- `mobile/app/app/unlock.test.ts` (new): unit tests for `classifyUnlockError` covering the `SecureStoreUnavailableError` branch (asserting against `new SecureStoreUnavailableError().message`, not a copied string), a custom-message instance, a plain `Error`, and a non-Error thrown value.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Catch block distinguishes `SecureStoreUnavailableError` and surfaces `err.message` | ✅ | `classifyUnlockError` branches on `instanceof`; used in catch |
| Other errors keep generic "Authentication failed. Please try again." | ✅ | Fallback branch + test for plain Error / non-Error |
| Branching implemented as exported pure function | ✅ | `export function classifyUnlockError` |
| New test covers both branches | ✅ | 4 cases in `unlock.test.ts` |
| No changes to `keychain.ts` or the `!success`/mnemonic catch paths | ✅ | `git diff` shows only the two intended files; catch paths unchanged |
| `pnpm test` passes | ✅ | 5 suites / 62 tests pass, incl. new `app/unlock.test.ts` |
| `pnpm typecheck` passes | ✅ | `tsc --noEmit` exits 0 |

## Test Plan

Ran in `mobile/app` (worktree):
- `pnpm typecheck` — exit 0.
- `pnpm test` — `Test Suites: 5 passed`, `Tests: 62 passed`, including `PASS app/unlock.test.ts`.

Closes #801