### PR TITLE
docs(decisions): ADR 0002-0005 for the BTH bridge

### DIFF
--- a/docs/decisions/0002-bridge-custody-scp-validator-federation.md
+++ b/docs/decisions/0002-bridge-custody-scp-validator-federation.md
@@ -3,7 +3,7 @@
 **Status**: Accepted
 **Date**: 2026-07-13
 **Decision Makers**: Core Team
-**Related**: [Epic #816](https://github.com/botho-project/botho/issues/816), issues #817, #821, #826, #827; ADR 0003–0005
+**Related**: [Epic #816](https://github.com/botho-project/botho/issues/816), issues #817, #824, #826, #827; ADR 0003–0005
 
 ## Context
 
@@ -21,7 +21,7 @@ Who holds the threshold keys that authorize wBTH minting and BTH reserve release
 
 Concretely:
 
-- **BTH reserve release** is authorized by a t-of-n threshold of the validators' **Ed25519** node keys, reusing the operator-signed-action machinery shipped in P4.4 (`operator_action.rs` domain-separated envelopes, `operator_nonce.rs` reserve-then-apply replay protection, `rpc/operator.rs` audit log). See ADR-linked issue #821 for the attestation protocol.
+- **BTH reserve release** is authorized by a t-of-n threshold of the validators' **Ed25519** node keys, reusing the operator-signed-action machinery shipped in P4.4 (`operator_action.rs` domain-separated envelopes, `operator_nonce.rs` reserve-then-apply replay protection, `rpc/operator.rs` audit log). See ADR-linked issue #824 for the attestation protocol.
 - **Solana wBTH mint** is authorized by the same validators' **Ed25519** keys — Solana uses Ed25519 natively, so no new key type is required.
 - **Ethereum wBTH mint** requires **secp256k1**, which SCP node keys are not. Each validator therefore also operates a secp256k1 signer, and the Ethereum mint authority is a **Gnosis Safe** whose owners are those secp256k1 keys, holding `MINTER_ROLE` on `WrappedBTH.sol` (threshold-ECDSA/TSS is an acceptable alternative producing a single on-chain signature).
 - The **bridge threshold `t` is set no lower than the SCP safety threshold** — it must never be easier to move the reserve than to move consensus.
@@ -30,7 +30,7 @@ Concretely:
 
 ### Positive
 
-1. **Reuses an audited pattern.** The operator-signed-action envelope + nonce + audit-log design was security-reviewed in cycle-8; the attestation protocol (#821) mirrors it rather than inventing new signature-verification code.
+1. **Reuses an audited pattern.** The operator-signed-action envelope + nonce + audit-log design was security-reviewed in cycle-8; the attestation protocol (#824) mirrors it rather than inventing new signature-verification code.
 2. **Fewer distinct trust roots.** Users already trust the validator set for chain safety; no new federation membership/governance surface is introduced.
 3. **Natural Solana fit.** Validators sign Solana authorizations with their existing Ed25519 keys — the second chain adds little custody complexity (ADR 0005).
 
@@ -64,10 +64,10 @@ Concretely:
 
 ## Implementation
 
-See #821 (attestation/authorization protocol), #826 (contract-side threshold mint authority), and #827 (secp256k1 key provisioning + rotation in the ops runbook). Follow-on sub-decisions: exact `t` value and the Safe-vs-TSS choice for the Ethereum side.
+See #824 (attestation/authorization protocol), #826 (contract-side threshold mint authority), and #827 (secp256k1 key provisioning + rotation in the ops runbook). Follow-on sub-decisions: exact `t` value and the Safe-vs-TSS choice for the Ethereum side.
 
 ## References
 
-- Epic #816; issues #817, #821, #826, #827
+- Epic #816; issues #817, #824, #826, #827
 - `botho/src/operator_action.rs`, `botho/src/operator_nonce.rs`, `botho/src/rpc/operator.rs` (reused pattern)
 - ADR 0003 (peg), ADR 0004 (privacy), ADR 0005 (chain scope)

--- a/docs/decisions/0002-bridge-custody-scp-validator-federation.md
+++ b/docs/decisions/0002-bridge-custody-scp-validator-federation.md
@@ -1,0 +1,73 @@
+# ADR 0002: Bridge Custody & Trust Model — SCP Validator Federation
+
+**Status**: Accepted
+**Date**: 2026-07-13
+**Decision Makers**: Core Team
+**Related**: [Epic #816](https://github.com/botho-project/botho/issues/816), issues #817, #821, #826, #827; ADR 0003–0005
+
+## Context
+
+Botho is adding a bridge that locks native BTH and mints a wrapped ERC-20/SPL token (**wBTH**) on Ethereum and Solana, so holders can access DeFi liquidity and move value in and out (see the epic #816). A bridge is the single highest-value attack target in the system: whoever controls the mint authority on the destination chain and the reserve-release authority on Botho can print or drain funds. The existing `bridge/service` scaffold signs releases with a **single hot wallet** (`engine.rs`: "Sign with hot wallet"; config exposes `spend_key_file` / `private_key_file` / `mnemonic_file`) — an unacceptable single point of catastrophic failure.
+
+Botho has no EVM/SVM light client, so neither chain can natively verify the other. Every privileged cross-chain action (mint on a deposit, release on a burn) must therefore be authorized by **signatures from a trusted signer set**, not by on-chain proof of the counterparty chain's state.
+
+## Problem Statement
+
+Who holds the threshold keys that authorize wBTH minting and BTH reserve release, and how are those keys structured so that no single party can move funds?
+
+## Decision
+
+**The bridge federation is the SCP validator set, operating as a t-of-n threshold signer group.** The mechanism is threshold signing on both sides; the signer *identity* is the existing consensus validators rather than a separately-curated federation or a third-party custodian.
+
+Concretely:
+
+- **BTH reserve release** is authorized by a t-of-n threshold of the validators' **Ed25519** node keys, reusing the operator-signed-action machinery shipped in P4.4 (`operator_action.rs` domain-separated envelopes, `operator_nonce.rs` reserve-then-apply replay protection, `rpc/operator.rs` audit log). See ADR-linked issue #821 for the attestation protocol.
+- **Solana wBTH mint** is authorized by the same validators' **Ed25519** keys — Solana uses Ed25519 natively, so no new key type is required.
+- **Ethereum wBTH mint** requires **secp256k1**, which SCP node keys are not. Each validator therefore also operates a secp256k1 signer, and the Ethereum mint authority is a **Gnosis Safe** whose owners are those secp256k1 keys, holding `MINTER_ROLE` on `WrappedBTH.sol` (threshold-ECDSA/TSS is an acceptable alternative producing a single on-chain signature).
+- The **bridge threshold `t` is set no lower than the SCP safety threshold** — it must never be easier to move the reserve than to move consensus.
+
+## Consequences
+
+### Positive
+
+1. **Reuses an audited pattern.** The operator-signed-action envelope + nonce + audit-log design was security-reviewed in cycle-8; the attestation protocol (#821) mirrors it rather than inventing new signature-verification code.
+2. **Fewer distinct trust roots.** Users already trust the validator set for chain safety; no new federation membership/governance surface is introduced.
+3. **Natural Solana fit.** Validators sign Solana authorizations with their existing Ed25519 keys — the second chain adds little custody complexity (ADR 0005).
+
+### Negative
+
+1. **Bridge safety is coupled to consensus safety.** A validator-majority compromise now also drains the reserve, and conversely bridge-key operations must meet validator-grade opsec. The two risk domains are no longer isolated.
+2. **The validator set is small.** It currently has n-of-n fragility below 4 nodes; a small `n` means a small bridge quorum. **Growing and hardening the validator set is now a soft prerequisite** to holding meaningful bridge value.
+3. **Validators must run a second (secp256k1) signer** for the Ethereum side, with its own provisioning, storage, and rotation (tracked in the ops runbook, #827).
+
+### Neutral
+
+1. The Ethereum authority is a Gnosis Safe (v1) rather than threshold-ECDSA — a battle-tested choice that can migrate to TSS later without changing the Botho side.
+2. Bridge threshold `t` and SCP threshold are configured together but remain distinct knobs.
+
+## Alternatives Considered
+
+### 1. Separate curated federation
+
+- Pro: isolates blast radius — a bridge-key compromise does not touch consensus and vice versa.
+- Con: introduces a new signer-set governance/membership surface and a second set of keys to trust; the maintainer preferred not to stand up a distinct trust root.
+
+### 2. Third-party / MPC custody service
+
+- Pro: offloads key-management risk to specialists.
+- Con: adds a trusted third party, recurring cost, and an external dependency contrary to the project's self-sovereign posture.
+
+### 3. Trustless light-client bridge
+
+- Pro: no trusted signer set at all.
+- Con: infeasible — Botho has no EVM/SVM VM to run a counterparty light client, and verifying SCP proofs on Ethereum is impractical. Not available near-term.
+
+## Implementation
+
+See #821 (attestation/authorization protocol), #826 (contract-side threshold mint authority), and #827 (secp256k1 key provisioning + rotation in the ops runbook). Follow-on sub-decisions: exact `t` value and the Safe-vs-TSS choice for the Ethereum side.
+
+## References
+
+- Epic #816; issues #817, #821, #826, #827
+- `botho/src/operator_action.rs`, `botho/src/operator_nonce.rs`, `botho/src/rpc/operator.rs` (reused pattern)
+- ADR 0003 (peg), ADR 0004 (privacy), ADR 0005 (chain scope)

--- a/docs/decisions/0003-wbth-peg-factor-1-wrapping-and-demurrage-settlement.md
+++ b/docs/decisions/0003-wbth-peg-factor-1-wrapping-and-demurrage-settlement.md
@@ -77,7 +77,7 @@ How does the bridge keep `Σ(wBTH outstanding) == locked BTH reserve` given that
 
 ## Implementation
 
-See #831 (the consensus settlement op: charge formula, tag-rewrite rule, inheritance-bound carve-out, lottery routing, ring-signature interaction) and #825 (reserve accounting / proof-of-reserves consuming the factor-1 invariant). The bridge deposit path (#824/#822) enforces factor-1 eligibility before minting.
+See #831 (the consensus settlement op: charge formula, tag-rewrite rule, inheritance-bound carve-out, lottery routing, ring-signature interaction) and #825 (reserve accounting / proof-of-reserves consuming the factor-1 invariant). The bridge deposit path (#823/#821) enforces factor-1 eligibility before minting.
 
 ## References
 

--- a/docs/decisions/0003-wbth-peg-factor-1-wrapping-and-demurrage-settlement.md
+++ b/docs/decisions/0003-wbth-peg-factor-1-wrapping-and-demurrage-settlement.md
@@ -1,0 +1,87 @@
+# ADR 0003: wBTH Peg — Factor-1 Wrapping + Demurrage-Settlement On-ramp
+
+**Status**: Accepted
+**Date**: 2026-07-13
+**Decision Makers**: Core Team
+**Related**: [Epic #816](https://github.com/botho-project/botho/issues/816), issues #818, #825, #831; ADR 0002, 0004, 0005
+
+## Context
+
+The bridge locks native BTH in a reserve and mints wBTH 1:1 on Ethereum/Solana. For the peg to hold, the locked reserve must remain equal to the outstanding wrapped supply **over time**, not just at the instant of locking.
+
+Botho applies **demurrage**: a holding charge on wealthy-cluster coins, paid at spend time, that funds the redistribution lottery pool (`cluster-tax/src/demurrage.rs`). The charge is:
+
+```
+charge = value × rate × (factor − 1)/(max_factor − 1) × elapsed / blocks_per_year
+```
+
+where `factor` is the coin's cluster factor (1.0×–6.0× in `FACTOR_SCALE` units), derived from cluster wealth (`ClusterFactorCurve::factor(cluster_wealth)`). A generic bridge would hit a peg-breaking problem: BTH locked in the reserve would **demur while wrapped**, so the reserve shrinks below the wrapped supply and the bridge silently becomes fractionally reserved.
+
+## Problem Statement
+
+How does the bridge keep `Σ(wBTH outstanding) == locked BTH reserve` given that reserve BTH is subject to demurrage while locked?
+
+## Decision
+
+**Only factor-1 (background/commerce) coins are wrappable, and a new demurrage-settlement operation lets holders pay to reclassify a wealthy coin down to factor-1.** This keeps the peg *by construction* rather than by exemption or rebasing.
+
+1. **Factor-1-only wrapping.** Because of the `(factor − 1)` term, a factor-1 coin pays **exactly zero demurrage, permanently** — independent of `elapsed`. Restricting the reserve to factor-1 coins means the reserve never decays, so the peg invariant holds over time with no special "reserve class" and no consensus exemption. Wrap eligibility is checkable at deposit: the output the bridge receives carries a `ClusterTagVector`, so the bridge reads its factor directly and mints only for factor-1 deposits.
+
+2. **Demurrage-settlement op (the on-ramp).** A holder of a wealthy-cluster coin cannot wrap it directly. A new operation lets them **pay a charge to reclassify the coin to factor-1/background**, after which it is wrappable. The settlement **fee is routed to the redistribution lottery pool** — the same sink demurrage charges already feed. Net effect: the only sanctioned way to shed cluster provenance is to pay for it, and that payment funds redistribution. This is the **one consensus-level piece** of the bridge (new transaction semantics + a validation-rule carve-out in the cluster-tag inheritance bound); it is specified and tracked in **#831**.
+
+3. **Unwrap yields factor-1 provenance.** Releases produce background/factor-1 outputs, matching what went in, so the bridge cannot be used to launder a high-cluster coin into a fresh low-factor one.
+
+4. **Post-wrap demurrage escape is accepted.** Once wrapped, coins sit in transparent wBTH and pay no further demurrage. This is treated as "they settled on the way in," keeping wBTH a clean 1:1 DeFi asset.
+
+## Consequences
+
+### Positive
+
+1. **Peg-stable by construction.** The reserve holds only zero-demurrage coins, so `Σ(wBTH) == reserve` cannot drift from decay — no exemption logic, no rebasing, no operator subsidy.
+2. **No hard fork of a live chain.** Botho is pre-mainnet; the settlement op is added before mainnet, consistent with the no-hard-forks-before-mainnet posture.
+3. **Aligned with the redistribution design.** The settlement charge funds the lottery pool, so wrapping wealthy value becomes a redistribution event rather than an escape hatch — the wealthy pay their demurrage dues to gain DeFi access.
+4. **Cheap eligibility check.** Factor is already carried on outputs; the bridge and the proof-of-reserves reconciler (#825) read it directly.
+
+### Negative
+
+1. **Introduces a consensus-level mechanism.** The settlement op touches the audited cluster-tag inheritance bound (#713/#581) — the one place cluster mass may legitimately drop. It needs consensus-grade determinism and adversarial review (#831), or it becomes a laundering/inflation vector.
+2. **Wealthy holders face friction.** They must settle (pay) before wrapping — intended, but a UX cost that must be surfaced clearly.
+3. **Permanent demurrage escape post-wrap.** A holder can settle once, wrap, and stay in wBTH demurrage-free forever. Accepted as a deliberate economic stance, but it does let sufficiently motivated wealthy value exit the demurrage regime via the bridge.
+
+### Neutral
+
+1. The peg invariant generalizes across chains: `Σ(wBTH on ETH) + Σ(wBTH on SOL) == locked reserve` (ADR 0005).
+2. The settlement charge formula (full prospective demurrage vs. a multiple vs. accrued-to-date) is a follow-on design question resolved in #831; it must be churn-invariant like the existing demurrage.
+
+## Alternatives Considered
+
+### 1. Exempt the reserve from demurrage
+
+- Pro: simple peg; no wrap-eligibility restriction.
+- Con: requires the demurrage mechanism to recognize a special reserve class — a consensus change of similar weight without the redistribution benefit, and a standing carve-out rather than a paid, auditable transition.
+
+### 2. Rebasing wBTH
+
+- Pro: exact 1:1 backing maintained as the reserve demurs.
+- Con: rebasing tokens are composability-hostile in DeFi — undermines the entire reason to wrap.
+
+### 3. Bridge absorbs the decay (operator top-up)
+
+- Pro: users see a clean 1:1 asset.
+- Con: an unbounded operator subsidy and a solvency risk if underfunded.
+
+### 4. wBTH intentionally demurrage-free with no eligibility gate
+
+- Pro: simplest technically.
+- Con: lets any wealthy coin escape demurrage by wrapping with no settlement — a straight redistribution leak, not a paid transition.
+
+## Implementation
+
+See #831 (the consensus settlement op: charge formula, tag-rewrite rule, inheritance-bound carve-out, lottery routing, ring-signature interaction) and #825 (reserve accounting / proof-of-reserves consuming the factor-1 invariant). The bridge deposit path (#824/#822) enforces factor-1 eligibility before minting.
+
+## References
+
+- Epic #816; issues #818, #825, #831
+- `cluster-tax/src/demurrage.rs`, `cluster-tax/src/fee_curve.rs` (`cluster_factor`), `cluster-tax/src/lottery.rs`
+- `botho/src/ledger/store.rs` `check_cluster_tag_inheritance` (#713/#581 bound the settlement op must coordinate with)
+- ADR 0002 (custody), ADR 0004 (privacy), ADR 0005 (chain scope)

--- a/docs/decisions/0004-bridge-privacy-semantics.md
+++ b/docs/decisions/0004-bridge-privacy-semantics.md
@@ -3,7 +3,7 @@
 **Status**: Accepted
 **Date**: 2026-07-13
 **Decision Makers**: Core Team
-**Related**: [Epic #816](https://github.com/botho-project/botho/issues/816), issues #819, #823, #824, #826; ADR 0002, 0003, 0005
+**Related**: [Epic #816](https://github.com/botho-project/botho/issues/816), issues #819, #822, #823, #826; ADR 0002, 0003, 0005
 
 ## Context
 
@@ -56,9 +56,9 @@ Specifically:
 
 ## Implementation
 
-The lock-side amount-revelation mechanism (commitment opening vs. cleartext) is pinned in #824 (deposit watcher). Fresh-stealth release is enforced in #823. The user-facing "wrapping exits the anonymity set" warning is a wallet/UX task. A privacy design note documenting the accepted vectors goes under `docs/security/`.
+The lock-side amount-revelation mechanism (commitment opening vs. cleartext) is pinned in #823 (deposit watcher). Fresh-stealth release is enforced in #822. The user-facing "wrapping exits the anonymity set" warning is a wallet/UX task. A privacy design note documenting the accepted vectors goes under `docs/security/`.
 
 ## References
 
-- Epic #816; issues #819, #823, #824
+- Epic #816; issues #819, #822, #823
 - ADR 0002 (custody), ADR 0003 (peg), ADR 0005 (chain scope)

--- a/docs/decisions/0004-bridge-privacy-semantics.md
+++ b/docs/decisions/0004-bridge-privacy-semantics.md
@@ -1,0 +1,64 @@
+# ADR 0004: Bridge Privacy Semantics
+
+**Status**: Accepted
+**Date**: 2026-07-13
+**Decision Makers**: Core Team
+**Related**: [Epic #816](https://github.com/botho-project/botho/issues/816), issues #819, #823, #824, #826; ADR 0002, 0003, 0005
+
+## Context
+
+Botho is privacy-by-default: senders are hidden in CLSAG rings, recipients receive to one-time stealth addresses, and amounts are hidden in Pedersen commitments. wBTH on Ethereum and Solana is fully transparent. The bridge is therefore a deliberate privacy boundary, and its exact leakage semantics must be designed rather than left implicit.
+
+## Problem Statement
+
+What privacy does a user retain when wrapping BTH into wBTH and unwrapping back, and how hard should v1 work to limit deanonymization at the boundary?
+
+## Decision
+
+**v1 re-shields the recipient on unwrap by releasing to a fresh one-time stealth address, and accepts the residual amount + timing correlation across the bridge as documented behavior.** Denomination-bucketing and randomized-delay unlinkability is deferred to a later privacy enhancement.
+
+Specifically:
+
+1. **Lock reveals the amount.** To mint the correct wBTH, the bridge must learn the deposited amount — via a verified Pedersen commitment opening or a cleartext amount on the deposit to the bridge address. This is an unavoidable, deliberate privacy exit. The design must ensure it leaks only the amount, not the source ring.
+2. **The wrapped side is public.** Anyone holding/moving wBTH is linkable on Ethereum/Solana. The wallet UX must warn clearly that **wrapping exits the anonymity set.**
+3. **Unwrap re-shields the recipient.** A burn → release pays out to a **fresh one-time stealth address** (never a reused address), breaking the on-Botho link to the destination-chain burn. The `WrappedBTH.bridgeBurn` `bthAddress` path must resolve to a fresh stealth output.
+4. **Residual leakage is documented and accepted for v1.** Amount correlation and timing correlation across the bridge remain. Bucketing + delay would break them but adds real UX friction and engine complexity; it is a later enhancement, not a v1 requirement.
+
+## Consequences
+
+### Positive
+
+1. **Recipient unlinkability on the way back in.** Unwrapped funds land at a fresh stealth address, so the released BTH is not trivially tied to the burner's transparent-chain identity.
+2. **Ships v1 without heavy machinery.** No denomination protocol or timing-mix engine is required to launch.
+3. **Honest threat model.** The exact vectors are written down (see the privacy design note under `docs/security/`), so users and integrators understand the trade-off.
+
+### Negative
+
+1. **Amount + timing correlation persists.** An observer correlating a distinctive wrap amount with a same-size unwrap shortly after can link the two ends. Sophisticated deanonymization at the boundary is possible in v1.
+2. **Wrapping is a one-way privacy exit** for the wrapped value while it stays on the transparent chain.
+
+### Neutral
+
+1. Because only factor-1/background coins are wrappable (ADR 0003), the amount revealed at lock is of a background coin — the cluster/wealth dimension is already the least sensitive class.
+2. Bucketing/delay remains an open future enhancement, tracked separately if pursued.
+
+## Alternatives Considered
+
+### 1. Buckets + randomized delay to break correlation
+
+- Pro: meaningfully breaks amount + timing linkage across the bridge.
+- Con: real UX friction (fixed denominations, added latency) and engine complexity; deferred rather than blocking v1.
+
+### 2. No re-shield promise (fully public)
+
+- Pro: least work.
+- Con: weakest privacy story for a privacy chain; rejected — re-shielding on release is cheap and worth it.
+
+## Implementation
+
+The lock-side amount-revelation mechanism (commitment opening vs. cleartext) is pinned in #824 (deposit watcher). Fresh-stealth release is enforced in #823. The user-facing "wrapping exits the anonymity set" warning is a wallet/UX task. A privacy design note documenting the accepted vectors goes under `docs/security/`.
+
+## References
+
+- Epic #816; issues #819, #823, #824
+- ADR 0002 (custody), ADR 0003 (peg), ADR 0005 (chain scope)

--- a/docs/decisions/0005-bridge-v1-chain-scope-ethereum-and-solana.md
+++ b/docs/decisions/0005-bridge-v1-chain-scope-ethereum-and-solana.md
@@ -32,7 +32,7 @@ Does bridge v1 launch Ethereum-only, or Ethereum and Solana together?
 
 ### Neutral
 
-1. Solana finality/commitment semantics differ from Ethereum confirmations; the watchers (#824) handle each chain's reorg/finality model separately.
+1. Solana finality/commitment semantics differ from Ethereum confirmations; the watchers (#823) handle each chain's reorg/finality model separately.
 2. If schedule pressure emerges, Ethereum can still ship first with Solana following — the decision commits to both in scope, not to simultaneous release under all conditions.
 
 ## Alternatives Considered
@@ -44,7 +44,7 @@ Does bridge v1 launch Ethereum-only, or Ethereum and Solana together?
 
 ## Implementation
 
-Ripples into #822 (mint on both chains), #823/#824 (release + watchers handle burns from either chain), #826 (harden both `WrappedBTH.sol` and the `wbth` Anchor program), #825 (two-chain peg invariant), #828/#829 (test both — EVM fork tests and Solana test-validator), and #830 (audit both, including an external audit of each token program).
+Ripples into #821 (mint on both chains), #822/#823 (release + watchers handle burns from either chain), #826 (harden both `WrappedBTH.sol` and the `wbth` Anchor program), #825 (two-chain peg invariant), #828/#829 (test both — EVM fork tests and Solana test-validator), and #830 (audit both, including an external audit of each token program).
 
 ## References
 

--- a/docs/decisions/0005-bridge-v1-chain-scope-ethereum-and-solana.md
+++ b/docs/decisions/0005-bridge-v1-chain-scope-ethereum-and-solana.md
@@ -1,0 +1,52 @@
+# ADR 0005: Bridge v1 Chain Scope — Ethereum and Solana
+
+**Status**: Accepted
+**Date**: 2026-07-13
+**Decision Makers**: Core Team
+**Related**: [Epic #816](https://github.com/botho-project/botho/issues/816), issue #820; ADR 0002–0004
+
+## Context
+
+The existing bridge scaffold already models both Ethereum (`contracts/ethereum/contracts/WrappedBTH.sol`, `EthereumConfig`) and Solana (`contracts/solana/programs/wbth`, `SolanaConfig`). The first bridge release must pick which chains it ships and audits.
+
+## Problem Statement
+
+Does bridge v1 launch Ethereum-only, or Ethereum and Solana together?
+
+## Decision
+
+**Bridge v1 ships both Ethereum and Solana.** Every downstream work item (mint, release, watchers, contract hardening, reserve accounting, testing, audit) covers both chains.
+
+## Consequences
+
+### Positive
+
+1. **Both major DeFi ecosystems at launch.** Users reach Ethereum and Solana liquidity from day one.
+2. **Solana is comparatively cheap on the custody axis.** Solana uses **Ed25519**, the same key type as Botho node keys, so the SCP-validator federation (ADR 0002) signs Solana mint authorizations natively — only the Ethereum side needs the secp256k1/Gnosis-Safe detour. The added chain is lighter than a second EVM chain would be.
+3. **The peg invariant generalizes cleanly:** `Σ(wBTH on ETH) + Σ(wBTH on SOL) == locked BTH reserve` (ADR 0003, #825).
+
+### Negative
+
+1. **Larger surface.** Implementation, testing, and audit roughly double versus Ethereum-only: two mint paths (alloy + Anchor CPI), two burn watchers, two token programs to harden, and two contract audits.
+2. **Slower to a safe launch.** Both chains must clear the Phase-3 security gate (#830) before any mainnet value — the audit scope now spans Solidity and the Anchor program.
+
+### Neutral
+
+1. Solana finality/commitment semantics differ from Ethereum confirmations; the watchers (#824) handle each chain's reorg/finality model separately.
+2. If schedule pressure emerges, Ethereum can still ship first with Solana following — the decision commits to both in scope, not to simultaneous release under all conditions.
+
+## Alternatives Considered
+
+### 1. Ethereum-only for v1 (original recommendation)
+
+- Pro: minimal custody/testing/audit surface; fastest path to a safe, audited launch; Ethereum is where the deepest DeFi liquidity is.
+- Con: leaves the already-scaffolded Solana program unused and Solana users unserved at launch. The maintainer chose to serve both.
+
+## Implementation
+
+Ripples into #822 (mint on both chains), #823/#824 (release + watchers handle burns from either chain), #826 (harden both `WrappedBTH.sol` and the `wbth` Anchor program), #825 (two-chain peg invariant), #828/#829 (test both — EVM fork tests and Solana test-validator), and #830 (audit both, including an external audit of each token program).
+
+## References
+
+- Epic #816; issue #820
+- ADR 0002 (custody), ADR 0003 (peg), ADR 0004 (privacy)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -18,6 +18,10 @@ ADRs are immutable once accepted. If a decision changes, a new ADR supersedes th
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
 | [0001](0001-deprecate-lion-ring-signatures.md) | Deprecate LION Ring Signatures | Accepted | 2026-01-03 |
+| [0002](0002-bridge-custody-scp-validator-federation.md) | Bridge Custody & Trust Model — SCP Validator Federation | Accepted | 2026-07-13 |
+| [0003](0003-wbth-peg-factor-1-wrapping-and-demurrage-settlement.md) | wBTH Peg — Factor-1 Wrapping + Demurrage-Settlement On-ramp | Accepted | 2026-07-13 |
+| [0004](0004-bridge-privacy-semantics.md) | Bridge Privacy Semantics | Accepted | 2026-07-13 |
+| [0005](0005-bridge-v1-chain-scope-ethereum-and-solana.md) | Bridge v1 Chain Scope — Ethereum and Solana | Accepted | 2026-07-13 |
 
 ## ADR Statuses
 


### PR DESCRIPTION
## Summary

Records the four Phase-0 bridge decisions (epic #816) as ADRs, following the `docs/decisions/` process. Companion to the implementation-task breakdowns now posted on issues #821–#827 and #831.

| ADR | Decision |
|-----|----------|
| [0002](https://github.com/botho-project/botho/blob/docs/bridge-decisions-adr/docs/decisions/0002-bridge-custody-scp-validator-federation.md) | **Custody** — reuse the SCP validator set as the t-of-n federation. Ed25519 for BTH + Solana; secp256k1 via a Gnosis Safe (`MINTER_ROLE`) for Ethereum. Bridge threshold ≥ SCP safety threshold. |
| [0003](https://github.com/botho-project/botho/blob/docs/bridge-decisions-adr/docs/decisions/0003-wbth-peg-factor-1-wrapping-and-demurrage-settlement.md) | **Peg** — factor-1-only wrapping (background coins pay zero demurrage → reserve peg-stable by construction) + a demurrage-settlement on-ramp whose fee funds the lottery pool (#831). |
| [0004](https://github.com/botho-project/botho/blob/docs/bridge-decisions-adr/docs/decisions/0004-bridge-privacy-semantics.md) | **Privacy** — fresh stealth address on release; residual amount/timing correlation documented + accepted for v1. |
| [0005](https://github.com/botho-project/botho/blob/docs/bridge-decisions-adr/docs/decisions/0005-bridge-v1-chain-scope-ethereum-and-solana.md) | **Scope** — Ethereum AND Solana in v1 (Solana signs natively with Ed25519). |

## Key consequence captured

ADR 0003's settlement op is the **one consensus-level piece** of the bridge (new tx semantics + a tightly-bounded carve-out in the #713/#581 cluster-tag inheritance rule). Everything else is an application-level service. Pre-mainnet, so not a live-chain fork.

## Follow-through (not in this PR)

Each implementation issue (#821–#827, #831) now carries a granular, code-anchored task checklist + test tasks derived from these decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)