### PR TITLE
fix(web-wallet): distinct poll-exhausted state on success page (no email over-promise)

### DIFF
--- a/web/packages/web-wallet/src/locales/en/node.json
+++ b/web/packages/web-wallet/src/locales/en/node.json
@@ -54,6 +54,7 @@
     "viewStatus": "View your node status",
     "linkError": "We couldn't confirm this checkout. If you just paid, refresh in a moment; otherwise start over from the node page.",
     "noSession": "Your subscription is being set up. Check your email for a secure link to your node's status page.",
+    "stillProvisioning": "Your node is still being set up. Refresh this page in a minute to get your secure status link.",
     "openWallet": "Open Wallet",
     "backToHome": "Back to home"
   },

--- a/web/packages/web-wallet/src/locales/es/node.json
+++ b/web/packages/web-wallet/src/locales/es/node.json
@@ -54,6 +54,7 @@
     "viewStatus": "Ver el estado de tu nodo",
     "linkError": "No pudimos confirmar este pago. Si acabas de pagar, actualiza en un momento; si no, vuelve a empezar desde la página del nodo.",
     "noSession": "Tu suscripción se está configurando. Revisa tu correo para encontrar un enlace seguro a la página de estado de tu nodo.",
+    "stillProvisioning": "Tu nodo todavía se está configurando. Actualiza esta página en un minuto para obtener tu enlace seguro de estado.",
     "openWallet": "Abrir el monedero",
     "backToHome": "Volver al inicio"
   },

--- a/web/packages/web-wallet/src/pages/node-success.test.tsx
+++ b/web/packages/web-wallet/src/pages/node-success.test.tsx
@@ -4,8 +4,9 @@
  * Success-page (`NodeSuccessPage`) state coverage (#805 part 1). The page
  * exchanges Stripe's `session_id` for a magic-link status URL via the
  * control-plane Worker, polling while provisioning lands. These tests assert the
- * pending → ready transition, the terminal-error state, and the no-session
- * fallback, with `fetchSessionStatus` mocked (no network).
+ * pending → ready transition, the terminal-error state, the no-session
+ * fallback, and the poll-exhausted fallback (#809 — must NOT promise an email,
+ * which is env-gated), with `fetchSessionStatus` mocked (no network).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, waitFor } from '@testing-library/react'
@@ -40,6 +41,7 @@ describe('NodeSuccessPage', () => {
   })
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     window.history.replaceState({}, '', '/node/success')
   })
 
@@ -78,6 +80,23 @@ describe('NodeSuccessPage', () => {
     await waitFor(() => expect(screen.getByText('View your node status')).toBeTruthy(), {
       timeout: 6000,
     })
+  })
+
+  it('shows the still-provisioning fallback (no email promise) when polling exhausts', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/node/success?session_id=cs_test_slow')
+    // Provisioning never lands within the attempt cap.
+    fetchSessionStatusMock.mockResolvedValue({ kind: 'pending' })
+    renderSuccess()
+    // Drain the initial poll plus every retry interval up to the cap (20 × 3s).
+    for (let i = 0; i < 20; i++) {
+      await vi.advanceTimersByTimeAsync(3000)
+    }
+    expect(fetchSessionStatusMock).toHaveBeenCalledTimes(20)
+    // Poll-exhaustion copy asks the user to refresh — it must NOT promise an
+    // email (the status email is env-gated; #809).
+    expect(screen.getByText(/still being set up/i)).toBeTruthy()
+    expect(screen.queryByText(/check your email/i)).toBeNull()
   })
 
   it('shows the terminal error state on a 401 (stops polling)', async () => {

--- a/web/packages/web-wallet/src/pages/node.tsx
+++ b/web/packages/web-wallet/src/pages/node.tsx
@@ -256,7 +256,7 @@ function NodePageShell({ children }: { children: React.ReactNode }) {
 
 /** Delay (ms) between `/session-status` polls while provisioning is pending. */
 const SESSION_POLL_INTERVAL_MS = 3000
-/** Stop polling after this many attempts (~1 min at 3s) — the email is the fallback. */
+/** Stop polling after this many attempts (~1 min at 3s) — then ask the user to refresh. */
 const SESSION_POLL_MAX_ATTEMPTS = 20
 
 /** Exchange state for the success page's `session_id` → status-link poll. */
@@ -265,6 +265,7 @@ type SessionExchangeState =
   | { kind: 'ready'; statusUrl: string }
   | { kind: 'error' }
   | { kind: 'no-session' }
+  | { kind: 'poll-exhausted' }
 
 /**
  * Post-checkout success page (#458 §4, #805 part 1). Stripe redirects here after
@@ -275,7 +276,9 @@ type SessionExchangeState =
  *   - pending: a spinner while the node comes up,
  *   - ready:   a "View your node status" link,
  *   - error:   a fallback if the session can't be confirmed,
- *   - no-session: the plain confirmation when no `session_id` is present.
+ *   - no-session: the plain confirmation when no `session_id` is present,
+ *   - poll-exhausted: provisioning outlasted the poll cap — ask the user to
+ *     refresh (no email promise: the status email is env-gated, #809).
  */
 export function NodeSuccessPage() {
   const { t } = useTranslation('node')
@@ -302,7 +305,7 @@ export function NodeSuccessPage() {
         }
         // pending → keep polling until we hit the attempt cap.
         if (attempts >= SESSION_POLL_MAX_ATTEMPTS) {
-          setState({ kind: 'no-session' })
+          setState({ kind: 'poll-exhausted' })
           return
         }
         timer = setTimeout(() => void poll(), SESSION_POLL_INTERVAL_MS)
@@ -313,9 +316,9 @@ export function NodeSuccessPage() {
           setState({ kind: 'error' })
           return
         }
-        // Transient error: retry until the cap, then fall back to the email note.
+        // Transient error: retry until the cap, then ask the user to refresh.
         if (attempts >= SESSION_POLL_MAX_ATTEMPTS) {
-          setState({ kind: 'no-session' })
+          setState({ kind: 'poll-exhausted' })
           return
         }
         timer = setTimeout(() => void poll(), SESSION_POLL_INTERVAL_MS)
@@ -365,6 +368,10 @@ export function NodeSuccessPage() {
 
         {state.kind === 'no-session' && (
           <p className="text-sm text-ghost mb-6">{t('success.noSession')}</p>
+        )}
+
+        {state.kind === 'poll-exhausted' && (
+          <p className="text-sm text-ghost mb-6">{t('success.stillProvisioning')}</p>
         )}
 
         <div className="flex flex-col gap-3">


### PR DESCRIPTION
Closes #809

## Problem

`NodeSuccessPage` reused the `no-session` state — and its `success.noSession` copy, "Check your email for a secure link…" — as the terminal fallback when the `/session-status` poll exhausted its attempt cap (`SESSION_POLL_MAX_ATTEMPTS`, ~1 min) or when transient errors persisted. The status email (PR #808 part 2, Resend) is env-gated: with `RESEND_API_KEY` unset the webhook never sends it. So a valid, paid checkout with merely slow provisioning told the user to check an email that may never arrive.

## Fix

- Added a distinct `poll-exhausted` member to `SessionExchangeState`; both exhaustion paths (pending cap and persistent transient error) now set it instead of `no-session`.
- `no-session` + `success.noSession` remain reserved for the genuine missing-`session_id` case.
- New `success.stillProvisioning` copy (English + Spanish) asks the user to refresh the page — no email promise: "Your node is still being set up. Refresh this page in a minute to get your secure status link." A refresh restarts the poll with the same `session_id`, landing on the `ready` state's status link once provisioning finishes (no `statusUrl` exists yet at exhaustion time, so a refresh is the recovery path).
- Test: fake-timer coverage that draining the 20-attempt cap renders the refresh copy and not the email copy.

## Test Plan

- [x] `pnpm -r typecheck` — all packages pass
- [x] `pnpm test:run` — 865 passed, 10 skipped (88 files), including the new poll-exhaustion test and the existing node-success + node.i18n suites
- [x] `pnpm --filter @botho/web-wallet build` — production build (tsc + vite) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)