### PR TITLE
bridge: reorg-safe chain watchers — BTH deposit (SCP finality) + Ethereum burn (confirmations)

### DIFF
--- a/bridge/service/src/db.rs
+++ b/bridge/service/src/db.rs
@@ -65,6 +65,52 @@ pub struct ReleaseClaim {
     pub confirmed_at: Option<DateTime<Utc>>,
 }
 
+/// Persisted scan progress for a chain watcher.
+///
+/// One row per source chain. `last_height` is the last FULLY processed
+/// block (all its events handled and idempotency rows written), so a
+/// restart resumes at `last_height + 1` without missing events.
+/// `last_block_hash` is the canonical hash observed for that height —
+/// watchers on reorg-capable chains compare it against the node's current
+/// canonical hash to detect a reorg at/behind the cursor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WatcherCursor {
+    /// Source chain this cursor tracks.
+    pub chain: Chain,
+    /// Last fully processed block height (slot on Solana).
+    pub last_height: u64,
+    /// Canonical block hash observed at `last_height` (None where the
+    /// chain has no reorgs to guard against, e.g. SCP-final BTH).
+    pub last_block_hash: Option<String>,
+}
+
+/// A row in the `processed_burns` idempotency table.
+///
+/// One row exists per source-chain burn event that has ever created a
+/// burn order. The `source_key` UNIQUE constraint makes event→order
+/// creation exactly-once: a rescan (cursor rewind) or a reorg re-add of
+/// the same burn finds the existing row and reuses its order instead of
+/// creating a duplicate release.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BurnRecord {
+    /// Stable identity of the burn event: `"<source_tx>#<ordinal>"` where
+    /// ordinal is the event's position among burn events of the SAME
+    /// transaction (stable across reorgs, unlike the absolute log index).
+    pub source_key: String,
+    /// Bridge order created for this burn.
+    pub order_id: Uuid,
+    /// Source chain of the burn.
+    pub chain: Chain,
+    /// Block height (slot) the burn was last observed in.
+    pub block_number: u64,
+    /// Canonical block hash the burn was last observed in.
+    pub block_hash: Option<String>,
+    /// True while the burn's block has been observed reorged out and the
+    /// event has not yet been re-observed in a canonical block. An
+    /// orphaned burn must never advance toward release.
+    pub orphaned: bool,
+}
+
 /// Database wrapper for thread-safe access.
 #[derive(Clone)]
 pub struct Database {
@@ -168,6 +214,25 @@ impl Database {
 
             CREATE UNIQUE INDEX IF NOT EXISTS idx_release_claims_order_hash
                 ON release_claims(order_id_hash);
+
+            CREATE TABLE IF NOT EXISTS watcher_cursors (
+                chain TEXT PRIMARY KEY,
+                last_height INTEGER NOT NULL,
+                last_block_hash TEXT,
+                updated_at INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS processed_burns (
+                source_key TEXT PRIMARY KEY,
+                order_id TEXT NOT NULL REFERENCES bridge_orders(id),
+                chain TEXT NOT NULL,
+                block_number INTEGER NOT NULL,
+                block_hash TEXT,
+                orphaned INTEGER NOT NULL DEFAULT 0,
+                processed_at INTEGER NOT NULL
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_burns_order ON processed_burns(order_id);
             "#,
         )
         .map_err(|e| format!("Migration failed: {}", e))?;
@@ -207,7 +272,12 @@ impl Database {
     /// Insert a new order.
     pub fn insert_order(&self, order: &BridgeOrder) -> Result<(), String> {
         let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        Self::insert_order_stmt(&conn, order)
+    }
 
+    /// Execute the order INSERT against `conn` (also used inside
+    /// transactions, e.g. [`Database::insert_burn_order`]).
+    fn insert_order_stmt(conn: &Connection, order: &BridgeOrder) -> Result<(), String> {
         let mint_auth_json = order
             .mint_authorization
             .as_ref()
@@ -371,6 +441,252 @@ impl Database {
         .map_err(|e| format!("Insert failed: {}", e))?;
 
         Ok(())
+    }
+
+    /// Record a detected deposit on an `AwaitingDeposit` order: stamps the
+    /// REVEALED amount (ADR 0004) and the deposit tx as `source_tx`, and
+    /// advances the order to `DepositDetected`.
+    ///
+    /// The SQL `status = 'awaiting_deposit'` guard makes this both a state
+    /// transition check and an idempotency layer: replaying the same
+    /// deposit (cursor rewind) is a no-op. Returns whether the order was
+    /// updated.
+    pub fn record_deposit_detected(
+        &self,
+        order_id: &Uuid,
+        source_tx: &str,
+        amount: u64,
+    ) -> Result<bool, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let changed = conn
+            .execute(
+                r#"
+                UPDATE bridge_orders
+                SET status = 'deposit_detected', source_tx = ?1, amount = ?2, updated_at = ?3
+                WHERE id = ?4 AND status = 'awaiting_deposit'
+                "#,
+                params![
+                    source_tx,
+                    amount as i64,
+                    Utc::now().timestamp(),
+                    order_id.to_string()
+                ],
+            )
+            .map_err(|e| format!("Update failed: {}", e))?;
+
+        Ok(changed > 0)
+    }
+
+    // === Watcher cursors (restart/resume durability) ===
+
+    /// Load the persisted scan cursor for a chain, if any.
+    pub fn get_cursor(&self, chain: Chain) -> Result<Option<WatcherCursor>, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let mut stmt = conn
+            .prepare("SELECT last_height, last_block_hash FROM watcher_cursors WHERE chain = ?1")
+            .map_err(|e| format!("Prepare failed: {}", e))?;
+
+        stmt.query_row(params![chain.to_string()], |row| {
+            let last_height: i64 = row.get(0)?;
+            let last_block_hash: Option<String> = row.get(1)?;
+            Ok(WatcherCursor {
+                chain,
+                last_height: last_height as u64,
+                last_block_hash,
+            })
+        })
+        .optional()
+        .map_err(|e| format!("Query failed: {}", e))
+    }
+
+    /// Persist the scan cursor for a chain. Watchers call this only AFTER
+    /// a block is fully processed, so a crash replays (never skips) the
+    /// in-flight block; the idempotency tables deduplicate the replay.
+    pub fn set_cursor(
+        &self,
+        chain: Chain,
+        last_height: u64,
+        last_block_hash: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        conn.execute(
+            r#"
+            INSERT OR REPLACE INTO watcher_cursors (chain, last_height, last_block_hash, updated_at)
+            VALUES (?1, ?2, ?3, ?4)
+            "#,
+            params![
+                chain.to_string(),
+                last_height as i64,
+                last_block_hash,
+                Utc::now().timestamp()
+            ],
+        )
+        .map_err(|e| format!("Insert failed: {}", e))?;
+
+        Ok(())
+    }
+
+    // === Burn idempotency table ===
+
+    /// Atomically create a burn order together with its `processed_burns`
+    /// idempotency row.
+    ///
+    /// Exactly-once by `source_key`: if the burn was already recorded (a
+    /// cursor replay or reorg re-add), NOTHING is written — the whole
+    /// transaction rolls back and `Ok(false)` is returned so the caller
+    /// reuses the existing order. The single transaction closes the
+    /// crash window between "order inserted" and "idempotency row written".
+    pub fn insert_burn_order(
+        &self,
+        order: &BridgeOrder,
+        source_key: &str,
+        block_number: u64,
+        block_hash: Option<&str>,
+    ) -> Result<bool, String> {
+        let mut conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Transaction failed: {}", e))?;
+
+        Self::insert_order_stmt(&tx, order)?;
+
+        let changed = tx
+            .execute(
+                r#"
+                INSERT OR IGNORE INTO processed_burns (
+                    source_key, order_id, chain, block_number, block_hash, orphaned, processed_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6)
+                "#,
+                params![
+                    source_key,
+                    order.id.to_string(),
+                    order.source_chain.to_string(),
+                    block_number as i64,
+                    block_hash,
+                    Utc::now().timestamp()
+                ],
+            )
+            .map_err(|e| format!("Insert failed: {}", e))?;
+
+        if changed == 0 {
+            // Duplicate source_key: drop the transaction (rolls back the
+            // order insert) — the existing record wins.
+            return Ok(false);
+        }
+
+        tx.commit().map_err(|e| format!("Commit failed: {}", e))?;
+        Ok(true)
+    }
+
+    /// Look up a burn record by its stable source key.
+    pub fn get_burn_by_source(&self, source_key: &str) -> Result<Option<BurnRecord>, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT source_key, order_id, chain, block_number, block_hash, orphaned
+                FROM processed_burns WHERE source_key = ?1
+                "#,
+            )
+            .map_err(|e| format!("Prepare failed: {}", e))?;
+
+        stmt.query_row(params![source_key], Self::row_to_burn)
+            .optional()
+            .map_err(|e| format!("Query failed: {}", e))
+    }
+
+    /// Look up the burn record backing an order.
+    pub fn get_burn_by_order(&self, order_id: &Uuid) -> Result<Option<BurnRecord>, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT source_key, order_id, chain, block_number, block_hash, orphaned
+                FROM processed_burns WHERE order_id = ?1
+                "#,
+            )
+            .map_err(|e| format!("Prepare failed: {}", e))?;
+
+        stmt.query_row(params![order_id.to_string()], Self::row_to_burn)
+            .optional()
+            .map_err(|e| format!("Query failed: {}", e))
+    }
+
+    /// Update where a burn was (re-)observed on the source chain and clear
+    /// its orphaned flag — used when a reorged-out burn is re-included in a
+    /// new canonical block (idempotent by order id: same record, same
+    /// order, new location).
+    pub fn update_burn_location(
+        &self,
+        source_key: &str,
+        block_number: u64,
+        block_hash: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        conn.execute(
+            r#"
+            UPDATE processed_burns
+            SET block_number = ?1, block_hash = ?2, orphaned = 0
+            WHERE source_key = ?3
+            "#,
+            params![block_number as i64, block_hash, source_key],
+        )
+        .map_err(|e| format!("Update failed: {}", e))?;
+
+        Ok(())
+    }
+
+    /// Flag a burn whose block was reorged out. Returns true if the flag
+    /// was newly set (so callers can audit-log the orphaning exactly once).
+    pub fn mark_burn_orphaned(&self, source_key: &str) -> Result<bool, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let changed = conn
+            .execute(
+                "UPDATE processed_burns SET orphaned = 1 WHERE source_key = ?1 AND orphaned = 0",
+                params![source_key],
+            )
+            .map_err(|e| format!("Update failed: {}", e))?;
+
+        Ok(changed > 0)
+    }
+
+    /// Count audit-log entries with the given action (test/ops helper).
+    pub fn count_audit_action(&self, action: &str) -> Result<i64, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        conn.query_row(
+            "SELECT COUNT(*) FROM audit_log WHERE action = ?1",
+            params![action],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Query failed: {}", e))
+    }
+
+    /// Convert a database row to a BurnRecord.
+    fn row_to_burn(row: &rusqlite::Row<'_>) -> SqliteResult<BurnRecord> {
+        let source_key: String = row.get(0)?;
+        let order_id_str: String = row.get(1)?;
+        let chain_str: String = row.get(2)?;
+        let block_number: i64 = row.get(3)?;
+        let block_hash: Option<String> = row.get(4)?;
+        let orphaned: i64 = row.get(5)?;
+
+        Ok(BurnRecord {
+            source_key,
+            order_id: Uuid::parse_str(&order_id_str).unwrap_or_default(),
+            chain: chain_str.parse().unwrap_or(Chain::Ethereum),
+            block_number: block_number as u64,
+            block_hash,
+            orphaned: orphaned != 0,
+        })
     }
 
     // === Mint idempotency table ===
@@ -1151,5 +1467,120 @@ mod tests {
         let stored = db.get_order(&order.id).unwrap().unwrap();
         assert_eq!(stored.mint_authorization, order.mint_authorization);
         assert!(stored.dest_confirmed_at.is_none());
+    }
+
+    #[test]
+    fn test_watcher_cursor_roundtrip() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        assert!(db.get_cursor(Chain::Ethereum).unwrap().is_none());
+
+        db.set_cursor(Chain::Ethereum, 100, Some("0xaa")).unwrap();
+        let cursor = db.get_cursor(Chain::Ethereum).unwrap().unwrap();
+        assert_eq!(cursor.last_height, 100);
+        assert_eq!(cursor.last_block_hash.as_deref(), Some("0xaa"));
+
+        // Upsert replaces; per-chain rows are independent.
+        db.set_cursor(Chain::Ethereum, 101, Some("0xbb")).unwrap();
+        db.set_cursor(Chain::Bth, 7, None).unwrap();
+        let eth = db.get_cursor(Chain::Ethereum).unwrap().unwrap();
+        assert_eq!(eth.last_height, 101);
+        assert_eq!(eth.last_block_hash.as_deref(), Some("0xbb"));
+        let bth = db.get_cursor(Chain::Bth).unwrap().unwrap();
+        assert_eq!(bth.last_height, 7);
+        assert!(bth.last_block_hash.is_none());
+    }
+
+    fn burn_order(source_tx: &str) -> BridgeOrder {
+        BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            0,
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+            "bth_stealth_addr".to_string(),
+            source_tx.to_string(),
+        )
+    }
+
+    #[test]
+    fn test_insert_burn_order_exactly_once_by_source_key() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let first = burn_order("0xburn");
+        assert!(db
+            .insert_burn_order(&first, "0xburn#0", 50, Some("0xblock50"))
+            .unwrap());
+
+        // Replay with the SAME source key (cursor rewind / reorg re-add):
+        // nothing is written, including the duplicate order.
+        let dup = burn_order("0xburn");
+        assert!(!db
+            .insert_burn_order(&dup, "0xburn#0", 51, Some("0xblock51"))
+            .unwrap());
+        assert!(db.get_order(&dup.id).unwrap().is_none());
+
+        let rec = db.get_burn_by_source("0xburn#0").unwrap().unwrap();
+        assert_eq!(rec.order_id, first.id);
+        assert_eq!(rec.block_number, 50);
+        assert!(!rec.orphaned);
+        assert_eq!(
+            db.get_burn_by_order(&first.id).unwrap().unwrap().source_key,
+            "0xburn#0"
+        );
+    }
+
+    #[test]
+    fn test_burn_orphan_and_relocate() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let order = burn_order("0xburn");
+        db.insert_burn_order(&order, "0xburn#0", 50, Some("0xold"))
+            .unwrap();
+
+        // Orphan flag is set exactly once.
+        assert!(db.mark_burn_orphaned("0xburn#0").unwrap());
+        assert!(!db.mark_burn_orphaned("0xburn#0").unwrap());
+        assert!(db.get_burn_by_source("0xburn#0").unwrap().unwrap().orphaned);
+
+        // Re-inclusion relocates the record and clears the flag.
+        db.update_burn_location("0xburn#0", 52, Some("0xnew"))
+            .unwrap();
+        let rec = db.get_burn_by_source("0xburn#0").unwrap().unwrap();
+        assert_eq!(rec.block_number, 52);
+        assert_eq!(rec.block_hash.as_deref(), Some("0xnew"));
+        assert!(!rec.orphaned);
+    }
+
+    #[test]
+    fn test_record_deposit_detected_guarded_and_idempotent() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bridge_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        db.insert_order(&order).unwrap();
+
+        // First detection records the revealed amount + source tx.
+        assert!(db
+            .record_deposit_detected(&order.id, "0xdeposit", 999_000_000_000)
+            .unwrap());
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::DepositDetected);
+        assert_eq!(stored.source_tx.as_deref(), Some("0xdeposit"));
+        assert_eq!(stored.amount, 999_000_000_000);
+
+        // Replay is a no-op (status guard).
+        assert!(!db.record_deposit_detected(&order.id, "0xother", 1).unwrap());
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.source_tx.as_deref(), Some("0xdeposit"));
+        assert_eq!(stored.amount, 999_000_000_000);
     }
 }

--- a/bridge/service/src/engine.rs
+++ b/bridge/service/src/engine.rs
@@ -12,7 +12,7 @@ use crate::{
     db::Database,
     mint::{ethereum::EthMinter, solana::SolMinter, ConfirmationStatus, Minter},
     release::{bth::BthReleaser, PreparedRelease, ReleaseConfirmation, Releaser},
-    watchers::{BthWatcher, EthereumWatcher},
+    watchers::{BthWatcher, EthereumWatcher, SolanaWatcher},
 };
 
 /// Shutdown signal type.
@@ -112,6 +112,19 @@ impl BridgeEngine {
             }
         });
 
+        // Spawn the Solana watcher
+        let sol_watcher = SolanaWatcher::new(
+            self.config.solana.clone(),
+            self.db.clone(),
+            self.shutdown_tx.subscribe(),
+        );
+
+        let sol_handle = tokio::spawn(async move {
+            if let Err(e) = sol_watcher.run().await {
+                error!("Solana watcher error: {}", e);
+            }
+        });
+
         // Spawn the order processing loop
         let minters = Self::build_minters(&self.config);
         let releaser = Self::build_releaser(&self.config);
@@ -153,7 +166,7 @@ impl BridgeEngine {
         let _ = self.shutdown_tx.send(());
 
         // Wait for all components to finish
-        let _ = tokio::join!(bth_handle, eth_handle, process_handle);
+        let _ = tokio::join!(bth_handle, eth_handle, sol_handle, process_handle);
 
         info!("Bridge engine stopped");
         Ok(())

--- a/bridge/service/src/watchers/bth.rs
+++ b/bridge/service/src/watchers/bth.rs
@@ -1,16 +1,139 @@
 // Copyright (c) 2024 The Botho Foundation
 
-//! BTH chain watcher for monitoring deposits.
+//! BTH chain watcher for monitoring deposits (mint flow).
+//!
+//! Scans finalized BTH blocks for outputs paying the bridge's stealth
+//! address, matches each deposit to its `AwaitingDeposit` order via the
+//! deposit memo, and drives `AwaitingDeposit -> DepositDetected ->
+//! DepositConfirmed`.
+//!
+//! ## Finality (SCP)
+//!
+//! `BthConfig::confirmations_required == 0` means SCP-final: Botho blocks
+//! are final at inclusion (SCP externalization), so the watcher scans up to
+//! the tip and detection implies finality. A non-zero value makes the scan
+//! lag the tip by that many blocks (belt-and-suspenders for operators who
+//! want depth on top of SCP), so scanned blocks still always meet the
+//! requirement — either way a detected deposit advances straight through
+//! `DepositDetected` to `DepositConfirmed`.
+//!
+//! ## Privacy boundary (ADR 0004)
+//!
+//! The amount carried on a [`BthDeposit`] is the REVEALED deposit amount —
+//! the deliberate privacy exit of the bridge. The transport
+//! ([`BthChainClient`] implementation) is responsible for view-key stealth
+//! scanning and verifying the commitment opening; only the amount (never
+//! the source ring) crosses this boundary.
+//!
+//! ## Peg eligibility (ADR 0003)
+//!
+//! Only factor-1 (background/commerce) coins are wrappable: a factor-1
+//! coin pays exactly zero demurrage forever, so a factor-1-only reserve
+//! cannot decay below the outstanding wBTH supply. Deposits whose cluster
+//! factor is not 1.0 are rejected before confirmation (the order fails and
+//! an audit entry is written).
+//!
+//! ## Implementation status
+//!
+//! The deterministic scan/match/gate/dedup pipeline is implemented and
+//! tested against [`BthChainClient`]. The live transport (`ws_url`
+//! NewBlock subscription + `view_key_file` stealth scanning + commitment
+//! opening) is a fail-safe `TODO(#828)` stub: until it is wired, the
+//! watcher polls, logs, and creates no state.
 
-use bth_bridge_core::BthConfig;
+use async_trait::async_trait;
+use bth_bridge_core::{BridgeOrder, BthConfig, Chain, OrderStatus};
 use std::time::Duration;
 use tokio::sync::broadcast;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
+use super::WatchError;
 use crate::{db::Database, engine::ShutdownSignal};
 
+/// Fixed-point scale for cluster factors, matching
+/// `cluster-tax::demurrage::FACTOR_SCALE` (1000 = factor 1.0×). A deposit
+/// is wrap-eligible iff its factor is exactly `FACTOR_SCALE` (ADR 0003).
+pub const FACTOR_SCALE: u64 = 1000;
+
+/// Delay between scan passes.
+const POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// A deposit to the bridge stealth address, as decoded by the transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BthDeposit {
+    /// BTH transaction hash (idempotency key in `processed_deposits`).
+    pub tx_hash: String,
+    /// REVEALED deposit amount in picocredits (ADR 0004): the transport
+    /// has already verified the commitment opening.
+    pub amount: u64,
+    /// Deposit memo carrying the order UUID (see
+    /// [`BridgeOrder::generate_memo`]); `None` if absent/undecodable.
+    pub memo: Option<[u8; 64]>,
+    /// Cluster factor of the received output in [`FACTOR_SCALE`] units,
+    /// read from its `ClusterTagVector` (ADR 0003 eligibility gate).
+    pub cluster_factor: u64,
+}
+
+/// A finalized BTH block with the bridge-relevant deposits already
+/// extracted by the transport's view-key scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BthBlock {
+    /// Block height.
+    pub height: u64,
+    /// Block id (hash) — persisted with the cursor for audit purposes.
+    pub block_id: String,
+    /// Deposits paying the bridge stealth address in this block.
+    pub deposits: Vec<BthDeposit>,
+}
+
+/// Read access to the BTH chain, mockable for tests.
+#[async_trait]
+pub trait BthChainClient: Send + Sync {
+    /// Current chain tip height.
+    async fn tip_height(&self) -> Result<u64, WatchError>;
+
+    /// Fetch the block at `height` with bridge deposits decoded, or
+    /// `None` if the node does not have that height yet.
+    async fn block_at(&self, height: u64) -> Result<Option<BthBlock>, WatchError>;
+}
+
+/// Live transport against a BTH node.
+///
+/// TODO(#828): implement against `BthConfig::ws_url` — subscribe to
+/// NewBlock, and for each block run the view-key stealth scan
+/// (`view_key_file`) over outputs, verify the Pedersen commitment opening
+/// to reveal the amount (ADR 0004), read the output's `ClusterTagVector`
+/// factor (ADR 0003), and decode the 64-byte deposit memo. Until then this
+/// client is a fail-safe stub: it reports `NotImplemented` and the watcher
+/// creates no state.
+pub struct NodeBthClient {
+    #[allow(dead_code)]
+    config: BthConfig,
+}
+
+impl NodeBthClient {
+    /// Build a client from configuration. Does not perform network I/O.
+    pub fn new(config: BthConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl BthChainClient for NodeBthClient {
+    async fn tip_height(&self) -> Result<u64, WatchError> {
+        Err(WatchError::NotImplemented(
+            "BTH node websocket transport (ws_url NewBlock subscription) pending #828".to_string(),
+        ))
+    }
+
+    async fn block_at(&self, _height: u64) -> Result<Option<BthBlock>, WatchError> {
+        Err(WatchError::NotImplemented(
+            "BTH block fetch + view-key stealth scan pending #828".to_string(),
+        ))
+    }
+}
+
 /// BTH watcher monitors the BTH chain for deposits to the bridge address.
-#[allow(dead_code)]
 pub struct BthWatcher {
     config: BthConfig,
     db: Database,
@@ -29,7 +152,9 @@ impl BthWatcher {
 
     /// Run the watcher.
     pub async fn run(mut self) -> Result<(), String> {
-        info!("Starting BTH watcher for {}", self.config.rpc_url);
+        info!("Starting BTH watcher for {}", self.config.ws_url);
+
+        let client = NodeBthClient::new(self.config.clone());
 
         loop {
             // Check for shutdown first
@@ -44,22 +169,557 @@ impl BthWatcher {
                 }
             }
 
-            self.poll_for_deposits().await;
+            match self.scan_once(&client).await {
+                Ok(blocks) if blocks > 0 => {
+                    debug!("BTH watcher processed {} block(s)", blocks);
+                }
+                Ok(_) => {}
+                Err(WatchError::NotImplemented(msg)) => {
+                    // Fail-safe transport stub: no state is created.
+                    debug!("BTH watcher idle: {}", msg);
+                }
+                Err(e) => warn!("BTH scan failed (will retry): {}", e),
+            }
+
+            tokio::select! {
+                _ = self.shutdown.recv() => {
+                    info!("BTH watcher shutting down");
+                    return Ok(());
+                }
+                _ = tokio::time::sleep(POLL_INTERVAL) => {}
+            }
         }
     }
 
-    /// Poll for new deposits.
-    async fn poll_for_deposits(&self) {
-        // TODO: In a full implementation, we would:
-        // 1. Connect to BTH WebSocket at self.config.ws_url
-        // 2. Subscribe to NewBlock events
-        // 3. For each block, scan outputs for bridge's stealth address
-        // 4. Use view private key for stealth detection
-        // 5. Match deposits to pending orders via encrypted memo
-        //
-        // For now, we just poll periodically as a placeholder.
+    /// One scan pass: process every finalized block past the persisted
+    /// cursor. Returns the number of blocks processed.
+    ///
+    /// The cursor is persisted only AFTER a block is fully processed, so a
+    /// restart resumes at the right block; `processed_deposits` plus the
+    /// `record_deposit_detected` status guard deduplicate any replay.
+    pub async fn scan_once(&self, client: &dyn BthChainClient) -> Result<u64, WatchError> {
+        let tip = client.tip_height().await?;
 
-        debug!("Polling for BTH deposits...");
-        tokio::time::sleep(Duration::from_secs(30)).await;
+        // Finality target: with confirmations_required == 0 (SCP-final)
+        // every included block is final, so scan to the tip; otherwise lag
+        // the tip so scanned blocks always meet the depth requirement.
+        let target = tip.saturating_sub(self.config.confirmations_required as u64);
+
+        let mut next = match self.db.get_cursor(Chain::Bth).map_err(WatchError::Db)? {
+            Some(cursor) => cursor.last_height + 1,
+            // First run: start from genesis. Operators bootstrapping
+            // against a long-lived chain can seed the watcher_cursors row
+            // to skip history.
+            None => 0,
+        };
+
+        let mut processed = 0u64;
+        while next <= target {
+            let Some(block) = client.block_at(next).await? else {
+                break;
+            };
+
+            for deposit in &block.deposits {
+                self.process_deposit(block.height, deposit)?;
+            }
+
+            // Persist only after the block is fully processed.
+            self.db
+                .set_cursor(Chain::Bth, block.height, Some(&block.block_id))
+                .map_err(WatchError::Db)?;
+
+            processed += 1;
+            next += 1;
+        }
+
+        Ok(processed)
+    }
+
+    /// Handle one deposit from a finalized block: dedup, memo→order match,
+    /// factor-1 gate (ADR 0003), then detect + confirm.
+    fn process_deposit(&self, height: u64, deposit: &BthDeposit) -> Result<(), WatchError> {
+        let db = &self.db;
+
+        // Idempotency layer independent of the cursor: a cursor rewind or
+        // crash replay of an already-processed tx is a no-op.
+        if db
+            .is_deposit_processed(&deposit.tx_hash)
+            .map_err(WatchError::Db)?
+        {
+            debug!("Deposit {} already processed; skipping", deposit.tx_hash);
+            return Ok(());
+        }
+
+        // Match to a pending order via the memo-embedded order UUID.
+        let Some(order_id) = deposit
+            .memo
+            .as_ref()
+            .and_then(BridgeOrder::order_id_from_memo)
+        else {
+            warn!(
+                "Deposit {} at height {} has no decodable order memo; leaving unmatched",
+                deposit.tx_hash, height
+            );
+            db.log_audit(
+                None,
+                "deposit_unmatched",
+                &format!(
+                    "tx={} height={} amount={}",
+                    deposit.tx_hash, height, deposit.amount
+                ),
+            )
+            .map_err(WatchError::Db)?;
+            return Ok(());
+        };
+
+        let Some(order) = db.get_order(&order_id).map_err(WatchError::Db)? else {
+            warn!(
+                "Deposit {} references unknown order {}; leaving unmatched",
+                deposit.tx_hash, order_id
+            );
+            db.log_audit(
+                None,
+                "deposit_unknown_order",
+                &format!("tx={} order={}", deposit.tx_hash, order_id),
+            )
+            .map_err(WatchError::Db)?;
+            return Ok(());
+        };
+
+        if order.status != OrderStatus::AwaitingDeposit {
+            debug!(
+                "Deposit {} for order {} in status {}; not awaiting a deposit — skipping",
+                deposit.tx_hash, order.id, order.status
+            );
+            return Ok(());
+        }
+
+        // Factor-1 eligibility gate (ADR 0003): only zero-demurrage
+        // (background/commerce) coins may enter the reserve, otherwise the
+        // locked reserve decays below the outstanding wBTH supply.
+        if deposit.cluster_factor != FACTOR_SCALE {
+            let reason = format!(
+                "deposit {} is not factor-1 (factor {}/{}); only factor-1 coins are \
+                 wrappable per ADR 0003 — settle demurrage (#831) and retry",
+                deposit.tx_hash, deposit.cluster_factor, FACTOR_SCALE
+            );
+            warn!("Rejecting order {}: {}", order.id, reason);
+            db.mark_deposit_processed(&deposit.tx_hash, &order.id)
+                .map_err(WatchError::Db)?;
+            db.update_order_status(
+                &order.id,
+                &OrderStatus::Failed {
+                    reason: reason.clone(),
+                },
+                None,
+            )
+            .map_err(WatchError::Db)?;
+            db.log_audit(Some(&order.id), "deposit_rejected_non_factor1", &reason)
+                .map_err(WatchError::Db)?;
+            return Ok(());
+        }
+
+        if deposit.amount == 0 {
+            let reason = format!("deposit {} has zero revealed amount", deposit.tx_hash);
+            warn!("Rejecting order {}: {}", order.id, reason);
+            db.mark_deposit_processed(&deposit.tx_hash, &order.id)
+                .map_err(WatchError::Db)?;
+            db.update_order_status(
+                &order.id,
+                &OrderStatus::Failed {
+                    reason: reason.clone(),
+                },
+                None,
+            )
+            .map_err(WatchError::Db)?;
+            db.log_audit(Some(&order.id), "deposit_rejected_zero_amount", &reason)
+                .map_err(WatchError::Db)?;
+            return Ok(());
+        }
+
+        // Detect: record the REVEALED amount (authoritative over the
+        // amount quoted at order creation, ADR 0004) and the deposit tx as
+        // source_tx. The status guard doubles as a replay no-op.
+        let detected = db
+            .record_deposit_detected(&order.id, &deposit.tx_hash, deposit.amount)
+            .map_err(WatchError::Db)?;
+        if !detected {
+            debug!(
+                "Order {} no longer awaiting deposit; skipping {}",
+                order.id, deposit.tx_hash
+            );
+            return Ok(());
+        }
+        db.mark_deposit_processed(&deposit.tx_hash, &order.id)
+            .map_err(WatchError::Db)?;
+
+        if deposit.amount != order.amount {
+            db.log_audit(
+                Some(&order.id),
+                "deposit_amount_mismatch",
+                &format!("expected={} revealed={}", order.amount, deposit.amount),
+            )
+            .map_err(WatchError::Db)?;
+        }
+        db.log_audit(
+            Some(&order.id),
+            "deposit_detected",
+            &format!(
+                "tx={} height={} amount={}",
+                deposit.tx_hash, height, deposit.amount
+            ),
+        )
+        .map_err(WatchError::Db)?;
+
+        // Confirm: scanned blocks already meet the finality requirement
+        // (SCP-final at inclusion when confirmations_required == 0, else
+        // the scan lags the tip by the requirement), so detection implies
+        // finality and the order advances straight to DepositConfirmed.
+        db.update_order_status(&order.id, &OrderStatus::DepositConfirmed, None)
+            .map_err(WatchError::Db)?;
+        db.log_audit(
+            Some(&order.id),
+            "deposit_confirmed",
+            &format!(
+                "tx={} height={} scp_final={}",
+                deposit.tx_hash,
+                height,
+                self.config.confirmations_required == 0
+            ),
+        )
+        .map_err(WatchError::Db)?;
+
+        info!(
+            "Deposit {} confirmed for order {} ({} picocredits, height {})",
+            deposit.tx_hash, order.id, deposit.amount, height
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{collections::BTreeMap, sync::Mutex};
+
+    /// In-memory BTH chain for driving the watcher deterministically.
+    struct MockBthClient {
+        blocks: Mutex<BTreeMap<u64, BthBlock>>,
+    }
+
+    impl MockBthClient {
+        fn new() -> Self {
+            Self {
+                blocks: Mutex::new(BTreeMap::new()),
+            }
+        }
+
+        /// Append the next block (height = current tip + 1, or 0).
+        fn push_block(&self, deposits: Vec<BthDeposit>) -> u64 {
+            let mut blocks = self.blocks.lock().unwrap();
+            let height = blocks.keys().next_back().map(|h| h + 1).unwrap_or(0);
+            blocks.insert(
+                height,
+                BthBlock {
+                    height,
+                    block_id: format!("bth_block_{}", height),
+                    deposits,
+                },
+            );
+            height
+        }
+    }
+
+    #[async_trait]
+    impl BthChainClient for MockBthClient {
+        async fn tip_height(&self) -> Result<u64, WatchError> {
+            Ok(*self.blocks.lock().unwrap().keys().next_back().unwrap_or(&0))
+        }
+
+        async fn block_at(&self, height: u64) -> Result<Option<BthBlock>, WatchError> {
+            Ok(self.blocks.lock().unwrap().get(&height).cloned())
+        }
+    }
+
+    fn setup(confirmations_required: u32) -> (BthWatcher, Database) {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let config = BthConfig {
+            rpc_url: "http://localhost:7101".to_string(),
+            ws_url: "ws://localhost:7101/ws".to_string(),
+            view_key_file: None,
+            spend_key_file: None,
+            confirmations_required,
+        };
+        let (_tx, rx) = broadcast::channel(1);
+        // _tx dropped: try_recv returns Closed, but tests drive scan_once
+        // directly, never run().
+        (BthWatcher::new(config, db.clone(), rx), db)
+    }
+
+    fn awaiting_order(db: &Database, amount: u64) -> BridgeOrder {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            amount,
+            1_000_000_000,
+            "bridge_stealth_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        order.generate_memo();
+        db.insert_order(&order).unwrap();
+        order
+    }
+
+    fn deposit_for(order: &BridgeOrder, tx: &str, amount: u64, factor: u64) -> BthDeposit {
+        BthDeposit {
+            tx_hash: tx.to_string(),
+            amount,
+            memo: order.memo,
+            cluster_factor: factor,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_factor1_deposit_detects_and_confirms_at_scp_finality() {
+        // confirmations_required == 0: SCP-final at inclusion.
+        let (watcher, db) = setup(0);
+        let client = MockBthClient::new();
+        let order = awaiting_order(&db, 1_000_000_000_000);
+
+        // Revealed amount differs from the quoted amount: the revealed
+        // amount is authoritative (ADR 0004).
+        client.push_block(vec![deposit_for(
+            &order,
+            "0xdep1",
+            750_000_000_000,
+            FACTOR_SCALE,
+        )]);
+
+        watcher.scan_once(&client).await.unwrap();
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::DepositConfirmed);
+        assert_eq!(stored.source_tx.as_deref(), Some("0xdep1"));
+        assert_eq!(
+            stored.amount, 750_000_000_000,
+            "revealed amount is recorded"
+        );
+        assert!(db.is_deposit_processed("0xdep1").unwrap());
+        assert_eq!(db.count_audit_action("deposit_detected").unwrap(), 1);
+        assert_eq!(db.count_audit_action("deposit_confirmed").unwrap(), 1);
+        assert_eq!(db.count_audit_action("deposit_amount_mismatch").unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_non_factor1_deposit_rejected_with_audit() {
+        let (watcher, db) = setup(0);
+        let client = MockBthClient::new();
+
+        // A factor-2.5 deposit must be rejected (ADR 0003)...
+        let rejected = awaiting_order(&db, 1_000_000_000_000);
+        client.push_block(vec![deposit_for(
+            &rejected,
+            "0xwealthy",
+            1_000_000_000_000,
+            2_500,
+        )]);
+        watcher.scan_once(&client).await.unwrap();
+
+        let stored = db.get_order(&rejected.id).unwrap().unwrap();
+        assert!(
+            matches!(stored.status, OrderStatus::Failed { ref reason } if reason.contains("factor-1")),
+            "order must fail with a factor-1 reason, got {}",
+            stored.status
+        );
+        assert_eq!(
+            db.count_audit_action("deposit_rejected_non_factor1")
+                .unwrap(),
+            1
+        );
+        // The rejected tx is still marked processed (no reprocessing loop).
+        assert!(db.is_deposit_processed("0xwealthy").unwrap());
+
+        // ...while an identical factor-1 deposit confirms.
+        let accepted = awaiting_order(&db, 1_000_000_000_000);
+        client.push_block(vec![deposit_for(
+            &accepted,
+            "0xsettled",
+            1_000_000_000_000,
+            FACTOR_SCALE,
+        )]);
+        watcher.scan_once(&client).await.unwrap();
+
+        let stored = db.get_order(&accepted.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::DepositConfirmed);
+    }
+
+    #[tokio::test]
+    async fn test_confirmation_lag_when_depth_required() {
+        // confirmations_required = 2: the scan lags the tip, so a deposit
+        // at the tip is not touched until it is 2 deep.
+        let (watcher, db) = setup(2);
+        let client = MockBthClient::new();
+        let order = awaiting_order(&db, 1_000_000_000_000);
+
+        client.push_block(vec![]); // height 0
+        client.push_block(vec![]); // height 1
+        client.push_block(vec![deposit_for(
+            &order,
+            "0xdep",
+            1_000_000_000_000,
+            FACTOR_SCALE,
+        )]); // height 2 (tip)
+
+        watcher.scan_once(&client).await.unwrap();
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(
+            stored.status,
+            OrderStatus::AwaitingDeposit,
+            "deposit at the tip must not be processed before the depth requirement"
+        );
+
+        client.push_block(vec![]); // height 3
+        watcher.scan_once(&client).await.unwrap();
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::AwaitingDeposit,
+            "one confirmation is still below the requirement"
+        );
+
+        client.push_block(vec![]); // height 4: deposit now 2 deep
+        watcher.scan_once(&client).await.unwrap();
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::DepositConfirmed
+        );
+    }
+
+    #[tokio::test]
+    async fn test_restart_resumes_from_cursor_without_missing_or_duplicating() {
+        let (watcher, db) = setup(0);
+        let client = MockBthClient::new();
+        let first = awaiting_order(&db, 1_000_000_000_000);
+
+        client.push_block(vec![]);
+        client.push_block(vec![deposit_for(
+            &first,
+            "0xdep1",
+            1_000_000_000_000,
+            FACTOR_SCALE,
+        )]);
+        watcher.scan_once(&client).await.unwrap();
+
+        let cursor = db.get_cursor(Chain::Bth).unwrap().unwrap();
+        assert_eq!(cursor.last_height, 1);
+        assert_eq!(cursor.last_block_hash.as_deref(), Some("bth_block_1"));
+
+        // "Restart": a fresh watcher on the same db must resume at height 2
+        // and pick up only the new block — no re-processing of old blocks.
+        let (_tx, rx) = broadcast::channel(1);
+        let watcher2 = BthWatcher::new(
+            BthConfig {
+                rpc_url: String::new(),
+                ws_url: String::new(),
+                view_key_file: None,
+                spend_key_file: None,
+                confirmations_required: 0,
+            },
+            db.clone(),
+            rx,
+        );
+
+        let second = awaiting_order(&db, 2_000_000_000_000);
+        client.push_block(vec![deposit_for(
+            &second,
+            "0xdep2",
+            2_000_000_000_000,
+            FACTOR_SCALE,
+        )]);
+
+        let processed = watcher2.scan_once(&client).await.unwrap();
+        assert_eq!(processed, 1, "only the new block is scanned after restart");
+
+        assert_eq!(
+            db.get_order(&first.id).unwrap().unwrap().status,
+            OrderStatus::DepositConfirmed
+        );
+        assert_eq!(
+            db.get_order(&second.id).unwrap().unwrap().status,
+            OrderStatus::DepositConfirmed
+        );
+        // Exactly one detect/confirm per deposit across the restart.
+        assert_eq!(db.count_audit_action("deposit_detected").unwrap(), 2);
+        assert_eq!(db.count_audit_action("deposit_confirmed").unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_cursor_rewind_replay_is_deduplicated() {
+        let (watcher, db) = setup(0);
+        let client = MockBthClient::new();
+        let order = awaiting_order(&db, 1_000_000_000_000);
+
+        client.push_block(vec![]); // height 0
+        client.push_block(vec![deposit_for(
+            &order,
+            "0xdep",
+            1_000_000_000_000,
+            FACTOR_SCALE,
+        )]); // height 1
+        watcher.scan_once(&client).await.unwrap();
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::DepositConfirmed
+        );
+        assert_eq!(db.get_cursor(Chain::Bth).unwrap().unwrap().last_height, 1);
+
+        // Simulate a non-atomically-advanced cursor (rewound behind
+        // already-processed blocks): replaying block 1 must be a complete
+        // no-op thanks to processed_deposits.
+        db.set_cursor(Chain::Bth, 0, None).unwrap();
+        let replayed = watcher.scan_once(&client).await.unwrap();
+        assert_eq!(replayed, 1, "block 1 is scanned again after the rewind");
+
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::DepositConfirmed);
+        assert_eq!(
+            db.count_audit_action("deposit_detected").unwrap(),
+            1,
+            "replay after cursor rewind must not re-detect"
+        );
+        assert_eq!(db.count_audit_action("deposit_confirmed").unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_unmatched_and_unknown_deposits_are_audited_not_fatal() {
+        let (watcher, db) = setup(0);
+        let client = MockBthClient::new();
+
+        // No memo at all.
+        let no_memo = BthDeposit {
+            tx_hash: "0xnomemo".to_string(),
+            amount: 5,
+            memo: None,
+            cluster_factor: FACTOR_SCALE,
+        };
+        // Memo referencing an order that does not exist.
+        let mut ghost = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1,
+            0,
+            "a".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        ghost.generate_memo();
+        let unknown = deposit_for(&ghost, "0xghost", 5, FACTOR_SCALE);
+
+        client.push_block(vec![no_memo, unknown]);
+        watcher.scan_once(&client).await.unwrap();
+
+        assert_eq!(db.count_audit_action("deposit_unmatched").unwrap(), 1);
+        assert_eq!(db.count_audit_action("deposit_unknown_order").unwrap(), 1);
+        // Cursor still advanced past the block.
+        assert_eq!(db.get_cursor(Chain::Bth).unwrap().unwrap().last_height, 0);
     }
 }

--- a/bridge/service/src/watchers/bth.rs
+++ b/bridge/service/src/watchers/bth.rs
@@ -452,6 +452,10 @@ mod tests {
             view_key_file: None,
             spend_key_file: None,
             confirmations_required,
+            reserve_address: None,
+            release_signers: Vec::new(),
+            release_threshold: 0,
+            release_confirmations_required: 0,
         };
         let (_tx, rx) = broadcast::channel(1);
         // _tx dropped: try_recv returns Closed, but tests drive scan_once
@@ -625,6 +629,10 @@ mod tests {
                 view_key_file: None,
                 spend_key_file: None,
                 confirmations_required: 0,
+                reserve_address: None,
+                release_signers: Vec::new(),
+                release_threshold: 0,
+                release_confirmations_required: 0,
             },
             db.clone(),
             rx,

--- a/bridge/service/src/watchers/ethereum.rs
+++ b/bridge/service/src/watchers/ethereum.rs
@@ -1,16 +1,201 @@
 // Copyright (c) 2024 The Botho Foundation
 
-//! Ethereum chain watcher for monitoring wBTH burns.
+//! Ethereum chain watcher for monitoring wBTH burns (burn flow).
+//!
+//! Scans the `WrappedBTH` contract for `BridgeBurn(from, amount,
+//! bthAddress)` events and drives `BurnDetected -> BurnConfirmed`:
+//!
+//! - **Detection** runs up to the tip: each new burn atomically creates a
+//!   `BridgeOrder::new_burn` at `BurnDetected` plus its `processed_burns`
+//!   idempotency row (keyed by `"<tx_hash>#<ordinal>"`, stable across reorgs),
+//!   so a rescan or reorg re-add can never create a second order.
+//! - **Confirmation** requires `confirmations_required` blocks of depth AND a
+//!   canonical-hash re-check of the burn's block (same pattern as
+//!   `mint::ethereum::check_confirmation`): an orphaned burn is flagged and
+//!   never advances toward `ReleasePending`/`Released`; if the burn is
+//!   re-included, the existing record is relocated and confirms once.
+//! - **Cursor reorg safety**: the persisted cursor stores the canonical hash of
+//!   the last scanned block. If that hash is no longer canonical the cursor
+//!   rolls back by the confirmation window (persisted BEFORE re-scanning) and
+//!   the range is replayed; the idempotency layer deduplicates the replay. A
+//!   reorg deeper than `confirmations_required` is outside the safety
+//!   assumption the confirmation requirement itself already makes.
 
-use bth_bridge_core::EthereumConfig;
-use std::time::Duration;
+use alloy::{
+    eips::BlockNumberOrTag,
+    primitives::Address,
+    providers::{DynProvider, Provider, ProviderBuilder},
+    rpc::types::{Filter, Log},
+    sol,
+    sol_types::SolEvent,
+};
+use async_trait::async_trait;
+use bth_bridge_core::{BridgeOrder, Chain, EthereumConfig, OrderStatus};
+use std::{collections::HashMap, time::Duration};
 use tokio::sync::broadcast;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
+use super::WatchError;
 use crate::{db::Database, engine::ShutdownSignal};
 
+sol! {
+    /// Burn event of the wBTH token
+    /// (`contracts/ethereum/contracts/WrappedBTH.sol`).
+    #[allow(missing_docs)]
+    interface IWrappedBTHEvents {
+        event BridgeBurn(address indexed from, uint256 amount, string bthAddress);
+    }
+}
+
+/// Delay between scan passes.
+const POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// A decoded `BridgeBurn` event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BurnEvent {
+    /// Transaction hash the burn was emitted in (0x-prefixed).
+    pub tx_hash: String,
+    /// Absolute log index within the block (used only to order events of
+    /// the same transaction; NOT part of the idempotency key, because it
+    /// shifts when other transactions move in a reorg).
+    pub log_index: u64,
+    /// Block number the burn was observed in.
+    pub block_number: u64,
+    /// Block hash the burn was observed in (0x-prefixed).
+    pub block_hash: String,
+    /// Burner address (0x-prefixed).
+    pub from: String,
+    /// Burned amount in picocredits (wBTH has 12 decimals, 1:1 with BTH).
+    pub amount: u64,
+    /// Destination BTH address. Per ADR 0004 the release pays a FRESH
+    /// one-time stealth address resolved from this (enforced in #822).
+    pub bth_address: String,
+}
+
+/// Stable idempotency key for a burn: the source tx hash plus the event's
+/// ordinal among burn events of the SAME transaction. Relative intra-tx
+/// event order is deterministic, so the key survives re-inclusion in a
+/// different block (unlike the absolute log index).
+pub fn burn_source_key(tx_hash: &str, ordinal: u32) -> String {
+    format!("{}#{}", tx_hash, ordinal)
+}
+
+/// Pair each event with its per-transaction ordinal, ordered by
+/// (block, log index) so processing and key assignment are deterministic.
+pub fn with_tx_ordinals(mut events: Vec<BurnEvent>) -> Vec<(BurnEvent, u32)> {
+    events.sort_by(|a, b| (a.block_number, a.log_index).cmp(&(b.block_number, b.log_index)));
+    let mut per_tx: HashMap<String, u32> = HashMap::new();
+    events
+        .into_iter()
+        .map(|event| {
+            let counter = per_tx.entry(event.tx_hash.clone()).or_insert(0);
+            let ordinal = *counter;
+            *counter += 1;
+            (event, ordinal)
+        })
+        .collect()
+}
+
+/// Decode an RPC log into a [`BurnEvent`]. Returns `None` for logs that do
+/// not decode as `BridgeBurn`, are pending (missing block/tx metadata), or
+/// carry an amount that cannot be a real BTH quantity (> u64 picocredits).
+pub fn decode_burn_log(log: &Log) -> Option<BurnEvent> {
+    let decoded = IWrappedBTHEvents::BridgeBurn::decode_log(&log.inner).ok()?;
+    let amount: u64 = decoded.data.amount.try_into().ok()?;
+    Some(BurnEvent {
+        tx_hash: format!("{:#x}", log.transaction_hash?),
+        log_index: log.log_index?,
+        block_number: log.block_number?,
+        block_hash: format!("{:#x}", log.block_hash?),
+        from: format!("{:#x}", decoded.data.from),
+        amount,
+        bth_address: decoded.data.bthAddress.clone(),
+    })
+}
+
+/// Read access to the Ethereum chain, mockable for tests.
+#[async_trait]
+pub trait EthChainClient: Send + Sync {
+    /// Latest (tip) block number.
+    async fn latest_block(&self) -> Result<u64, WatchError>;
+
+    /// Canonical block hash at `number` (0x-prefixed), or `None` if the
+    /// canonical chain does not (or no longer does) reach that height.
+    async fn block_hash_at(&self, number: u64) -> Result<Option<String>, WatchError>;
+
+    /// All `BridgeBurn` events of the wBTH contract in `[from, to]`
+    /// (canonical chain only).
+    async fn burn_events(&self, from: u64, to: u64) -> Result<Vec<BurnEvent>, WatchError>;
+}
+
+/// Live transport via alloy (same provider pattern as `mint::ethereum`).
+pub struct AlloyEthClient {
+    provider: DynProvider,
+    wbth: Address,
+}
+
+impl AlloyEthClient {
+    /// Build a client from configuration. Does not perform network I/O.
+    pub fn new(config: &EthereumConfig) -> Result<Self, WatchError> {
+        let wbth: Address = config
+            .wbth_contract
+            .parse()
+            .map_err(|e| WatchError::Config(format!("invalid wbth_contract: {}", e)))?;
+        let url = config
+            .rpc_url
+            .parse()
+            .map_err(|e| WatchError::Config(format!("invalid ethereum rpc_url: {}", e)))?;
+        let provider = ProviderBuilder::new().connect_http(url).erased();
+        Ok(Self { provider, wbth })
+    }
+}
+
+#[async_trait]
+impl EthChainClient for AlloyEthClient {
+    async fn latest_block(&self) -> Result<u64, WatchError> {
+        self.provider
+            .get_block_number()
+            .await
+            .map_err(|e| WatchError::Rpc(format!("get_block_number failed: {}", e)))
+    }
+
+    async fn block_hash_at(&self, number: u64) -> Result<Option<String>, WatchError> {
+        let block = self
+            .provider
+            .get_block_by_number(BlockNumberOrTag::Number(number))
+            .await
+            .map_err(|e| WatchError::Rpc(format!("get_block_by_number failed: {}", e)))?;
+        Ok(block.map(|b| format!("{:#x}", b.header.hash)))
+    }
+
+    async fn burn_events(&self, from: u64, to: u64) -> Result<Vec<BurnEvent>, WatchError> {
+        let filter = Filter::new()
+            .address(self.wbth)
+            .event_signature(IWrappedBTHEvents::BridgeBurn::SIGNATURE_HASH)
+            .from_block(from)
+            .to_block(to);
+
+        let logs = self
+            .provider
+            .get_logs(&filter)
+            .await
+            .map_err(|e| WatchError::Rpc(format!("get_logs failed: {}", e)))?;
+
+        let mut events = Vec::with_capacity(logs.len());
+        for log in &logs {
+            match decode_burn_log(log) {
+                Some(event) => events.push(event),
+                None => warn!(
+                    "Skipping undecodable/overflowing BridgeBurn log in tx {:?}",
+                    log.transaction_hash
+                ),
+            }
+        }
+        Ok(events)
+    }
+}
+
 /// Ethereum watcher monitors the wBTH contract for burn events.
-#[allow(dead_code)]
 pub struct EthereumWatcher {
     config: EthereumConfig,
     db: Database,
@@ -34,6 +219,16 @@ impl EthereumWatcher {
             self.config.wbth_contract
         );
 
+        // Fail-safe: a misconfigured contract/RPC disables the watcher
+        // (no orders are created) instead of crashing the engine.
+        let client = match AlloyEthClient::new(&self.config) {
+            Ok(client) => Some(client),
+            Err(e) => {
+                warn!("Ethereum watcher disabled: {}", e);
+                None
+            }
+        };
+
         loop {
             // Check for shutdown first
             match self.shutdown.try_recv() {
@@ -47,20 +242,686 @@ impl EthereumWatcher {
                 }
             }
 
-            self.poll_for_burns().await;
+            if let Some(client) = &client {
+                if let Err(e) = self.scan_once(client).await {
+                    warn!("Ethereum scan failed (will retry): {}", e);
+                }
+            }
+
+            tokio::select! {
+                _ = self.shutdown.recv() => {
+                    info!("Ethereum watcher shutting down");
+                    return Ok(());
+                }
+                _ = tokio::time::sleep(POLL_INTERVAL) => {}
+            }
         }
     }
 
-    /// Poll for burn events.
-    async fn poll_for_burns(&self) {
-        // TODO: In a full implementation, we would:
-        // 1. Use alloy to subscribe to BridgeBurn events
-        // 2. Parse the burn amount and BTH address from the event
-        // 3. Create a burn order in the database
-        //
-        // For now, we just poll periodically as a placeholder.
+    /// The window rolled back on a detected reorg. Reorgs deeper than the
+    /// confirmation requirement are outside the bridge's safety model.
+    fn reorg_window(&self) -> u64 {
+        (self.config.confirmations_required as u64).max(1)
+    }
 
-        debug!("Polling for Ethereum burn events...");
-        tokio::time::sleep(Duration::from_secs(30)).await;
+    /// One scan pass: cursor integrity check, burn detection up to the
+    /// tip, then depth + canonical-hash confirmation.
+    pub async fn scan_once(&self, client: &dyn EthChainClient) -> Result<(), WatchError> {
+        let tip = client.latest_block().await?;
+
+        // 1. Cursor integrity: if the last scanned block was reorged out, roll back
+        //    (persisting the rolled-back cursor BEFORE the re-scan) and replay;
+        //    idempotency dedups already-seen burns.
+        let from = match self
+            .db
+            .get_cursor(Chain::Ethereum)
+            .map_err(WatchError::Db)?
+        {
+            Some(cursor) => {
+                let canonical = client.block_hash_at(cursor.last_height).await?;
+                let reorged = match (&cursor.last_block_hash, &canonical) {
+                    (Some(stored), Some(now)) => stored != now,
+                    // Canonical chain no longer reaches the cursor height.
+                    (Some(_), None) => true,
+                    (None, _) => false,
+                };
+                if reorged {
+                    let rollback_to = cursor.last_height.saturating_sub(self.reorg_window());
+                    let rollback_hash = client.block_hash_at(rollback_to).await?;
+                    self.db
+                        .set_cursor(Chain::Ethereum, rollback_to, rollback_hash.as_deref())
+                        .map_err(WatchError::Db)?;
+                    self.db
+                        .log_audit(
+                            None,
+                            "eth_cursor_reorg",
+                            &format!(
+                                "cursor height {} hash {:?} no longer canonical ({:?}); \
+                                 rolled back to {}",
+                                cursor.last_height, cursor.last_block_hash, canonical, rollback_to
+                            ),
+                        )
+                        .map_err(WatchError::Db)?;
+                    warn!(
+                        "Ethereum reorg at/behind cursor height {}; re-scanning from {}",
+                        cursor.last_height,
+                        rollback_to + 1
+                    );
+                    rollback_to + 1
+                } else {
+                    cursor.last_height + 1
+                }
+            }
+            // First run: cover the current unfinalized window. Operators
+            // backfilling history can seed the watcher_cursors row.
+            None => tip.saturating_sub(self.config.confirmations_required as u64),
+        };
+
+        // 2. Detection up to the tip: burns enter at BurnDetected.
+        if from <= tip {
+            let events = client.burn_events(from, tip).await?;
+            for (event, ordinal) in with_tx_ordinals(events) {
+                self.process_burn(&event, ordinal)?;
+            }
+            let tip_hash = client.block_hash_at(tip).await?;
+            self.db
+                .set_cursor(Chain::Ethereum, tip, tip_hash.as_deref())
+                .map_err(WatchError::Db)?;
+        }
+
+        // 3. Confirmation: depth + canonical re-check.
+        self.confirm_detected_burns(client, tip).await
+    }
+
+    /// Handle one detected burn event: exactly-once order creation, or —
+    /// for a burn already on record (rescan / reorg re-add) — relocation
+    /// of the existing record, idempotent by its order id.
+    fn process_burn(&self, event: &BurnEvent, ordinal: u32) -> Result<(), WatchError> {
+        let source_key = burn_source_key(&event.tx_hash, ordinal);
+
+        if let Some(existing) = self
+            .db
+            .get_burn_by_source(&source_key)
+            .map_err(WatchError::Db)?
+        {
+            let moved = existing.block_number != event.block_number
+                || existing.block_hash.as_deref() != Some(event.block_hash.as_str());
+            if moved || existing.orphaned {
+                // Reorg re-add: same burn, new canonical location. The
+                // existing order is reused — processed exactly once.
+                self.db
+                    .update_burn_location(&source_key, event.block_number, Some(&event.block_hash))
+                    .map_err(WatchError::Db)?;
+                self.db
+                    .log_audit(
+                        Some(&existing.order_id),
+                        "burn_relocated",
+                        &format!(
+                            "tx={} moved to block {} ({})",
+                            event.tx_hash, event.block_number, event.block_hash
+                        ),
+                    )
+                    .map_err(WatchError::Db)?;
+                info!(
+                    "Burn {} re-observed at block {}; order {} relocated",
+                    source_key, event.block_number, existing.order_id
+                );
+            } else {
+                debug!("Burn {} already recorded; skipping", source_key);
+            }
+            return Ok(());
+        }
+
+        // The contract enforces these; defense in depth against a
+        // misbehaving RPC.
+        if event.amount == 0 || event.bth_address.is_empty() {
+            self.db
+                .log_audit(
+                    None,
+                    "burn_invalid",
+                    &format!(
+                        "tx={} amount={} bth_address_len={}",
+                        event.tx_hash,
+                        event.amount,
+                        event.bth_address.len()
+                    ),
+                )
+                .map_err(WatchError::Db)?;
+            return Ok(());
+        }
+
+        // NOTE: the burn-side bridge fee (deducted from the released BTH)
+        // is applied by the release path (#822); orders are created with
+        // fee 0 here so the watcher stays fee-policy agnostic.
+        let order = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            event.amount,
+            0,
+            event.from.clone(),
+            event.bth_address.clone(),
+            event.tx_hash.clone(),
+        );
+
+        let inserted = self
+            .db
+            .insert_burn_order(
+                &order,
+                &source_key,
+                event.block_number,
+                Some(&event.block_hash),
+            )
+            .map_err(WatchError::Db)?;
+        if inserted {
+            self.db
+                .log_audit(
+                    Some(&order.id),
+                    "burn_detected",
+                    &format!(
+                        "tx={} amount={} block={} ({})",
+                        event.tx_hash, event.amount, event.block_number, event.block_hash
+                    ),
+                )
+                .map_err(WatchError::Db)?;
+            info!(
+                "Detected wBTH burn {} for {} picocredits -> order {}",
+                source_key, event.amount, order.id
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Advance `BurnDetected` orders to `BurnConfirmed` once their burn is
+    /// `confirmations_required` deep in a still-canonical block. An
+    /// orphaned burn is flagged (exactly once) and does NOT advance — it
+    /// waits to be re-observed in a canonical block.
+    async fn confirm_detected_burns(
+        &self,
+        client: &dyn EthChainClient,
+        tip: u64,
+    ) -> Result<(), WatchError> {
+        let required = self.config.confirmations_required as u64;
+        let detected = self
+            .db
+            .get_orders_by_status("burn_detected")
+            .map_err(WatchError::Db)?;
+
+        for order in detected {
+            if order.source_chain != Chain::Ethereum {
+                continue;
+            }
+            let Some(record) = self
+                .db
+                .get_burn_by_order(&order.id)
+                .map_err(WatchError::Db)?
+            else {
+                continue;
+            };
+
+            let confirmations = if tip >= record.block_number {
+                tip - record.block_number + 1
+            } else {
+                0
+            };
+            if confirmations < required {
+                debug!(
+                    "Burn {} for order {} at {} confirmation(s) (< {}); waiting",
+                    record.source_key, order.id, confirmations, required
+                );
+                continue;
+            }
+
+            // Depth reached — the burn's block must still be canonical
+            // before any BTH can ever be released for it.
+            let canonical = client.block_hash_at(record.block_number).await?;
+            let still_canonical = matches!(
+                (&canonical, &record.block_hash),
+                (Some(now), Some(seen)) if now == seen
+            );
+
+            if still_canonical {
+                if !order.status.can_transition_to(&OrderStatus::BurnConfirmed) {
+                    warn!(
+                        "Order {} cannot transition {} -> burn_confirmed; skipping",
+                        order.id, order.status
+                    );
+                    continue;
+                }
+                self.db
+                    .update_order_status(&order.id, &OrderStatus::BurnConfirmed, None)
+                    .map_err(WatchError::Db)?;
+                self.db
+                    .log_audit(
+                        Some(&order.id),
+                        "burn_confirmed",
+                        &format!(
+                            "tx={} block={} confirmations={}",
+                            record.source_key, record.block_number, confirmations
+                        ),
+                    )
+                    .map_err(WatchError::Db)?;
+                info!(
+                    "Burn {} confirmed at {} confirmations; order {} ready for release",
+                    record.source_key, confirmations, order.id
+                );
+            } else if self
+                .db
+                .mark_burn_orphaned(&record.source_key)
+                .map_err(WatchError::Db)?
+            {
+                self.db
+                    .log_audit(
+                        Some(&order.id),
+                        "burn_orphaned",
+                        &format!(
+                            "tx={} block {} ({:?}) reorged out (canonical now {:?})",
+                            record.source_key, record.block_number, record.block_hash, canonical
+                        ),
+                    )
+                    .map_err(WatchError::Db)?;
+                warn!(
+                    "Burn {} reorged out before confirmation; order {} held at BurnDetected",
+                    record.source_key, order.id
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{B256, U256};
+    use std::{collections::BTreeMap, sync::Mutex};
+
+    // === Pure helpers ===
+
+    fn addr(byte: u8) -> Address {
+        Address::from([byte; 20])
+    }
+
+    fn rpc_burn_log(
+        contract: Address,
+        from: Address,
+        amount: U256,
+        bth_address: &str,
+        block_number: u64,
+        block_hash: u8,
+        tx_hash: u8,
+        log_index: u64,
+    ) -> Log {
+        let event = IWrappedBTHEvents::BridgeBurn {
+            from,
+            amount,
+            bthAddress: bth_address.to_string(),
+        };
+        Log {
+            inner: alloy::primitives::Log {
+                address: contract,
+                data: event.encode_log_data(),
+            },
+            block_number: Some(block_number),
+            block_hash: Some(B256::from([block_hash; 32])),
+            transaction_hash: Some(B256::from([tx_hash; 32])),
+            log_index: Some(log_index),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_decode_burn_log_roundtrip() {
+        let log = rpc_burn_log(
+            addr(0xEE),
+            addr(0x11),
+            U256::from(999_000_000_000u64),
+            "bth_stealth",
+            42,
+            0xB0,
+            0x71,
+            3,
+        );
+        let event = decode_burn_log(&log).unwrap();
+        assert_eq!(event.amount, 999_000_000_000);
+        assert_eq!(event.bth_address, "bth_stealth");
+        assert_eq!(event.block_number, 42);
+        assert_eq!(event.log_index, 3);
+        assert_eq!(event.from, format!("{:#x}", addr(0x11)));
+        assert_eq!(event.tx_hash, format!("{:#x}", B256::from([0x71u8; 32])));
+    }
+
+    #[test]
+    fn test_decode_burn_log_rejects_amount_overflow() {
+        // An amount that cannot fit u64 picocredits cannot be a real BTH
+        // quantity — the log is skipped rather than truncated.
+        let log = rpc_burn_log(
+            addr(0xEE),
+            addr(0x11),
+            U256::from(u64::MAX) + U256::from(1u8),
+            "bth_stealth",
+            42,
+            0xB0,
+            0x71,
+            0,
+        );
+        assert!(decode_burn_log(&log).is_none());
+    }
+
+    #[test]
+    fn test_tx_ordinals_stable_regardless_of_input_order() {
+        let mk = |tx: &str, block: u64, log_index: u64| BurnEvent {
+            tx_hash: tx.to_string(),
+            log_index,
+            block_number: block,
+            block_hash: "0xb".to_string(),
+            from: "0xf".to_string(),
+            amount: 1,
+            bth_address: "a".to_string(),
+        };
+        // Two burns in the same tx plus one in another tx, shuffled.
+        let events = vec![mk("0xt1", 5, 9), mk("0xt2", 5, 4), mk("0xt1", 5, 2)];
+        let keyed: Vec<(String, u32)> = with_tx_ordinals(events)
+            .into_iter()
+            .map(|(e, o)| (e.tx_hash, o))
+            .collect();
+        assert_eq!(
+            keyed,
+            vec![
+                ("0xt1".to_string(), 0), // log_index 2 first
+                ("0xt2".to_string(), 0),
+                ("0xt1".to_string(), 1), // log_index 9 second
+            ]
+        );
+        assert_eq!(burn_source_key("0xt1", 1), "0xt1#1");
+    }
+
+    // === Watcher scenarios against a mock chain ===
+
+    struct MockChain {
+        /// height -> canonical block hash
+        hashes: BTreeMap<u64, String>,
+        /// All events ever emitted; only those whose (height, hash) is
+        /// still canonical are visible via burn_events.
+        events: Vec<BurnEvent>,
+    }
+
+    struct MockEthClient {
+        chain: Mutex<MockChain>,
+    }
+
+    impl MockEthClient {
+        fn new() -> Self {
+            Self {
+                chain: Mutex::new(MockChain {
+                    hashes: BTreeMap::new(),
+                    events: Vec::new(),
+                }),
+            }
+        }
+
+        /// Extend the canonical chain to `height` (inclusive), hashing
+        /// blocks with the given fork tag.
+        fn extend_to(&self, height: u64, fork: &str) {
+            let mut chain = self.chain.lock().unwrap();
+            let start = chain.hashes.keys().next_back().map(|h| h + 1).unwrap_or(0);
+            for h in start..=height {
+                chain.hashes.insert(h, format!("0x{}_{}", fork, h));
+            }
+        }
+
+        /// Reorg: replace canonical blocks from `from_height` up to the
+        /// current tip with a new fork's hashes (orphaning events there).
+        fn reorg_from(&self, from_height: u64, fork: &str, new_tip: u64) {
+            let mut chain = self.chain.lock().unwrap();
+            let tip = *chain.hashes.keys().next_back().unwrap();
+            for h in from_height..=tip.max(new_tip) {
+                if h <= new_tip {
+                    chain.hashes.insert(h, format!("0x{}_{}", fork, h));
+                } else {
+                    chain.hashes.remove(&h);
+                }
+            }
+        }
+
+        fn block_hash(&self, height: u64) -> Option<String> {
+            self.chain.lock().unwrap().hashes.get(&height).cloned()
+        }
+
+        /// Emit a burn event in the CURRENT canonical block at `height`.
+        fn emit_burn(&self, tx: &str, amount: u64, bth_address: &str, height: u64) {
+            let hash = self.block_hash(height).expect("block must exist");
+            self.chain.lock().unwrap().events.push(BurnEvent {
+                tx_hash: tx.to_string(),
+                log_index: 0,
+                block_number: height,
+                block_hash: hash,
+                from: "0xburner".to_string(),
+                amount,
+                bth_address: bth_address.to_string(),
+            });
+        }
+    }
+
+    #[async_trait]
+    impl EthChainClient for MockEthClient {
+        async fn latest_block(&self) -> Result<u64, WatchError> {
+            Ok(*self
+                .chain
+                .lock()
+                .unwrap()
+                .hashes
+                .keys()
+                .next_back()
+                .unwrap_or(&0))
+        }
+
+        async fn block_hash_at(&self, number: u64) -> Result<Option<String>, WatchError> {
+            Ok(self.block_hash(number))
+        }
+
+        async fn burn_events(&self, from: u64, to: u64) -> Result<Vec<BurnEvent>, WatchError> {
+            let chain = self.chain.lock().unwrap();
+            Ok(chain
+                .events
+                .iter()
+                .filter(|e| {
+                    e.block_number >= from
+                        && e.block_number <= to
+                        // Only canonical events are visible.
+                        && chain.hashes.get(&e.block_number) == Some(&e.block_hash)
+                })
+                .cloned()
+                .collect())
+        }
+    }
+
+    fn setup(confirmations_required: u32) -> (EthereumWatcher, Database) {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let config = EthereumConfig {
+            rpc_url: "http://localhost:8545".to_string(),
+            wbth_contract: "0x00000000000000000000000000000000000000ee".to_string(),
+            safe_address: None,
+            chain_id: 1,
+            private_key_file: None,
+            confirmations_required,
+            gas_price_strategy: Default::default(),
+        };
+        let (_tx, rx) = broadcast::channel(1);
+        (EthereumWatcher::new(config, db.clone(), rx), db)
+    }
+
+    fn burn_orders(db: &Database) -> Vec<BridgeOrder> {
+        // Matches burn_detected + burn_confirmed via the LIKE prefix.
+        db.get_orders_by_status("burn").unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_confirmation_counting_gates_burn_confirmed() {
+        let (watcher, db) = setup(3);
+        let client = MockEthClient::new();
+
+        client.extend_to(5, "main");
+        client.emit_burn("0xburn1", 1_000_000_000_000, "bth_dest", 5);
+
+        // Tip 5, burn at 5 -> 1 confirmation: detected, NOT confirmed.
+        watcher.scan_once(&client).await.unwrap();
+        let orders = burn_orders(&db);
+        assert_eq!(orders.len(), 1);
+        assert_eq!(orders[0].status, OrderStatus::BurnDetected);
+        assert_eq!(orders[0].amount, 1_000_000_000_000);
+        assert_eq!(orders[0].dest_address, "bth_dest");
+        assert_eq!(orders[0].source_tx.as_deref(), Some("0xburn1"));
+
+        // 2 confirmations: still below the threshold of 3.
+        client.extend_to(6, "main");
+        watcher.scan_once(&client).await.unwrap();
+        assert_eq!(burn_orders(&db)[0].status, OrderStatus::BurnDetected);
+
+        // 3 confirmations: threshold met, block canonical -> confirmed.
+        client.extend_to(7, "main");
+        watcher.scan_once(&client).await.unwrap();
+        let orders = burn_orders(&db);
+        assert_eq!(orders.len(), 1, "still exactly one order");
+        assert_eq!(orders[0].status, OrderStatus::BurnConfirmed);
+        assert_eq!(db.count_audit_action("burn_detected").unwrap(), 1);
+        assert_eq!(db.count_audit_action("burn_confirmed").unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_orphaned_burn_never_confirms() {
+        let (watcher, db) = setup(2);
+        let client = MockEthClient::new();
+
+        client.extend_to(4, "main");
+        client.emit_burn("0xburn1", 5_000_000_000, "bth_dest", 4);
+        watcher.scan_once(&client).await.unwrap();
+        assert_eq!(burn_orders(&db)[0].status, OrderStatus::BurnDetected);
+
+        // Reorg out the burn's block; the new fork reaches height 7
+        // (deep enough that raw depth would satisfy the threshold).
+        client.reorg_from(4, "fork", 7);
+        watcher.scan_once(&client).await.unwrap();
+
+        let orders = burn_orders(&db);
+        assert_eq!(orders.len(), 1);
+        assert_eq!(
+            orders[0].status,
+            OrderStatus::BurnDetected,
+            "an orphaned burn must not advance toward release"
+        );
+        let record = db.get_burn_by_order(&orders[0].id).unwrap().unwrap();
+        assert!(record.orphaned);
+        assert_eq!(db.count_audit_action("burn_orphaned").unwrap(), 1);
+        assert_eq!(db.count_audit_action("eth_cursor_reorg").unwrap(), 1);
+
+        // Further passes: still held, orphan audit not duplicated.
+        client.extend_to(9, "fork");
+        watcher.scan_once(&client).await.unwrap();
+        assert_eq!(burn_orders(&db)[0].status, OrderStatus::BurnDetected);
+        assert_eq!(db.count_audit_action("burn_orphaned").unwrap(), 1);
+        assert_eq!(db.count_audit_action("burn_confirmed").unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_reorg_readd_processed_exactly_once() {
+        let (watcher, db) = setup(2);
+        let client = MockEthClient::new();
+
+        client.extend_to(4, "main");
+        client.emit_burn("0xburn1", 5_000_000_000, "bth_dest", 4);
+        watcher.scan_once(&client).await.unwrap();
+        let order_id = burn_orders(&db)[0].id;
+
+        // Orphan it...
+        client.reorg_from(4, "fork", 5);
+        watcher.scan_once(&client).await.unwrap();
+        assert!(db.get_burn_by_order(&order_id).unwrap().unwrap().orphaned);
+
+        // ...then the same tx is re-included at height 6 on the new fork.
+        client.extend_to(6, "fork");
+        client.emit_burn("0xburn1", 5_000_000_000, "bth_dest", 6);
+        watcher.scan_once(&client).await.unwrap();
+
+        // Same single order, relocated, no longer orphaned.
+        let orders = burn_orders(&db);
+        assert_eq!(orders.len(), 1, "re-add must reuse the existing order");
+        assert_eq!(orders[0].id, order_id);
+        let record = db.get_burn_by_order(&order_id).unwrap().unwrap();
+        assert!(!record.orphaned);
+        assert_eq!(record.block_number, 6);
+        assert_eq!(db.count_audit_action("burn_relocated").unwrap(), 1);
+
+        // Reaches the threshold on the new fork -> confirmed exactly once.
+        client.extend_to(7, "fork");
+        watcher.scan_once(&client).await.unwrap();
+        let orders = burn_orders(&db);
+        assert_eq!(orders.len(), 1);
+        assert_eq!(orders[0].id, order_id);
+        assert_eq!(orders[0].status, OrderStatus::BurnConfirmed);
+        assert_eq!(db.count_audit_action("burn_detected").unwrap(), 1);
+        assert_eq!(db.count_audit_action("burn_confirmed").unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_restart_resumes_from_cursor() {
+        let (watcher, db) = setup(2);
+        let client = MockEthClient::new();
+
+        client.extend_to(5, "main");
+        client.emit_burn("0xburn1", 1_000, "bth_dest", 5);
+        watcher.scan_once(&client).await.unwrap();
+
+        let cursor = db.get_cursor(Chain::Ethereum).unwrap().unwrap();
+        assert_eq!(cursor.last_height, 5);
+        assert_eq!(cursor.last_block_hash.as_deref(), Some("0xmain_5"));
+
+        // "Restart": a fresh watcher on the SAME database.
+        let (_tx2, rx2) = broadcast::channel(1);
+        let watcher2 = EthereumWatcher::new(watcher.config.clone(), db.clone(), rx2);
+
+        client.extend_to(6, "main");
+        client.emit_burn("0xburn2", 2_000, "bth_dest2", 6);
+        watcher2.scan_once(&client).await.unwrap();
+
+        // Both burns exist exactly once; no duplicate of burn1.
+        let orders = burn_orders(&db);
+        assert_eq!(orders.len(), 2);
+        assert_eq!(db.count_audit_action("burn_detected").unwrap(), 2);
+        // burn1 now at 2 confirmations -> confirmed; burn2 at 1 -> detected.
+        let by_tx = |tx: &str| {
+            orders
+                .iter()
+                .find(|o| o.source_tx.as_deref() == Some(tx))
+                .unwrap()
+                .clone()
+        };
+        assert_eq!(by_tx("0xburn1").status, OrderStatus::BurnConfirmed);
+        assert_eq!(by_tx("0xburn2").status, OrderStatus::BurnDetected);
+    }
+
+    #[tokio::test]
+    async fn test_cursor_rewind_replay_is_noop() {
+        let (watcher, db) = setup(1);
+        let client = MockEthClient::new();
+
+        client.extend_to(3, "main");
+        client.emit_burn("0xburn1", 1_000, "bth_dest", 3);
+        watcher.scan_once(&client).await.unwrap();
+        assert_eq!(burn_orders(&db).len(), 1);
+
+        // Rewind the cursor behind the processed block and replay: the
+        // processed_burns source key dedups the event.
+        db.set_cursor(Chain::Ethereum, 0, Some("0xmain_0")).unwrap();
+        watcher.scan_once(&client).await.unwrap();
+
+        assert_eq!(
+            burn_orders(&db).len(),
+            1,
+            "replay must not duplicate the order"
+        );
+        assert_eq!(db.count_audit_action("burn_detected").unwrap(), 1);
     }
 }

--- a/bridge/service/src/watchers/mod.rs
+++ b/bridge/service/src/watchers/mod.rs
@@ -1,9 +1,54 @@
 // Copyright (c) 2024 The Botho Foundation
 
-//! Chain watchers for monitoring deposits and burns.
+//! Chain watchers for monitoring deposits and burns (#823).
+//!
+//! Each source chain gets a watcher that drives events into the order
+//! state machine with three shared safety properties:
+//!
+//! 1. **Durable cursors** — per-chain scan progress lives in the
+//!    `watcher_cursors` table and is persisted only after a block is fully
+//!    processed, so a restart resumes without missing events and a crash
+//!    replays (never skips) the in-flight block.
+//! 2. **Idempotent event→order creation** — deposits dedup on
+//!    `processed_deposits` (by tx hash) and burns on `processed_burns` (by
+//!    `"<source_tx>#<ordinal>"`), independent of the cursor, so cursor rewinds
+//!    and reorg re-adds can never double-process.
+//! 3. **Reorg safety** — orders only advance to their `*Confirmed` state at the
+//!    chain's finality: SCP finality on BTH, `confirmations_required` depth
+//!    plus a canonical-block-hash re-check on Ethereum, and `Finalized`
+//!    commitment on Solana.
 
 mod bth;
 mod ethereum;
+mod solana;
 
 pub use bth::BthWatcher;
 pub use ethereum::EthereumWatcher;
+pub use solana::SolanaWatcher;
+
+/// Errors from chain watchers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum WatchError {
+    /// Misconfiguration (bad address, unparsable URL, ...).
+    Config(String),
+    /// RPC / network failure (retryable next poll).
+    Rpc(String),
+    /// Database failure.
+    Db(String),
+    /// Transport not yet wired up (BTH websocket / Solana RPC, see #828).
+    NotImplemented(String),
+}
+
+impl std::fmt::Display for WatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WatchError::Config(m) => write!(f, "config error: {}", m),
+            WatchError::Rpc(m) => write!(f, "rpc error: {}", m),
+            WatchError::Db(m) => write!(f, "db error: {}", m),
+            WatchError::NotImplemented(m) => write!(f, "not implemented: {}", m),
+        }
+    }
+}
+
+impl std::error::Error for WatchError {}

--- a/bridge/service/src/watchers/solana.rs
+++ b/bridge/service/src/watchers/solana.rs
@@ -1,0 +1,289 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Solana chain watcher for monitoring wBTH burns (burn flow).
+//!
+//! Watches the `wbth_bridge` Anchor program
+//! (`contracts/solana/programs/wbth`) for `BridgeBurnEvent { user, amount,
+//! bth_address, slot }` emissions and drives `BurnDetected ->
+//! BurnConfirmed`, mirroring the Ethereum watcher:
+//!
+//! - **Commitment as the reorg guard**: burns are only accepted at `Finalized`
+//!   commitment (rooted, cannot be rolled back), regardless of the configured
+//!   [`SolanaCommitment`] — the analogue of Ethereum's depth + canonical-hash
+//!   re-check. A slot observed below `Finalized` that gets rolled back is
+//!   treated like an Ethereum orphan: the order is held at `BurnDetected` and
+//!   never advances toward release.
+//! - **Idempotency**: orders are created via `Database::insert_burn_order`
+//!   keyed by `"<signature>#<ordinal>"`, so a cursor replay or a
+//!   rolled-back-then-re-landed burn reuses the same order (exactly-once by
+//!   order id).
+//! - **Cursor**: scan progress (last processed slot) persists in
+//!   `watcher_cursors` under [`Chain::Solana`].
+//!
+//! ## Implementation status
+//!
+//! The deterministic pieces are implemented and unit-tested here: the
+//! Anchor event discriminator and the borsh event decoder
+//! ([`parse_bridge_burn_event`]), so the exact bytes emitted on-chain are
+//! pinned. The RPC transport (`getSignaturesForAddress` /
+//! `getTransaction` at `Finalized` over `SolanaConfig::wbth_program`)
+//! requires the `solana-client` dependency stack, which is deferred (same
+//! reasoning as `mint::solana`); [`SolanaWatcher::poll_for_burns`] is a
+//! fail-safe `TODO(#828)` stub until the harness lands — it polls, logs,
+//! and creates no state.
+
+use bth_bridge_core::{SolanaCommitment, SolanaConfig};
+use sha2::{Digest, Sha256};
+use std::time::Duration;
+use tokio::sync::broadcast;
+use tracing::{debug, info, warn};
+
+use crate::{db::Database, engine::ShutdownSignal};
+
+/// Delay between poll passes.
+const POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Compute the Anchor event discriminator: the first 8 bytes of
+/// `sha256("event:<Name>")`. Consumed by the #828 transport wiring.
+#[allow(dead_code)]
+pub fn anchor_event_discriminator(event_name: &str) -> [u8; 8] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"event:");
+    hasher.update(event_name.as_bytes());
+    let digest = hasher.finalize();
+    let mut disc = [0u8; 8];
+    disc.copy_from_slice(&digest[..8]);
+    disc
+}
+
+/// A decoded `BridgeBurnEvent` from the wBTH program. Consumed by the
+/// #828 transport wiring.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SolanaBurn {
+    /// Burner's pubkey (raw 32 bytes).
+    pub user: [u8; 32],
+    /// Burned amount in picocredits (wBTH mint uses 12 decimals, 1:1).
+    pub amount: u64,
+    /// Destination BTH address. Per ADR 0004 the release pays a FRESH
+    /// one-time stealth address resolved from this (enforced in #822).
+    pub bth_address: String,
+    /// Slot the program observed at emission time.
+    pub slot: u64,
+}
+
+/// Decode the borsh-serialized `BridgeBurnEvent` (with its 8-byte Anchor
+/// event discriminator prefix) as emitted by
+/// `contracts/solana/programs/wbth`:
+///
+/// ```text
+/// [ discriminator: 8 ][ user: Pubkey 32 ][ amount: u64 LE ]
+/// [ bth_address: u32 LE length + utf8 bytes ][ slot: u64 LE ]
+/// ```
+///
+/// Returns `None` on a wrong discriminator, truncation, trailing bytes,
+/// or a non-UTF-8 address. Consumed by the #828 transport wiring.
+#[allow(dead_code)]
+pub fn parse_bridge_burn_event(data: &[u8]) -> Option<SolanaBurn> {
+    let expected = anchor_event_discriminator("BridgeBurnEvent");
+    let rest = data.strip_prefix(expected.as_slice())?;
+
+    // user: Pubkey (32 bytes)
+    let (user_bytes, rest) = rest.split_at_checked(32)?;
+    let mut user = [0u8; 32];
+    user.copy_from_slice(user_bytes);
+
+    // amount: u64 LE
+    let (amount_bytes, rest) = rest.split_at_checked(8)?;
+    let amount = u64::from_le_bytes(amount_bytes.try_into().ok()?);
+
+    // bth_address: borsh string (u32 LE length + bytes)
+    let (len_bytes, rest) = rest.split_at_checked(4)?;
+    let len = u32::from_le_bytes(len_bytes.try_into().ok()?) as usize;
+    let (addr_bytes, rest) = rest.split_at_checked(len)?;
+    let bth_address = std::str::from_utf8(addr_bytes).ok()?.to_string();
+
+    // slot: u64 LE, and nothing may follow.
+    let (slot_bytes, rest) = rest.split_at_checked(8)?;
+    if !rest.is_empty() {
+        return None;
+    }
+    let slot = u64::from_le_bytes(slot_bytes.try_into().ok()?);
+
+    Some(SolanaBurn {
+        user,
+        amount,
+        bth_address,
+        slot,
+    })
+}
+
+/// Whether a commitment level is acceptable as the burn-side reorg guard.
+/// Only `Finalized` (rooted) slots cannot be rolled back.
+pub fn commitment_is_final(commitment: SolanaCommitment) -> bool {
+    matches!(commitment, SolanaCommitment::Finalized)
+}
+
+/// Solana watcher monitors the wBTH program for burn events.
+pub struct SolanaWatcher {
+    config: SolanaConfig,
+    #[allow(dead_code)]
+    db: Database,
+    shutdown: ShutdownSignal,
+}
+
+impl SolanaWatcher {
+    /// Create a new Solana watcher.
+    pub fn new(config: SolanaConfig, db: Database, shutdown: ShutdownSignal) -> Self {
+        Self {
+            config,
+            db,
+            shutdown,
+        }
+    }
+
+    /// Run the watcher.
+    pub async fn run(mut self) -> Result<(), String> {
+        info!(
+            "Starting Solana watcher for program {}",
+            self.config.wbth_program
+        );
+
+        if !commitment_is_final(self.config.commitment) {
+            warn!(
+                "solana.commitment is {:?}; burns are only accepted at Finalized commitment \
+                 (the reorg guard) regardless of this setting",
+                self.config.commitment
+            );
+        }
+
+        loop {
+            // Check for shutdown first
+            match self.shutdown.try_recv() {
+                Ok(_) | Err(broadcast::error::TryRecvError::Closed) => {
+                    info!("Solana watcher shutting down");
+                    return Ok(());
+                }
+                Err(broadcast::error::TryRecvError::Empty)
+                | Err(broadcast::error::TryRecvError::Lagged(_)) => {
+                    // No shutdown signal, continue
+                }
+            }
+
+            self.poll_for_burns().await;
+
+            tokio::select! {
+                _ = self.shutdown.recv() => {
+                    info!("Solana watcher shutting down");
+                    return Ok(());
+                }
+                _ = tokio::time::sleep(POLL_INTERVAL) => {}
+            }
+        }
+    }
+
+    /// Poll for burn events.
+    ///
+    /// TODO(#828): wire the RPC transport (needs the `solana-client`
+    /// stack, deferred as in `mint::solana`):
+    /// 1. Load the resume slot from `db.get_cursor(Chain::Solana)`.
+    /// 2. `getSignaturesForAddress(SolanaConfig::wbth_program)` at FINALIZED
+    ///    commitment only (see [`commitment_is_final`]) from the cursor slot;
+    ///    fetch each transaction and decode program-data logs via
+    ///    [`parse_bridge_burn_event`].
+    /// 3. For each burn, create the order exactly-once with
+    ///    `db.insert_burn_order(new_burn(Chain::Solana, ..),
+    ///    "<signature>#<ordinal>", slot, None)` at `BurnDetected`, then —
+    ///    because Finalized slots cannot roll back — advance straight to
+    ///    `BurnConfirmed` (the Ethereum watcher's canonical-hash re-check is
+    ///    unnecessary at Finalized). A slot rolled back below Finalized is
+    ///    never observed, so the Ethereum orphan path has no Solana analogue to
+    ///    trigger.
+    /// 4. Persist `db.set_cursor(Chain::Solana, slot, None)` only after all
+    ///    burns in that slot are processed.
+    ///
+    /// Fail-safe: until wired, this creates no state.
+    async fn poll_for_burns(&self) {
+        debug!(
+            "Solana watcher idle: burn scan transport for program {} pending #828",
+            self.config.wbth_program
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode_event(user: [u8; 32], amount: u64, bth_address: &str, slot: u64) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&anchor_event_discriminator("BridgeBurnEvent"));
+        data.extend_from_slice(&user);
+        data.extend_from_slice(&amount.to_le_bytes());
+        data.extend_from_slice(&(bth_address.len() as u32).to_le_bytes());
+        data.extend_from_slice(bth_address.as_bytes());
+        data.extend_from_slice(&slot.to_le_bytes());
+        data
+    }
+
+    #[test]
+    fn test_event_discriminator_known_vector() {
+        // sha256("event:BridgeBurnEvent")[..8] — pinned so a silent rename
+        // of the on-chain event breaks tests, not the live watcher.
+        let disc = anchor_event_discriminator("BridgeBurnEvent");
+        let mut hasher = Sha256::new();
+        hasher.update(b"event:BridgeBurnEvent");
+        assert_eq!(disc, hasher.finalize()[..8]);
+        assert_ne!(disc, anchor_event_discriminator("BridgeMintEvent"));
+    }
+
+    #[test]
+    fn test_parse_bridge_burn_event_roundtrip() {
+        let user = [7u8; 32];
+        let data = encode_event(user, 999_000_000_000, "bth_stealth_addr", 12345);
+
+        let burn = parse_bridge_burn_event(&data).unwrap();
+        assert_eq!(burn.user, user);
+        assert_eq!(burn.amount, 999_000_000_000);
+        assert_eq!(burn.bth_address, "bth_stealth_addr");
+        assert_eq!(burn.slot, 12345);
+    }
+
+    #[test]
+    fn test_parse_bridge_burn_event_rejects_malformed() {
+        let good = encode_event([1u8; 32], 5, "addr", 9);
+
+        // Wrong discriminator.
+        let mut wrong_disc = good.clone();
+        wrong_disc[..8].copy_from_slice(&anchor_event_discriminator("BridgeMintEvent"));
+        assert!(parse_bridge_burn_event(&wrong_disc).is_none());
+
+        // Truncated at every boundary.
+        for cut in [4, 8, 20, 40, 44, 46, good.len() - 1] {
+            assert!(
+                parse_bridge_burn_event(&good[..cut]).is_none(),
+                "truncation at {} must be rejected",
+                cut
+            );
+        }
+
+        // Trailing bytes.
+        let mut trailing = good.clone();
+        trailing.push(0);
+        assert!(parse_bridge_burn_event(&trailing).is_none());
+
+        // Non-UTF-8 address bytes.
+        let mut bad_utf8 = encode_event([1u8; 32], 5, "ab", 9);
+        let addr_start = 8 + 32 + 8 + 4;
+        bad_utf8[addr_start] = 0xFF;
+        bad_utf8[addr_start + 1] = 0xFE;
+        assert!(parse_bridge_burn_event(&bad_utf8).is_none());
+    }
+
+    #[test]
+    fn test_only_finalized_commitment_is_a_reorg_guard() {
+        assert!(commitment_is_final(SolanaCommitment::Finalized));
+        assert!(!commitment_is_final(SolanaCommitment::Confirmed));
+        assert!(!commitment_is_final(SolanaCommitment::Processed));
+    }
+}


### PR DESCRIPTION
Closes #823 (part of epic #816).

Implements the reorg-safe chain-watcher layer per the expanded checklist (issue comment "Implementation tasks expanded 2026-07-13") and ADRs 0003/0004, reusing the #838 (PR #838) engine patterns: trait-mocked chain clients, alloy provider + canonical-hash re-check, idempotency tables written atomically with state transitions.

## Fully implemented

**Shared cursor persistence (`bridge/service/src/db.rs`)**
- `watcher_cursors` table (`chain PK, last_height, last_block_hash, updated_at`) with `get_cursor` / `set_cursor`; watchers persist only AFTER a block is fully processed, so a crash replays (never skips) the in-flight block.
- `processed_burns` idempotency table keyed by `"<source_tx>#<ordinal>"` (per-tx event ordinal — stable across reorgs, unlike the absolute log index) with an `orphaned` flag; `insert_burn_order` creates the order + idempotency row in ONE SQLite transaction, closing the crash window between them.
- `record_deposit_detected` stamps the revealed amount + `source_tx` with a `status = 'awaiting_deposit'` SQL guard (transition check doubling as replay dedup).

**BTH deposit watcher (`bridge/service/src/watchers/bth.rs`)**
- Full deterministic pipeline against a mockable `BthChainClient`: cursor-driven block scan, memo -> order UUID matching, REVEALED-amount extraction (ADR 0004; revealed amount is authoritative, mismatches audited), deposit tx recorded as `source_tx`.
- Factor-1 eligibility gate (ADR 0003): `cluster_factor != FACTOR_SCALE (1000)` fails the order with an `deposit_rejected_non_factor1` audit entry; factor-1 deposits proceed.
- SCP finality: `confirmations_required == 0` = final at inclusion (scan to tip); non-zero lags the tip by the requirement — either way scanned blocks always meet finality, so detection advances `AwaitingDeposit -> DepositDetected -> DepositConfirmed`.
- `mark_deposit_processed` / `is_deposit_processed` as the cursor-independent dedup layer.

**Ethereum burn watcher (`bridge/service/src/watchers/ethereum.rs`)**
- REAL alloy transport (`AlloyEthClient`): `get_logs` filtered on the wBTH contract + `BridgeBurn(address indexed, uint256, string)` signature, `get_block_by_number` canonical-hash lookups — same provider pattern as `mint/ethereum.rs`.
- Detection to the tip creates `BridgeOrder::new_burn(Chain::Ethereum, ..)` at `BurnDetected`, exactly-once by source key; amount overflow (> u64 picocredits) and zero-amount/empty-address logs are rejected.
- Confirmation requires `confirmations_required` depth AND that the burn's block hash is still canonical (mint/ethereum.rs pattern). Orphaned burns are flagged (audited once) and held at `BurnDetected` — they can never reach `ReleasePending`/`Released`. A reorg re-add relocates the existing record and confirms the SAME order exactly once.
- Cursor reorg safety: the cursor stores the last scanned block's hash; on mismatch (or the canonical chain no longer reaching the cursor height) it rolls back by the confirmation window, persists the rolled-back cursor BEFORE re-scanning, and the idempotency layer dedups the replay.

**Solana burn watcher (`bridge/service/src/watchers/solana.rs`, wired in `mod.rs` + engine)**
- `SolanaWatcher { config, db, shutdown }` mirroring the BTH/Ethereum shape (`new`, `run` with the `shutdown.try_recv` loop), spawned by the engine.
- Deterministic pieces pinned by tests: Anchor event discriminator (`sha256("event:BridgeBurnEvent")[..8]`) and the borsh `BridgeBurnEvent { user, amount, bth_address, slot }` decoder.
- Commitment-as-reorg-guard: only `Finalized` is accepted (`commitment_is_final`); a non-Finalized config logs a warning at startup.

## Stubbed (fail-safe: no state is ever created)

- `NodeBthClient` (BTH `ws_url` NewBlock subscription + `view_key_file` stealth scan + commitment opening) — `TODO(#828)`, returns `NotImplemented`; the watcher idles.
- `SolanaWatcher::poll_for_burns` RPC transport (`getSignaturesForAddress`/`getTransaction` at Finalized) — `TODO(#828)`, needs the deferred `solana-client` stack (same reasoning as `mint/solana.rs`).
- Burn-side fee is 0 at order creation; fee policy at release belongs to #822 (noted inline).

## Test Plan

- [x] `cargo test -p bth-bridge-service -p bth-bridge-core` — 61 tests pass (46 service incl. 20 new watcher/db tests + 15 core)
- [x] `cargo clippy -p bth-bridge-service -p bth-bridge-core --all-targets` — no warnings
- [x] `cargo fmt` applied
- [x] Factor-≠1 deposit rejected/held with audit entry; identical factor-1 deposit confirms (`test_non_factor1_deposit_rejected_with_audit`)
- [x] Revealed amount extracted + `DepositDetected -> DepositConfirmed` at SCP finality with `confirmations_required == 0` (`test_factor1_deposit_detects_and_confirms_at_scp_finality`); depth-lag behavior when non-zero (`test_confirmation_lag_when_depth_required`)
- [x] Confirmation counting: burn below threshold stays `BurnDetected`, advances only at the threshold (`test_confirmation_counting_gates_burn_confirmed`)
- [x] Reorg orphan: orphaned burn rolls back and does NOT advance toward release (`test_orphaned_burn_never_confirms`)
- [x] Reorg re-add: orphaned-then-re-included burn processed exactly once, idempotent by order id (`test_reorg_readd_processed_exactly_once`)
- [x] Restart/resume durability on both chains (`test_restart_resumes_from_cursor*`)
- [x] Cursor rewind + idempotency dedup: replaying processed events is a no-op even with a rewound cursor (`test_cursor_rewind_replay_is_deduplicated`, `test_cursor_rewind_replay_is_noop`, plus db-level `test_insert_burn_order_exactly_once_by_source_key`)
- [x] No dependency changes (`cargo deny` not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
