### PR TITLE
docs(security): cycle-8 internal audit report

### DIFF
--- a/audits/2026-07-12-cycle8.md
+++ b/audits/2026-07-12-cycle8.md
@@ -1,0 +1,204 @@
+# Internal Security Audit Report - Cycle 8
+
+**Date**: 2026-07-12
+**Auditor**: Internal (Claude Code assisted, main-session review)
+**Scope**: The 107 commits since cycle 7 (`cd3407a` → `b0c1ad0d`). Focus areas:
+(1) the **entirely-new operator-signed quorum-curation WRITE path** (P4.4: #748/#750/#753/#754/#755/#756 — envelope verify, replay-protected nonce store, gate-routed apply, persisted audit log, browser key-vault + envelope composer #751/#758),
+(2) **consensus deltas** — cluster-tag inheritance bound tightened to per-ring maximum (#713/#581), auto-trusted-peer quorum gate (#680), minting gated on startup fleet-tip sync (#780/#766), picocredits fee/policy migration (#712),
+(3) the **BaaS control-plane** additions — `session_id`→status-token exchange (#808), Resend email delivery, provisioner IAM policy fix,
+(4) **cycle-7 finding closures** — overflow-checks (#671), sentry/rustls-0.23 (#665), cargo-deny gate (#660),
+(5) dependency advisories at the new commit.
+**Commit**: `b0c1ad0d`
+
+---
+
+## Executive Summary
+
+Cycle 8 audits the largest new **attacker-reachable write surface** added since
+the block-acceptance hardening of cycles 6–7: the operator-signed quorum-curation
+path (#709 epic, P4.4). Unlike prior cycles this is a *new* privileged RPC that
+mutates consensus-critical config, so it received the deepest review. The result
+is reassuring — the path is fail-closed, signature-first, replay-safe, and routes
+its apply through the **same** intersection-checked quorum gate as ordinary peer
+churn, so it introduces no second quorum constructor and cannot install a forkable
+set the gate would otherwise refuse.
+
+- **Operator write path (#748/#750/#753/#754/#755/#756) is well-constructed.**
+  The verifier is a first-failure-wins pipeline that places **no secret-dependent
+  check before signature verification** (§9 oracle-risk item): steps 1–2 (config
+  gate, signer selection) are a non-empty test and a fingerprint scan over
+  **public** keys; step 3 verifies Ed25519 over the *received* canonical bytes +
+  domain separator, and only then parses them (**parse-after-verify**, finding 1).
+  Unknown/duplicate top-level JSON keys are rejected, integers-only is enforced
+  (`as_u64` rejects `5.0`), `targetNode` binds the envelope to one node, freshness
+  is saturating-arithmetic bounded (≤300 s lifetime, 30 s skew), and the nonce
+  store is **reserve-then-apply, durably persisted before apply returns**, so a
+  crash in the gap can never let an envelope apply twice. The v1 action allowlist
+  (`pin_member`/`unpin_member`/`set_max_auto_members`) deliberately **excludes**
+  mode/threshold edits, bounding a compromised-dashboard attack to recoverable
+  liveness; a membership-1 hard floor (no override) and a signed
+  `acknowledgeDegenerate` requirement for shrinking below the 4-node BFT floor
+  protect against self-fork.
+- **Audit-log posture (#750) resists log-spam DoS.** Only **authenticated**
+  outcomes append to the JSONL log; pre-signature failures (reachable by any
+  anonymous caller) only bump a counter surfaced in `node_getStatus` and emit
+  **rate-limited** `debug!` — never a file write. This closes the unbounded
+  disk-fill primitive that naive audit logging would open (their "finding 3").
+- **Browser key-vault (#751) has no plaintext path.** The operator secret is
+  wrapped with the wallet's audited `VaultKey` (AES-256-GCM + PBKDF2) under a
+  **mandatory** passphrase, held in a session-only closure with `wipe()`, and never
+  sent to the Pages host. The envelope composer is the sole producer of the signed
+  bytes and re-derives a fresh nonce per envelope (a dry-run and its real apply are
+  distinct signed strings, finding 1).
+- **Consensus deltas are determinism-preserving and tighten, not loosen.** The
+  cluster-tag inflation bound (#713/#581) moved from Σ-over-all-ring-members to
+  Σ-over-rings-of-per-ring-**maximum**, removing the `ring_size` inflation
+  multiplier an attacker could source via cluster-tagged decoys; the fix computes
+  per-member mass (summing a member's own entries) **before** the per-ring max, so
+  it stays liveness-safe even if a tag vector carried duplicate cluster ids. All
+  still pure integer/`BTreeMap` — no fork. The auto-peer quorum gate (#680) and the
+  startup sync gate (#780) are both **local sequencing / admission** changes with
+  no SCP wire-format or validity-function change (no hard fork), and #780 fixes the
+  #766 live halt where a restarted node minted at a stale slot.
+- **BaaS additions preserve the cycle-7 posture.** The new `/session-status` route
+  is a read-only GET that fails closed on missing config, mints a token only from
+  the **Stripe-verified** customer id (never a client-supplied one), and collapses
+  unknown/unpaid/malformed sessions to one generic 401 (no leak). Session ids are
+  shape-checked (`cs_…`) before URL interpolation. The webhook
+  signature-before-side-effect ordering is untouched.
+
+**Cycle-7 findings all closed or on-track:**
+- **D1 (rustls-webpki 0.102.8)** — **CLOSED**. `sentry` is now 0.46.2 (#665) and
+  the vulnerable `rustls-webpki` 0.102.8 is gone from the tree; only the clean
+  `0.103.13` (via `rustls 0.23.35`) remains (`cargo tree -p botho -i rustls-webpki`).
+- **overflow-checks** latent footgun — **CLOSED**. Release profile now sets
+  `overflow-checks = true` with a benched `curve25519-dalek` exemption (#671/#663).
+- **cargo-deny PR gate** (recommended since cycle 6) — **DONE** (#660).
+- **D1 (hickory-proto DNS DoS)** — **carried**; still 0.25.2 (no fixed version;
+  blocked on the libp2p 0.56→0.57 bump), ignored-with-tracking in `deny.toml`, DNS
+  lookups already bounded by a 5 s timeout (#668). NOTE: #659 was closed COMPLETED
+  when its DNS-timeout half landed, so the upstream-bump tracking lapsed — re-opened
+  as **#813** this cycle.
+
+The one **new actionable item** is a dependency delta: a new **unsound** advisory
+in `scc` (via the `serial_test` **dev-dependency**) and the two pre-existing
+**yanked** crates (`core2`, `keccak`) that remain transitive-only. None are
+node-runtime-reachable.
+
+**Overall Status**: Healthy — new operator write path is fail-closed and
+fork-safe; all cycle-7 code findings verified closed; one new dev-only Medium (deps).
+
+| Severity | Cycle 7 open | Cycle 8 new | Verified closed | Open after cycle 8 |
+|----------|--------------|-------------|-----------------|--------------------|
+| Critical | 0            | 0           | —               | 0                  |
+| High     | 1 (H4)       | 0           | —               | 1 (H4, carried/ACCEPTED #715) |
+| Medium   | 6            | 1 (deps)    | 1 (D1 webpki)   | 6                  |
+| Low      | 3            | 0           | —               | 3                  |
+
+---
+
+## Verification of Cycle-7 Findings
+
+| ID | Cycle-7 finding | Cycle-8 status | Evidence |
+|----|-----------------|----------------|----------|
+| D1 (webpki) | rustls-webpki 0.102.8 node-reachable, no in-semver fix | **Closed** | `sentry` 0.46.2 (#665) drops the `rustls 0.22` chain; `cargo tree -p botho -i rustls-webpki` shows only clean 0.103.13 via `rustls 0.23.35` |
+| D1 (hickory) | hickory-proto 0.25.2 DNS DoS ×2, node-reachable | **Carried, tracked** | still 0.25.2 (no fixed version; libp2p 0.56 pin); ignored-with-tracking in `deny.toml` under #659; DNS bounded by 5 s timeout (#668) |
+| overflow-checks | `overflow-checks=false` latent footgun in release | **Closed** | `Cargo.toml:235` `overflow-checks = true`; benched `curve25519-dalek` exemption at `:244` (#671/#663) |
+| cargo-deny gate | CI advisory gate recommended, not wired | **Done** | cargo-deny is now a PR gate (#660); `deny.toml` ignore list justified per-entry |
+| H4 | lottery candidate cap grindability | **Carried (ACCEPTED)** | disposition recorded ACCEPTED in #715/#718 (not re-audited this cycle) |
+
+---
+
+## New Finding
+
+### [MEDIUM] D2: New/residual dependency advisories (all dev- or transitive-only)
+
+**Status**: Open (new; supersedes cycle-7 D1's dependency bookkeeping)
+
+`cargo audit` at `b0c1ad0d` reports 4 items; `cargo deny check advisories` returns
+**ok** (all either clean or justified-ignored). None are botho-node-runtime-reachable:
+
+- **`scc` 2.4.0 — RUSTSEC-2026-0205 (unsound, `Array::insert` double-free if a
+  compare fn panics).** Reached ONLY via `serial_test 3.2.0`, a **dev-dependency**
+  of `bth-consensus-scp` / `botho`. Not in the shipped node binary. *Action: bump
+  `serial_test`/`scc` when a fixed release lands; dev-only, low urgency.*
+- **`rand` 0.7.3 — RUSTSEC-2026-0097.** Reached ONLY via `tauri`→`wry`→`selectors`
+  →`phf` for the **desktop wallet**, not the node. Same disposition as cycle-7.
+- **`core2` 0.4.0 (yanked)** and **`keccak` 0.1.5 (yanked)** — transitive under
+  `libp2p`/`multihash` and the `bth-crypto` merlin/sha3 stack respectively. Yanked,
+  not vulnerable; no drop-in in-tree replacement. *Action: track for the next
+  `libp2p`/crypto bump.*
+
+The hickory-proto DNS advisories remain the only genuinely node-reachable items and
+are carried under #659 (see above). `deny.toml` also still ignores the GTK3/Tauri
+desktop-only unmaintained set (unchanged from cycle 7).
+
+**Recommended action:**
+1. Bump `serial_test` to drop `scc` 2.4.0 when upstream ships a fixed release — **#814**.
+2. Re-check `core2`/`keccak` at the next `libp2p` 0.57 evaluation (also the hickory
+   0.26 path) — **#813** (successor to the closed #659).
+3. No node-runtime exposure — this is dependency hygiene, hence Medium not High.
+
+**Follow-up issues filed this cycle:** #813 (libp2p 0.57 / hickory 0.26 upgrade —
+node-reachable DNS advisories + core2/keccak yanks), #814 (serial_test/scc dev-dep).
+
+---
+
+## What Was Confirmed Healthy (no finding)
+
+- **Operator verifier pipeline** (`operator_action.rs`): config-gate → signer-select
+  (public-key scan) → **signature over received bytes** → parse-after-verify
+  (unknown/dup keys + floats rejected) → target-bind → saturating freshness →
+  reserve-then-apply nonce → payload policy → **existing** gate → install → persist.
+  No secret-dependent check precedes signature verification.
+- **Nonce store** (`operator_nonce.rs`): atomic temp-file+rename+fsync, owner-only
+  `0600`, GC on every reserve, corrupt-file = hard error (never silently reopen a
+  replay slot), in-memory rollback if the durable write fails.
+- **Audit log** (`rpc/operator.rs`): append-only JSONL `0600`; authenticated-only
+  appends; pre-signature failures counter-only + rate-limited trace; poisoned-lock
+  reads return empty (never fabricate); malformed lines skipped on load (observability
+  must not brick the node).
+- **Operator key file** (`operator_key.rs`): Argon2id + ChaCha20-Poly1305, empty
+  passphrase refused, `create_new` no-clobber, `Zeroizing` on the secret scalar.
+- **Loop-side apply** (`commands/run.rs` `process_operator_action`): routes through
+  `gated_scp_quorum_set` on a config **clone**; gate refusal keeps the previous safe
+  set and burns no nonce; `Config::save` failure surfaces truthfully rather than
+  claiming a clean apply (anti-#541).
+- **Quorum gate** (`gated_scp_quorum_set`): auto peers capped + deterministically
+  trimmed by NodeID; every candidate passes `symmetric_quorum_has_intersection`
+  before install; initial-seed refusal falls back to majority (always intersects).
+- **Cluster-tag inheritance bound** (`ledger/store.rs`): per-ring-max, per-member
+  mass summed first; pure integer/`BTreeMap` — deterministic.
+- **BaaS** (`session-status.ts`, `index.ts`): fail-closed config, Stripe-verified
+  customer id only, generic no-leak rejections, `cs_…` shape-check, webhook
+  signature-before-side-effect intact.
+
+---
+
+## Automated Checks
+
+| Check | Cycle 7 | Cycle 8 |
+|-------|---------|---------|
+| `cargo build -p botho --lib` | (not re-run) | **PASS** (47s, 20 warnings, 0 errors) |
+| `cargo deny check advisories` | — | **ok** (all clean or justified-ignored) |
+| `cargo audit` | node-reachable: hickory×2, rustls-webpki×4 | node-reachable: hickory×2 (tracked #659); dev/desktop-only: scc, rand; yanked: core2, keccak. **rustls-webpki cleared.** |
+| Block-acceptance Criticals (C1–C7) | 7 of 7 | unchanged — 7 of 7 (no consensus-acceptance regression in the diff) |
+
+*(Full `cargo test` suite not re-run this cycle; each reviewed feature ships its own
+regression tests — operator envelope/nonce/audit unit tests, the gated-quorum and
+`should_arm_minting` unit matrices, cluster-tag per-ring-max cases, and the
+cross-language canonicalization drift guard #771.)*
+
+---
+
+## Recommendations for Next Audit
+
+1. **Re-deep-audit H4** (lottery candidate-cap grindability) — ACCEPTED in #715 but
+   never re-verified in code since cycle 6; confirm the disposition still holds.
+2. **libp2p 0.57 / hickory 0.26 path (#659)** — the only node-reachable dep item;
+   re-check `core2`/`keccak` yanks fall out with it.
+3. **Operator write path at scale** — this cycle audited the single-node verifier
+   and apply; a future cycle should model an operator-key-compromise scenario across
+   the live fleet (the allowlist bounds it to liveness, but verify recovery via the
+   quorum-edit-recovery runbook #752/#760 end-to-end).
+4. **`serial_test`/`scc` bump** when a fixed release lands (D2).

--- a/audits/README.md
+++ b/audits/README.md
@@ -47,6 +47,7 @@ Security auditing is iterative. Each internal audit:
 |------|---------|-------|----------|------|--------|-----|--------|
 | 2026-07-12 (c8) | Internal | Delta - Operator write path + consensus/BaaS | **0** | **0** | 1 new | 3 | **Healthy** |
 | 2026-07-05 (c7) | Internal | Delta - Verification (block-acceptance + BaaS + u128) | **0** | **0** | 1 new | 3 | **Healthy** |
+| 2026-06-11 (c6) | Internal | Delta - Block-acceptance path + consensus economics | **5** | 6 | 8 | 4 | Issues Found (all Criticals fixed by c7) |
 | 2026-01-03 (c5) | Internal | Full - Post Onion Gossip | **0** | **0** | 6 | 5 | **Clean** |
 | 2026-01-03 (c4) | Internal | Full - Post Security Fixes | **0** | **0** | 6 | 5 | **Clean** |
 | 2026-01-03 (c3) | Internal | Full - Post LION Deprecation | **0** | **0** | 10 | 8 | **Clean** |

--- a/audits/README.md
+++ b/audits/README.md
@@ -45,6 +45,8 @@ Security auditing is iterative. Each internal audit:
 
 | Date | Auditor | Scope | Critical | High | Medium | Low | Status |
 |------|---------|-------|----------|------|--------|-----|--------|
+| 2026-07-12 (c8) | Internal | Delta - Operator write path + consensus/BaaS | **0** | **0** | 1 new | 3 | **Healthy** |
+| 2026-07-05 (c7) | Internal | Delta - Verification (block-acceptance + BaaS + u128) | **0** | **0** | 1 new | 3 | **Healthy** |
 | 2026-01-03 (c5) | Internal | Full - Post Onion Gossip | **0** | **0** | 6 | 5 | **Clean** |
 | 2026-01-03 (c4) | Internal | Full - Post Security Fixes | **0** | **0** | 6 | 5 | **Clean** |
 | 2026-01-03 (c3) | Internal | Full - Post LION Deprecation | **0** | **0** | 10 | 8 | **Clean** |
@@ -63,6 +65,9 @@ External audit will be commissioned when:
 
 ## Report Index
 
+- [2026-07-12 Cycle 8](2026-07-12-cycle8.md) - Operator-signed quorum-curation write path (P4.4), consensus deltas, BaaS status-link; cycle-7 findings closed
+- [2026-07-05 Cycle 7](2026-07-05-cycle7.md) - Verification cycle: block-acceptance C1–C7 confirmed, BaaS worker, u128 widening, dep advisories
+- [2026-06-11 Cycle 6](2026-06-11-cycle6.md) - Block-acceptance hardening, 5 Criticals + Highs
 - [2026-01-03 Cycle 5](2026-01-03-cycle5.md) - Onion Gossip Phase 1 audit, 531 tests (+39%)
 - [2026-01-03 Cycle 4](2026-01-03-cycle4.md) - Security fixes verified, clippy warnings reduced 76%
 - [2026-01-03 Cycle 3](2026-01-03-cycle3.md) - LION deprecation, all Critical/High resolved


### PR DESCRIPTION
## Summary

Internal security audit **cycle 8**, covering the 107 commits since cycle 7 (`cd3407a` → `b0c1ad0d`). Adds `audits/2026-07-12-cycle8.md` and updates the `audits/README.md` index.

**Overall Status: Healthy** — no Critical or High findings. One new dev-only Medium (dependency hygiene). All cycle-7 code findings verified closed.

## Focus: the new operator-signed quorum-curation WRITE path (P4.4)

The deepest review went to the largest new attacker-reachable, consensus-mutating RPC added since the block-acceptance hardening (#748/#750/#753/#754/#755/#756 + browser #751/#758). It holds up:

- **Signature-first, fail-closed verifier** — no secret-dependent check precedes Ed25519 verification; verifies over the *received* canonical bytes then parses (parse-after-verify), rejecting unknown/duplicate keys and floats.
- **Replay-safe** — reserve-then-apply nonce store, durably persisted before apply returns; corrupt store is a hard error (never a silent replay-slot reopen).
- **Fork-safe apply** — routes through the *same* intersection-checked quorum gate as peer churn; membership-1 hard floor + signed `acknowledgeDegenerate` below the BFT floor; allowlist excludes mode/threshold edits.
- **No log-spam DoS** — only authenticated outcomes append to the audit log; anonymous pre-signature failures are counter-only + rate-limited.
- **Browser key-vault** — audited `VaultKey`, mandatory passphrase, session-only secret, no plaintext path.

## Consensus deltas (determinism-preserving)

- Cluster-tag inflation bound tightened to per-ring maximum (#713/#581) — removes the `ring_size` decoy-sourced multiplier.
- Auto-peer quorum gate (#680) and startup fleet-sync minting gate (#780, fixes the #766 live halt) — local sequencing only, no SCP wire/validity change (no hard fork).

## Cycle-7 findings closed

- rustls-webpki 0.102.8 cleared (sentry 0.46.2, #665)
- release `overflow-checks = true` (#671)
- cargo-deny PR gate wired (#660)

## New finding — D2 (Medium, dependency hygiene)

`scc` unsoundness via the `serial_test` **dev-dependency**, plus yanked `core2`/`keccak` transitives. None node-runtime-reachable. hickory-proto DNS advisories remain the only node-reachable deps, carried under #659.

## Checks

- `cargo build -p botho --lib` — PASS (0 errors)
- `cargo deny check advisories` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)