### PR TITLE
feat(baas): status-link delivery — session_id→token exchange + success page + Resend email

### DIFF
--- a/web/packages/baas-worker/.dev.vars.example
+++ b/web/packages/baas-worker/.dev.vars.example
@@ -32,6 +32,15 @@ WALLET_BASE_URL=http://localhost:5173
 # Where Stripe returns the user after they close the Customer Portal.
 PORTAL_RETURN_URL=http://localhost:5173/node/status
 
+# --- status-link email (#805 part 2, OPTIONAL) ----------------------------
+# Resend API key. When UNSET the worker still works — the /node/success page's
+# on-page status link is the primary delivery path — so this is skip-if-absent,
+# not required. Set it (and verify the botho.io domain in Resend) to also mail
+# the status link on first provision. NEVER commit a real value.
+# RESEND_API_KEY=re_REPLACE_ME
+# Verified sender for the status-link email (only used when RESEND_API_KEY is set).
+RESEND_FROM_ADDRESS=Botho <nodes@botho.io>
+
 # Browser origins allowed to call /checkout, /status, /portal during local dev.
 ALLOWED_ORIGINS=http://localhost:5173
 

--- a/web/packages/baas-worker/src/index.test.ts
+++ b/web/packages/baas-worker/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import worker, { handleCheckout, type Env } from './index'
+import worker, { handleCheckout, handleSessionStatus, type Env } from './index'
 
 const ENV: Env = {
   STRIPE_SECRET_KEY: 'sk_test_dummy',
@@ -117,6 +117,119 @@ describe('handleCheckout', () => {
   })
 })
 
+// Minimal D1 fake: `first<NodeRow>()` returns the seeded row for getByCustomer.
+function fakeDbWithNode(row: Record<string, unknown> | null) {
+  const stmt = {
+    bind: () => stmt,
+    first: async () => row,
+    run: async () => ({ success: true }),
+    all: async () => ({ results: [] }),
+  }
+  return { prepare: () => stmt } as unknown as Env['DB']
+}
+
+const SESSION_ENV: Env = {
+  ...ENV,
+  STATUS_LINK_SECRET: 'status-secret',
+  WALLET_BASE_URL: 'https://botho.io',
+}
+
+function stripePaidSession() {
+  return vi.fn(async () =>
+    new Response(JSON.stringify({ payment_status: 'paid', customer: 'cus_paid' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+}
+
+describe('handleSessionStatus', () => {
+  const NODE_ROW = {
+    user: 'cus_paid',
+    stripe_customer: 'cus_paid',
+    subscription_id: 'sub_1',
+    node_id: 'abc123',
+    instance_id: 'i-1',
+    region: 'us-west-2',
+    rpc_url: 'https://node-abc123.testnet.botho.io/rpc',
+    state: 'running',
+    created_at: 1,
+    updated_at: 1,
+  }
+
+  function get(sessionId?: string): Request {
+    const q = sessionId != null ? `?session_id=${encodeURIComponent(sessionId)}` : ''
+    return new Request(`https://control.botho.io/session-status${q}`, { method: 'GET' })
+  }
+
+  it('returns 200 + a status URL for a paid session with a provisioned node', async () => {
+    const env = { ...SESSION_ENV, DB: fakeDbWithNode(NODE_ROW) }
+    const res = await handleSessionStatus(
+      get('cs_test_abc'),
+      env,
+      stripePaidSession() as unknown as typeof fetch,
+    )
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as { status: string; statusUrl: string }
+    expect(json.status).toBe('ready')
+    expect(json.statusUrl).toContain('https://botho.io/node/status?token=')
+  })
+
+  it('returns 202 pending when the session is paid but the node row is absent', async () => {
+    const env = { ...SESSION_ENV, DB: fakeDbWithNode(null) }
+    const res = await handleSessionStatus(
+      get('cs_test_abc'),
+      env,
+      stripePaidSession() as unknown as typeof fetch,
+    )
+    expect(res.status).toBe(202)
+    const json = (await res.json()) as { status: string }
+    expect(json.status).toBe('pending')
+  })
+
+  it('returns a generic 401 for an unpaid session (no leak)', async () => {
+    const env = { ...SESSION_ENV, DB: fakeDbWithNode(NODE_ROW) }
+    const unpaid = vi.fn(async () =>
+      new Response(JSON.stringify({ payment_status: 'unpaid', customer: 'cus_paid' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const res = await handleSessionStatus(get('cs_test_abc'), env, unpaid as unknown as typeof fetch)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns a generic 401 for an unknown session (Stripe 404)', async () => {
+    const env = { ...SESSION_ENV, DB: fakeDbWithNode(NODE_ROW) }
+    const missing = vi.fn(async () =>
+      new Response(JSON.stringify({ error: { message: 'no such session' } }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const res = await handleSessionStatus(get('cs_missing'), env, missing as unknown as typeof fetch)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when session_id is missing', async () => {
+    const env = { ...SESSION_ENV, DB: fakeDbWithNode(NODE_ROW) }
+    const res = await handleSessionStatus(get(), env, stripePaidSession() as unknown as typeof fetch)
+    expect(res.status).toBe(400)
+  })
+
+  it('fails closed with 500 when STATUS_LINK_SECRET is unset (never calls Stripe)', async () => {
+    const env = { ...SESSION_ENV, STATUS_LINK_SECRET: '', DB: fakeDbWithNode(NODE_ROW) }
+    const fetchMock = stripePaidSession()
+    const res = await handleSessionStatus(
+      get('cs_test_abc'),
+      env,
+      fetchMock as unknown as typeof fetch,
+    )
+    expect(res.status).toBe(500)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
 describe('fetch routing', () => {
   it('responds 200 on /healthz', async () => {
     const res = await worker.fetch(
@@ -145,6 +258,15 @@ describe('fetch routing', () => {
       new Request('https://control.botho.io/webhook', { method: 'POST', body: '{}' }),
       webhookEnv,
     )
+    expect(res.status).toBe(400)
+  })
+
+  it('routes /session-status (missing session_id) to its handler -> 400, not 404', async () => {
+    const res = await worker.fetch(
+      new Request('https://control.botho.io/session-status', { method: 'GET' }),
+      SESSION_ENV,
+    )
+    // 400 (missing session_id) proves the route EXISTS and is wired.
     expect(res.status).toBe(400)
   })
 

--- a/web/packages/baas-worker/src/index.ts
+++ b/web/packages/baas-worker/src/index.ts
@@ -36,12 +36,14 @@ import {
   verifyStripeSignature,
   type WebhookEnv,
 } from './webhook'
-import { verifyStatusToken } from './status-link'
+import { mintStatusToken, verifyStatusToken } from './status-link'
 import {
   createPortalSession,
   lookupStatusForCustomer,
   StripePortalError,
 } from './status'
+import { exchangeSessionForStatus, buildStatusUrl } from './session-status'
+import { sendStatusLinkEmail, retrieveCustomerEmail } from './resend'
 import { D1NodeStore, type D1Like } from './node-store'
 import { reconcileOnce } from './reconcile'
 import {
@@ -94,6 +96,22 @@ export {
   type StatusResponse,
   type NodeHealth,
 } from './status'
+export {
+  retrieveCheckoutSession,
+  exchangeSessionForStatus,
+  buildStatusUrl,
+  StripeSessionError,
+  type SessionExchange,
+  type RetrievedSession,
+} from './session-status'
+export {
+  sendStatusLinkEmail,
+  retrieveCustomerEmail,
+  buildStatusLinkEmailBody,
+  DEFAULT_STATUS_FROM_ADDRESS,
+  type StatusLinkEmail,
+  type SendResult,
+} from './resend'
 
 /** Env keys used only by the `/status` + `/portal` surface (P6.3). */
 export interface StatusEnv {
@@ -112,6 +130,17 @@ export interface StatusEnv {
    * (e.g. "https://botho.io/node/status"). Worker var.
    */
   PORTAL_RETURN_URL?: string
+  /**
+   * Resend API key for status-link email delivery (#805 part 2). OPTIONAL: when
+   * unset the webhook skips the email entirely (the on-page /node/success link is
+   * the primary path). Worker secret when present, never the repo.
+   */
+  RESEND_API_KEY?: string
+  /**
+   * Verified `botho.io` sender for the status-link email (e.g.
+   * "Botho <nodes@botho.io>"). Worker var; falls back to a default when unset.
+   */
+  RESEND_FROM_ADDRESS?: string
 }
 
 export interface Env
@@ -204,6 +233,52 @@ export async function handleCheckout(
 }
 
 /**
+ * Env-gated status-link email dispatch fired on first successful provision
+ * (#805 part 2). FULLY INERT unless `RESEND_API_KEY` is set — with the key unset
+ * it logs-and-returns, never a 500, never blocking the webhook's ACK to Stripe.
+ *
+ * When enabled it: mints the same HMAC status token from the (verified) customer
+ * id, builds the `/node/status` URL, retrieves the customer's email from Stripe,
+ * and sends via Resend. Any failure (no email on file, Resend error) is logged
+ * and swallowed — provisioning already succeeded, and the on-page /node/success
+ * link is the primary delivery path.
+ */
+export async function dispatchStatusEmail(
+  env: Env,
+  customerId: string,
+  fetchImpl: typeof fetch = boundFetch,
+): Promise<void> {
+  if (!env.RESEND_API_KEY) {
+    // Optional feature: skip silently (the on-page success link still works).
+    return
+  }
+  if (!env.STATUS_LINK_SECRET || !env.WALLET_BASE_URL || !env.STRIPE_SECRET_KEY) {
+    console.warn('resend: status-link email skipped — status/stripe env incomplete')
+    return
+  }
+
+  try {
+    const email = await retrieveCustomerEmail(customerId, env.STRIPE_SECRET_KEY, fetchImpl)
+    if (!email) {
+      console.warn('resend: no email on file for customer, skipping status-link email')
+      return
+    }
+    const token = await mintStatusToken(customerId, env.STATUS_LINK_SECRET)
+    const statusUrl = buildStatusUrl(env.WALLET_BASE_URL, token)
+    const result = await sendStatusLinkEmail(
+      { to: email, statusUrl },
+      { apiKey: env.RESEND_API_KEY, from: env.RESEND_FROM_ADDRESS, fetchImpl },
+    )
+    if (!result.ok) {
+      console.error('resend: status-link email failed', result.status, result.error)
+    }
+  } catch (err) {
+    // Never let email failure affect the webhook ACK.
+    console.error('resend: status-link email dispatch error', err)
+  }
+}
+
+/**
  * Handle POST /webhook — the signature-verified Stripe → provision/deprovision
  * join (P7.2 / #506, #458 §2/§5). Exported for direct unit testing.
  *
@@ -218,7 +293,8 @@ export async function handleCheckout(
  *      subscription_id). Unknown event types are a 2xx no-op.
  *
  * `depsFor` is injectable so tests supply in-memory fakes; in production it
- * defaults to `depsFromEnv(env)` (real EC2/DNS/D1 clients).
+ * defaults to `depsFromEnv(env)` (real EC2/DNS/D1 clients). `notify` is likewise
+ * injectable so tests assert the part-2 status-email dispatch without network I/O.
  *
  * No CORS here: Stripe calls server-to-server, not from a browser.
  */
@@ -226,6 +302,11 @@ export async function handleWebhook(
   request: Request,
   env: Env,
   depsFor: (env: Env) => ReturnType<typeof depsFromEnv> = (e) => depsFromEnv(e),
+  notify: (
+    env: Env,
+    customerId: string,
+    fetchImpl?: typeof fetch,
+  ) => Promise<void> = dispatchStatusEmail,
 ): Promise<Response> {
   if (request.method !== 'POST') {
     return jsonResponse({ error: 'method not allowed' }, 405)
@@ -281,6 +362,15 @@ export async function handleWebhook(
     // reconciliation cron (SEC #508) is the safety net for stuck work.
     if (handled.action === 'provision' && !handled.outcome.ok) {
       console.error('webhook: provision failed', handled.subscriptionId, handled.outcome.code)
+    } else if (
+      handled.action === 'provision' &&
+      handled.outcome.ok &&
+      handled.outcome.created
+    ) {
+      // First successful provision (a fresh D1 insert, never a webhook replay).
+      // Mail the customer their status link (#805 part 2). Fully inert unless
+      // RESEND_API_KEY is set; never throws / blocks the ACK to Stripe.
+      await notify(env, handled.outcome.record.stripeCustomer)
     } else if (handled.action === 'teardown' && !handled.result.ok) {
       console.error('webhook: teardown failed', handled.subscriptionId, handled.result.error)
     }
@@ -370,6 +460,85 @@ export async function handleStatus(
     return jsonResponse(result.status, 200, cors)
   } catch (err) {
     console.error('status: lookup error', err)
+    return jsonResponse({ error: 'internal error' }, 500, cors)
+  }
+}
+
+/**
+ * Handle GET /session-status — the post-checkout `session_id` → status-token
+ * exchange for the success page (#805 part 1, #458 §4).
+ *
+ * The browser lands on `/node/success?session_id=cs_...` after Stripe checkout.
+ * That `session_id` is the only credential the payer's browser holds; we exchange
+ * it server-side for the same signed magic-link the `/status` page uses:
+ *   session_id → Stripe session retrieve → payment_status=paid → customer id
+ *              → mintStatusToken → status URL.
+ *
+ * Provisioning is asynchronous (the webhook writes the D1 row), so the paid-but-
+ * row-absent case returns a distinct `pending` signal (HTTP 202) the frontend
+ * polls on — NOT an error. Exported for direct unit testing.
+ *
+ *   200 -> { status: 'ready', statusUrl } once the node row exists
+ *   202 -> { status: 'pending' } paid, but provisioning hasn't landed yet
+ *   400 -> missing session_id
+ *   401 -> unknown / unpaid / malformed session (generic — no data leak)
+ *   500 -> service not configured
+ *
+ * Unknown, unpaid, and malformed sessions all answer with the SAME generic 401,
+ * mirroring `/status`'s no-leak precedent.
+ */
+export async function handleSessionStatus(
+  request: Request,
+  env: Env,
+  fetchImpl: typeof fetch = boundFetch,
+): Promise<Response> {
+  const origin = request.headers.get('Origin')
+  const cors = corsHeaders(env, origin)
+
+  if (request.method !== 'GET') {
+    return jsonResponse({ error: 'method not allowed' }, 405, cors)
+  }
+
+  // Fail closed if the signing secret / Stripe key / wallet base url are unset —
+  // we need all three to retrieve the session and mint a token.
+  if (!env.STATUS_LINK_SECRET || !env.STRIPE_SECRET_KEY || !env.WALLET_BASE_URL) {
+    console.error('session-status: not configured')
+    return jsonResponse({ error: 'service not configured' }, 500, cors)
+  }
+
+  const url = new URL(request.url)
+  const sessionId = url.searchParams.get('session_id')
+  if (!sessionId) {
+    return jsonResponse({ error: 'session_id is required' }, 400, cors)
+  }
+
+  let store: D1NodeStore
+  try {
+    store = storeFromEnv(env)
+  } catch (err) {
+    console.error('session-status: store unavailable', err)
+    return jsonResponse({ error: 'service not configured' }, 500, cors)
+  }
+
+  try {
+    const result = await exchangeSessionForStatus(sessionId, {
+      stripeSecretKey: env.STRIPE_SECRET_KEY,
+      statusLinkSecret: env.STATUS_LINK_SECRET,
+      walletBaseUrl: env.WALLET_BASE_URL,
+      store,
+      fetchImpl,
+    })
+    if (result.kind === 'ready') {
+      return jsonResponse({ status: 'ready', statusUrl: result.statusUrl }, 200, cors)
+    }
+    if (result.kind === 'pending') {
+      return jsonResponse({ status: 'pending' }, 202, cors)
+    }
+    // Generic 401 — never reveal which check failed or whether a node exists.
+    console.warn('session-status: rejected:', result.reason)
+    return jsonResponse({ error: 'unauthorized' }, 401, cors)
+  } catch (err) {
+    console.error('session-status: exchange error', err)
     return jsonResponse({ error: 'internal error' }, 500, cors)
   }
 }
@@ -504,6 +673,10 @@ export default {
 
     if (url.pathname === '/status') {
       return handleStatus(request, env)
+    }
+
+    if (url.pathname === '/session-status') {
+      return handleSessionStatus(request, env)
     }
 
     if (url.pathname === '/portal') {

--- a/web/packages/baas-worker/src/resend.test.ts
+++ b/web/packages/baas-worker/src/resend.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  buildStatusLinkEmailBody,
+  retrieveCustomerEmail,
+  sendStatusLinkEmail,
+} from './resend'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('buildStatusLinkEmailBody', () => {
+  it('includes the status URL in both text and html, plus a cancel note', () => {
+    const { subject, text, html } = buildStatusLinkEmailBody({
+      to: 'a@b.com',
+      statusUrl: 'https://botho.io/node/status?token=cus_A.1.sig',
+    })
+    expect(subject).toMatch(/Botho node/i)
+    expect(text).toContain('https://botho.io/node/status?token=cus_A.1.sig')
+    expect(html).toContain('https://botho.io/node/status?token=cus_A.1.sig')
+    expect(text.toLowerCase()).toContain('cancel')
+  })
+
+  it('links the billing portal when a manage URL is supplied', () => {
+    const { html } = buildStatusLinkEmailBody({
+      to: 'a@b.com',
+      statusUrl: 'https://botho.io/node/status?token=t',
+      manageUrl: 'https://billing.stripe.com/p/session_abc',
+    })
+    expect(html).toContain('https://billing.stripe.com/p/session_abc')
+  })
+})
+
+describe('sendStatusLinkEmail', () => {
+  it('POSTs to the Resend API with a bearer key and the built payload', async () => {
+    const fetchMock = vi.fn(async () => json({ id: 're_123' }))
+    const result = await sendStatusLinkEmail(
+      { to: 'a@b.com', statusUrl: 'https://botho.io/node/status?token=t' },
+      {
+        apiKey: 'rk_test',
+        from: 'Botho <nodes@botho.io>',
+        fetchImpl: fetchMock as unknown as typeof fetch,
+      },
+    )
+    expect(result.ok).toBe(true)
+    if (result.ok) expect(result.id).toBe('re_123')
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://api.resend.com/emails')
+    expect(init.method).toBe('POST')
+    const headers = init.headers as Record<string, string>
+    expect(headers.Authorization).toBe('Bearer rk_test')
+    const payload = JSON.parse(init.body as string) as {
+      from: string
+      to: string
+      subject: string
+    }
+    expect(payload.from).toBe('Botho <nodes@botho.io>')
+    expect(payload.to).toBe('a@b.com')
+    expect(payload.subject.length).toBeGreaterThan(0)
+  })
+
+  it('returns a non-throwing error result on a Resend 4xx', async () => {
+    const fetchMock = vi.fn(async () => json({ message: 'domain not verified' }, 403))
+    const result = await sendStatusLinkEmail(
+      { to: 'a@b.com', statusUrl: 'https://botho.io/node/status?token=t' },
+      { apiKey: 'rk_test', fetchImpl: fetchMock as unknown as typeof fetch },
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(403)
+  })
+})
+
+describe('retrieveCustomerEmail', () => {
+  it('reads the email off the Stripe customer', async () => {
+    const fetchMock = vi.fn(async () => json({ id: 'cus_A', email: 'buyer@example.com' }))
+    const email = await retrieveCustomerEmail(
+      'cus_A',
+      'sk_test',
+      fetchMock as unknown as typeof fetch,
+    )
+    expect(email).toBe('buyer@example.com')
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://api.stripe.com/v1/customers/cus_A')
+    const headers = init.headers as Record<string, string>
+    expect(headers['Stripe-Version']).toBe('2024-06-20')
+  })
+
+  it('returns undefined (never throws) on error', async () => {
+    const fetchMock = vi.fn(async () => json({ error: 'nope' }, 404))
+    const email = await retrieveCustomerEmail(
+      'cus_missing',
+      'sk_test',
+      fetchMock as unknown as typeof fetch,
+    )
+    expect(email).toBeUndefined()
+  })
+})

--- a/web/packages/baas-worker/src/resend.ts
+++ b/web/packages/baas-worker/src/resend.ts
@@ -1,0 +1,156 @@
+/**
+ * Resend transactional-email client for the status-link delivery (#805 part 2,
+ * #458 §4).
+ *
+ * On the FIRST successful provision (a fresh D1 insert, not a webhook replay) the
+ * webhook path mails the customer their magic-link status URL, so they don't have
+ * to keep the success-page tab open while the node comes up. This module is the
+ * pure, injectable core of that send:
+ *
+ *   - `fetchImpl` defaults to `boundFetch` (workerd requires the bound global — a
+ *     bare `fetch` throws `Illegal invocation` in production; see `bound-fetch.ts`),
+ *   - it is ENV-GATED at the call site: with `RESEND_API_KEY` unset the webhook
+ *     skips the send entirely (log-and-skip, never a 500, never a blocked ACK to
+ *     Stripe), so the Worker functions fully without Resend configured,
+ *   - it never throws to the webhook: a send failure is surfaced as a returned
+ *     error so the caller logs it and still ACKs Stripe (provisioning already
+ *     succeeded; the reconciliation cron + the on-page link are the safety nets).
+ *
+ * No secret lives in the repo — `RESEND_API_KEY` and the verified `botho.io`
+ * sender address (`RESEND_FROM_ADDRESS`) are Worker secrets / vars, supplied by
+ * the operator once the domain is verified.
+ */
+
+import { boundFetch } from './bound-fetch'
+
+/** Default sender if `RESEND_FROM_ADDRESS` is unset (must be a verified domain). */
+export const DEFAULT_STATUS_FROM_ADDRESS = 'Botho <nodes@botho.io>'
+
+/** Inputs for the status-link email. */
+export interface StatusLinkEmail {
+  /** Recipient (the Stripe customer's email). */
+  to: string
+  /** The `/node/status?token=…` URL the customer opens. */
+  statusUrl: string
+  /** Optional Stripe Customer Portal URL for the cancel-anytime note. */
+  manageUrl?: string
+}
+
+/** Outcome of a send attempt. Never throws — the caller logs and ACKs Stripe. */
+export type SendResult =
+  | { ok: true; id?: string }
+  | { ok: false; error: string; status?: number }
+
+/**
+ * Build the plain-text + minimal-HTML body for the status-link email. Kept pure
+ * so the copy can be asserted in tests without any network I/O.
+ */
+export function buildStatusLinkEmailBody(email: StatusLinkEmail): {
+  subject: string
+  text: string
+  html: string
+} {
+  const subject = 'Your Botho node is on its way'
+  const manageLine = email.manageUrl
+    ? `\n\nManage or cancel your subscription anytime: ${email.manageUrl}`
+    : '\n\nYou can cancel anytime from your node status page.'
+
+  const text =
+    `Thanks for subscribing to a managed Botho node.\n\n` +
+    `Your node is being provisioned now. Open your private status page to see ` +
+    `its RPC endpoint, live health, and a one-click link to open it in the wallet:\n\n` +
+    `${email.statusUrl}\n\n` +
+    `This link is your access to the node — keep it private.` +
+    manageLine
+
+  const manageHtml = email.manageUrl
+    ? `<p style="color:#6b7280;font-size:14px">Manage or cancel your subscription anytime: ` +
+      `<a href="${email.manageUrl}">billing portal</a>.</p>`
+    : `<p style="color:#6b7280;font-size:14px">You can cancel anytime from your node status page.</p>`
+
+  const html =
+    `<p>Thanks for subscribing to a managed Botho node.</p>` +
+    `<p>Your node is being provisioned now. Open your private status page to see ` +
+    `its RPC endpoint, live health, and a one-click link to open it in the wallet:</p>` +
+    `<p><a href="${email.statusUrl}">View your node status</a></p>` +
+    `<p style="color:#6b7280;font-size:14px">This link is your access to the node — keep it private.</p>` +
+    manageHtml
+
+  return { subject, text, html }
+}
+
+/**
+ * Send the status-link email via the Resend REST API
+ * (`POST https://api.resend.com/emails`).
+ *
+ * `fetchImpl` is injectable (defaults to `boundFetch`) so tests assert on the
+ * exact request without network I/O. Returns a discriminated result instead of
+ * throwing so the webhook can log a failure and still ACK Stripe.
+ */
+export async function sendStatusLinkEmail(
+  email: StatusLinkEmail,
+  opts: { apiKey: string; from?: string; fetchImpl?: typeof fetch },
+): Promise<SendResult> {
+  const fetchImpl = opts.fetchImpl ?? boundFetch
+  const from = opts.from && opts.from.length > 0 ? opts.from : DEFAULT_STATUS_FROM_ADDRESS
+  const { subject, text, html } = buildStatusLinkEmailBody(email)
+
+  let resp: Response
+  try {
+    resp = await fetchImpl('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${opts.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ from, to: email.to, subject, text, html }),
+    })
+  } catch {
+    return { ok: false, error: 'could not reach Resend' }
+  }
+
+  const json = (await resp.json().catch(() => ({}))) as {
+    id?: string
+    message?: string
+    error?: { message?: string }
+  }
+
+  if (!resp.ok) {
+    return {
+      ok: false,
+      error: json.error?.message ?? json.message ?? `Resend returned HTTP ${resp.status}`,
+      status: resp.status,
+    }
+  }
+  return { ok: true, id: json.id }
+}
+
+/**
+ * Retrieve a Stripe customer's email address (needed as the email recipient —
+ * the D1 node row stores the customer id, not the email). Returns `undefined`
+ * on any error / a customer without an email so the caller simply skips the send
+ * rather than failing the webhook. `fetchImpl` defaults to `boundFetch`.
+ */
+export async function retrieveCustomerEmail(
+  customerId: string,
+  stripeSecretKey: string,
+  fetchImpl: typeof fetch = boundFetch,
+): Promise<string | undefined> {
+  try {
+    const resp = await fetchImpl(
+      `https://api.stripe.com/v1/customers/${encodeURIComponent(customerId)}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${stripeSecretKey}`,
+          'Stripe-Version': '2024-06-20',
+        },
+      },
+    )
+    if (!resp.ok) return undefined
+    const json = (await resp.json().catch(() => ({}))) as { email?: string }
+    return json.email && json.email.length > 0 ? json.email : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/web/packages/baas-worker/src/session-status.test.ts
+++ b/web/packages/baas-worker/src/session-status.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  buildStatusUrl,
+  exchangeSessionForStatus,
+  retrieveCheckoutSession,
+  StripeSessionError,
+} from './session-status'
+import { verifyStatusToken } from './status-link'
+import { FakeStore } from './test-fakes'
+import type { NewNodeRecord } from './node-store'
+
+const SECRET = 'test-status-link-secret'
+const STRIPE_KEY = 'sk_test_dummy'
+const WALLET_BASE = 'https://botho.io'
+
+function stripeJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function seedNode(store: FakeStore, over: Partial<NewNodeRecord> = {}) {
+  return store.insertProvisioning({
+    user: 'cus_paid',
+    stripeCustomer: 'cus_paid',
+    subscriptionId: 'sub_1',
+    nodeId: 'abc123',
+    region: 'us-west-2',
+    rpcUrl: 'https://node-abc123.testnet.botho.io/rpc',
+    ...over,
+  })
+}
+
+describe('retrieveCheckoutSession', () => {
+  it('GETs the Stripe session with a pinned API version + bearer auth', async () => {
+    const fetchMock = vi.fn(async () =>
+      stripeJson({ payment_status: 'paid', customer: 'cus_paid' }),
+    )
+    const out = await retrieveCheckoutSession(
+      'cs_test_abc',
+      STRIPE_KEY,
+      fetchMock as unknown as typeof fetch,
+    )
+    expect(out.paymentStatus).toBe('paid')
+    expect(out.customerId).toBe('cus_paid')
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://api.stripe.com/v1/checkout/sessions/cs_test_abc')
+    expect(init.method).toBe('GET')
+    const headers = init.headers as Record<string, string>
+    expect(headers.Authorization).toBe(`Bearer ${STRIPE_KEY}`)
+    expect(headers['Stripe-Version']).toBe('2024-06-20')
+  })
+
+  it('coerces an expanded customer object to its id', async () => {
+    const fetchMock = vi.fn(async () =>
+      stripeJson({ payment_status: 'paid', customer: { id: 'cus_paid' } }),
+    )
+    const out = await retrieveCheckoutSession(
+      'cs_test_abc',
+      STRIPE_KEY,
+      fetchMock as unknown as typeof fetch,
+    )
+    expect(out.customerId).toBe('cus_paid')
+  })
+
+  it('throws StripeSessionError on a 404', async () => {
+    const fetchMock = vi.fn(async () => stripeJson({ error: { message: 'no such session' } }, 404))
+    await expect(
+      retrieveCheckoutSession('cs_missing', STRIPE_KEY, fetchMock as unknown as typeof fetch),
+    ).rejects.toBeInstanceOf(StripeSessionError)
+  })
+})
+
+describe('buildStatusUrl', () => {
+  it('appends the token to the /node/status route and trims trailing slashes', () => {
+    expect(buildStatusUrl('https://botho.io/', 'cus_A.1.sig')).toBe(
+      'https://botho.io/node/status?token=cus_A.1.sig',
+    )
+  })
+})
+
+describe('exchangeSessionForStatus', () => {
+  const opts = (store: FakeStore, fetchImpl: typeof fetch) => ({
+    stripeSecretKey: STRIPE_KEY,
+    statusLinkSecret: SECRET,
+    walletBaseUrl: WALLET_BASE,
+    store,
+    fetchImpl,
+    nowSeconds: 1_000,
+  })
+
+  it('returns a ready status URL with a verifiable token for a paid session + provisioned node', async () => {
+    const store = new FakeStore()
+    await seedNode(store)
+    const fetchMock = vi.fn(async () =>
+      stripeJson({ payment_status: 'paid', customer: 'cus_paid' }),
+    )
+    const result = await exchangeSessionForStatus(
+      'cs_test_abc',
+      opts(store, fetchMock as unknown as typeof fetch),
+    )
+    expect(result.kind).toBe('ready')
+    if (result.kind !== 'ready') throw new Error('expected ready')
+    expect(result.statusUrl).toContain('https://botho.io/node/status?token=')
+
+    // The minted token is valid and binds to the paying customer.
+    const verified = await verifyStatusToken(result.token, SECRET, { nowSeconds: 1_001 })
+    expect(verified.ok).toBe(true)
+    if (verified.ok) expect(verified.customerId).toBe('cus_paid')
+  })
+
+  it('returns pending (not an error) when the session is paid but the node row is absent', async () => {
+    const store = new FakeStore() // empty — webhook hasn't landed
+    const fetchMock = vi.fn(async () =>
+      stripeJson({ payment_status: 'paid', customer: 'cus_paid' }),
+    )
+    const result = await exchangeSessionForStatus(
+      'cs_test_abc',
+      opts(store, fetchMock as unknown as typeof fetch),
+    )
+    expect(result.kind).toBe('pending')
+  })
+
+  it('rejects an unpaid session generically', async () => {
+    const store = new FakeStore()
+    await seedNode(store)
+    const fetchMock = vi.fn(async () =>
+      stripeJson({ payment_status: 'unpaid', customer: 'cus_paid' }),
+    )
+    const result = await exchangeSessionForStatus(
+      'cs_test_abc',
+      opts(store, fetchMock as unknown as typeof fetch),
+    )
+    expect(result.kind).toBe('rejected')
+  })
+
+  it('rejects an unknown session (Stripe 404) generically', async () => {
+    const store = new FakeStore()
+    const fetchMock = vi.fn(async () => stripeJson({ error: { message: 'no such session' } }, 404))
+    const result = await exchangeSessionForStatus(
+      'cs_unknown',
+      opts(store, fetchMock as unknown as typeof fetch),
+    )
+    expect(result.kind).toBe('rejected')
+  })
+
+  it('rejects a malformed session id WITHOUT calling Stripe', async () => {
+    const store = new FakeStore()
+    const fetchMock = vi.fn(async () => stripeJson({}))
+    const result = await exchangeSessionForStatus(
+      'not-a-session',
+      opts(store, fetchMock as unknown as typeof fetch),
+    )
+    expect(result.kind).toBe('rejected')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/web/packages/baas-worker/src/session-status.ts
+++ b/web/packages/baas-worker/src/session-status.ts
@@ -1,0 +1,201 @@
+/**
+ * `session_id` → status-token exchange for the post-checkout success page
+ * (P6.3 of #458, §4; issue #805).
+ *
+ * After a Stripe Checkout completes, the browser lands on
+ * `/node/success?session_id=cs_...`. That `session_id` is the only credential the
+ * payer's browser holds, so we exchange it — server-side — for the same signed,
+ * expiring magic-link token the `/status` page already uses:
+ *
+ *     session_id
+ *       → retrieve the Checkout Session from Stripe (STRIPE_SECRET_KEY)
+ *       → confirm payment_status === 'paid'
+ *       → read the `customer` id off the session
+ *       → mintStatusToken(customerId)         (status-link.ts, keyed on cus_...)
+ *       → build the `/node/status?token=…` URL the page links to
+ *
+ * Provisioning is asynchronous: the D1 row is written by the signature-verified
+ * webhook, which can lag the success redirect by seconds. So the exchange has a
+ * distinct "pending" outcome (session is paid, but the node row is not in D1 yet)
+ * that the frontend polls on, versus a terminal rejection for an unknown / unpaid
+ * / malformed session.
+ *
+ * Security: the token is minted from the *verified* Stripe customer id (never a
+ * client-supplied one), and this module never reveals which check failed — an
+ * unknown, unpaid, or malformed session and an unretrievable one all collapse to
+ * the same generic rejection, mirroring the `/status` 401 no-leak precedent.
+ *
+ * Pure / injectable: `fetchImpl` defaults to `boundFetch` (workerd requires the
+ * bound global — a bare `fetch` throws `Illegal invocation` in production, see
+ * `bound-fetch.ts`) and the store is injected, so NO real Stripe / D1 call
+ * happens in a test path.
+ */
+
+import { boundFetch } from './bound-fetch'
+import type { NodeStore } from './node-store'
+import { mintStatusToken } from './status-link'
+
+/** A Stripe Checkout Session id looks like `cs_...` (test: `cs_test_...`). */
+function isPlausibleSessionId(id: string): boolean {
+  // Reject anything not shaped like a Stripe checkout session id so we never
+  // interpolate junk into the Stripe request URL.
+  return /^cs_[A-Za-z0-9_]+$/.test(id)
+}
+
+/** Error thrown when Stripe rejects (or errors on) the session retrieve. */
+export class StripeSessionError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message)
+    this.name = 'StripeSessionError'
+  }
+}
+
+/** The fields we read off a retrieved Checkout Session. */
+export interface RetrievedSession {
+  /** `paid` once the payment has settled; `unpaid` / `no_payment_required` otherwise. */
+  paymentStatus: string
+  /** Stripe customer id (`cus_...`) created for the subscription, if present. */
+  customerId?: string
+}
+
+/**
+ * Retrieve a Stripe Checkout Session by id.
+ *
+ * Follows the established Stripe call shape (`stripe-subscriptions.ts` /
+ * `checkout.ts`): `Authorization: Bearer`, pinned `Stripe-Version: 2024-06-20`,
+ * and a `fetchImpl` that defaults to `boundFetch`.
+ *
+ *   - 200 → `{ paymentStatus, customerId }`
+ *   - 404 → THROW `StripeSessionError(…, 404)` (no such session — treated as a
+ *           terminal generic rejection by the caller)
+ *   - any other non-2xx → THROW `StripeSessionError` (transient / auth)
+ */
+export async function retrieveCheckoutSession(
+  sessionId: string,
+  stripeSecretKey: string,
+  fetchImpl: typeof fetch = boundFetch,
+): Promise<RetrievedSession> {
+  const resp = await fetchImpl(
+    `https://api.stripe.com/v1/checkout/sessions/${encodeURIComponent(sessionId)}`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${stripeSecretKey}`,
+        'Stripe-Version': '2024-06-20',
+      },
+    },
+  )
+
+  const json = (await resp.json().catch(() => ({}))) as {
+    payment_status?: string
+    customer?: string | { id?: string }
+    error?: { message?: string }
+  }
+
+  if (!resp.ok) {
+    throw new StripeSessionError(
+      json.error?.message ?? `Stripe returned HTTP ${resp.status}`,
+      resp.status,
+    )
+  }
+
+  const customer = json.customer
+  const customerId =
+    typeof customer === 'string'
+      ? customer || undefined
+      : customer && typeof customer === 'object' && typeof customer.id === 'string'
+        ? customer.id || undefined
+        : undefined
+
+  return { paymentStatus: json.payment_status ?? 'unpaid', customerId }
+}
+
+/** Outcome of exchanging a `session_id` for a status token / URL. */
+export type SessionExchange =
+  /** Paid session + a provisioned node row → the status link is ready. */
+  | { kind: 'ready'; statusUrl: string; token: string }
+  /**
+   * Paid session, but the node row is not in D1 yet (provisioning lag). The
+   * frontend should keep polling — this is NOT an error.
+   */
+  | { kind: 'pending' }
+  /**
+   * Unknown / unpaid / malformed session, or the customer has no node and never
+   * will from this session. Terminal — the frontend must stop polling. The
+   * generic `reason` is for server logs only; it is never surfaced to the client.
+   */
+  | { kind: 'rejected'; reason: string }
+
+/**
+ * Build the `/node/status?token=…` URL a returning user opens. `walletBaseUrl`
+ * is the site origin (e.g. `https://botho.io`); the token rides as the `token`
+ * query param the status page already reads.
+ */
+export function buildStatusUrl(walletBaseUrl: string, token: string): string {
+  const base = walletBaseUrl.replace(/\/+$/, '')
+  return `${base}/node/status?token=${encodeURIComponent(token)}`
+}
+
+/**
+ * Exchange a `session_id` for a status URL.
+ *
+ * Steps (all failures collapse to a generic `rejected`, never leaking which):
+ *   1. Shape-check the session id (`cs_…`).
+ *   2. Retrieve the session from Stripe; a 404 / any error → rejected.
+ *   3. Require `payment_status === 'paid'` and a `customer` id → else rejected.
+ *   4. Look up the node row by that customer id. Absent → `pending` (the webhook
+ *      hasn't landed yet); present → mint a token and return the `ready` URL.
+ *
+ * `nowSeconds` is threaded into `mintStatusToken` for deterministic tests.
+ */
+export async function exchangeSessionForStatus(
+  sessionId: string,
+  opts: {
+    stripeSecretKey: string
+    statusLinkSecret: string
+    walletBaseUrl: string
+    store: NodeStore
+    fetchImpl?: typeof fetch
+    nowSeconds?: number
+  },
+): Promise<SessionExchange> {
+  if (!isPlausibleSessionId(sessionId)) {
+    return { kind: 'rejected', reason: 'malformed session id' }
+  }
+
+  let session: RetrievedSession
+  try {
+    session = await retrieveCheckoutSession(
+      sessionId,
+      opts.stripeSecretKey,
+      opts.fetchImpl ?? boundFetch,
+    )
+  } catch (err) {
+    const reason =
+      err instanceof StripeSessionError
+        ? `stripe session retrieve failed (${err.status})`
+        : 'stripe session retrieve error'
+    return { kind: 'rejected', reason }
+  }
+
+  if (session.paymentStatus !== 'paid') {
+    return { kind: 'rejected', reason: `session not paid (${session.paymentStatus})` }
+  }
+  if (!session.customerId) {
+    return { kind: 'rejected', reason: 'session has no customer' }
+  }
+
+  const node = await opts.store.getByCustomer(session.customerId)
+  if (!node) {
+    // Paid, but the provisioning webhook hasn't written the row yet.
+    return { kind: 'pending' }
+  }
+
+  const token = await mintStatusToken(session.customerId, opts.statusLinkSecret, {
+    nowSeconds: opts.nowSeconds,
+  })
+  return { kind: 'ready', statusUrl: buildStatusUrl(opts.walletBaseUrl, token), token }
+}

--- a/web/packages/baas-worker/src/webhook-handler.test.ts
+++ b/web/packages/baas-worker/src/webhook-handler.test.ts
@@ -7,8 +7,8 @@
  * AWS / DNS / D1 is touched.
  */
 
-import { describe, it, expect } from 'vitest'
-import { handleWebhook, type Env } from './index'
+import { describe, it, expect, vi } from 'vitest'
+import { handleWebhook, dispatchStatusEmail, type Env } from './index'
 import { hmacSha256Hex } from './webhook'
 import { FakeDns, FakeEc2, FakeStore } from './test-fakes'
 import type { ProvisionerDeps } from './provisioner'
@@ -223,5 +223,95 @@ describe('handleWebhook', () => {
     const res = await handleWebhook(req, badEnv, depsFor)
     expect(res.status).toBe(500)
     expect(deps.ec2.runCalls).toHaveLength(0)
+  })
+
+  // --- #805 part 2: status-link email dispatch on first provision ----------
+
+  it('fires the status-email notify with the customer id on FIRST provision', async () => {
+    const { depsFor } = makeDeps()
+    const notify = vi.fn(async (_env: Env, _customerId: string) => {})
+    const req = await signedRequest({
+      type: 'checkout.session.completed',
+      data: {
+        object: { subscription: 'sub_notify', customer: 'cus_notify', metadata: { region: 'us-west-2' } },
+      },
+    })
+    const res = await handleWebhook(req, ENV, depsFor, notify)
+    expect(res.status).toBe(200)
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(notify.mock.calls[0][1]).toBe('cus_notify')
+  })
+
+  it('does NOT fire the notify on a replayed (already-provisioned) delivery', async () => {
+    const { depsFor } = makeDeps()
+    const notify = vi.fn(async (_env: Env, _customerId: string) => {})
+    const event = {
+      type: 'checkout.session.completed',
+      data: {
+        object: { subscription: 'sub_replay', customer: 'cus_replay', metadata: { region: 'us-west-2' } },
+      },
+    }
+    await handleWebhook(await signedRequest(event), ENV, depsFor, notify)
+    await handleWebhook(await signedRequest(event), ENV, depsFor, notify)
+    // Only the first (created) provision triggers an email.
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  it('the real notify is INERT (no HTTP, webhook still 200s) when RESEND_API_KEY is unset', async () => {
+    const { depsFor } = makeDeps()
+    // No RESEND_API_KEY in ENV → dispatchStatusEmail must skip without any fetch.
+    const emailFetch = vi.fn(async () => new Response('{}', { status: 200 }))
+    const notify = (env: Env, customerId: string) =>
+      dispatchStatusEmail(env, customerId, emailFetch as unknown as typeof fetch)
+    const req = await signedRequest({
+      type: 'checkout.session.completed',
+      data: {
+        object: { subscription: 'sub_off', customer: 'cus_off', metadata: { region: 'us-west-2' } },
+      },
+    })
+    const res = await handleWebhook(req, ENV, depsFor, notify)
+    expect(res.status).toBe(200)
+    expect(emailFetch).not.toHaveBeenCalled()
+  })
+
+  it('the real notify sends via Resend (customer lookup + email) when RESEND_API_KEY is set', async () => {
+    const { depsFor } = makeDeps()
+    // First call = Stripe customer retrieve, second = Resend send.
+    const emailFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'cus_on', email: 'buyer@example.com' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 're_ok' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    const gatedEnv: Env = {
+      ...ENV,
+      RESEND_API_KEY: 'rk_test',
+      STATUS_LINK_SECRET: 'status-secret',
+      WALLET_BASE_URL: 'https://botho.io',
+    }
+    const notify = (env: Env, customerId: string) =>
+      dispatchStatusEmail(env, customerId, emailFetch as unknown as typeof fetch)
+    const req = await signedRequest({
+      type: 'checkout.session.completed',
+      data: {
+        object: { subscription: 'sub_on', customer: 'cus_on', metadata: { region: 'us-west-2' } },
+      },
+    })
+    const res = await handleWebhook(req, gatedEnv, depsFor, notify)
+    expect(res.status).toBe(200)
+    // Customer retrieve then Resend send.
+    expect(emailFetch).toHaveBeenCalledTimes(2)
+    const resendCall = emailFetch.mock.calls[1] as unknown as [string, RequestInit]
+    expect(resendCall[0]).toBe('https://api.resend.com/emails')
+    const payload = JSON.parse(resendCall[1].body as string) as { to: string }
+    expect(payload.to).toBe('buyer@example.com')
   })
 })

--- a/web/packages/baas-worker/wrangler.toml
+++ b/web/packages/baas-worker/wrangler.toml
@@ -19,6 +19,13 @@
 #                       this; it binds to ONE Stripe customer so a user only ever
 #                       sees their own node. Any long random string. Required for
 #                       /status and /portal.
+#   RESEND_API_KEY      (OPTIONAL, #805 part 2) Resend API key for status-link
+#                       email delivery on first provision. When UNSET the worker
+#                       still functions fully — the /node/success page's on-page
+#                       link is the primary delivery path — so this is a
+#                       skip-if-absent optional secret, NOT a fail-closed gate.
+#                       Set with `wrangler secret put RESEND_API_KEY` once the
+#                       botho.io sending domain is verified in Resend.
 #   --- provisioner (#502, #458 §3/§5) — a DEDICATED, tightly-scoped IAM user ---
 #   AWS_ACCESS_KEY_ID       provisioner IAM user access key.
 #   AWS_SECRET_ACCESS_KEY   provisioner IAM user secret key.
@@ -71,6 +78,9 @@ ALLOWED_ORIGINS = "https://botho.io,https://wallet.botho.io"
 WALLET_BASE_URL = "https://botho.io"
 # Where Stripe returns the user after they close the Customer Portal.
 PORTAL_RETURN_URL = "https://botho.io/node/status"
+# Verified botho.io sender for the status-link email (#805 part 2). Only used
+# when RESEND_API_KEY (a secret) is also set; safe to leave as-is otherwise.
+RESEND_FROM_ADDRESS = "Botho <nodes@botho.io>"
 
 # --- provisioner non-secret config (#502) ---------------------------------
 # Compute shape (proven seed/faucet node). Non-secret identifiers.

--- a/web/packages/web-wallet/src/lib/node-status.test.ts
+++ b/web/packages/web-wallet/src/lib/node-status.test.ts
@@ -3,6 +3,8 @@ import {
   NodeStatusError,
   createPortalUrl,
   fetchNodeStatus,
+  fetchSessionStatus,
+  sessionIdFromSearch,
   tokenFromSearch,
   type NodeStatus,
 } from './node-status'
@@ -66,6 +68,52 @@ describe('fetchNodeStatus', () => {
     })
     await expect(
       fetchNodeStatus('cus_A.1.sig', fetchMock as unknown as typeof fetch),
+    ).rejects.toBeInstanceOf(NodeStatusError)
+  })
+})
+
+describe('sessionIdFromSearch', () => {
+  it('extracts the session_id param', () => {
+    expect(sessionIdFromSearch('?session_id=cs_test_abc')).toBe('cs_test_abc')
+  })
+  it('returns null when absent or empty', () => {
+    expect(sessionIdFromSearch('')).toBeNull()
+    expect(sessionIdFromSearch('?token=x')).toBeNull()
+    expect(sessionIdFromSearch('?session_id=')).toBeNull()
+  })
+})
+
+describe('fetchSessionStatus', () => {
+  it('GETs /session-status?session_id= and returns a ready status URL on 200', async () => {
+    const fetchMock = vi.fn(async () =>
+      okResponse({ status: 'ready', statusUrl: 'https://botho.io/node/status?token=t' }),
+    )
+    const result = await fetchSessionStatus('cs_test_abc', fetchMock as unknown as typeof fetch)
+    expect(result).toEqual({ kind: 'ready', statusUrl: 'https://botho.io/node/status?token=t' })
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toMatch(/\/session-status\?session_id=cs_test_abc$/)
+    expect(init.method).toBe('GET')
+  })
+
+  it('maps a 202 to a pending result (keep polling)', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ status: 'pending' }, 202))
+    const result = await fetchSessionStatus('cs_test_abc', fetchMock as unknown as typeof fetch)
+    expect(result).toEqual({ kind: 'pending' })
+  })
+
+  it('throws a terminal 401 for an unknown/unpaid session (stop polling)', async () => {
+    const fetchMock = vi.fn(async () => okResponse({ error: 'unauthorized' }, 401))
+    await expect(
+      fetchSessionStatus('cs_bad', fetchMock as unknown as typeof fetch),
+    ).rejects.toMatchObject({ status: 401 })
+  })
+
+  it('throws NodeStatusError when the network is unreachable', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('network down')
+    })
+    await expect(
+      fetchSessionStatus('cs_test_abc', fetchMock as unknown as typeof fetch),
     ).rejects.toBeInstanceOf(NodeStatusError)
   })
 })

--- a/web/packages/web-wallet/src/lib/node-status.ts
+++ b/web/packages/web-wallet/src/lib/node-status.ts
@@ -99,6 +99,79 @@ export async function fetchNodeStatus(
   }
 }
 
+/** The `session_id` query-param name Stripe appends to the success URL. */
+export const SESSION_ID_PARAM = 'session_id'
+
+/**
+ * Read the Stripe `session_id` from a query string (the success page is opened as
+ * `/node/success?session_id=…`). Returns null when absent.
+ */
+export function sessionIdFromSearch(search: string): string | null {
+  try {
+    const v = new URLSearchParams(search).get(SESSION_ID_PARAM)
+    return v && v.trim() !== '' ? v.trim() : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Outcome of exchanging a Stripe `session_id` for a status link on the success
+ * page. `pending` means the payment is confirmed but provisioning hasn't written
+ * the node row yet — the caller should keep polling. `ready` carries the
+ * `/node/status?token=…` URL to link to.
+ */
+export type SessionStatus =
+  | { kind: 'ready'; statusUrl: string }
+  | { kind: 'pending' }
+
+/**
+ * Exchange a Stripe `session_id` for the node status URL via the control-plane
+ * Worker (#805 part 1). `fetchImpl` is injectable for tests.
+ *
+ * Response mapping (mirrors the Worker's `/session-status` contract):
+ *   - 200 → `{ kind: 'ready', statusUrl }`
+ *   - 202 → `{ kind: 'pending' }` (still provisioning — poll again)
+ *   - 401 → throw `NodeStatusError(…, 401)` — unknown/unpaid/malformed session,
+ *           terminal, the caller must STOP polling
+ *   - other → throw `NodeStatusError` (transient; the caller may retry)
+ */
+export async function fetchSessionStatus(
+  sessionId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SessionStatus> {
+  const url = `${baasEndpoint()}/session-status?${SESSION_ID_PARAM}=${encodeURIComponent(sessionId)}`
+  let resp: Response
+  try {
+    resp = await fetchImpl(url, { method: 'GET' })
+  } catch {
+    throw new NodeStatusError('Could not reach the status service. Try again.')
+  }
+
+  if (resp.status === 202) {
+    return { kind: 'pending' }
+  }
+  if (!resp.ok) {
+    if (resp.status === 401) {
+      // Terminal: unknown / unpaid / malformed session — do NOT keep polling.
+      throw new NodeStatusError('This checkout link is invalid or has expired.', 401)
+    }
+    throw new NodeStatusError('Could not confirm your checkout.', resp.status)
+  }
+
+  let json: { status?: string; statusUrl?: string }
+  try {
+    json = (await resp.json()) as typeof json
+  } catch {
+    throw new NodeStatusError('Unexpected response from the status service.', resp.status)
+  }
+  if (json.status === 'pending') return { kind: 'pending' }
+  if (json.status === 'ready' && typeof json.statusUrl === 'string' && json.statusUrl.length > 0) {
+    return { kind: 'ready', statusUrl: json.statusUrl }
+  }
+  throw new NodeStatusError('Unexpected response from the status service.', resp.status)
+}
+
 /**
  * Open a Stripe Customer Portal session for the authenticated user and return
  * the hosted URL to redirect the browser to. The caller redirects.

--- a/web/packages/web-wallet/src/locales/en/node.json
+++ b/web/packages/web-wallet/src/locales/en/node.json
@@ -49,7 +49,11 @@
   },
   "success": {
     "title": "Subscription started",
-    "body": "Thanks! Your managed node is being provisioned. We'll email you a secure link to your node's status page — it shows your private RPC URL, the node's health, and a one-click link to open it in the wallet.",
+    "body": "Thanks! Your managed node is being provisioned. Use the secure link below to reach your node's status page — it shows your private RPC URL, the node's health, and a one-click link to open it in the wallet.",
+    "provisioning": "Setting up your node… this usually takes a minute.",
+    "viewStatus": "View your node status",
+    "linkError": "We couldn't confirm this checkout. If you just paid, refresh in a moment; otherwise start over from the node page.",
+    "noSession": "Your subscription is being set up. Check your email for a secure link to your node's status page.",
     "openWallet": "Open Wallet",
     "backToHome": "Back to home"
   },

--- a/web/packages/web-wallet/src/locales/es/node.json
+++ b/web/packages/web-wallet/src/locales/es/node.json
@@ -49,7 +49,11 @@
   },
   "success": {
     "title": "Suscripción iniciada",
-    "body": "¡Gracias! Tu nodo gestionado se está aprovisionando. Te enviaremos por correo un enlace seguro a la página de estado de tu nodo, que muestra tu URL de RPC privada, la salud del nodo y un enlace de un clic para abrirlo en el monedero.",
+    "body": "¡Gracias! Tu nodo gestionado se está aprovisionando. Usa el enlace seguro de abajo para acceder a la página de estado de tu nodo, que muestra tu URL de RPC privada, la salud del nodo y un enlace de un clic para abrirlo en el monedero.",
+    "provisioning": "Configurando tu nodo… esto suele tardar un minuto.",
+    "viewStatus": "Ver el estado de tu nodo",
+    "linkError": "No pudimos confirmar este pago. Si acabas de pagar, actualiza en un momento; si no, vuelve a empezar desde la página del nodo.",
+    "noSession": "Tu suscripción se está configurando. Revisa tu correo para encontrar un enlace seguro a la página de estado de tu nodo.",
     "openWallet": "Abrir el monedero",
     "backToHome": "Volver al inicio"
   },

--- a/web/packages/web-wallet/src/pages/node-success.test.tsx
+++ b/web/packages/web-wallet/src/pages/node-success.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Success-page (`NodeSuccessPage`) state coverage (#805 part 1). The page
+ * exchanges Stripe's `session_id` for a magic-link status URL via the
+ * control-plane Worker, polling while provisioning lands. These tests assert the
+ * pending → ready transition, the terminal-error state, and the no-session
+ * fallback, with `fetchSessionStatus` mocked (no network).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { NodeStatusError, type SessionStatus } from '../lib/node-status'
+
+const fetchSessionStatusMock = vi.fn<(id: string) => Promise<SessionStatus>>()
+vi.mock('../lib/node-status', async () => {
+  const actual = await vi.importActual<typeof import('../lib/node-status')>('../lib/node-status')
+  return {
+    ...actual,
+    fetchSessionStatus: (id: string) => fetchSessionStatusMock(id),
+  }
+})
+
+// Imported AFTER the mock is registered.
+import { NodeSuccessPage } from './node'
+import i18n from '../lib/i18n'
+
+function renderSuccess() {
+  return render(
+    <MemoryRouter initialEntries={['/node/success']}>
+      <NodeSuccessPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('NodeSuccessPage', () => {
+  beforeEach(async () => {
+    fetchSessionStatusMock.mockReset()
+    await i18n.changeLanguage('en')
+  })
+  afterEach(() => {
+    cleanup()
+    window.history.replaceState({}, '', '/node/success')
+  })
+
+  it('shows the no-session fallback when no session_id is present', () => {
+    window.history.replaceState({}, '', '/node/success')
+    renderSuccess()
+    expect(screen.getByRole('heading', { name: 'Subscription started' })).toBeTruthy()
+    // No session_id → the plain email-fallback copy, no spinner poll.
+    expect(fetchSessionStatusMock).not.toHaveBeenCalled()
+    expect(screen.getByText(/Check your email/i)).toBeTruthy()
+  })
+
+  it('renders a "View your node status" link once the exchange is ready', async () => {
+    window.history.replaceState({}, '', '/node/success?session_id=cs_test_abc')
+    fetchSessionStatusMock.mockResolvedValue({
+      kind: 'ready',
+      statusUrl: 'https://botho.io/node/status?token=cus_A.1.sig',
+    })
+    renderSuccess()
+    const link = (await screen.findByText('View your node status')).closest('a')
+    expect(link?.getAttribute('href')).toBe('https://botho.io/node/status?token=cus_A.1.sig')
+  })
+
+  it('shows the pending spinner while provisioning, then the ready link', async () => {
+    window.history.replaceState({}, '', '/node/success?session_id=cs_test_abc')
+    fetchSessionStatusMock
+      .mockResolvedValueOnce({ kind: 'pending' })
+      .mockResolvedValue({
+        kind: 'ready',
+        statusUrl: 'https://botho.io/node/status?token=t',
+      })
+    renderSuccess()
+    // First poll → pending copy.
+    expect(await screen.findByText(/Setting up your node/i)).toBeTruthy()
+    // Second poll (after the interval) → ready link.
+    await waitFor(() => expect(screen.getByText('View your node status')).toBeTruthy(), {
+      timeout: 6000,
+    })
+  })
+
+  it('shows the terminal error state on a 401 (stops polling)', async () => {
+    window.history.replaceState({}, '', '/node/success?session_id=cs_bad')
+    fetchSessionStatusMock.mockRejectedValue(new NodeStatusError('expired', 401))
+    renderSuccess()
+    expect(await screen.findByText(/couldn't confirm this checkout/i)).toBeTruthy()
+    // Only one attempt — a terminal 401 does not retry.
+    expect(fetchSessionStatusMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/packages/web-wallet/src/pages/node.i18n.test.tsx
+++ b/web/packages/web-wallet/src/pages/node.i18n.test.tsx
@@ -90,6 +90,8 @@ describe('node pages i18n', () => {
   it('renders the success page in English by default', () => {
     renderAt('/node/success', <NodeSuccessPage />)
     expect(screen.getByRole('heading', { name: 'Subscription started' })).toBeTruthy()
+    // No session_id → the no-session fallback copy renders in English.
+    expect(screen.getByText(/Check your email/i)).toBeTruthy()
   })
 
   it('renders the success page in Spanish under /es', async () => {
@@ -97,6 +99,8 @@ describe('node pages i18n', () => {
     renderAt('/es/node/success', <NodeSuccessPage />)
     expect(screen.getByRole('heading', { name: 'Suscripción iniciada' })).toBeTruthy()
     expect(screen.queryByRole('heading', { name: 'Subscription started' })).toBeNull()
+    // The no-session fallback copy is translated too (informal tú register).
+    expect(screen.getByText(/Revisa tu correo/i)).toBeTruthy()
   })
 
   it('renders the status page state badge in English by default', async () => {

--- a/web/packages/web-wallet/src/pages/node.tsx
+++ b/web/packages/web-wallet/src/pages/node.tsx
@@ -25,7 +25,10 @@ import {
 import {
   createPortalUrl,
   fetchNodeStatus,
+  fetchSessionStatus,
+  sessionIdFromSearch,
   tokenFromSearch,
+  NodeStatusError,
   type NodeStatus,
 } from '../lib/node-status'
 import { LocaleSwitcher } from '../components/LocaleSwitcher'
@@ -251,14 +254,81 @@ function NodePageShell({ children }: { children: React.ReactNode }) {
   )
 }
 
+/** Delay (ms) between `/session-status` polls while provisioning is pending. */
+const SESSION_POLL_INTERVAL_MS = 3000
+/** Stop polling after this many attempts (~1 min at 3s) — the email is the fallback. */
+const SESSION_POLL_MAX_ATTEMPTS = 20
+
+/** Exchange state for the success page's `session_id` → status-link poll. */
+type SessionExchangeState =
+  | { kind: 'pending' }
+  | { kind: 'ready'; statusUrl: string }
+  | { kind: 'error' }
+  | { kind: 'no-session' }
+
 /**
- * Post-checkout success page (#458 §4). Stripe redirects here after a completed
- * checkout (`/node/success?session_id=...`). Provisioning is asynchronous (the
- * webhook launches the node), so this confirms the subscription and points the
- * user at the live status page once they have their magic link.
+ * Post-checkout success page (#458 §4, #805 part 1). Stripe redirects here after
+ * a completed checkout (`/node/success?session_id=...`). Provisioning is
+ * asynchronous (the webhook launches the node), so this page exchanges the
+ * `session_id` for a magic-link status URL via the control-plane Worker, polling
+ * while provisioning lands and rendering:
+ *   - pending: a spinner while the node comes up,
+ *   - ready:   a "View your node status" link,
+ *   - error:   a fallback if the session can't be confirmed,
+ *   - no-session: the plain confirmation when no `session_id` is present.
  */
 export function NodeSuccessPage() {
   const { t } = useTranslation('node')
+  const sessionId =
+    typeof window !== 'undefined' ? sessionIdFromSearch(window.location.search) : null
+  const [state, setState] = useState<SessionExchangeState>(
+    sessionId ? { kind: 'pending' } : { kind: 'no-session' },
+  )
+
+  useEffect(() => {
+    if (!sessionId) return
+    let cancelled = false
+    let attempts = 0
+    let timer: ReturnType<typeof setTimeout> | undefined
+
+    const poll = async () => {
+      attempts += 1
+      try {
+        const result = await fetchSessionStatus(sessionId)
+        if (cancelled) return
+        if (result.kind === 'ready') {
+          setState({ kind: 'ready', statusUrl: result.statusUrl })
+          return
+        }
+        // pending → keep polling until we hit the attempt cap.
+        if (attempts >= SESSION_POLL_MAX_ATTEMPTS) {
+          setState({ kind: 'no-session' })
+          return
+        }
+        timer = setTimeout(() => void poll(), SESSION_POLL_INTERVAL_MS)
+      } catch (err) {
+        if (cancelled) return
+        // A terminal 401 (unknown/expired session) stops polling with an error.
+        if (err instanceof NodeStatusError && err.status === 401) {
+          setState({ kind: 'error' })
+          return
+        }
+        // Transient error: retry until the cap, then fall back to the email note.
+        if (attempts >= SESSION_POLL_MAX_ATTEMPTS) {
+          setState({ kind: 'no-session' })
+          return
+        }
+        timer = setTimeout(() => void poll(), SESSION_POLL_INTERVAL_MS)
+      }
+    }
+
+    void poll()
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [sessionId])
+
   return (
     <NodePageShell>
       <Card className="max-w-md w-full p-6 sm:p-8 text-center">
@@ -269,9 +339,37 @@ export function NodeSuccessPage() {
           {t('success.title')}
         </h1>
         <p className="text-sm sm:text-base text-ghost mb-6">{t('success.body')}</p>
+
+        {state.kind === 'pending' && (
+          <div className="flex items-center justify-center gap-2 text-ghost mb-6">
+            <Loader2 className="animate-spin" size={18} />
+            <span className="text-sm">{t('success.provisioning')}</span>
+          </div>
+        )}
+
+        {state.kind === 'ready' && (
+          <a href={state.statusUrl} className="block mb-6">
+            <Button size="lg" className="w-full justify-center gap-2">
+              <ExternalLink size={18} />
+              {t('success.viewStatus')}
+            </Button>
+          </a>
+        )}
+
+        {state.kind === 'error' && (
+          <div className="mb-6 p-3 rounded-lg bg-warning/10 border border-warning/30 flex gap-2 text-sm text-warning text-left">
+            <AlertCircle size={18} className="shrink-0 mt-0.5" />
+            <span>{t('success.linkError')}</span>
+          </div>
+        )}
+
+        {state.kind === 'no-session' && (
+          <p className="text-sm text-ghost mb-6">{t('success.noSession')}</p>
+        )}
+
         <div className="flex flex-col gap-3">
           <Link to="/wallet">
-            <Button size="lg" className="w-full justify-center">
+            <Button size="lg" variant="ghost" className="w-full justify-center">
               {t('success.openWallet')}
             </Button>
           </Link>


### PR DESCRIPTION
Closes #805

After a completed Stripe checkout, the customer had no path to their node's status page: `/node/success` received `session_id` but nothing consumed it, and the success copy over-promised an email the worker could not send. This lands both parts the maintainer requested (exchange first, Resend behind an env gate).

## Part 1 — `session_id` → status-token exchange
- **New worker endpoint** `GET /session-status?session_id=cs_…`: retrieves the Stripe Checkout Session (`STRIPE_SECRET_KEY`, `Bearer`, pinned `Stripe-Version: 2024-06-20`), confirms `payment_status === 'paid'`, reads the **customer** id off the session, looks it up via `NodeStore.getByCustomer` (same authz-scoped lookup `/status` uses), mints the HMAC status token (`mintStatusToken`), and returns the `/node/status?token=…` URL.
  - `200 ready` · `202 pending` (paid but the D1 row hasn't been written yet — provisioning lag; the frontend polls) · generic `401` for unknown/unpaid/malformed (no-leak, mirrors `/status`) · `400` missing param · `500` fail-closed when config is incomplete.
- **`NodeSuccessPage`** reads `session_id` on mount and polls `/session-status`, rendering **pending / ready / error / no-session** states (mirrors the existing `NodeStatusPage` loading/error pattern).
- **`fetchSessionStatus`** added to `node-status.ts` following the `fetchNodeStatus`/`createPortalUrl` shape (202 = pending/keep-polling, 401 = terminal/stop-polling).
- **en + es `node.json`**: `success.body` no longer promises an email; new keys for the pending/ready/error/no-session sub-states (both locales).

## Part 2 — Resend email (env-gated, fully inert without `RESEND_API_KEY`)
- **New `resend.ts`**: sends the status link on **first** successful provision (`created === true`, never a webhook replay), from the verified `botho.io` sender. `dispatchStatusEmail` is wired into `handleWebhook`'s post-provision path — **log-and-skip when `RESEND_API_KEY` is absent**, never a 500, never blocks the Stripe ACK. Recipient email is fetched from Stripe (the D1 row stores only the customer id).
- `RESEND_API_KEY` / `RESEND_FROM_ADDRESS` documented in `wrangler.toml` + `.dev.vars.example` as optional operator-provided config (skip-if-absent, not fail-closed).

## boundFetch discipline
Every new outbound HTTP call (Stripe session retrieve, Stripe customer retrieve, Resend send) defaults its injectable `fetchImpl` to `boundFetch` — a bare `fetch` throws `Illegal invocation` in workerd (tonight's `4ab7e8cb` incident).

## Tests — `pnpm check:ci` green
- Typecheck: all 8 packages pass.
- Vitest: **847 passed** / 10 skipped (live-node).
- `wrangler deploy --dry-run`: passes.
- Worker: paid → token minted; unpaid/unknown/malformed → generic 401; paid-but-row-absent → 202 pending; endpoint routing; fail-closed config; Resend gated off → no-op (webhook still 200s); Resend gated on (mocked) → correct payload/recipient.
- Frontend: `fetchSessionStatus` (ready/pending/terminal-401/unreachable); success-page pending→ready transition + error/no-session; en/es i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)