### PR TITLE
security(deps): bump serial_test to 3.5.0 to drop scc 2.4.0 unsoundness (RUSTSEC-2026-0205)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2580,7 +2580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.112",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7864,15 +7864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7964,12 +7955,6 @@ dependencies = [
  "quote",
  "syn 2.0.112",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdp"
@@ -8291,23 +8276,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Closes #814

## Summary

Cycle-8 audit finding D2: `cargo audit` flagged **RUSTSEC-2026-0205** (`scc` 2.4.0 — `Array::insert` violates exception safety if the compare fn panics, potential double-free, informational/unsound). It was reached only via `serial_test 3.2.0`, a dev-dependency of `bth-consensus-scp` and `botho` — no runtime exposure in the shipped binary.

**Resolution (path a — upstream fix exists):** `serial_test 3.5.0` dropped its `scc` dependency entirely. The workspace requirement is already `serial_test = "3"`, so this is a **lockfile-only** change: `cargo update -p serial_test --precise 3.5.0` removes `scc 2.4.0` and `sdd 3.0.10` from the graph outright (better than bumping scc past the patched 3.8.4 — the crate is simply gone).

No changes to Cargo.toml or deny.toml. The pre-existing `advisory-not-detected` warning for RUSTSEC-2025-0119 in deny.toml is unrelated (fires in CI but not on some local cargo-deny versions; the in-file comment says to keep the ignore).

## Test Plan

- [x] `grep scc Cargo.lock` — scc no longer present; `cargo tree -i scc` confirms nothing pulls it
- [x] `cargo deny check advisories` (CI gate) — `advisories ok`
- [x] `cargo audit --json` — RUSTSEC-2026-0205 absent from both vulnerabilities and warnings; the 4 remaining vulns are the known justified-ignored set (RUSTSEC-2026-0118/0119 hickory-proto → #659, RUSTSEC-2026-0194/0195 quick-xml desktop-only)
- [x] `cargo test -p bth-consensus-scp` — 100 passed, 0 failed, 2 ignored (serial_test is exercised at test runtime; suite is green on 3.5.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)