### PR TITLE
bridge: federation attestation + authorization protocol (replay-safe, order-bound)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,6 +2018,7 @@ name = "bth-bridge-core"
 version = "0.3.2"
 dependencies = [
  "chrono",
+ "ed25519-dalek",
  "hex",
  "serde",
  "serde_json",

--- a/bridge/core/Cargo.toml
+++ b/bridge/core/Cargo.toml
@@ -19,5 +19,8 @@ toml = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true, features = ["std"] }
 
-[dev-dependencies]
+# Attestation envelope protocol (#824): federation Ed25519 signatures and
+# canonical-JSON envelope parsing, mirroring the operator-signed-action
+# machinery.
+ed25519-dalek = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }

--- a/bridge/core/src/attestation.rs
+++ b/bridge/core/src/attestation.rs
@@ -10,12 +10,26 @@
 //!   `MINTER_ROLE` on `WrappedBTH.sol`.
 //! - **Solana**: validators sign natively with their Ed25519 node keys.
 //!
-//! The attestation *protocol* (signature collection, envelopes, nonces) is
-//! issue #824 and lives outside this crate. This module only defines the
-//! artifact that protocol produces — [`MintAuthorization`] — which the mint
-//! submission path (issue #821) consumes.
+//! This module defines both the **artifacts** the protocol produces
+//! ([`MintAuthorization`] / [`ReleaseAuthorization`], consumed by the mint
+//! and release submission paths) and the **attestation envelope protocol**
+//! itself (#824): domain-separated, order-bound, single-use signed
+//! envelopes mirroring the operator-signed-action machinery
+//! (`botho/src/operator_action.rs`, P4.4), aggregated to the federation
+//! threshold by [`AttestationSet`]. Signature *collection over the network*
+//! between federation members is TODO(#828); everything cryptographic —
+//! signing, verification, replay rejection, order binding, thresholding —
+//! is implemented here and in `bridge/service/src/attestation.rs`.
 
+use ed25519_dalek::{Signature as Ed25519Signature, SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use uuid::Uuid;
+
+use crate::{
+    chains::Chain,
+    order::{derive_order_id, BridgeOrder, OrderType},
+};
 
 /// The signature scheme used by an attestation, per destination chain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -185,6 +199,1116 @@ impl ReleaseAuthorization {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Mint payload digest (the mint-side equivalent of `release_payload_digest`)
+// ---------------------------------------------------------------------------
+
+/// Domain-separation tag for the Solana wBTH-mint attestation payload.
+///
+/// Distinct from [`RELEASE_ATTESTATION_DOMAIN_TAG`] and from the Ethereum
+/// mint path (which signs the Gnosis Safe EIP-712 transaction hash instead,
+/// per ADR 0002), so a signature over one chain's mint can never be replayed
+/// as another chain's mint or as a release.
+pub const MINT_ATTESTATION_DOMAIN_TAG_SOL: &[u8] = b"botho-bridge-mint-sol-v1";
+
+/// Domain-separation tag for the Ethereum wBTH-mint attestation payload.
+///
+/// NOTE: production Ethereum mint authorizations sign the **Gnosis Safe
+/// EIP-712 transaction hash** (secp256k1 owner signatures, ADR 0002), which
+/// already binds the chain id, Safe address, calldata (order id, amount,
+/// recipient) and Safe nonce. This tag exists so the digest construction is
+/// defined for both destination chains and provably differs per chain.
+pub const MINT_ATTESTATION_DOMAIN_TAG_ETH: &[u8] = b"botho-bridge-mint-eth-v1";
+
+/// Compute the digest a federation member signs to authorize one wBTH mint
+/// on `dest_chain` (Ed25519 on Solana; see
+/// [`MINT_ATTESTATION_DOMAIN_TAG_ETH`] for the Ethereum SafeTx caveat).
+///
+/// `sha256(domain_tag || order_id || amount_le || recipient_len_le ||
+/// recipient)` — the exact structure of [`release_payload_digest`], with a
+/// per-destination-chain domain tag, so:
+/// - a mint signature for order X can never authorize order Y (order id);
+/// - a mint signature for chain C can never authorize chain D (domain tag);
+/// - a mint signature can never be replayed as a release (domain tag).
+pub fn mint_payload_digest(
+    dest_chain: Chain,
+    order_id: &[u8; 32],
+    amount: u64,
+    recipient: &str,
+) -> Result<[u8; 32], String> {
+    use sha2::{Digest, Sha256};
+    let tag = match dest_chain {
+        Chain::Ethereum => MINT_ATTESTATION_DOMAIN_TAG_ETH,
+        Chain::Solana => MINT_ATTESTATION_DOMAIN_TAG_SOL,
+        Chain::Bth => return Err("cannot mint wBTH on the BTH chain".to_string()),
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(tag);
+    hasher.update(order_id);
+    hasher.update(amount.to_le_bytes());
+    hasher.update((recipient.len() as u64).to_le_bytes());
+    hasher.update(recipient.as_bytes());
+    Ok(hasher.finalize().into())
+}
+
+// ---------------------------------------------------------------------------
+// Attestation envelope protocol (#824) — mirrors botho/src/operator_action.rs
+// ---------------------------------------------------------------------------
+
+/// Envelope domain separator for attestations whose privileged action
+/// executes on **Ethereum** (wBTH mint via the Gnosis Safe).
+pub const ATTEST_DOMAIN_ETH: &[u8] = b"botho-bridge-attest-eth-v1";
+
+/// Envelope domain separator for attestations whose privileged action
+/// executes on **Solana** (wBTH mint via the bridge program).
+pub const ATTEST_DOMAIN_SOL: &[u8] = b"botho-bridge-attest-sol-v1";
+
+/// Envelope domain separator for attestations whose privileged action
+/// executes on **BTH** (reserve release).
+pub const ATTEST_DOMAIN_BTH: &[u8] = b"botho-bridge-attest-bth-v1";
+
+/// The only envelope version v1 verifiers accept. Unknown versions are
+/// rejected with no downgrade path.
+pub const ATTESTATION_ENVELOPE_VERSION: u64 = 1;
+
+/// Maximum lifetime of an attestation envelope in seconds
+/// (`expiresAt - issuedAt`). Mirrors the operator-action bound; a captured
+/// envelope expires and cannot be replayed after the window.
+pub const MAX_ATTESTATION_LIFETIME_SECS: u64 = 300;
+
+/// Clock-skew allowance for the freshness check (`issuedAt - skew <= now`).
+pub const ATTESTATION_CLOCK_SKEW_SECS: u64 = 30;
+
+/// The envelope domain separator for a given **target chain** (the chain the
+/// privileged action executes on). A signature over one chain's envelope can
+/// never verify under another chain's domain — cross-domain binding.
+pub fn attestation_domain(target_chain: Chain) -> &'static [u8] {
+    match target_chain {
+        Chain::Ethereum => ATTEST_DOMAIN_ETH,
+        Chain::Solana => ATTEST_DOMAIN_SOL,
+        Chain::Bth => ATTEST_DOMAIN_BTH,
+    }
+}
+
+/// The exact byte string an attestation envelope signature covers:
+/// `attestation_domain(target_chain) || envelope_bytes`.
+pub fn attestation_signed_message(target_chain: Chain, envelope_bytes: &[u8]) -> Vec<u8> {
+    let domain = attestation_domain(target_chain);
+    let mut msg = Vec::with_capacity(domain.len() + envelope_bytes.len());
+    msg.extend_from_slice(domain);
+    msg.extend_from_slice(envelope_bytes);
+    msg
+}
+
+/// The v1 attestation action allowlist. Any action outside this enum is
+/// rejected fail-closed — these are the ONLY two privileged actions the
+/// bridge federation can authorize (mirrors `operator_action::ActionKind`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttestationKind {
+    /// `bridge.mint_wbth` — "the BTH deposit funding `order_id` is final;
+    /// mint `amount` wBTH to `dest_address` on `dest_chain`".
+    MintWbth {
+        /// Destination chain (Ethereum or Solana — never Bth).
+        dest_chain: Chain,
+        /// Recipient address on the destination chain.
+        dest_address: String,
+        /// Net amount to mint, in picocredits.
+        amount: u64,
+        /// The bridge order UUID (the 32-byte on-chain id is derived via
+        /// [`derive_order_id`]).
+        order_id: Uuid,
+        /// The finalized BTH deposit transaction hash being attested.
+        source_tx: String,
+        /// Ethereum only: the Gnosis Safe nonce the secp256k1 payload
+        /// signature is bound to (the SafeTx hash covers it). REQUIRED for
+        /// `dest_chain: Ethereum`, and must be ABSENT for Solana, so every
+        /// logical attestation has exactly one canonical encoding.
+        safe_nonce: Option<u64>,
+    },
+    /// `bridge.release_bth` — "the wBTH burn funding `order_id` is final;
+    /// release `amount` picocredits from the reserve to `bth_address`".
+    ReleaseBth {
+        /// Chain the wBTH was burned on (Ethereum or Solana).
+        source_chain: Chain,
+        /// Recipient BTH address (paid as a fresh one-time stealth output).
+        bth_address: String,
+        /// Net amount to release, in picocredits.
+        amount: u64,
+        /// The bridge order UUID.
+        order_id: Uuid,
+        /// The finalized burn transaction hash being attested.
+        source_tx: String,
+    },
+}
+
+impl AttestationKind {
+    /// The wire `action` string for this variant.
+    pub fn name(&self) -> &'static str {
+        match self {
+            AttestationKind::MintWbth { .. } => "bridge.mint_wbth",
+            AttestationKind::ReleaseBth { .. } => "bridge.release_bth",
+        }
+    }
+
+    /// The chain the privileged action executes on — the envelope
+    /// domain-separator selector.
+    pub fn target_chain(&self) -> Chain {
+        match self {
+            AttestationKind::MintWbth { dest_chain, .. } => *dest_chain,
+            AttestationKind::ReleaseBth { .. } => Chain::Bth,
+        }
+    }
+
+    /// The bridge order UUID this attestation is bound to.
+    pub fn order_uuid(&self) -> Uuid {
+        match self {
+            AttestationKind::MintWbth { order_id, .. }
+            | AttestationKind::ReleaseBth { order_id, .. } => *order_id,
+        }
+    }
+
+    /// The deterministic 32-byte on-chain order id ([`derive_order_id`]).
+    pub fn order_id_bytes(&self) -> [u8; 32] {
+        derive_order_id(&self.order_uuid())
+    }
+
+    /// The attested net amount in picocredits.
+    pub fn amount(&self) -> u64 {
+        match self {
+            AttestationKind::MintWbth { amount, .. }
+            | AttestationKind::ReleaseBth { amount, .. } => *amount,
+        }
+    }
+
+    /// The attested recipient (destination address / BTH payout address).
+    pub fn recipient(&self) -> &str {
+        match self {
+            AttestationKind::MintWbth { dest_address, .. } => dest_address,
+            AttestationKind::ReleaseBth { bth_address, .. } => bth_address,
+        }
+    }
+
+    /// The finalized source transaction being attested.
+    pub fn source_tx(&self) -> &str {
+        match self {
+            AttestationKind::MintWbth { source_tx, .. }
+            | AttestationKind::ReleaseBth { source_tx, .. } => source_tx,
+        }
+    }
+
+    /// The action's `params` object as it appears in the envelope, for the
+    /// audit log. Reconstructed from the parsed action so an audit entry
+    /// never re-reads untrusted bytes.
+    pub fn params_value(&self) -> Value {
+        match self {
+            AttestationKind::MintWbth {
+                dest_chain,
+                dest_address,
+                amount,
+                order_id,
+                source_tx,
+                safe_nonce,
+            } => {
+                let mut v = serde_json::json!({
+                    "amount": amount,
+                    "destAddress": dest_address,
+                    "destChain": dest_chain.to_string(),
+                    "orderId": order_id.to_string(),
+                    "sourceTx": source_tx,
+                });
+                if let Some(n) = safe_nonce {
+                    v["safeNonce"] = Value::from(*n);
+                }
+                v
+            }
+            AttestationKind::ReleaseBth {
+                source_chain,
+                bth_address,
+                amount,
+                order_id,
+                source_tx,
+            } => serde_json::json!({
+                "amount": amount,
+                "bthAddress": bth_address,
+                "orderId": order_id.to_string(),
+                "sourceChain": source_chain.to_string(),
+                "sourceTx": source_tx,
+            }),
+        }
+    }
+
+    /// The canonical (lexicographically key-ordered, whitespace-free)
+    /// `params` JSON for the signed envelope bytes. Built by hand so the
+    /// canonical form never depends on `serde_json` feature flags.
+    fn canonical_params(&self) -> String {
+        let s = |v: &str| serde_json::to_string(v).expect("string serialization is infallible");
+        match self {
+            AttestationKind::MintWbth {
+                dest_chain,
+                dest_address,
+                amount,
+                order_id,
+                source_tx,
+                safe_nonce,
+            } => {
+                let safe_nonce = match safe_nonce {
+                    Some(n) => format!("\"safeNonce\":{n},"),
+                    None => String::new(),
+                };
+                format!(
+                    "{{\"amount\":{amount},\"destAddress\":{dest},\"destChain\":{chain},\
+                     \"orderId\":{order},{safe_nonce}\"sourceTx\":{src}}}",
+                    dest = s(dest_address),
+                    chain = s(&dest_chain.to_string()),
+                    order = s(&order_id.to_string()),
+                    src = s(source_tx),
+                )
+            }
+            AttestationKind::ReleaseBth {
+                source_chain,
+                bth_address,
+                amount,
+                order_id,
+                source_tx,
+            } => format!(
+                "{{\"amount\":{amount},\"bthAddress\":{addr},\"orderId\":{order},\
+                 \"sourceChain\":{chain},\"sourceTx\":{src}}}",
+                addr = s(bth_address),
+                order = s(&order_id.to_string()),
+                chain = s(&source_chain.to_string()),
+                src = s(source_tx),
+            ),
+        }
+    }
+
+    /// The Ed25519 payload digest this attestation's `payloadSignature`
+    /// must cover:
+    ///
+    /// - `ReleaseBth` → [`release_payload_digest`] (verified downstream by
+    ///   `validate_release_attestation` before any reserve spend);
+    /// - `MintWbth { dest_chain: Solana }` → [`mint_payload_digest`].
+    ///
+    /// `MintWbth { dest_chain: Ethereum }` has NO Ed25519 payload digest:
+    /// per ADR 0002 its payload signature is a secp256k1 owner signature
+    /// over the Gnosis Safe EIP-712 transaction hash (computed by the
+    /// service layer, which knows the Safe/chain parameters).
+    pub fn ed25519_payload_digest(&self) -> Result<[u8; 32], String> {
+        match self {
+            AttestationKind::ReleaseBth {
+                bth_address,
+                amount,
+                ..
+            } => Ok(release_payload_digest(
+                &self.order_id_bytes(),
+                *amount,
+                bth_address,
+            )),
+            AttestationKind::MintWbth {
+                dest_chain: Chain::Solana,
+                dest_address,
+                amount,
+                ..
+            } => mint_payload_digest(Chain::Solana, &self.order_id_bytes(), *amount, dest_address),
+            AttestationKind::MintWbth { .. } => Err(
+                "Ethereum mint attestations sign the Gnosis Safe transaction hash \
+                 (secp256k1); there is no Ed25519 payload digest"
+                    .to_string(),
+            ),
+        }
+    }
+}
+
+/// Why an attestation was rejected. Mirrors `operator_action::RejectReason`:
+/// [`AttestationRejectReason::is_authenticated`] discriminates pre-signature
+/// failures (reachable by any unauthenticated caller — rate-limit + count
+/// only) from authenticated refusals (audit-logged).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttestationRejectReason {
+    /// No federation is configured for the attestation's target chain.
+    NotConfigured,
+    /// `signerKeyId` matched no configured federation member (pre-signature).
+    UnknownSigner,
+    /// The envelope could not be read far enough to attempt signature
+    /// verification (pre-signature — unauthenticated caller).
+    Malformed(String),
+    /// A signature (envelope or payload) did not verify (pre-signature).
+    BadSignature,
+    /// The attestation is bound to a different order / amount / recipient /
+    /// chain / source tx than the on-record order (post-signature).
+    WrongOrder(String),
+    /// Freshness failed: expired, not-yet-valid beyond skew, or lifetime
+    /// exceeded (post-signature).
+    Stale(String),
+    /// The `(signerKeyId, nonce)` pair was already consumed — a replay
+    /// (post-signature).
+    ReplayedNonce,
+    /// Fewer than `t` distinct valid signers have attested (post-signature;
+    /// not a per-envelope failure but part of the outcome taxonomy).
+    BelowThreshold(String),
+    /// Payload validity failed: unknown/duplicate keys, unknown action or
+    /// version, out-of-range values (post-signature).
+    InvalidPayload(String),
+    /// Infrastructure failure (e.g. the nonce store could not persist).
+    /// Never a clean rejection — the caller must retry, not conclude.
+    Internal(String),
+}
+
+impl AttestationRejectReason {
+    /// Whether this rejection is for an AUTHENTICATED envelope (signature
+    /// already verified). Only authenticated outcomes are audit-logged;
+    /// pre-signature failures are rate-limited + counted.
+    pub fn is_authenticated(&self) -> bool {
+        !matches!(
+            self,
+            AttestationRejectReason::NotConfigured
+                | AttestationRejectReason::UnknownSigner
+                | AttestationRejectReason::Malformed(_)
+                | AttestationRejectReason::BadSignature
+        )
+    }
+
+    /// A short, stable machine tag for the audit log. Contains no secret
+    /// material and no attacker-controlled free text.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            AttestationRejectReason::NotConfigured => "not_configured",
+            AttestationRejectReason::UnknownSigner => "unknown_signer",
+            AttestationRejectReason::Malformed(_) => "malformed",
+            AttestationRejectReason::BadSignature => "bad_signature",
+            AttestationRejectReason::WrongOrder(_) => "wrong_order",
+            AttestationRejectReason::Stale(_) => "stale",
+            AttestationRejectReason::ReplayedNonce => "replayed_nonce",
+            AttestationRejectReason::BelowThreshold(_) => "below_threshold",
+            AttestationRejectReason::InvalidPayload(_) => "invalid_payload",
+            AttestationRejectReason::Internal(_) => "internal",
+        }
+    }
+
+    /// A human-facing message (safe to return to the submitter).
+    pub fn message(&self) -> String {
+        match self {
+            AttestationRejectReason::NotConfigured => {
+                "no federation configured for this target chain".to_string()
+            }
+            AttestationRejectReason::UnknownSigner => {
+                "signer is not a configured federation member".to_string()
+            }
+            AttestationRejectReason::Malformed(d) => format!("malformed attestation: {d}"),
+            AttestationRejectReason::BadSignature => "signature verification failed".to_string(),
+            AttestationRejectReason::WrongOrder(d) => {
+                format!("attestation does not match the order: {d}")
+            }
+            AttestationRejectReason::Stale(d) => format!("attestation not fresh: {d}"),
+            AttestationRejectReason::ReplayedNonce => "nonce already used (replay)".to_string(),
+            AttestationRejectReason::BelowThreshold(d) => format!("below threshold: {d}"),
+            AttestationRejectReason::InvalidPayload(d) => format!("invalid payload: {d}"),
+            AttestationRejectReason::Internal(d) => format!("internal error: {d}"),
+        }
+    }
+}
+
+/// The structured verdict of ingesting one attestation envelope — the seam
+/// the audit log hooks onto (mirrors `operator_action::OperatorActionOutcome`).
+#[derive(Debug, Clone)]
+pub struct AttestationOutcome {
+    /// Whether the attestation was accepted into its threshold set.
+    pub accepted: bool,
+    /// Whether the envelope's signature verified (audit-log gate: only
+    /// authenticated outcomes are logged).
+    pub authenticated: bool,
+    /// Stable machine tag: `accepted` or `refused:<reason-tag>`.
+    pub tag: String,
+    /// Human-facing detail.
+    pub message: String,
+    /// Signer identity, when authenticated.
+    pub signer_key_id: Option<String>,
+    /// The attempted action name, when parsed.
+    pub action: Option<String>,
+    /// The bound order UUID, when parsed.
+    pub order_id: Option<Uuid>,
+    /// Distinct valid signers collected for this `(order, action)` so far.
+    pub signers: u32,
+    /// The configured federation threshold `t`.
+    pub threshold: u32,
+}
+
+impl AttestationOutcome {
+    /// Build an accepted outcome with threshold progress `signers/threshold`.
+    pub fn accept(parsed: &ParsedAttestation, signers: u32, threshold: u32) -> Self {
+        Self {
+            accepted: true,
+            authenticated: true,
+            tag: "accepted".to_string(),
+            message: format!("attestation accepted ({signers}/{threshold} distinct signers)"),
+            signer_key_id: Some(parsed.signer_key_id.clone()),
+            action: Some(parsed.action.name().to_string()),
+            order_id: Some(parsed.action.order_uuid()),
+            signers,
+            threshold,
+        }
+    }
+
+    /// Build a refusal outcome. `parsed` is `Some` once the envelope parsed
+    /// (post-signature), giving the signer + action for the audit log.
+    pub fn refuse(
+        reason: &AttestationRejectReason,
+        parsed: Option<&ParsedAttestation>,
+        signers: u32,
+        threshold: u32,
+    ) -> Self {
+        Self {
+            accepted: false,
+            authenticated: reason.is_authenticated(),
+            tag: format!("refused:{}", reason.tag()),
+            message: reason.message(),
+            signer_key_id: parsed.map(|p| p.signer_key_id.clone()),
+            action: parsed.map(|p| p.action.name().to_string()),
+            order_id: parsed.map(|p| p.action.order_uuid()),
+            signers,
+            threshold,
+        }
+    }
+}
+
+/// A signed attestation envelope: the canonical JSON string exactly as the
+/// federation member signed it, plus TWO detached signatures.
+///
+/// - `signature_hex` covers `attestation_domain(target_chain) ||
+///   envelope_bytes` — it authenticates the envelope (nonce, freshness window,
+///   action) and provides the cross-domain binding.
+/// - `payload_signature_hex` covers the chain-specific payload digest
+///   ([`AttestationKind::ed25519_payload_digest`], or the Gnosis Safe
+///   transaction hash for Ethereum mints). This is the signature that survives
+///   into [`MintAuthorization`]/[`ReleaseAuthorization`] and is re-verified by
+///   the mint/release path before any privileged action.
+///
+/// Verification is always over the RECEIVED bytes; the envelope is parsed
+/// only AFTER its signature verifies (parse-after-verify), and the parser
+/// rejects unknown or duplicate keys so one signed byte string can never
+/// carry two logical attestations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AttestationEnvelope {
+    /// The canonical JSON envelope string, verbatim, as signed.
+    pub envelope: String,
+    /// Detached signature over the domain-separated envelope bytes
+    /// (lowercase hex; 64-byte Ed25519 or 65-byte secp256k1 `{r, s, v}`).
+    pub signature_hex: String,
+    /// Detached signature over the chain-specific payload digest
+    /// (lowercase hex; same scheme as `signature_hex`).
+    pub payload_signature_hex: String,
+}
+
+/// A fully-parsed, structurally-validated attestation (after signature
+/// verification).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedAttestation {
+    /// The attested action (allowlisted, order-bound).
+    pub action: AttestationKind,
+    /// Unix seconds the envelope was issued.
+    pub issued_at: u64,
+    /// Unix seconds the envelope expires (freshness window).
+    pub expires_at: u64,
+    /// Single-use nonce (per signer), consumed via the nonce store.
+    pub nonce: String,
+    /// Signer identity: lowercase hex of the Ed25519 public key (64 chars)
+    /// or of the 20-byte Ethereum owner address (40 chars).
+    pub signer_key_id: String,
+    /// Envelope version (always [`ATTESTATION_ENVELOPE_VERSION`]).
+    pub v: u64,
+}
+
+impl ParsedAttestation {
+    /// The chain the privileged action executes on.
+    pub fn target_chain(&self) -> Chain {
+        self.action.target_chain()
+    }
+}
+
+impl AttestationEnvelope {
+    /// Verify an Ed25519-signed attestation (BTH releases and Solana mints,
+    /// per ADR 0002) and parse it.
+    ///
+    /// Pipeline (no secret-dependent check precedes signature verification):
+    /// 1. decode both signatures (pre-signature `Malformed`);
+    /// 2. peek the target chain from the (unverified) bytes purely to select
+    ///    the domain separator — a lying peek changes the signed message and
+    ///    fails verification;
+    /// 3. verify the envelope signature over `domain || received_bytes`
+    ///    (`verify_strict`, rejecting malleable/low-order signatures);
+    /// 4. parse THOSE EXACT bytes (parse-after-verify; unknown/duplicate keys
+    ///    and unknown versions rejected);
+    /// 5. verify the payload signature over the parsed action's Ed25519 payload
+    ///    digest with the SAME key.
+    pub fn verify_and_parse_ed25519(
+        &self,
+        verifying_key: &VerifyingKey,
+    ) -> Result<ParsedAttestation, AttestationRejectReason> {
+        let env_sig =
+            decode_sig64(&self.signature_hex).map_err(AttestationRejectReason::Malformed)?;
+        let payload_sig = decode_sig64(&self.payload_signature_hex)
+            .map_err(AttestationRejectReason::Malformed)?;
+
+        let target = peek_target_chain(&self.envelope)?;
+        if target == Chain::Ethereum {
+            // Ethereum-target attestations are secp256k1 (SafeTx); handing
+            // one to the Ed25519 verifier is a routing error, pre-signature.
+            return Err(AttestationRejectReason::Malformed(
+                "Ethereum-target attestations use the secp256k1 path".to_string(),
+            ));
+        }
+
+        let msg = attestation_signed_message(target, self.envelope.as_bytes());
+        verifying_key
+            .verify_strict(&msg, &Ed25519Signature::from_bytes(&env_sig))
+            .map_err(|_| AttestationRejectReason::BadSignature)?;
+
+        // Parse-after-verify: the signature is valid over exactly these
+        // bytes; NOW parse them.
+        let parsed = parse_attestation_envelope(&self.envelope)
+            .map_err(AttestationRejectReason::InvalidPayload)?;
+
+        // The payload signature must cover the digest derived from the
+        // (now-verified) action, with the same key.
+        let digest = parsed
+            .action
+            .ed25519_payload_digest()
+            .map_err(AttestationRejectReason::InvalidPayload)?;
+        verifying_key
+            .verify_strict(&digest, &Ed25519Signature::from_bytes(&payload_sig))
+            .map_err(|_| AttestationRejectReason::BadSignature)?;
+
+        Ok(parsed)
+    }
+}
+
+fn decode_sig64(hex_str: &str) -> Result<[u8; 64], String> {
+    let bytes =
+        hex::decode(hex_str.trim()).map_err(|_| "signature is not valid hex".to_string())?;
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| "ed25519 signature must be 64 bytes".to_string())
+}
+
+/// Peek the `signerKeyId` out of the (still-unverified) envelope bytes,
+/// ONLY to select which configured federation key to verify against. Drives
+/// no security decision on its own: if the presented id names a key the
+/// bytes were not signed with, signature verification fails.
+pub fn peek_signer_key_id(envelope: &str) -> Result<String, AttestationRejectReason> {
+    let value: Value = serde_json::from_str(envelope).map_err(|_| {
+        AttestationRejectReason::Malformed("envelope is not valid JSON".to_string())
+    })?;
+    value
+        .as_object()
+        .and_then(|o| o.get("signerKeyId"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            AttestationRejectReason::Malformed("envelope missing string `signerKeyId`".to_string())
+        })
+}
+
+/// Peek the target chain out of the (still-unverified) envelope bytes, ONLY
+/// to select the domain separator / verification scheme. Like
+/// [`peek_signer_key_id`] this is a hint: a lying value changes the signed
+/// message (different domain) and fails signature verification.
+pub fn peek_target_chain(envelope: &str) -> Result<Chain, AttestationRejectReason> {
+    let value: Value = serde_json::from_str(envelope).map_err(|_| {
+        AttestationRejectReason::Malformed("envelope is not valid JSON".to_string())
+    })?;
+    let obj = value.as_object().ok_or_else(|| {
+        AttestationRejectReason::Malformed("envelope must be a JSON object".to_string())
+    })?;
+    let action = obj.get("action").and_then(|v| v.as_str()).ok_or_else(|| {
+        AttestationRejectReason::Malformed("envelope missing string `action`".to_string())
+    })?;
+    match action {
+        "bridge.release_bth" => Ok(Chain::Bth),
+        "bridge.mint_wbth" => {
+            let dest = obj
+                .get("params")
+                .and_then(|p| p.as_object())
+                .and_then(|p| p.get("destChain"))
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    AttestationRejectReason::Malformed(
+                        "mint envelope missing string `params.destChain`".to_string(),
+                    )
+                })?;
+            parse_canonical_chain(dest).map_err(AttestationRejectReason::Malformed)
+        }
+        other => Err(AttestationRejectReason::Malformed(format!(
+            "action `{other}` is not in the v1 allowlist"
+        ))),
+    }
+}
+
+/// Parse a chain from its canonical wire string ONLY (`ethereum` /
+/// `solana` / `bth`). Aliases are rejected so every logical attestation has
+/// exactly one canonical byte encoding.
+fn parse_canonical_chain(s: &str) -> Result<Chain, String> {
+    match s {
+        "bth" => Ok(Chain::Bth),
+        "ethereum" => Ok(Chain::Ethereum),
+        "solana" => Ok(Chain::Solana),
+        other => Err(format!("`{other}` is not a canonical chain name")),
+    }
+}
+
+/// Build the canonical (lexicographically key-ordered, whitespace-free,
+/// integers-only) envelope string for signing.
+pub fn canonical_attestation_envelope(
+    kind: &AttestationKind,
+    signer_key_id: &str,
+    nonce: &str,
+    issued_at: u64,
+    expires_at: u64,
+) -> String {
+    let s = |v: &str| serde_json::to_string(v).expect("string serialization is infallible");
+    format!(
+        "{{\"action\":{action},\"expiresAt\":{expires_at},\"issuedAt\":{issued_at},\
+         \"nonce\":{nonce},\"params\":{params},\"signerKeyId\":{signer},\"v\":{v}}}",
+        action = s(kind.name()),
+        nonce = s(nonce),
+        params = kind.canonical_params(),
+        signer = s(signer_key_id),
+        v = ATTESTATION_ENVELOPE_VERSION,
+    )
+}
+
+/// Build and Ed25519-sign a complete attestation envelope (BTH releases and
+/// Solana mints). The signer identity is the lowercase hex of the Ed25519
+/// public key. Fails for Ethereum-target kinds (secp256k1, service layer).
+pub fn sign_attestation_ed25519(
+    kind: &AttestationKind,
+    signing_key: &SigningKey,
+    nonce: &str,
+    issued_at: u64,
+    expires_at: u64,
+) -> Result<AttestationEnvelope, String> {
+    use ed25519_dalek::Signer as _;
+
+    let payload_digest = kind.ed25519_payload_digest()?;
+    let signer_key_id = hex::encode(signing_key.verifying_key().as_bytes());
+    let envelope =
+        canonical_attestation_envelope(kind, &signer_key_id, nonce, issued_at, expires_at);
+    let msg = attestation_signed_message(kind.target_chain(), envelope.as_bytes());
+
+    Ok(AttestationEnvelope {
+        signature_hex: hex::encode(signing_key.sign(&msg).to_bytes()),
+        payload_signature_hex: hex::encode(signing_key.sign(&payload_digest).to_bytes()),
+        envelope,
+    })
+}
+
+/// Parse the canonical envelope bytes, REJECTING unknown or duplicate keys
+/// (at every nesting level) and any type/shape error, so a single signed
+/// byte string can never carry two logical attestations.
+pub fn parse_attestation_envelope(bytes: &str) -> Result<ParsedAttestation, String> {
+    reject_duplicate_keys(bytes)?;
+
+    let value: Value =
+        serde_json::from_str(bytes).map_err(|e| format!("envelope is not valid JSON: {e}"))?;
+    let obj: &Map<String, Value> = value
+        .as_object()
+        .ok_or_else(|| "envelope must be a JSON object".to_string())?;
+
+    const KNOWN_KEYS: &[&str] = &[
+        "action",
+        "expiresAt",
+        "issuedAt",
+        "nonce",
+        "params",
+        "signerKeyId",
+        "v",
+    ];
+    for key in obj.keys() {
+        if !KNOWN_KEYS.contains(&key.as_str()) {
+            return Err(format!("unknown envelope field `{key}`"));
+        }
+    }
+
+    let v = get_u64(obj, "v")?;
+    if v != ATTESTATION_ENVELOPE_VERSION {
+        return Err(format!(
+            "unsupported envelope version {v} (expected {ATTESTATION_ENVELOPE_VERSION})"
+        ));
+    }
+
+    let issued_at = get_u64(obj, "issuedAt")?;
+    let expires_at = get_u64(obj, "expiresAt")?;
+    let nonce = get_str(obj, "nonce")?.to_string();
+    let signer_key_id = get_str(obj, "signerKeyId")?.to_string();
+    let action_name = get_str(obj, "action")?.to_string();
+
+    let params_obj = obj
+        .get("params")
+        .ok_or_else(|| "missing field `params`".to_string())?
+        .as_object()
+        .ok_or_else(|| "`params` must be an object".to_string())?;
+
+    let action = parse_attestation_action(&action_name, params_obj)?;
+
+    Ok(ParsedAttestation {
+        action,
+        issued_at,
+        expires_at,
+        nonce,
+        signer_key_id,
+        v,
+    })
+}
+
+/// Map an `action` string + `params` to a v1 [`AttestationKind`], failing
+/// closed on anything outside the allowlist.
+fn parse_attestation_action(
+    action: &str,
+    params: &Map<String, Value>,
+) -> Result<AttestationKind, String> {
+    match action {
+        "bridge.mint_wbth" => {
+            const KNOWN: &[&str] = &[
+                "amount",
+                "destAddress",
+                "destChain",
+                "orderId",
+                "safeNonce",
+                "sourceTx",
+            ];
+            for key in params.keys() {
+                if !KNOWN.contains(&key.as_str()) {
+                    return Err(format!("unknown mint param `{key}`"));
+                }
+            }
+            let dest_chain = parse_canonical_chain(get_str(params, "destChain")?)?;
+            let safe_nonce = match params.get("safeNonce") {
+                None => None,
+                Some(v) => Some(
+                    v.as_u64()
+                        .ok_or_else(|| "`safeNonce` must be a non-negative integer".to_string())?,
+                ),
+            };
+            match dest_chain {
+                Chain::Bth => return Err("cannot mint wBTH on the BTH chain".to_string()),
+                Chain::Ethereum if safe_nonce.is_none() => {
+                    return Err("Ethereum mint attestations require `safeNonce`".to_string())
+                }
+                Chain::Solana if safe_nonce.is_some() => {
+                    return Err("`safeNonce` is only valid for Ethereum mints".to_string())
+                }
+                _ => {}
+            }
+            Ok(AttestationKind::MintWbth {
+                dest_chain,
+                dest_address: get_str(params, "destAddress")?.to_string(),
+                amount: get_u64(params, "amount")?,
+                order_id: parse_uuid(get_str(params, "orderId")?)?,
+                source_tx: get_str(params, "sourceTx")?.to_string(),
+                safe_nonce,
+            })
+        }
+        "bridge.release_bth" => {
+            const KNOWN: &[&str] = &["amount", "bthAddress", "orderId", "sourceChain", "sourceTx"];
+            for key in params.keys() {
+                if !KNOWN.contains(&key.as_str()) {
+                    return Err(format!("unknown release param `{key}`"));
+                }
+            }
+            let source_chain = parse_canonical_chain(get_str(params, "sourceChain")?)?;
+            if source_chain == Chain::Bth {
+                return Err("release source chain cannot be bth".to_string());
+            }
+            Ok(AttestationKind::ReleaseBth {
+                source_chain,
+                bth_address: get_str(params, "bthAddress")?.to_string(),
+                amount: get_u64(params, "amount")?,
+                order_id: parse_uuid(get_str(params, "orderId")?)?,
+                source_tx: get_str(params, "sourceTx")?.to_string(),
+            })
+        }
+        other => Err(format!("action `{other}` is not in the v1 allowlist")),
+    }
+}
+
+fn parse_uuid(s: &str) -> Result<Uuid, String> {
+    Uuid::parse_str(s).map_err(|_| "`orderId` is not a valid UUID".to_string())
+}
+
+fn get_str<'a>(obj: &'a Map<String, Value>, key: &str) -> Result<&'a str, String> {
+    obj.get(key)
+        .ok_or_else(|| format!("missing field `{key}`"))?
+        .as_str()
+        .ok_or_else(|| format!("`{key}` must be a string"))
+}
+
+/// Read an integer field, REJECTING non-integers (`serde_json` parses `5.0`
+/// as a float, so `as_u64` returns `None` — fail-closed).
+fn get_u64(obj: &Map<String, Value>, key: &str) -> Result<u64, String> {
+    obj.get(key)
+        .ok_or_else(|| format!("missing field `{key}`"))?
+        .as_u64()
+        .ok_or_else(|| format!("`{key}` must be a non-negative integer"))
+}
+
+/// Reject any JSON value containing a duplicated object key at ANY nesting
+/// level. `serde_json::Map` silently collapses duplicates (last-wins), which
+/// would let two logical envelopes share one signed byte string.
+fn reject_duplicate_keys(bytes: &str) -> Result<(), String> {
+    use serde::de::{DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
+
+    struct AnyChecker;
+    impl<'de> DeserializeSeed<'de> for AnyChecker {
+        type Value = ();
+        fn deserialize<D: Deserializer<'de>>(self, d: D) -> Result<(), D::Error> {
+            d.deserialize_any(AnyVisitor)
+        }
+    }
+
+    struct AnyVisitor;
+    impl<'de> Visitor<'de> for AnyVisitor {
+        type Value = ();
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("any JSON value with unique object keys")
+        }
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
+            let mut seen = std::collections::HashSet::new();
+            while let Some(key) = map.next_key::<String>()? {
+                map.next_value_seed(AnyChecker)?;
+                if !seen.insert(key.clone()) {
+                    return Err(serde::de::Error::custom(format!("duplicate key `{key}`")));
+                }
+            }
+            Ok(())
+        }
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
+            while seq.next_element_seed(AnyChecker)?.is_some() {}
+            Ok(())
+        }
+        fn visit_bool<E>(self, _: bool) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_i64<E>(self, _: i64) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_u64<E>(self, _: u64) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_f64<E>(self, _: f64) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_str<E>(self, _: &str) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_unit<E>(self) -> Result<(), E> {
+            Ok(())
+        }
+    }
+
+    let mut de = serde_json::Deserializer::from_str(bytes);
+    AnyChecker
+        .deserialize(&mut de)
+        .map_err(|e| format!("{e}"))?;
+    Ok(())
+}
+
+/// Freshness check: `issuedAt - skew <= now <= expiresAt` and
+/// `expiresAt - issuedAt <= MAX_ATTESTATION_LIFETIME_SECS`. All arithmetic
+/// is saturating so crafted timestamps can never panic. A captured
+/// attestation expires and cannot be replayed after the window.
+pub fn check_attestation_freshness(
+    parsed: &ParsedAttestation,
+    now: u64,
+) -> Result<(), AttestationRejectReason> {
+    if parsed.expires_at < parsed.issued_at {
+        return Err(AttestationRejectReason::Stale(
+            "expiresAt precedes issuedAt".to_string(),
+        ));
+    }
+    if parsed.expires_at.saturating_sub(parsed.issued_at) > MAX_ATTESTATION_LIFETIME_SECS {
+        return Err(AttestationRejectReason::Stale(format!(
+            "lifetime exceeds {MAX_ATTESTATION_LIFETIME_SECS}s"
+        )));
+    }
+    if now < parsed.issued_at.saturating_sub(ATTESTATION_CLOCK_SKEW_SECS) {
+        return Err(AttestationRejectReason::Stale(
+            "issuedAt is in the future".to_string(),
+        ));
+    }
+    if now > parsed.expires_at {
+        return Err(AttestationRejectReason::Stale("expired".to_string()));
+    }
+    Ok(())
+}
+
+/// Bind an attestation to its on-record [`BridgeOrder`]: every field the
+/// federation attested must match the order the engine is processing. A
+/// validly-signed attestation for order A presented against order B is
+/// rejected here even with a fresh nonce.
+pub fn check_order_binding(
+    parsed: &ParsedAttestation,
+    order: &BridgeOrder,
+) -> Result<(), AttestationRejectReason> {
+    let wrong = |d: String| Err(AttestationRejectReason::WrongOrder(d));
+    let action = &parsed.action;
+
+    if action.order_uuid() != order.id {
+        return wrong(format!(
+            "attestation is bound to order {}, not {}",
+            action.order_uuid(),
+            order.id
+        ));
+    }
+    if action.amount() != order.net_amount() {
+        return wrong(format!(
+            "attestation authorizes {} picocredits, order nets {}",
+            action.amount(),
+            order.net_amount()
+        ));
+    }
+    if action.recipient() != order.dest_address {
+        return wrong("attestation recipient does not match order destination".to_string());
+    }
+    match order.source_tx.as_deref() {
+        Some(tx) if tx == action.source_tx() => {}
+        Some(_) => return wrong("attestation source tx does not match order".to_string()),
+        None => return wrong("order has no confirmed source tx on record".to_string()),
+    }
+
+    match action {
+        AttestationKind::MintWbth { dest_chain, .. } => {
+            if order.order_type != OrderType::Mint {
+                return wrong("mint attestation presented for a non-mint order".to_string());
+            }
+            if *dest_chain != order.dest_chain {
+                return wrong(format!(
+                    "attestation targets {}, order mints on {}",
+                    dest_chain, order.dest_chain
+                ));
+            }
+        }
+        AttestationKind::ReleaseBth { source_chain, .. } => {
+            if order.order_type != OrderType::Burn {
+                return wrong("release attestation presented for a non-burn order".to_string());
+            }
+            if order.dest_chain != Chain::Bth {
+                return wrong("release attestation for an order not paying out on BTH".to_string());
+            }
+            if *source_chain != order.source_chain {
+                return wrong(format!(
+                    "attestation sources from {}, order burned on {}",
+                    source_chain, order.source_chain
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Collects verified per-signer attestations for ONE `(order, action)` and
+/// answers the threshold question. Deduplicates by signer identity: the
+/// same federation member attesting twice (even with distinct nonces)
+/// counts ONCE toward `t`.
+#[derive(Debug, Clone)]
+pub struct AttestationSet {
+    order_id: Uuid,
+    action: String,
+    target_chain: Chain,
+    /// Ethereum mints only: the Safe nonce every collected payload
+    /// signature is bound to. Signatures over different Safe nonces cannot
+    /// be combined into one `execTransaction`, so mismatches are rejected.
+    safe_nonce: Option<u64>,
+    entries: Vec<(String, AttestationSignature)>,
+}
+
+impl AttestationSet {
+    /// Start a set keyed to `parsed`'s order, action, and target chain.
+    pub fn for_attestation(parsed: &ParsedAttestation) -> Self {
+        let safe_nonce = match &parsed.action {
+            AttestationKind::MintWbth { safe_nonce, .. } => *safe_nonce,
+            AttestationKind::ReleaseBth { .. } => None,
+        };
+        Self {
+            order_id: parsed.action.order_uuid(),
+            action: parsed.action.name().to_string(),
+            target_chain: parsed.action.target_chain(),
+            safe_nonce,
+            entries: Vec::new(),
+        }
+    }
+
+    /// Whether `parsed` belongs to this set (same order, action, chain, and
+    /// — for Ethereum — the same Safe nonce).
+    fn matches(&self, parsed: &ParsedAttestation) -> Result<(), String> {
+        if parsed.action.order_uuid() != self.order_id
+            || parsed.action.name() != self.action
+            || parsed.action.target_chain() != self.target_chain
+        {
+            return Err("attestation does not match this set's (order, action)".to_string());
+        }
+        if let AttestationKind::MintWbth { safe_nonce, .. } = &parsed.action {
+            if *safe_nonce != self.safe_nonce {
+                return Err(format!(
+                    "attestation is bound to Safe nonce {:?}, set collects {:?} — signatures \
+                     over different Safe nonces cannot be combined",
+                    safe_nonce, self.safe_nonce
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Insert a VERIFIED attestation's payload signature. Returns `Ok(true)`
+    /// for a new distinct signer, `Ok(false)` if this signer already counted
+    /// (double-count resistance), `Err` if the attestation does not belong
+    /// to this set.
+    pub fn insert(
+        &mut self,
+        parsed: &ParsedAttestation,
+        signature: AttestationSignature,
+    ) -> Result<bool, String> {
+        self.matches(parsed)?;
+        if self
+            .entries
+            .iter()
+            .any(|(id, _)| *id == parsed.signer_key_id)
+        {
+            return Ok(false);
+        }
+        self.entries.push((parsed.signer_key_id.clone(), signature));
+        Ok(true)
+    }
+
+    /// Distinct signers collected so far.
+    pub fn distinct_signers(&self) -> u32 {
+        self.entries.len() as u32
+    }
+
+    /// Whether `signer_key_id` has already been counted toward the
+    /// threshold.
+    pub fn contains_signer(&self, signer_key_id: &str) -> bool {
+        self.entries.iter().any(|(id, _)| id == signer_key_id)
+    }
+
+    /// Whether at least `threshold` DISTINCT verified signers have attested.
+    /// A zero threshold NEVER authorizes — a t-of-n federation always
+    /// requires at least one signature.
+    pub fn is_threshold_met(&self, threshold: u32) -> bool {
+        threshold >= 1 && self.distinct_signers() >= threshold
+    }
+
+    /// The collected payload signatures (one per distinct signer), for
+    /// assembly into a [`MintAuthorization`] / [`ReleaseAuthorization`].
+    pub fn signatures(&self) -> Vec<AttestationSignature> {
+        self.entries.iter().map(|(_, s)| s.clone()).collect()
+    }
+
+    /// The Safe nonce this set's Ethereum payload signatures are bound to.
+    pub fn safe_nonce(&self) -> Option<u64> {
+        self.safe_nonce
+    }
+}
+
 /// Hex serde for `Vec<u8>`.
 mod hex_bytes {
     use serde::{self, Deserialize, Deserializer, Serializer};
@@ -313,5 +1437,509 @@ mod tests {
         let back: ReleaseAuthorization = serde_json::from_str(&json).unwrap();
         assert_eq!(auth, back);
         assert_eq!(auth.digest(), back.digest());
+    }
+
+    // === #824 attestation envelope protocol ===
+
+    fn signing_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn mint_order_sol() -> BridgeOrder {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Solana,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bth_deposit_addr".to_string(),
+            "So11111111111111111111111111111111111111112".to_string(),
+        );
+        order.source_tx = Some("bth_deposit_tx".to_string());
+        order
+    }
+
+    fn burn_order_from_eth() -> BridgeOrder {
+        BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+            "bth_user_stealth_addr".to_string(),
+            "0xburntx".to_string(),
+        )
+    }
+
+    fn mint_kind(order: &BridgeOrder) -> AttestationKind {
+        AttestationKind::MintWbth {
+            dest_chain: order.dest_chain,
+            dest_address: order.dest_address.clone(),
+            amount: order.net_amount(),
+            order_id: order.id,
+            source_tx: order.source_tx.clone().unwrap(),
+            safe_nonce: if order.dest_chain == Chain::Ethereum {
+                Some(7)
+            } else {
+                None
+            },
+        }
+    }
+
+    fn release_kind(order: &BridgeOrder) -> AttestationKind {
+        AttestationKind::ReleaseBth {
+            source_chain: order.source_chain,
+            bth_address: order.dest_address.clone(),
+            amount: order.net_amount(),
+            order_id: order.id,
+            source_tx: order.source_tx.clone().unwrap(),
+        }
+    }
+
+    fn now() -> u64 {
+        1_800_000_000
+    }
+
+    fn sign(kind: &AttestationKind, sk: &SigningKey, nonce: &str) -> AttestationEnvelope {
+        sign_attestation_ed25519(kind, sk, nonce, now(), now() + 120).unwrap()
+    }
+
+    #[test]
+    fn test_mint_digest_golden_vector_and_binding() {
+        use sha2::{Digest, Sha256};
+
+        // Pinned construction: sha256(tag || order_id || amount_le ||
+        // recipient_len_le || recipient). Must never change — in-flight
+        // mint attestations bind to it.
+        let order_id = [5u8; 32];
+        let digest =
+            mint_payload_digest(Chain::Solana, &order_id, 999_000_000_000, "sol_addr").unwrap();
+        let expected: [u8; 32] = {
+            let mut hasher = Sha256::new();
+            hasher.update(b"botho-bridge-mint-sol-v1");
+            hasher.update([5u8; 32]);
+            hasher.update(999_000_000_000u64.to_le_bytes());
+            hasher.update((b"sol_addr".len() as u64).to_le_bytes());
+            hasher.update(b"sol_addr");
+            hasher.finalize().into()
+        };
+        assert_eq!(digest, expected);
+
+        // Binds every field.
+        let base = mint_payload_digest(Chain::Solana, &[1u8; 32], 100, "addr").unwrap();
+        assert_ne!(
+            base,
+            mint_payload_digest(Chain::Solana, &[2u8; 32], 100, "addr").unwrap()
+        );
+        assert_ne!(
+            base,
+            mint_payload_digest(Chain::Solana, &[1u8; 32], 101, "addr").unwrap()
+        );
+        assert_ne!(
+            base,
+            mint_payload_digest(Chain::Solana, &[1u8; 32], 100, "addr2").unwrap()
+        );
+
+        // Cross-chain and cross-action domain separation: the same fields
+        // produce a DIFFERENT digest per destination chain, and differ from
+        // the release digest — no signature is reusable across chains or
+        // between mint and release.
+        let eth = mint_payload_digest(Chain::Ethereum, &[1u8; 32], 100, "addr").unwrap();
+        assert_ne!(base, eth);
+        assert_ne!(base, release_payload_digest(&[1u8; 32], 100, "addr"));
+        assert_ne!(eth, release_payload_digest(&[1u8; 32], 100, "addr"));
+
+        // No BTH-destination mints.
+        assert!(mint_payload_digest(Chain::Bth, &[1u8; 32], 100, "addr").is_err());
+    }
+
+    #[test]
+    fn test_envelope_roundtrip_release_and_solana_mint() {
+        let sk = signing_key(1);
+
+        for (order, kind) in [(burn_order_from_eth(), None), (mint_order_sol(), Some(()))] {
+            let kind = if kind.is_some() {
+                mint_kind(&order)
+            } else {
+                release_kind(&order)
+            };
+            let env = sign(&kind, &sk, "0011223344556677");
+            let parsed = env.verify_and_parse_ed25519(&sk.verifying_key()).unwrap();
+            assert_eq!(parsed.action, kind);
+            assert_eq!(parsed.v, ATTESTATION_ENVELOPE_VERSION);
+            assert_eq!(parsed.nonce, "0011223344556677");
+            assert_eq!(
+                parsed.signer_key_id,
+                hex::encode(sk.verifying_key().as_bytes())
+            );
+            assert!(check_attestation_freshness(&parsed, now()).is_ok());
+            assert!(check_order_binding(&parsed, &order).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_tampered_envelope_fails_signature() {
+        let sk = signing_key(1);
+        let order = burn_order_from_eth();
+        let mut env = sign(&release_kind(&order), &sk, "aa");
+
+        // Inflate the attested amount in the raw bytes without re-signing.
+        env.envelope = env.envelope.replace("999000000000", "999000000001");
+        assert_eq!(
+            env.verify_and_parse_ed25519(&sk.verifying_key()),
+            Err(AttestationRejectReason::BadSignature)
+        );
+    }
+
+    #[test]
+    fn test_wrong_key_fails_signature() {
+        let sk = signing_key(1);
+        let other = signing_key(2);
+        let order = burn_order_from_eth();
+        let env = sign(&release_kind(&order), &sk, "aa");
+        assert_eq!(
+            env.verify_and_parse_ed25519(&other.verifying_key()),
+            Err(AttestationRejectReason::BadSignature)
+        );
+    }
+
+    #[test]
+    fn test_cross_domain_signature_reuse_fails() {
+        use ed25519_dalek::Signer as _;
+
+        // A signature produced under the WRONG chain domain (e.g. an
+        // attacker replaying bytes signed for another chain's domain, or a
+        // buggy signer) must not verify: the verifier derives the domain
+        // from the envelope's own target chain.
+        let sk = signing_key(1);
+        let order = burn_order_from_eth();
+        let kind = release_kind(&order); // target chain = Bth
+        let signer_key_id = hex::encode(sk.verifying_key().as_bytes());
+        let envelope =
+            canonical_attestation_envelope(&kind, &signer_key_id, "aa", now(), now() + 120);
+
+        // Sign under the SOLANA domain instead of the BTH domain.
+        let wrong_msg = attestation_signed_message(Chain::Solana, envelope.as_bytes());
+        let payload = kind.ed25519_payload_digest().unwrap();
+        let env = AttestationEnvelope {
+            envelope,
+            signature_hex: hex::encode(sk.sign(&wrong_msg).to_bytes()),
+            payload_signature_hex: hex::encode(sk.sign(&payload).to_bytes()),
+        };
+        assert_eq!(
+            env.verify_and_parse_ed25519(&sk.verifying_key()),
+            Err(AttestationRejectReason::BadSignature)
+        );
+    }
+
+    #[test]
+    fn test_ethereum_kind_rejected_on_ed25519_path() {
+        let sk = signing_key(1);
+        let mut order = mint_order_sol();
+        order.dest_chain = Chain::Ethereum;
+        order.dest_address = "0x1234567890abcdef1234567890abcdef12345678".to_string();
+        let kind = mint_kind(&order);
+        // Ethereum kinds cannot be Ed25519-signed at all.
+        assert!(sign_attestation_ed25519(&kind, &sk, "aa", now(), now() + 120).is_err());
+
+        // And a hand-built Ethereum-target envelope is refused pre-signature
+        // by the Ed25519 verifier (routing error).
+        let envelope = canonical_attestation_envelope(&kind, "someid", "aa", now(), now() + 120);
+        let env = AttestationEnvelope {
+            envelope,
+            signature_hex: hex::encode([0u8; 64]),
+            payload_signature_hex: hex::encode([0u8; 64]),
+        };
+        assert!(matches!(
+            env.verify_and_parse_ed25519(&sk.verifying_key()),
+            Err(AttestationRejectReason::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn test_payload_signature_over_wrong_digest_fails() {
+        use ed25519_dalek::Signer as _;
+
+        // Valid envelope signature, but the payload signature covers a
+        // DIFFERENT digest (another amount): rejected — the authorization
+        // artifact must be signed over exactly the attested payload.
+        let sk = signing_key(1);
+        let order = burn_order_from_eth();
+        let kind = release_kind(&order);
+        let mut env = sign(&kind, &sk, "aa");
+
+        let wrong_digest =
+            release_payload_digest(&kind.order_id_bytes(), kind.amount() + 1, kind.recipient());
+        env.payload_signature_hex = hex::encode(sk.sign(&wrong_digest).to_bytes());
+        assert_eq!(
+            env.verify_and_parse_ed25519(&sk.verifying_key()),
+            Err(AttestationRejectReason::BadSignature)
+        );
+    }
+
+    #[test]
+    fn test_parser_rejects_structural_attacks() {
+        // Unknown top-level key.
+        assert!(parse_attestation_envelope(
+            "{\"action\":\"bridge.release_bth\",\"evil\":1,\"expiresAt\":10,\"issuedAt\":5,\
+             \"nonce\":\"n\",\"params\":{},\"signerKeyId\":\"s\",\"v\":1}"
+        )
+        .unwrap_err()
+        .contains("unknown envelope field"));
+
+        // Duplicate top-level key (serde_json would silently last-win).
+        assert!(parse_attestation_envelope(
+            "{\"action\":\"bridge.release_bth\",\"action\":\"bridge.mint_wbth\",\
+             \"expiresAt\":10,\"issuedAt\":5,\"nonce\":\"n\",\"params\":{},\
+             \"signerKeyId\":\"s\",\"v\":1}"
+        )
+        .unwrap_err()
+        .contains("duplicate key"));
+
+        // Duplicate NESTED key inside params.
+        let dup_nested = format!(
+            "{{\"action\":\"bridge.release_bth\",\"expiresAt\":10,\"issuedAt\":5,\
+             \"nonce\":\"n\",\"params\":{{\"amount\":1,\"amount\":2,\"bthAddress\":\"a\",\
+             \"orderId\":\"{}\",\"sourceChain\":\"ethereum\",\"sourceTx\":\"t\"}},\
+             \"signerKeyId\":\"s\",\"v\":1}}",
+            Uuid::nil()
+        );
+        assert!(parse_attestation_envelope(&dup_nested)
+            .unwrap_err()
+            .contains("duplicate key"));
+
+        // Unknown version: no downgrade path.
+        assert!(parse_attestation_envelope(
+            "{\"action\":\"bridge.release_bth\",\"expiresAt\":10,\"issuedAt\":5,\
+             \"nonce\":\"n\",\"params\":{},\"signerKeyId\":\"s\",\"v\":2}"
+        )
+        .unwrap_err()
+        .contains("unsupported envelope version"));
+
+        // Floats are not integers.
+        assert!(parse_attestation_envelope(
+            "{\"action\":\"bridge.release_bth\",\"expiresAt\":10.0,\"issuedAt\":5,\
+             \"nonce\":\"n\",\"params\":{},\"signerKeyId\":\"s\",\"v\":1}"
+        )
+        .unwrap_err()
+        .contains("must be a non-negative integer"));
+
+        // Unknown action.
+        assert!(parse_attestation_envelope(
+            "{\"action\":\"bridge.self_destruct\",\"expiresAt\":10,\"issuedAt\":5,\
+             \"nonce\":\"n\",\"params\":{},\"signerKeyId\":\"s\",\"v\":1}"
+        )
+        .unwrap_err()
+        .contains("not in the v1 allowlist"));
+
+        // Chain aliases are rejected: one canonical encoding per attestation.
+        let alias = format!(
+            "{{\"action\":\"bridge.mint_wbth\",\"expiresAt\":10,\"issuedAt\":5,\
+             \"nonce\":\"n\",\"params\":{{\"amount\":1,\"destAddress\":\"a\",\
+             \"destChain\":\"sol\",\"orderId\":\"{}\",\"sourceTx\":\"t\"}},\
+             \"signerKeyId\":\"s\",\"v\":1}}",
+            Uuid::nil()
+        );
+        assert!(parse_attestation_envelope(&alias)
+            .unwrap_err()
+            .contains("not a canonical chain name"));
+
+        // safeNonce rules: required for Ethereum, forbidden for Solana.
+        let eth_missing = format!(
+            "{{\"action\":\"bridge.mint_wbth\",\"expiresAt\":10,\"issuedAt\":5,\
+             \"nonce\":\"n\",\"params\":{{\"amount\":1,\"destAddress\":\"a\",\
+             \"destChain\":\"ethereum\",\"orderId\":\"{}\",\"sourceTx\":\"t\"}},\
+             \"signerKeyId\":\"s\",\"v\":1}}",
+            Uuid::nil()
+        );
+        assert!(parse_attestation_envelope(&eth_missing)
+            .unwrap_err()
+            .contains("require `safeNonce`"));
+        let sol_with_nonce = format!(
+            "{{\"action\":\"bridge.mint_wbth\",\"expiresAt\":10,\"issuedAt\":5,\
+             \"nonce\":\"n\",\"params\":{{\"amount\":1,\"destAddress\":\"a\",\
+             \"destChain\":\"solana\",\"orderId\":\"{}\",\"safeNonce\":3,\
+             \"sourceTx\":\"t\"}},\"signerKeyId\":\"s\",\"v\":1}}",
+            Uuid::nil()
+        );
+        assert!(parse_attestation_envelope(&sol_with_nonce)
+            .unwrap_err()
+            .contains("only valid for Ethereum"));
+    }
+
+    #[test]
+    fn test_freshness_window() {
+        let sk = signing_key(1);
+        let order = burn_order_from_eth();
+        let kind = release_kind(&order);
+
+        let fresh = |issued: u64, expires: u64| {
+            sign_attestation_ed25519(&kind, &sk, "aa", issued, expires)
+                .unwrap()
+                .verify_and_parse_ed25519(&sk.verifying_key())
+                .unwrap()
+        };
+
+        // Valid window.
+        assert!(check_attestation_freshness(&fresh(now(), now() + 200), now()).is_ok());
+        // Expired.
+        assert!(matches!(
+            check_attestation_freshness(&fresh(now() - 300, now() - 100), now()),
+            Err(AttestationRejectReason::Stale(_))
+        ));
+        // Issued in the future beyond skew.
+        assert!(matches!(
+            check_attestation_freshness(&fresh(now() + 100, now() + 300), now()),
+            Err(AttestationRejectReason::Stale(_))
+        ));
+        // Lifetime over the cap.
+        assert!(matches!(
+            check_attestation_freshness(&fresh(now(), now() + 400), now()),
+            Err(AttestationRejectReason::Stale(_))
+        ));
+        // expiresAt precedes issuedAt (saturating, no panic).
+        assert!(matches!(
+            check_attestation_freshness(&fresh(now(), now() - 1), now()),
+            Err(AttestationRejectReason::Stale(_))
+        ));
+    }
+
+    #[test]
+    fn test_order_binding_rejects_cross_order_reuse() {
+        let sk = signing_key(1);
+        let order_a = burn_order_from_eth();
+        let order_b = burn_order_from_eth(); // fresh UUID, same shape
+
+        let env = sign(&release_kind(&order_a), &sk, "aa");
+        let parsed = env.verify_and_parse_ed25519(&sk.verifying_key()).unwrap();
+
+        // Bound to order A: order B is rejected even though every other
+        // field (amount, recipient, chains, source tx) matches.
+        assert!(check_order_binding(&parsed, &order_a).is_ok());
+        assert!(matches!(
+            check_order_binding(&parsed, &order_b),
+            Err(AttestationRejectReason::WrongOrder(_))
+        ));
+    }
+
+    #[test]
+    fn test_order_binding_rejects_field_mismatches() {
+        let sk = signing_key(1);
+        let order = burn_order_from_eth();
+        let env = sign(&release_kind(&order), &sk, "aa");
+        let parsed = env.verify_and_parse_ed25519(&sk.verifying_key()).unwrap();
+
+        let wrong = |mutate: &dyn Fn(&mut BridgeOrder)| {
+            let mut o = order.clone();
+            mutate(&mut o);
+            matches!(
+                check_order_binding(&parsed, &o),
+                Err(AttestationRejectReason::WrongOrder(_))
+            )
+        };
+
+        assert!(wrong(&|o| o.fee += 1)); // net amount shifts
+        assert!(wrong(&|o| o.dest_address = "attacker_addr".to_string()));
+        assert!(wrong(&|o| o.source_tx = Some("0xothertx".to_string())));
+        assert!(wrong(&|o| o.source_tx = None));
+        assert!(wrong(&|o| o.source_chain = Chain::Solana));
+        assert!(wrong(&|o| o.order_type = OrderType::Mint));
+    }
+
+    #[test]
+    fn test_mint_attestation_does_not_bind_to_other_chain_order() {
+        // A Solana mint attestation presented against an (otherwise
+        // identical) Ethereum order fails order binding: chain/domain +
+        // order binding together make cross-chain replay impossible.
+        let sk = signing_key(1);
+        let sol_order = mint_order_sol();
+        let env = sign(&mint_kind(&sol_order), &sk, "aa");
+        let parsed = env.verify_and_parse_ed25519(&sk.verifying_key()).unwrap();
+
+        let mut eth_order = sol_order.clone();
+        eth_order.dest_chain = Chain::Ethereum;
+        assert!(matches!(
+            check_order_binding(&parsed, &eth_order),
+            Err(AttestationRejectReason::WrongOrder(_))
+        ));
+    }
+
+    #[test]
+    fn test_attestation_set_thresholding_and_double_count() {
+        let order = burn_order_from_eth();
+        let kind = release_kind(&order);
+        let (k1, k2) = (signing_key(1), signing_key(2));
+
+        let parse = |sk: &SigningKey, nonce: &str| {
+            sign(&kind, sk, nonce)
+                .verify_and_parse_ed25519(&sk.verifying_key())
+                .unwrap()
+        };
+        let sig_of = |sk: &SigningKey| AttestationSignature {
+            signer: sk.verifying_key().as_bytes().to_vec(),
+            signature: vec![0u8; 64],
+        };
+
+        let p1 = parse(&k1, "n1");
+        let mut set = AttestationSet::for_attestation(&p1);
+        assert!(!set.is_threshold_met(2));
+        assert!(!set.is_threshold_met(0), "threshold 0 NEVER authorizes");
+
+        assert!(set.insert(&p1, sig_of(&k1)).unwrap());
+        assert_eq!(set.distinct_signers(), 1);
+        assert!(!set.is_threshold_met(2), "t-1 signers must not authorize");
+        assert!(!set.is_threshold_met(0), "threshold 0 NEVER authorizes");
+
+        // The SAME signer with a fresh nonce counts ONCE.
+        let p1b = parse(&k1, "n2");
+        assert!(!set.insert(&p1b, sig_of(&k1)).unwrap());
+        assert_eq!(set.distinct_signers(), 1);
+        assert!(!set.is_threshold_met(2));
+
+        // The t-th DISTINCT signer flips it to authorized.
+        let p2 = parse(&k2, "n3");
+        assert!(set.insert(&p2, sig_of(&k2)).unwrap());
+        assert!(set.is_threshold_met(2));
+        assert_eq!(set.signatures().len(), 2);
+
+        // A different order's attestation cannot enter this set.
+        let other = burn_order_from_eth();
+        let env = sign(&release_kind(&other), &k1, "n4");
+        let p_other = env.verify_and_parse_ed25519(&k1.verifying_key()).unwrap();
+        assert!(set.insert(&p_other, sig_of(&k1)).is_err());
+    }
+
+    #[test]
+    fn test_reject_taxonomy_authentication_split() {
+        // Pre-signature reasons are unauthenticated (rate-limit + count
+        // only); post-signature reasons are audit-logged.
+        for r in [
+            AttestationRejectReason::NotConfigured,
+            AttestationRejectReason::UnknownSigner,
+            AttestationRejectReason::Malformed("x".into()),
+            AttestationRejectReason::BadSignature,
+        ] {
+            assert!(!r.is_authenticated(), "{:?}", r);
+        }
+        for r in [
+            AttestationRejectReason::WrongOrder("x".into()),
+            AttestationRejectReason::Stale("x".into()),
+            AttestationRejectReason::ReplayedNonce,
+            AttestationRejectReason::BelowThreshold("x".into()),
+            AttestationRejectReason::InvalidPayload("x".into()),
+        ] {
+            assert!(r.is_authenticated(), "{:?}", r);
+        }
+    }
+
+    #[test]
+    fn test_peeks_match_parsed_values() {
+        let sk = signing_key(1);
+        let order = mint_order_sol();
+        let env = sign(&mint_kind(&order), &sk, "aa");
+
+        assert_eq!(
+            peek_signer_key_id(&env.envelope).unwrap(),
+            hex::encode(sk.verifying_key().as_bytes())
+        );
+        assert_eq!(peek_target_chain(&env.envelope).unwrap(), Chain::Solana);
+        assert!(peek_target_chain("not json").is_err());
     }
 }

--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -150,6 +150,22 @@ pub struct EthereumConfig {
     /// Gas price strategy
     #[serde(default)]
     pub gas_price_strategy: GasPriceStrategy,
+
+    /// Hex-encoded 20-byte Ethereum addresses of the mint federation — the
+    /// Gnosis Safe owners (the SCP validators' secp256k1 keys, per
+    /// ADR 0002). Every Ethereum mint attestation must be signed by one of
+    /// these. Empty disables federation attestation for Ethereum mints
+    /// (development only — the engine then uses the dev stub provider).
+    #[serde(default)]
+    pub mint_signers: Vec<String>,
+
+    /// The threshold `t` of distinct federation signatures required to
+    /// authorize an Ethereum wBTH mint (the Safe's own on-chain threshold
+    /// should equal it). Per ADR 0002 this must be no lower than the SCP
+    /// safety threshold in production. Must be >= 1 whenever `mint_signers`
+    /// is non-empty (a zero-threshold federation authorizes nothing).
+    #[serde(default)]
+    pub mint_threshold: u32,
 }
 
 fn default_eth_confirmations() -> u32 {
@@ -171,6 +187,19 @@ pub struct SolanaConfig {
     /// Commitment level
     #[serde(default)]
     pub commitment: SolanaCommitment,
+
+    /// Hex-encoded 32-byte Ed25519 public keys of the mint federation (the
+    /// SCP validators' node keys, per ADR 0002). Every Solana mint
+    /// attestation must be signed by one of these. Empty disables
+    /// federation attestation for Solana mints (development only).
+    #[serde(default)]
+    pub mint_signers: Vec<String>,
+
+    /// The threshold `t` of distinct federation signatures required to
+    /// authorize a Solana wBTH mint. Must be >= 1 whenever `mint_signers`
+    /// is non-empty.
+    #[serde(default)]
+    pub mint_threshold: u32,
 }
 
 /// Bridge-specific settings.
@@ -213,6 +242,24 @@ pub struct BridgeSettings {
     /// Enable testnet mode
     #[serde(default)]
     pub testnet: bool,
+
+    /// Path to this bridge node's Ed25519 attestation signing key (hex,
+    /// 32-byte seed) — its federation identity for BTH releases and Solana
+    /// mints (per ADR 0002, the validator's node key). `None` disables
+    /// local attestation signing.
+    #[serde(default)]
+    pub attestation_ed25519_key_file: Option<String>,
+
+    /// Path to this bridge node's secp256k1 attestation signing key (hex,
+    /// 32 bytes) — its Gnosis Safe owner identity for Ethereum mints.
+    /// `None` disables local Ethereum mint attestation signing.
+    #[serde(default)]
+    pub attestation_secp256k1_key_file: Option<String>,
+
+    /// Path of the persisted attestation nonce store (replay protection
+    /// across restarts). Defaults to `<db_path>.attestation-nonces.json`.
+    #[serde(default)]
+    pub attestation_nonce_file: Option<String>,
 }
 
 fn default_fee_bps() -> u32 {
@@ -308,12 +355,16 @@ impl Default for BridgeConfig {
                 private_key_file: None,
                 confirmations_required: 12,
                 gas_price_strategy: GasPriceStrategy::default(),
+                mint_signers: Vec::new(),
+                mint_threshold: 0,
             },
             solana: SolanaConfig {
                 rpc_url: "http://localhost:8899".to_string(),
                 wbth_program: "11111111111111111111111111111111".to_string(),
                 keypair_file: None,
                 commitment: SolanaCommitment::default(),
+                mint_signers: Vec::new(),
+                mint_threshold: 0,
             },
             bridge: BridgeSettings {
                 mnemonic_file: "bridge_mnemonic.enc".to_string(),
@@ -326,6 +377,9 @@ impl Default for BridgeConfig {
                 order_expiry_minutes: default_order_expiry(),
                 max_retries: default_max_retries(),
                 testnet: false,
+                attestation_ed25519_key_file: None,
+                attestation_secp256k1_key_file: None,
+                attestation_nonce_file: None,
             },
             reserve: ReserveSettings::default(),
         }

--- a/bridge/core/src/lib.rs
+++ b/bridge/core/src/lib.rs
@@ -13,15 +13,23 @@
 pub mod attestation;
 pub mod chains;
 pub mod config;
+pub mod nonce;
 pub mod order;
 
 pub use attestation::{
-    release_payload_digest, AttestationSignature, MintAuthorization, ReleaseAuthorization,
-    SignatureScheme, RELEASE_ATTESTATION_DOMAIN_TAG,
+    attestation_domain, attestation_signed_message, canonical_attestation_envelope,
+    check_attestation_freshness, check_order_binding, mint_payload_digest,
+    parse_attestation_envelope, peek_signer_key_id, peek_target_chain, release_payload_digest,
+    sign_attestation_ed25519, AttestationEnvelope, AttestationKind, AttestationOutcome,
+    AttestationRejectReason, AttestationSet, AttestationSignature, MintAuthorization,
+    ParsedAttestation, ReleaseAuthorization, SignatureScheme, ATTESTATION_ENVELOPE_VERSION,
+    ATTEST_DOMAIN_BTH, ATTEST_DOMAIN_ETH, ATTEST_DOMAIN_SOL, MAX_ATTESTATION_LIFETIME_SECS,
+    RELEASE_ATTESTATION_DOMAIN_TAG,
 };
 pub use chains::{Chain, ChainAddress};
 pub use config::{
     BridgeConfig, BthConfig, EthereumConfig, GasPriceStrategy, ReserveSettings, SolanaCommitment,
     SolanaConfig,
 };
+pub use nonce::{NonceStore, ReserveOutcome};
 pub use order::{derive_order_id, BridgeOrder, OrderStatus, OrderType};

--- a/bridge/core/src/nonce.rs
+++ b/bridge/core/src/nonce.rs
@@ -1,0 +1,368 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Persisted attestation nonce store — the seen-nonce leg of replay
+//! protection for the federation attestation protocol (#824).
+//!
+//! This is a port of the node's operator-action nonce store
+//! (`botho/src/operator_nonce.rs`, #749) into the bridge crates, with the
+//! same guarantees:
+//!
+//! 1. **Single-use nonces.** A `(signer_key_id, nonce)` pair can be
+//!    [`reserve`](NonceStore::reserve)d exactly once; a second attempt is a
+//!    [`ReserveOutcome::Replay`].
+//! 2. **Persistence across restarts.** File-backed stores flush atomically
+//!    (temp file + rename, owner-only permissions) on every successful reserve,
+//!    so a bridge restart inside an attestation's validity window does not
+//!    reopen a replay slot.
+//! 3. **Reserve-then-apply fail-safe.** The verifier reserves the nonce BEFORE
+//!    counting the attestation toward the threshold; a crash in the gap leaves
+//!    the nonce consumed, so a single signed envelope can never count twice.
+//!    The recovery path is a re-signed fresh-nonce envelope.
+//! 4. **Bounded retention.** Expired entries are garbage-collected on every
+//!    reserve, bounding the store by the attestation rate within one validity
+//!    window.
+//!
+//! An [`in_memory`](NonceStore::in_memory) mode exists for tests and for
+//! deployments that have not configured a persistence path — the engine
+//! logs loudly when it falls back to it, because a restart then DOES reopen
+//! replay slots (mitigated by the freshness window).
+
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+/// Current on-disk format version for the nonce store file.
+const NONCE_STORE_VERSION: u32 = 1;
+
+/// The outcome of attempting to [`reserve`](NonceStore::reserve) a nonce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReserveOutcome {
+    /// The nonce was previously unseen and is now recorded (consumed). The
+    /// caller may proceed to count the attestation.
+    Reserved,
+    /// The `(signer_key_id, nonce)` pair was already recorded — this is a
+    /// replay and MUST be rejected by the caller.
+    Replay,
+}
+
+impl ReserveOutcome {
+    /// Convenience: `true` iff the reservation succeeded (fresh nonce).
+    pub fn is_reserved(self) -> bool {
+        matches!(self, ReserveOutcome::Reserved)
+    }
+
+    /// Convenience: `true` iff this was a replay (nonce already seen).
+    pub fn is_replay(self) -> bool {
+        matches!(self, ReserveOutcome::Replay)
+    }
+}
+
+/// Composite key identifying a consumed nonce: the signer identity plus the
+/// nonce. Scoped per signer so two federation members cannot collide. A NUL
+/// separator can never appear in the hex fields, so the join is unambiguous.
+fn store_key(signer_key_id: &str, nonce: &str) -> String {
+    format!("{signer_key_id}\0{nonce}")
+}
+
+/// On-disk representation of the nonce store.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct NonceStoreFile {
+    /// File-format version (currently [`NONCE_STORE_VERSION`]).
+    version: u32,
+    /// Map from composite `store_key` to the entry's `expiresAt` (unix
+    /// seconds). Only the expiry is retained; that is all GC needs.
+    entries: HashMap<String, u64>,
+}
+
+impl Default for NonceStoreFile {
+    fn default() -> Self {
+        Self {
+            version: NONCE_STORE_VERSION,
+            entries: HashMap::new(),
+        }
+    }
+}
+
+/// A persisted, garbage-collected set of consumed attestation nonces.
+#[derive(Debug)]
+pub struct NonceStore {
+    /// `None` for in-memory stores (tests / unconfigured deployments).
+    path: Option<PathBuf>,
+    file: NonceStoreFile,
+}
+
+impl NonceStore {
+    /// Open (or create) the nonce store at `path`.
+    ///
+    /// A missing file yields an empty store (created lazily on the first
+    /// successful reserve). A file that fails to parse is a hard error
+    /// rather than being silently discarded — silently wiping the store
+    /// would reopen every replay slot it was protecting.
+    pub fn open(path: &Path) -> Result<Self, String> {
+        let file = if path.exists() {
+            let contents = std::fs::read_to_string(path)
+                .map_err(|e| format!("failed to read nonce store {}: {}", path.display(), e))?;
+            let parsed: NonceStoreFile = serde_json::from_str(&contents).map_err(|e| {
+                format!(
+                    "failed to parse nonce store {} — refusing to continue with a corrupt \
+                     store rather than silently reopening replay slots: {}",
+                    path.display(),
+                    e
+                )
+            })?;
+            if parsed.version != NONCE_STORE_VERSION {
+                return Err(format!(
+                    "unsupported nonce store version {} at {} (expected {})",
+                    parsed.version,
+                    path.display(),
+                    NONCE_STORE_VERSION
+                ));
+            }
+            parsed
+        } else {
+            NonceStoreFile::default()
+        };
+
+        Ok(Self {
+            path: Some(path.to_path_buf()),
+            file,
+        })
+    }
+
+    /// A store with no persistence. Replay protection holds only within the
+    /// process lifetime; the attestation freshness window bounds the
+    /// residual restart exposure.
+    pub fn in_memory() -> Self {
+        Self {
+            path: None,
+            file: NonceStoreFile::default(),
+        }
+    }
+
+    /// Attempt to consume `(signer_key_id, nonce)`, expiring at `expires_at`
+    /// (unix seconds), treating `now` as the current time for garbage
+    /// collection.
+    ///
+    /// On [`ReserveOutcome::Reserved`] a file-backed store durably persists
+    /// the nonce BEFORE returning — reserve-then-apply is crash-safe. On
+    /// [`ReserveOutcome::Replay`] nothing is written.
+    pub fn reserve(
+        &mut self,
+        signer_key_id: &str,
+        nonce: &str,
+        expires_at: u64,
+        now: u64,
+    ) -> Result<ReserveOutcome, String> {
+        // GC first so bursts never accumulate.
+        self.gc(now);
+
+        let key = store_key(signer_key_id, nonce);
+        if self.file.entries.contains_key(&key) {
+            return Ok(ReserveOutcome::Replay);
+        }
+
+        self.file.entries.insert(key.clone(), expires_at);
+        // Persist BEFORE returning Ok. If the write fails, roll the
+        // in-memory insert back so memory and disk stay consistent — the
+        // caller must treat a non-durable reservation as failure.
+        if let Err(e) = self.persist() {
+            self.file.entries.remove(&key);
+            return Err(e);
+        }
+
+        Ok(ReserveOutcome::Reserved)
+    }
+
+    /// Number of currently-retained (un-GC'd) entries.
+    pub fn len(&self) -> usize {
+        self.file.entries.len()
+    }
+
+    /// Whether the store currently holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.file.entries.is_empty()
+    }
+
+    /// Drop every entry whose `expires_at <= now`.
+    pub fn gc(&mut self, now: u64) {
+        self.file
+            .entries
+            .retain(|_, &mut expires_at| expires_at > now);
+    }
+
+    /// Atomically write the current store to disk with owner-only
+    /// permissions (no-op for in-memory stores). Writes a sibling temp file
+    /// and renames so a crash mid-write can never leave a corrupt store.
+    fn persist(&self) -> Result<(), String> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).map_err(|e| {
+                    format!("failed to create directory {}: {}", parent.display(), e)
+                })?;
+            }
+        }
+
+        let json = serde_json::to_string_pretty(&self.file)
+            .map_err(|e| format!("failed to serialize nonce store: {}", e))?;
+
+        // Unique-ish temp path in the same directory (same filesystem, so
+        // the rename is atomic).
+        let tmp_path = path.with_extension(format!("json.tmp.{}", std::process::id()));
+
+        {
+            use std::io::Write;
+            let mut opts = std::fs::OpenOptions::new();
+            opts.write(true).create(true).truncate(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600);
+            }
+            let mut f = opts.open(&tmp_path).map_err(|e| {
+                format!(
+                    "failed to open temp nonce store {}: {}",
+                    tmp_path.display(),
+                    e
+                )
+            })?;
+            f.write_all(json.as_bytes()).map_err(|e| {
+                format!(
+                    "failed to write temp nonce store {}: {}",
+                    tmp_path.display(),
+                    e
+                )
+            })?;
+            f.sync_all().map_err(|e| {
+                format!(
+                    "failed to fsync temp nonce store {}: {}",
+                    tmp_path.display(),
+                    e
+                )
+            })?;
+        }
+
+        std::fs::rename(&tmp_path, path).map_err(|e| {
+            format!(
+                "failed to rename {} -> {}: {}",
+                tmp_path.display(),
+                path.display(),
+                e
+            )
+        })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SIGNER: &str = "a1b2c3d4e5f60708";
+    const NONCE_A: &str = "9f2c00112233445566778899aabbccdd";
+    const NONCE_B: &str = "0011223344556677889900aabbccddee";
+
+    fn tmp_store_path() -> PathBuf {
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "bth-bridge-nonce-test-{}-{}",
+            std::process::id(),
+            n
+        ));
+        dir.join("attestation-nonces.json")
+    }
+
+    #[test]
+    fn first_reserve_succeeds_replay_is_rejected() {
+        let mut store = NonceStore::in_memory();
+        let now = 1_000;
+        let expires = now + 300;
+
+        assert_eq!(
+            store.reserve(SIGNER, NONCE_A, expires, now).unwrap(),
+            ReserveOutcome::Reserved
+        );
+        assert_eq!(
+            store.reserve(SIGNER, NONCE_A, expires, now).unwrap(),
+            ReserveOutcome::Replay
+        );
+        // Different nonce / different signer are independent.
+        assert!(store
+            .reserve(SIGNER, NONCE_B, expires, now)
+            .unwrap()
+            .is_reserved());
+        assert!(store
+            .reserve("00000000deadbeef", NONCE_A, expires, now)
+            .unwrap()
+            .is_reserved());
+    }
+
+    #[test]
+    fn replay_protection_survives_a_restart_within_the_window() {
+        let path = tmp_store_path();
+        let now = 1_000;
+        let expires = now + 300;
+
+        {
+            let mut store = NonceStore::open(&path).unwrap();
+            assert!(store
+                .reserve(SIGNER, NONCE_A, expires, now)
+                .unwrap()
+                .is_reserved());
+            // `store` drops here — simulating process exit.
+        }
+
+        let now2 = now + 60;
+        let mut reopened = NonceStore::open(&path).unwrap();
+        assert_eq!(
+            reopened.reserve(SIGNER, NONCE_A, expires, now2).unwrap(),
+            ReserveOutcome::Replay,
+            "a restart inside the window must not reopen the replay slot"
+        );
+        // A re-signed fresh-nonce envelope is the recovery path.
+        assert!(reopened
+            .reserve(SIGNER, NONCE_B, expires, now2)
+            .unwrap()
+            .is_reserved());
+
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn expired_entries_are_gcd_on_insert() {
+        let mut store = NonceStore::in_memory();
+        let expires = 1_300u64;
+        for i in 0..100u64 {
+            let nonce = format!("{i:032x}");
+            assert!(store
+                .reserve(SIGNER, &nonce, expires, 1_000)
+                .unwrap()
+                .is_reserved());
+        }
+        assert_eq!(store.len(), 100);
+
+        // Past expiry: the stale entries are GC'd on the next insert.
+        assert!(store
+            .reserve(SIGNER, &format!("{:032x}", 9999u64), 1_600, 1_400)
+            .unwrap()
+            .is_reserved());
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn corrupt_store_file_is_a_hard_error_not_a_silent_wipe() {
+        let path = tmp_store_path();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"this is not json").unwrap();
+        let err = NonceStore::open(&path).unwrap_err();
+        assert!(err.contains("failed to parse nonce store"), "{err}");
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/bridge/service/src/attestation.rs
+++ b/bridge/service/src/attestation.rs
@@ -1,18 +1,72 @@
 // Copyright (c) 2024 The Botho Foundation
 
-//! Attestation provider — the engine's source of [`MintAuthorization`]s.
+//! Attestation provider — the engine's source of [`MintAuthorization`]s and
+//! [`ReleaseAuthorization`]s (#824).
 //!
-//! The real implementation is the #824 validator attestation protocol
-//! (t-of-n threshold signing by the SCP validator federation, ADR 0002),
-//! which mirrors the operator-signed-action envelope/nonce machinery from
-//! P4.4. This module defines the interface the mint engine consumes and a
-//! development stub, so #821 (mint submission) and #824 (signature
-//! collection) can land independently.
+//! Per ADR 0002 the SCP validator set doubles as the bridge's t-of-n
+//! federation. This module implements the validator attestation protocol on
+//! top of the envelope machinery in `bth_bridge_core::attestation`:
+//!
+//! - **Ingest pipeline**
+//!   ([`FederationAttestationProvider::submit_attestation`]): the single seam
+//!   every federation attestation flows through, mirroring the operator-action
+//!   verifier's fail-closed ordering — signer selection (public data only) →
+//!   signature verification over the received, domain-separated bytes →
+//!   parse-after-verify → freshness → durable nonce reserve
+//!   (reserve-then-apply) → order binding → threshold aggregation with
+//!   distinct-signer dedupe.
+//! - **Key domains** (ADR 0002): BTH releases and Solana mints are Ed25519
+//!   (validator node keys); Ethereum mints are secp256k1 — the payload
+//!   signature is a Gnosis Safe owner signature over the EIP-712 SafeTx hash
+//!   wrapping `bridgeMint(to, amount, orderId)` at an attested Safe nonce, so
+//!   the aggregated signatures are directly consumable by
+//!   `Safe.execTransaction`.
+//! - **Local signing**: the bridge node self-attests with its own federation
+//!   keys through the SAME ingest pipeline (its own envelopes get no special
+//!   trust). Envelope transport between federation members is `TODO(#828)`;
+//!   until then a threshold above 1 simply never authorizes — fail-safe, orders
+//!   stay in their confirmed state.
+//!
+//! [`StubAttestationProvider`] remains the development fallback when no
+//! federation is configured, and [`DisabledAttestationProvider`] is the
+//! fail-closed provider installed when a federation is configured but
+//! invalid.
 
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use alloy::{
+    network::TransactionBuilder,
+    primitives::{keccak256, Address, Signature as EcdsaSignature, U256},
+    providers::{DynProvider, Provider, ProviderBuilder},
+    rpc::types::TransactionRequest,
+    signers::{local::PrivateKeySigner, SignerSync},
+    sol_types::SolCall,
+};
 use async_trait::async_trait;
 use bth_bridge_core::{
-    BridgeOrder, Chain, MintAuthorization, ReleaseAuthorization, SignatureScheme,
+    attestation::{
+        canonical_attestation_envelope, check_attestation_freshness, check_order_binding,
+        parse_attestation_envelope, peek_signer_key_id, peek_target_chain,
+        sign_attestation_ed25519, AttestationEnvelope, AttestationKind, AttestationOutcome,
+        AttestationRejectReason, AttestationSet, ParsedAttestation,
+    },
+    attestation_signed_message,
+    nonce::{NonceStore, ReserveOutcome},
+    AttestationSignature, BridgeConfig, BridgeOrder, Chain, MintAuthorization, OrderType,
+    ReleaseAuthorization, SignatureScheme,
 };
+use chrono::Utc;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::mint::ethereum::{encode_bridge_mint_calldata, safe_tx_hash, IGnosisSafe};
+
+/// Validity window the local signer stamps on its own attestations.
+const SELF_ATTESTATION_LIFETIME_SECS: u64 = 120;
 
 /// Source of threshold mint and release authorizations.
 #[async_trait]
@@ -31,7 +85,7 @@ pub trait AttestationProvider: Send + Sync {
     async fn authorize_release(&self, order: &BridgeOrder) -> Result<ReleaseAuthorization, String>;
 }
 
-/// Development stub pending #824.
+/// Development stub used when NO attestation federation is configured.
 ///
 /// Returns an authorization bound to the order's on-chain id with an EMPTY
 /// signature set and threshold 0. This satisfies the local threshold check,
@@ -44,7 +98,6 @@ pub struct StubAttestationProvider;
 #[async_trait]
 impl AttestationProvider for StubAttestationProvider {
     async fn authorize_mint(&self, order: &BridgeOrder) -> Result<MintAuthorization, String> {
-        // TODO(#824): replace with the validator threshold-signing protocol.
         let scheme = match order.dest_chain {
             Chain::Ethereum => SignatureScheme::Secp256k1,
             Chain::Solana => SignatureScheme::Ed25519,
@@ -60,9 +113,6 @@ impl AttestationProvider for StubAttestationProvider {
     }
 
     async fn authorize_release(&self, order: &BridgeOrder) -> Result<ReleaseAuthorization, String> {
-        // TODO(#824): replace with the validator threshold-signing protocol
-        // (Ed25519 signatures over release_payload_digest, mirroring the
-        // operator-signed-action envelope/nonce machinery per ADR 0002).
         if order.dest_chain != Chain::Bth {
             return Err("release authorizations are only for the BTH chain".to_string());
         }
@@ -71,8 +121,8 @@ impl AttestationProvider for StubAttestationProvider {
         // signer count only when the configured federation threshold floor
         // is also 0 (development). Any production configuration
         // (release_threshold >= 1) rejects this stub before any reserve
-        // key material is touched — and release construction itself is
-        // additionally gated on #828.
+        // key material is touched — and BthReleaser::new refuses a zero
+        // threshold outright once release signers are configured (#842).
         Ok(ReleaseAuthorization {
             order_id: order.order_id_bytes(),
             amount: order.net_amount(),
@@ -80,5 +130,1246 @@ impl AttestationProvider for StubAttestationProvider {
             threshold: 0,
             signatures: vec![],
         })
+    }
+}
+
+/// Fail-closed provider installed when an attestation federation is
+/// configured but invalid: every authorization request errors, so orders
+/// stay in their confirmed, retryable state until the operator fixes the
+/// configuration. Never silently downgrades to the permissive stub.
+pub struct DisabledAttestationProvider {
+    reason: String,
+}
+
+impl DisabledAttestationProvider {
+    /// Build a disabled provider carrying the configuration error.
+    pub fn new(reason: String) -> Self {
+        Self { reason }
+    }
+}
+
+#[async_trait]
+impl AttestationProvider for DisabledAttestationProvider {
+    async fn authorize_mint(&self, _order: &BridgeOrder) -> Result<MintAuthorization, String> {
+        Err(format!(
+            "attestation provider disabled (fix the federation configuration): {}",
+            self.reason
+        ))
+    }
+
+    async fn authorize_release(
+        &self,
+        _order: &BridgeOrder,
+    ) -> Result<ReleaseAuthorization, String> {
+        Err(format!(
+            "attestation provider disabled (fix the federation configuration): {}",
+            self.reason
+        ))
+    }
+}
+
+/// Source of the Gnosis Safe's current nonce (the value the SafeTx payload
+/// signatures bind to). Abstracted so tests can inject a fixed nonce.
+#[async_trait]
+pub trait SafeNonceSource: Send + Sync {
+    /// The Safe's current on-chain `nonce()`.
+    async fn safe_nonce(&self) -> Result<u64, String>;
+}
+
+/// Production [`SafeNonceSource`]: reads `Safe.nonce()` over JSON-RPC.
+pub struct RpcSafeNonceSource {
+    provider: DynProvider,
+    safe: Address,
+}
+
+impl RpcSafeNonceSource {
+    /// Build from the configured Ethereum RPC URL and Safe address. Does
+    /// not perform network I/O.
+    pub fn new(rpc_url: &str, safe: Address) -> Result<Self, String> {
+        let url = rpc_url
+            .parse()
+            .map_err(|e| format!("invalid ethereum rpc_url: {}", e))?;
+        Ok(Self {
+            provider: ProviderBuilder::new().connect_http(url).erased(),
+            safe,
+        })
+    }
+}
+
+#[async_trait]
+impl SafeNonceSource for RpcSafeNonceSource {
+    async fn safe_nonce(&self) -> Result<u64, String> {
+        let call = TransactionRequest::default()
+            .with_to(self.safe)
+            .with_input(IGnosisSafe::nonceCall {}.abi_encode());
+        let ret = self
+            .provider
+            .call(call)
+            .await
+            .map_err(|e| format!("safe nonce() call failed: {}", e))?;
+        let nonce = IGnosisSafe::nonceCall::abi_decode_returns(&ret)
+            .map_err(|e| format!("safe nonce() decode failed: {}", e))?;
+        u64::try_from(nonce).map_err(|_| "safe nonce exceeds u64".to_string())
+    }
+}
+
+/// The Ethereum mint federation: Gnosis Safe owners (secp256k1, ADR 0002)
+/// plus the Safe parameters the SafeTx payload digest binds to.
+struct EthFederation {
+    owners: Vec<Address>,
+    threshold: u32,
+    chain_id: u64,
+    safe: Address,
+    wbth: Address,
+    nonce_source: Arc<dyn SafeNonceSource>,
+}
+
+/// An Ed25519 federation (Solana mints / BTH releases: validator node keys).
+struct Ed25519Federation {
+    signers: Vec<VerifyingKey>,
+    threshold: u32,
+}
+
+/// Mutable collection state, behind one lock: the durable nonce store and
+/// the per-`(order, action)` threshold sets.
+struct Tracker {
+    nonces: NonceStore,
+    sets: HashMap<(Uuid, &'static str), AttestationSet>,
+}
+
+/// The real #824 provider: verifies, replay-checks, order-binds, and
+/// aggregates federation attestations to threshold. See the module docs.
+pub struct FederationAttestationProvider {
+    eth: Option<EthFederation>,
+    sol: Option<Ed25519Federation>,
+    bth: Option<Ed25519Federation>,
+    local_ed25519: Option<SigningKey>,
+    local_secp256k1: Option<PrivateKeySigner>,
+    tracker: Mutex<Tracker>,
+}
+
+/// Parse a hex-encoded 32-byte Ed25519 public key list into verifying keys.
+fn parse_ed25519_federation(signers: &[String], what: &str) -> Result<Vec<VerifyingKey>, String> {
+    let mut keys = Vec::with_capacity(signers.len());
+    for hex_key in signers {
+        let bytes: [u8; 32] = hex::decode(hex_key.trim())
+            .map_err(|e| format!("bad {} key hex {}: {}", what, hex_key, e))?
+            .try_into()
+            .map_err(|_| format!("{} key {} is not 32 bytes", what, hex_key))?;
+        keys.push(
+            VerifyingKey::from_bytes(&bytes)
+                .map_err(|e| format!("{} key {} is invalid: {}", what, hex_key, e))?,
+        );
+    }
+    Ok(keys)
+}
+
+/// Enforce a sane federation threshold at construction time: whenever a
+/// federation is configured, a zero (or unsatisfiable) threshold is a
+/// configuration error — a t-of-n federation with t = 0 would authorize
+/// privileged actions with NO signatures (#842).
+fn check_threshold(threshold: u32, n: usize, what: &str) -> Result<(), String> {
+    if threshold == 0 {
+        return Err(format!(
+            "{}: threshold must be >= 1 when signers are configured \
+             (threshold 0 would authorize with no signatures)",
+            what
+        ));
+    }
+    if threshold as usize > n {
+        return Err(format!(
+            "{}: threshold {} exceeds the {} configured signer(s)",
+            what, threshold, n
+        ));
+    }
+    Ok(())
+}
+
+/// The signer identity string for an Ethereum owner address: lowercase hex,
+/// no 0x prefix (40 chars).
+fn eth_signer_key_id(address: &Address) -> String {
+    hex::encode(address.as_slice())
+}
+
+impl FederationAttestationProvider {
+    /// Build the provider from configuration.
+    ///
+    /// Returns `Ok(None)` when NO federation is configured anywhere (pure
+    /// development — the engine falls back to [`StubAttestationProvider`]),
+    /// `Ok(Some(_))` when at least one federation is configured and valid,
+    /// and `Err` when a federation is configured but invalid (the engine
+    /// then installs [`DisabledAttestationProvider`] — never the stub).
+    pub fn from_config(config: &BridgeConfig) -> Result<Option<Self>, String> {
+        let eth_cfg = &config.ethereum;
+        let eth = if eth_cfg.mint_signers.is_empty() {
+            None
+        } else {
+            check_threshold(
+                eth_cfg.mint_threshold,
+                eth_cfg.mint_signers.len(),
+                "ethereum.mint_threshold",
+            )?;
+            let mut owners = Vec::with_capacity(eth_cfg.mint_signers.len());
+            for s in &eth_cfg.mint_signers {
+                owners.push(
+                    s.trim()
+                        .parse::<Address>()
+                        .map_err(|e| format!("bad ethereum mint signer {}: {}", s, e))?,
+                );
+            }
+            let safe: Address = eth_cfg
+                .safe_address
+                .as_deref()
+                .ok_or_else(|| {
+                    "ethereum.safe_address is required for mint attestations (ADR 0002)".to_string()
+                })?
+                .parse()
+                .map_err(|e| format!("invalid safe_address: {}", e))?;
+            let wbth: Address = eth_cfg
+                .wbth_contract
+                .parse()
+                .map_err(|e| format!("invalid wbth_contract: {}", e))?;
+            let nonce_source: Arc<dyn SafeNonceSource> =
+                Arc::new(RpcSafeNonceSource::new(&eth_cfg.rpc_url, safe)?);
+            Some(EthFederation {
+                owners,
+                threshold: eth_cfg.mint_threshold,
+                chain_id: eth_cfg.chain_id,
+                safe,
+                wbth,
+                nonce_source,
+            })
+        };
+
+        let sol = if config.solana.mint_signers.is_empty() {
+            None
+        } else {
+            check_threshold(
+                config.solana.mint_threshold,
+                config.solana.mint_signers.len(),
+                "solana.mint_threshold",
+            )?;
+            Some(Ed25519Federation {
+                signers: parse_ed25519_federation(&config.solana.mint_signers, "solana mint")?,
+                threshold: config.solana.mint_threshold,
+            })
+        };
+
+        let bth = if config.bth.release_signers.is_empty() {
+            None
+        } else {
+            check_threshold(
+                config.bth.release_threshold,
+                config.bth.release_signers.len(),
+                "bth.release_threshold",
+            )?;
+            Some(Ed25519Federation {
+                signers: parse_ed25519_federation(&config.bth.release_signers, "bth release")?,
+                threshold: config.bth.release_threshold,
+            })
+        };
+
+        if eth.is_none() && sol.is_none() && bth.is_none() {
+            return Ok(None);
+        }
+
+        let local_ed25519 = match config.bridge.attestation_ed25519_key_file.as_deref() {
+            Some(path) => {
+                let raw = std::fs::read_to_string(path)
+                    .map_err(|e| format!("cannot read attestation_ed25519_key_file: {}", e))?;
+                let bytes: [u8; 32] = hex::decode(raw.trim())
+                    .map_err(|e| format!("bad ed25519 attestation key hex: {}", e))?
+                    .try_into()
+                    .map_err(|_| "ed25519 attestation key is not 32 bytes".to_string())?;
+                Some(SigningKey::from_bytes(&bytes))
+            }
+            None => None,
+        };
+        let local_secp256k1 = match config.bridge.attestation_secp256k1_key_file.as_deref() {
+            Some(path) => {
+                let raw = std::fs::read_to_string(path)
+                    .map_err(|e| format!("cannot read attestation_secp256k1_key_file: {}", e))?;
+                Some(
+                    raw.trim()
+                        .parse::<PrivateKeySigner>()
+                        .map_err(|e| format!("bad secp256k1 attestation key: {}", e))?,
+                )
+            }
+            None => None,
+        };
+
+        // Durable replay store: a restart inside an attestation's validity
+        // window must not reopen a replay slot.
+        let nonce_path = config
+            .bridge
+            .attestation_nonce_file
+            .clone()
+            .unwrap_or_else(|| format!("{}.attestation-nonces.json", config.bridge.db_path));
+        let nonces = NonceStore::open(std::path::Path::new(&nonce_path))?;
+
+        Ok(Some(Self {
+            eth,
+            sol,
+            bth,
+            local_ed25519,
+            local_secp256k1,
+            tracker: Mutex::new(Tracker {
+                nonces,
+                sets: HashMap::new(),
+            }),
+        }))
+    }
+
+    /// The configured threshold for a target chain's federation.
+    fn threshold_for(&self, chain: Chain) -> Option<u32> {
+        match chain {
+            Chain::Ethereum => self.eth.as_ref().map(|f| f.threshold),
+            Chain::Solana => self.sol.as_ref().map(|f| f.threshold),
+            Chain::Bth => self.bth.as_ref().map(|f| f.threshold),
+        }
+    }
+
+    /// Distinct signers collected so far for `(order, action)`.
+    fn progress(&self, order_id: Uuid, action: &'static str) -> u32 {
+        self.tracker
+            .lock()
+            .expect("tracker lock poisoned")
+            .sets
+            .get(&(order_id, action))
+            .map(|s| s.distinct_signers())
+            .unwrap_or(0)
+    }
+
+    /// Ingest one federation attestation for `order` at the current wall
+    /// clock. This is the RPC seam validators will submit envelopes through
+    /// once inter-node transport lands (`TODO(#828)` — the endpoint routes
+    /// the peeked order id to the on-record order, then calls this).
+    #[allow(dead_code)] // the #828 transport endpoint's entry point
+    pub fn submit_attestation(
+        &self,
+        envelope: &AttestationEnvelope,
+        order: &BridgeOrder,
+    ) -> AttestationOutcome {
+        self.submit_attestation_at(envelope, order, Utc::now().timestamp().max(0) as u64)
+    }
+
+    /// [`submit_attestation`](Self::submit_attestation) with an explicit
+    /// clock, for deterministic tests.
+    pub fn submit_attestation_at(
+        &self,
+        envelope: &AttestationEnvelope,
+        order: &BridgeOrder,
+        now: u64,
+    ) -> AttestationOutcome {
+        let outcome = self.verify_and_aggregate(envelope, order, now);
+        if outcome.accepted {
+            info!(
+                "attestation accepted: order={} action={:?} signer={:?} progress={}/{}",
+                order.id, outcome.action, outcome.signer_key_id, outcome.signers, outcome.threshold
+            );
+        } else {
+            warn!(
+                "attestation refused: order={} tag={} detail={}",
+                order.id, outcome.tag, outcome.message
+            );
+        }
+        outcome
+    }
+
+    /// The fail-closed ingest pipeline. Ordering mirrors the operator-action
+    /// verifier: no secret-dependent step precedes signature verification,
+    /// the nonce is durably reserved BEFORE the attestation can count
+    /// (reserve-then-apply), and every failure is first-failure-wins.
+    fn verify_and_aggregate(
+        &self,
+        envelope: &AttestationEnvelope,
+        order: &BridgeOrder,
+        now: u64,
+    ) -> AttestationOutcome {
+        // Steps 1-2: routing + signer selection over PUBLIC data. The peeks
+        // read unverified bytes but drive no security decision: a lying
+        // value selects a key/domain the signature then fails against.
+        let chain = match peek_target_chain(&envelope.envelope) {
+            Ok(c) => c,
+            Err(r) => return AttestationOutcome::refuse(&r, None, 0, 0),
+        };
+        let Some(threshold) = self.threshold_for(chain) else {
+            return AttestationOutcome::refuse(&AttestationRejectReason::NotConfigured, None, 0, 0);
+        };
+        let signer_key_id = match peek_signer_key_id(&envelope.envelope) {
+            Ok(id) => id,
+            Err(r) => return AttestationOutcome::refuse(&r, None, 0, threshold),
+        };
+
+        // Step 3: signature verification + parse-after-verify, per the
+        // ADR 0002 key domain for the target chain.
+        let refuse = |r: AttestationRejectReason, parsed: Option<&ParsedAttestation>| {
+            let signers = parsed
+                .map(|p| self.progress(p.action.order_uuid(), p.action.name()))
+                .unwrap_or(0);
+            AttestationOutcome::refuse(&r, parsed, signers, threshold)
+        };
+
+        let (parsed, signer_bytes) = match chain {
+            Chain::Ethereum => {
+                let fed = self.eth.as_ref().expect("threshold_for checked eth");
+                let Some(owner) = fed
+                    .owners
+                    .iter()
+                    .find(|a| eth_signer_key_id(a) == signer_key_id)
+                else {
+                    return refuse(AttestationRejectReason::UnknownSigner, None);
+                };
+                match verify_and_parse_secp256k1(envelope, *owner, fed) {
+                    Ok(p) => (p, owner.as_slice().to_vec()),
+                    Err(r) => return refuse(r, None),
+                }
+            }
+            Chain::Solana | Chain::Bth => {
+                let fed = match chain {
+                    Chain::Solana => self.sol.as_ref().expect("threshold_for checked sol"),
+                    _ => self.bth.as_ref().expect("threshold_for checked bth"),
+                };
+                let Some(key) = fed
+                    .signers
+                    .iter()
+                    .find(|k| hex::encode(k.as_bytes()) == signer_key_id)
+                else {
+                    return refuse(AttestationRejectReason::UnknownSigner, None);
+                };
+                match envelope.verify_and_parse_ed25519(key) {
+                    Ok(p) => (p, key.as_bytes().to_vec()),
+                    Err(r) => return refuse(r, None),
+                }
+            }
+        };
+
+        // Step 4: freshness — a captured envelope dies with its window.
+        if let Err(r) = check_attestation_freshness(&parsed, now) {
+            return refuse(r, Some(&parsed));
+        }
+
+        let mut tracker = self.tracker.lock().expect("tracker lock poisoned");
+
+        // Step 5: durable nonce reserve (reserve-then-apply). Each signer
+        // can consume a given nonce exactly once; a crash after the reserve
+        // fails safe (the envelope can never count twice — the signer
+        // re-signs with a fresh nonce).
+        match tracker
+            .nonces
+            .reserve(&parsed.signer_key_id, &parsed.nonce, parsed.expires_at, now)
+        {
+            Ok(ReserveOutcome::Reserved) => {}
+            Ok(ReserveOutcome::Replay) => {
+                drop(tracker);
+                return refuse(AttestationRejectReason::ReplayedNonce, Some(&parsed));
+            }
+            Err(e) => {
+                drop(tracker);
+                return refuse(AttestationRejectReason::Internal(e), Some(&parsed));
+            }
+        }
+
+        // Step 6: order binding — the attestation must match the on-record
+        // order in every field (id, amount, recipient, chains, source tx).
+        if let Err(r) = check_order_binding(&parsed, order) {
+            drop(tracker);
+            return refuse(r, Some(&parsed));
+        }
+
+        // Step 7: threshold aggregation, deduped by signer identity.
+        let payload_sig = match hex::decode(envelope.payload_signature_hex.trim()) {
+            Ok(b) => b,
+            Err(_) => {
+                drop(tracker);
+                return refuse(
+                    AttestationRejectReason::Malformed("payload signature is not hex".to_string()),
+                    Some(&parsed),
+                );
+            }
+        };
+        let set = tracker
+            .sets
+            .entry((order.id, parsed.action.name()))
+            .or_insert_with(|| AttestationSet::for_attestation(&parsed));
+        match set.insert(
+            &parsed,
+            AttestationSignature {
+                signer: signer_bytes,
+                signature: payload_sig,
+            },
+        ) {
+            Ok(_new_signer) => {
+                let signers = set.distinct_signers();
+                drop(tracker);
+                AttestationOutcome::accept(&parsed, signers, threshold)
+            }
+            Err(e) => {
+                let signers = set.distinct_signers();
+                drop(tracker);
+                AttestationOutcome::refuse(
+                    &AttestationRejectReason::InvalidPayload(e),
+                    Some(&parsed),
+                    signers,
+                    threshold,
+                )
+            }
+        }
+    }
+
+    /// Build the [`AttestationKind`] for a mint order.
+    fn mint_kind(order: &BridgeOrder, safe_nonce: Option<u64>) -> Result<AttestationKind, String> {
+        if order.order_type != OrderType::Mint {
+            return Err("not a mint order".to_string());
+        }
+        Ok(AttestationKind::MintWbth {
+            dest_chain: order.dest_chain,
+            dest_address: order.dest_address.clone(),
+            amount: order.net_amount(),
+            order_id: order.id,
+            source_tx: order
+                .source_tx
+                .clone()
+                .ok_or_else(|| "order has no confirmed deposit tx on record".to_string())?,
+            safe_nonce,
+        })
+    }
+
+    /// Build the [`AttestationKind`] for a burn order's release.
+    fn release_kind(order: &BridgeOrder) -> Result<AttestationKind, String> {
+        if order.order_type != OrderType::Burn || order.dest_chain != Chain::Bth {
+            return Err("not a BTH-destined burn order".to_string());
+        }
+        Ok(AttestationKind::ReleaseBth {
+            source_chain: order.source_chain,
+            bth_address: order.dest_address.clone(),
+            amount: order.net_amount(),
+            order_id: order.id,
+            source_tx: order
+                .source_tx
+                .clone()
+                .ok_or_else(|| "order has no confirmed burn tx on record".to_string())?,
+        })
+    }
+
+    /// Self-attest with the local Ed25519 key (Solana mints / BTH releases)
+    /// through the SAME ingest pipeline as any other federation member.
+    fn self_attest_ed25519(
+        &self,
+        kind: &AttestationKind,
+        order: &BridgeOrder,
+    ) -> Result<(), String> {
+        let Some(sk) = &self.local_ed25519 else {
+            return Ok(()); // no local signer — rely on peers (#828)
+        };
+        let my_id = hex::encode(sk.verifying_key().as_bytes());
+        if self.set_contains(order.id, kind.name(), &my_id) {
+            return Ok(()); // already counted; do not burn another nonce
+        }
+
+        let now = Utc::now().timestamp().max(0) as u64;
+        let envelope = sign_attestation_ed25519(
+            kind,
+            sk,
+            &Uuid::new_v4().simple().to_string(),
+            now,
+            now + SELF_ATTESTATION_LIFETIME_SECS,
+        )?;
+        let outcome = self.submit_attestation_at(&envelope, order, now);
+        if !outcome.accepted {
+            return Err(format!(
+                "self-attestation refused ({}): {}",
+                outcome.tag, outcome.message
+            ));
+        }
+        Ok(())
+    }
+
+    fn set_contains(&self, order_id: Uuid, action: &'static str, signer_key_id: &str) -> bool {
+        self.tracker
+            .lock()
+            .expect("tracker lock poisoned")
+            .sets
+            .get(&(order_id, action))
+            .map(|s| s.contains_signer(signer_key_id))
+            .unwrap_or(false)
+    }
+
+    /// If the threshold is met for `(order, action)`, take the collected
+    /// signatures (dropping the set — a later re-authorization, e.g. after
+    /// a reorg unwind, re-collects against fresh chain state).
+    fn take_if_threshold_met(
+        &self,
+        order_id: Uuid,
+        action: &'static str,
+        threshold: u32,
+    ) -> Option<Vec<AttestationSignature>> {
+        let mut tracker = self.tracker.lock().expect("tracker lock poisoned");
+        let met = tracker
+            .sets
+            .get(&(order_id, action))
+            .map(|s| s.is_threshold_met(threshold))
+            .unwrap_or(false);
+        if !met {
+            return None;
+        }
+        tracker
+            .sets
+            .remove(&(order_id, action))
+            .map(|s| s.signatures())
+    }
+}
+
+/// Verify a secp256k1 (Ethereum-domain) attestation envelope against a Safe
+/// owner address and parse it.
+///
+/// - The envelope signature is ECDSA over `keccak256(domain || bytes)`, checked
+///   by address recovery against the expected owner.
+/// - The payload signature is the Gnosis Safe owner signature over the EIP-712
+///   SafeTx hash wrapping `bridgeMint(to, amount, orderId)` at the attested
+///   Safe nonce — exactly the bytes `assemble_safe_signatures` later hands to
+///   `Safe.execTransaction`.
+fn verify_and_parse_secp256k1(
+    envelope: &AttestationEnvelope,
+    expected_owner: Address,
+    fed: &EthFederation,
+) -> Result<ParsedAttestation, AttestationRejectReason> {
+    let env_sig =
+        EcdsaSignature::from_raw(&hex::decode(envelope.signature_hex.trim()).map_err(|_| {
+            AttestationRejectReason::Malformed("signature is not valid hex".to_string())
+        })?)
+        .map_err(|_| {
+            AttestationRejectReason::Malformed("signature is not a 65-byte {r,s,v}".to_string())
+        })?;
+
+    let msg = attestation_signed_message(Chain::Ethereum, envelope.envelope.as_bytes());
+    let recovered = env_sig
+        .recover_address_from_prehash(&keccak256(&msg))
+        .map_err(|_| AttestationRejectReason::BadSignature)?;
+    if recovered != expected_owner {
+        return Err(AttestationRejectReason::BadSignature);
+    }
+
+    // Parse-after-verify: the signature is valid over exactly these bytes.
+    let parsed = parse_attestation_envelope(&envelope.envelope)
+        .map_err(AttestationRejectReason::InvalidPayload)?;
+
+    let AttestationKind::MintWbth {
+        dest_chain: Chain::Ethereum,
+        dest_address,
+        amount,
+        safe_nonce: Some(safe_nonce),
+        ..
+    } = &parsed.action
+    else {
+        return Err(AttestationRejectReason::InvalidPayload(
+            "secp256k1 attestations are only for Ethereum mints".to_string(),
+        ));
+    };
+
+    // The payload signature must be the owner's signature over THIS order's
+    // SafeTx digest (binding chain id, Safe, calldata = order id + amount +
+    // recipient, and the attested Safe nonce).
+    let to: Address = dest_address.parse().map_err(|e| {
+        AttestationRejectReason::InvalidPayload(format!("invalid destAddress: {}", e))
+    })?;
+    let calldata =
+        encode_bridge_mint_calldata(to, U256::from(*amount), parsed.action.order_id_bytes());
+    let digest = safe_tx_hash(
+        fed.chain_id,
+        fed.safe,
+        fed.wbth,
+        &calldata,
+        U256::from(*safe_nonce),
+    );
+    let payload_sig = EcdsaSignature::from_raw(
+        &hex::decode(envelope.payload_signature_hex.trim()).map_err(|_| {
+            AttestationRejectReason::Malformed("payload signature is not valid hex".to_string())
+        })?,
+    )
+    .map_err(|_| {
+        AttestationRejectReason::Malformed("payload signature is not a 65-byte {r,s,v}".to_string())
+    })?;
+    let payload_signer = payload_sig
+        .recover_address_from_prehash(&digest)
+        .map_err(|_| AttestationRejectReason::BadSignature)?;
+    if payload_signer != expected_owner {
+        return Err(AttestationRejectReason::BadSignature);
+    }
+
+    Ok(parsed)
+}
+
+/// Build and secp256k1-sign a complete Ethereum mint attestation envelope
+/// (validator-side tooling; also used by tests). The signer identity is the
+/// lowercase hex of the owner's Ethereum address; the payload signature is
+/// the Safe owner signature over the SafeTx hash at `kind.safe_nonce`.
+pub fn sign_attestation_secp256k1(
+    kind: &AttestationKind,
+    signer: &PrivateKeySigner,
+    chain_id: u64,
+    safe: Address,
+    wbth: Address,
+    nonce: &str,
+    issued_at: u64,
+    expires_at: u64,
+) -> Result<AttestationEnvelope, String> {
+    let AttestationKind::MintWbth {
+        dest_chain: Chain::Ethereum,
+        dest_address,
+        amount,
+        safe_nonce: Some(safe_nonce),
+        ..
+    } = kind
+    else {
+        return Err(
+            "secp256k1 attestations are only for Ethereum mints (with a Safe nonce)".to_string(),
+        );
+    };
+
+    let signer_key_id = eth_signer_key_id(&signer.address());
+    let envelope =
+        canonical_attestation_envelope(kind, &signer_key_id, nonce, issued_at, expires_at);
+
+    let msg = attestation_signed_message(Chain::Ethereum, envelope.as_bytes());
+    let env_sig = signer
+        .sign_hash_sync(&keccak256(&msg))
+        .map_err(|e| format!("envelope signing failed: {}", e))?;
+
+    let to: Address = dest_address
+        .parse()
+        .map_err(|e| format!("invalid destAddress: {}", e))?;
+    let calldata = encode_bridge_mint_calldata(to, U256::from(*amount), kind.order_id_bytes());
+    let digest = safe_tx_hash(chain_id, safe, wbth, &calldata, U256::from(*safe_nonce));
+    let payload_sig = signer
+        .sign_hash_sync(&digest)
+        .map_err(|e| format!("payload signing failed: {}", e))?;
+
+    Ok(AttestationEnvelope {
+        envelope,
+        signature_hex: hex::encode(env_sig.as_bytes()),
+        payload_signature_hex: hex::encode(payload_sig.as_bytes()),
+    })
+}
+
+#[async_trait]
+impl AttestationProvider for FederationAttestationProvider {
+    async fn authorize_mint(&self, order: &BridgeOrder) -> Result<MintAuthorization, String> {
+        match order.dest_chain {
+            Chain::Ethereum => {
+                let fed = self.eth.as_ref().ok_or_else(|| {
+                    "no Ethereum mint federation configured — refusing to authorize (fail-safe)"
+                        .to_string()
+                })?;
+
+                // Self-attest with the local Safe owner key, binding to the
+                // set's Safe nonce (or the current on-chain nonce for a
+                // fresh set) so all collected signatures share one SafeTx.
+                if let Some(signer) = &self.local_secp256k1 {
+                    let my_id = eth_signer_key_id(&signer.address());
+                    if !self.set_contains(order.id, "bridge.mint_wbth", &my_id) {
+                        let safe_nonce = {
+                            let tracker = self.tracker.lock().expect("tracker lock poisoned");
+                            tracker
+                                .sets
+                                .get(&(order.id, "bridge.mint_wbth"))
+                                .and_then(|s| s.safe_nonce())
+                        };
+                        let safe_nonce = match safe_nonce {
+                            Some(n) => n,
+                            None => fed.nonce_source.safe_nonce().await?,
+                        };
+                        let kind = Self::mint_kind(order, Some(safe_nonce))?;
+                        let now = Utc::now().timestamp().max(0) as u64;
+                        let envelope = sign_attestation_secp256k1(
+                            &kind,
+                            signer,
+                            fed.chain_id,
+                            fed.safe,
+                            fed.wbth,
+                            &Uuid::new_v4().simple().to_string(),
+                            now,
+                            now + SELF_ATTESTATION_LIFETIME_SECS,
+                        )?;
+                        let outcome = self.submit_attestation_at(&envelope, order, now);
+                        if !outcome.accepted {
+                            return Err(format!(
+                                "self-attestation refused ({}): {}",
+                                outcome.tag, outcome.message
+                            ));
+                        }
+                    }
+                }
+
+                // TODO(#828): request + ingest envelopes from the other
+                // federation members. Until that transport exists a
+                // threshold above the locally-signable count simply never
+                // authorizes — fail-safe.
+                let collected = self.progress(order.id, "bridge.mint_wbth");
+                match self.take_if_threshold_met(order.id, "bridge.mint_wbth", fed.threshold) {
+                    Some(signatures) => Ok(MintAuthorization {
+                        order_id: order.order_id_bytes(),
+                        scheme: SignatureScheme::Secp256k1,
+                        threshold: fed.threshold,
+                        signatures,
+                    }),
+                    None => Err(format!(
+                        "attestation threshold not met ({}/{} distinct signers); \
+                         federation transport pending #828",
+                        collected, fed.threshold
+                    )),
+                }
+            }
+            Chain::Solana => {
+                let fed = self.sol.as_ref().ok_or_else(|| {
+                    "no Solana mint federation configured — refusing to authorize (fail-safe)"
+                        .to_string()
+                })?;
+                let kind = Self::mint_kind(order, None)?;
+                self.self_attest_ed25519(&kind, order)?;
+
+                // TODO(#828): federation transport (see the Ethereum arm).
+                let collected = self.progress(order.id, "bridge.mint_wbth");
+                match self.take_if_threshold_met(order.id, "bridge.mint_wbth", fed.threshold) {
+                    Some(signatures) => Ok(MintAuthorization {
+                        order_id: order.order_id_bytes(),
+                        scheme: SignatureScheme::Ed25519,
+                        threshold: fed.threshold,
+                        signatures,
+                    }),
+                    None => Err(format!(
+                        "attestation threshold not met ({}/{} distinct signers); \
+                         federation transport pending #828",
+                        collected, fed.threshold
+                    )),
+                }
+            }
+            Chain::Bth => Err("cannot mint to the BTH chain".to_string()),
+        }
+    }
+
+    async fn authorize_release(&self, order: &BridgeOrder) -> Result<ReleaseAuthorization, String> {
+        let fed = self.bth.as_ref().ok_or_else(|| {
+            "no BTH release federation configured — refusing to authorize (fail-safe)".to_string()
+        })?;
+        let kind = Self::release_kind(order)?;
+        self.self_attest_ed25519(&kind, order)?;
+
+        // TODO(#828): federation transport (see authorize_mint).
+        let collected = self.progress(order.id, "bridge.release_bth");
+        match self.take_if_threshold_met(order.id, "bridge.release_bth", fed.threshold) {
+            Some(signatures) => Ok(ReleaseAuthorization {
+                order_id: order.order_id_bytes(),
+                amount: order.net_amount(),
+                recipient: order.dest_address.clone(),
+                threshold: fed.threshold,
+                signatures,
+            }),
+            None => Err(format!(
+                "attestation threshold not met ({}/{} distinct signers); \
+                 federation transport pending #828",
+                collected, fed.threshold
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::B256;
+    use bth_bridge_core::OrderStatus;
+
+    const NOW: u64 = 1_700_000_000;
+
+    fn signing_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn eth_signer(seed: u8) -> PrivateKeySigner {
+        PrivateKeySigner::from_bytes(&B256::from([seed; 32])).unwrap()
+    }
+
+    fn empty_tracker() -> Mutex<Tracker> {
+        Mutex::new(Tracker {
+            nonces: NonceStore::in_memory(),
+            sets: HashMap::new(),
+        })
+    }
+
+    /// Provider with only a BTH release federation (Ed25519).
+    fn bth_provider(
+        keys: &[&SigningKey],
+        threshold: u32,
+        local: Option<SigningKey>,
+    ) -> FederationAttestationProvider {
+        FederationAttestationProvider {
+            eth: None,
+            sol: None,
+            bth: Some(Ed25519Federation {
+                signers: keys.iter().map(|k| k.verifying_key()).collect(),
+                threshold,
+            }),
+            local_ed25519: local,
+            local_secp256k1: None,
+            tracker: empty_tracker(),
+        }
+    }
+
+    struct FixedSafeNonce(u64);
+
+    #[async_trait]
+    impl SafeNonceSource for FixedSafeNonce {
+        async fn safe_nonce(&self) -> Result<u64, String> {
+            Ok(self.0)
+        }
+    }
+
+    const CHAIN_ID: u64 = 1;
+
+    fn safe_addr() -> Address {
+        Address::repeat_byte(0x5a)
+    }
+
+    fn wbth_addr() -> Address {
+        Address::repeat_byte(0xeb)
+    }
+
+    /// Provider with only an Ethereum mint federation (secp256k1 Safe
+    /// owners), reading the Safe nonce from a fixed test source.
+    fn eth_provider(
+        owners: &[&PrivateKeySigner],
+        threshold: u32,
+        safe_nonce: u64,
+        local: Option<PrivateKeySigner>,
+    ) -> FederationAttestationProvider {
+        FederationAttestationProvider {
+            eth: Some(EthFederation {
+                owners: owners.iter().map(|s| s.address()).collect(),
+                threshold,
+                chain_id: CHAIN_ID,
+                safe: safe_addr(),
+                wbth: wbth_addr(),
+                nonce_source: Arc::new(FixedSafeNonce(safe_nonce)),
+            }),
+            sol: None,
+            bth: None,
+            local_ed25519: None,
+            local_secp256k1: local,
+            tracker: empty_tracker(),
+        }
+    }
+
+    fn burn_order() -> BridgeOrder {
+        let mut order = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+            "bth_user_stealth_addr".to_string(),
+            "0xburntx".to_string(),
+        );
+        order.set_status(OrderStatus::BurnConfirmed);
+        order
+    }
+
+    fn eth_mint_order() -> BridgeOrder {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bth_deposit_addr".to_string(),
+            format!("0x{}", hex::encode([0x11u8; 20])),
+        );
+        order.source_tx = Some("bth_deposit_tx".to_string());
+        order.set_status(OrderStatus::DepositConfirmed);
+        order
+    }
+
+    fn sol_mint_order() -> BridgeOrder {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Solana,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bth_deposit_addr".to_string(),
+            "So1anaRecipient1111111111111111111111111111".to_string(),
+        );
+        order.source_tx = Some("bth_deposit_tx".to_string());
+        order.set_status(OrderStatus::DepositConfirmed);
+        order
+    }
+
+    /// Ed25519-sign a release attestation for `order` with `sk`.
+    fn release_envelope(order: &BridgeOrder, sk: &SigningKey, nonce: &str) -> AttestationEnvelope {
+        let kind = FederationAttestationProvider::release_kind(order).unwrap();
+        sign_attestation_ed25519(&kind, sk, nonce, NOW, NOW + 120).unwrap()
+    }
+
+    /// secp256k1-sign an Ethereum mint attestation for `order`.
+    fn eth_mint_envelope(
+        order: &BridgeOrder,
+        signer: &PrivateKeySigner,
+        safe_nonce: u64,
+        nonce: &str,
+    ) -> AttestationEnvelope {
+        let kind = FederationAttestationProvider::mint_kind(order, Some(safe_nonce)).unwrap();
+        sign_attestation_secp256k1(
+            &kind,
+            signer,
+            CHAIN_ID,
+            safe_addr(),
+            wbth_addr(),
+            nonce,
+            NOW,
+            NOW + 120,
+        )
+        .unwrap()
+    }
+
+    // -- Ed25519 (BTH release) pipeline -----------------------------------
+
+    #[test]
+    fn pipeline_accepts_valid_release_attestation_then_rejects_replay() {
+        let (k1, k2) = (signing_key(1), signing_key(2));
+        let provider = bth_provider(&[&k1, &k2], 2, None);
+        let order = burn_order();
+
+        let envelope = release_envelope(&order, &k1, "nonce-a");
+        let outcome = provider.submit_attestation_at(&envelope, &order, NOW);
+        assert!(outcome.accepted, "{}: {}", outcome.tag, outcome.message);
+        assert_eq!((outcome.signers, outcome.threshold), (1, 2));
+
+        // The SAME envelope again: the durable nonce reserve rejects it.
+        let replay = provider.submit_attestation_at(&envelope, &order, NOW);
+        assert!(!replay.accepted);
+        assert_eq!(replay.tag, "refused:replayed_nonce");
+        assert!(replay.authenticated, "replays are post-signature refusals");
+        assert_eq!(provider.progress(order.id, "bridge.release_bth"), 1);
+    }
+
+    #[test]
+    fn pipeline_rejects_unknown_signer_without_counting_it() {
+        let (k1, k2, byzantine) = (signing_key(1), signing_key(2), signing_key(66));
+        let provider = bth_provider(&[&k1, &k2], 2, None);
+        let order = burn_order();
+
+        let envelope = release_envelope(&order, &byzantine, "nonce-b");
+        let outcome = provider.submit_attestation_at(&envelope, &order, NOW);
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.tag, "refused:unknown_signer");
+        assert!(!outcome.authenticated, "unknown signer is pre-signature");
+        assert_eq!(provider.progress(order.id, "bridge.release_bth"), 0);
+    }
+
+    #[test]
+    fn pipeline_rejects_tampered_envelope_bytes() {
+        let k1 = signing_key(1);
+        let provider = bth_provider(&[&k1], 1, None);
+        let order = burn_order();
+
+        let mut envelope = release_envelope(&order, &k1, "nonce-c");
+        // Inflate the attested amount (net = 999_000_000_000 picocredits).
+        let tampered = envelope.envelope.replace("999000000000", "999000000001");
+        assert_ne!(tampered, envelope.envelope, "tamper must change the bytes");
+        envelope.envelope = tampered;
+        let outcome = provider.submit_attestation_at(&envelope, &order, NOW);
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.tag, "refused:bad_signature");
+        assert_eq!(provider.progress(order.id, "bridge.release_bth"), 0);
+    }
+
+    #[test]
+    fn pipeline_rejects_cross_order_reuse_even_with_a_fresh_nonce() {
+        let k1 = signing_key(1);
+        let provider = bth_provider(&[&k1], 1, None);
+        let order_a = burn_order();
+        let order_b = burn_order(); // distinct UUID
+
+        let envelope = release_envelope(&order_a, &k1, "nonce-d");
+        let outcome = provider.submit_attestation_at(&envelope, &order_b, NOW);
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.tag, "refused:wrong_order");
+        assert_eq!(provider.progress(order_b.id, "bridge.release_bth"), 0);
+        assert_eq!(provider.progress(order_a.id, "bridge.release_bth"), 0);
+    }
+
+    #[test]
+    fn pipeline_rejects_expired_attestation() {
+        let k1 = signing_key(1);
+        let provider = bth_provider(&[&k1], 1, None);
+        let order = burn_order();
+
+        let envelope = release_envelope(&order, &k1, "nonce-e");
+        let outcome = provider.submit_attestation_at(&envelope, &order, NOW + 121);
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.tag, "refused:stale");
+    }
+
+    #[test]
+    fn pipeline_refuses_attestation_for_an_unconfigured_target_chain() {
+        let k1 = signing_key(1);
+        // BTH-only provider: a Solana mint attestation has no federation.
+        let provider = bth_provider(&[&k1], 1, None);
+        let order = sol_mint_order();
+        let kind = FederationAttestationProvider::mint_kind(&order, None).unwrap();
+        let envelope = sign_attestation_ed25519(&kind, &k1, "nonce-f", NOW, NOW + 120).unwrap();
+
+        let outcome = provider.submit_attestation_at(&envelope, &order, NOW);
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.tag, "refused:not_configured");
+    }
+
+    #[test]
+    fn pipeline_same_signer_with_fresh_nonces_counts_once_toward_threshold() {
+        let (k1, k2) = (signing_key(1), signing_key(2));
+        let provider = bth_provider(&[&k1, &k2], 2, None);
+        let order = burn_order();
+
+        let first = release_envelope(&order, &k1, "nonce-g1");
+        assert!(provider.submit_attestation_at(&first, &order, NOW).accepted);
+
+        // The same signer re-signs with a FRESH nonce: not a replay, but it
+        // must not double-count.
+        let second = release_envelope(&order, &k1, "nonce-g2");
+        let outcome = provider.submit_attestation_at(&second, &order, NOW);
+        assert!(outcome.accepted);
+        assert_eq!(outcome.signers, 1, "same signer counts once");
+        assert!(provider
+            .take_if_threshold_met(order.id, "bridge.release_bth", 2)
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn authorize_release_meets_threshold_and_output_verifies_downstream() {
+        let (k1, k2, k3) = (signing_key(1), signing_key(2), signing_key(3));
+        // Local signer k1, federation {k1, k2, k3}, threshold 2.
+        let provider = bth_provider(&[&k1, &k2, &k3], 2, Some(k1.clone()));
+        let order = burn_order();
+
+        // 1/2: only the local self-attestation — fail-safe, no authorization.
+        let below = provider.authorize_release(&order).await;
+        assert!(below.is_err());
+        assert!(below.unwrap_err().contains("1/2"), "progress is reported");
+
+        // Peer k2 submits (transport = #828; here injected directly).
+        let peer = release_envelope(&order, &k2, "nonce-h");
+        assert!(provider.submit_attestation_at(&peer, &order, NOW).accepted);
+
+        // 2/2: authorized, with one payload signature per distinct signer.
+        let auth = provider.authorize_release(&order).await.unwrap();
+        assert_eq!(auth.order_id, order.order_id_bytes());
+        assert_eq!(auth.amount, order.net_amount());
+        assert_eq!(auth.recipient, order.dest_address);
+        assert_eq!(auth.threshold, 2);
+        assert_eq!(auth.signatures.len(), 2);
+
+        // End-to-end: the authorization is exactly what the release path's
+        // own validator (#840) accepts against the pinned federation.
+        let federation = vec![k1.verifying_key(), k2.verifying_key(), k3.verifying_key()];
+        crate::release::bth::validate_release_attestation(&order, &auth, &federation, 2)
+            .expect("collected authorization must satisfy the release validator");
+    }
+
+    // -- secp256k1 (Ethereum mint) pipeline --------------------------------
+
+    #[tokio::test]
+    async fn authorize_mint_eth_collects_safe_owner_signatures_to_threshold() {
+        let (o1, o2) = (eth_signer(1), eth_signer(2));
+        let provider = eth_provider(&[&o1, &o2], 2, 7, None);
+        let order = eth_mint_order();
+
+        // Below threshold: fail-safe.
+        let e1 = eth_mint_envelope(&order, &o1, 7, "nonce-i1");
+        assert!(provider.submit_attestation_at(&e1, &order, NOW).accepted);
+        assert!(provider.authorize_mint(&order).await.is_err());
+
+        let e2 = eth_mint_envelope(&order, &o2, 7, "nonce-i2");
+        assert!(provider.submit_attestation_at(&e2, &order, NOW).accepted);
+
+        let auth = provider.authorize_mint(&order).await.unwrap();
+        assert_eq!(auth.scheme, SignatureScheme::Secp256k1);
+        assert_eq!(auth.threshold, 2);
+        assert_eq!(auth.signatures.len(), 2);
+        assert!(auth.meets_threshold());
+
+        // Every collected payload signature is a Safe owner signature over
+        // THIS order's SafeTx digest at the attested Safe nonce — directly
+        // consumable by Safe.execTransaction.
+        let to: Address = order.dest_address.parse().unwrap();
+        let calldata =
+            encode_bridge_mint_calldata(to, U256::from(order.net_amount()), order.order_id_bytes());
+        let digest = safe_tx_hash(
+            CHAIN_ID,
+            safe_addr(),
+            wbth_addr(),
+            &calldata,
+            U256::from(7u64),
+        );
+        let owners: Vec<Address> = vec![o1.address(), o2.address()];
+        for sig in &auth.signatures {
+            let ecdsa = EcdsaSignature::from_raw(&sig.signature).unwrap();
+            let recovered = ecdsa.recover_address_from_prehash(&digest).unwrap();
+            assert!(owners.contains(&recovered));
+            assert_eq!(sig.signer, recovered.as_slice().to_vec());
+        }
+    }
+
+    #[test]
+    fn pipeline_rejects_eth_attestation_at_a_different_safe_nonce() {
+        let (o1, o2) = (eth_signer(1), eth_signer(2));
+        let provider = eth_provider(&[&o1, &o2], 2, 7, None);
+        let order = eth_mint_order();
+
+        let e1 = eth_mint_envelope(&order, &o1, 7, "nonce-j1");
+        assert!(provider.submit_attestation_at(&e1, &order, NOW).accepted);
+
+        // Signatures over different Safe nonces cannot share one
+        // execTransaction — the set refuses to mix them.
+        let e2 = eth_mint_envelope(&order, &o2, 8, "nonce-j2");
+        let outcome = provider.submit_attestation_at(&e2, &order, NOW);
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.tag, "refused:invalid_payload");
+        assert_eq!(provider.progress(order.id, "bridge.mint_wbth"), 1);
+    }
+
+    #[test]
+    fn pipeline_rejects_eth_envelope_from_a_non_owner() {
+        let (o1, byzantine) = (eth_signer(1), eth_signer(66));
+        let provider = eth_provider(&[&o1], 1, 7, None);
+        let order = eth_mint_order();
+
+        let envelope = eth_mint_envelope(&order, &byzantine, 7, "nonce-k");
+        let outcome = provider.submit_attestation_at(&envelope, &order, NOW);
+        assert!(!outcome.accepted);
+        assert_eq!(outcome.tag, "refused:unknown_signer");
+    }
+
+    // -- construction / configuration ---------------------------------------
+
+    #[test]
+    fn from_config_none_when_no_federation_configured() {
+        let config = BridgeConfig::default();
+        assert!(FederationAttestationProvider::from_config(&config)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn from_config_rejects_zero_or_unsatisfiable_threshold() {
+        // #842 at the provider layer: signers with threshold 0 is a
+        // configuration error, never a permissive federation.
+        let mut config = BridgeConfig::default();
+        config.solana.mint_signers = vec![hex::encode(signing_key(1).verifying_key().as_bytes())];
+        config.solana.mint_threshold = 0;
+        let err = FederationAttestationProvider::from_config(&config)
+            .err()
+            .expect("threshold 0 with signers must be refused");
+        assert!(err.contains("threshold must be >= 1"), "{err}");
+
+        config.solana.mint_threshold = 2; // only one signer
+        let err = FederationAttestationProvider::from_config(&config)
+            .err()
+            .expect("threshold above n must be refused");
+        assert!(err.contains("exceeds"), "{err}");
     }
 }

--- a/bridge/service/src/engine.rs
+++ b/bridge/service/src/engine.rs
@@ -9,7 +9,10 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     api,
-    attestation::{AttestationProvider, StubAttestationProvider},
+    attestation::{
+        AttestationProvider, DisabledAttestationProvider, FederationAttestationProvider,
+        StubAttestationProvider,
+    },
     db::Database,
     mint::{ethereum::EthMinter, solana::SolMinter, ConfirmationStatus, Minter},
     release::{bth::BthReleaser, PreparedRelease, ReleaseConfirmation, Releaser},
@@ -84,6 +87,38 @@ impl BridgeEngine {
         }
     }
 
+    /// Build the attestation provider (#824).
+    ///
+    /// - Federation configured and valid → the real
+    ///   [`FederationAttestationProvider`].
+    /// - Federation configured but INVALID → [`DisabledAttestationProvider`]
+    ///   (fail-closed: authorizations error, orders stay retryable). Never
+    ///   silently downgrades to the permissive stub.
+    /// - No federation configured → the development stub.
+    fn build_attestation_provider(config: &BridgeConfig) -> Arc<dyn AttestationProvider> {
+        match FederationAttestationProvider::from_config(config) {
+            Ok(Some(provider)) => {
+                info!("federation attestation provider active (ADR 0002 t-of-n custody)");
+                Arc::new(provider)
+            }
+            Ok(None) => {
+                warn!(
+                    "no attestation federation configured; using the development stub \
+                     provider (threshold 0 — production authorities reject its output)"
+                );
+                Arc::new(StubAttestationProvider)
+            }
+            Err(e) => {
+                error!(
+                    "attestation federation misconfigured: {}; refusing to authorize any \
+                     mint or release until the configuration is fixed",
+                    e
+                );
+                Arc::new(DisabledAttestationProvider::new(e))
+            }
+        }
+    }
+
     /// Run the bridge engine.
     pub async fn run(self) -> Result<(), String> {
         info!("Starting bridge engine");
@@ -130,8 +165,7 @@ impl BridgeEngine {
         // Spawn the order processing loop
         let minters = Self::build_minters(&self.config);
         let releaser = Self::build_releaser(&self.config);
-        // TODO(#824): swap the stub for the validator attestation protocol.
-        let attestation: Arc<dyn AttestationProvider> = Arc::new(StubAttestationProvider);
+        let attestation = Self::build_attestation_provider(&self.config);
         let processor = OrderProcessor::new(
             self.config.clone(),
             self.db.clone(),
@@ -357,6 +391,16 @@ impl OrderProcessor {
             .authorize_mint(order)
             .await
             .map_err(|e| format!("attestation failed: {}", e))?;
+        self.db.log_audit(
+            Some(&order.id),
+            "attestation_authorized",
+            &format!(
+                "action=bridge.mint_wbth chain={} threshold={} signers={}",
+                order.dest_chain,
+                auth.threshold,
+                auth.signatures.len()
+            ),
+        )?;
 
         // Build + sign (no broadcast yet).
         let prepared = minter
@@ -610,6 +654,15 @@ impl OrderProcessor {
             .authorize_release(order)
             .await
             .map_err(|e| format!("attestation failed: {}", e))?;
+        self.db.log_audit(
+            Some(&order.id),
+            "attestation_authorized",
+            &format!(
+                "action=bridge.release_bth threshold={} signers={}",
+                auth.threshold,
+                auth.signatures.len()
+            ),
+        )?;
 
         // Build + threshold-sign (no broadcast yet). Nothing was recorded
         // in the claim, so a failure here (including the #828

--- a/bridge/service/src/release/bth.rs
+++ b/bridge/service/src/release/bth.rs
@@ -198,6 +198,21 @@ impl BthReleaser {
             )));
         }
 
+        // #842: a configured federation with threshold 0 would accept an
+        // authorization carrying ZERO signatures (0 distinct signers >=
+        // threshold 0) — i.e. an enabled releaser that spends the reserve
+        // with no federation authorization at all. Refuse at construction;
+        // burn orders then stay BurnConfirmed like any other misconfig.
+        // (threshold 0 with NO signers remains the documented dev-only
+        // no-pinning mode.)
+        if !federation.is_empty() && config.release_threshold == 0 {
+            return Err(ReleaseError::Config(
+                "release_threshold must be >= 1 when release_signers are configured \
+                 (threshold 0 would authorize reserve spends with no signatures)"
+                    .to_string(),
+            ));
+        }
+
         Ok(Self { config, federation })
     }
 
@@ -529,6 +544,19 @@ mod tests {
             BthReleaser::new(cfg),
             Err(ReleaseError::Config(_))
         ));
+
+        // #842: a configured federation with threshold 0 must be refused —
+        // it would authorize reserve spends with zero signatures.
+        let cfg = test_config(&[&k1, &k2], 0);
+        assert!(matches!(
+            BthReleaser::new(cfg),
+            Err(ReleaseError::Config(_))
+        ));
+
+        // The documented dev-only escape hatch (no signers, threshold 0)
+        // still constructs.
+        let cfg = test_config(&[], 0);
+        assert!(BthReleaser::new(cfg).is_ok());
     }
 
     #[tokio::test]

--- a/bridge/service/src/watchers/ethereum.rs
+++ b/bridge/service/src/watchers/ethereum.rs
@@ -748,6 +748,8 @@ mod tests {
             private_key_file: None,
             confirmations_required,
             gas_price_strategy: Default::default(),
+            mint_signers: Vec::new(),
+            mint_threshold: 0,
         };
         let (_tx, rx) = broadcast::channel(1);
         (EthereumWatcher::new(config, db.clone(), rx), db)


### PR DESCRIPTION
Closes #824
Closes #842

Part of the bridge epic #816 (ADR 0002 custody). Implements the t-of-n federation attestation protocol: SCP validators sign domain-separated, order-bound, single-use envelopes over confirmed deposits/burns; the bridge verifies, replay-checks, order-binds, and aggregates them to threshold into the `MintAuthorization` / `ReleaseAuthorization` artifacts the mint (#838) and release (#840) paths already consume.

## Implemented (real, tested)

**`bridge/core/src/attestation.rs` — envelope protocol** (mirrors `operator_action.rs`, P4.4)
- `AttestationKind` v1 allowlist: `bridge.mint_wbth` / `bridge.release_bth`, each carrying chain, recipient, amount, order UUID, finalized source tx (+ the Safe nonce for Ethereum mints).
- Per-target-chain envelope domains (`botho-bridge-attest-{eth,sol,bth}-v1`): a signature over one chain's envelope can never verify under another's (cross-domain binding).
- Canonical-JSON envelope with parse-after-verify: verification is over the received bytes; the parser rejects unknown/duplicate keys (at every nesting level), non-integer numerics, non-canonical chain aliases, and unknown versions — one signed byte string can never carry two logical attestations.
- Two detached signatures per envelope: the domain-separated envelope signature (authenticates nonce/freshness/action) and the chain-specific **payload** signature (`release_payload_digest`, `mint_payload_digest`, or the Gnosis Safe EIP-712 SafeTx hash) — the payload signature is what survives into the authorization and is re-verified by the mint/release path before any privileged action.
- Freshness window (300s max lifetime, 30s skew, saturating arithmetic), `check_order_binding` (order id, net amount, recipient, chains, source tx all must match the on-record order), `AttestationSet` (distinct-signer dedupe; Ethereum sets refuse to mix Safe nonces; threshold 0 never authorizes), rejection taxonomy with authenticated/pre-signature split.

**`bridge/core/src/nonce.rs` — durable replay store** (port of `botho/src/operator_nonce.rs`)
- Reserve-then-apply `(signer, nonce)` consumption, atomic owner-only persistence, GC by expiry, corrupt-store = hard error (never a silent wipe).

**`bridge/service/src/attestation.rs` — `FederationAttestationProvider`**
- Fail-closed ingest pipeline (`submit_attestation`): peek routing (public data only) → signature verify per ADR 0002 key domain → parse-after-verify → freshness → durable nonce reserve → order binding → threshold aggregation.
- Key domains per ADR 0002: **Ed25519** (`verify_strict`) for BTH releases + Solana mints; **secp256k1** for Ethereum mints — the payload signature is a Safe owner signature over the EIP-712 SafeTx hash wrapping `bridgeMint(to, amount, orderId)` at the attested Safe nonce, so aggregated signatures are directly consumable by `Safe.execTransaction` (via the existing `safe_tx_hash` helper).
- Local self-attestation goes through the SAME pipeline (no special trust for the node's own envelopes).
- Config: `ethereum.mint_signers`/`mint_threshold`, `solana.mint_signers`/`mint_threshold` (BTH release federation reuses the existing #840 `bth.release_*` fields), local signing key paths, nonce-store path. Misconfiguration installs a fail-closed `DisabledAttestationProvider` — never the permissive dev stub.

**#842 — `BthReleaser::new`** now refuses `release_threshold == 0` when release signers are configured (a zero-threshold federation would authorize reserve spends with zero signatures). The documented dev-only escape hatch (no signers at all) still constructs. Same guard at provider construction (`check_threshold`).

**Engine**: provider selection (federation / disabled / stub) replaces the #824 TODO; every threshold authorization is audit-logged with action, threshold, and signer count.

## Stubbed (fail-safe)

- **Network transport between federation members is TODO(#828)**: `submit_attestation` is the ingest seam the transport endpoint will call; until it lands, a threshold above the locally-signable count simply never authorizes — orders stay in their confirmed, retryable state. No permissive fallback.
- Per-attestation JSONL audit entries ride the tracing log for now; the DB audit row is written at authorization time. Full per-envelope audit persistence can move into the #828 endpoint where the DB handle lives.

## Test Plan

- [x] `cargo test -p bth-bridge-core -p bth-bridge-service` — 119 passed, 0 failed (40 core + 79 service)
- [x] `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets` — 0 warnings
- [x] `cargo +nightly-2025-12-03 fmt --check` — clean
- [x] `cargo deny check advisories` — ok (Cargo.lock adds only the workspace `ed25519-dalek` edge to `bth-bridge-core`)

Coverage of the issue's required adversarial/property tests:
- **Replay**: same envelope twice → `refused:replayed_nonce`; nonce store reopen within the window keeps the slot closed (`nonce::tests::replay_protection_survives_a_restart_within_the_window`).
- **Cross-order reuse**: envelope for order A vs order B → `refused:wrong_order`, even with a fresh nonce (core + pipeline tests).
- **Cross-domain reuse**: signatures fail across BTH/Solana/Ethereum domains; Ethereum-target envelopes are refused on the Ed25519 path (core tests).
- **Below threshold**: t−1 distinct signers never authorize; the t-th flips it (`authorize_release_meets_threshold_and_output_verifies_downstream`, `authorize_mint_eth_collects_safe_owner_signatures_to_threshold`).
- **Byzantine signer**: non-federation key → `refused:unknown_signer` (doesn't count); tampered bytes → `refused:bad_signature`.
- **Double-count resistance**: same signer, fresh nonces → counts once toward t.
- **End-to-end**: a collected `ReleaseAuthorization` passes the release path's own `validate_release_attestation` (#840), and every collected Ethereum payload signature recovers to a Safe owner over the exact SafeTx digest.
- **Structural attacks**: duplicate keys, unknown fields, float amounts, chain aliases, version downgrades all rejected before parse output is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)