### PR TITLE
chore(deny): point hickory/libp2p ignore comments at live tracker #813

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -47,21 +47,25 @@ ignore = [
     # --- Cycle-7 audit (issue #658) --------------------------------------
     # Advisories firing against the live RustSec DB as of 2026-07-05 that have
     # no in-semver fix available or whose fix is deferred. Each is justified
-    # below. The hickory/libp2p upgrade path is tracked in follow-up issue #659
-    # (Slice B); the DNS advisories are node-reachable and monitored there.
+    # below. The hickory/libp2p upgrade path is tracked in issue #813
+    # (successor to closed #659); the DNS advisories are node-reachable and
+    # monitored there.
 
     # hickory-proto 0.25.2 - node-reachable DNS resolver (libp2p-dns / mdns).
-    # Fix requires hickory >=0.26.1, blocked on the libp2p 0.56 -> 0.57 upgrade.
-    "RUSTSEC-2026-0119",  # hickory-proto O(n^2) CPU exhaustion on name compression (#659)
-    "RUSTSEC-2026-0118",  # hickory-proto NSEC3 unbounded loop - no fixed version exists; monitor (#659)
+    # Fix requires hickory >=0.26.1, blocked on the libp2p 0.56 -> 0.57 upgrade
+    # (rust-libp2p master is already on hickory 0.26.1; 0.57 not yet released
+    # as of 2026-07-13). Blast radius capped by the query_dns_seeds() timeout
+    # (#668).
+    "RUSTSEC-2026-0119",  # hickory-proto O(n^2) CPU exhaustion on name compression (#813)
+    "RUSTSEC-2026-0118",  # hickory-proto NSEC3 unbounded loop - no fixed version exists; monitor (#813)
 
     # quick-xml 0.38.4 - desktop-wallet only (tauri/plist), not node-reachable.
     "RUSTSEC-2026-0194",  # quick-xml quadratic duplicate-attribute check (desktop-only)
     "RUSTSEC-2026-0195",  # quick-xml unbounded namespace-declaration allocation (desktop-only)
 
     # core2 0.4.0 - yanked/unmaintained, libp2p -> multihash transitive.
-    # No fix until the libp2p upgrade (#659). Warning-level.
-    "RUSTSEC-2026-0105",  # core2 unmaintained/yanked (libp2p transitive, #659)
+    # No fix until the libp2p upgrade (#813). Warning-level.
+    "RUSTSEC-2026-0105",  # core2 unmaintained/yanked (libp2p transitive, #813)
 
     # bincode 1.3.3 - unmaintained; no safe upgrade (2.x is a different API).
     "RUSTSEC-2025-0141",  # bincode unmaintained (no safe upgrade)


### PR DESCRIPTION
## Summary

Tracking-only follow-up for #813 (successor to closed #659). The full libp2p upgrade is **not yet possible upstream**, so this PR does the actionable subset: re-point the `deny.toml` ignore comments for the hickory advisories (RUSTSEC-2026-0118 / RUSTSEC-2026-0119) and the core2 yank (RUSTSEC-2026-0105) from the closed #659 to the live tracker #813, and record the current upstream state inline.

## Upstream state (2026-07-13)

- Latest libp2p release is **0.56.0** — no 0.57 exists. `libp2p-dns 0.44.0` pins `hickory-resolver ^0.25.2`; `libp2p-mdns 0.48.0` pins `hickory-proto ^0.25.2`.
- rust-libp2p `master` has already moved to hickory **0.26.1**, so the next release should clear RUSTSEC-2026-0119.
- hickory-resolver 0.26.1 is out, but bumping only our direct pin would not remove hickory-proto 0.25.2 from the node's tree (libp2p 0.56 still pulls it) and would duplicate the dependency, so the direct pin holds until the libp2p bump.
- RUSTSEC-2026-0118 still has no fixed version anywhere; remains accept-and-monitor.

Full details posted on the issue: https://github.com/botho-project/botho/issues/813#issuecomment-4959636429

**Updates #813** — deliberately NOT "Closes": the issue stays open to track the actual libp2p 0.56 → 0.57 upgrade once upstream releases.

## Test Plan

- [x] `cargo deny check advisories` passes in the worktree (`advisories ok`; the only warning is the pre-existing, comment-documented `RUSTSEC-2025-0119` advisory-not-detected case).
- [x] Comment-only change to `deny.toml` — no ignore entries added or removed, no dependency changes, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)