### PR TITLE
feat(bridge): BTH reserve release / send with exactly-once claims and threshold attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,6 +2035,7 @@ dependencies = [
  "bth-bridge-core",
  "chrono",
  "clap",
+ "ed25519-dalek",
  "hex",
  "rusqlite",
  "serde_json",

--- a/bridge/core/src/attestation.rs
+++ b/bridge/core/src/attestation.rs
@@ -88,6 +88,103 @@ impl MintAuthorization {
     }
 }
 
+/// Domain-separation tag for the BTH reserve-release attestation payload.
+///
+/// Mirrors the operator-signed-action pattern (`botho/src/operator_action.rs`
+/// `DOMAIN_SEPARATOR`, per ADR 0002): every federation signature covers this
+/// tag so a release signature can never be confused with (or replayed as) an
+/// operator action, a mint attestation, or any other Ed25519 payload signed
+/// by a validator node key. Changing this tag invalidates all in-flight
+/// release authorizations.
+pub const RELEASE_ATTESTATION_DOMAIN_TAG: &[u8] = b"botho-bridge-release-v1";
+
+/// Compute the digest the federation signs to authorize one BTH release.
+///
+/// `sha256(domain_tag || order_id || amount_le || recipient_len_le ||
+/// recipient)`
+///
+/// The digest binds the authorization to:
+/// - the deterministic on-chain **order id** (replay safety: the release
+///   engine's `release_claims` table plus the order state machine allow at most
+///   one release per order id, so a replayed authorization cannot trigger a
+///   second reserve spend);
+/// - the exact **net amount** in picocredits; and
+/// - the exact **recipient** BTH address (length-prefixed so the encoding is
+///   unambiguous).
+///
+/// The #824 attestation protocol produces signatures over exactly these
+/// bytes; the release engine verifies them before any reserve key material
+/// is touched.
+pub fn release_payload_digest(order_id: &[u8; 32], amount: u64, recipient: &str) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(RELEASE_ATTESTATION_DOMAIN_TAG);
+    hasher.update(order_id);
+    hasher.update(amount.to_le_bytes());
+    hasher.update((recipient.len() as u64).to_le_bytes());
+    hasher.update(recipient.as_bytes());
+    hasher.finalize().into()
+}
+
+/// Threshold authorization for a single BTH reserve release, produced by the
+/// #824 attestation protocol and bound to one bridge burn order.
+///
+/// Per ADR 0002, releases are authorized by a t-of-n threshold of the SCP
+/// validators' **Ed25519 node keys** (the scheme is always Ed25519 on the
+/// BTH side, so no scheme field is carried). Each signature covers
+/// [`release_payload_digest`], binding the order id, net amount, and
+/// recipient address — a signature for one order can never authorize a
+/// different amount, recipient, or a second release.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReleaseAuthorization {
+    /// The deterministic 32-byte order id this authorization is bound to.
+    /// Must equal [`crate::order::BridgeOrder::order_id_bytes`] for the
+    /// burn order being released.
+    #[serde(with = "hex_array_32")]
+    pub order_id: [u8; 32],
+
+    /// Net amount to pay the recipient, in picocredits
+    /// ([`crate::order::BridgeOrder::net_amount`]).
+    pub amount: u64,
+
+    /// The recipient's BTH address (`bridgeBurn`'s `bthAddress`). The
+    /// release transaction pays a **fresh one-time stealth output** derived
+    /// from this address (ADR 0004) — never a static payout key.
+    pub recipient: String,
+
+    /// The threshold `t` required by the federation configuration. Per
+    /// ADR 0002 this is never lower than the SCP safety threshold.
+    pub threshold: u32,
+
+    /// Collected validator Ed25519 signatures over
+    /// [`ReleaseAuthorization::digest`]. Must contain at least `threshold`
+    /// entries from distinct signers to be usable.
+    pub signatures: Vec<AttestationSignature>,
+}
+
+impl ReleaseAuthorization {
+    /// The digest every federation signature must cover.
+    pub fn digest(&self) -> [u8; 32] {
+        release_payload_digest(&self.order_id, self.amount, &self.recipient)
+    }
+
+    /// Whether enough distinct signers have signed to meet the threshold.
+    ///
+    /// This only counts distinct signer identities — cryptographic
+    /// verification of each signature (and federation membership) is the
+    /// release engine's job (`validate_release_attestation`).
+    pub fn meets_threshold(&self) -> bool {
+        let mut signers: Vec<&[u8]> = self
+            .signatures
+            .iter()
+            .map(|s| s.signer.as_slice())
+            .collect();
+        signers.sort();
+        signers.dedup();
+        signers.len() as u32 >= self.threshold
+    }
+}
+
 /// Hex serde for `Vec<u8>`.
 mod hex_bytes {
     use serde::{self, Deserialize, Deserializer, Serializer};
@@ -159,5 +256,62 @@ mod tests {
         let json = serde_json::to_string(&auth).unwrap();
         let back: MintAuthorization = serde_json::from_str(&json).unwrap();
         assert_eq!(auth, back);
+    }
+
+    #[test]
+    fn test_release_digest_golden_vector() {
+        use sha2::{Digest, Sha256};
+
+        // Pinned construction: sha256(tag || order_id || amount_le ||
+        // recipient_len_le || recipient). This must never change — in-flight
+        // release authorizations bind to it.
+        let order_id = [3u8; 32];
+        let digest = release_payload_digest(&order_id, 999_000_000_000, "bth_stealth_addr");
+
+        let expected: [u8; 32] = {
+            let mut hasher = Sha256::new();
+            hasher.update(b"botho-bridge-release-v1");
+            hasher.update([3u8; 32]);
+            hasher.update(999_000_000_000u64.to_le_bytes());
+            hasher.update((b"bth_stealth_addr".len() as u64).to_le_bytes());
+            hasher.update(b"bth_stealth_addr");
+            hasher.finalize().into()
+        };
+        assert_eq!(digest, expected);
+    }
+
+    #[test]
+    fn test_release_digest_binds_all_fields() {
+        let base = release_payload_digest(&[1u8; 32], 100, "addr");
+        // Different order id, amount, or recipient each produce a different
+        // digest — a signature cannot be replayed across any of them.
+        assert_ne!(base, release_payload_digest(&[2u8; 32], 100, "addr"));
+        assert_ne!(base, release_payload_digest(&[1u8; 32], 101, "addr"));
+        assert_ne!(base, release_payload_digest(&[1u8; 32], 100, "addr2"));
+    }
+
+    #[test]
+    fn test_release_authorization_threshold_and_serde() {
+        let mut auth = ReleaseAuthorization {
+            order_id: [7u8; 32],
+            amount: 42,
+            recipient: "bth_addr".to_string(),
+            threshold: 2,
+            signatures: vec![sig(1)],
+        };
+        assert!(!auth.meets_threshold());
+
+        auth.signatures.push(sig(2));
+        assert!(auth.meets_threshold());
+
+        // Duplicate signers do not count twice.
+        auth.signatures = vec![sig(1), sig(1)];
+        assert!(!auth.meets_threshold());
+
+        auth.signatures = vec![sig(1), sig(2)];
+        let json = serde_json::to_string(&auth).unwrap();
+        let back: ReleaseAuthorization = serde_json::from_str(&json).unwrap();
+        assert_eq!(auth, back);
+        assert_eq!(auth.digest(), back.digest());
     }
 }

--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -38,6 +38,35 @@ pub struct BthConfig {
     /// Number of confirmations required (0 for SCP finality)
     #[serde(default)]
     pub confirmations_required: u32,
+
+    /// The reserve wallet's public BTH address. Release transactions spend
+    /// reserve-owned outputs and return change to this address (preserving
+    /// factor-1/background provenance per ADR 0003). `None` disables
+    /// release submission (watch-only deployments).
+    #[serde(default)]
+    pub reserve_address: Option<String>,
+
+    /// Hex-encoded 32-byte Ed25519 public keys of the release federation
+    /// (the SCP validators' node keys, per ADR 0002). Every release
+    /// attestation signature must come from this set. Empty disables
+    /// federation-membership checking (development only).
+    #[serde(default)]
+    pub release_signers: Vec<String>,
+
+    /// The threshold `t` of distinct federation signatures required to
+    /// authorize a reserve release. Per ADR 0002 this must be set no lower
+    /// than the SCP safety threshold in production; the default of 0 is a
+    /// development value that authorizes nothing spendable on its own
+    /// (release construction is additionally gated on #824/#828).
+    #[serde(default)]
+    pub release_threshold: u32,
+
+    /// Confirmation depth required before a submitted release transaction
+    /// is considered final and the order advances `ReleasePending ->
+    /// Released`. 0 (the default) means SCP externalization finality: the
+    /// transaction's block is final as soon as it appears.
+    #[serde(default)]
+    pub release_confirmations_required: u32,
 }
 
 /// Ethereum connection configuration.
@@ -216,6 +245,10 @@ impl Default for BridgeConfig {
                 view_key_file: None,
                 spend_key_file: None,
                 confirmations_required: 0,
+                reserve_address: None,
+                release_signers: Vec::new(),
+                release_threshold: 0,
+                release_confirmations_required: 0,
             },
             ethereum: EthereumConfig {
                 rpc_url: "http://localhost:8545".to_string(),
@@ -270,5 +303,46 @@ mod tests {
         let config = BridgeConfig::default();
         assert_eq!(config.bridge.fee_bps, 10);
         assert!(!config.bridge.testnet);
+    }
+
+    #[test]
+    fn test_bth_release_knobs_default_and_parse() {
+        // Defaults: release submission disabled, SCP finality.
+        let config = BridgeConfig::default();
+        assert!(config.bth.reserve_address.is_none());
+        assert!(config.bth.release_signers.is_empty());
+        assert_eq!(config.bth.release_threshold, 0);
+        assert_eq!(config.bth.release_confirmations_required, 0);
+
+        // A pre-existing config without the release knobs still parses.
+        let legacy: BthConfig = toml::from_str(
+            r#"
+            rpc_url = "http://localhost:7101"
+            ws_url = "ws://localhost:7101/ws"
+            "#,
+        )
+        .unwrap();
+        assert!(legacy.reserve_address.is_none());
+        assert_eq!(legacy.release_confirmations_required, 0);
+
+        // The release knobs round-trip from TOML.
+        let configured: BthConfig = toml::from_str(
+            r#"
+            rpc_url = "http://localhost:7101"
+            ws_url = "ws://localhost:7101/ws"
+            reserve_address = "bth_reserve_addr"
+            release_signers = ["aa", "bb"]
+            release_threshold = 3
+            release_confirmations_required = 2
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            configured.reserve_address.as_deref(),
+            Some("bth_reserve_addr")
+        );
+        assert_eq!(configured.release_signers.len(), 2);
+        assert_eq!(configured.release_threshold, 3);
+        assert_eq!(configured.release_confirmations_required, 2);
     }
 }

--- a/bridge/core/src/lib.rs
+++ b/bridge/core/src/lib.rs
@@ -15,7 +15,10 @@ pub mod chains;
 pub mod config;
 pub mod order;
 
-pub use attestation::{AttestationSignature, MintAuthorization, SignatureScheme};
+pub use attestation::{
+    release_payload_digest, AttestationSignature, MintAuthorization, ReleaseAuthorization,
+    SignatureScheme, RELEASE_ATTESTATION_DOMAIN_TAG,
+};
 pub use chains::{Chain, ChainAddress};
 pub use config::{
     BridgeConfig, BthConfig, EthereumConfig, GasPriceStrategy, SolanaCommitment, SolanaConfig,

--- a/bridge/core/src/order.rs
+++ b/bridge/core/src/order.rs
@@ -170,6 +170,14 @@ impl OrderStatus {
     ///   tx is orphaned before finality the order rolls back to
     ///   `DepositConfirmed` and is re-submitted, instead of terminally failing
     ///   (the BTH deposit is still confirmed and owed).
+    /// - `ReleasePending -> BurnConfirmed`: release unwind. If a submitted BTH
+    ///   release tx provably cannot land (dropped and its inputs spent
+    ///   elsewhere, or invalid against the chain) the order rolls back to
+    ///   `BurnConfirmed` and is re-submitted — the wBTH burn is still confirmed
+    ///   and owed. Callers must only take this edge when the old tx can never
+    ///   resurface (see `confirm_release` in the bridge service): BTH has no
+    ///   on-chain order-id guard, so unwinding a tx that could still land would
+    ///   risk a double release.
     /// - Any non-terminal status to `Failed`.
     /// - `AwaitingDeposit` / `DepositDetected` to `Expired`.
     ///
@@ -189,6 +197,8 @@ impl OrderStatus {
         match (self, next) {
             // Reorg unwind: submitted mint orphaned before finality.
             (OrderStatus::MintPending, OrderStatus::DepositConfirmed) => true,
+            // Release unwind: submitted BTH release provably dropped.
+            (OrderStatus::ReleasePending, OrderStatus::BurnConfirmed) => true,
             // Any non-terminal order may fail.
             (_, OrderStatus::Failed { .. }) => true,
             // Only orders still waiting on a deposit can expire.
@@ -394,6 +404,7 @@ impl BridgeOrder {
         if matches!(
             (&self.status, &status),
             (OrderStatus::MintPending, OrderStatus::DepositConfirmed)
+                | (OrderStatus::ReleasePending, OrderStatus::BurnConfirmed)
         ) {
             self.dest_tx = None;
             self.dest_confirmed_at = None;
@@ -553,6 +564,46 @@ mod tests {
         order.try_set_status(OrderStatus::DepositConfirmed).unwrap();
         assert_eq!(order.status, OrderStatus::DepositConfirmed);
         assert!(order.dest_tx.is_none(), "reorg unwind must clear dest_tx");
+        assert!(order.dest_confirmed_at.is_none());
+    }
+
+    #[test]
+    fn test_release_flow_transitions() {
+        // Forward path.
+        assert!(OrderStatus::BurnDetected.can_transition_to(&OrderStatus::BurnConfirmed));
+        assert!(OrderStatus::BurnConfirmed.can_transition_to(&OrderStatus::ReleasePending));
+        assert!(OrderStatus::ReleasePending.can_transition_to(&OrderStatus::Released));
+
+        // No skipping the submission stage or the finality gate.
+        assert!(!OrderStatus::BurnConfirmed.can_transition_to(&OrderStatus::Released));
+        assert!(!OrderStatus::BurnDetected.can_transition_to(&OrderStatus::ReleasePending));
+
+        // Released is terminal and frozen.
+        assert!(!OrderStatus::Released.can_transition_to(&OrderStatus::ReleasePending));
+
+        // Burn orders cannot expire (the burn already happened; BTH is owed).
+        assert!(!OrderStatus::BurnConfirmed.can_transition_to(&OrderStatus::Expired));
+    }
+
+    #[test]
+    fn test_release_unwind_transition() {
+        // ReleasePending -> BurnConfirmed is the release rollback edge.
+        assert!(OrderStatus::ReleasePending.can_transition_to(&OrderStatus::BurnConfirmed));
+
+        let mut order = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            0,
+            "0xsource".to_string(),
+            "bth_addr".to_string(),
+            "0xburntx".to_string(),
+        );
+        order.set_status(OrderStatus::ReleasePending);
+        order.dest_tx = Some("bth_release_tx".to_string());
+
+        order.try_set_status(OrderStatus::BurnConfirmed).unwrap();
+        assert_eq!(order.status, OrderStatus::BurnConfirmed);
+        assert!(order.dest_tx.is_none(), "release unwind must clear dest_tx");
         assert!(order.dest_confirmed_at.is_none());
     }
 

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -33,6 +33,10 @@ alloy = { workspace = true, features = [
     "sol-types",
 ] }
 
+# BTH release attestation verification (ADR 0002: federation Ed25519
+# signatures, mirroring the operator-signed-action machinery)
+ed25519-dalek = { workspace = true, features = ["std"] }
+
 # Database
 rusqlite = { version = "0.31", features = ["bundled"] }
 

--- a/bridge/service/src/attestation.rs
+++ b/bridge/service/src/attestation.rs
@@ -10,15 +10,25 @@
 //! collection) can land independently.
 
 use async_trait::async_trait;
-use bth_bridge_core::{BridgeOrder, Chain, MintAuthorization, SignatureScheme};
+use bth_bridge_core::{
+    BridgeOrder, Chain, MintAuthorization, ReleaseAuthorization, SignatureScheme,
+};
 
-/// Source of threshold mint authorizations.
+/// Source of threshold mint and release authorizations.
 #[async_trait]
 pub trait AttestationProvider: Send + Sync {
     /// Obtain a threshold authorization for minting `order` on its
     /// destination chain. Blocks (or errors) until the federation threshold
     /// is met — the engine never submits an unauthorized mint.
     async fn authorize_mint(&self, order: &BridgeOrder) -> Result<MintAuthorization, String>;
+
+    /// Obtain a threshold authorization for releasing `order`'s BTH from
+    /// the reserve. Blocks (or errors) until the federation threshold is
+    /// met — the engine never signs an unauthorized reserve spend. The
+    /// returned authorization is bound to this order's deterministic id,
+    /// its exact `net_amount()`, and its exact destination address (see
+    /// [`bth_bridge_core::release_payload_digest`]).
+    async fn authorize_release(&self, order: &BridgeOrder) -> Result<ReleaseAuthorization, String>;
 }
 
 /// Development stub pending #824.
@@ -44,6 +54,29 @@ impl AttestationProvider for StubAttestationProvider {
         Ok(MintAuthorization {
             order_id: order.order_id_bytes(),
             scheme,
+            threshold: 0,
+            signatures: vec![],
+        })
+    }
+
+    async fn authorize_release(&self, order: &BridgeOrder) -> Result<ReleaseAuthorization, String> {
+        // TODO(#824): replace with the validator threshold-signing protocol
+        // (Ed25519 signatures over release_payload_digest, mirroring the
+        // operator-signed-action envelope/nonce machinery per ADR 0002).
+        if order.dest_chain != Chain::Bth {
+            return Err("release authorizations are only for the BTH chain".to_string());
+        }
+
+        // Empty signature set with threshold 0: passes the local distinct-
+        // signer count only when the configured federation threshold floor
+        // is also 0 (development). Any production configuration
+        // (release_threshold >= 1) rejects this stub before any reserve
+        // key material is touched — and release construction itself is
+        // additionally gated on #828.
+        Ok(ReleaseAuthorization {
+            order_id: order.order_id_bytes(),
+            amount: order.net_amount(),
+            recipient: order.dest_address.clone(),
             threshold: 0,
             signatures: vec![],
         })

--- a/bridge/service/src/db.rs
+++ b/bridge/service/src/db.rs
@@ -4,7 +4,7 @@
 
 use bth_bridge_core::{BridgeOrder, Chain, MintAuthorization, OrderStatus, OrderType};
 use chrono::{DateTime, TimeZone, Utc};
-use rusqlite::{params, Connection, Result as SqliteResult};
+use rusqlite::{params, Connection, Result as SqliteResult, TransactionBehavior};
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
 
@@ -28,6 +28,40 @@ pub struct MintRecord {
     /// When the transaction was persisted (always before first broadcast).
     pub submitted_at: DateTime<Utc>,
     /// When the transaction reached the required confirmation depth.
+    pub confirmed_at: Option<DateTime<Utc>>,
+}
+
+/// A row in the `release_claims` exactly-once table.
+///
+/// One row exists per burn order that has ever entered the release path.
+/// The claim is taken (row inserted with a NULL tx hash) BEFORE any signing
+/// or submission; the signed transaction's hash and raw bytes are recorded
+/// BEFORE the first broadcast. The `order_id` PRIMARY KEY is the
+/// service-side exactly-once guard: a concurrent tick or a post-restart
+/// re-entry finds the existing claim and either resumes with the recorded
+/// transaction (never re-signing with new inputs — a reserve double-spend
+/// risk) or, if nothing was recorded, knows nothing was ever broadcast and
+/// may safely sign fresh.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseClaim {
+    /// Bridge order UUID (string form).
+    pub order_id: Uuid,
+    /// Hex encoding of the 32-byte deterministic order id bound to the
+    /// release attestation.
+    pub order_id_hash: String,
+    /// BTH transaction hash of the signed release, `None` until a
+    /// transaction has been signed and durably recorded.
+    pub release_tx_hash: Option<String>,
+    /// The exact signed transaction bytes, persisted with the hash so a
+    /// resume after restart re-broadcasts the SAME transaction.
+    pub release_tx_raw: Option<Vec<u8>>,
+    /// When the claim was taken (always before signing).
+    pub claimed_at: DateTime<Utc>,
+    /// When the signed transaction was recorded (always before first
+    /// broadcast).
+    pub submitted_at: Option<DateTime<Utc>>,
+    /// When the transaction reached the required confirmation depth
+    /// (SCP finality by default).
     pub confirmed_at: Option<DateTime<Utc>>,
 }
 
@@ -121,6 +155,19 @@ impl Database {
             );
 
             CREATE UNIQUE INDEX IF NOT EXISTS idx_mints_order_hash ON mints(order_id_hash);
+
+            CREATE TABLE IF NOT EXISTS release_claims (
+                order_id TEXT PRIMARY KEY REFERENCES bridge_orders(id),
+                order_id_hash TEXT NOT NULL,
+                release_tx_hash TEXT,
+                release_tx_raw BLOB,
+                claimed_at INTEGER NOT NULL,
+                submitted_at INTEGER,
+                confirmed_at INTEGER
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_release_claims_order_hash
+                ON release_claims(order_id_hash);
             "#,
         )
         .map_err(|e| format!("Migration failed: {}", e))?;
@@ -451,6 +498,205 @@ impl Database {
         tx.commit().map_err(|e| format!("Commit failed: {}", e))
     }
 
+    // === Release exactly-once claims ===
+
+    /// Take (or find) the durable release claim for a burn order.
+    ///
+    /// Runs as a `BEGIN IMMEDIATE` transaction so the claim is durably
+    /// serialized against any concurrent writer BEFORE the caller does any
+    /// signing or submission. Returns the claim row:
+    ///
+    /// - `release_tx_hash == None`: this caller holds a fresh (or not yet
+    ///   signed) claim — nothing was ever recorded, so nothing was ever
+    ///   broadcast; it is safe to build and sign a transaction.
+    /// - `release_tx_hash == Some(tx)`: a transaction was already signed and
+    ///   recorded (possibly before a crash). The caller MUST reuse it and never
+    ///   sign a second transaction with different inputs.
+    pub fn try_claim_release(
+        &self,
+        order_id: &Uuid,
+        order_id_hash: &str,
+    ) -> Result<ReleaseClaim, String> {
+        {
+            let mut conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+            let tx = conn
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(|e| format!("Transaction failed: {}", e))?;
+
+            tx.execute(
+                r#"
+                INSERT OR IGNORE INTO release_claims (
+                    order_id, order_id_hash, release_tx_hash, release_tx_raw,
+                    claimed_at, submitted_at, confirmed_at
+                ) VALUES (?1, ?2, NULL, NULL, ?3, NULL, NULL)
+                "#,
+                params![order_id.to_string(), order_id_hash, Utc::now().timestamp(),],
+            )
+            .map_err(|e| format!("Insert failed: {}", e))?;
+
+            tx.commit().map_err(|e| format!("Commit failed: {}", e))?;
+        }
+
+        self.get_release_by_order(order_id)?
+            .ok_or_else(|| "Release claim missing after insert".to_string())
+    }
+
+    /// Record the signed release transaction for a claimed order, exactly
+    /// once.
+    ///
+    /// Must be called BEFORE the transaction is first broadcast so a crash
+    /// between broadcast and persistence cannot lose the tx. Both the hash
+    /// and the raw signed bytes are stored so a post-restart resume
+    /// re-broadcasts the SAME transaction instead of re-signing with new
+    /// inputs (which could double-spend the reserve).
+    ///
+    /// If a transaction was already recorded (a lost race), the EXISTING
+    /// record is returned unchanged and the caller must discard its own
+    /// transaction without broadcasting it.
+    pub fn record_release_tx(
+        &self,
+        order_id: &Uuid,
+        tx_hash: &str,
+        tx_raw: &[u8],
+    ) -> Result<ReleaseClaim, String> {
+        {
+            let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+            conn.execute(
+                r#"
+                UPDATE release_claims
+                SET release_tx_hash = ?1, release_tx_raw = ?2, submitted_at = ?3
+                WHERE order_id = ?4 AND release_tx_hash IS NULL
+                "#,
+                params![
+                    tx_hash,
+                    tx_raw,
+                    Utc::now().timestamp(),
+                    order_id.to_string()
+                ],
+            )
+            .map_err(|e| format!("Update failed: {}", e))?;
+        }
+
+        self.get_release_by_order(order_id)?
+            .ok_or_else(|| "Release claim missing while recording tx".to_string())
+    }
+
+    /// Get the release claim for an order, if the release path was ever
+    /// entered.
+    pub fn get_release_by_order(&self, order_id: &Uuid) -> Result<Option<ReleaseClaim>, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT order_id, order_id_hash, release_tx_hash, release_tx_raw,
+                       claimed_at, submitted_at, confirmed_at
+                FROM release_claims WHERE order_id = ?1
+                "#,
+            )
+            .map_err(|e| format!("Prepare failed: {}", e))?;
+
+        stmt.query_row(params![order_id.to_string()], Self::row_to_release)
+            .optional()
+            .map_err(|e| format!("Query failed: {}", e))
+    }
+
+    /// Mark an order's release as confirmed at the required depth.
+    ///
+    /// Atomically stamps `release_claims.confirmed_at` and moves the order
+    /// to `Released` with `dest_confirmed_at` set. The caller must have
+    /// validated the `ReleasePending -> Released` transition (finality
+    /// gating) before calling.
+    pub fn mark_release_confirmed(&self, order_id: &Uuid) -> Result<(), String> {
+        let mut conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let now = Utc::now().timestamp();
+
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Transaction failed: {}", e))?;
+
+        tx.execute(
+            r#"
+            UPDATE release_claims SET confirmed_at = ?1
+            WHERE order_id = ?2 AND confirmed_at IS NULL
+            "#,
+            params![now, order_id.to_string()],
+        )
+        .map_err(|e| format!("Update release_claims failed: {}", e))?;
+
+        tx.execute(
+            r#"
+            UPDATE bridge_orders
+            SET status = 'released', dest_confirmed_at = ?1, updated_at = ?1
+            WHERE id = ?2 AND status = 'release_pending'
+            "#,
+            params![now, order_id.to_string()],
+        )
+        .map_err(|e| format!("Update order failed: {}", e))?;
+
+        tx.commit().map_err(|e| format!("Commit failed: {}", e))
+    }
+
+    /// Release unwind: roll a `ReleasePending` order back to
+    /// `BurnConfirmed`.
+    ///
+    /// Atomically deletes the UNCONFIRMED claim and clears the order's
+    /// `dest_tx`, so `submit_release` re-runs cleanly. Confirmed releases
+    /// are never rolled back.
+    ///
+    /// The caller must only unwind when the recorded transaction PROVABLY
+    /// cannot land (see `ReleaseConfirmation::Dropped`): BTH has no
+    /// on-chain order-id guard, so re-signing with different inputs while
+    /// the old transaction could still land would risk a double release.
+    pub fn rollback_release(&self, order_id: &Uuid) -> Result<(), String> {
+        let mut conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let now = Utc::now().timestamp();
+
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Transaction failed: {}", e))?;
+
+        tx.execute(
+            "DELETE FROM release_claims WHERE order_id = ?1 AND confirmed_at IS NULL",
+            params![order_id.to_string()],
+        )
+        .map_err(|e| format!("Delete release claim failed: {}", e))?;
+
+        tx.execute(
+            r#"
+            UPDATE bridge_orders
+            SET status = 'burn_confirmed', dest_tx = NULL,
+                dest_confirmed_at = NULL, updated_at = ?1
+            WHERE id = ?2 AND status = 'release_pending'
+            "#,
+            params![now, order_id.to_string()],
+        )
+        .map_err(|e| format!("Update order failed: {}", e))?;
+
+        tx.commit().map_err(|e| format!("Commit failed: {}", e))
+    }
+
+    /// Convert a database row to a ReleaseClaim.
+    fn row_to_release(row: &rusqlite::Row<'_>) -> SqliteResult<ReleaseClaim> {
+        let order_id_str: String = row.get(0)?;
+        let order_id_hash: String = row.get(1)?;
+        let release_tx_hash: Option<String> = row.get(2)?;
+        let release_tx_raw: Option<Vec<u8>> = row.get(3)?;
+        let claimed_at: i64 = row.get(4)?;
+        let submitted_at: Option<i64> = row.get(5)?;
+        let confirmed_at: Option<i64> = row.get(6)?;
+
+        Ok(ReleaseClaim {
+            order_id: Uuid::parse_str(&order_id_str).unwrap_or_default(),
+            order_id_hash,
+            release_tx_hash,
+            release_tx_raw,
+            claimed_at: Utc.timestamp_opt(claimed_at, 0).unwrap(),
+            submitted_at: submitted_at.and_then(|t| Utc.timestamp_opt(t, 0).single()),
+            confirmed_at: confirmed_at.and_then(|t| Utc.timestamp_opt(t, 0).single()),
+        })
+    }
+
     /// Convert a database row to a MintRecord.
     fn row_to_mint(row: &rusqlite::Row<'_>) -> SqliteResult<MintRecord> {
         let order_id_str: String = row.get(0)?;
@@ -755,6 +1001,131 @@ mod tests {
         assert!(mint.is_some(), "confirmed mint record must survive");
         let stored = db.get_order(&order.id).unwrap().unwrap();
         assert_eq!(stored.status, OrderStatus::Completed);
+    }
+
+    fn setup_burn_order(db: &Database) -> BridgeOrder {
+        let mut order = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+            "bth_user_stealth_addr".to_string(),
+            "0xburntx".to_string(),
+        );
+        order.set_status(OrderStatus::BurnConfirmed);
+        db.insert_order(&order).unwrap();
+        order
+    }
+
+    #[test]
+    fn test_release_claim_exactly_once() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_burn_order(&db);
+        let hash = hex::encode(order.order_id_bytes());
+
+        // First claim: fresh, no tx recorded.
+        let first = db.try_claim_release(&order.id, &hash).unwrap();
+        assert!(first.release_tx_hash.is_none());
+        assert!(first.submitted_at.is_none());
+        assert!(first.confirmed_at.is_none());
+
+        // Record the signed tx (before broadcast).
+        let recorded = db
+            .record_release_tx(&order.id, "bth_tx_one", &[0xde, 0xad])
+            .unwrap();
+        assert_eq!(recorded.release_tx_hash.as_deref(), Some("bth_tx_one"));
+        assert_eq!(recorded.release_tx_raw.as_deref(), Some(&[0xde, 0xad][..]));
+        assert!(recorded.submitted_at.is_some());
+
+        // A re-claim (concurrent tick / post-restart) returns the SAME
+        // recorded tx — the caller must reuse it, never sign a second one.
+        let reclaim = db.try_claim_release(&order.id, &hash).unwrap();
+        assert_eq!(reclaim.release_tx_hash.as_deref(), Some("bth_tx_one"));
+
+        // A duplicate record with a DIFFERENT tx must not overwrite:
+        // exactly-once.
+        let second = db
+            .record_release_tx(&order.id, "bth_tx_two", &[0xbe, 0xef])
+            .unwrap();
+        assert_eq!(
+            second.release_tx_hash.as_deref(),
+            Some("bth_tx_one"),
+            "a recorded release tx must never be replaced"
+        );
+        assert_eq!(second.release_tx_raw.as_deref(), Some(&[0xde, 0xad][..]));
+    }
+
+    #[test]
+    fn test_release_confirm_flow() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_burn_order(&db);
+        let hash = hex::encode(order.order_id_bytes());
+
+        db.try_claim_release(&order.id, &hash).unwrap();
+        db.record_release_tx(&order.id, "bth_tx", &[1]).unwrap();
+        db.update_order_status(&order.id, &OrderStatus::ReleasePending, Some("bth_tx"))
+            .unwrap();
+
+        db.mark_release_confirmed(&order.id).unwrap();
+
+        let claim = db.get_release_by_order(&order.id).unwrap().unwrap();
+        assert!(claim.confirmed_at.is_some());
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::Released);
+        assert!(stored.dest_confirmed_at.is_some());
+    }
+
+    #[test]
+    fn test_release_rollback_clears_unconfirmed() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_burn_order(&db);
+        let hash = hex::encode(order.order_id_bytes());
+
+        db.try_claim_release(&order.id, &hash).unwrap();
+        db.record_release_tx(&order.id, "bth_dropped", &[1])
+            .unwrap();
+        db.update_order_status(&order.id, &OrderStatus::ReleasePending, Some("bth_dropped"))
+            .unwrap();
+
+        // Provably-dead tx: unwind to BurnConfirmed, claim gone.
+        db.rollback_release(&order.id).unwrap();
+
+        assert!(db.get_release_by_order(&order.id).unwrap().is_none());
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::BurnConfirmed);
+        assert!(stored.dest_tx.is_none());
+
+        // Re-entry after rollback takes a fresh claim.
+        let fresh = db.try_claim_release(&order.id, &hash).unwrap();
+        assert!(fresh.release_tx_hash.is_none());
+    }
+
+    #[test]
+    fn test_release_rollback_never_touches_confirmed() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_burn_order(&db);
+        let hash = hex::encode(order.order_id_bytes());
+
+        db.try_claim_release(&order.id, &hash).unwrap();
+        db.record_release_tx(&order.id, "bth_tx", &[1]).unwrap();
+        db.update_order_status(&order.id, &OrderStatus::ReleasePending, Some("bth_tx"))
+            .unwrap();
+        db.mark_release_confirmed(&order.id).unwrap();
+
+        // A late rollback attempt must be a no-op on a confirmed release.
+        db.rollback_release(&order.id).unwrap();
+
+        assert!(
+            db.get_release_by_order(&order.id).unwrap().is_some(),
+            "confirmed release claim must survive"
+        );
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::Released);
     }
 
     #[test]

--- a/bridge/service/src/engine.rs
+++ b/bridge/service/src/engine.rs
@@ -11,6 +11,7 @@ use crate::{
     attestation::{AttestationProvider, StubAttestationProvider},
     db::Database,
     mint::{ethereum::EthMinter, solana::SolMinter, ConfirmationStatus, Minter},
+    release::{bth::BthReleaser, PreparedRelease, ReleaseConfirmation, Releaser},
     watchers::{BthWatcher, EthereumWatcher},
 };
 
@@ -65,6 +66,22 @@ impl BridgeEngine {
         minters
     }
 
+    /// Build the BTH reserve-release backend from configuration.
+    ///
+    /// If the releaser cannot be constructed (missing reserve address, bad
+    /// federation key, unsatisfiable threshold, ...) release submission is
+    /// disabled with a warning: confirmed burns stay in `BurnConfirmed`
+    /// until the config is fixed — they are never dropped or failed.
+    fn build_releaser(config: &BridgeConfig) -> Option<Arc<dyn Releaser>> {
+        match BthReleaser::new(config.bth.clone()) {
+            Ok(releaser) => Some(Arc::new(releaser)),
+            Err(e) => {
+                warn!("BTH release disabled: {}", e);
+                None
+            }
+        }
+    }
+
     /// Run the bridge engine.
     pub async fn run(self) -> Result<(), String> {
         info!("Starting bridge engine");
@@ -97,10 +114,16 @@ impl BridgeEngine {
 
         // Spawn the order processing loop
         let minters = Self::build_minters(&self.config);
+        let releaser = Self::build_releaser(&self.config);
         // TODO(#824): swap the stub for the validator attestation protocol.
         let attestation: Arc<dyn AttestationProvider> = Arc::new(StubAttestationProvider);
-        let processor =
-            OrderProcessor::new(self.config.clone(), self.db.clone(), minters, attestation);
+        let processor = OrderProcessor::new(
+            self.config.clone(),
+            self.db.clone(),
+            minters,
+            releaser,
+            attestation,
+        );
         let mut shutdown_rx = self.shutdown_tx.subscribe();
 
         let process_handle = tokio::spawn(async move {
@@ -142,6 +165,7 @@ struct OrderProcessor {
     config: BridgeConfig,
     db: Database,
     minters: HashMap<Chain, Arc<dyn Minter>>,
+    releaser: Option<Arc<dyn Releaser>>,
     attestation: Arc<dyn AttestationProvider>,
 }
 
@@ -150,12 +174,14 @@ impl OrderProcessor {
         config: BridgeConfig,
         db: Database,
         minters: HashMap<Chain, Arc<dyn Minter>>,
+        releaser: Option<Arc<dyn Releaser>>,
         attestation: Arc<dyn AttestationProvider>,
     ) -> Self {
         Self {
             config,
             db,
             minters,
+            releaser,
             attestation,
         }
     }
@@ -183,11 +209,19 @@ impl OrderProcessor {
             }
         }
 
-        // Process confirmed burns (need to release BTH)
+        // Stage 3: confirmed burns need a BTH release submitted.
         let burn_orders = self.db.get_orders_by_status("burn_confirmed")?;
         for order in burn_orders {
-            if let Err(e) = self.process_burn_order(&order).await {
-                warn!("Failed to process burn order {}: {}", order.id, e);
+            if let Err(e) = self.submit_release(&order).await {
+                warn!("Failed to submit release for order {}: {}", order.id, e);
+            }
+        }
+
+        // Stage 4: submitted releases need confirmation (or unwind).
+        let pending_releases = self.db.get_orders_by_status("release_pending")?;
+        for order in pending_releases {
+            if let Err(e) = self.confirm_release(&order).await {
+                warn!("Failed to confirm release for order {}: {}", order.id, e);
             }
         }
 
@@ -408,23 +442,256 @@ impl OrderProcessor {
         Ok(())
     }
 
-    /// Process a burn order (burn confirmed, need to release BTH).
-    async fn process_burn_order(&self, order: &BridgeOrder) -> Result<(), String> {
+    /// Release submission stage: `BurnConfirmed -> ReleasePending`.
+    ///
+    /// Exactly-once: a durable claim in the `release_claims` table is taken
+    /// BEFORE any signing, and the signed transaction (hash + raw bytes) is
+    /// recorded BEFORE the first broadcast. A crash or concurrent tick at
+    /// any point either finds no recorded tx (nothing was ever broadcast —
+    /// safe to sign fresh) or finds the recorded tx and reuses it — the
+    /// engine NEVER signs a second release with different reserve inputs,
+    /// which could double-spend the reserve (BTH has no on-chain order-id
+    /// guard; the claims table is the release-side exactly-once guard).
+    async fn submit_release(&self, order: &BridgeOrder) -> Result<(), String> {
         info!(
-            "Processing burn order {} for {} picocredits",
-            order.id, order.amount
-        );
-
-        // TODO(#822): Implement actual BTH release (threshold-signed per
-        // ADR 0002, reusing the operator-signed-action machinery).
-        info!(
-            "Would send {} BTH to {}",
+            "Processing burn order {}: release {} picocredits to {}",
+            order.id,
             order.net_amount(),
             order.dest_address
         );
 
+        if order.dest_chain != Chain::Bth {
+            self.db.update_order_status(
+                &order.id,
+                &OrderStatus::Failed {
+                    reason: format!(
+                        "burn orders release on the BTH chain, not {}",
+                        order.dest_chain
+                    ),
+                },
+                None,
+            )?;
+            return Ok(());
+        }
+
+        let Some(releaser) = self.releaser.as_ref() else {
+            // Not failed: releasing is unconfigured/disabled. The order
+            // stays BurnConfirmed and is retried when the operator fixes
+            // the configuration.
+            return Err("BTH release not configured".to_string());
+        };
+
+        // Durable exactly-once claim, taken BEFORE any signing/submission.
+        let claim = self
+            .db
+            .try_claim_release(&order.id, &hex::encode(order.order_id_bytes()))?;
+
+        // Idempotency: a previously signed tx (crash between persistence
+        // and status update, or a re-poll) is reused, never re-signed.
+        if let Some(existing_tx) = claim.release_tx_hash {
+            info!(
+                "Order {} already has release tx {}; resuming without re-signing",
+                order.id, existing_tx
+            );
+            self.db.update_order_status(
+                &order.id,
+                &OrderStatus::ReleasePending,
+                Some(&existing_tx),
+            )?;
+            // Re-broadcast the exact recorded bytes (idempotent; "already
+            // known" is success). A failure here is non-fatal: the
+            // confirmation stage keeps polling and this path re-runs.
+            if let Some(raw) = claim.release_tx_raw {
+                let prepared = PreparedRelease {
+                    tx_hash: existing_tx.clone(),
+                    raw,
+                };
+                if let Err(e) = releaser.broadcast(&prepared).await {
+                    warn!(
+                        "Re-broadcast of recorded release tx {} for order {} failed: {}",
+                        existing_tx, order.id, e
+                    );
+                }
+            }
+            return Ok(());
+        }
+
+        // Threshold attestation from the validator federation (#824),
+        // bound to this exact order id, amount, and recipient. The
+        // releaser re-verifies every signature before touching reserve key
+        // material.
+        let auth = self
+            .attestation
+            .authorize_release(order)
+            .await
+            .map_err(|e| format!("attestation failed: {}", e))?;
+
+        // Build + threshold-sign (no broadcast yet). Nothing was recorded
+        // in the claim, so a failure here (including the #828
+        // NotImplemented stub) leaves the order BurnConfirmed for a clean
+        // retry — no reserve funds have moved.
+        let prepared = releaser
+            .prepare_release(order, &auth)
+            .await
+            .map_err(|e| format!("prepare_release failed: {}", e))?;
+
+        // Persist the signed tx BEFORE broadcast — the exactly-once guard.
+        let record = self
+            .db
+            .record_release_tx(&order.id, &prepared.tx_hash, &prepared.raw)?;
+        let recorded_tx = record
+            .release_tx_hash
+            .ok_or_else(|| "release tx missing after record".to_string())?;
         self.db
-            .update_order_status(&order.id, &OrderStatus::ReleasePending, None)?;
+            .update_order_status(&order.id, &OrderStatus::ReleasePending, Some(&recorded_tx))?;
+        self.db.log_audit(
+            Some(&order.id),
+            "release_submitted",
+            &format!(
+                "chain=bth tx={} amount={} recipient={}",
+                recorded_tx,
+                order.net_amount(),
+                order.dest_address
+            ),
+        )?;
+
+        if recorded_tx != prepared.tx_hash {
+            // Lost a race with another submission path: the recorded tx
+            // wins; do not broadcast ours.
+            warn!(
+                "Order {} already recorded release tx {}; discarding freshly signed {}",
+                order.id, recorded_tx, prepared.tx_hash
+            );
+            return Ok(());
+        }
+
+        // Broadcast the SAME signed tx with bounded retries. A persistent
+        // failure leaves the order ReleasePending: the resume path
+        // re-broadcasts the recorded bytes and the confirmation stage
+        // detects a provably-dead tx and unwinds it for re-submission.
+        let mut attempt = 0u32;
+        loop {
+            match releaser.broadcast(&prepared).await {
+                Ok(()) => {
+                    info!(
+                        "Broadcast release tx {} for order {}",
+                        prepared.tx_hash, order.id
+                    );
+                    break;
+                }
+                Err(e) => {
+                    attempt += 1;
+                    if attempt > self.config.bridge.max_retries {
+                        warn!(
+                            "Broadcast of {} failed after {} attempts: {}; leaving order {} \
+                             ReleasePending for resume/confirmation to handle",
+                            prepared.tx_hash, attempt, e, order.id
+                        );
+                        break;
+                    }
+                    warn!(
+                        "Broadcast attempt {}/{} for {} failed: {}; retrying same signed tx",
+                        attempt, self.config.bridge.max_retries, prepared.tx_hash, e
+                    );
+                    tokio::time::sleep(BROADCAST_RETRY_DELAY).await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Release confirmation stage: `ReleasePending -> Released` (or unwind).
+    ///
+    /// `Released` only fires once the releaser reports the configured
+    /// confirmation requirement met (`release_confirmations_required`;
+    /// 0 = SCP externalization finality).
+    async fn confirm_release(&self, order: &BridgeOrder) -> Result<(), String> {
+        let Some(releaser) = self.releaser.as_ref() else {
+            return Err("BTH release not configured".to_string());
+        };
+
+        let dest_tx = match &order.dest_tx {
+            Some(tx) => tx.clone(),
+            None => match self
+                .db
+                .get_release_by_order(&order.id)?
+                .and_then(|c| c.release_tx_hash)
+            {
+                Some(tx) => tx,
+                None => {
+                    // ReleasePending with no recorded tx is inconsistent
+                    // state (should be unreachable): unwind for
+                    // re-submission — nothing was ever signed/broadcast.
+                    warn!(
+                        "Order {} is ReleasePending with no recorded release tx; rolling back",
+                        order.id
+                    );
+                    self.db.rollback_release(&order.id)?;
+                    return Ok(());
+                }
+            },
+        };
+
+        match releaser
+            .check_confirmation(order, &dest_tx)
+            .await
+            .map_err(|e| format!("check_confirmation failed: {}", e))?
+        {
+            ReleaseConfirmation::Confirmed => {
+                if !order.status.can_transition_to(&OrderStatus::Released) {
+                    return Err(format!(
+                        "order {} cannot be released from status {}",
+                        order.id, order.status
+                    ));
+                }
+                self.db.mark_release_confirmed(&order.id)?;
+                self.db.log_audit(
+                    Some(&order.id),
+                    "release_confirmed",
+                    &format!("chain=bth tx={}", dest_tx),
+                )?;
+                info!(
+                    "Release for order {} confirmed on BTH (tx {})",
+                    order.id, dest_tx
+                );
+            }
+            ReleaseConfirmation::Pending { confirmations } => {
+                debug!(
+                    "Release tx {} for order {} at {} confirmation(s); waiting",
+                    dest_tx, order.id, confirmations
+                );
+            }
+            ReleaseConfirmation::Dropped => {
+                // Unwind: ReleasePending -> BurnConfirmed. Only reported
+                // when the recorded tx PROVABLY cannot land (its key images
+                // were spent by a different tx, or it is permanently
+                // invalid), so re-signing a fresh tx on the next tick
+                // cannot double-release.
+                warn!(
+                    "Release tx {} for order {} provably dropped; \
+                     rolling back to BurnConfirmed for re-submission",
+                    dest_tx, order.id
+                );
+                self.db.rollback_release(&order.id)?;
+                self.db.log_audit(
+                    Some(&order.id),
+                    "release_dropped",
+                    &format!("chain=bth tx={}", dest_tx),
+                )?;
+            }
+            ReleaseConfirmation::Failed { reason } => {
+                warn!(
+                    "Release tx {} for order {} failed: {}",
+                    dest_tx, order.id, reason
+                );
+                // The claim is left intact deliberately: a Failed release
+                // needs operator attention, and any retry must reuse the
+                // recorded tx rather than sign a competing reserve spend.
+                self.db
+                    .update_order_status(&order.id, &OrderStatus::Failed { reason }, None)?;
+            }
+        }
 
         Ok(())
     }
@@ -448,9 +715,12 @@ impl OrderProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mint::{MintError, PreparedMint};
+    use crate::{
+        mint::{MintError, PreparedMint},
+        release::ReleaseError,
+    };
     use async_trait::async_trait;
-    use bth_bridge_core::MintAuthorization;
+    use bth_bridge_core::{MintAuthorization, ReleaseAuthorization};
     use std::sync::{
         atomic::{AtomicU32, Ordering},
         Mutex,
@@ -517,7 +787,71 @@ mod tests {
         }
     }
 
+    /// Programmable in-memory releaser for driving the engine in tests.
+    struct MockReleaser {
+        prepare_calls: AtomicU32,
+        broadcast_calls: AtomicU32,
+        next_tx: Mutex<String>,
+        confirmation: Mutex<ReleaseConfirmation>,
+        /// Attestations seen by prepare_release (order-binding assertions).
+        last_auth: Mutex<Option<ReleaseAuthorization>>,
+    }
+
+    impl MockReleaser {
+        fn new() -> Self {
+            Self {
+                prepare_calls: AtomicU32::new(0),
+                broadcast_calls: AtomicU32::new(0),
+                next_tx: Mutex::new("bth_release_tx_1".to_string()),
+                confirmation: Mutex::new(ReleaseConfirmation::Pending { confirmations: 0 }),
+                last_auth: Mutex::new(None),
+            }
+        }
+
+        fn set_next_tx(&self, tx: &str) {
+            *self.next_tx.lock().unwrap() = tx.to_string();
+        }
+
+        fn set_confirmation(&self, status: ReleaseConfirmation) {
+            *self.confirmation.lock().unwrap() = status;
+        }
+    }
+
+    #[async_trait]
+    impl Releaser for MockReleaser {
+        async fn prepare_release(
+            &self,
+            _order: &BridgeOrder,
+            auth: &ReleaseAuthorization,
+        ) -> Result<PreparedRelease, ReleaseError> {
+            self.prepare_calls.fetch_add(1, Ordering::SeqCst);
+            *self.last_auth.lock().unwrap() = Some(auth.clone());
+            Ok(PreparedRelease {
+                tx_hash: self.next_tx.lock().unwrap().clone(),
+                raw: vec![0xca, 0xfe],
+            })
+        }
+
+        async fn broadcast(&self, _prepared: &PreparedRelease) -> Result<(), ReleaseError> {
+            self.broadcast_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn check_confirmation(
+            &self,
+            _order: &BridgeOrder,
+            _dest_tx: &str,
+        ) -> Result<ReleaseConfirmation, ReleaseError> {
+            Ok(self.confirmation.lock().unwrap().clone())
+        }
+    }
+
     fn setup() -> (OrderProcessor, Arc<MockMinter>, Database) {
+        let (processor, minter, _releaser, db) = setup_full();
+        (processor, minter, db)
+    }
+
+    fn setup_full() -> (OrderProcessor, Arc<MockMinter>, Arc<MockReleaser>, Database) {
         let db = Database::open_in_memory().unwrap();
         db.migrate().unwrap();
 
@@ -525,13 +859,16 @@ mod tests {
         let mut minters: HashMap<Chain, Arc<dyn Minter>> = HashMap::new();
         minters.insert(Chain::Ethereum, minter.clone());
 
+        let releaser = Arc::new(MockReleaser::new());
+
         let processor = OrderProcessor::new(
             BridgeConfig::default(),
             db.clone(),
             minters,
+            Some(releaser.clone()),
             Arc::new(StubAttestationProvider),
         );
-        (processor, minter, db)
+        (processor, minter, releaser, db)
     }
 
     fn insert_confirmed_deposit(db: &Database) -> BridgeOrder {
@@ -705,5 +1042,239 @@ mod tests {
 
         let stored = db.get_order(&order.id).unwrap().unwrap();
         assert!(matches!(stored.status, OrderStatus::Failed { .. }));
+    }
+
+    // === Release (burn) path ===
+
+    fn insert_confirmed_burn(db: &Database) -> BridgeOrder {
+        let mut order = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+            "bth_user_stealth_addr".to_string(),
+            "0xburntx".to_string(),
+        );
+        order.set_status(OrderStatus::BurnConfirmed);
+        db.insert_order(&order).unwrap();
+        order
+    }
+
+    #[tokio::test]
+    async fn test_release_submit_then_finality_gating() {
+        let (processor, _minter, releaser, db) = setup_full();
+        let order = insert_confirmed_burn(&db);
+
+        // Submission: BurnConfirmed -> ReleasePending with a recorded tx
+        // (claim taken and tx recorded BEFORE broadcast).
+        processor.process_pending_orders().await.unwrap();
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::ReleasePending);
+        assert_eq!(stored.dest_tx.as_deref(), Some("bth_release_tx_1"));
+        let claim = db.get_release_by_order(&order.id).unwrap().unwrap();
+        assert_eq!(claim.release_tx_hash.as_deref(), Some("bth_release_tx_1"));
+        assert_eq!(claim.release_tx_raw.as_deref(), Some(&[0xca, 0xfe][..]));
+        assert_eq!(releaser.prepare_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(releaser.broadcast_calls.load(Ordering::SeqCst), 1);
+
+        // The attestation handed to the releaser was bound to THIS order:
+        // id, net amount, and recipient.
+        let auth = releaser.last_auth.lock().unwrap().clone().unwrap();
+        assert_eq!(auth.order_id, order.order_id_bytes());
+        assert_eq!(auth.amount, order.net_amount());
+        assert_eq!(auth.recipient, order.dest_address);
+
+        // Gating: while below the confirmation requirement the order must
+        // NOT reach Released.
+        releaser.set_confirmation(ReleaseConfirmation::Pending { confirmations: 0 });
+        processor.process_pending_orders().await.unwrap();
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(
+            stored.status,
+            OrderStatus::ReleasePending,
+            "ReleasePending must not advance before finality"
+        );
+        assert!(stored.dest_confirmed_at.is_none());
+
+        // Finality reached (SCP externalization by default): Released.
+        releaser.set_confirmation(ReleaseConfirmation::Confirmed);
+        processor.process_pending_orders().await.unwrap();
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::Released);
+        assert!(stored.dest_confirmed_at.is_some());
+        let claim = db.get_release_by_order(&order.id).unwrap().unwrap();
+        assert!(claim.confirmed_at.is_some());
+
+        // No double-release: the tx was signed exactly once end to end.
+        assert_eq!(releaser.prepare_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_release_resume_after_crash_reuses_recorded_tx() {
+        let (processor, _minter, releaser, db) = setup_full();
+        let order = insert_confirmed_burn(&db);
+
+        // Simulate a crash AFTER the release tx was signed and persisted
+        // but BEFORE the order status advanced: claim row with a recorded
+        // tx exists, order still BurnConfirmed.
+        db.try_claim_release(&order.id, &hex::encode(order.order_id_bytes()))
+            .unwrap();
+        db.record_release_tx(&order.id, "bth_persisted_before_crash", &[0xaa])
+            .unwrap();
+
+        processor.process_pending_orders().await.unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::ReleasePending);
+        assert_eq!(
+            stored.dest_tx.as_deref(),
+            Some("bth_persisted_before_crash")
+        );
+        // Exactly-once: NO new tx was signed — the recorded one was reused
+        // (and re-broadcast, which is idempotent).
+        assert_eq!(releaser.prepare_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(releaser.broadcast_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_release_crash_after_claim_before_sign_is_safe() {
+        let (processor, _minter, releaser, db) = setup_full();
+        let order = insert_confirmed_burn(&db);
+
+        // Crash AFTER the claim was taken but BEFORE anything was signed:
+        // claim exists with no recorded tx. Nothing was ever broadcast, so
+        // signing fresh on resume is safe — and must happen exactly once.
+        db.try_claim_release(&order.id, &hex::encode(order.order_id_bytes()))
+            .unwrap();
+
+        processor.process_pending_orders().await.unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::ReleasePending);
+        assert_eq!(stored.dest_tx.as_deref(), Some("bth_release_tx_1"));
+        assert_eq!(releaser.prepare_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_release_replayed_burn_single_release() {
+        let (processor, _minter, releaser, db) = setup_full();
+        let order = insert_confirmed_burn(&db);
+
+        // Multiple ticks over the same confirmed burn (a replayed burn
+        // event re-marking the order, or overlapping ticks) must produce
+        // exactly one signed release.
+        processor.process_pending_orders().await.unwrap();
+        processor.process_pending_orders().await.unwrap();
+        processor.process_pending_orders().await.unwrap();
+
+        assert_eq!(
+            releaser.prepare_calls.load(Ordering::SeqCst),
+            1,
+            "a burn order must be signed exactly once"
+        );
+        let claim = db.get_release_by_order(&order.id).unwrap().unwrap();
+        assert_eq!(claim.release_tx_hash.as_deref(), Some("bth_release_tx_1"));
+
+        // Even if the order is forced back to BurnConfirmed (replayed burn
+        // confirmation), the recorded tx is reused — never re-signed.
+        db.update_order_status(&order.id, &OrderStatus::BurnConfirmed, None)
+            .unwrap();
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(releaser.prepare_calls.load(Ordering::SeqCst), 1);
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::ReleasePending);
+        assert_eq!(stored.dest_tx.as_deref(), Some("bth_release_tx_1"));
+    }
+
+    #[tokio::test]
+    async fn test_release_dropped_unwinds_and_resubmits() {
+        let (processor, _minter, releaser, db) = setup_full();
+        let order = insert_confirmed_burn(&db);
+
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::ReleasePending
+        );
+
+        // Provably-dead tx: unwind to BurnConfirmed; the next tick signs a
+        // fresh tx (safe only because Dropped guarantees the old one can
+        // never land).
+        releaser.set_confirmation(ReleaseConfirmation::Dropped);
+        processor.process_pending_orders().await.unwrap();
+
+        releaser.set_next_tx("bth_release_tx_2");
+        releaser.set_confirmation(ReleaseConfirmation::Pending { confirmations: 0 });
+        processor.process_pending_orders().await.unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::ReleasePending);
+        let claim = db.get_release_by_order(&order.id).unwrap().unwrap();
+        assert_eq!(
+            claim.release_tx_hash.as_deref(),
+            Some("bth_release_tx_2"),
+            "re-submission after a provably-dead tx signs a fresh tx"
+        );
+        assert_eq!(claim.order_id_hash, hex::encode(order.order_id_bytes()));
+        assert_eq!(releaser.prepare_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn test_release_failed_marks_order_failed_keeps_claim() {
+        let (processor, _minter, releaser, db) = setup_full();
+        let order = insert_confirmed_burn(&db);
+
+        processor.process_pending_orders().await.unwrap();
+
+        releaser.set_confirmation(ReleaseConfirmation::Failed {
+            reason: "wrong recipient output".to_string(),
+        });
+        processor.process_pending_orders().await.unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert!(matches!(stored.status, OrderStatus::Failed { .. }));
+        // The claim survives so any operator-driven retry reuses the
+        // recorded tx instead of signing a competing reserve spend.
+        assert!(db.get_release_by_order(&order.id).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_release_unconfigured_leaves_order_retryable() {
+        // No releaser configured: the burn order must stay BurnConfirmed
+        // (retry when the operator fixes the config), NOT fail or advance.
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let processor = OrderProcessor::new(
+            BridgeConfig::default(),
+            db.clone(),
+            HashMap::new(),
+            None,
+            Arc::new(StubAttestationProvider),
+        );
+        let order = insert_confirmed_burn(&db);
+
+        processor.process_pending_orders().await.unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::BurnConfirmed);
+        assert!(db.get_release_by_order(&order.id).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_release_pending_without_tx_rolls_back() {
+        let (processor, _minter, _releaser, db) = setup_full();
+        let order = insert_confirmed_burn(&db);
+
+        // Force the inconsistent state: ReleasePending with no claim.
+        db.update_order_status(&order.id, &OrderStatus::ReleasePending, None)
+            .unwrap();
+
+        processor.process_pending_orders().await.unwrap();
+
+        // The confirm stage unwinds it; the SAME tick's submit stage has
+        // already run, so it lands back at BurnConfirmed and is
+        // re-submitted next tick.
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::BurnConfirmed);
     }
 }

--- a/bridge/service/src/main.rs
+++ b/bridge/service/src/main.rs
@@ -14,6 +14,7 @@ mod attestation;
 mod db;
 mod engine;
 mod mint;
+mod release;
 mod watchers;
 
 use bth_bridge_core::BridgeConfig;

--- a/bridge/service/src/release/bth.rs
+++ b/bridge/service/src/release/bth.rs
@@ -17,10 +17,10 @@
 //! - **Federation attestation verification**
 //!   ([`validate_release_attestation`]): real Ed25519 verification of every
 //!   signature over the domain-separated release digest
-//!   ([`bth_bridge_core::release_payload_digest`]), bound to the exact order id
-//!   + amount + recipient; federation-membership and distinct-signer threshold
-//!   checks. No reserve key material is touched until this passes — no single
-//!   node can spend the reserve.
+//!   ([`bth_bridge_core::release_payload_digest`]), bound to the exact order
+//!   id, amount, and recipient; federation-membership and distinct-signer
+//!   threshold checks. No reserve key material is touched until this passes —
+//!   no single node can spend the reserve.
 //! - **Configuration validation** ([`BthReleaser::new`]): reserve address
 //!   present, federation keys parse to valid Ed25519 points, threshold is
 //!   satisfiable by the configured signer set.

--- a/bridge/service/src/release/bth.rs
+++ b/bridge/service/src/release/bth.rs
@@ -1,0 +1,555 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! BTH reserve release (threshold-signed reserve spend, ADR 0002).
+//!
+//! On a confirmed wBTH burn, the bridge pays `net_amount()` picocredits
+//! from the locked BTH reserve to the burn's `bthAddress`, as a **fresh
+//! one-time stealth output** (ADR 0004), spending only **factor-1 /
+//! background-provenance** reserve outputs (ADR 0003) so the release cannot
+//! launder cluster provenance and the change keeps the reserve
+//! zero-demurrage.
+//!
+//! ## Implementation status
+//!
+//! The deterministic, consensus-critical pieces are implemented and
+//! unit-tested here:
+//!
+//! - **Federation attestation verification**
+//!   ([`validate_release_attestation`]): real Ed25519 verification of every
+//!   signature over the domain-separated release digest
+//!   ([`bth_bridge_core::release_payload_digest`]), bound to the exact order id
+//!   + amount + recipient; federation-membership and distinct-signer threshold
+//!   checks. No reserve key material is touched until this passes — no single
+//!   node can spend the reserve.
+//! - **Configuration validation** ([`BthReleaser::new`]): reserve address
+//!   present, federation keys parse to valid Ed25519 points, threshold is
+//!   satisfiable by the configured signer set.
+//!
+//! The RPC-dependent bodies (reserve UTXO scan, transaction construction,
+//! CLSAG signing, `tx_submit`, confirmation polling) are `TODO(#828)` stubs
+//! returning [`ReleaseError::NotImplemented`] — they need a live BTH node
+//! and the wallet transaction-builder stack, wired and validated end to end
+//! by the #828 test harness. Each stub documents the exact pipeline it must
+//! implement; the engine-side exactly-once machinery (release claims,
+//! record-before-broadcast, submit/confirm split) is fully live and tested
+//! against a mock releaser.
+
+use async_trait::async_trait;
+use bth_bridge_core::{BridgeOrder, BthConfig, ReleaseAuthorization};
+use ed25519_dalek::{Signature, VerifyingKey};
+
+use super::{PreparedRelease, ReleaseConfirmation, ReleaseError, Releaser};
+
+/// Validate that `auth` authorizes releasing `order`'s BTH, verifying every
+/// federation signature.
+///
+/// Checks, in order:
+/// 1. the authorization is bound to THIS order's deterministic on-chain id (a
+///    replayed authorization for a different order is rejected);
+/// 2. the authorized amount equals the order's `net_amount()` and the recipient
+///    equals the order's `dest_address` (the digest binds both, but the
+///    explicit field check gives a precise error before verifying);
+/// 3. the claimed threshold is at least the configured federation floor
+///    (`bth.release_threshold`, per ADR 0002 never lower than the SCP safety
+///    threshold);
+/// 4. every signature is a valid Ed25519 signature by a configured federation
+///    member over the domain-separated release digest; and
+/// 5. at least `threshold` DISTINCT federation members signed (duplicate or
+///    repeated signers count once).
+pub fn validate_release_attestation(
+    order: &BridgeOrder,
+    auth: &ReleaseAuthorization,
+    federation: &[VerifyingKey],
+    threshold_floor: u32,
+) -> Result<(), ReleaseError> {
+    if auth.order_id != order.order_id_bytes() {
+        return Err(ReleaseError::Attestation(
+            "attestation order id does not match order".to_string(),
+        ));
+    }
+    if auth.amount != order.net_amount() {
+        return Err(ReleaseError::Attestation(format!(
+            "attestation authorizes {} picocredits, order releases {}",
+            auth.amount,
+            order.net_amount()
+        )));
+    }
+    if auth.recipient != order.dest_address {
+        return Err(ReleaseError::Attestation(
+            "attestation recipient does not match order destination".to_string(),
+        ));
+    }
+    if auth.threshold < threshold_floor {
+        return Err(ReleaseError::Attestation(format!(
+            "attestation threshold {} is below the configured federation threshold {}",
+            auth.threshold, threshold_floor
+        )));
+    }
+
+    let digest = auth.digest();
+    let mut valid_signers: Vec<[u8; 32]> = Vec::with_capacity(auth.signatures.len());
+
+    for sig in &auth.signatures {
+        let signer_bytes: [u8; 32] = sig.signer.as_slice().try_into().map_err(|_| {
+            ReleaseError::Attestation(format!(
+                "ed25519 signer must be a 32-byte pubkey, got {} bytes",
+                sig.signer.len()
+            ))
+        })?;
+        let sig_bytes: [u8; 64] = sig.signature.as_slice().try_into().map_err(|_| {
+            ReleaseError::Attestation(format!(
+                "ed25519 signature must be 64 bytes, got {}",
+                sig.signature.len()
+            ))
+        })?;
+
+        // Federation membership: an empty configured set is development
+        // mode (no membership pinning); otherwise every signer must be a
+        // configured validator key.
+        let key = if federation.is_empty() {
+            VerifyingKey::from_bytes(&signer_bytes).map_err(|e| {
+                ReleaseError::Attestation(format!("invalid ed25519 public key: {}", e))
+            })?
+        } else {
+            *federation
+                .iter()
+                .find(|k| k.as_bytes() == &signer_bytes)
+                .ok_or_else(|| {
+                    ReleaseError::Attestation(format!(
+                        "signer {} is not a configured federation member",
+                        hex::encode(signer_bytes)
+                    ))
+                })?
+        };
+
+        // Every carried signature must verify — a single forged signature
+        // fails the whole attestation rather than being silently skipped.
+        key.verify_strict(&digest, &Signature::from_bytes(&sig_bytes))
+            .map_err(|e| {
+                ReleaseError::Attestation(format!(
+                    "signature by {} does not verify: {}",
+                    hex::encode(signer_bytes),
+                    e
+                ))
+            })?;
+
+        if !valid_signers.contains(&signer_bytes) {
+            valid_signers.push(signer_bytes);
+        }
+    }
+
+    if (valid_signers.len() as u32) < auth.threshold {
+        return Err(ReleaseError::Attestation(format!(
+            "attestation has {} distinct valid signer(s), threshold is {}",
+            valid_signers.len(),
+            auth.threshold
+        )));
+    }
+
+    Ok(())
+}
+
+/// BTH reserve-release backend.
+///
+/// See the module docs: attestation verification and configuration
+/// validation are live; transaction construction / submission /
+/// confirmation are `TODO(#828)` stubs.
+pub struct BthReleaser {
+    config: BthConfig,
+    /// Parsed federation verifying keys (from `bth.release_signers`).
+    federation: Vec<VerifyingKey>,
+}
+
+impl BthReleaser {
+    /// Build a releaser from configuration. Does not perform network I/O.
+    ///
+    /// Fails (disabling release submission — burn orders stay
+    /// `BurnConfirmed`, never dropped) if the reserve address is missing,
+    /// any federation key is malformed, or the threshold exceeds the
+    /// configured signer count.
+    pub fn new(config: BthConfig) -> Result<Self, ReleaseError> {
+        if config.reserve_address.as_deref().unwrap_or("").is_empty() {
+            return Err(ReleaseError::Config(
+                "bth.reserve_address is not configured".to_string(),
+            ));
+        }
+
+        let mut federation = Vec::with_capacity(config.release_signers.len());
+        for hex_key in &config.release_signers {
+            let bytes: [u8; 32] = hex::decode(hex_key)
+                .map_err(|e| {
+                    ReleaseError::Config(format!("bad federation key hex {}: {}", hex_key, e))
+                })?
+                .try_into()
+                .map_err(|_| {
+                    ReleaseError::Config(format!("federation key {} is not 32 bytes", hex_key))
+                })?;
+            let key = VerifyingKey::from_bytes(&bytes).map_err(|e| {
+                ReleaseError::Config(format!("federation key {} is invalid: {}", hex_key, e))
+            })?;
+            federation.push(key);
+        }
+
+        if !federation.is_empty() && config.release_threshold as usize > federation.len() {
+            return Err(ReleaseError::Config(format!(
+                "release_threshold {} exceeds the {} configured federation signer(s)",
+                config.release_threshold,
+                federation.len()
+            )));
+        }
+
+        Ok(Self { config, federation })
+    }
+
+    /// The confirmation depth a release must reach before `Released`
+    /// (0 = SCP externalization finality).
+    #[allow(dead_code)]
+    pub fn required_confirmations(&self) -> u32 {
+        self.config.release_confirmations_required
+    }
+}
+
+#[async_trait]
+impl Releaser for BthReleaser {
+    async fn prepare_release(
+        &self,
+        order: &BridgeOrder,
+        auth: &ReleaseAuthorization,
+    ) -> Result<PreparedRelease, ReleaseError> {
+        // Threshold authorization FIRST: no reserve spend is ever
+        // constructed without a verified federation attestation bound to
+        // this exact order id, amount, and recipient (ADR 0002).
+        validate_release_attestation(order, auth, &self.federation, self.config.release_threshold)?;
+
+        // TODO(#828): construct and sign the release transaction against a
+        // live BTH node. The pipeline (mirroring the web wallet's
+        // send flow in web/packages/wasm-signer/src/send.ts and
+        // botho/src/commands/send.rs):
+        //   1. Load reserve-owned outputs: `chain_getOutputs` + ownership scan with the
+        //      reserve view key (scanOwnedOutputs), derive key images, and drop
+        //      spent/pending ones via `chain_areKeyImagesSpent`
+        //      (spendableOwnedOutputs).
+        //   2. Filter to FACTOR-1 / BACKGROUND-provenance outputs only (ADR 0003): keep
+        //      outputs whose ClusterTagVector computes to factor 1x
+        //      (transaction/types/src/cluster_tags.rs,
+        //      transaction/core/src/validation/cluster_fee.rs) so the reserve never
+        //      spends — or launders — wealthy-cluster coins.
+        //   3. Greedily select inputs covering net_amount() + the BTH fee.
+        //   4. Build a FRESH one-time stealth output to auth.recipient (ADR 0004):
+        //      decode the address to a RecipientAddress and derive a per-release
+        //      one-time key (TxOutput::new_with_memo in botho/src/commands/send.rs) —
+        //      never a static payout key; two releases to the same address must produce
+        //      distinct one-time keys. Assert the recipient output carries NO cluster
+        //      tags.
+        //   5. Route change back to self.config.reserve_address, preserving
+        //      factor-1/background provenance for future releases.
+        //   6. Gather ring decoys for each input from the on-chain pool, excluding the
+        //      real inputs and the genesis placeholder (decoy-gathering + SpendInput
+        //      assembly in send.ts).
+        //   7. Threshold-sign per #824 (t-of-n federation signing of the tx digest),
+        //      produce the node-verifiable CLSAG-signed tx (build_and_sign_inner in
+        //      web/packages/wasm-signer/src/lib.rs), and SELF-VERIFY before returning.
+        //   8. Return PreparedRelease { tx_hash, raw } — the engine persists BOTH
+        //      before the first broadcast so a crash after signing resumes with the
+        //      same signed tx and never re-signs with new inputs (double-spend risk).
+        Err(ReleaseError::NotImplemented(
+            "BTH release tx construction pending #824 (federation signing) and #828 \
+             (live-node wallet-send wiring)"
+                .to_string(),
+        ))
+    }
+
+    async fn broadcast(&self, _prepared: &PreparedRelease) -> Result<(), ReleaseError> {
+        // TODO(#828): submit via the node's `tx_submit` JSON-RPC
+        // (botho/src/rpc/mod.rs) at self.config.rpc_url. Idempotent: an
+        // "already known" / duplicate-key-image-for-the-same-tx rejection of
+        // our OWN recorded hash is success (the tx was submitted before a
+        // restart).
+        Err(ReleaseError::NotImplemented(
+            "BTH tx_submit wiring pending #828".to_string(),
+        ))
+    }
+
+    async fn check_confirmation(
+        &self,
+        _order: &BridgeOrder,
+        _dest_tx: &str,
+    ) -> Result<ReleaseConfirmation, ReleaseError> {
+        // TODO(#828): poll the node for the tx's block inclusion and depth:
+        //   - depth >= self.config.release_confirmations_required (0 = SCP
+        //     externalization finality: in-a-block == final) -> Confirmed.
+        //   - not yet included -> Pending { confirmations }.
+        //   - PROVABLY dead only (key images spent by a DIFFERENT tx per
+        //     `chain_areKeyImagesSpent`, or permanently invalid) -> Dropped, which
+        //     unwinds ReleasePending -> BurnConfirmed for a fresh submission. A
+        //     merely-unseen tx must stay Pending and be re-broadcast — BTH has no
+        //     on-chain order-id guard, so re-signing while the old tx could still land
+        //     risks a double release.
+        Err(ReleaseError::NotImplemented(
+            "BTH confirmation polling pending #828".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bth_bridge_core::{AttestationSignature, Chain};
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn test_config(signers: &[&SigningKey], threshold: u32) -> BthConfig {
+        BthConfig {
+            rpc_url: "http://localhost:7101".to_string(),
+            ws_url: "ws://localhost:7101/ws".to_string(),
+            view_key_file: None,
+            spend_key_file: None,
+            confirmations_required: 0,
+            reserve_address: Some("bth_reserve_addr".to_string()),
+            release_signers: signers
+                .iter()
+                .map(|k| hex::encode(k.verifying_key().as_bytes()))
+                .collect(),
+            release_threshold: threshold,
+            release_confirmations_required: 0,
+        }
+    }
+
+    fn burn_order() -> BridgeOrder {
+        let mut order = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+            "bth_user_stealth_addr".to_string(),
+            "0xburntx".to_string(),
+        );
+        order.set_status(bth_bridge_core::OrderStatus::BurnConfirmed);
+        order
+    }
+
+    fn signing_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn signed_auth(
+        order: &BridgeOrder,
+        keys: &[&SigningKey],
+        threshold: u32,
+    ) -> ReleaseAuthorization {
+        let mut auth = ReleaseAuthorization {
+            order_id: order.order_id_bytes(),
+            amount: order.net_amount(),
+            recipient: order.dest_address.clone(),
+            threshold,
+            signatures: vec![],
+        };
+        let digest = auth.digest();
+        for key in keys {
+            auth.signatures.push(AttestationSignature {
+                signer: key.verifying_key().as_bytes().to_vec(),
+                signature: key.sign(&digest).to_bytes().to_vec(),
+            });
+        }
+        auth
+    }
+
+    fn federation(keys: &[&SigningKey]) -> Vec<VerifyingKey> {
+        keys.iter().map(|k| k.verifying_key()).collect()
+    }
+
+    #[test]
+    fn test_valid_threshold_attestation_accepted() {
+        let (k1, k2, k3) = (signing_key(1), signing_key(2), signing_key(3));
+        let order = burn_order();
+        let auth = signed_auth(&order, &[&k1, &k2], 2);
+        let fed = federation(&[&k1, &k2, &k3]);
+
+        assert!(validate_release_attestation(&order, &auth, &fed, 2).is_ok());
+    }
+
+    #[test]
+    fn test_below_threshold_rejected() {
+        let (k1, k2) = (signing_key(1), signing_key(2));
+        let order = burn_order();
+        let fed = federation(&[&k1, &k2]);
+
+        // Fewer than t signatures.
+        let auth = signed_auth(&order, &[&k1], 2);
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+
+        // The SAME signer twice does not meet a threshold of 2.
+        let auth = signed_auth(&order, &[&k1, &k1], 2);
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+
+        // A claimed threshold below the configured federation floor is
+        // rejected even if its own signature count is met.
+        let auth = signed_auth(&order, &[&k1], 1);
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+    }
+
+    #[test]
+    fn test_wrong_binding_rejected() {
+        let (k1, k2) = (signing_key(1), signing_key(2));
+        let order = burn_order();
+        let fed = federation(&[&k1, &k2]);
+
+        // Bound to a DIFFERENT order id (replay from another order).
+        let mut auth = signed_auth(&order, &[&k1, &k2], 2);
+        auth.order_id = [0u8; 32];
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+
+        // Amount tampered after signing: field check catches the mismatch
+        // with the order before any signature is even inspected.
+        let mut auth = signed_auth(&order, &[&k1, &k2], 2);
+        auth.amount += 1;
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+
+        // Recipient tampered after signing.
+        let mut auth = signed_auth(&order, &[&k1, &k2], 2);
+        auth.recipient = "attacker_addr".to_string();
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+    }
+
+    #[test]
+    fn test_signature_over_wrong_digest_rejected() {
+        let (k1, k2) = (signing_key(1), signing_key(2));
+        let order = burn_order();
+        let fed = federation(&[&k1, &k2]);
+
+        // Signatures made over a DIFFERENT payload (stale authorization for
+        // another amount) pasted into an auth whose fields match the order:
+        // Ed25519 verification over the digest catches it.
+        let mut stale = signed_auth(&order, &[&k1, &k2], 2);
+        stale.amount = order.net_amount() + 5; // signed digest binds this
+        let digest = stale.digest();
+        let mut auth = signed_auth(&order, &[], 2);
+        for key in [&k1, &k2] {
+            auth.signatures.push(AttestationSignature {
+                signer: key.verifying_key().as_bytes().to_vec(),
+                signature: key.sign(&digest).to_bytes().to_vec(),
+            });
+        }
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+    }
+
+    #[test]
+    fn test_non_federation_signer_rejected() {
+        let (k1, k2, outsider) = (signing_key(1), signing_key(2), signing_key(9));
+        let order = burn_order();
+        let fed = federation(&[&k1, &k2]);
+
+        // A valid signature from a key OUTSIDE the configured federation
+        // must be rejected, even alongside a valid member signature.
+        let auth = signed_auth(&order, &[&k1, &outsider], 2);
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+    }
+
+    #[test]
+    fn test_malformed_signature_material_rejected() {
+        let (k1, k2) = (signing_key(1), signing_key(2));
+        let order = burn_order();
+        let fed = federation(&[&k1, &k2]);
+
+        let mut auth = signed_auth(&order, &[&k1, &k2], 2);
+        auth.signatures[0].signer = vec![1u8; 16]; // not 32 bytes
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+
+        let mut auth = signed_auth(&order, &[&k1, &k2], 2);
+        auth.signatures[0].signature = vec![0u8; 63]; // not 64 bytes
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+
+        // A corrupted (non-verifying) signature fails the WHOLE attestation
+        // even when enough other valid signatures exist.
+        let k3 = signing_key(3);
+        let fed3 = federation(&[&k1, &k2, &k3]);
+        let mut auth = signed_auth(&order, &[&k1, &k2, &k3], 2);
+        auth.signatures[2].signature = vec![0u8; 64];
+        assert!(matches!(
+            validate_release_attestation(&order, &auth, &fed3, 2),
+            Err(ReleaseError::Attestation(_))
+        ));
+    }
+
+    #[test]
+    fn test_releaser_config_validation() {
+        let (k1, k2) = (signing_key(1), signing_key(2));
+
+        // Valid.
+        assert!(BthReleaser::new(test_config(&[&k1, &k2], 2)).is_ok());
+
+        // Missing reserve address disables release submission.
+        let mut cfg = test_config(&[&k1, &k2], 2);
+        cfg.reserve_address = None;
+        assert!(matches!(
+            BthReleaser::new(cfg),
+            Err(ReleaseError::Config(_))
+        ));
+
+        // Threshold unsatisfiable by the configured signer set.
+        let cfg = test_config(&[&k1, &k2], 3);
+        assert!(matches!(
+            BthReleaser::new(cfg),
+            Err(ReleaseError::Config(_))
+        ));
+
+        // Malformed federation key.
+        let mut cfg = test_config(&[&k1], 1);
+        cfg.release_signers = vec!["zz-not-hex".to_string()];
+        assert!(matches!(
+            BthReleaser::new(cfg),
+            Err(ReleaseError::Config(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_prepare_release_gates_on_attestation_before_stub() {
+        let (k1, k2) = (signing_key(1), signing_key(2));
+        let releaser = BthReleaser::new(test_config(&[&k1, &k2], 2)).unwrap();
+        let order = burn_order();
+
+        // A bad attestation is rejected as Attestation (the gate fires
+        // BEFORE the NotImplemented construction stub).
+        let auth = signed_auth(&order, &[&k1], 2);
+        assert!(matches!(
+            releaser.prepare_release(&order, &auth).await,
+            Err(ReleaseError::Attestation(_))
+        ));
+
+        // A valid attestation reaches the #828 construction stub.
+        let auth = signed_auth(&order, &[&k1, &k2], 2);
+        assert!(matches!(
+            releaser.prepare_release(&order, &auth).await,
+            Err(ReleaseError::NotImplemented(_))
+        ));
+    }
+}

--- a/bridge/service/src/release/mod.rs
+++ b/bridge/service/src/release/mod.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! BTH reserve-release submission and confirmation.
+//!
+//! The burn flow's destination side: on a confirmed wBTH burn, the bridge
+//! pays the user's BTH address from the locked reserve. [`Releaser`] splits
+//! a release into three retryable stages so the engine can guarantee
+//! exactly-once releasing (mirroring the mint-side [`crate::mint::Minter`]):
+//!
+//! 1. [`Releaser::prepare_release`] — build and threshold-sign the BTH
+//!    transaction locally (no broadcast). The resulting [`PreparedRelease`]
+//!    carries the exact raw bytes so a retry re-broadcasts the SAME transaction
+//!    (same inputs / key images) instead of signing a competing one — the
+//!    engine persists both the tx hash AND the raw bytes to the
+//!    `release_claims` table BEFORE the first broadcast, so a post-restart
+//!    resume re-broadcasts rather than re-signs.
+//! 2. [`Releaser::broadcast`] — submit via the node's `tx_submit` RPC.
+//!    Idempotent: "already known" / key-image-already-spent-by-this-tx
+//!    responses are success.
+//! 3. [`Releaser::check_confirmation`] — poll until the configured depth
+//!    (`release_confirmations_required`; 0 = SCP externalization finality) is
+//!    met, reporting a provably-dead transaction so the engine can unwind
+//!    `ReleasePending -> BurnConfirmed` and re-submit.
+//!
+//! Unlike the mint side, BTH has **no on-chain order-id guard**: the ONLY
+//! double-release protections are the `release_claims` idempotency table,
+//! the never-re-sign-after-record rule above, and key-image conflicts
+//! between transactions that spend the same reserve inputs. The unwind edge
+//! is therefore restricted to transactions that provably cannot land (see
+//! [`ReleaseConfirmation::Dropped`]).
+
+pub mod bth;
+
+use async_trait::async_trait;
+use bth_bridge_core::{BridgeOrder, ReleaseAuthorization};
+
+/// Errors from release submission / confirmation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReleaseError {
+    /// Misconfiguration (missing reserve address, bad federation key, ...).
+    Config(String),
+    /// The provided attestation does not authorize this release.
+    Attestation(String),
+    /// RPC / network failure (retryable).
+    /// TODO(#828): constructed by the live-node RPC wiring.
+    #[allow(dead_code)]
+    Rpc(String),
+    /// Functionality not yet wired up (BTH wallet-send RPC, see #828).
+    NotImplemented(String),
+}
+
+impl std::fmt::Display for ReleaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReleaseError::Config(m) => write!(f, "config error: {}", m),
+            ReleaseError::Attestation(m) => write!(f, "attestation error: {}", m),
+            ReleaseError::Rpc(m) => write!(f, "rpc error: {}", m),
+            ReleaseError::NotImplemented(m) => write!(f, "not implemented: {}", m),
+        }
+    }
+}
+
+impl std::error::Error for ReleaseError {}
+
+/// A fully signed, ready-to-broadcast BTH release transaction.
+#[derive(Debug, Clone)]
+pub struct PreparedRelease {
+    /// BTH transaction hash. Known before broadcast.
+    pub tx_hash: String,
+    /// The exact signed bytes to (re)broadcast. Persisted alongside the
+    /// hash so a crash after signing NEVER leads to re-signing with
+    /// different inputs (which could double-spend the reserve).
+    pub raw: Vec<u8>,
+}
+
+/// Result of polling a submitted release transaction.
+///
+/// The engine consumes every variant; production construction is the
+/// `TODO(#828)` confirmation-polling wiring (tests construct them via the
+/// mock releaser), hence the `dead_code` allowance.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReleaseConfirmation {
+    /// Not yet at the required depth; keep the order in `ReleasePending`.
+    Pending {
+        /// Confirmations observed so far (0 = not yet in a block).
+        confirmations: u64,
+    },
+    /// Required depth reached (SCP finality by default) and the recipient
+    /// output is present: safe to advance to `Released`.
+    Confirmed,
+    /// The transaction **provably cannot land**: its key images were spent
+    /// by a different transaction, or it is permanently invalid against the
+    /// chain. Implementations must NOT report a merely-unseen transaction
+    /// as `Dropped` — with no on-chain order-id guard on BTH, unwinding and
+    /// re-signing while the old tx could still land risks a double release.
+    /// The engine reacts by rolling the order back to `BurnConfirmed` and
+    /// re-running submission (which signs a fresh transaction).
+    Dropped,
+    /// The transaction landed but is wrong (e.g. pays the wrong output).
+    /// Requires operator attention; the order is marked `Failed`.
+    Failed {
+        /// Human-readable failure description.
+        reason: String,
+    },
+}
+
+/// A BTH reserve-release backend.
+#[async_trait]
+pub trait Releaser: Send + Sync {
+    /// Build and threshold-sign the release transaction for `order`,
+    /// authorized by `auth` (the #824 threshold attestation). Verifies the
+    /// attestation before any reserve key material is touched. Does NOT
+    /// broadcast.
+    async fn prepare_release(
+        &self,
+        order: &BridgeOrder,
+        auth: &ReleaseAuthorization,
+    ) -> Result<PreparedRelease, ReleaseError>;
+
+    /// Broadcast (or re-broadcast) a prepared transaction. Idempotent:
+    /// "already known" responses are success.
+    async fn broadcast(&self, prepared: &PreparedRelease) -> Result<(), ReleaseError>;
+
+    /// Poll the confirmation state of a submitted release transaction.
+    async fn check_confirmation(
+        &self,
+        order: &BridgeOrder,
+        dest_tx: &str,
+    ) -> Result<ReleaseConfirmation, ReleaseError>;
+}


### PR DESCRIPTION
Closes #822

Part of the bridge epic #816. Builds directly on the mint engine merged in #838, reusing its record-before-broadcast idempotency, submit/confirm stage split, and guarded state-machine transitions for the burn/release side.

## What this does

Replaces the `process_burn_order` "Would send" stub in `bridge/service/src/engine.rs` with a real BTH reserve-release path for confirmed wBTH burns (source Ethereum or Solana, `dest_chain == Bth`). The mint path is untouched.

## Fully implemented (live + tested)

- **Exactly-once release claims** (`bridge/service/src/db.rs`): new `release_claims` table keyed on `order_id` (PRIMARY KEY) with a unique index on the deterministic order-id hash. The claim is taken in a `BEGIN IMMEDIATE` transaction BEFORE any signing; the signed tx **hash AND raw bytes** are recorded BEFORE the first broadcast. A concurrent tick or post-restart re-entry either finds no recorded tx (nothing was broadcast — safe to sign fresh) or reuses the recorded tx — the engine **never re-signs with different reserve inputs** (double-spend risk; BTH has no on-chain order-id guard, unlike the mint side's #826).
- **Submit/confirm split** (`bridge/service/src/engine.rs`): `submit_release` (`BurnConfirmed -> ReleasePending`, claim -> attest -> sign -> record -> status -> broadcast with bounded retries) and `confirm_release` (`ReleasePending -> Released` only at the configured finality depth; default 0 = SCP externalization). Resume path re-broadcasts the recorded raw bytes idempotently.
- **Unwind edge** (`bridge/core/src/order.rs`): `ReleasePending -> BurnConfirmed`, guarded by `can_transition_to` and restricted (in docs + engine semantics) to transactions that **provably cannot land** — a merely-unseen tx must stay Pending, because re-signing while the old tx could still land risks a double release. `Failed` releases keep the claim intact so retries reuse the same signed tx.
- **Threshold release authorization** (ADR 0002): new `ReleaseAuthorization` in `bridge/core/src/attestation.rs`, bound to order id + net amount + recipient through a domain-separated digest (`release_payload_digest`, tag `botho-bridge-release-v1`, golden-vector tested, mirroring the operator-signed-action `DOMAIN_SEPARATOR` pattern). `bridge/service/src/release/bth.rs` performs **real Ed25519 verification** (`verify_strict`) of every signature, enforces federation membership against the configured validator key set, a distinct-signer threshold, and a configured threshold floor — all BEFORE any reserve key material would be touched. Replay safety comes from the order-id binding + the claims table + the order state machine (one release per order id); the envelope/nonce collection protocol itself is #824.
- **Config knobs** (`bridge/core/src/config.rs`): `BthConfig.reserve_address`, `release_signers` (hex Ed25519 keys), `release_threshold`, `release_confirmations_required` (default 0 = SCP finality), threaded through `BridgeConfig::default` and TOML-backward-compatible.
- **Fail-safe wiring**: a misconfigured/absent releaser or a failed attestation leaves burn orders in `BurnConfirmed` (retryable) — they are never dropped or failed by configuration problems.

## Stubbed (fail-safe, after the attestation gate)

Following the exact `mint/solana.rs` pattern, the live-node RPC bodies in `bridge/service/src/release/bth.rs` return `NotImplemented` with `TODO(#828)` markers documenting the pinned pipeline:

- `prepare_release` tx construction: reserve UTXO scan (`chain_getOutputs` + ownership scan + `chain_areKeyImagesSpent`), **factor-1/background-only input selection** (ADR 0003), **fresh one-time stealth output** to the burn's `bthAddress` (ADR 0004; never a static payout key), factor-1-preserving change back to the reserve, ring decoy gathering, t-of-n threshold signing (#824) producing the CLSAG-signed tx, self-verify.
- `broadcast`: `tx_submit` wiring ("already known" = success).
- `check_confirmation`: depth polling vs `release_confirmations_required`; `Dropped` only for provably-dead txs.

Because the stub fires only AFTER attestation validation passes and BEFORE anything is recorded, today's deployments keep burn orders safely in `BurnConfirmed` with zero reserve exposure.

Issue-checklist items that inherently require the #828 live-node harness (fresh-stealth distinctness on-chain, factor-1 provenance of actual selected inputs, ETH-testnet -> BTH-testnet integration) are covered at the deterministic layer here (digest binding, validation gates, documented invariants) and complete under #828. Note: this PR keeps the #838 pattern that #839 (DB-layer transition enforcement) will harden — status updates go through guarded `can_transition_to` checks at the engine layer plus status-scoped SQL `WHERE` clauses.

## Test Plan

- [x] `cargo test -p bth-bridge-core -p bth-bridge-service` — 65 tests, all passing:
  - restart mid-release, both crash points: after claim + recorded hash (resumes with the SAME tx, `prepare` never re-called) and after claim but before signing (signs exactly once) — `test_release_resume_after_crash_reuses_recorded_tx`, `test_release_crash_after_claim_before_sign_is_safe`
  - replayed confirmed burn / repeated ticks -> exactly one signed release; a duplicate `record_release_tx` with a different hash never overwrites — `test_release_replayed_burn_single_release`, `test_release_claim_exactly_once`
  - threshold authorization: fewer than `t` signers, duplicate signer, threshold below the configured floor, attestation bound to a different order id / amount / recipient, signatures over a stale digest, non-federation signer, malformed or corrupted signature — all rejected before the construction stub — `release::bth` tests
  - finality gating: stays `ReleasePending` below the requirement, then `Released` with `dest_confirmed_at`; `Failed` keeps the claim; `Dropped` unwinds to `BurnConfirmed` and re-submits fresh — engine + db tests
  - release digest golden vector + field-binding; state-machine edges (`ReleasePending -> BurnConfirmed` unwind clears `dest_tx`, terminal `Released` frozen, burn orders cannot expire)
  - config: legacy TOML without the new knobs still parses; knobs round-trip
- [x] `cargo clippy --all-targets -p bth-bridge-core -p bth-bridge-service` — zero warnings
- [x] `cargo +nightly-2025-12-03 fmt -- --check` (repo's pinned-nightly convention) — clean
- [x] `cargo deny check advisories` — ok (Cargo.lock only adds the existing workspace `ed25519-dalek` to bridge-service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
