### PR TITLE
feat(web-wallet): validate custom RPC endpoint network + show host on trigger

### DIFF
--- a/web/packages/web-wallet/src/components/NetworkSelector.test.tsx
+++ b/web/packages/web-wallet/src/components/NetworkSelector.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Interaction coverage for the NetworkSelector custom-endpoint UI (#806):
+ *   - the collapsed trigger shows the truncated active custom host (not the
+ *     literal "Custom RPC") when a custom endpoint is active,
+ *   - manual entry routes the pasted endpoint through `setCustomEndpoint` and
+ *     surfaces its validationError on rejection.
+ *
+ * The context is mocked (as in OfflineBanner.test.tsx) so this suite tests the
+ * component's wiring, not the validation internals — those live in
+ * `config/networks.test.ts`.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
+import type { NetworkConfig, NodeHealth } from '../config/networks'
+import { INGRESS_NODES } from '../config/networks'
+import { NetworkSelector } from './NetworkSelector'
+
+const useNetworkMock = vi.fn()
+vi.mock('../contexts/network', () => ({ useNetwork: () => useNetworkMock() }))
+
+const CUSTOM_NETWORK: NetworkConfig = {
+  id: 'custom',
+  name: 'Custom',
+  rpcEndpoint: 'https://node-1tsb0k9x2q.testnet.botho.io/rpc',
+  networkId: 'botho-custom',
+  isTestnet: false,
+}
+
+const SEED_NETWORK: NetworkConfig = {
+  id: 'testnet:seed',
+  name: 'Testnet',
+  rpcEndpoint: 'https://seed.botho.io/rpc',
+  networkId: 'botho-testnet',
+  isTestnet: true,
+}
+
+interface Overrides {
+  ingressId?: string
+  network?: NetworkConfig
+  setCustomEndpoint?: (endpoint: string) => Promise<boolean>
+  isValidating?: boolean
+  validationError?: string | null
+}
+
+function setup(overrides: Overrides = {}) {
+  const setCustomEndpoint = overrides.setCustomEndpoint ?? vi.fn(async () => true)
+  const nodeHealth: Record<string, NodeHealth> = {}
+  for (const n of INGRESS_NODES) nodeHealth[n.id] = { status: 'online', chainHeight: 1, synced: true }
+  useNetworkMock.mockReturnValue({
+    network: overrides.network ?? SEED_NETWORK,
+    ingressId: overrides.ingressId ?? 'seed',
+    ingressNodes: INGRESS_NODES,
+    nodeHealth,
+    selectIngress: vi.fn(),
+    setCustomEndpoint,
+    isValidating: overrides.isValidating ?? false,
+    validationError: overrides.validationError ?? null,
+    startHealthPolling: vi.fn(() => () => {}),
+  })
+  return { setCustomEndpoint }
+}
+
+describe('NetworkSelector trigger label', () => {
+  beforeEach(() => {
+    cleanup()
+    useNetworkMock.mockReset()
+  })
+
+  it('shows the selected built-in ingress name when not on a custom node', () => {
+    setup({ ingressId: 'seed', network: SEED_NETWORK })
+    render(<NetworkSelector />)
+    expect(screen.getByText('US seed 1')).toBeTruthy()
+  })
+
+  it('shows the truncated custom host (not "Custom RPC") when on a custom node', () => {
+    setup({ ingressId: 'custom', network: CUSTOM_NETWORK })
+    render(<NetworkSelector />)
+    // Long leftmost label is shortened; operator domain stays intact.
+    expect(screen.getByText('node-1tsb0….testnet.botho.io')).toBeTruthy()
+    // The literal generic label is NOT used on the collapsed trigger.
+    expect(screen.queryByText(/^Custom RPC$/)).toBeNull()
+  })
+})
+
+describe('NetworkSelector manual custom-endpoint entry', () => {
+  beforeEach(() => {
+    cleanup()
+    useNetworkMock.mockReset()
+  })
+
+  function openCustomInput() {
+    // Open the dropdown, then reveal the custom-endpoint input row.
+    fireEvent.click(screen.getByRole('button', { name: /US seed 1/i }))
+    fireEvent.click(screen.getByText('Custom RPC'))
+  }
+
+  it('routes a pasted endpoint through setCustomEndpoint', async () => {
+    const setCustomEndpoint = vi.fn(async () => true)
+    setup({ setCustomEndpoint })
+    render(<NetworkSelector />)
+    openCustomInput()
+
+    const input = screen.getByPlaceholderText('https://node.example.com/rpc')
+    fireEvent.change(input, { target: { value: 'https://node-x.testnet.botho.io/rpc' } })
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }))
+
+    await waitFor(() =>
+      expect(setCustomEndpoint).toHaveBeenCalledWith('https://node-x.testnet.botho.io/rpc'),
+    )
+  })
+
+  it('surfaces the validation error when the endpoint is rejected', () => {
+    setup({
+      setCustomEndpoint: vi.fn(async () => false),
+      validationError: 'This node is on a different network (botho-mainnet)',
+    })
+    render(<NetworkSelector />)
+    openCustomInput()
+    expect(screen.getByText('This node is on a different network (botho-mainnet)')).toBeTruthy()
+  })
+
+  it('does not call setCustomEndpoint for an empty input', () => {
+    const setCustomEndpoint = vi.fn(async () => true)
+    setup({ setCustomEndpoint })
+    render(<NetworkSelector />)
+    openCustomInput()
+    // Connect is disabled while the input is empty.
+    const connect = screen.getByRole('button', { name: /connect/i }) as HTMLButtonElement
+    expect(connect.disabled).toBe(true)
+    fireEvent.click(connect)
+    expect(setCustomEndpoint).not.toHaveBeenCalled()
+  })
+})

--- a/web/packages/web-wallet/src/components/NetworkSelector.tsx
+++ b/web/packages/web-wallet/src/components/NetworkSelector.tsx
@@ -17,6 +17,31 @@ function HealthDot({ health }: { health: NodeHealth | undefined }) {
   return <div className={`w-2 h-2 rounded-full shrink-0 ${color}`} />
 }
 
+/**
+ * Truncate a custom endpoint down to a short host label for the collapsed
+ * trigger, e.g. `https://node-1tsb0k9x2q.testnet.botho.io/rpc` ->
+ * `node-1tsb0k….testnet.botho.io`. Only the first (leftmost) label is
+ * shortened, so the operator domain stays recognizable. Falls back to the raw
+ * endpoint when it cannot be parsed as a URL.
+ */
+function truncateCustomHost(endpoint: string): string {
+  let host: string
+  try {
+    host = new URL(endpoint).hostname
+  } catch {
+    return endpoint
+  }
+  const dot = host.indexOf('.')
+  if (dot === -1) {
+    // No domain suffix — truncate the bare host if it's long.
+    return host.length > 14 ? `${host.slice(0, 12)}…` : host
+  }
+  const first = host.slice(0, dot)
+  const rest = host.slice(dot) // includes leading '.'
+  const shortFirst = first.length > 12 ? `${first.slice(0, 10)}…` : first
+  return `${shortFirst}${rest}`
+}
+
 /** One-line health summary text for a node. */
 function healthLabel(health: NodeHealth | undefined): string {
   if (!health || health.status === 'checking') return 'Checking…'
@@ -94,9 +119,14 @@ export function NetworkSelector({ className = '' }: NetworkSelectorProps) {
     }
   }
 
-  // Label shown on the trigger button: the selected ingress node's name.
+  // Label shown on the trigger button: the selected ingress node's name, or the
+  // truncated host of the active custom endpoint when on a custom node so the
+  // collapsed trigger reflects WHICH node the wallet is talking to (not a
+  // generic "Custom RPC").
   const selectedNode = ingressNodes.find((n) => n.id === ingressId)
-  const triggerLabel = selectedNode?.name ?? (ingressId === 'custom' ? 'Custom RPC' : 'Node')
+  const triggerLabel =
+    selectedNode?.name ??
+    (ingressId === 'custom' ? truncateCustomHost(network.rpcEndpoint) : 'Node')
 
   return (
     <div className={`relative ${className}`} ref={dropdownRef}>

--- a/web/packages/web-wallet/src/config/networks.test.ts
+++ b/web/packages/web-wallet/src/config/networks.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Unit coverage for the custom-RPC persistence + validation path (#806).
+ *
+ * The deep-link + trust-gate flow is covered in `contexts/network-deep-link.test.tsx`;
+ * this suite exercises the lower-level config helpers the manual-entry picker
+ * relies on: the localStorage persistence round-trip, and the HTTPS-shape /
+ * reachability / network-match gates in `validateRpcEndpointForNetwork`.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  EXPECTED_NETWORK_ID,
+  fetchNodeHealth,
+  saveSelectedNetwork,
+  loadSelectedNetwork,
+  saveSelectedIngress,
+  loadSelectedIngress,
+  validateRpcEndpointForNetwork,
+  DEFAULT_INGRESS_ID,
+  DEFAULT_NETWORK_ID,
+} from './networks'
+
+// jsdom serves an opaque origin, so localStorage is unavailable — shim it.
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock })
+
+/** Build a fetch stub whose node_getStatus returns the given result object. */
+function stubStatus(result: Record<string, unknown> | null, ok = true) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok,
+      json: async () => (result === null ? { error: 'boom' } : { jsonrpc: '2.0', id: 1, result }),
+    })),
+  )
+}
+
+describe('custom-endpoint persistence round-trip', () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => localStorage.clear())
+
+  it('saves and restores a custom endpoint via saveSelectedNetwork/loadSelectedNetwork', () => {
+    saveSelectedNetwork('custom', 'https://node-x.testnet.botho.io/rpc')
+    const loaded = loadSelectedNetwork()
+    expect(loaded.networkId).toBe('custom')
+    expect(loaded.customEndpoint).toBe('https://node-x.testnet.botho.io/rpc')
+  })
+
+  it('clears the custom endpoint when a built-in ingress is selected', () => {
+    saveSelectedNetwork('custom', 'https://node-x.testnet.botho.io/rpc')
+    saveSelectedIngress('seed2')
+    const loaded = loadSelectedNetwork()
+    // Selecting an ingress resets the network key and drops the custom endpoint.
+    expect(loaded.networkId).toBe(DEFAULT_NETWORK_ID)
+    expect(loaded.customEndpoint).toBeUndefined()
+    expect(loadSelectedIngress()).toBe('seed2')
+  })
+
+  it('defaults to the built-in ingress when nothing is persisted', () => {
+    expect(loadSelectedNetwork().networkId).toBe(DEFAULT_NETWORK_ID)
+    expect(loadSelectedIngress()).toBe(DEFAULT_INGRESS_ID)
+  })
+})
+
+describe('validateRpcEndpointForNetwork', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('rejects a plain-http non-loopback endpoint before any network call', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const result = await validateRpcEndpointForNetwork('http://node.example.com/rpc')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/https/i)
+    // Shape check short-circuits — no fetch is made.
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-URL string', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const result = await validateRpcEndpointForNetwork('not a url')
+    expect(result.ok).toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects an https endpoint that is unreachable', async () => {
+    stubStatus(null, false)
+    const result = await validateRpcEndpointForNetwork('https://down.botho.io/rpc')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/connect/i)
+  })
+
+  it('rejects an https endpoint on a different network', async () => {
+    stubStatus({ chainHeight: 5, synced: true, network: 'botho-mainnet' })
+    const result = await validateRpcEndpointForNetwork('https://node-x.botho.io/rpc')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('botho-mainnet')
+  })
+
+  it('accepts an https endpoint on the expected network', async () => {
+    stubStatus({ chainHeight: 5, synced: true, network: EXPECTED_NETWORK_ID })
+    const result = await validateRpcEndpointForNetwork('https://node-x.testnet.botho.io/rpc')
+    expect(result.ok).toBe(true)
+  })
+
+  it('exempts loopback hosts from the network-match check (dev workflow)', async () => {
+    stubStatus({ chainHeight: 1, synced: false, network: 'botho-dev' })
+    const result = await validateRpcEndpointForNetwork('http://localhost:17101/rpc')
+    expect(result.ok).toBe(true)
+  })
+
+  it('accepts an https endpoint that omits the network field (older node)', async () => {
+    stubStatus({ chainHeight: 5, synced: true })
+    const result = await validateRpcEndpointForNetwork('https://node-x.testnet.botho.io/rpc')
+    expect(result.ok).toBe(true)
+  })
+})
+
+describe('fetchNodeHealth captures the reported network', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('surfaces the network field from node_getStatus', async () => {
+    stubStatus({ chainHeight: 9, synced: true, network: 'botho-testnet' })
+    const health = await fetchNodeHealth('https://node-x.testnet.botho.io/rpc')
+    expect(health.status).toBe('online')
+    expect(health.network).toBe('botho-testnet')
+  })
+})

--- a/web/packages/web-wallet/src/config/networks.ts
+++ b/web/packages/web-wallet/src/config/networks.ts
@@ -9,6 +9,8 @@
  * regardless of which ingress is selected.
  */
 
+import { isValidRpcUrl } from '../lib/custom-rpc-link'
+
 export interface NetworkConfig {
   id: string
   name: string
@@ -148,6 +150,15 @@ export const NETWORKS: Record<string, NetworkConfig> = {
 export const DEFAULT_NETWORK_ID = 'testnet'
 
 /**
+ * The network identifier a custom RPC endpoint must report (via `node_getStatus`'s
+ * `network` field) to be adopted as the wallet's ingress. A node on any other
+ * network (e.g. `botho-mainnet`) is rejected so the user can't silently point the
+ * testnet wallet at a wrong-network node. Matches `networkForIngress`'s
+ * `networkId` for the built-in testnet ingress.
+ */
+export const EXPECTED_NETWORK_ID = 'botho-testnet'
+
+/**
  * Get network configuration by ID
  */
 export function getNetwork(id: string): NetworkConfig | undefined {
@@ -185,6 +196,11 @@ export interface NodeHealth {
   synced?: boolean
   /** Sync progress percentage (0-100). */
   syncProgress?: number
+  /**
+   * The network the node reports (e.g. `botho-testnet`), when online. Used to
+   * reject a custom endpoint that answers but is on a different network.
+   */
+  network?: string
 }
 
 /**
@@ -212,7 +228,12 @@ export async function fetchNodeHealth(endpoint: string): Promise<NodeHealth> {
     if (!response.ok) return { status: 'offline' }
 
     const json = (await response.json()) as {
-      result?: { chainHeight?: number; synced?: boolean; syncProgress?: number }
+      result?: {
+        chainHeight?: number
+        synced?: boolean
+        syncProgress?: number
+        network?: string
+      }
       error?: unknown
     }
     if (json.error || !json.result) return { status: 'offline' }
@@ -222,14 +243,73 @@ export async function fetchNodeHealth(endpoint: string): Promise<NodeHealth> {
       chainHeight: json.result.chainHeight,
       synced: json.result.synced,
       syncProgress: json.result.syncProgress,
+      network: json.result.network,
     }
   } catch {
     return { status: 'offline' }
   }
 }
 
+/** True for loopback hosts (localhost / 127.0.0.1), which are exempt from the
+ * network-match check so local-dev nodes reporting a non-testnet network name
+ * still work. Mirrors `classifyRpcHost`'s loopback-as-`known` treatment. */
+function isLoopbackHost(endpoint: string): boolean {
+  try {
+    const host = new URL(endpoint).hostname.toLowerCase()
+    return host === 'localhost' || host === '127.0.0.1'
+  } catch {
+    return false
+  }
+}
+
 /**
- * Validate that an RPC endpoint is reachable
+ * Outcome of validating a custom RPC endpoint before adoption. `ok: true` means
+ * the endpoint passed the HTTPS-shape, reachability, and network-match checks and
+ * is safe to persist; `ok: false` carries a user-facing `error` message.
+ */
+export type RpcEndpointValidation = { ok: true } | { ok: false; error: string }
+
+/**
+ * Validate a custom RPC endpoint before adopting it as the wallet's ingress.
+ *
+ * Applied identically to the manually-pasted picker path and the accepted `?rpc=`
+ * deep link (#587). Three gates, cheapest first:
+ *   1. HTTPS-shape: must be `https://` (or `http://localhost` for dev) — reuses
+ *      `isValidRpcUrl` so both entry paths share the deep link's scheme check.
+ *   2. Reachability: `node_getStatus` must answer.
+ *   3. Network match: the reported `network` must equal `EXPECTED_NETWORK_ID`
+ *      (`botho-testnet`), so a wrong-network node is rejected instead of silently
+ *      connecting. Loopback hosts are exempt (local dev nodes may report other
+ *      network names).
+ */
+export async function validateRpcEndpointForNetwork(
+  endpoint: string,
+): Promise<RpcEndpointValidation> {
+  if (!isValidRpcUrl(endpoint)) {
+    return { ok: false, error: 'Enter a valid https:// endpoint.' }
+  }
+
+  const health = await fetchNodeHealth(endpoint)
+  if (health.status !== 'online') {
+    return { ok: false, error: 'Could not connect to endpoint' }
+  }
+
+  if (!isLoopbackHost(endpoint) && health.network && health.network !== EXPECTED_NETWORK_ID) {
+    return {
+      ok: false,
+      error: `This node is on a different network (${health.network})`,
+    }
+  }
+
+  return { ok: true }
+}
+
+/**
+ * Validate that an RPC endpoint is reachable.
+ *
+ * @deprecated Prefer `validateRpcEndpointForNetwork`, which also enforces the
+ * HTTPS shape and network match. Retained for callers that only need a boolean
+ * reachability probe.
  */
 export async function validateRpcEndpoint(endpoint: string): Promise<boolean> {
   const health = await fetchNodeHealth(endpoint)

--- a/web/packages/web-wallet/src/contexts/network-deep-link.test.tsx
+++ b/web/packages/web-wallet/src/contexts/network-deep-link.test.tsx
@@ -164,6 +164,41 @@ describe('custom-RPC deep link is gated by the NetworkProvider (#587)', () => {
     expect(localStorage.getItem('botho_custom_node_from_link')).toBe('node-x.testnet.botho.io')
   })
 
+  it('accept rejects a wrong-network node and leaves the prior node intact (#806)', async () => {
+    // The link's node answers node_getStatus but reports a different network.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          jsonrpc: '2.0',
+          id: 1,
+          result: { chainHeight: 1, synced: true, network: 'botho-mainnet' },
+        }),
+      })),
+    )
+    setSearch(rpcQuery('https://node-x.testnet.botho.io/rpc'))
+    render(
+      <NetworkProvider>
+        <Probe />
+      </NetworkProvider>,
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('pending-host').textContent).toBe('node-x.testnet.botho.io'),
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('accept'))
+    })
+
+    // Validation failed on the network mismatch: prompt clears, but we stay on
+    // the prior default node and never persist the custom endpoint.
+    await waitFor(() => expect(screen.getByTestId('pending-host').textContent).toBe('none'))
+    expect(screen.getByTestId('ingress').textContent).toBe('seed')
+    expect(screen.getByTestId('from-link').textContent).toBe('none')
+    expect(localStorage.getItem('botho_custom_node_from_link')).toBeNull()
+  })
+
   it('revert returns to the default node and clears the marker', async () => {
     setSearch(rpcQuery('https://node-x.testnet.botho.io/rpc'))
     render(

--- a/web/packages/web-wallet/src/contexts/network.tsx
+++ b/web/packages/web-wallet/src/contexts/network.tsx
@@ -22,7 +22,7 @@ import {
   saveSelectedIngress,
   loadSelectedIngress,
   loadSelectedNetwork,
-  validateRpcEndpoint,
+  validateRpcEndpointForNetwork,
   fetchNodeHealth,
   saveCustomNodeFromLink,
   loadCustomNodeFromLink,
@@ -237,14 +237,16 @@ export function NetworkProvider({ children }: { children: ReactNode }) {
     }))
 
     try {
-      // Validate the endpoint is reachable
-      const isValid = await validateRpcEndpoint(endpoint)
+      // Validate the endpoint: https shape, reachability, and network match.
+      // Shared by the manual picker path and the accepted `?rpc=` deep link so
+      // both enforce the same guardrails before persisting (#587).
+      const validation = await validateRpcEndpointForNetwork(endpoint)
 
-      if (!isValid) {
+      if (!validation.ok) {
         setState(s => ({
           ...s,
           isValidating: false,
-          validationError: 'Could not connect to endpoint',
+          validationError: validation.error,
         }))
         return false
       }


### PR DESCRIPTION
## Summary

Closes the four verified gaps in the custom-RPC default flow (#806). The core
persistence + deep-link plumbing already ships (a custom endpoint set via
`setCustomEndpoint` persists to `localStorage` and is restored app-wide by
`NetworkProvider.getInitialNetwork()`; the `/node/status` "Open in wallet" deep
link already routes through the `CustomRpcTrustGate` into that same path). This
PR hardens the two adoption paths so they share the same guardrails and reflects
the active custom node on the selector.

## Changes

- **HTTPS/shape check on manual entry**: the manual picker path now reuses
  `isValidRpcUrl` from `custom-rpc-link.ts` (the same helper the deep-link path
  uses), so a plain-`http://` non-loopback endpoint is rejected before any
  network call.
- **Network-match gate**: `fetchNodeHealth` now captures the `network` field
  from `node_getStatus`, and a new `validateRpcEndpointForNetwork` rejects an
  endpoint reporting a network other than `botho-testnet` (`EXPECTED_NETWORK_ID`)
  with a clear message. Loopback hosts (localhost / 127.0.0.1) are exempt so
  local-dev nodes keep working, mirroring `classifyRpcHost`'s loopback treatment.
- **Shared validation for both entry paths**: `setCustomEndpoint` now calls
  `validateRpcEndpointForNetwork`, so the accepted `?rpc=` deep link
  (`acceptPendingRpcLink` -> `setCustomEndpoint`) is rejected on a wrong-network
  node instead of silently connecting. Non-blocking UX preserved (existing
  `isValidating` spinner during the probe).
- **Trigger label**: the collapsed `NetworkSelector` trigger now shows the
  truncated active custom host (e.g. `node-1tsb0….testnet.botho.io`) instead of
  the literal "Custom RPC" when a custom endpoint is active; health-dot behavior
  is unchanged.
- **Tests**: new `config/networks.test.ts` (persistence round-trip + all
  validation gates), new `NetworkSelector.test.tsx` (manual entry routes through
  `setCustomEndpoint`, validation-error surfacing, trigger-label truncation), and
  a new wrong-network accept case in `network-deep-link.test.tsx`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Plain-`http://` (non-loopback) manual entry rejected before any network call | ✅ | `validateRpcEndpointForNetwork` short-circuits on `isValidRpcUrl`; test asserts `fetch` is never called |
| `https://` endpoint reporting a non-`botho-testnet` network rejected, not persisted | ✅ | Network-match gate returns `This node is on a different network (…)`; covered in `networks.test.ts` |
| Wrong-network `?rpc=` deep link rejected on trust-gate accept | ✅ | `acceptPendingRpcLink` -> `setCustomEndpoint` shares the gate; new case in `network-deep-link.test.tsx` asserts ingress stays `seed` |
| Valid custom endpoint persists across reload/navigation (regression guard) | ✅ | Unchanged `saveSelectedNetwork`/`getInitialNetwork` path; persistence round-trip test added |
| Collapsed trigger shows truncated custom host + health dot | ✅ | `truncateCustomHost` on the trigger; `NetworkSelector.test.tsx` asserts the truncated host renders and "Custom RPC" is not the trigger label |
| Revert to built-in ingress clears custom endpoint + "from a link" marker | ✅ | Unchanged `revertCustomNode`/`selectIngress`; existing deep-link revert test still green |
| `typecheck` and `test` pass | ✅ | `pnpm -r typecheck` clean; `pnpm test:run` = 864 passed / 10 skipped |

## Test Plan

- `pnpm -r typecheck` — all 8 web packages clean.
- `pnpm test:run` — 864 passed, 10 skipped (81 files), including the 3 new/extended suites.

**i18n note**: `NetworkSelector.tsx` is currently unlocalized English (no i18next
namespace — strings like "Custom RPC", "Trusted RPC ingress", "Connect" are
hardcoded). New user-visible strings ("Enter a valid https:// endpoint.", the
network-mismatch message) follow that existing convention rather than expanding
scope to localize the component. Flagging here per the issue's i18n-discipline note.

**check:ci note**: the `check:ci` script's final step is a `wrangler deploy
--dry-run` for `@botho/baas-worker`, which requires Cloudflare auth unavailable
in the build sandbox. The two substantive steps (`pnpm -r typecheck`,
`pnpm test:run`) both pass.

Closes #806