### PR TITLE
feat(contracts): harden WrappedBTH.sol — Safe custody, order-id replay guard, auto-pause breaker

### DIFF
--- a/bridge/service/src/mint/ethereum.rs
+++ b/bridge/service/src/mint/ethereum.rs
@@ -13,9 +13,9 @@
 //! ```
 //!
 //! The `bytes32` order id (`BridgeOrder::order_id_bytes`) is the on-chain
-//! idempotency key. NOTE: `WrappedBTH.sol` currently names this parameter
-//! `bthTxHash`; #826 renames it to `orderId` and adds the duplicate-order
-//! guard. The ABI (selector) is unchanged by that rename.
+//! idempotency key: `WrappedBTH.sol` records it in `processedOrders` and
+//! reverts on a duplicate (#826), closing the double-mint window even if
+//! an authorization is re-submitted.
 
 use alloy::{
     eips::{eip2718::Encodable2718, BlockNumberOrTag},
@@ -39,9 +39,8 @@ sol! {
     /// Typed binding for the wBTH token (`contracts/ethereum/contracts/WrappedBTH.sol`).
     #[allow(missing_docs)]
     interface IWrappedBTH {
-        /// #826 renames `bthTxHash` -> `orderId`; the selector is identical.
-        function bridgeMint(address to, uint256 amount, bytes32 bthTxHash) external;
-        event BridgeMint(address indexed to, uint256 amount, bytes32 indexed bthTxHash);
+        function bridgeMint(address to, uint256 amount, bytes32 orderId) external;
+        event BridgeMint(address indexed to, uint256 amount, bytes32 indexed orderId);
     }
 
     /// Gnosis Safe (v1.3+) surface used by the bridge.
@@ -90,7 +89,7 @@ pub fn encode_bridge_mint_calldata(to: Address, amount: U256, order_id: [u8; 32]
     IWrappedBTH::bridgeMintCall {
         to,
         amount,
-        bthTxHash: B256::from(order_id),
+        orderId: B256::from(order_id),
     }
     .abi_encode()
 }
@@ -205,7 +204,7 @@ pub fn find_bridge_mint_event(logs: &[Log], wbth: Address, order_id: [u8; 32]) -
     logs.iter().any(|log| {
         log.address() == wbth
             && log.topic0() == Some(&IWrappedBTH::BridgeMint::SIGNATURE_HASH)
-            // topics: [signature, to (indexed), bthTxHash/orderId (indexed)]
+            // topics: [signature, to (indexed), orderId (indexed)]
             && log.topics().get(2) == Some(&order_topic)
     })
 }
@@ -572,7 +571,7 @@ mod tests {
         let decoded = IWrappedBTH::bridgeMintCall::abi_decode(&calldata).unwrap();
         assert_eq!(decoded.to, to);
         assert_eq!(decoded.amount, amount);
-        assert_eq!(decoded.bthTxHash, B256::from(order_id));
+        assert_eq!(decoded.orderId, B256::from(order_id));
     }
 
     #[test]

--- a/contracts/ethereum/.gitignore
+++ b/contracts/ethereum/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+artifacts/
+cache/
+typechain-types/
+coverage/
+coverage.json
+.env
+package-lock.json

--- a/contracts/ethereum/README.md
+++ b/contracts/ethereum/README.md
@@ -1,0 +1,86 @@
+# wBTH — Wrapped BTH on Ethereum
+
+`WrappedBTH.sol` is the ERC-20 token minted 1:1 against BTH locked in the
+bridge reserve (epic #816). One wBTH base unit equals one picocredit
+(`decimals() == 12`); no scaling happens anywhere across the bridge boundary.
+
+## Security model (decided in #826)
+
+### Custody — ADR 0002
+
+No single key can mint. Roles are granted at deployment to Gnosis Safes,
+never to EOAs, and the deployer receives no roles:
+
+| Role | Holder | Purpose |
+|------|--------|---------|
+| `MINTER_ROLE` | Validator Safe (t-of-n secp256k1, owners = SCP validators; t ≥ SCP safety threshold) | The only mint path: `Safe.execTransaction → bridgeMint` with threshold owner signatures from the #824 attestation |
+| `DEFAULT_ADMIN_ROLE` | Governance Safe (distinct from the validator Safe) | Rate-limit / breaker configuration, role administration |
+| `PAUSER_ROLE` | Guardian Safe (may be lower-threshold) | Fast `pause()` / `unpause()` — fail-safe only, cannot move funds |
+
+Record the concrete Safe addresses + thresholds here per deployment:
+
+| Network | wBTH | Admin Safe | Minter Safe | Pauser Safe |
+|---------|------|-----------|-------------|-------------|
+| (none deployed yet) | | | | |
+
+### Replay-proof, order-bound minting
+
+`bridgeMint(to, amount, orderId)` consumes a unique `bytes32` order id
+(the bridge order id from the attestation protocol, #824) recorded in
+`processedOrders`. A duplicate reverts — this is the on-chain guard that
+closes the residual double-mint window even if the off-chain service
+retries or is compromised into re-submitting an authorization. The
+function/event ABI is bound by `bridge/service/src/mint/ethereum.rs`
+(`bridgeMint(address,uint256,bytes32)`, `BridgeMint` with indexed `to` and
+`orderId`); do not change these signatures without updating the Rust side.
+
+### Upgradeability — immutable, no proxy
+
+The contract is deliberately not upgradeable. A proxy admin is a rug
+vector that would negate the Safe-threshold custody model (whoever can
+upgrade can mint), contrary to the project's no-hard-forks / minimal-trust
+posture. Trade-off: bugs are handled by `pause()`, deploying a corrected
+token, and migrating balances through the bridge itself (burn on old,
+mint on new). Accepted and documented in the contract NatSpec.
+
+### Rate limits + circuit breaker
+
+- `maxMintPerTx` (default 1M BTH) and `dailyMintLimit` (default 10M BTH),
+  both in picocredits; the daily counter lazily resets on the first mint
+  of a later UTC day (correct across multi-day gaps).
+- **Auto-pause breaker:** when cumulative daily volume reaches
+  `autoPauseThreshold` (default = the daily limit; 0 disables), the
+  contract pauses itself — anomalous volume becomes a hard stop requiring
+  guardian review, not just a revert. The service-side breaker (#827)
+  complements this.
+- The per-recipient mint cooldown was removed: recipient rotation
+  bypassed it trivially, while honest multi-order throughput was griefed.
+
+### Burn path
+
+`bridgeBurn(amount, bthAddress)` is the only burn path; it emits the
+`BridgeBurn` event that authorizes the native-chain release (watched by
+`bridge/service/src/watchers/ethereum.rs`). The open ERC20Burnable
+surface was removed because a plain `burn` destroys wBTH without a
+redemption destination, stranding locked reserve and breaking the supply
+invariant `totalSupply == Σ mints − Σ event-bearing burns`.
+
+### Reentrancy
+
+OpenZeppelin ERC-20 v5 `_mint`/`_burn` make no external calls (no
+ERC-777 hooks), so no reentrant path exists today. Defense-in-depth:
+strict checks-effects-interactions ordering plus `ReentrancyGuard` on
+both bridge entrypoints, so the property survives future edits.
+
+## Development
+
+```bash
+npm install
+npm run compile
+npm test
+```
+
+The test suite covers access control (Safe-only mint, no deployer
+roles), order-id replay, rate limits + daily reset boundaries, pause +
+auto-pause breaker, decimals/unit pinning against the Rust bindings, and
+a randomized supply-accounting invariant run.

--- a/contracts/ethereum/contracts/WrappedBTH.sol
+++ b/contracts/ethereum/contracts/WrappedBTH.sol
@@ -2,118 +2,239 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /**
  * @title WrappedBTH
- * @dev Wrapped BTH (wBTH) ERC-20 token for bridging BTH to Ethereum.
+ * @notice Wrapped BTH (wBTH) ERC-20 token for bridging BTH to Ethereum.
  *
- * Key features:
- * - 12 decimals (matches BTH's picocredits base unit)
- * - Minting controlled by bridge operator (MINTER_ROLE)
- * - Users can burn to redeem BTH on the native chain
- * - Rate limiting for security (daily caps, per-tx limits)
- * - Pausable for emergency situations
+ * @dev Key properties:
+ * - 12 decimals: 1 wBTH base unit == 1 picocredit, 1:1 with native BTH.
+ *   All amounts (including `maxMintPerTx` / `dailyMintLimit`) are raw
+ *   picocredits with no additional scaling anywhere across the bridge
+ *   boundary.
+ * - Minting is order-bound and replay-proof: every `bridgeMint` consumes a
+ *   unique `orderId` (the bridge order id from the attestation protocol,
+ *   see #824) recorded in `processedOrders`. A duplicate order id reverts,
+ *   closing the double-mint window even if the off-chain service retries
+ *   or is compromised into re-submitting an authorization.
+ * - Burning to redeem native BTH is ONLY possible via `bridgeBurn`, which
+ *   emits the `BridgeBurn` event the bridge watchers rely on. The open
+ *   ERC20Burnable surface (`burn`/`burnFrom`) was deliberately removed: a
+ *   plain burn destroys wBTH without a redemption destination, silently
+ *   stranding the corresponding locked BTH reserve and breaking the
+ *   watcher-tracked supply invariant (totalSupply == sum(mints) - sum(burns
+ *   with a BridgeBurn event)).
+ *
+ * ## Custody (ADR 0002)
+ * Per ADR 0002 (docs/decisions/0002-bridge-custody-scp-validator-federation.md)
+ * the mint authority is the SCP validator federation operating a Gnosis Safe
+ * whose owners are the validators' secp256k1 keys:
+ * - `MINTER_ROLE` is granted at deployment to the validator Gnosis Safe
+ *   (t-of-n, with t no lower than the SCP safety threshold). Threshold
+ *   enforcement lives in the Safe, NOT in this contract — no single EOA can
+ *   ever hold a mint path in the deployed configuration.
+ * - `DEFAULT_ADMIN_ROLE` (rate-limit / breaker configuration, role
+ *   administration) is granted to a SEPARATE governance Safe so that
+ *   parameter changes and minting cannot be authorized by the same quorum.
+ * - `PAUSER_ROLE` is granted to a guardian Safe that may use a LOWER
+ *   threshold than the mint quorum: pausing is a fail-safe action (it can
+ *   only halt the bridge, never move funds), so fast incident response is
+ *   preferred over a high bar.
+ * The deployer receives NO roles. Safe addresses and thresholds for each
+ * deployment are recorded in contracts/ethereum/README.md.
+ *
+ * ## Upgradeability: immutable (no proxy)
+ * This contract is deliberately NOT upgradeable. Rationale (mirrors the
+ * project's no-hard-forks / minimal-trust posture):
+ * - A proxy admin key is a rug vector: whoever can upgrade can mint or
+ *   freeze at will, which negates the Safe-threshold custody model.
+ * - The contract's job is small and stable (mint/burn/limits/pause); bugs
+ *   are handled by pausing, deploying a corrected token, and migrating
+ *   balances via the bridge itself (burn on old, mint on new).
+ * The trade-off (redeployment instead of in-place fixes) is accepted and
+ * documented in contracts/ethereum/README.md.
+ *
+ * ## Reentrancy
+ * Neither `_mint` nor `_burn` in OpenZeppelin ERC-20 v5 performs external
+ * calls (no ERC-777 style hooks), so there is no reentrant path today.
+ * Defense-in-depth is still applied: strict checks-effects-interactions
+ * ordering (all rate-limit and replay-guard state is written BEFORE
+ * `_mint`/`_burn`) plus OpenZeppelin `ReentrancyGuard` on both bridge
+ * entrypoints, so the properties survive future modifications.
+ *
+ * ## Rate limiting & circuit breaker
+ * - `maxMintPerTx` caps any single mint.
+ * - `dailyMintLimit` caps mints per UTC day (day = block.timestamp / 1 days;
+ *   the counter lazily resets on the first mint of a later day, which is
+ *   correct across multi-day gaps).
+ * - Auto-pause breaker: when cumulative daily mints reach
+ *   `autoPauseThreshold`, the contract pauses itself (the triggering mint
+ *   still succeeds — it is within the daily limit) and requires the
+ *   guardian to investigate and unpause. This converts "anomalous volume"
+ *   from a soft revert into a hard stop. Set to 0 to disable; defaults to
+ *   `dailyMintLimit`.
+ * - The previous per-recipient mint cooldown was REMOVED: an attacker
+ *   trivially bypasses it by rotating recipient addresses, while it griefs
+ *   honest throughput (two legitimate orders to the same recipient within
+ *   the window would fail). It provided no security beyond the per-tx and
+ *   daily caps above.
  */
-contract WrappedBTH is ERC20, ERC20Burnable, AccessControl, Pausable {
+contract WrappedBTH is ERC20, AccessControl, Pausable, ReentrancyGuard {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
-    // BTH has 12 decimals (picocredits), we match this for 1:1 mapping
+    /// @dev BTH has 12 decimals (picocredits); wBTH matches for a 1:1 peg.
     uint8 private constant DECIMALS = 12;
 
-    // Rate limiting configuration
-    uint256 public mintCooldown = 1 minutes;
+    // ------------------------------------------------------------------
+    // Rate limiting / circuit breaker configuration (picocredits)
+    // ------------------------------------------------------------------
+
+    /// @notice Maximum amount a single `bridgeMint` may mint.
     uint256 public maxMintPerTx = 1_000_000 * 10 ** 12; // 1M BTH
+
+    /// @notice Maximum cumulative amount mintable per UTC day.
     uint256 public dailyMintLimit = 10_000_000 * 10 ** 12; // 10M BTH
 
-    // Rate limiting state
-    mapping(address => uint256) public lastMintTime;
+    /// @notice When `dailyMinted` reaches this value the contract
+    ///         auto-pauses (0 disables the breaker).
+    uint256 public autoPauseThreshold = 10_000_000 * 10 ** 12;
+
+    // ------------------------------------------------------------------
+    // Rate limiting / replay-guard state
+    // ------------------------------------------------------------------
+
+    /// @notice Cumulative amount minted during the current UTC day.
     uint256 public dailyMinted;
+
+    /// @notice UTC day index (block.timestamp / 1 days) of the last reset.
     uint256 public lastResetDay;
 
-    // Events for bridge monitoring
-    event BridgeMint(
-        address indexed to,
-        uint256 amount,
-        bytes32 indexed bthTxHash
-    );
+    /// @notice Replay guard: order ids that have already been minted.
+    mapping(bytes32 => bool) public processedOrders;
 
-    event BridgeBurn(
-        address indexed from,
-        uint256 amount,
-        string bthAddress
-    );
+    // ------------------------------------------------------------------
+    // Events (bridge watchers bind these signatures — do not change them
+    // without updating bridge/service/src/mint/ethereum.rs and
+    // bridge/service/src/watchers/ethereum.rs)
+    // ------------------------------------------------------------------
 
+    /// @notice Emitted on every successful mint, bound to the bridge order.
+    /// @dev Signature `BridgeMint(address,uint256,bytes32)` with `to` and
+    ///      `orderId` indexed is relied upon by the mint confirmation logic.
+    event BridgeMint(address indexed to, uint256 amount, bytes32 indexed orderId);
+
+    /// @notice Emitted on every burn-for-redemption; `bthAddress` is the
+    ///         native-chain destination (resolved to a fresh one-time
+    ///         stealth address by the bridge, per ADR 0004).
+    event BridgeBurn(address indexed from, uint256 amount, string bthAddress);
+
+    /// @notice Emitted whenever a limit or the breaker threshold changes.
     event RateLimitUpdated(
-        uint256 mintCooldown,
         uint256 maxMintPerTx,
-        uint256 dailyMintLimit
+        uint256 dailyMintLimit,
+        uint256 autoPauseThreshold
     );
 
-    constructor() ERC20("Wrapped BTH", "wBTH") {
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _grantRole(MINTER_ROLE, msg.sender);
-        _grantRole(PAUSER_ROLE, msg.sender);
+    /// @notice Emitted when the auto-pause circuit breaker trips.
+    event AutoPaused(uint256 dailyMinted, uint256 threshold);
+
+    /**
+     * @param adminSafe  Governance Safe: role administration + limit/breaker
+     *                   configuration (`DEFAULT_ADMIN_ROLE`).
+     * @param minterSafe Validator Gnosis Safe (t-of-n secp256k1, ADR 0002):
+     *                   the ONLY mint authority (`MINTER_ROLE`).
+     * @param pauserSafe Guardian Safe (may be lower-threshold for fast
+     *                   incident response): pause/unpause (`PAUSER_ROLE`).
+     * @dev The deployer receives no roles; distinct Safes are strongly
+     *      recommended so configuration, minting and pausing require
+     *      different quorums.
+     */
+    constructor(
+        address adminSafe,
+        address minterSafe,
+        address pauserSafe
+    ) ERC20("Wrapped BTH", "wBTH") {
+        require(adminSafe != address(0), "Invalid admin");
+        require(minterSafe != address(0), "Invalid minter");
+        require(pauserSafe != address(0), "Invalid pauser");
+
+        _grantRole(DEFAULT_ADMIN_ROLE, adminSafe);
+        _grantRole(MINTER_ROLE, minterSafe);
+        _grantRole(PAUSER_ROLE, pauserSafe);
         lastResetDay = block.timestamp / 1 days;
     }
 
     /**
-     * @dev Returns the number of decimals (12 to match BTH).
+     * @notice Returns 12 — one wBTH base unit is one picocredit (1:1 BTH).
      */
     function decimals() public pure override returns (uint8) {
         return DECIMALS;
     }
 
     /**
-     * @dev Mint wBTH when BTH is deposited to the bridge.
-     * @param to Recipient address
-     * @param amount Amount in picocredits (12 decimals)
-     * @param bthTxHash BTH transaction hash for tracking
+     * @notice Mint wBTH for a locked-BTH bridge order.
+     * @dev Only callable by the validator Safe (`MINTER_ROLE`). Replay-proof:
+     *      each `orderId` can be minted exactly once. All state (replay
+     *      guard, daily accounting) is written before `_mint`
+     *      (checks-effects-interactions).
+     * @param to Recipient address.
+     * @param amount Amount in picocredits (12 decimals), no extra scaling.
+     * @param orderId Unique bridge order id (attestation-bound, see #824);
+     *        the on-chain idempotency key.
      */
     function bridgeMint(
         address to,
         uint256 amount,
-        bytes32 bthTxHash
-    ) external onlyRole(MINTER_ROLE) whenNotPaused {
+        bytes32 orderId
+    ) external onlyRole(MINTER_ROLE) whenNotPaused nonReentrant {
         require(to != address(0), "Invalid recipient");
         require(amount > 0, "Amount must be positive");
         require(amount <= maxMintPerTx, "Exceeds max mint per tx");
-        require(
-            block.timestamp >= lastMintTime[to] + mintCooldown,
-            "Cooldown active"
-        );
+        require(orderId != bytes32(0), "Invalid order id");
+        require(!processedOrders[orderId], "Order already processed");
 
-        // Reset daily limit if new day
+        // Lazily reset the daily counter on the first mint of a later day
+        // (strictly-greater comparison, so multi-day gaps reset correctly).
         uint256 today = block.timestamp / 1 days;
         if (today > lastResetDay) {
             dailyMinted = 0;
             lastResetDay = today;
         }
 
-        require(
-            dailyMinted + amount <= dailyMintLimit,
-            "Daily limit exceeded"
-        );
+        require(dailyMinted + amount <= dailyMintLimit, "Daily limit exceeded");
 
-        lastMintTime[to] = block.timestamp;
+        // Effects before interaction.
+        processedOrders[orderId] = true;
         dailyMinted += amount;
 
         _mint(to, amount);
-        emit BridgeMint(to, amount, bthTxHash);
+        emit BridgeMint(to, amount, orderId);
+
+        // Circuit breaker: anomalous cumulative volume halts the bridge
+        // instead of merely reverting subsequent mints, forcing a human
+        // (guardian Safe) to investigate before minting resumes.
+        if (autoPauseThreshold != 0 && dailyMinted >= autoPauseThreshold) {
+            _pause();
+            emit AutoPaused(dailyMinted, autoPauseThreshold);
+        }
     }
 
     /**
-     * @dev Burn wBTH to receive BTH on the native chain.
-     * @param amount Amount to burn (in picocredits)
-     * @param bthAddress BTH address to receive funds (stealth address string)
+     * @notice Burn wBTH to redeem native BTH.
+     * @dev This is the ONLY burn path (no open `burn`/`burnFrom`); the
+     *      emitted `BridgeBurn` event is what authorizes the native-chain
+     *      release, so a burn without it would strand reserve funds.
+     * @param amount Amount to burn (picocredits).
+     * @param bthAddress Destination BTH address (stealth-address string).
      */
     function bridgeBurn(
         uint256 amount,
         string calldata bthAddress
-    ) external whenNotPaused {
+    ) external whenNotPaused nonReentrant {
         require(amount > 0, "Amount must be positive");
         require(bytes(bthAddress).length > 0, "Invalid BTH address");
 
@@ -122,54 +243,54 @@ contract WrappedBTH is ERC20, ERC20Burnable, AccessControl, Pausable {
     }
 
     /**
-     * @dev Pause all bridge operations.
+     * @notice Pause all bridge operations (mint AND burn).
      */
     function pause() external onlyRole(PAUSER_ROLE) {
         _pause();
     }
 
     /**
-     * @dev Unpause bridge operations.
+     * @notice Unpause bridge operations.
      */
     function unpause() external onlyRole(PAUSER_ROLE) {
         _unpause();
     }
 
     /**
-     * @dev Update the mint cooldown period.
-     * @param _cooldown New cooldown in seconds
-     */
-    function setMintCooldown(
-        uint256 _cooldown
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        mintCooldown = _cooldown;
-        emit RateLimitUpdated(mintCooldown, maxMintPerTx, dailyMintLimit);
-    }
-
-    /**
-     * @dev Update the maximum mint per transaction.
-     * @param _max New maximum in picocredits
+     * @notice Update the maximum mint per transaction.
+     * @param _max New maximum in picocredits.
      */
     function setMaxMintPerTx(
         uint256 _max
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         maxMintPerTx = _max;
-        emit RateLimitUpdated(mintCooldown, maxMintPerTx, dailyMintLimit);
+        emit RateLimitUpdated(maxMintPerTx, dailyMintLimit, autoPauseThreshold);
     }
 
     /**
-     * @dev Update the daily mint limit.
-     * @param _limit New daily limit in picocredits
+     * @notice Update the daily mint limit.
+     * @param _limit New daily limit in picocredits.
      */
     function setDailyMintLimit(
         uint256 _limit
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         dailyMintLimit = _limit;
-        emit RateLimitUpdated(mintCooldown, maxMintPerTx, dailyMintLimit);
+        emit RateLimitUpdated(maxMintPerTx, dailyMintLimit, autoPauseThreshold);
     }
 
     /**
-     * @dev Returns the remaining daily mint capacity.
+     * @notice Update the auto-pause breaker threshold (0 disables).
+     * @param _threshold New threshold in picocredits.
+     */
+    function setAutoPauseThreshold(
+        uint256 _threshold
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        autoPauseThreshold = _threshold;
+        emit RateLimitUpdated(maxMintPerTx, dailyMintLimit, autoPauseThreshold);
+    }
+
+    /**
+     * @notice Remaining mint capacity for the current UTC day.
      */
     function remainingDailyMint() external view returns (uint256) {
         uint256 today = block.timestamp / 1 days;
@@ -180,16 +301,5 @@ contract WrappedBTH is ERC20, ERC20Burnable, AccessControl, Pausable {
             return 0;
         }
         return dailyMintLimit - dailyMinted;
-    }
-
-    /**
-     * @dev Returns the time until an address can mint again.
-     */
-    function cooldownRemaining(address account) external view returns (uint256) {
-        uint256 nextMintTime = lastMintTime[account] + mintCooldown;
-        if (block.timestamp >= nextMintTime) {
-            return 0;
-        }
-        return nextMintTime - block.timestamp;
     }
 }

--- a/contracts/ethereum/scripts/deploy.ts
+++ b/contracts/ethereum/scripts/deploy.ts
@@ -1,0 +1,41 @@
+import { ethers } from "hardhat";
+
+/**
+ * Deploy WrappedBTH.
+ *
+ * Per ADR 0002 the three roles MUST be held by Gnosis Safes, not EOAs:
+ *   WBTH_ADMIN_SAFE  – governance Safe (DEFAULT_ADMIN_ROLE: limits/roles)
+ *   WBTH_MINTER_SAFE – validator Safe (MINTER_ROLE: t-of-n secp256k1)
+ *   WBTH_PAUSER_SAFE – guardian Safe (PAUSER_ROLE: pause/unpause)
+ *
+ * The deployer key receives NO roles. Record the Safe addresses and their
+ * thresholds in contracts/ethereum/README.md for every deployment.
+ */
+async function main() {
+  const adminSafe = process.env.WBTH_ADMIN_SAFE;
+  const minterSafe = process.env.WBTH_MINTER_SAFE;
+  const pauserSafe = process.env.WBTH_PAUSER_SAFE;
+
+  if (!adminSafe || !minterSafe || !pauserSafe) {
+    throw new Error(
+      "Set WBTH_ADMIN_SAFE, WBTH_MINTER_SAFE and WBTH_PAUSER_SAFE (Gnosis Safe addresses, per ADR 0002)"
+    );
+  }
+
+  const [deployer] = await ethers.getSigners();
+  console.log(`Deployer (receives NO roles): ${deployer.address}`);
+  console.log(`Admin (governance) Safe:      ${adminSafe}`);
+  console.log(`Minter (validator) Safe:      ${minterSafe}`);
+  console.log(`Pauser (guardian) Safe:       ${pauserSafe}`);
+
+  const WrappedBTH = await ethers.getContractFactory("WrappedBTH");
+  const wbth = await WrappedBTH.deploy(adminSafe, minterSafe, pauserSafe);
+  await wbth.waitForDeployment();
+
+  console.log(`WrappedBTH deployed at: ${await wbth.getAddress()}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/ethereum/test/WrappedBTH.test.ts
+++ b/contracts/ethereum/test/WrappedBTH.test.ts
@@ -1,0 +1,542 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import {
+  loadFixture,
+  time,
+} from "@nomicfoundation/hardhat-toolbox/network-helpers";
+
+/**
+ * WrappedBTH unit + invariant tests (#826).
+ *
+ * The Safes from ADR 0002 are simulated with EOAs here: threshold
+ * enforcement lives inside the Gnosis Safe, not in this contract, so the
+ * contract-level property under test is "only the MINTER_ROLE holder can
+ * mint" (plus: the deployer holds no roles at all).
+ */
+
+const PICO = 10n ** 12n; // 1 BTH = 10^12 picocredits (12 decimals)
+const MAX_TX = 1_000_000n * PICO;
+const DAILY = 10_000_000n * PICO;
+
+/** Deterministic order ids. */
+function oid(n: number | string): string {
+  return ethers.keccak256(ethers.toUtf8Bytes(`order-${n}`));
+}
+
+describe("WrappedBTH", function () {
+  async function deployFixture() {
+    const [deployer, admin, minter, pauser, user, other] =
+      await ethers.getSigners();
+
+    const WrappedBTH = await ethers.getContractFactory("WrappedBTH", deployer);
+    const wbth = await WrappedBTH.deploy(
+      admin.address,
+      minter.address,
+      pauser.address
+    );
+    await wbth.waitForDeployment();
+
+    // Pin the clock to one hour past a UTC-day boundary so tests that
+    // issue several mints "on the same day" can never straddle midnight.
+    const now = await time.latest();
+    const nextDayStart = (Math.floor(now / 86400) + 1) * 86400;
+    await time.increaseTo(nextDayStart + 3600);
+
+    return { wbth, deployer, admin, minter, pauser, user, other };
+  }
+
+  describe("deployment & role custody (ADR 0002)", function () {
+    it("has 12 decimals (1 base unit == 1 picocredit)", async function () {
+      const { wbth } = await loadFixture(deployFixture);
+      expect(await wbth.decimals()).to.equal(12);
+      expect(await wbth.name()).to.equal("Wrapped BTH");
+      expect(await wbth.symbol()).to.equal("wBTH");
+    });
+
+    it("treats amounts as raw picocredits (5 BTH = 5 * 10^12 units)", async function () {
+      const { wbth, minter, user } = await loadFixture(deployFixture);
+      await wbth.connect(minter).bridgeMint(user.address, 5n * PICO, oid(1));
+      expect(await wbth.balanceOf(user.address)).to.equal(5n * PICO);
+      expect(ethers.formatUnits(await wbth.balanceOf(user.address), 12)).to.equal(
+        "5.0"
+      );
+    });
+
+    it("grants NO roles to the deployer", async function () {
+      const { wbth, deployer } = await loadFixture(deployFixture);
+      const adminRole = await wbth.DEFAULT_ADMIN_ROLE();
+      const minterRole = await wbth.MINTER_ROLE();
+      const pauserRole = await wbth.PAUSER_ROLE();
+      expect(await wbth.hasRole(adminRole, deployer.address)).to.equal(false);
+      expect(await wbth.hasRole(minterRole, deployer.address)).to.equal(false);
+      expect(await wbth.hasRole(pauserRole, deployer.address)).to.equal(false);
+    });
+
+    it("grants each role to its designated Safe only", async function () {
+      const { wbth, admin, minter, pauser } = await loadFixture(deployFixture);
+      const adminRole = await wbth.DEFAULT_ADMIN_ROLE();
+      const minterRole = await wbth.MINTER_ROLE();
+      const pauserRole = await wbth.PAUSER_ROLE();
+      expect(await wbth.hasRole(adminRole, admin.address)).to.equal(true);
+      expect(await wbth.hasRole(minterRole, minter.address)).to.equal(true);
+      expect(await wbth.hasRole(pauserRole, pauser.address)).to.equal(true);
+      // No cross-holding.
+      expect(await wbth.hasRole(minterRole, admin.address)).to.equal(false);
+      expect(await wbth.hasRole(adminRole, minter.address)).to.equal(false);
+      expect(await wbth.hasRole(pauserRole, minter.address)).to.equal(false);
+    });
+
+    it("rejects zero addresses for any role holder", async function () {
+      const [_, admin, minter, pauser] = await ethers.getSigners();
+      const WrappedBTH = await ethers.getContractFactory("WrappedBTH");
+      await expect(
+        WrappedBTH.deploy(ethers.ZeroAddress, minter.address, pauser.address)
+      ).to.be.revertedWith("Invalid admin");
+      await expect(
+        WrappedBTH.deploy(admin.address, ethers.ZeroAddress, pauser.address)
+      ).to.be.revertedWith("Invalid minter");
+      await expect(
+        WrappedBTH.deploy(admin.address, minter.address, ethers.ZeroAddress)
+      ).to.be.revertedWith("Invalid pauser");
+    });
+
+    it("ships with breaker defaults: autoPauseThreshold == dailyMintLimit", async function () {
+      const { wbth } = await loadFixture(deployFixture);
+      expect(await wbth.maxMintPerTx()).to.equal(MAX_TX);
+      expect(await wbth.dailyMintLimit()).to.equal(DAILY);
+      expect(await wbth.autoPauseThreshold()).to.equal(DAILY);
+    });
+  });
+
+  describe("ABI compatibility with the Rust bindings", function () {
+    // bridge/service/src/mint/ethereum.rs binds these exact signatures;
+    // bridge/service/src/watchers/ethereum.rs binds BridgeBurn.
+    it("pins bridgeMint(address,uint256,bytes32) selector", async function () {
+      const { wbth } = await loadFixture(deployFixture);
+      const fn = wbth.interface.getFunction("bridgeMint")!;
+      expect(fn.selector).to.equal(
+        ethers.id("bridgeMint(address,uint256,bytes32)").slice(0, 10)
+      );
+    });
+
+    it("pins BridgeMint/BridgeBurn event signatures and indexing", async function () {
+      const { wbth, minter, user } = await loadFixture(deployFixture);
+      const mintEv = wbth.interface.getEvent("BridgeMint")!;
+      expect(mintEv.topicHash).to.equal(
+        ethers.id("BridgeMint(address,uint256,bytes32)")
+      );
+      const burnEv = wbth.interface.getEvent("BridgeBurn")!;
+      expect(burnEv.topicHash).to.equal(
+        ethers.id("BridgeBurn(address,uint256,string)")
+      );
+
+      // Topic layout relied on by find_bridge_mint_event():
+      // [signature, to (indexed), orderId (indexed)].
+      const orderId = oid("abi");
+      const tx = await wbth
+        .connect(minter)
+        .bridgeMint(user.address, PICO, orderId);
+      const receipt = await tx.wait();
+      const log = receipt!.logs.find((l) => l.topics[0] === mintEv.topicHash)!;
+      expect(log.topics[1]).to.equal(
+        ethers.zeroPadValue(user.address.toLowerCase(), 32)
+      );
+      expect(log.topics[2]).to.equal(orderId);
+    });
+
+    it("exposes NO open burn/burnFrom (bridgeBurn is the only burn path)", async function () {
+      const { wbth } = await loadFixture(deployFixture);
+      expect(wbth.interface.hasFunction("burn(uint256)")).to.equal(false);
+      expect(wbth.interface.hasFunction("burnFrom(address,uint256)")).to.equal(
+        false
+      );
+    });
+  });
+
+  describe("access control", function () {
+    it("only the minter Safe can bridgeMint", async function () {
+      const { wbth, deployer, admin, pauser, user } =
+        await loadFixture(deployFixture);
+      for (const caller of [deployer, admin, pauser, user]) {
+        await expect(
+          wbth.connect(caller).bridgeMint(user.address, PICO, oid("ac"))
+        ).to.be.revertedWithCustomError(
+          wbth,
+          "AccessControlUnauthorizedAccount"
+        );
+      }
+    });
+
+    it("minter mints; balances and totalSupply update", async function () {
+      const { wbth, minter, user } = await loadFixture(deployFixture);
+      await expect(wbth.connect(minter).bridgeMint(user.address, PICO, oid(1)))
+        .to.emit(wbth, "BridgeMint")
+        .withArgs(user.address, PICO, oid(1));
+      expect(await wbth.balanceOf(user.address)).to.equal(PICO);
+      expect(await wbth.totalSupply()).to.equal(PICO);
+    });
+
+    it("only the admin Safe administers roles", async function () {
+      const { wbth, admin, minter, other } = await loadFixture(deployFixture);
+      const minterRole = await wbth.MINTER_ROLE();
+      await expect(
+        wbth.connect(minter).grantRole(minterRole, other.address)
+      ).to.be.revertedWithCustomError(wbth, "AccessControlUnauthorizedAccount");
+      await wbth.connect(admin).grantRole(minterRole, other.address);
+      expect(await wbth.hasRole(minterRole, other.address)).to.equal(true);
+      await wbth.connect(admin).revokeRole(minterRole, other.address);
+      expect(await wbth.hasRole(minterRole, other.address)).to.equal(false);
+    });
+
+    it("only the admin Safe can change limits and the breaker", async function () {
+      const { wbth, admin, minter, pauser } = await loadFixture(deployFixture);
+      for (const caller of [minter, pauser]) {
+        await expect(
+          wbth.connect(caller).setMaxMintPerTx(1)
+        ).to.be.revertedWithCustomError(
+          wbth,
+          "AccessControlUnauthorizedAccount"
+        );
+        await expect(
+          wbth.connect(caller).setDailyMintLimit(1)
+        ).to.be.revertedWithCustomError(
+          wbth,
+          "AccessControlUnauthorizedAccount"
+        );
+        await expect(
+          wbth.connect(caller).setAutoPauseThreshold(1)
+        ).to.be.revertedWithCustomError(
+          wbth,
+          "AccessControlUnauthorizedAccount"
+        );
+      }
+      await expect(wbth.connect(admin).setMaxMintPerTx(123n))
+        .to.emit(wbth, "RateLimitUpdated")
+        .withArgs(123n, DAILY, DAILY);
+    });
+  });
+
+  describe("mint validation", function () {
+    it("rejects zero recipient, zero amount, zero order id, oversize tx", async function () {
+      const { wbth, minter, user } = await loadFixture(deployFixture);
+      await expect(
+        wbth.connect(minter).bridgeMint(ethers.ZeroAddress, PICO, oid(1))
+      ).to.be.revertedWith("Invalid recipient");
+      await expect(
+        wbth.connect(minter).bridgeMint(user.address, 0, oid(1))
+      ).to.be.revertedWith("Amount must be positive");
+      await expect(
+        wbth.connect(minter).bridgeMint(user.address, PICO, ethers.ZeroHash)
+      ).to.be.revertedWith("Invalid order id");
+      await expect(
+        wbth.connect(minter).bridgeMint(user.address, MAX_TX + 1n, oid(1))
+      ).to.be.revertedWith("Exceeds max mint per tx");
+      // Boundary: exactly maxMintPerTx is allowed.
+      await wbth.connect(minter).bridgeMint(user.address, MAX_TX, oid(1));
+    });
+  });
+
+  describe("order-id replay guard", function () {
+    it("rejects a duplicate order id (idempotent mint)", async function () {
+      const { wbth, minter, user, other } = await loadFixture(deployFixture);
+      await wbth.connect(minter).bridgeMint(user.address, PICO, oid("dup"));
+      expect(await wbth.processedOrders(oid("dup"))).to.equal(true);
+
+      // Same id replayed — identical args, different args, different
+      // recipient: all must revert.
+      await expect(
+        wbth.connect(minter).bridgeMint(user.address, PICO, oid("dup"))
+      ).to.be.revertedWith("Order already processed");
+      await expect(
+        wbth.connect(minter).bridgeMint(other.address, 2n * PICO, oid("dup"))
+      ).to.be.revertedWith("Order already processed");
+    });
+
+    it("allows distinct order ids", async function () {
+      const { wbth, minter, user } = await loadFixture(deployFixture);
+      await wbth.connect(minter).bridgeMint(user.address, PICO, oid(1));
+      await wbth.connect(minter).bridgeMint(user.address, PICO, oid(2));
+      expect(await wbth.balanceOf(user.address)).to.equal(2n * PICO);
+    });
+
+    it("keeps the guard across day rollovers (permanent, not daily)", async function () {
+      const { wbth, minter, user } = await loadFixture(deployFixture);
+      await wbth.connect(minter).bridgeMint(user.address, PICO, oid("perm"));
+      await time.increase(3 * 86400);
+      await expect(
+        wbth.connect(minter).bridgeMint(user.address, PICO, oid("perm"))
+      ).to.be.revertedWith("Order already processed");
+    });
+  });
+
+  describe("daily limit accounting", function () {
+    it("enforces the daily cap cumulatively (no recipient-rotation bypass)", async function () {
+      const { wbth, admin, minter, user, other } =
+        await loadFixture(deployFixture);
+      await wbth.connect(admin).setAutoPauseThreshold(0); // isolate the cap
+
+      // 10 x 1M BTH to alternating recipients consumes the full cap.
+      for (let i = 0; i < 10; i++) {
+        const to = i % 2 === 0 ? user.address : other.address;
+        await wbth.connect(minter).bridgeMint(to, MAX_TX, oid(`cap-${i}`));
+      }
+      expect(await wbth.dailyMinted()).to.equal(DAILY);
+      expect(await wbth.remainingDailyMint()).to.equal(0);
+      await expect(
+        wbth.connect(minter).bridgeMint(user.address, 1n, oid("cap-over"))
+      ).to.be.revertedWith("Daily limit exceeded");
+    });
+
+    it("resets after one day and after multi-day gaps", async function () {
+      const { wbth, admin, minter, user } = await loadFixture(deployFixture);
+      await wbth.connect(admin).setAutoPauseThreshold(0);
+
+      await wbth.connect(minter).bridgeMint(user.address, MAX_TX, oid("d0"));
+      expect(await wbth.remainingDailyMint()).to.equal(DAILY - MAX_TX);
+
+      // Next day: full capacity again.
+      await time.increase(86400);
+      expect(await wbth.remainingDailyMint()).to.equal(DAILY);
+      await wbth.connect(minter).bridgeMint(user.address, MAX_TX, oid("d1"));
+      expect(await wbth.dailyMinted()).to.equal(MAX_TX);
+
+      // Multi-day gap with NO mint on the intermediate days: the lazy
+      // reset must still fire (strictly-greater comparison).
+      await time.increase(5 * 86400);
+      expect(await wbth.remainingDailyMint()).to.equal(DAILY);
+      for (let i = 0; i < 10; i++) {
+        await wbth
+          .connect(minter)
+          .bridgeMint(user.address, MAX_TX, oid(`gap-${i}`));
+      }
+      expect(await wbth.dailyMinted()).to.equal(DAILY);
+    });
+
+    it("keeps remainingDailyMint consistent with the mutating branch", async function () {
+      const { wbth, admin, minter, user } = await loadFixture(deployFixture);
+      await wbth.connect(admin).setAutoPauseThreshold(0);
+      await wbth
+        .connect(minter)
+        .bridgeMint(user.address, 3n * PICO, oid("view"));
+      expect(await wbth.remainingDailyMint()).to.equal(DAILY - 3n * PICO);
+
+      // Lowering the limit below what was already minted floors at 0.
+      await wbth.connect(admin).setDailyMintLimit(PICO);
+      expect(await wbth.remainingDailyMint()).to.equal(0);
+      await expect(
+        wbth.connect(minter).bridgeMint(user.address, 1n, oid("view2"))
+      ).to.be.revertedWith("Daily limit exceeded");
+    });
+  });
+
+  describe("pause (manual circuit breaker)", function () {
+    it("pauser pauses/unpauses; mint AND burn are gated", async function () {
+      const { wbth, minter, pauser, user } = await loadFixture(deployFixture);
+      await wbth.connect(minter).bridgeMint(user.address, 2n * PICO, oid(1));
+
+      await wbth.connect(pauser).pause();
+      await expect(
+        wbth.connect(minter).bridgeMint(user.address, PICO, oid(2))
+      ).to.be.revertedWithCustomError(wbth, "EnforcedPause");
+      await expect(
+        wbth.connect(user).bridgeBurn(PICO, "bth1destination")
+      ).to.be.revertedWithCustomError(wbth, "EnforcedPause");
+
+      await wbth.connect(pauser).unpause();
+      await wbth.connect(minter).bridgeMint(user.address, PICO, oid(2));
+      await wbth.connect(user).bridgeBurn(PICO, "bth1destination");
+    });
+
+    it("only the pauser Safe can pause/unpause", async function () {
+      const { wbth, admin, minter, pauser, user } =
+        await loadFixture(deployFixture);
+      for (const caller of [admin, minter, user]) {
+        await expect(
+          wbth.connect(caller).pause()
+        ).to.be.revertedWithCustomError(
+          wbth,
+          "AccessControlUnauthorizedAccount"
+        );
+      }
+      await wbth.connect(pauser).pause();
+      for (const caller of [admin, minter, user]) {
+        await expect(
+          wbth.connect(caller).unpause()
+        ).to.be.revertedWithCustomError(
+          wbth,
+          "AccessControlUnauthorizedAccount"
+        );
+      }
+    });
+  });
+
+  describe("auto-pause circuit breaker", function () {
+    it("trips when cumulative daily volume reaches the threshold", async function () {
+      const { wbth, admin, minter, pauser, user } =
+        await loadFixture(deployFixture);
+      await wbth.connect(admin).setAutoPauseThreshold(3n * MAX_TX);
+
+      await wbth.connect(minter).bridgeMint(user.address, MAX_TX, oid(1));
+      await wbth.connect(minter).bridgeMint(user.address, MAX_TX, oid(2));
+      expect(await wbth.paused()).to.equal(false);
+
+      // The crossing mint SUCCEEDS (it is within the daily limit) but
+      // flips the breaker for everything after it.
+      await expect(wbth.connect(minter).bridgeMint(user.address, MAX_TX, oid(3)))
+        .to.emit(wbth, "AutoPaused")
+        .withArgs(3n * MAX_TX, 3n * MAX_TX);
+      expect(await wbth.paused()).to.equal(true);
+      expect(await wbth.balanceOf(user.address)).to.equal(3n * MAX_TX);
+      await expect(
+        wbth.connect(minter).bridgeMint(user.address, PICO, oid(4))
+      ).to.be.revertedWithCustomError(wbth, "EnforcedPause");
+
+      // Guardian review + unpause resumes (daily accounting continues).
+      await wbth.connect(pauser).unpause();
+      await wbth.connect(minter).bridgeMint(user.address, PICO, oid(4));
+    });
+
+    it("trips at the full daily limit by default", async function () {
+      const { wbth, minter, user } = await loadFixture(deployFixture);
+      for (let i = 0; i < 10; i++) {
+        await wbth
+          .connect(minter)
+          .bridgeMint(user.address, MAX_TX, oid(`def-${i}`));
+      }
+      expect(await wbth.paused()).to.equal(true);
+    });
+
+    it("is disabled when the threshold is 0", async function () {
+      const { wbth, admin, minter, user } = await loadFixture(deployFixture);
+      await wbth.connect(admin).setAutoPauseThreshold(0);
+      for (let i = 0; i < 10; i++) {
+        await wbth
+          .connect(minter)
+          .bridgeMint(user.address, MAX_TX, oid(`off-${i}`));
+      }
+      expect(await wbth.paused()).to.equal(false);
+    });
+  });
+
+  describe("bridgeBurn", function () {
+    it("burns and emits the redemption event the watcher binds", async function () {
+      const { wbth, minter, user } = await loadFixture(deployFixture);
+      await wbth.connect(minter).bridgeMint(user.address, 5n * PICO, oid(1));
+      await expect(wbth.connect(user).bridgeBurn(2n * PICO, "bth1stealthaddr"))
+        .to.emit(wbth, "BridgeBurn")
+        .withArgs(user.address, 2n * PICO, "bth1stealthaddr");
+      expect(await wbth.balanceOf(user.address)).to.equal(3n * PICO);
+      expect(await wbth.totalSupply()).to.equal(3n * PICO);
+    });
+
+    it("rejects zero amount, empty destination, and over-balance burns", async function () {
+      const { wbth, minter, user } = await loadFixture(deployFixture);
+      await wbth.connect(minter).bridgeMint(user.address, PICO, oid(1));
+      await expect(
+        wbth.connect(user).bridgeBurn(0, "bth1x")
+      ).to.be.revertedWith("Amount must be positive");
+      await expect(wbth.connect(user).bridgeBurn(PICO, "")).to.be.revertedWith(
+        "Invalid BTH address"
+      );
+      await expect(
+        wbth.connect(user).bridgeBurn(2n * PICO, "bth1x")
+      ).to.be.revertedWithCustomError(wbth, "ERC20InsufficientBalance");
+    });
+  });
+
+  describe("reentrancy", function () {
+    // OZ ERC-20 v5 _mint/_burn make no external calls (no ERC-777 hooks),
+    // so no reentrant path can be triggered from a test. These tests pin
+    // the defense-in-depth posture: contract recipients get no callback,
+    // and state (replay guard, daily accounting) is committed before the
+    // token movement (checks-effects-interactions).
+    it("mints to a contract recipient without invoking any hook", async function () {
+      const { wbth, admin, minter, pauser, user } =
+        await loadFixture(deployFixture);
+      // Any contract address works as a hook-less recipient; use a second
+      // token instance rather than shipping a mock.
+      const WrappedBTH = await ethers.getContractFactory("WrappedBTH");
+      const recipient = await WrappedBTH.deploy(
+        admin.address,
+        minter.address,
+        pauser.address
+      );
+      await recipient.waitForDeployment();
+
+      const to = await recipient.getAddress();
+      await wbth.connect(minter).bridgeMint(to, PICO, oid("contract"));
+      expect(await wbth.balanceOf(to)).to.equal(PICO);
+    });
+
+    it("commits the replay guard before the mint (CEI)", async function () {
+      const { wbth, minter, user } = await loadFixture(deployFixture);
+      const tx = await wbth
+        .connect(minter)
+        .bridgeMint(user.address, PICO, oid("cei"));
+      await tx.wait();
+      expect(await wbth.processedOrders(oid("cei"))).to.equal(true);
+    });
+  });
+
+  describe("supply accounting invariant (randomized)", function () {
+    it("totalSupply == sum(mints) - sum(burns) under random ops", async function () {
+      const { wbth, admin, minter, user, other } =
+        await loadFixture(deployFixture);
+      // Disable the breaker so the run exercises many days of flow.
+      await wbth.connect(admin).setAutoPauseThreshold(0);
+
+      // Deterministic PRNG (mulberry32) so failures reproduce.
+      let seed = 0x5eed826;
+      const rand = () => {
+        seed |= 0;
+        seed = (seed + 0x6d2b79f5) | 0;
+        let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+
+      let minted = 0n;
+      let burned = 0n;
+      const holders = [user, other];
+
+      for (let i = 0; i < 120; i++) {
+        const roll = rand();
+        if (roll < 0.55) {
+          // Mint a random amount to a random holder.
+          const amount = (BigInt(Math.floor(rand() * 1_000_000)) + 1n) * PICO;
+          const to = holders[Math.floor(rand() * holders.length)];
+          try {
+            await wbth
+              .connect(minter)
+              .bridgeMint(to.address, amount, oid(`fuzz-${i}`));
+            minted += amount;
+          } catch (e: any) {
+            // Only the daily cap may reject an otherwise-valid mint here.
+            expect(String(e.message)).to.contain("Daily limit exceeded");
+          }
+        } else if (roll < 0.85) {
+          // Burn a random fraction of a random holder's balance.
+          const from = holders[Math.floor(rand() * holders.length)];
+          const balance = await wbth.balanceOf(from.address);
+          if (balance > 0n) {
+            const amount =
+              (balance * BigInt(1 + Math.floor(rand() * 100))) / 100n;
+            await wbth.connect(from).bridgeBurn(amount, "bth1fuzz");
+            burned += amount;
+          }
+        } else {
+          // Jump time by 1..72 hours (exercises the daily reset).
+          await time.increase(3600 * (1 + Math.floor(rand() * 72)));
+        }
+
+        // Invariants after every operation.
+        expect(await wbth.totalSupply()).to.equal(minted - burned);
+        expect(await wbth.dailyMinted()).to.be.lte(await wbth.dailyMintLimit());
+      }
+
+      // The run must have actually exercised both paths.
+      expect(minted).to.be.gt(0n);
+      expect(burned).to.be.gt(0n);
+    });
+  });
+});

--- a/contracts/ethereum/tsconfig.json
+++ b/contracts/ethereum/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
Closes #826

Hardens the Ethereum wBTH contract per ADR 0002 and the #826 checklist. The Solana half of #826's expanded checklist is decomposed to #850 (this PR is scoped to `contracts/ethereum/` + the anticipated cosmetic Rust-binding rename).

## Decisions made (documented in NatSpec + `contracts/ethereum/README.md`)

| Decision | Choice | Rationale |
|---|---|---|
| Mint custody | `MINTER_ROLE` → validator **Gnosis Safe** (t-of-n secp256k1, ADR 0002); threshold enforcement lives in the Safe, not the contract | Matches the merged Rust mint path (`Safe.execTransaction → bridgeMint`); no single-EOA mint path — the deployer receives **no roles**, and admin (governance Safe) / pauser (guardian Safe, may be lower-threshold for fast response) are distinct quorums |
| Idempotency key | `bridgeMint(to, amount, orderId)` + `processedOrders[orderId]` on-chain replay guard (revert on duplicate) | The hard prerequisite closing the residual double-mint window flagged in the #838 review; the bytes32 param was renamed `bthTxHash → orderId` — **ABI selector and event topic hashes unchanged**, exactly as anticipated in `mint/ethereum.rs` |
| Upgradeability | **Immutable, no proxy** | A proxy admin is a rug vector that negates Safe-threshold custody; fits the no-hard-forks / minimal-trust posture. Recovery path: pause → deploy corrected token → migrate via the bridge (burn old / mint new) |
| Circuit breaker | **Auto-pause** when cumulative daily mints reach `autoPauseThreshold` (default = `dailyMintLimit`; 0 disables), plus the existing manual `pause()` | Anomalous volume becomes a hard stop requiring guardian review instead of a soft revert; complements the service-side breaker (#827) |
| Mint cooldown | **Removed** | Per-recipient `lastMintTime[to]` was bypassable by recipient rotation (no security) while griefing honest multi-order throughput; real controls are per-tx cap + daily cap + breaker + Safe threshold |
| Open burn surface | **Removed `ERC20Burnable`** — `bridgeBurn` is the only burn path | A plain `burn` destroys wBTH with no `BridgeBurn` redemption event, stranding locked reserve and breaking the watcher-tracked supply invariant |
| Reentrancy | Strict CEI (replay guard + daily accounting written before `_mint`) **plus** `ReentrancyGuard` on both entrypoints | OZ ERC-20 v5 `_mint`/`_burn` make no external calls, so no path exists today; the guard is cheap defense-in-depth that survives future edits |
| Daily-limit accounting | Verified correct: lazy reset uses strictly-greater day comparison, so multi-day gaps reset properly; `remainingDailyMint()` aligned (incl. limit lowered below already-minted) | Pinned by tests, including the recipient-rotation and reset-boundary cases from the issue |
| Decimals | `decimals() == 12` pinned by test; all limits are raw picocredits, no scaling anywhere | Matches `mint/ethereum.rs` (1 base unit = 1 picocredit, 1:1 BTH) |

## Rust bindings

Interface-compatible: `bridgeMint(address,uint256,bytes32)` selector and `BridgeMint`/`BridgeBurn` topic hashes are byte-identical. Only the cosmetic param-name rename (`bthTxHash → orderId`) + stale “#826 will…” comment cleanup landed in `bridge/service/src/mint/ethereum.rs`; `watchers/ethereum.rs` untouched. A dedicated test pins the selector and the `[sig, to, orderId]` topic layout the Rust `find_bridge_mint_event` relies on.

## Test Plan

- [x] `npx hardhat test` — **30/30 passing**: role custody (deployer has no roles, Safe-only mint), ABI pinning vs Rust bindings, mint validation (zero addr/amount/orderId, per-tx boundary), order-id replay (duplicate reverts, permanent across day rollovers), daily-limit accounting (cumulative across rotated recipients, single/multi-day lazy reset, view/mutating alignment), manual pause gating mint+burn with role enforcement, auto-pause breaker (trip/cross/resume, default-at-limit, 0-disables), burn path (event args, over-balance, empty destination), reentrancy posture (contract recipient, CEI ordering), and a 120-op seeded randomized run asserting `totalSupply == Σmints − Σburns` and `dailyMinted ≤ dailyMintLimit` after every op
- [x] `cargo test -p bth-bridge-service` — **102/102 passing** after the binding rename
- [x] `cargo fmt -p bth-bridge-service --check` clean

Note: no CI workflow currently compiles/tests `contracts/ethereum` (only the Solana crate's fmt is checked); worth a small follow-up workflow, left out here to respect scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)