### PR TITLE
bridge: implement Ethereum wBTH mint via alloy (replace engine.rs TODO)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,611 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-trie",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5cc30538e90795a57647bef8d8864aad6e8d86190617009b4ef8d8b647b49a"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "phf 0.14.0",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "alloy-tx-macros",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.6",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-core"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more 2.1.1",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more 2.1.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 2.1.1",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "indexmap 2.12.1",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.4",
+ "rapidhash",
+ "ruint",
+ "rustc-hash 2.1.1",
+ "secp256k1 0.31.1",
+ "serde",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru 0.16.4",
+ "parking_lot",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.6",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.12.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "sha3 0.11.0",
+ "syn 2.0.112",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
+dependencies = [
+ "alloy-json-abi",
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.112",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
+dependencies = [
+ "alloy-json-rpc",
+ "auto_impl",
+ "base64 0.22.1",
+ "derive_more 2.1.1",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "itertools 0.14.0",
+ "reqwest 0.13.4",
+ "serde_json",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 2.1.1",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +826,269 @@ dependencies = [
  "blake2",
  "cpufeatures 0.2.17",
  "password-hash",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
+dependencies = [
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -467,10 +1335,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -674,12 +1576,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
+dependencies = [
+ "bitcoin-internals",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
+dependencies = [
+ "hex-conservative 0.3.2",
+]
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
+
+[[package]]
 name = "bitcoin_hashes"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
- "hex-conservative",
+ "bitcoin-io",
+ "hex-conservative 0.2.2",
 ]
 
 [[package]]
@@ -728,6 +1658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array 0.4.10",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +1682,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
 ]
 
 [[package]]
@@ -835,7 +1786,7 @@ dependencies = [
  "rand_distr",
  "randomx-rs",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "rpassword",
  "rustls",
@@ -901,7 +1852,7 @@ dependencies = [
  "hex",
  "rand 0.8.6",
  "rand_core 0.6.4",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tempfile",
@@ -919,7 +1870,7 @@ dependencies = [
  "axum 0.7.9",
  "chrono",
  "clap",
- "reqwest",
+ "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
@@ -944,7 +1895,7 @@ dependencies = [
  "bth-wasm-signer",
  "hex",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -976,7 +1927,7 @@ dependencies = [
  "hex",
  "libc",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "rpassword",
  "serde",
  "serde_json",
@@ -1069,6 +2020,8 @@ dependencies = [
  "chrono",
  "hex",
  "serde",
+ "serde_json",
+ "sha2",
  "toml 0.9.10+spec-1.1.0",
  "uuid",
 ]
@@ -1077,10 +2030,15 @@ dependencies = [
 name = "bth-bridge-service"
 version = "0.3.2"
 dependencies = [
+ "alloy",
+ "async-trait",
  "bth-bridge-core",
  "chrono",
  "clap",
+ "hex",
  "rusqlite",
+ "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tracing",
@@ -1127,7 +2085,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.10.8",
  "siphasher 1.0.1",
  "tracing",
  "tracing-subscriber",
@@ -1303,7 +2261,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rand_hc 0.3.2",
  "schnorrkel-og",
- "semver",
+ "semver 1.0.27",
  "serde",
  "serde_json",
  "sha2",
@@ -1403,7 +2361,7 @@ dependencies = [
  "k256",
  "rand 0.8.6",
  "sha2",
- "sha3",
+ "sha3 0.10.8",
  "thiserror 1.0.69",
  "tiny-bip39",
  "zeroize",
@@ -1696,7 +2654,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_derive",
- "sha3",
+ "sha3 0.10.8",
  "subtle",
 ]
 
@@ -1768,6 +2726,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "c-kzg"
+version = "2.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,7 +2791,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.27",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -1832,7 +2805,7 @@ checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.27",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -2134,6 +3107,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,6 +3161,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -2491,7 +3485,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "rand_core 0.6.4",
- "rustc_version",
+ "rustc_version 0.4.1",
  "serde",
  "subtle",
  "zeroize",
@@ -2514,8 +3508,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -2533,12 +3537,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.112",
 ]
@@ -2580,7 +3609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -2653,16 +3682,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "syn 2.0.112",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.112",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2671,7 +3743,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
@@ -2683,6 +3755,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
+ "block-buffer 0.12.1",
  "crypto-common 0.2.2",
 ]
 
@@ -2877,6 +3950,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature 2.2.0",
  "spki 0.7.3",
 ]
@@ -2909,10 +3983,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -2931,6 +4020,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2943,7 +4033,7 @@ checksum = "55a075fc573c64510038d7ee9abc7990635863992f83ebc52c8b433b8411a02e"
 dependencies = [
  "cc",
  "memchr",
- "rustc_version",
+ "rustc_version 0.4.1",
  "toml 0.9.10+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
@@ -2980,6 +4070,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
@@ -3068,6 +4178,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,7 +4240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset 0.9.1",
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -3150,6 +4282,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -3201,6 +4339,12 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3344,6 +4488,12 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
+
+[[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "fxhash"
@@ -3780,7 +4930,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -3788,6 +4938,22 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashlink"
@@ -3868,6 +5034,15 @@ name = "hex-conservative"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
 ]
@@ -4531,6 +5706,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4568,7 +5761,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -4576,10 +5769,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.112",
+]
 
 [[package]]
 name = "jobserver"
@@ -4633,6 +5875,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2",
  "signature 2.2.0",
 ]
@@ -4654,6 +5897,16 @@ checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5dc2c0d691cbf7595cde551ced329cca99c2387c2cbc97754c5d0cd045d3ee"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -5057,7 +6310,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
- "lru",
+ "lru 0.12.5",
  "multistream-select",
  "rand 0.8.6",
  "smallvec",
@@ -5220,6 +6473,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5230,6 +6492,17 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "macro-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
 
 [[package]]
 name = "maplit"
@@ -5450,7 +6723,7 @@ dependencies = [
  "hybrid-array 0.2.3",
  "kem",
  "rand_core 0.6.4",
- "sha3",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -5608,7 +6881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.10.0",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "ndk-sys",
  "num_enum",
@@ -5628,7 +6901,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.0",
 ]
 
 [[package]]
@@ -5870,6 +7143,20 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "nybbles"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
+dependencies = [
+ "alloy-rlp",
+ "cfg-if",
+ "proptest",
+ "ruint",
+ "serde",
+ "smallvec",
+]
 
 [[package]]
 name = "objc2"
@@ -6168,6 +7455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "opentelemetry"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6444,6 +7737,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6471,6 +7774,15 @@ checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_shared 0.14.0",
 ]
 
 [[package]]
@@ -6573,6 +7885,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.1",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher 1.0.1",
 ]
@@ -6890,6 +8211,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7135,6 +8478,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
@@ -7215,6 +8559,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -7225,6 +8570,7 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+ "serde",
 ]
 
 [[package]]
@@ -7293,6 +8639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+ "serde",
 ]
 
 [[package]]
@@ -7364,6 +8711,15 @@ dependencies = [
  "cmake",
  "libc",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -7544,6 +8900,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.2",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7600,6 +8993,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -7668,6 +9071,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.6",
+ "rand 0.9.4",
+ "rlp",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7723,11 +9161,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -7771,6 +9218,7 @@ version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -7778,6 +9226,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -7800,11 +9260,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7861,6 +9349,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7984,8 +9481,73 @@ dependencies = [
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
+ "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.6",
+ "secp256k1-sys 0.10.1",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.4",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -7996,7 +9558,7 @@ checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
- "derive_more",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
@@ -8004,6 +9566,15 @@ dependencies = [
  "precomputed-hash",
  "servo_arc",
  "smallvec",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
 ]
 
 [[package]]
@@ -8017,6 +9588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "sentry"
 version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8024,7 +9604,7 @@ checksum = "d92d893ba7469d361a6958522fa440e4e2bc8bf4c5803cd1bf40b9af63f8f9a8"
 dependencies = [
  "cfg_aliases",
  "httpdate",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "sentry-backtrace",
  "sentry-contexts",
@@ -8056,7 +9636,7 @@ dependencies = [
  "hostname 0.4.2",
  "libc",
  "os_info",
- "rustc_version",
+ "rustc_version 0.4.1",
  "sentry-core",
  "uname",
 ]
@@ -8268,10 +9848,20 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.112",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -8364,6 +9954,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6287fd675f713484342a89cbf0a386abef5f15919cfad607e5e1f19e1e15331"
+dependencies = [
+ "cc",
+ "cfg-if",
+]
+
+[[package]]
 name = "shake"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8439,6 +10049,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8476,6 +10096,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smawk"
@@ -8504,7 +10127,7 @@ dependencies = [
  "curve25519-dalek",
  "rand_core 0.6.4",
  "ring",
- "rustc_version",
+ "rustc_version 0.4.1",
  "sha2",
  "subtle",
 ]
@@ -8732,6 +10355,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-solidity"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8823,7 +10458,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "lazy_static",
  "libc",
  "log",
@@ -8886,7 +10521,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http 1.4.0",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -8899,7 +10534,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_repr",
@@ -8933,7 +10568,7 @@ dependencies = [
  "heck 0.5.0",
  "json-patch",
  "schemars 0.8.22",
- "semver",
+ "semver 1.0.27",
  "serde",
  "serde_json",
  "tauri-utils",
@@ -8956,7 +10591,7 @@ dependencies = [
  "png",
  "proc-macro2",
  "quote",
- "semver",
+ "semver 1.0.27",
  "serde",
  "serde_json",
  "sha2",
@@ -9032,7 +10667,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http 1.4.0",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -9055,7 +10690,7 @@ checksum = "187a3f26f681bdf028f796ccf57cf478c1ee422c50128e5a0a6ebeb3f5910065"
 dependencies = [
  "gtk",
  "http 1.4.0",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -9098,7 +10733,7 @@ dependencies = [
  "quote",
  "regex",
  "schemars 0.8.22",
- "semver",
+ "semver 1.0.27",
  "serde",
  "serde-untagged",
  "serde_json",
@@ -9209,6 +10844,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -9355,6 +10999,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -9781,6 +11426,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
@@ -10378,7 +12029,21 @@ dependencies = [
  "bitflags 2.10.0",
  "hashbrown 0.15.5",
  "indexmap 2.12.1",
- "semver",
+ "semver 1.0.27",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -10453,6 +12118,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -11327,6 +13001,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11438,7 +13121,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.12.1",
  "log",
- "semver",
+ "semver 1.0.27",
  "serde",
  "serde_derive",
  "serde_json",
@@ -11470,7 +13153,7 @@ dependencies = [
  "html5ever",
  "http 1.4.0",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "kuchikiki",
  "libc",
  "ndk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ rust-version = "1.83.0"
 [workspace.dependencies]
 aead = { version = "0.5", default-features = false }
 aes = "0.8"
+alloy = { version = "1", default-features = false }
 aes-gcm = "0.10"
 aligned-cmov = "2"
 anyhow = "1"

--- a/bridge/core/Cargo.toml
+++ b/bridge/core/Cargo.toml
@@ -17,3 +17,7 @@ chrono = { workspace = true, features = ["serde", "std", "clock"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 toml = { workspace = true }
 hex = { workspace = true }
+sha2 = { workspace = true, features = ["std"] }
+
+[dev-dependencies]
+serde_json = { workspace = true, features = ["std"] }

--- a/bridge/core/src/attestation.rs
+++ b/bridge/core/src/attestation.rs
@@ -1,0 +1,163 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Mint authorization types produced by the validator attestation protocol.
+//!
+//! Per ADR 0002 (bridge custody), every wBTH mint must be authorized by a
+//! t-of-n threshold of the SCP validator federation:
+//!
+//! - **Ethereum**: each validator operates a secp256k1 signer; the collected
+//!   signatures are the owner signatures for the Gnosis Safe that holds
+//!   `MINTER_ROLE` on `WrappedBTH.sol`.
+//! - **Solana**: validators sign natively with their Ed25519 node keys.
+//!
+//! The attestation *protocol* (signature collection, envelopes, nonces) is
+//! issue #824 and lives outside this crate. This module only defines the
+//! artifact that protocol produces — [`MintAuthorization`] — which the mint
+//! submission path (issue #821) consumes.
+
+use serde::{Deserialize, Serialize};
+
+/// The signature scheme used by an attestation, per destination chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignatureScheme {
+    /// secp256k1 ECDSA (Ethereum Gnosis Safe owner signatures).
+    Secp256k1,
+    /// Ed25519 (Solana native validator keys).
+    Ed25519,
+}
+
+/// A single validator's signature over a mint authorization payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttestationSignature {
+    /// Signer identity. For secp256k1 this is the 20-byte Ethereum address
+    /// of the Safe owner; for Ed25519 this is the 32-byte public key.
+    #[serde(with = "hex_bytes")]
+    pub signer: Vec<u8>,
+
+    /// Signature bytes. 65 bytes ({r, s, v}) for secp256k1 Safe owner
+    /// signatures; 64 bytes for Ed25519.
+    #[serde(with = "hex_bytes")]
+    pub signature: Vec<u8>,
+}
+
+/// Threshold authorization for a single wBTH mint, produced by the #824
+/// attestation protocol and bound to one bridge order.
+///
+/// The signed payload is chain-specific:
+/// - Ethereum: the Gnosis Safe transaction hash (EIP-712) wrapping
+///   `bridgeMint(to, amount, orderId)`.
+/// - Solana: the transaction message containing the `bridge_mint` instruction
+///   with the same `orderId`.
+///
+/// Binding to the on-chain `orderId` (not just the BTH deposit tx) means a
+/// replayed authorization can never mint twice: the destination contract
+/// rejects a duplicate order id (#826), and the Safe nonce / Solana
+/// blockhash rejects a replayed transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MintAuthorization {
+    /// The deterministic 32-byte on-chain order id this authorization is
+    /// bound to. Must equal [`crate::order::BridgeOrder::order_id_bytes`]
+    /// for the order being minted.
+    #[serde(with = "hex_array_32")]
+    pub order_id: [u8; 32],
+
+    /// Signature scheme (implied by the destination chain).
+    pub scheme: SignatureScheme,
+
+    /// The threshold `t` required by the federation configuration. Per
+    /// ADR 0002 this is never lower than the SCP safety threshold.
+    pub threshold: u32,
+
+    /// Collected validator signatures. Must contain at least `threshold`
+    /// entries from distinct signers to be usable.
+    pub signatures: Vec<AttestationSignature>,
+}
+
+impl MintAuthorization {
+    /// Whether enough distinct signers have signed to meet the threshold.
+    pub fn meets_threshold(&self) -> bool {
+        let mut signers: Vec<&[u8]> = self
+            .signatures
+            .iter()
+            .map(|s| s.signer.as_slice())
+            .collect();
+        signers.sort();
+        signers.dedup();
+        signers.len() as u32 >= self.threshold
+    }
+}
+
+/// Hex serde for `Vec<u8>`.
+mod hex_bytes {
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&hex::encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        hex::decode(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Hex serde for `[u8; 32]`.
+mod hex_array_32 {
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&hex::encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<[u8; 32], D::Error> {
+        let s = String::deserialize(deserializer)?;
+        let bytes = hex::decode(&s).map_err(serde::de::Error::custom)?;
+        bytes
+            .try_into()
+            .map_err(|_| serde::de::Error::custom("order_id must be 32 bytes"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sig(signer: u8) -> AttestationSignature {
+        AttestationSignature {
+            signer: vec![signer; 20],
+            signature: vec![0u8; 65],
+        }
+    }
+
+    #[test]
+    fn test_meets_threshold() {
+        let mut auth = MintAuthorization {
+            order_id: [7u8; 32],
+            scheme: SignatureScheme::Secp256k1,
+            threshold: 2,
+            signatures: vec![sig(1)],
+        };
+        assert!(!auth.meets_threshold());
+
+        auth.signatures.push(sig(2));
+        assert!(auth.meets_threshold());
+
+        // Duplicate signers do not count twice.
+        auth.signatures = vec![sig(1), sig(1)];
+        assert!(!auth.meets_threshold());
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let auth = MintAuthorization {
+            order_id: [9u8; 32],
+            scheme: SignatureScheme::Ed25519,
+            threshold: 3,
+            signatures: vec![sig(1), sig(2)],
+        };
+        let json = serde_json::to_string(&auth).unwrap();
+        let back: MintAuthorization = serde_json::from_str(&json).unwrap();
+        assert_eq!(auth, back);
+    }
+}

--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -49,6 +49,15 @@ pub struct EthereumConfig {
     /// wBTH contract address
     pub wbth_contract: String,
 
+    /// Gnosis Safe address holding `MINTER_ROLE` on the wBTH contract.
+    ///
+    /// Per ADR 0002, the Ethereum mint authority is a Gnosis Safe whose
+    /// owners are the validators' secp256k1 keys. Mints are submitted as
+    /// `Safe.execTransaction` wrapping `bridgeMint`. `None` disables mint
+    /// submission (watch-only deployments).
+    #[serde(default)]
+    pub safe_address: Option<String>,
+
     /// Chain ID (1 for mainnet, 5 for goerli, etc.)
     pub chain_id: u64,
 
@@ -211,6 +220,7 @@ impl Default for BridgeConfig {
             ethereum: EthereumConfig {
                 rpc_url: "http://localhost:8545".to_string(),
                 wbth_contract: "0x0000000000000000000000000000000000000000".to_string(),
+                safe_address: None,
                 chain_id: 1,
                 private_key_file: None,
                 confirmations_required: 12,

--- a/bridge/core/src/lib.rs
+++ b/bridge/core/src/lib.rs
@@ -10,10 +10,14 @@
 //! - Configuration structures
 //! - Rate limiting logic
 
+pub mod attestation;
 pub mod chains;
 pub mod config;
 pub mod order;
 
+pub use attestation::{AttestationSignature, MintAuthorization, SignatureScheme};
 pub use chains::{Chain, ChainAddress};
-pub use config::{BridgeConfig, BthConfig, EthereumConfig, SolanaConfig};
-pub use order::{BridgeOrder, OrderStatus, OrderType};
+pub use config::{
+    BridgeConfig, BthConfig, EthereumConfig, GasPriceStrategy, SolanaCommitment, SolanaConfig,
+};
+pub use order::{derive_order_id, BridgeOrder, OrderStatus, OrderType};

--- a/bridge/core/src/order.rs
+++ b/bridge/core/src/order.rs
@@ -4,9 +4,29 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use crate::chains::Chain;
+use crate::{attestation::MintAuthorization, chains::Chain};
+
+/// Domain-separation tag for deriving the on-chain 32-byte order id from the
+/// order UUID. Changing this tag is a bridge-breaking change: in-flight
+/// orders would derive different on-chain ids.
+const ORDER_ID_DOMAIN_TAG: &[u8] = b"botho-bridge-order-id-v1";
+
+/// Derive the deterministic 32-byte on-chain order id from an order UUID.
+///
+/// Both destination chains bind mints to this same value: Ethereum passes it
+/// as the `bytes32` idempotency key of `WrappedBTH.bridgeMint` and Solana as
+/// the `[u8; 32]` argument of the `bridge_mint` instruction. The contract-side
+/// duplicate-order guard (#826) plus this derivation make a replayed
+/// attestation unable to mint twice.
+pub fn derive_order_id(order_uuid: &Uuid) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(ORDER_ID_DOMAIN_TAG);
+    hasher.update(order_uuid.as_bytes());
+    hasher.finalize().into()
+}
 
 /// Custom serde for memo field (fixed-size byte array)
 mod memo_serde {
@@ -138,6 +158,46 @@ impl OrderStatus {
             _ => None,
         }
     }
+
+    /// Check whether a transition from `self` to `next` is allowed.
+    ///
+    /// Allowed transitions:
+    /// - The forward happy path (each status to its [`OrderStatus::next`]). In
+    ///   particular `MintPending -> Completed` — callers must only take this
+    ///   edge once the destination-chain confirmation requirement is met (see
+    ///   `confirm_mint` in the bridge service).
+    /// - `MintPending -> DepositConfirmed`: reorg unwind. If a submitted mint
+    ///   tx is orphaned before finality the order rolls back to
+    ///   `DepositConfirmed` and is re-submitted, instead of terminally failing
+    ///   (the BTH deposit is still confirmed and owed).
+    /// - Any non-terminal status to `Failed`.
+    /// - `AwaitingDeposit` / `DepositDetected` to `Expired`.
+    ///
+    /// Terminal states allow no transitions.
+    pub fn can_transition_to(&self, next: &OrderStatus) -> bool {
+        if self.is_terminal() {
+            return false;
+        }
+
+        // Forward happy path.
+        if let Some(expected) = self.next() {
+            if std::mem::discriminant(&expected) == std::mem::discriminant(next) {
+                return true;
+            }
+        }
+
+        match (self, next) {
+            // Reorg unwind: submitted mint orphaned before finality.
+            (OrderStatus::MintPending, OrderStatus::DepositConfirmed) => true,
+            // Any non-terminal order may fail.
+            (_, OrderStatus::Failed { .. }) => true,
+            // Only orders still waiting on a deposit can expire.
+            (OrderStatus::AwaitingDeposit | OrderStatus::DepositDetected, OrderStatus::Expired) => {
+                true
+            }
+            _ => false,
+        }
+    }
 }
 
 impl std::fmt::Display for OrderStatus {
@@ -201,6 +261,19 @@ pub struct BridgeOrder {
     #[serde(with = "memo_serde")]
     pub memo: Option<[u8; 64]>,
 
+    /// Threshold attestation authorizing the mint (produced by the #824
+    /// attestation protocol once the deposit is confirmed). `None` until
+    /// the federation has signed.
+    #[serde(default)]
+    pub mint_authorization: Option<MintAuthorization>,
+
+    /// When the destination-chain transaction (`dest_tx`) reached the
+    /// required confirmation depth / finality. `None` while unconfirmed —
+    /// confirmation waits are reorg-aware: `dest_tx` may be set and later
+    /// cleared again if the tx is orphaned before this is set.
+    #[serde(default)]
+    pub dest_confirmed_at: Option<DateTime<Utc>>,
+
     /// Order creation timestamp
     pub created_at: DateTime<Utc>,
 
@@ -232,6 +305,8 @@ impl BridgeOrder {
             status: OrderStatus::AwaitingDeposit,
             error_message: None,
             memo: None,
+            mint_authorization: None,
+            dest_confirmed_at: None,
             created_at: now,
             updated_at: now,
         }
@@ -261,9 +336,19 @@ impl BridgeOrder {
             status: OrderStatus::BurnDetected,
             error_message: None,
             memo: None,
+            mint_authorization: None,
+            dest_confirmed_at: None,
             created_at: now,
             updated_at: now,
         }
+    }
+
+    /// The deterministic 32-byte on-chain order id for this order.
+    ///
+    /// See [`derive_order_id`]. Both the Ethereum and Solana mint paths
+    /// bind their on-chain mint to this exact value.
+    pub fn order_id_bytes(&self) -> [u8; 32] {
+        derive_order_id(&self.id)
     }
 
     /// Generate a memo containing the order ID for deposit identification.
@@ -290,6 +375,32 @@ impl BridgeOrder {
     pub fn set_status(&mut self, status: OrderStatus) {
         self.status = status;
         self.updated_at = Utc::now();
+    }
+
+    /// Guarded status transition. Returns an error (and leaves the order
+    /// unmodified) if [`OrderStatus::can_transition_to`] rejects the edge.
+    ///
+    /// Rolling back from `MintPending` to `DepositConfirmed` (reorg unwind)
+    /// clears `dest_tx` and `dest_confirmed_at` so the order is re-submitted
+    /// cleanly.
+    pub fn try_set_status(&mut self, status: OrderStatus) -> Result<(), String> {
+        if !self.status.can_transition_to(&status) {
+            return Err(format!(
+                "invalid order status transition: {} -> {}",
+                self.status, status
+            ));
+        }
+
+        if matches!(
+            (&self.status, &status),
+            (OrderStatus::MintPending, OrderStatus::DepositConfirmed)
+        ) {
+            self.dest_tx = None;
+            self.dest_confirmed_at = None;
+        }
+
+        self.set_status(status);
+        Ok(())
     }
 
     /// Mark the order as failed.
@@ -360,5 +471,102 @@ mod tests {
         assert!(OrderStatus::DepositConfirmed.is_actionable());
         assert!(OrderStatus::BurnConfirmed.is_actionable());
         assert!(!OrderStatus::AwaitingDeposit.is_actionable());
+    }
+
+    #[test]
+    fn test_order_id_derivation_is_stable() {
+        // Fixed UUID -> fixed on-chain order id. This vector must never
+        // change: in-flight orders bind to it on both chains.
+        let uuid = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let id1 = derive_order_id(&uuid);
+        let id2 = derive_order_id(&uuid);
+        assert_eq!(id1, id2, "derivation must be deterministic");
+
+        // Golden vector: sha256("botho-bridge-order-id-v1" || uuid_bytes).
+        let expected = {
+            let mut hasher = Sha256::new();
+            hasher.update(b"botho-bridge-order-id-v1");
+            hasher.update(uuid.as_bytes());
+            let out: [u8; 32] = hasher.finalize().into();
+            out
+        };
+        assert_eq!(id1, expected);
+
+        // Distinct orders derive distinct ids.
+        let other = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+        assert_ne!(derive_order_id(&other), id1);
+    }
+
+    #[test]
+    fn test_order_id_bytes_matches_free_function() {
+        // The ETH path calls order.order_id_bytes(); the Solana path may
+        // derive from the UUID directly. Both must agree.
+        let order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            0,
+            "addr".to_string(),
+            "0x...".to_string(),
+        );
+        assert_eq!(order.order_id_bytes(), derive_order_id(&order.id));
+    }
+
+    #[test]
+    fn test_guarded_transitions_happy_path() {
+        assert!(OrderStatus::DepositConfirmed.can_transition_to(&OrderStatus::MintPending));
+        assert!(OrderStatus::MintPending.can_transition_to(&OrderStatus::Completed));
+        assert!(OrderStatus::AwaitingDeposit.can_transition_to(&OrderStatus::DepositDetected));
+    }
+
+    #[test]
+    fn test_guarded_transitions_reject_skips() {
+        // Cannot skip confirmation gating: DepositConfirmed -> Completed
+        // must go through MintPending.
+        assert!(!OrderStatus::DepositConfirmed.can_transition_to(&OrderStatus::Completed));
+        // Cannot complete before submitting.
+        assert!(!OrderStatus::DepositDetected.can_transition_to(&OrderStatus::MintPending));
+        // Terminal states are frozen.
+        assert!(!OrderStatus::Completed.can_transition_to(&OrderStatus::MintPending));
+        assert!(!OrderStatus::Failed {
+            reason: "x".to_string()
+        }
+        .can_transition_to(&OrderStatus::DepositConfirmed));
+        // Orders past the deposit stage cannot expire.
+        assert!(!OrderStatus::MintPending.can_transition_to(&OrderStatus::Expired));
+    }
+
+    #[test]
+    fn test_reorg_unwind_transition() {
+        // MintPending -> DepositConfirmed is the reorg rollback edge.
+        assert!(OrderStatus::MintPending.can_transition_to(&OrderStatus::DepositConfirmed));
+
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            0,
+            "addr".to_string(),
+            "0x...".to_string(),
+        );
+        order.set_status(OrderStatus::MintPending);
+        order.dest_tx = Some("0xdeadbeef".to_string());
+
+        order.try_set_status(OrderStatus::DepositConfirmed).unwrap();
+        assert_eq!(order.status, OrderStatus::DepositConfirmed);
+        assert!(order.dest_tx.is_none(), "reorg unwind must clear dest_tx");
+        assert!(order.dest_confirmed_at.is_none());
+    }
+
+    #[test]
+    fn test_try_set_status_rejects_invalid() {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            0,
+            "addr".to_string(),
+            "0x...".to_string(),
+        );
+        // AwaitingDeposit -> Completed is not a legal edge.
+        assert!(order.try_set_status(OrderStatus::Completed).is_err());
+        assert_eq!(order.status, OrderStatus::AwaitingDeposit);
     }
 }

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -17,6 +17,21 @@ bth-bridge-core = { workspace = true }
 
 # Async runtime
 tokio = { workspace = true, features = ["full"] }
+async-trait = { workspace = true }
+
+# Ethereum (wBTH mint submission per ADR 0002: Gnosis Safe execTransaction)
+alloy = { workspace = true, features = [
+    "consensus",
+    "contract",
+    "eips",
+    "network",
+    "provider-http",
+    "reqwest",
+    "reqwest-rustls-tls",
+    "rpc-types",
+    "signer-local",
+    "sol-types",
+] }
 
 # Database
 rusqlite = { version = "0.31", features = ["bundled"] }
@@ -24,6 +39,9 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 # Utilities
 chrono = { workspace = true, features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
+hex = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
+sha2 = { workspace = true, features = ["std"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { workspace = true, features = ["derive"] }

--- a/bridge/service/src/attestation.rs
+++ b/bridge/service/src/attestation.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Attestation provider — the engine's source of [`MintAuthorization`]s.
+//!
+//! The real implementation is the #824 validator attestation protocol
+//! (t-of-n threshold signing by the SCP validator federation, ADR 0002),
+//! which mirrors the operator-signed-action envelope/nonce machinery from
+//! P4.4. This module defines the interface the mint engine consumes and a
+//! development stub, so #821 (mint submission) and #824 (signature
+//! collection) can land independently.
+
+use async_trait::async_trait;
+use bth_bridge_core::{BridgeOrder, Chain, MintAuthorization, SignatureScheme};
+
+/// Source of threshold mint authorizations.
+#[async_trait]
+pub trait AttestationProvider: Send + Sync {
+    /// Obtain a threshold authorization for minting `order` on its
+    /// destination chain. Blocks (or errors) until the federation threshold
+    /// is met — the engine never submits an unauthorized mint.
+    async fn authorize_mint(&self, order: &BridgeOrder) -> Result<MintAuthorization, String>;
+}
+
+/// Development stub pending #824.
+///
+/// Returns an authorization bound to the order's on-chain id with an EMPTY
+/// signature set and threshold 0. This satisfies the local threshold check,
+/// but a real Gnosis Safe / on-chain multisig authority will reject the
+/// submission (no owner signatures), so it cannot mint against production
+/// contracts. Useful against dev deployments whose Safe threshold is 0 or
+/// whose authority is a plain EOA.
+pub struct StubAttestationProvider;
+
+#[async_trait]
+impl AttestationProvider for StubAttestationProvider {
+    async fn authorize_mint(&self, order: &BridgeOrder) -> Result<MintAuthorization, String> {
+        // TODO(#824): replace with the validator threshold-signing protocol.
+        let scheme = match order.dest_chain {
+            Chain::Ethereum => SignatureScheme::Secp256k1,
+            Chain::Solana => SignatureScheme::Ed25519,
+            Chain::Bth => return Err("cannot mint to the BTH chain".to_string()),
+        };
+
+        Ok(MintAuthorization {
+            order_id: order.order_id_bytes(),
+            scheme,
+            threshold: 0,
+            signatures: vec![],
+        })
+    }
+}

--- a/bridge/service/src/db.rs
+++ b/bridge/service/src/db.rs
@@ -2,11 +2,34 @@
 
 //! SQLite database for bridge order tracking.
 
-use bth_bridge_core::{BridgeOrder, Chain, OrderStatus, OrderType};
-use chrono::{TimeZone, Utc};
+use bth_bridge_core::{BridgeOrder, Chain, MintAuthorization, OrderStatus, OrderType};
+use chrono::{DateTime, TimeZone, Utc};
 use rusqlite::{params, Connection, Result as SqliteResult};
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
+
+/// A row in the `mints` idempotency table.
+///
+/// One row exists per order that has ever had a destination-chain mint
+/// transaction prepared. The `order_id` UNIQUE constraint is the service-side
+/// exactly-once guard: a resubmission finds the existing row and reuses the
+/// prior transaction instead of double-minting. (The contract-side order-id
+/// guard, #826, is the on-chain backstop.)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MintRecord {
+    /// Bridge order UUID (string form).
+    pub order_id: Uuid,
+    /// Hex encoding of the 32-byte on-chain order id bound to the mint.
+    pub order_id_hash: String,
+    /// Destination chain the mint was submitted to.
+    pub chain: Chain,
+    /// Destination-chain transaction id (ETH tx hash / Solana signature).
+    pub dest_tx: String,
+    /// When the transaction was persisted (always before first broadcast).
+    pub submitted_at: DateTime<Utc>,
+    /// When the transaction reached the required confirmation depth.
+    pub confirmed_at: Option<DateTime<Utc>>,
+}
 
 /// Database wrapper for thread-safe access.
 #[derive(Clone)]
@@ -87,9 +110,49 @@ impl Database {
 
             CREATE INDEX IF NOT EXISTS idx_audit_order ON audit_log(order_id);
             CREATE INDEX IF NOT EXISTS idx_audit_created ON audit_log(created_at);
+
+            CREATE TABLE IF NOT EXISTS mints (
+                order_id TEXT PRIMARY KEY REFERENCES bridge_orders(id),
+                order_id_hash TEXT NOT NULL,
+                chain TEXT NOT NULL,
+                dest_tx TEXT NOT NULL,
+                submitted_at INTEGER NOT NULL,
+                confirmed_at INTEGER
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_mints_order_hash ON mints(order_id_hash);
             "#,
         )
         .map_err(|e| format!("Migration failed: {}", e))?;
+
+        // Columns added to bridge_orders after the initial schema shipped.
+        // CREATE TABLE IF NOT EXISTS does not add columns to existing
+        // databases, so guard each with a pragma check.
+        Self::ensure_column(&conn, "bridge_orders", "mint_authorization", "TEXT")?;
+        Self::ensure_column(&conn, "bridge_orders", "dest_confirmed_at", "INTEGER")?;
+
+        Ok(())
+    }
+
+    /// Add a column to `table` if it does not already exist.
+    fn ensure_column(conn: &Connection, table: &str, column: &str, ty: &str) -> Result<(), String> {
+        let mut stmt = conn
+            .prepare(&format!("PRAGMA table_info({})", table))
+            .map_err(|e| format!("Pragma failed: {}", e))?;
+
+        let existing: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|e| format!("Pragma query failed: {}", e))?
+            .collect::<SqliteResult<Vec<_>>>()
+            .map_err(|e| format!("Pragma collect failed: {}", e))?;
+
+        if !existing.iter().any(|c| c == column) {
+            conn.execute(
+                &format!("ALTER TABLE {} ADD COLUMN {} {}", table, column, ty),
+                [],
+            )
+            .map_err(|e| format!("Add column failed: {}", e))?;
+        }
 
         Ok(())
     }
@@ -98,13 +161,20 @@ impl Database {
     pub fn insert_order(&self, order: &BridgeOrder) -> Result<(), String> {
         let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
 
+        let mint_auth_json = order
+            .mint_authorization
+            .as_ref()
+            .map(|a| serde_json::to_string(a).map_err(|e| format!("Serialize failed: {}", e)))
+            .transpose()?;
+
         conn.execute(
             r#"
             INSERT INTO bridge_orders (
                 id, order_type, source_chain, dest_chain, amount, fee,
                 source_tx, dest_tx, source_address, dest_address,
-                status, error_message, memo, created_at, updated_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+                status, error_message, memo, mint_authorization,
+                dest_confirmed_at, created_at, updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
             "#,
             params![
                 order.id.to_string(),
@@ -120,6 +190,8 @@ impl Database {
                 order.status.to_string(),
                 order.error_message,
                 order.memo.as_ref().map(|m| m.to_vec()),
+                mint_auth_json,
+                order.dest_confirmed_at.map(|t| t.timestamp()),
                 order.created_at.timestamp(),
                 order.updated_at.timestamp(),
             ],
@@ -138,14 +210,15 @@ impl Database {
                 r#"
                 SELECT id, order_type, source_chain, dest_chain, amount, fee,
                        source_tx, dest_tx, source_address, dest_address,
-                       status, error_message, memo, created_at, updated_at
+                       status, error_message, memo, mint_authorization,
+                       dest_confirmed_at, created_at, updated_at
                 FROM bridge_orders WHERE id = ?1
                 "#,
             )
             .map_err(|e| format!("Prepare failed: {}", e))?;
 
         let result = stmt
-            .query_row(params![id.to_string()], |row| Self::row_to_order(row))
+            .query_row(params![id.to_string()], Self::row_to_order)
             .optional()
             .map_err(|e| format!("Query failed: {}", e))?;
 
@@ -161,7 +234,8 @@ impl Database {
                 r#"
                 SELECT id, order_type, source_chain, dest_chain, amount, fee,
                        source_tx, dest_tx, source_address, dest_address,
-                       status, error_message, memo, created_at, updated_at
+                       status, error_message, memo, mint_authorization,
+                       dest_confirmed_at, created_at, updated_at
                 FROM bridge_orders WHERE status LIKE ?1
                 ORDER BY created_at ASC
                 "#,
@@ -252,6 +326,150 @@ impl Database {
         Ok(())
     }
 
+    // === Mint idempotency table ===
+
+    /// Record a prepared mint transaction for an order, exactly once.
+    ///
+    /// Must be called BEFORE the transaction is first broadcast so that a
+    /// crash between broadcast and persistence cannot lose the tx id.
+    ///
+    /// If a row already exists for this order (a resubmission after a crash
+    /// or retry), the EXISTING record is returned unchanged and the caller
+    /// must reuse its `dest_tx` instead of broadcasting a new transaction —
+    /// this is the service-side exactly-once guard.
+    pub fn record_mint_submitted(
+        &self,
+        order_id: &Uuid,
+        order_id_hash: &str,
+        chain: Chain,
+        dest_tx: &str,
+    ) -> Result<MintRecord, String> {
+        {
+            let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+            conn.execute(
+                r#"
+                INSERT OR IGNORE INTO mints (
+                    order_id, order_id_hash, chain, dest_tx, submitted_at, confirmed_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, NULL)
+                "#,
+                params![
+                    order_id.to_string(),
+                    order_id_hash,
+                    chain.to_string(),
+                    dest_tx,
+                    Utc::now().timestamp(),
+                ],
+            )
+            .map_err(|e| format!("Insert failed: {}", e))?;
+        }
+
+        self.get_mint_by_order(order_id)?
+            .ok_or_else(|| "Mint record missing after insert".to_string())
+    }
+
+    /// Get the mint record for an order, if a mint was ever submitted.
+    pub fn get_mint_by_order(&self, order_id: &Uuid) -> Result<Option<MintRecord>, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT order_id, order_id_hash, chain, dest_tx, submitted_at, confirmed_at
+                FROM mints WHERE order_id = ?1
+                "#,
+            )
+            .map_err(|e| format!("Prepare failed: {}", e))?;
+
+        stmt.query_row(params![order_id.to_string()], Self::row_to_mint)
+            .optional()
+            .map_err(|e| format!("Query failed: {}", e))
+    }
+
+    /// Mark an order's mint as confirmed at the required depth.
+    ///
+    /// Atomically stamps `mints.confirmed_at` and moves the order to
+    /// `Completed` with `dest_confirmed_at` set. The caller must have
+    /// validated the `MintPending -> Completed` transition (confirmation
+    /// gating) before calling.
+    pub fn mark_mint_confirmed(&self, order_id: &Uuid) -> Result<(), String> {
+        let mut conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let now = Utc::now().timestamp();
+
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Transaction failed: {}", e))?;
+
+        tx.execute(
+            "UPDATE mints SET confirmed_at = ?1 WHERE order_id = ?2 AND confirmed_at IS NULL",
+            params![now, order_id.to_string()],
+        )
+        .map_err(|e| format!("Update mints failed: {}", e))?;
+
+        tx.execute(
+            r#"
+            UPDATE bridge_orders
+            SET status = 'completed', dest_confirmed_at = ?1, updated_at = ?1
+            WHERE id = ?2 AND status = 'mint_pending'
+            "#,
+            params![now, order_id.to_string()],
+        )
+        .map_err(|e| format!("Update order failed: {}", e))?;
+
+        tx.commit().map_err(|e| format!("Commit failed: {}", e))
+    }
+
+    /// Reorg unwind: roll a `MintPending` order back to `DepositConfirmed`.
+    ///
+    /// Atomically deletes the UNCONFIRMED mint record and clears the order's
+    /// `dest_tx`, so `submit_mint` re-runs cleanly against the same on-chain
+    /// order id. Confirmed mints are never rolled back.
+    pub fn rollback_mint(&self, order_id: &Uuid) -> Result<(), String> {
+        let mut conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let now = Utc::now().timestamp();
+
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Transaction failed: {}", e))?;
+
+        tx.execute(
+            "DELETE FROM mints WHERE order_id = ?1 AND confirmed_at IS NULL",
+            params![order_id.to_string()],
+        )
+        .map_err(|e| format!("Delete mint failed: {}", e))?;
+
+        tx.execute(
+            r#"
+            UPDATE bridge_orders
+            SET status = 'deposit_confirmed', dest_tx = NULL,
+                dest_confirmed_at = NULL, updated_at = ?1
+            WHERE id = ?2 AND status = 'mint_pending'
+            "#,
+            params![now, order_id.to_string()],
+        )
+        .map_err(|e| format!("Update order failed: {}", e))?;
+
+        tx.commit().map_err(|e| format!("Commit failed: {}", e))
+    }
+
+    /// Convert a database row to a MintRecord.
+    fn row_to_mint(row: &rusqlite::Row<'_>) -> SqliteResult<MintRecord> {
+        let order_id_str: String = row.get(0)?;
+        let order_id_hash: String = row.get(1)?;
+        let chain_str: String = row.get(2)?;
+        let dest_tx: String = row.get(3)?;
+        let submitted_at: i64 = row.get(4)?;
+        let confirmed_at: Option<i64> = row.get(5)?;
+
+        Ok(MintRecord {
+            order_id: Uuid::parse_str(&order_id_str).unwrap_or_default(),
+            order_id_hash,
+            chain: chain_str.parse().unwrap_or(Chain::Ethereum),
+            dest_tx,
+            submitted_at: Utc.timestamp_opt(submitted_at, 0).unwrap(),
+            confirmed_at: confirmed_at.and_then(|t| Utc.timestamp_opt(t, 0).single()),
+        })
+    }
+
     /// Log an audit event.
     pub fn log_audit(
         &self,
@@ -293,8 +511,10 @@ impl Database {
         let status_str: String = row.get(10)?;
         let error_message: Option<String> = row.get(11)?;
         let memo_bytes: Option<Vec<u8>> = row.get(12)?;
-        let created_at: i64 = row.get(13)?;
-        let updated_at: i64 = row.get(14)?;
+        let mint_auth_json: Option<String> = row.get(13)?;
+        let dest_confirmed_at: Option<i64> = row.get(14)?;
+        let created_at: i64 = row.get(15)?;
+        let updated_at: i64 = row.get(16)?;
 
         let memo = memo_bytes.and_then(|b| {
             if b.len() == 64 {
@@ -305,6 +525,9 @@ impl Database {
                 None
             }
         });
+
+        let mint_authorization: Option<MintAuthorization> =
+            mint_auth_json.and_then(|j| serde_json::from_str(&j).ok());
 
         Ok(BridgeOrder {
             id: Uuid::parse_str(&id_str).unwrap_or_default(),
@@ -323,6 +546,8 @@ impl Database {
             status: parse_status(&status_str, error_message.clone()),
             error_message,
             memo,
+            mint_authorization,
+            dest_confirmed_at: dest_confirmed_at.and_then(|t| Utc.timestamp_opt(t, 0).single()),
             created_at: Utc.timestamp_opt(created_at, 0).unwrap(),
             updated_at: Utc.timestamp_opt(updated_at, 0).unwrap(),
         })
@@ -420,5 +645,140 @@ mod tests {
         db.mark_deposit_processed(tx_hash, &order.id).unwrap();
 
         assert!(db.is_deposit_processed(tx_hash).unwrap());
+    }
+
+    fn setup_mint_order(db: &Database) -> BridgeOrder {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bth_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        order.set_status(OrderStatus::DepositConfirmed);
+        db.insert_order(&order).unwrap();
+        order
+    }
+
+    #[test]
+    fn test_mint_idempotency_duplicate_order_id_exactly_once() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_mint_order(&db);
+        let hash = hex::encode(order.order_id_bytes());
+
+        // First submission records the tx.
+        let first = db
+            .record_mint_submitted(&order.id, &hash, Chain::Ethereum, "0xtx_one")
+            .unwrap();
+        assert_eq!(first.dest_tx, "0xtx_one");
+        assert!(first.confirmed_at.is_none());
+
+        // A duplicate submission with a DIFFERENT tx must return the
+        // original record unchanged: exactly-once.
+        let second = db
+            .record_mint_submitted(&order.id, &hash, Chain::Ethereum, "0xtx_two")
+            .unwrap();
+        assert_eq!(
+            second.dest_tx, "0xtx_one",
+            "duplicate order_id must reuse the prior tx, never a new one"
+        );
+        assert_eq!(first.order_id, second.order_id);
+    }
+
+    #[test]
+    fn test_mint_confirm_flow() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_mint_order(&db);
+        let hash = hex::encode(order.order_id_bytes());
+
+        db.record_mint_submitted(&order.id, &hash, Chain::Ethereum, "0xtx")
+            .unwrap();
+        db.update_order_status(&order.id, &OrderStatus::MintPending, Some("0xtx"))
+            .unwrap();
+
+        db.mark_mint_confirmed(&order.id).unwrap();
+
+        let mint = db.get_mint_by_order(&order.id).unwrap().unwrap();
+        assert!(mint.confirmed_at.is_some());
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::Completed);
+        assert!(stored.dest_confirmed_at.is_some());
+    }
+
+    #[test]
+    fn test_mint_rollback_clears_unconfirmed() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_mint_order(&db);
+        let hash = hex::encode(order.order_id_bytes());
+
+        db.record_mint_submitted(&order.id, &hash, Chain::Ethereum, "0xreorged")
+            .unwrap();
+        db.update_order_status(&order.id, &OrderStatus::MintPending, Some("0xreorged"))
+            .unwrap();
+
+        // Reorg unwind: back to DepositConfirmed, mint record gone.
+        db.rollback_mint(&order.id).unwrap();
+
+        assert!(db.get_mint_by_order(&order.id).unwrap().is_none());
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::DepositConfirmed);
+        assert!(stored.dest_tx.is_none());
+
+        // Re-submission after rollback records the NEW tx (same order id).
+        let resub = db
+            .record_mint_submitted(&order.id, &hash, Chain::Ethereum, "0xretry")
+            .unwrap();
+        assert_eq!(resub.dest_tx, "0xretry");
+    }
+
+    #[test]
+    fn test_mint_rollback_never_touches_confirmed() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_mint_order(&db);
+        let hash = hex::encode(order.order_id_bytes());
+
+        db.record_mint_submitted(&order.id, &hash, Chain::Ethereum, "0xtx")
+            .unwrap();
+        db.update_order_status(&order.id, &OrderStatus::MintPending, Some("0xtx"))
+            .unwrap();
+        db.mark_mint_confirmed(&order.id).unwrap();
+
+        // A late rollback attempt must be a no-op on a confirmed mint.
+        db.rollback_mint(&order.id).unwrap();
+
+        let mint = db.get_mint_by_order(&order.id).unwrap();
+        assert!(mint.is_some(), "confirmed mint record must survive");
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::Completed);
+    }
+
+    #[test]
+    fn test_order_new_fields_roundtrip() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            0,
+            "bth_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        order.mint_authorization = Some(bth_bridge_core::MintAuthorization {
+            order_id: order.order_id_bytes(),
+            scheme: bth_bridge_core::SignatureScheme::Secp256k1,
+            threshold: 2,
+            signatures: vec![],
+        });
+        db.insert_order(&order).unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.mint_authorization, order.mint_authorization);
+        assert!(stored.dest_confirmed_at.is_none());
     }
 }

--- a/bridge/service/src/engine.rs
+++ b/bridge/service/src/engine.rs
@@ -3,17 +3,22 @@
 //! Bridge engine - coordinates watchers and order processing.
 
 use bth_bridge_core::{BridgeConfig, BridgeOrder, Chain, OrderStatus};
-use std::time::Duration;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::sync::broadcast;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
+    attestation::{AttestationProvider, StubAttestationProvider},
     db::Database,
+    mint::{ethereum::EthMinter, solana::SolMinter, ConfirmationStatus, Minter},
     watchers::{BthWatcher, EthereumWatcher},
 };
 
 /// Shutdown signal type.
 pub type ShutdownSignal = broadcast::Receiver<()>;
+
+/// Delay between re-broadcast attempts of an already-signed mint tx.
+const BROADCAST_RETRY_DELAY: Duration = Duration::from_secs(2);
 
 /// The main bridge engine that coordinates all components.
 pub struct BridgeEngine {
@@ -32,6 +37,32 @@ impl BridgeEngine {
             db,
             shutdown_tx,
         }
+    }
+
+    /// Build the per-chain minting backends from configuration.
+    ///
+    /// A chain whose minter cannot be constructed (missing Safe address,
+    /// bad contract address, ...) is skipped with a warning: deposits to
+    /// that chain stay in `DepositConfirmed` until the config is fixed —
+    /// they are never dropped or failed.
+    fn build_minters(config: &BridgeConfig) -> HashMap<Chain, Arc<dyn Minter>> {
+        let mut minters: HashMap<Chain, Arc<dyn Minter>> = HashMap::new();
+
+        match EthMinter::new(config.ethereum.clone()) {
+            Ok(minter) => {
+                minters.insert(Chain::Ethereum, Arc::new(minter));
+            }
+            Err(e) => warn!("Ethereum minting disabled: {}", e),
+        }
+
+        match SolMinter::new(config.solana.clone()) {
+            Ok(minter) => {
+                minters.insert(Chain::Solana, Arc::new(minter));
+            }
+            Err(e) => warn!("Solana minting disabled: {}", e),
+        }
+
+        minters
     }
 
     /// Run the bridge engine.
@@ -65,7 +96,11 @@ impl BridgeEngine {
         });
 
         // Spawn the order processing loop
-        let processor = OrderProcessor::new(self.config.clone(), self.db.clone());
+        let minters = Self::build_minters(&self.config);
+        // TODO(#824): swap the stub for the validator attestation protocol.
+        let attestation: Arc<dyn AttestationProvider> = Arc::new(StubAttestationProvider);
+        let processor =
+            OrderProcessor::new(self.config.clone(), self.db.clone(), minters, attestation);
         let mut shutdown_rx = self.shutdown_tx.subscribe();
 
         let process_handle = tokio::spawn(async move {
@@ -106,20 +141,45 @@ impl BridgeEngine {
 struct OrderProcessor {
     config: BridgeConfig,
     db: Database,
+    minters: HashMap<Chain, Arc<dyn Minter>>,
+    attestation: Arc<dyn AttestationProvider>,
 }
 
 impl OrderProcessor {
-    fn new(config: BridgeConfig, db: Database) -> Self {
-        Self { config, db }
+    fn new(
+        config: BridgeConfig,
+        db: Database,
+        minters: HashMap<Chain, Arc<dyn Minter>>,
+        attestation: Arc<dyn AttestationProvider>,
+    ) -> Self {
+        Self {
+            config,
+            db,
+            minters,
+            attestation,
+        }
     }
 
     /// Process all pending orders.
+    ///
+    /// Submission (`DepositConfirmed -> MintPending`) and confirmation
+    /// (`MintPending -> Completed`) are driven as separate retryable stages
+    /// so a crash or RPC failure between them never loses (or duplicates)
+    /// a mint.
     async fn process_pending_orders(&self) -> Result<(), String> {
-        // Process confirmed deposits (need to mint wBTH)
+        // Stage 1: confirmed deposits need a mint submitted.
         let deposit_orders = self.db.get_orders_by_status("deposit_confirmed")?;
         for order in deposit_orders {
-            if let Err(e) = self.process_mint_order(&order).await {
-                warn!("Failed to process mint order {}: {}", order.id, e);
+            if let Err(e) = self.submit_mint(&order).await {
+                warn!("Failed to submit mint for order {}: {}", order.id, e);
+            }
+        }
+
+        // Stage 2: submitted mints need confirmation (or reorg unwind).
+        let pending_mints = self.db.get_orders_by_status("mint_pending")?;
+        for order in pending_mints {
+            if let Err(e) = self.confirm_mint(&order).await {
+                warn!("Failed to confirm mint for order {}: {}", order.id, e);
             }
         }
 
@@ -137,50 +197,211 @@ impl OrderProcessor {
         Ok(())
     }
 
-    /// Process a mint order (deposit confirmed, need to mint wBTH).
-    async fn process_mint_order(&self, order: &BridgeOrder) -> Result<(), String> {
+    /// Submission stage: `DepositConfirmed -> MintPending`.
+    ///
+    /// Exactly-once: the `mints` table is consulted first and written
+    /// BEFORE the first broadcast, so a crash at any point either finds no
+    /// record (safe to prepare a fresh tx — nothing was broadcast) or finds
+    /// the recorded tx and reuses it (never signs a second competing mint).
+    async fn submit_mint(&self, order: &BridgeOrder) -> Result<(), String> {
         info!(
             "Processing mint order {} for {} picocredits",
             order.id, order.amount
         );
 
-        match order.dest_chain {
-            Chain::Ethereum => {
-                // TODO: Implement actual ETH minting via alloy
-                // For now, just log and update status
-                info!(
-                    "Would mint {} wBTH on Ethereum to {}",
-                    order.net_amount(),
-                    order.dest_address
-                );
+        if order.dest_chain == Chain::Bth {
+            self.db.update_order_status(
+                &order.id,
+                &OrderStatus::Failed {
+                    reason: "Cannot mint to BTH chain".to_string(),
+                },
+                None,
+            )?;
+            return Ok(());
+        }
 
-                // Simulate mint pending
-                self.db
-                    .update_order_status(&order.id, &OrderStatus::MintPending, None)?;
+        let Some(minter) = self.minters.get(&order.dest_chain) else {
+            // Not failed: minting for this chain is unconfigured/disabled.
+            // The order stays DepositConfirmed and is retried when the
+            // operator fixes the configuration.
+            return Err(format!(
+                "no minter configured for chain {}",
+                order.dest_chain
+            ));
+        };
 
-                // In real implementation, we'd wait for confirmation then:
-                // self.db.update_order_status(&order.id,
-                // &OrderStatus::Completed, Some(&tx_hash))?;
+        // Idempotency: a previously prepared tx (crash between persistence
+        // and status update, or a re-poll) is reused, never re-prepared.
+        if let Some(existing) = self.db.get_mint_by_order(&order.id)? {
+            info!(
+                "Order {} already has mint tx {}; resuming without re-submission",
+                order.id, existing.dest_tx
+            );
+            self.db.update_order_status(
+                &order.id,
+                &OrderStatus::MintPending,
+                Some(&existing.dest_tx),
+            )?;
+            return Ok(());
+        }
+
+        // Threshold attestation from the validator federation (#824).
+        let auth = self
+            .attestation
+            .authorize_mint(order)
+            .await
+            .map_err(|e| format!("attestation failed: {}", e))?;
+
+        // Build + sign (no broadcast yet).
+        let prepared = minter
+            .prepare_mint(order, &auth)
+            .await
+            .map_err(|e| format!("prepare_mint failed: {}", e))?;
+
+        // Persist the tx id BEFORE broadcast — the exactly-once guard.
+        let record = self.db.record_mint_submitted(
+            &order.id,
+            &hex::encode(order.order_id_bytes()),
+            order.dest_chain,
+            &prepared.tx_id,
+        )?;
+        self.db
+            .update_order_status(&order.id, &OrderStatus::MintPending, Some(&record.dest_tx))?;
+        self.db.log_audit(
+            Some(&order.id),
+            "mint_submitted",
+            &format!("chain={} tx={}", minter.chain(), record.dest_tx),
+        )?;
+
+        if record.dest_tx != prepared.tx_id {
+            // Lost a race with another submission path: the recorded tx
+            // wins; do not broadcast ours.
+            warn!(
+                "Order {} already recorded mint tx {}; discarding freshly prepared {}",
+                order.id, record.dest_tx, prepared.tx_id
+            );
+            return Ok(());
+        }
+
+        // Broadcast the SAME signed tx with bounded retries. A persistent
+        // failure leaves the order MintPending: the confirmation stage
+        // detects a never-landed tx as dropped and unwinds it for
+        // re-submission.
+        let mut attempt = 0u32;
+        loop {
+            match minter.broadcast(&prepared).await {
+                Ok(()) => {
+                    info!(
+                        "Broadcast mint tx {} for order {}",
+                        prepared.tx_id, order.id
+                    );
+                    break;
+                }
+                Err(e) => {
+                    attempt += 1;
+                    if attempt > self.config.bridge.max_retries {
+                        warn!(
+                            "Broadcast of {} failed after {} attempts: {}; leaving order {} \
+                             MintPending for the confirmation stage to unwind",
+                            prepared.tx_id, attempt, e, order.id
+                        );
+                        break;
+                    }
+                    warn!(
+                        "Broadcast attempt {}/{} for {} failed: {}; retrying same signed tx",
+                        attempt, self.config.bridge.max_retries, prepared.tx_id, e
+                    );
+                    tokio::time::sleep(BROADCAST_RETRY_DELAY).await;
+                }
             }
-            Chain::Solana => {
-                // TODO: Implement actual Solana minting
-                info!(
-                    "Would mint {} wBTH on Solana to {}",
-                    order.net_amount(),
-                    order.dest_address
-                );
-                self.db
-                    .update_order_status(&order.id, &OrderStatus::MintPending, None)?;
-            }
-            Chain::Bth => {
-                // Invalid - can't mint to BTH
-                self.db.update_order_status(
-                    &order.id,
-                    &OrderStatus::Failed {
-                        reason: "Cannot mint to BTH chain".to_string(),
-                    },
-                    None,
+        }
+
+        Ok(())
+    }
+
+    /// Confirmation stage: `MintPending -> Completed` (or reorg unwind).
+    ///
+    /// `Completed` only fires once the minter reports the configured
+    /// confirmation requirement met on a still-canonical block containing
+    /// the mint event bound to this order id.
+    async fn confirm_mint(&self, order: &BridgeOrder) -> Result<(), String> {
+        let Some(minter) = self.minters.get(&order.dest_chain) else {
+            return Err(format!(
+                "no minter configured for chain {}",
+                order.dest_chain
+            ));
+        };
+
+        let dest_tx = match &order.dest_tx {
+            Some(tx) => tx.clone(),
+            None => match self.db.get_mint_by_order(&order.id)? {
+                Some(record) => record.dest_tx,
+                None => {
+                    // MintPending with no recorded tx is inconsistent state
+                    // (should be unreachable): unwind for re-submission.
+                    warn!(
+                        "Order {} is MintPending with no recorded mint tx; rolling back",
+                        order.id
+                    );
+                    self.db.rollback_mint(&order.id)?;
+                    return Ok(());
+                }
+            },
+        };
+
+        match minter
+            .check_confirmation(order, &dest_tx)
+            .await
+            .map_err(|e| format!("check_confirmation failed: {}", e))?
+        {
+            ConfirmationStatus::Confirmed => {
+                if !order.status.can_transition_to(&OrderStatus::Completed) {
+                    return Err(format!(
+                        "order {} cannot complete from status {}",
+                        order.id, order.status
+                    ));
+                }
+                self.db.mark_mint_confirmed(&order.id)?;
+                self.db.log_audit(
+                    Some(&order.id),
+                    "mint_confirmed",
+                    &format!("chain={} tx={}", order.dest_chain, dest_tx),
                 )?;
+                info!(
+                    "Mint for order {} confirmed on {} (tx {})",
+                    order.id, order.dest_chain, dest_tx
+                );
+            }
+            ConfirmationStatus::Pending { confirmations } => {
+                debug!(
+                    "Mint tx {} for order {} at {} confirmation(s); waiting",
+                    dest_tx, order.id, confirmations
+                );
+            }
+            ConfirmationStatus::Reorged => {
+                // Reorg unwind: MintPending -> DepositConfirmed. The next
+                // processing tick re-runs submit_mint against the SAME
+                // on-chain order id, so even if the old tx resurfaces the
+                // contract-side guard (#826) keeps the mint exactly-once.
+                warn!(
+                    "Mint tx {} for order {} dropped/reorged before finality; \
+                     rolling back to DepositConfirmed for re-submission",
+                    dest_tx, order.id
+                );
+                self.db.rollback_mint(&order.id)?;
+                self.db.log_audit(
+                    Some(&order.id),
+                    "mint_reorged",
+                    &format!("chain={} tx={}", order.dest_chain, dest_tx),
+                )?;
+            }
+            ConfirmationStatus::Failed { reason } => {
+                warn!(
+                    "Mint tx {} for order {} failed: {}",
+                    dest_tx, order.id, reason
+                );
+                self.db
+                    .update_order_status(&order.id, &OrderStatus::Failed { reason }, None)?;
             }
         }
 
@@ -194,7 +415,8 @@ impl OrderProcessor {
             order.id, order.amount
         );
 
-        // TODO: Implement actual BTH sending
+        // TODO(#822): Implement actual BTH release (threshold-signed per
+        // ADR 0002, reusing the operator-signed-action machinery).
         info!(
             "Would send {} BTH to {}",
             order.net_amount(),
@@ -203,13 +425,6 @@ impl OrderProcessor {
 
         self.db
             .update_order_status(&order.id, &OrderStatus::ReleasePending, None)?;
-
-        // In real implementation:
-        // 1. Build BTH transaction
-        // 2. Sign with hot wallet
-        // 3. Submit via RPC
-        // 4. Wait for confirmation
-        // 5. Update status to Released
 
         Ok(())
     }
@@ -227,5 +442,268 @@ impl OrderProcessor {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mint::{MintError, PreparedMint};
+    use async_trait::async_trait;
+    use bth_bridge_core::MintAuthorization;
+    use std::sync::{
+        atomic::{AtomicU32, Ordering},
+        Mutex,
+    };
+
+    /// Programmable in-memory minter for driving the engine in tests.
+    struct MockMinter {
+        chain: Chain,
+        prepare_calls: AtomicU32,
+        broadcast_calls: AtomicU32,
+        next_tx: Mutex<String>,
+        confirmation: Mutex<ConfirmationStatus>,
+    }
+
+    impl MockMinter {
+        fn new(chain: Chain) -> Self {
+            Self {
+                chain,
+                prepare_calls: AtomicU32::new(0),
+                broadcast_calls: AtomicU32::new(0),
+                next_tx: Mutex::new("0xmock_tx_1".to_string()),
+                confirmation: Mutex::new(ConfirmationStatus::Pending { confirmations: 0 }),
+            }
+        }
+
+        fn set_next_tx(&self, tx: &str) {
+            *self.next_tx.lock().unwrap() = tx.to_string();
+        }
+
+        fn set_confirmation(&self, status: ConfirmationStatus) {
+            *self.confirmation.lock().unwrap() = status;
+        }
+    }
+
+    #[async_trait]
+    impl Minter for MockMinter {
+        fn chain(&self) -> Chain {
+            self.chain
+        }
+
+        async fn prepare_mint(
+            &self,
+            _order: &BridgeOrder,
+            _auth: &MintAuthorization,
+        ) -> Result<PreparedMint, MintError> {
+            self.prepare_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(PreparedMint {
+                tx_id: self.next_tx.lock().unwrap().clone(),
+                raw: vec![0xde, 0xad],
+            })
+        }
+
+        async fn broadcast(&self, _prepared: &PreparedMint) -> Result<(), MintError> {
+            self.broadcast_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn check_confirmation(
+            &self,
+            _order: &BridgeOrder,
+            _dest_tx: &str,
+        ) -> Result<ConfirmationStatus, MintError> {
+            Ok(self.confirmation.lock().unwrap().clone())
+        }
+    }
+
+    fn setup() -> (OrderProcessor, Arc<MockMinter>, Database) {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let minter = Arc::new(MockMinter::new(Chain::Ethereum));
+        let mut minters: HashMap<Chain, Arc<dyn Minter>> = HashMap::new();
+        minters.insert(Chain::Ethereum, minter.clone());
+
+        let processor = OrderProcessor::new(
+            BridgeConfig::default(),
+            db.clone(),
+            minters,
+            Arc::new(StubAttestationProvider),
+        );
+        (processor, minter, db)
+    }
+
+    fn insert_confirmed_deposit(db: &Database) -> BridgeOrder {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bth_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        order.set_status(OrderStatus::DepositConfirmed);
+        db.insert_order(&order).unwrap();
+        order
+    }
+
+    #[tokio::test]
+    async fn test_submit_then_confirmation_gating() {
+        let (processor, minter, db) = setup();
+        let order = insert_confirmed_deposit(&db);
+
+        // Submission: DepositConfirmed -> MintPending with a recorded tx.
+        processor.process_pending_orders().await.unwrap();
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::MintPending);
+        assert_eq!(stored.dest_tx.as_deref(), Some("0xmock_tx_1"));
+        assert!(db.get_mint_by_order(&order.id).unwrap().is_some());
+        assert_eq!(minter.prepare_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(minter.broadcast_calls.load(Ordering::SeqCst), 1);
+
+        // Gating: while below the confirmation requirement the order must
+        // NOT reach Completed.
+        minter.set_confirmation(ConfirmationStatus::Pending { confirmations: 3 });
+        processor.process_pending_orders().await.unwrap();
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(
+            stored.status,
+            OrderStatus::MintPending,
+            "MintPending must not advance before confirmations"
+        );
+        assert!(stored.dest_confirmed_at.is_none());
+
+        // Confirmed at depth: now (and only now) Completed.
+        minter.set_confirmation(ConfirmationStatus::Confirmed);
+        processor.process_pending_orders().await.unwrap();
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::Completed);
+        assert!(stored.dest_confirmed_at.is_some());
+        let mint = db.get_mint_by_order(&order.id).unwrap().unwrap();
+        assert!(mint.confirmed_at.is_some());
+
+        // No double-mint: prepare ran exactly once end to end.
+        assert_eq!(minter.prepare_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_resume_after_crash_reuses_recorded_tx() {
+        let (processor, minter, db) = setup();
+        let order = insert_confirmed_deposit(&db);
+
+        // Simulate a crash AFTER the mint tx was persisted but BEFORE the
+        // order status advanced: mints row exists, order still
+        // DepositConfirmed.
+        db.record_mint_submitted(
+            &order.id,
+            &hex::encode(order.order_id_bytes()),
+            Chain::Ethereum,
+            "0xpersisted_before_crash",
+        )
+        .unwrap();
+
+        processor.process_pending_orders().await.unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::MintPending);
+        assert_eq!(stored.dest_tx.as_deref(), Some("0xpersisted_before_crash"));
+        // Exactly-once: no new tx was prepared or broadcast.
+        assert_eq!(minter.prepare_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(minter.broadcast_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_reorg_unwinds_and_resubmits_same_order_id() {
+        let (processor, minter, db) = setup();
+        let order = insert_confirmed_deposit(&db);
+
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::MintPending
+        );
+
+        // Reorg before finality: unwind to DepositConfirmed.
+        minter.set_confirmation(ConfirmationStatus::Reorged);
+        processor.process_pending_orders().await.unwrap();
+        // (The same tick also re-submits, because submit runs before
+        // confirm; inspect the final state after both stages.)
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+
+        // Depending on tick interleaving the order is either back to
+        // DepositConfirmed (unwound this tick, resubmitted next) or already
+        // re-submitted. Drive one more tick with a fresh tx id to settle.
+        minter.set_next_tx("0xmock_tx_2");
+        minter.set_confirmation(ConfirmationStatus::Pending { confirmations: 0 });
+        processor.process_pending_orders().await.unwrap();
+
+        let stored2 = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored2.status, OrderStatus::MintPending);
+        let mint = db.get_mint_by_order(&order.id).unwrap().unwrap();
+        assert_eq!(mint.dest_tx, "0xmock_tx_2", "re-submission uses a fresh tx");
+        // Same on-chain order id across both submissions (the double-mint
+        // guard the contract enforces).
+        assert_eq!(mint.order_id_hash, hex::encode(order.order_id_bytes()));
+        assert_eq!(minter.prepare_calls.load(Ordering::SeqCst), 2);
+
+        let _ = stored;
+    }
+
+    #[tokio::test]
+    async fn test_failed_mint_marks_order_failed() {
+        let (processor, minter, db) = setup();
+        let order = insert_confirmed_deposit(&db);
+
+        processor.process_pending_orders().await.unwrap();
+
+        minter.set_confirmation(ConfirmationStatus::Failed {
+            reason: "no BridgeMint event".to_string(),
+        });
+        processor.process_pending_orders().await.unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert!(matches!(stored.status, OrderStatus::Failed { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_unconfigured_chain_leaves_order_retryable() {
+        let (processor, _minter, db) = setup();
+
+        // A Solana order with no Solana minter configured: the order must
+        // stay DepositConfirmed (retry later), NOT fail or complete.
+        let mut order = BridgeOrder::new_mint(
+            Chain::Solana,
+            1_000_000_000_000,
+            0,
+            "bth_addr".to_string(),
+            "So11111111111111111111111111111111111111112".to_string(),
+        );
+        order.set_status(OrderStatus::DepositConfirmed);
+        db.insert_order(&order).unwrap();
+
+        processor.process_pending_orders().await.unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::DepositConfirmed);
+    }
+
+    #[tokio::test]
+    async fn test_mint_to_bth_chain_fails_order() {
+        let (processor, _minter, db) = setup();
+
+        let mut order = BridgeOrder::new_mint(
+            Chain::Bth,
+            1_000_000_000_000,
+            0,
+            "bth_addr".to_string(),
+            "other_bth_addr".to_string(),
+        );
+        order.set_status(OrderStatus::DepositConfirmed);
+        db.insert_order(&order).unwrap();
+
+        processor.process_pending_orders().await.unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert!(matches!(stored.status, OrderStatus::Failed { .. }));
     }
 }

--- a/bridge/service/src/main.rs
+++ b/bridge/service/src/main.rs
@@ -10,8 +10,10 @@ use std::path::PathBuf;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
+mod attestation;
 mod db;
 mod engine;
+mod mint;
 mod watchers;
 
 use bth_bridge_core::BridgeConfig;

--- a/bridge/service/src/mint/ethereum.rs
+++ b/bridge/service/src/mint/ethereum.rs
@@ -1,0 +1,713 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Ethereum wBTH minting via alloy.
+//!
+//! Per ADR 0002, the Ethereum mint authority is a Gnosis Safe whose owners
+//! are the validators' secp256k1 keys and which holds `MINTER_ROLE` on
+//! `WrappedBTH.sol`. A mint is submitted as:
+//!
+//! ```text
+//! relayer EOA --eth_sendRawTransaction--> Safe.execTransaction(
+//!     to = WrappedBTH, data = bridgeMint(to, amount, orderId),
+//!     signatures = t-of-n owner signatures from the #824 attestation)
+//! ```
+//!
+//! The `bytes32` order id (`BridgeOrder::order_id_bytes`) is the on-chain
+//! idempotency key. NOTE: `WrappedBTH.sol` currently names this parameter
+//! `bthTxHash`; #826 renames it to `orderId` and adds the duplicate-order
+//! guard. The ABI (selector) is unchanged by that rename.
+
+use alloy::{
+    eips::{eip2718::Encodable2718, BlockNumberOrTag},
+    network::{EthereumWallet, TransactionBuilder},
+    primitives::{Address, Bytes, B256, U256},
+    providers::{DynProvider, Provider, ProviderBuilder},
+    rpc::types::{Log, TransactionRequest},
+    signers::local::PrivateKeySigner,
+    sol,
+    sol_types::{eip712_domain, SolCall, SolEvent, SolStruct},
+};
+use async_trait::async_trait;
+use bth_bridge_core::{
+    BridgeOrder, Chain, EthereumConfig, GasPriceStrategy, MintAuthorization, SignatureScheme,
+};
+use tracing::{debug, info, warn};
+
+use super::{ConfirmationStatus, MintError, Minter, PreparedMint};
+
+sol! {
+    /// Typed binding for the wBTH token (`contracts/ethereum/contracts/WrappedBTH.sol`).
+    #[allow(missing_docs)]
+    interface IWrappedBTH {
+        /// #826 renames `bthTxHash` -> `orderId`; the selector is identical.
+        function bridgeMint(address to, uint256 amount, bytes32 bthTxHash) external;
+        event BridgeMint(address indexed to, uint256 amount, bytes32 indexed bthTxHash);
+    }
+
+    /// Gnosis Safe (v1.3+) surface used by the bridge.
+    #[allow(missing_docs)]
+    interface IGnosisSafe {
+        function nonce() external view returns (uint256);
+        function execTransaction(
+            address to,
+            uint256 value,
+            bytes calldata data,
+            uint8 operation,
+            uint256 safeTxGas,
+            uint256 baseGas,
+            uint256 gasPrice,
+            address gasToken,
+            address payable refundReceiver,
+            bytes memory signatures
+        ) external payable returns (bool success);
+    }
+
+    /// Gnosis Safe EIP-712 transaction struct (for computing the digest the
+    /// #824 attestation signers must sign).
+    #[allow(missing_docs)]
+    struct SafeTx {
+        address to;
+        uint256 value;
+        bytes data;
+        uint8 operation;
+        uint256 safeTxGas;
+        uint256 baseGas;
+        uint256 gasPrice;
+        address gasToken;
+        address refundReceiver;
+        uint256 nonce;
+    }
+}
+
+/// Headroom multiplier applied to `eth_estimateGas` (percent).
+const GAS_HEADROOM_PERCENT: u64 = 125;
+
+/// Minimum priority fee (wei) so the tx is never submitted tip-less.
+const MIN_PRIORITY_FEE_WEI: u128 = 100_000_000; // 0.1 gwei
+
+/// Encode the `bridgeMint(to, amount, orderId)` calldata.
+pub fn encode_bridge_mint_calldata(to: Address, amount: U256, order_id: [u8; 32]) -> Vec<u8> {
+    IWrappedBTH::bridgeMintCall {
+        to,
+        amount,
+        bthTxHash: B256::from(order_id),
+    }
+    .abi_encode()
+}
+
+/// Compute the Gnosis Safe EIP-712 transaction hash for a `bridgeMint` call
+/// wrapped at the given Safe nonce. This is the digest the #824 attestation
+/// protocol must collect owner signatures over.
+pub fn safe_tx_hash(
+    chain_id: u64,
+    safe: Address,
+    wbth: Address,
+    mint_calldata: &[u8],
+    safe_nonce: U256,
+) -> B256 {
+    let tx = SafeTx {
+        to: wbth,
+        value: U256::ZERO,
+        data: Bytes::copy_from_slice(mint_calldata),
+        operation: 0,
+        safeTxGas: U256::ZERO,
+        baseGas: U256::ZERO,
+        gasPrice: U256::ZERO,
+        gasToken: Address::ZERO,
+        refundReceiver: Address::ZERO,
+        nonce: safe_nonce,
+    };
+    // Safe's domain separator only carries chainId + verifyingContract.
+    let domain = eip712_domain! {
+        chain_id: chain_id,
+        verifying_contract: safe,
+    };
+    tx.eip712_signing_hash(&domain)
+}
+
+/// Assemble the Safe `signatures` blob from a threshold attestation.
+///
+/// Gnosis Safe requires the 65-byte `{r, s, v}` owner signatures
+/// concatenated in ascending order of owner address, with no duplicates.
+pub fn assemble_safe_signatures(auth: &MintAuthorization) -> Result<Bytes, MintError> {
+    if auth.scheme != SignatureScheme::Secp256k1 {
+        return Err(MintError::Attestation(
+            "Ethereum mint requires secp256k1 attestation signatures".to_string(),
+        ));
+    }
+    if !auth.meets_threshold() {
+        return Err(MintError::Attestation(format!(
+            "attestation has {} signature(s), threshold is {}",
+            auth.signatures.len(),
+            auth.threshold
+        )));
+    }
+
+    let mut sigs = auth.signatures.clone();
+    sigs.sort_by(|a, b| a.signer.cmp(&b.signer));
+    sigs.dedup_by(|a, b| a.signer == b.signer);
+
+    let mut blob = Vec::with_capacity(sigs.len() * 65);
+    for sig in &sigs {
+        if sig.signer.len() != 20 {
+            return Err(MintError::Attestation(format!(
+                "safe owner identity must be a 20-byte address, got {} bytes",
+                sig.signer.len()
+            )));
+        }
+        if sig.signature.len() != 65 {
+            return Err(MintError::Attestation(format!(
+                "safe owner signature must be 65 bytes, got {}",
+                sig.signature.len()
+            )));
+        }
+        blob.extend_from_slice(&sig.signature);
+    }
+
+    Ok(blob.into())
+}
+
+/// Map the configured [`GasPriceStrategy`] to EIP-1559 fee fields, given the
+/// next block's base fee and the observed priority-fee percentiles from
+/// `eth_feeHistory` (10th / 50th / 90th).
+///
+/// Returns `(max_fee_per_gas, max_priority_fee_per_gas)` in wei.
+pub fn eip1559_fees(
+    strategy: GasPriceStrategy,
+    next_base_fee: u128,
+    tip_percentiles: [u128; 3],
+) -> (u128, u128) {
+    match strategy {
+        GasPriceStrategy::Fixed(gwei) => {
+            // Legacy-style fixed price: cap total and tip at the fixed value.
+            let wei = (gwei as u128) * 1_000_000_000;
+            (wei, wei)
+        }
+        _ => {
+            let tip = match strategy {
+                GasPriceStrategy::Low => tip_percentiles[0],
+                GasPriceStrategy::Medium => tip_percentiles[1],
+                GasPriceStrategy::High => tip_percentiles[2],
+                GasPriceStrategy::Fixed(_) => unreachable!(),
+            }
+            .max(MIN_PRIORITY_FEE_WEI);
+            // Double the base fee so the tx survives 100% base-fee growth
+            // while waiting for inclusion.
+            (next_base_fee.saturating_mul(2).saturating_add(tip), tip)
+        }
+    }
+}
+
+/// Scan receipt logs for the `BridgeMint` event bound to `order_id`, emitted
+/// by the wBTH contract.
+pub fn find_bridge_mint_event(logs: &[Log], wbth: Address, order_id: [u8; 32]) -> bool {
+    let order_topic = B256::from(order_id);
+    logs.iter().any(|log| {
+        log.address() == wbth
+            && log.topic0() == Some(&IWrappedBTH::BridgeMint::SIGNATURE_HASH)
+            // topics: [signature, to (indexed), bthTxHash/orderId (indexed)]
+            && log.topics().get(2) == Some(&order_topic)
+    })
+}
+
+/// Ethereum minting backend.
+pub struct EthMinter {
+    config: EthereumConfig,
+    provider: DynProvider,
+    wbth: Address,
+    safe: Address,
+    /// Relayer EOA that pays gas to submit `execTransaction`. `None` in
+    /// watch-only mode (confirmation polling still works).
+    relayer: Option<(Address, EthereumWallet)>,
+}
+
+impl EthMinter {
+    /// Build a minter from configuration. Does not perform network I/O.
+    pub fn new(config: EthereumConfig) -> Result<Self, MintError> {
+        let wbth: Address = config
+            .wbth_contract
+            .parse()
+            .map_err(|e| MintError::Config(format!("invalid wbth_contract: {}", e)))?;
+
+        let safe: Address = config
+            .safe_address
+            .as_deref()
+            .ok_or_else(|| {
+                MintError::Config(
+                    "ethereum.safe_address is required for mint submission (ADR 0002)".to_string(),
+                )
+            })?
+            .parse()
+            .map_err(|e| MintError::Config(format!("invalid safe_address: {}", e)))?;
+
+        let url = config
+            .rpc_url
+            .parse()
+            .map_err(|e| MintError::Config(format!("invalid ethereum rpc_url: {}", e)))?;
+        let provider = ProviderBuilder::new().connect_http(url).erased();
+
+        // TODO(#827): the relayer key file is currently read as plaintext
+        // hex; key provisioning/encryption is tracked in the ops runbook
+        // issue. The relayer is NOT a custody key — it only pays gas; the
+        // mint authority is the Safe threshold (ADR 0002).
+        let relayer = match config.private_key_file.as_deref() {
+            Some(path) => {
+                let raw = std::fs::read_to_string(path).map_err(|e| {
+                    MintError::Config(format!("cannot read private_key_file {}: {}", path, e))
+                })?;
+                let signer: PrivateKeySigner = raw
+                    .trim()
+                    .parse()
+                    .map_err(|e| MintError::Config(format!("invalid relayer key: {}", e)))?;
+                let address = signer.address();
+                Some((address, EthereumWallet::from(signer)))
+            }
+            None => None,
+        };
+
+        Ok(Self {
+            config,
+            provider,
+            wbth,
+            safe,
+            relayer,
+        })
+    }
+
+    /// Read the Safe's current nonce from chain.
+    async fn safe_nonce(&self) -> Result<U256, MintError> {
+        let call = TransactionRequest::default()
+            .with_to(self.safe)
+            .with_input(IGnosisSafe::nonceCall {}.abi_encode());
+        let ret = self
+            .provider
+            .call(call)
+            .await
+            .map_err(|e| MintError::Rpc(format!("safe nonce() call failed: {}", e)))?;
+        IGnosisSafe::nonceCall::abi_decode_returns(&ret)
+            .map_err(|e| MintError::Rpc(format!("safe nonce() decode failed: {}", e)))
+    }
+
+    /// Fetch fee-history-derived EIP-1559 fees per the configured strategy.
+    async fn current_fees(&self) -> Result<(u128, u128), MintError> {
+        if let GasPriceStrategy::Fixed(gwei) = self.config.gas_price_strategy {
+            return Ok(eip1559_fees(GasPriceStrategy::Fixed(gwei), 0, [0, 0, 0]));
+        }
+
+        let history = self
+            .provider
+            .get_fee_history(5, BlockNumberOrTag::Latest, &[10.0, 50.0, 90.0])
+            .await
+            .map_err(|e| MintError::Rpc(format!("eth_feeHistory failed: {}", e)))?;
+
+        // The last entry of base_fee_per_gas is the NEXT block's base fee.
+        let next_base_fee = history
+            .base_fee_per_gas
+            .last()
+            .copied()
+            .ok_or_else(|| MintError::Rpc("empty base_fee_per_gas".to_string()))?;
+
+        // Average each percentile column across the sampled blocks.
+        let mut tips = [0u128; 3];
+        if let Some(rewards) = &history.reward {
+            if !rewards.is_empty() {
+                for (i, tip) in tips.iter_mut().enumerate() {
+                    let sum: u128 = rewards.iter().filter_map(|r| r.get(i)).copied().sum();
+                    *tip = sum / rewards.len() as u128;
+                }
+            }
+        }
+
+        Ok(eip1559_fees(
+            self.config.gas_price_strategy,
+            next_base_fee,
+            tips,
+        ))
+    }
+}
+
+#[async_trait]
+impl Minter for EthMinter {
+    fn chain(&self) -> Chain {
+        Chain::Ethereum
+    }
+
+    async fn prepare_mint(
+        &self,
+        order: &BridgeOrder,
+        auth: &MintAuthorization,
+    ) -> Result<PreparedMint, MintError> {
+        let order_id = order.order_id_bytes();
+
+        // The attestation must be bound to THIS order's on-chain id — a
+        // replayed authorization for another order is rejected here, and a
+        // replay for the same order can only re-produce the same mint.
+        if auth.order_id != order_id {
+            return Err(MintError::Attestation(
+                "attestation order id does not match order".to_string(),
+            ));
+        }
+
+        let (relayer_addr, wallet) = self.relayer.as_ref().ok_or_else(|| {
+            MintError::Config("no relayer key configured (ethereum.private_key_file)".to_string())
+        })?;
+
+        let to: Address = order
+            .dest_address
+            .parse()
+            .map_err(|e| MintError::Config(format!("invalid dest_address: {}", e)))?;
+        let amount = U256::from(order.net_amount());
+
+        // Inner call: bridgeMint(to, amount, orderId) on wBTH.
+        let mint_calldata = encode_bridge_mint_calldata(to, amount, order_id);
+
+        // Safe wrapper: execTransaction with the threshold owner signatures.
+        let safe_nonce = self.safe_nonce().await?;
+        let signatures = assemble_safe_signatures(auth)?;
+        debug!(
+            "safe tx hash for order {}: {}",
+            order.id,
+            safe_tx_hash(
+                self.config.chain_id,
+                self.safe,
+                self.wbth,
+                &mint_calldata,
+                safe_nonce
+            )
+        );
+        let exec_calldata = IGnosisSafe::execTransactionCall {
+            to: self.wbth,
+            value: U256::ZERO,
+            data: mint_calldata.into(),
+            operation: 0,
+            safeTxGas: U256::ZERO,
+            baseGas: U256::ZERO,
+            gasPrice: U256::ZERO,
+            gasToken: Address::ZERO,
+            refundReceiver: Address::ZERO,
+            signatures,
+        }
+        .abi_encode();
+
+        // Relayer EOA nonce (pending, so sequential submissions chain).
+        let relayer_nonce = self
+            .provider
+            .get_transaction_count(*relayer_addr)
+            .pending()
+            .await
+            .map_err(|e| MintError::Rpc(format!("get_transaction_count failed: {}", e)))?;
+
+        let (max_fee, max_priority_fee) = self.current_fees().await?;
+
+        let mut tx = TransactionRequest::default()
+            .with_from(*relayer_addr)
+            .with_to(self.safe)
+            .with_input(exec_calldata)
+            .with_nonce(relayer_nonce)
+            .with_chain_id(self.config.chain_id)
+            .with_max_fee_per_gas(max_fee)
+            .with_max_priority_fee_per_gas(max_priority_fee);
+
+        let gas = self
+            .provider
+            .estimate_gas(tx.clone())
+            .await
+            .map_err(|e| MintError::Rpc(format!("eth_estimateGas failed: {}", e)))?;
+        tx = tx.with_gas_limit(gas.saturating_mul(GAS_HEADROOM_PERCENT) / 100);
+
+        // Sign locally. The raw bytes are kept so every retry re-broadcasts
+        // the SAME transaction (same relayer nonce, same Safe nonce, same
+        // order id) — a retry can therefore never double-mint.
+        let envelope = tx
+            .build(wallet)
+            .await
+            .map_err(|e| MintError::Config(format!("tx signing failed: {}", e)))?;
+
+        let tx_id = format!("{:#x}", envelope.tx_hash());
+        let raw = envelope.encoded_2718();
+
+        info!(
+            "prepared ETH mint for order {}: tx {} (safe nonce {}, {} wBTH to {})",
+            order.id,
+            tx_id,
+            safe_nonce,
+            order.net_amount(),
+            order.dest_address
+        );
+
+        Ok(PreparedMint { tx_id, raw })
+    }
+
+    async fn broadcast(&self, prepared: &PreparedMint) -> Result<(), MintError> {
+        match self.provider.send_raw_transaction(&prepared.raw).await {
+            Ok(pending) => {
+                debug!("broadcast ETH tx {}", pending.tx_hash());
+                Ok(())
+            }
+            Err(e) => {
+                let msg = e.to_string().to_lowercase();
+                // Idempotent re-broadcast: the node already has (or already
+                // mined) this exact transaction.
+                if msg.contains("already known")
+                    || msg.contains("already imported")
+                    || msg.contains("known transaction")
+                    || msg.contains("nonce too low")
+                {
+                    warn!(
+                        "ETH tx {} already known to the node ({}); treating as broadcast",
+                        prepared.tx_id, msg
+                    );
+                    Ok(())
+                } else {
+                    Err(MintError::Rpc(format!(
+                        "eth_sendRawTransaction failed: {}",
+                        e
+                    )))
+                }
+            }
+        }
+    }
+
+    async fn check_confirmation(
+        &self,
+        order: &BridgeOrder,
+        dest_tx: &str,
+    ) -> Result<ConfirmationStatus, MintError> {
+        let tx_hash: B256 = dest_tx
+            .parse()
+            .map_err(|e| MintError::Config(format!("invalid dest_tx {}: {}", dest_tx, e)))?;
+
+        let receipt = self
+            .provider
+            .get_transaction_receipt(tx_hash)
+            .await
+            .map_err(|e| MintError::Rpc(format!("get_transaction_receipt failed: {}", e)))?;
+
+        let Some(receipt) = receipt else {
+            // No receipt. If the node no longer knows the tx at all it was
+            // dropped (or its block reorged out and it was not re-included):
+            // unwind and re-submit.
+            let known = self
+                .provider
+                .get_transaction_by_hash(tx_hash)
+                .await
+                .map_err(|e| MintError::Rpc(format!("get_transaction_by_hash failed: {}", e)))?;
+            return Ok(if known.is_some() {
+                ConfirmationStatus::Pending { confirmations: 0 }
+            } else {
+                ConfirmationStatus::Reorged
+            });
+        };
+
+        if !receipt.status() {
+            return Ok(ConfirmationStatus::Failed {
+                reason: "execTransaction reverted on-chain".to_string(),
+            });
+        }
+
+        // The Safe swallows inner-call failures (ExecutionFailure) without
+        // reverting, so a successful receipt is not enough: require the
+        // BridgeMint event bound to this exact order id.
+        if !find_bridge_mint_event(receipt.inner.logs(), self.wbth, order.order_id_bytes()) {
+            return Ok(ConfirmationStatus::Failed {
+                reason: "tx executed but no BridgeMint event for this order id \
+                         (Safe inner call failed?)"
+                    .to_string(),
+            });
+        }
+
+        let Some(block_number) = receipt.block_number else {
+            return Ok(ConfirmationStatus::Pending { confirmations: 0 });
+        };
+
+        let current = self
+            .provider
+            .get_block_number()
+            .await
+            .map_err(|e| MintError::Rpc(format!("get_block_number failed: {}", e)))?;
+
+        let confirmations = current.saturating_sub(block_number) + 1;
+        if confirmations < self.config.confirmations_required as u64 {
+            return Ok(ConfirmationStatus::Pending { confirmations });
+        }
+
+        // Depth reached — verify the receipt's block is still canonical
+        // before declaring finality.
+        let block = self
+            .provider
+            .get_block_by_number(BlockNumberOrTag::Number(block_number))
+            .await
+            .map_err(|e| MintError::Rpc(format!("get_block_by_number failed: {}", e)))?;
+
+        match (block, receipt.block_hash) {
+            (Some(block), Some(receipt_hash)) if block.header.hash == receipt_hash => {
+                Ok(ConfirmationStatus::Confirmed)
+            }
+            _ => Ok(ConfirmationStatus::Reorged),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::LogData;
+    use bth_bridge_core::AttestationSignature;
+
+    fn addr(byte: u8) -> Address {
+        Address::from([byte; 20])
+    }
+
+    #[test]
+    fn test_bridge_mint_calldata_roundtrip() {
+        let to = addr(0x11);
+        let amount = U256::from(999_000_000_000u64);
+        let order_id = [7u8; 32];
+
+        let calldata = encode_bridge_mint_calldata(to, amount, order_id);
+
+        // Selector for bridgeMint(address,uint256,bytes32).
+        assert_eq!(&calldata[..4], IWrappedBTH::bridgeMintCall::SELECTOR);
+
+        let decoded = IWrappedBTH::bridgeMintCall::abi_decode(&calldata).unwrap();
+        assert_eq!(decoded.to, to);
+        assert_eq!(decoded.amount, amount);
+        assert_eq!(decoded.bthTxHash, B256::from(order_id));
+    }
+
+    #[test]
+    fn test_safe_signature_assembly_sorted_by_owner() {
+        let sig = |owner: u8, marker: u8| AttestationSignature {
+            signer: vec![owner; 20],
+            signature: vec![marker; 65],
+        };
+        // Provided out of order — must be emitted ascending by owner.
+        let auth = MintAuthorization {
+            order_id: [0u8; 32],
+            scheme: SignatureScheme::Secp256k1,
+            threshold: 2,
+            signatures: vec![sig(0xBB, 2), sig(0xAA, 1)],
+        };
+
+        let blob = assemble_safe_signatures(&auth).unwrap();
+        assert_eq!(blob.len(), 130);
+        assert_eq!(blob[0], 1, "lower owner address must come first");
+        assert_eq!(blob[65], 2);
+    }
+
+    #[test]
+    fn test_safe_signature_assembly_rejects_below_threshold() {
+        let auth = MintAuthorization {
+            order_id: [0u8; 32],
+            scheme: SignatureScheme::Secp256k1,
+            threshold: 2,
+            signatures: vec![AttestationSignature {
+                signer: vec![1u8; 20],
+                signature: vec![0u8; 65],
+            }],
+        };
+        assert!(matches!(
+            assemble_safe_signatures(&auth),
+            Err(MintError::Attestation(_))
+        ));
+    }
+
+    #[test]
+    fn test_safe_signature_assembly_rejects_wrong_scheme() {
+        let auth = MintAuthorization {
+            order_id: [0u8; 32],
+            scheme: SignatureScheme::Ed25519,
+            threshold: 0,
+            signatures: vec![],
+        };
+        assert!(matches!(
+            assemble_safe_signatures(&auth),
+            Err(MintError::Attestation(_))
+        ));
+    }
+
+    #[test]
+    fn test_gas_strategy_mapping() {
+        let base = 10_000_000_000u128; // 10 gwei
+        let tips = [
+            1_000_000_000u128, // p10
+            2_000_000_000,     // p50
+            5_000_000_000,     // p90
+        ];
+
+        let (max_low, tip_low) = eip1559_fees(GasPriceStrategy::Low, base, tips);
+        assert_eq!(tip_low, tips[0]);
+        assert_eq!(max_low, base * 2 + tips[0]);
+
+        let (max_med, tip_med) = eip1559_fees(GasPriceStrategy::Medium, base, tips);
+        assert_eq!(tip_med, tips[1]);
+        assert_eq!(max_med, base * 2 + tips[1]);
+
+        let (max_high, tip_high) = eip1559_fees(GasPriceStrategy::High, base, tips);
+        assert_eq!(tip_high, tips[2]);
+        assert_eq!(max_high, base * 2 + tips[2]);
+
+        // Fixed maps gwei -> wei on both fields (legacy-style price).
+        let (max_fixed, tip_fixed) = eip1559_fees(GasPriceStrategy::Fixed(30), base, tips);
+        assert_eq!(max_fixed, 30_000_000_000);
+        assert_eq!(tip_fixed, 30_000_000_000);
+
+        // Tip is floored so the tx is never tip-less.
+        let (_, tip_floor) = eip1559_fees(GasPriceStrategy::Low, base, [0, 0, 0]);
+        assert_eq!(tip_floor, MIN_PRIORITY_FEE_WEI);
+    }
+
+    #[test]
+    fn test_safe_tx_hash_binds_all_inputs() {
+        let calldata = encode_bridge_mint_calldata(addr(1), U256::from(5u8), [9u8; 32]);
+        let h = |chain: u64, nonce: u64| {
+            safe_tx_hash(chain, addr(0x5A), addr(0xEE), &calldata, U256::from(nonce))
+        };
+
+        // Deterministic.
+        assert_eq!(h(1, 0), h(1, 0));
+        // Changes with chain id and Safe nonce (replay protection).
+        assert_ne!(h(1, 0), h(5, 0));
+        assert_ne!(h(1, 0), h(1, 1));
+        // Changes with calldata (order id binding).
+        let other = encode_bridge_mint_calldata(addr(1), U256::from(5u8), [8u8; 32]);
+        assert_ne!(
+            safe_tx_hash(1, addr(2), addr(3), &calldata, U256::ZERO),
+            safe_tx_hash(1, addr(2), addr(3), &other, U256::ZERO)
+        );
+    }
+
+    fn mint_log(contract: Address, to: Address, order_id: [u8; 32]) -> Log {
+        Log {
+            inner: alloy::primitives::Log {
+                address: contract,
+                data: LogData::new_unchecked(
+                    vec![
+                        IWrappedBTH::BridgeMint::SIGNATURE_HASH,
+                        B256::left_padding_from(to.as_slice()),
+                        B256::from(order_id),
+                    ],
+                    U256::from(1u8).to_be_bytes_vec().into(),
+                ),
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_find_bridge_mint_event_matches_order_id() {
+        let wbth = addr(0xEE);
+        let order_id = [3u8; 32];
+
+        let logs = vec![mint_log(wbth, addr(1), order_id)];
+        assert!(find_bridge_mint_event(&logs, wbth, order_id));
+
+        // Wrong order id: a mint for a DIFFERENT order must not confirm
+        // this one.
+        assert!(!find_bridge_mint_event(&logs, wbth, [4u8; 32]));
+
+        // Right event shape but wrong emitting contract.
+        let spoofed = vec![mint_log(addr(0xDD), addr(1), order_id)];
+        assert!(!find_bridge_mint_event(&spoofed, wbth, order_id));
+    }
+}

--- a/bridge/service/src/mint/mod.rs
+++ b/bridge/service/src/mint/mod.rs
@@ -1,0 +1,109 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Destination-chain mint submission and confirmation.
+//!
+//! Each destination chain implements [`Minter`], which splits a mint into
+//! three retryable stages so the engine can guarantee exactly-once minting:
+//!
+//! 1. [`Minter::prepare_mint`] — build and sign the transaction locally (no
+//!    broadcast). The resulting [`PreparedMint`] carries the exact raw bytes so
+//!    a retry re-broadcasts the SAME transaction (same nonce, same on-chain
+//!    order id) instead of creating a competing one.
+//! 2. [`Minter::broadcast`] — send the raw transaction. The engine persists the
+//!    tx id to the `mints` idempotency table BEFORE the first broadcast.
+//! 3. [`Minter::check_confirmation`] — poll until the confirmation requirement
+//!    (`confirmations_required` blocks on Ethereum, the configured commitment
+//!    on Solana) is met, reporting reorgs so the engine can unwind `MintPending
+//!    -> DepositConfirmed` and re-submit.
+
+pub mod ethereum;
+pub mod solana;
+
+use async_trait::async_trait;
+use bth_bridge_core::{BridgeOrder, Chain, MintAuthorization};
+
+/// Errors from mint submission / confirmation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MintError {
+    /// Misconfiguration (bad address, missing key/Safe, ...).
+    Config(String),
+    /// The provided attestation does not authorize this mint.
+    Attestation(String),
+    /// RPC / network failure (retryable).
+    Rpc(String),
+    /// Functionality not yet wired up (Solana RPC bodies, see #828).
+    NotImplemented(String),
+}
+
+impl std::fmt::Display for MintError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MintError::Config(m) => write!(f, "config error: {}", m),
+            MintError::Attestation(m) => write!(f, "attestation error: {}", m),
+            MintError::Rpc(m) => write!(f, "rpc error: {}", m),
+            MintError::NotImplemented(m) => write!(f, "not implemented: {}", m),
+        }
+    }
+}
+
+impl std::error::Error for MintError {}
+
+/// A fully signed, ready-to-broadcast mint transaction.
+#[derive(Debug, Clone)]
+pub struct PreparedMint {
+    /// Destination-chain transaction id (0x-prefixed hash on Ethereum,
+    /// base58 signature on Solana). Known before broadcast.
+    pub tx_id: String,
+    /// The exact signed bytes to (re)broadcast.
+    pub raw: Vec<u8>,
+}
+
+/// Result of polling a submitted mint transaction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfirmationStatus {
+    /// Not yet at the required depth; keep the order in `MintPending`.
+    Pending {
+        /// Confirmations observed so far (0 = not yet mined / processed).
+        confirmations: u64,
+    },
+    /// Required depth reached, block canonical, and the mint event with the
+    /// bound order id is present: safe to advance to `Completed`.
+    Confirmed,
+    /// The transaction was dropped or its block reorged out before
+    /// finality. The engine must roll the order back to `DepositConfirmed`
+    /// and re-run submission against the same on-chain order id.
+    Reorged,
+    /// The transaction executed but the mint did not happen (e.g. the Safe
+    /// inner call failed / the contract rejected the mint). Requires
+    /// operator attention — auto-resubmitting could race a rate limit.
+    Failed {
+        /// Human-readable failure description.
+        reason: String,
+    },
+}
+
+/// A destination-chain minting backend.
+#[async_trait]
+pub trait Minter: Send + Sync {
+    /// The chain this minter submits to.
+    fn chain(&self) -> Chain;
+
+    /// Build and sign the mint transaction for `order`, authorized by
+    /// `auth` (the #824 threshold attestation). Does NOT broadcast.
+    async fn prepare_mint(
+        &self,
+        order: &BridgeOrder,
+        auth: &MintAuthorization,
+    ) -> Result<PreparedMint, MintError>;
+
+    /// Broadcast (or re-broadcast) a prepared transaction. Idempotent:
+    /// "already known" responses are success.
+    async fn broadcast(&self, prepared: &PreparedMint) -> Result<(), MintError>;
+
+    /// Poll the confirmation state of a submitted mint transaction.
+    async fn check_confirmation(
+        &self,
+        order: &BridgeOrder,
+        dest_tx: &str,
+    ) -> Result<ConfirmationStatus, MintError>;
+}

--- a/bridge/service/src/mint/solana.rs
+++ b/bridge/service/src/mint/solana.rs
@@ -1,0 +1,278 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Solana wBTH minting (Anchor program `wbth_bridge`).
+//!
+//! Per ADR 0002, Solana mint authorizations are signed natively by the
+//! validators' Ed25519 keys — no secp256k1 detour is needed. The on-chain
+//! program (`contracts/solana/programs/wbth`) exposes
+//! `bridge_mint(amount: u64, order_id: [u8; 32])` gated on the `Bridge` PDA
+//! (`seeds = [b"bridge"]`) authority. NOTE: the program currently names the
+//! second argument `bth_tx_hash`; #826 renames it to `order_id` and adds the
+//! duplicate-order guard. The Anchor discriminator is unchanged by that
+//! rename (it hashes the instruction NAME, `bridge_mint`).
+//!
+//! ## Implementation status
+//!
+//! The deterministic, chain-agnostic pieces are implemented and unit-tested
+//! here: attestation validation (Ed25519 scheme, order-id binding,
+//! threshold) and Anchor instruction-data construction (discriminator +
+//! borsh args), so the exact bytes that will land on-chain are pinned.
+//!
+//! The RPC-dependent bodies (recent-blockhash fetch, transaction assembly
+//! and Ed25519 multisig signing per #824, `send_transaction`,
+//! `get_signature_statuses` polling to the configured commitment) are
+//! `TODO(#824/#828)` stubs returning [`MintError::NotImplemented`]. They
+//! require the `solana-client`/`anchor-client` dependency stack, which is
+//! deferred to keep this workspace's dependency tree (curve25519-dalek v4,
+//! zeroize, etc.) unconflicted until the Solana test harness (#828) lands
+//! and can validate the wiring end to end.
+
+use async_trait::async_trait;
+use bth_bridge_core::{
+    BridgeOrder, Chain, MintAuthorization, SignatureScheme, SolanaCommitment, SolanaConfig,
+};
+use sha2::{Digest, Sha256};
+
+use super::{ConfirmationStatus, MintError, Minter, PreparedMint};
+
+/// Seed for the bridge state PDA (`seeds = [b"bridge"]` in the program).
+/// Consumed by the #828 transaction-assembly work (PDA derivation).
+#[allow(dead_code)]
+pub const BRIDGE_PDA_SEED: &[u8] = b"bridge";
+
+/// Compute the Anchor instruction discriminator for a global instruction:
+/// the first 8 bytes of `sha256("global:<name>")`.
+pub fn anchor_discriminator(instruction_name: &str) -> [u8; 8] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"global:");
+    hasher.update(instruction_name.as_bytes());
+    let digest = hasher.finalize();
+    let mut disc = [0u8; 8];
+    disc.copy_from_slice(&digest[..8]);
+    disc
+}
+
+/// Build the `bridge_mint(amount, order_id)` instruction data:
+/// 8-byte Anchor discriminator, then the borsh-encoded args
+/// (`u64` little-endian amount, raw 32-byte order id).
+pub fn encode_bridge_mint_instruction_data(amount: u64, order_id: [u8; 32]) -> Vec<u8> {
+    let mut data = Vec::with_capacity(8 + 8 + 32);
+    data.extend_from_slice(&anchor_discriminator("bridge_mint"));
+    data.extend_from_slice(&amount.to_le_bytes());
+    data.extend_from_slice(&order_id);
+    data
+}
+
+/// Validate that an attestation authorizes a Solana mint for `order`.
+pub fn validate_solana_attestation(
+    order: &BridgeOrder,
+    auth: &MintAuthorization,
+) -> Result<(), MintError> {
+    if auth.scheme != SignatureScheme::Ed25519 {
+        return Err(MintError::Attestation(
+            "Solana mint requires Ed25519 attestation signatures".to_string(),
+        ));
+    }
+    if auth.order_id != order.order_id_bytes() {
+        return Err(MintError::Attestation(
+            "attestation order id does not match order".to_string(),
+        ));
+    }
+    if !auth.meets_threshold() {
+        return Err(MintError::Attestation(format!(
+            "attestation has {} signature(s), threshold is {}",
+            auth.signatures.len(),
+            auth.threshold
+        )));
+    }
+    for sig in &auth.signatures {
+        if sig.signer.len() != 32 {
+            return Err(MintError::Attestation(format!(
+                "ed25519 signer must be a 32-byte pubkey, got {} bytes",
+                sig.signer.len()
+            )));
+        }
+        if sig.signature.len() != 64 {
+            return Err(MintError::Attestation(format!(
+                "ed25519 signature must be 64 bytes, got {}",
+                sig.signature.len()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Solana minting backend.
+///
+/// See the module docs: instruction construction and attestation validation
+/// are live; RPC submission/confirmation are `TODO(#824/#828)` stubs.
+pub struct SolMinter {
+    #[allow(dead_code)]
+    config: SolanaConfig,
+}
+
+impl SolMinter {
+    /// Build a minter from configuration. Does not perform network I/O.
+    pub fn new(config: SolanaConfig) -> Result<Self, MintError> {
+        if config.wbth_program.is_empty() {
+            return Err(MintError::Config(
+                "solana.wbth_program is empty".to_string(),
+            ));
+        }
+        Ok(Self { config })
+    }
+
+    /// The commitment level a mint must reach before `Completed`.
+    #[allow(dead_code)]
+    pub fn required_commitment(&self) -> SolanaCommitment {
+        self.config.commitment
+    }
+}
+
+#[async_trait]
+impl Minter for SolMinter {
+    fn chain(&self) -> Chain {
+        Chain::Solana
+    }
+
+    async fn prepare_mint(
+        &self,
+        order: &BridgeOrder,
+        auth: &MintAuthorization,
+    ) -> Result<PreparedMint, MintError> {
+        validate_solana_attestation(order, auth)?;
+
+        // The instruction bytes that will land on-chain are already pinned
+        // (and unit-tested) by encode_bridge_mint_instruction_data.
+        let _instruction_data =
+            encode_bridge_mint_instruction_data(order.net_amount(), order.order_id_bytes());
+
+        // TODO(#824/#828): assemble and sign the transaction. Requires the
+        // solana-sdk/anchor-client stack:
+        //   1. Derive the Bridge PDA (seeds=[b"bridge"]) and the recipient's associated
+        //      token account; prepend a create-idempotent-ATA instruction
+        //      (spl-associated-token-account).
+        //   2. Fetch a recent blockhash (or use a durable nonce account so the signed
+        //      tx never expires across retries).
+        //   3. Sign with the #824 Ed25519 multisig authority (validator threshold;
+        //      multisig authority PDA / Squads-style).
+        //   4. The first signature is the transaction id (base58) — return it in
+        //      PreparedMint.tx_id with the serialized tx in raw.
+        Err(MintError::NotImplemented(
+            "Solana transaction assembly/signing pending #824 (attestation) and #828 \
+             (solana-test-validator harness)"
+                .to_string(),
+        ))
+    }
+
+    async fn broadcast(&self, _prepared: &PreparedMint) -> Result<(), MintError> {
+        // TODO(#828): sendTransaction(base64(raw)) with
+        // skip_preflight=false; treat "AlreadyProcessed" as success
+        // (idempotent re-broadcast). The on-chain order-id guard (#826) and
+        // the blockhash/durable-nonce guarantee a resubmit cannot
+        // double-mint.
+        Err(MintError::NotImplemented(
+            "Solana send_transaction pending #828".to_string(),
+        ))
+    }
+
+    async fn check_confirmation(
+        &self,
+        _order: &BridgeOrder,
+        _dest_tx: &str,
+    ) -> Result<ConfirmationStatus, MintError> {
+        // TODO(#828): poll getSignatureStatuses(dest_tx) until the
+        // configured SolanaCommitment (default Finalized); confirm the
+        // BridgeMintEvent in the tx meta/logs, then Confirmed. A dropped /
+        // expired-blockhash signature (status None after the blockhash's
+        // last_valid_block_height) maps to Reorged so the engine rolls the
+        // order back to DepositConfirmed and re-submits.
+        Err(MintError::NotImplemented(
+            "Solana get_signature_statuses polling pending #828".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bth_bridge_core::AttestationSignature;
+
+    #[test]
+    fn test_anchor_discriminator_known_vector() {
+        // sha256("global:bridge_mint")[..8] — must match what Anchor
+        // computes for the deployed program. Pinned so a silent rename of
+        // the instruction breaks the build's tests, not mainnet.
+        let disc = anchor_discriminator("bridge_mint");
+        let mut hasher = Sha256::new();
+        hasher.update(b"global:bridge_mint");
+        assert_eq!(disc, hasher.finalize()[..8]);
+        // The #826 rename of the ARGUMENT (bth_tx_hash -> order_id) does
+        // not change the discriminator; renaming the INSTRUCTION would.
+        assert_ne!(disc, anchor_discriminator("bridgeMint"));
+    }
+
+    #[test]
+    fn test_bridge_mint_instruction_data_layout() {
+        let order_id = [7u8; 32];
+        let data = encode_bridge_mint_instruction_data(999_000_000_000, order_id);
+
+        assert_eq!(data.len(), 8 + 8 + 32);
+        assert_eq!(&data[..8], &anchor_discriminator("bridge_mint"));
+        assert_eq!(&data[8..16], &999_000_000_000u64.to_le_bytes());
+        assert_eq!(&data[16..48], &order_id);
+    }
+
+    fn order_and_auth() -> (BridgeOrder, MintAuthorization) {
+        let order = BridgeOrder::new_mint(
+            Chain::Solana,
+            1_000_000_000_000,
+            0,
+            "bth_addr".to_string(),
+            "So11111111111111111111111111111111111111112".to_string(),
+        );
+        let auth = MintAuthorization {
+            order_id: order.order_id_bytes(),
+            scheme: SignatureScheme::Ed25519,
+            threshold: 1,
+            signatures: vec![AttestationSignature {
+                signer: vec![1u8; 32],
+                signature: vec![2u8; 64],
+            }],
+        };
+        (order, auth)
+    }
+
+    #[test]
+    fn test_attestation_validation() {
+        let (order, auth) = order_and_auth();
+        assert!(validate_solana_attestation(&order, &auth).is_ok());
+
+        // Wrong scheme.
+        let mut bad = auth.clone();
+        bad.scheme = SignatureScheme::Secp256k1;
+        assert!(validate_solana_attestation(&order, &bad).is_err());
+
+        // Bound to a different order id (replay from another order).
+        let mut bad = auth.clone();
+        bad.order_id = [0u8; 32];
+        assert!(validate_solana_attestation(&order, &bad).is_err());
+
+        // Below threshold.
+        let mut bad = auth.clone();
+        bad.threshold = 2;
+        assert!(validate_solana_attestation(&order, &bad).is_err());
+    }
+
+    #[test]
+    fn test_same_order_id_binding_as_ethereum() {
+        // Both chains must bind the SAME 32-byte id for one order.
+        let (order, _) = order_and_auth();
+        let data = encode_bridge_mint_instruction_data(order.net_amount(), order.order_id_bytes());
+        assert_eq!(&data[16..48], order.order_id_bytes().as_slice());
+        assert_eq!(
+            order.order_id_bytes(),
+            bth_bridge_core::derive_order_id(&order.id)
+        );
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -69,6 +69,11 @@ ignore = [
     # rustls-pemfile 2.2.0 - unmaintained; no safe upgrade. Transitive via the
     # reqwest / rustls TLS stack.
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained (no safe upgrade)
+
+    # proc-macro-error2 2.0.1 - unmaintained; compile-time-only proc-macro
+    # helper, transitive via alloy-sol-macro (bridge-service #821). Never in
+    # the runtime dependency graph. No fixed alloy release exists yet.
+    "RUSTSEC-2026-0173",  # proc-macro-error2 unmaintained (alloy-sol-macro, build-time only)
 ]
 
 [licenses]


### PR DESCRIPTION
Closes #821 (part of epic #816; per ADR 0002 custody and ADR 0005 chain scope).

## What this implements

Replaces `engine.rs::process_mint_order`'s "Would mint … wBTH on Ethereum" stub with a real, exactly-once mint pipeline, following the expanded checklist in the issue comment.

### Fully implemented

**Shared / core (`bridge/core`)**
- `derive_order_id` / `BridgeOrder::order_id_bytes()`: deterministic, domain-tagged 32-byte on-chain order id from the order UUID; the SAME value is bound on both chains (golden-vector test pins it).
- `MintAuthorization` / `AttestationSignature` / `SignatureScheme` (`attestation.rs`): the artifact the #824 threshold-attestation protocol produces and this PR consumes (interface only — the protocol itself is #824).
- `OrderStatus::can_transition_to` + `BridgeOrder::try_set_status`: guarded transitions. `MintPending -> Completed` is the only path to completion, and `MintPending -> DepositConfirmed` is a first-class reorg-unwind edge (clears `dest_tx`/`dest_confirmed_at`) instead of terminal `Failed`.
- `BridgeOrder` gains `mint_authorization` and `dest_confirmed_at` (serde + SQLite round-trip).

**DB (`bridge/service/src/db.rs`)**
- `mints` idempotency table (`order_id` UNIQUE + unique `order_id_hash` index) with `record_mint_submitted` (INSERT OR IGNORE — returns the canonical prior row on duplicates), `get_mint_by_order`, `mark_mint_confirmed` (atomic with order completion), `rollback_mint` (atomic unwind; refuses to touch confirmed mints).
- Column migrations via `PRAGMA table_info` guard for existing databases.

**Engine (`bridge/service/src/engine.rs`)**
- `process_mint_order` split into `submit_mint` (`DepositConfirmed -> MintPending`) and `confirm_mint` (`MintPending -> Completed`), driven as separate retryable stages each tick.
- Exactly-once: tx id persisted to `mints` BEFORE first broadcast; resume-after-crash reuses the recorded tx (never prepares a second one); re-broadcast retries send the SAME signed bytes, capped at `bridge.max_retries`.
- Reorg unwind: `Reorged` rolls back to `DepositConfirmed` and re-submits against the same on-chain order id.
- Unconfigured chain leaves orders retryable in `DepositConfirmed` (never dropped/failed).

**Ethereum (`bridge/service/src/mint/ethereum.rs`)**
- alloy 1.8 provider from `EthereumConfig.rpc_url`; `sol!` bindings for `WrappedBTH.bridgeMint(address,uint256,bytes32)` + `BridgeMint` event (the #826 `bthTxHash` -> `orderId` rename does not change the selector; noted in code) and the Gnosis Safe (`nonce()`, `execTransaction`).
- Safe-authorized submission per ADR 0002: owner signatures from the attestation are validated (scheme/threshold/shape), sorted ascending by owner, and wrapped in `execTransaction`; Safe nonce read on-chain; relayer EOA signs and submits via `eth_sendRawTransaction`. New `ethereum.safe_address` config field.
- EIP-712 `SafeTx` digest helper (`safe_tx_hash`) — the exact payload #824 signers must sign.
- `GasPriceStrategy` -> EIP-1559 fees via `eth_feeHistory` percentiles (Low/Medium/High/Fixed), tip floored.
- Confirmation gating: receipt status + `BridgeMint` event bound to THIS order id (the Safe swallows inner-call failures, so event presence is required) + `confirmations_required` depth + canonical-block-hash re-check before `Completed`.
- Reorg detection: missing receipt + tx unknown to the node, or non-canonical block at depth, maps to `Reorged`.
- Idempotent broadcast: "already known"/"nonce too low" responses treated as success.

### Stubbed / deferred (explicitly)

- **Solana RPC bodies** (`mint/solana.rs`): `SolMinter` implements the same `Minter` trait, and the deterministic pieces ARE implemented and unit-tested (Ed25519 attestation validation, Anchor discriminator + `bridge_mint(amount, order_id)` instruction-data encoding, pinned to the deployed program's layout). The RPC-call bodies (blockhash fetch, tx assembly/signing, `send_transaction`, `get_signature_statuses` polling to the configured commitment) return `MintError::NotImplemented` with `TODO(#824/#828)` markers. Rationale: the `solana-client`/`anchor-client` stack is a heavy dependency tree with real conflict risk against this workspace (curve25519-dalek v4 etc.), and the wiring cannot be validated until the #828 `solana-test-validator` harness exists. The shared abstractions are NOT skipped — a Solana order flows through the same engine/db/idempotency machinery and fails safe (stays retryable).
- **Attestation protocol** (#824): consumed via the `AttestationProvider` trait; `StubAttestationProvider` (threshold 0, no signatures) is wired with a TODO. A production Safe will reject its empty signature set, so it cannot mint against real contracts.
- **BTH release path** (#822): untouched apart from a TODO reference.
- **Fork tests** (anvil/foundry deployed-`WrappedBTH` tests, Solana test-validator tests): deferred to #828 as the issue's test checklist anticipates; they need external toolchains not available in this repo's CI.

### Dependency note

Adds `alloy = "1"` (workspace) with a minimal feature set. `cargo deny check advisories licenses bans sources` passes after adding an ignore for RUSTSEC-2026-0173 (`proc-macro-error2` unmaintained — compile-time-only proc-macro transitive of `alloy-sol-macro`, never in the runtime graph, no fixed alloy release yet); justification is in `deny.toml`.

## Test Plan

All runnable in CI without external validators (39 tests, all passing):

- `cargo test -p bth-bridge-core`
  - orderId derivation: stability golden vector, uniqueness, ETH/Solana agreement
  - `OrderStatus` transition guards: happy path, skip rejection (no `DepositConfirmed -> Completed`), terminal freezing, reorg-unwind edge clears `dest_tx`
  - `MintAuthorization` threshold (distinct-signer dedup) + serde round-trip
- `cargo test -p bth-bridge-service`
  - db: duplicate `order_id` -> exactly-once (second submission returns the FIRST tx), confirm flow, rollback clears only unconfirmed mints, confirmed mints immune to rollback, new-field round-trip
  - ethereum (pure helpers): `bridgeMint` calldata selector/args round-trip, Safe signature assembly (owner-sorted, threshold/scheme rejection), gas-strategy -> EIP-1559 mapping incl. Fixed and tip floor, `SafeTx` EIP-712 digest binds chain id/nonce/calldata, `BridgeMint` event scan rejects wrong order id and spoofed contract
  - solana (pure helpers): Anchor discriminator golden vector, instruction-data layout, attestation validation, cross-chain order-id agreement
  - engine (mocked minter): submit -> confirmation gating (`Pending` never completes, `Confirmed` completes exactly once), crash-resume reuses recorded tx with zero new prepare/broadcast calls, reorg unwind + re-submission reuses the same order id with a fresh tx, `Failed` confirmation fails the order, unconfigured chain stays retryable, mint-to-BTH fails
- `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets` — clean
- `cargo +nightly-2025-12-03 fmt --all -- --check` — clean
- `cargo deny check advisories licenses bans sources` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)