### PR TITLE
bridge service: crash-safe idempotent order engine + monitoring / circuit-breaker (#827)

### DIFF
--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -50,6 +50,13 @@ pub struct ReserveSettings {
     /// the server.
     #[serde(default = "default_reserve_api_listen")]
     pub api_listen: String,
+
+    /// Days of reconciliation snapshot history to retain (#846: the table
+    /// grows one row per pass — ~525k rows/yr at the 60s default). Older
+    /// rows are pruned each pass; the most recent snapshot always
+    /// survives. 0 disables pruning.
+    #[serde(default = "default_snapshot_retention_days")]
+    pub snapshot_retention_days: u64,
 }
 
 fn default_reconcile_interval_secs() -> u64 {
@@ -60,12 +67,17 @@ fn default_reserve_api_listen() -> String {
     "127.0.0.1:9741".to_string()
 }
 
+fn default_snapshot_retention_days() -> u64 {
+    30
+}
+
 impl Default for ReserveSettings {
     fn default() -> Self {
         Self {
             tolerance_picocredits: 0,
             reconcile_interval_secs: default_reconcile_interval_secs(),
             api_listen: default_reserve_api_listen(),
+            snapshot_retention_days: default_snapshot_retention_days(),
         }
     }
 }
@@ -239,6 +251,20 @@ pub struct BridgeSettings {
     #[serde(default = "default_max_retries")]
     pub max_retries: u32,
 
+    /// Start with the circuit breaker tripped: the engine pauses the
+    /// submit stages (mints and releases) at startup until an operator
+    /// resumes via the API. Confirmation stages keep running so in-flight
+    /// orders settle. The runtime pause state lives in the database
+    /// (`bridge_state`) and survives restarts independently of this flag.
+    #[serde(default)]
+    pub paused: bool,
+
+    /// Actionable-order backlog above which the circuit breaker trips
+    /// automatically (a flood of orders is an anomaly signal — fail
+    /// closed and let an operator inspect). 0 disables the auto-trip.
+    #[serde(default = "default_max_pending_orders")]
+    pub max_pending_orders: u64,
+
     /// Enable testnet mode
     #[serde(default)]
     pub testnet: bool,
@@ -288,6 +314,10 @@ fn default_order_expiry() -> i64 {
 
 fn default_max_retries() -> u32 {
     3
+}
+
+fn default_max_pending_orders() -> u64 {
+    1_000
 }
 
 /// Gas price strategy for Ethereum transactions.
@@ -376,6 +406,8 @@ impl Default for BridgeConfig {
                 global_daily_limit: default_global_daily_limit(),
                 order_expiry_minutes: default_order_expiry(),
                 max_retries: default_max_retries(),
+                paused: false,
+                max_pending_orders: default_max_pending_orders(),
                 testnet: false,
                 attestation_ed25519_key_file: None,
                 attestation_secp256k1_key_file: None,
@@ -408,6 +440,35 @@ mod tests {
         let config = BridgeConfig::default();
         assert_eq!(config.bridge.fee_bps, 10);
         assert!(!config.bridge.testnet);
+        assert!(!config.bridge.paused);
+        assert_eq!(config.bridge.max_pending_orders, 1_000);
+    }
+
+    #[test]
+    fn test_breaker_knobs_parse() {
+        // A pre-existing config without the breaker knobs still parses
+        // with safe defaults, and the knobs round-trip from TOML.
+        let legacy: BridgeSettings = toml::from_str(
+            r#"
+            mnemonic_file = "m.enc"
+            db_path = "bridge.db"
+            "#,
+        )
+        .unwrap();
+        assert!(!legacy.paused);
+        assert_eq!(legacy.max_pending_orders, 1_000);
+
+        let configured: BridgeSettings = toml::from_str(
+            r#"
+            mnemonic_file = "m.enc"
+            db_path = "bridge.db"
+            paused = true
+            max_pending_orders = 50
+            "#,
+        )
+        .unwrap();
+        assert!(configured.paused);
+        assert_eq!(configured.max_pending_orders, 50);
     }
 
     #[test]
@@ -463,6 +524,7 @@ mod tests {
         let legacy: ReserveSettings = toml::from_str("").unwrap();
         assert_eq!(legacy.tolerance_picocredits, 0);
         assert_eq!(legacy.reconcile_interval_secs, 60);
+        assert_eq!(legacy.snapshot_retention_days, 30);
 
         // The knobs round-trip from TOML; empty api_listen disables.
         let configured: ReserveSettings = toml::from_str(

--- a/bridge/service/alerts.yml
+++ b/bridge/service/alerts.yml
@@ -1,0 +1,81 @@
+# Prometheus alert rules for the BTH bridge service (#827).
+#
+# Scrape target: GET /metrics on `[reserve] api_listen` (default
+# 127.0.0.1:9741). Response procedures for every alert:
+# docs/operations/runbooks/bridge-order-engine-recovery.md
+
+groups:
+  - name: bth-bridge
+    rules:
+      - alert: BridgeBreakerTripped
+        expr: bridge_paused == 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Bridge circuit breaker is tripped (submits halted)"
+          description: >
+            The bridge is paused (kill switch or auto-trip: backlog, global
+            volume cap, or reserve drift). Confirm stages keep settling
+            in-flight orders. Triage per the runbook before resuming via
+            POST /api/breaker.
+
+      - alert: BridgePegUnhealthy
+        expr: bridge_peg_healthy == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Proof-of-reserves reconciliation reports an unhealthy peg"
+          description: >
+            Wrapped supply vs locked reserve drifted beyond tolerance, or the
+            reserve custody check failed. The reconciler trips the breaker
+            automatically. Treat as a peg incident: freeze, reconcile, then
+            resume.
+
+      - alert: BridgeBacklogHigh
+        expr: bridge_actionable_backlog > 100
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Bridge actionable-order backlog is growing"
+          description: >
+            Orders are entering faster than they settle. At
+            bridge.max_pending_orders the breaker trips automatically.
+
+      - alert: BridgeStuckOrders
+        expr: bridge_stuck_orders > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Orders stuck past the age threshold"
+          description: >
+            Post-deposit orders have not advanced within
+            bridge.order_expiry_minutes. Funds have moved: they never
+            auto-expire — operator triage required (see the stuck-order
+            section of the runbook).
+
+      - alert: BridgeComponentDown
+        expr: bridge_component_healthy == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "A bridge component (signer / minter / releaser) is unavailable"
+          description: >
+            The engine fails closed for the affected flow (orders stay
+            retryable, nothing is dropped), but throughput is degraded until
+            the component's configuration is fixed.
+
+      - alert: BridgeApiDown
+        expr: up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Bridge /metrics endpoint is unreachable"
+          description: >
+            The bridge service (or its API listener) is down; order
+            processing state is unknown.

--- a/bridge/service/src/api.rs
+++ b/bridge/service/src/api.rs
@@ -1,23 +1,53 @@
 // Copyright (c) 2024 The Botho Foundation
 
-//! Proof-of-reserves HTTP API (#825).
+//! Bridge HTTP API: proof-of-reserves (#825) + monitoring and the
+//! circuit-breaker control surface (#827).
 //!
-//! Endpoints (contract for the metrics-daemon / `/network` dashboard):
+//! Endpoints:
+//! - `GET /health` -> `OK` (200) while healthy; `503` with a reason when the
+//!   bridge is paused (breaker tripped / kill switch) or the DB is unreachable.
+//!   Liveness probes and dashboards key off this.
+//! - `GET /api/status` -> operational snapshot: pause state, order counts by
+//!   status, actionable backlog, stuck-order count, component health
+//!   (attestation signer / minters / releaser), latest peg verdict.
+//! - `GET /metrics` -> the same data as Prometheus text (no external crate;
+//!   hand-rolled exposition format) for alerting (`bridge/service/alerts.yml`).
+//! - `POST /api/breaker` `{"paused": bool, "reason": "..."}` -> runtime
+//!   kill-switch toggle. Pausing halts the submit stages (mints and releases);
+//!   confirm stages keep running so in-flight orders settle. The listener binds
+//!   localhost by default — anyone who can reach this endpoint is an operator.
 //! - `GET /api/reserve/proof` -> the latest reconciliation snapshot:
 //!   `{lockedReserve, ethSupply, solSupply, totalWrapped, drift, inTolerance,
-//!   pegHealthy, takenAt}` (503 until the first pass runs).
-//! - `GET /health` -> `OK`.
+//!   pegHealthy, reserveBalanceChecked, takenAt}` (503 until the first pass
+//!   runs). `reserveBalanceChecked` (#846) distinguishes "custody checked OK"
+//!   from "custody never checked".
 //!
 //! The full per-chain detail (including in-flight allowances) is written
 //! to the `audit_log` by the reconciler; this surface serves the compact
-//! snapshot the dashboard renders.
+//! snapshots the dashboard renders.
 
-use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Json, Router};
-use serde::Serialize;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::db::{Database, ReserveSnapshot};
+
+/// Shared state of the API router.
+#[derive(Clone)]
+pub struct ApiState {
+    /// Bridge database (orders, breaker state, snapshots, health).
+    pub db: Database,
+    /// Age threshold in seconds after which a non-terminal post-deposit
+    /// order counts as stuck.
+    pub stuck_after_secs: i64,
+}
 
 /// Response body of `GET /api/reserve/proof`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -37,6 +67,11 @@ pub struct ReserveProofResponse {
     pub in_tolerance: bool,
     /// Peg red/green state (tolerance AND custody legs).
     pub peg_healthy: bool,
+    /// Whether the on-Botho reserve-balance custody leg was actually
+    /// checked this pass (#846: `pegHealthy: true` with
+    /// `reserveBalanceChecked: false` means "peg healthy, custody
+    /// unverified").
+    pub reserve_balance_checked: bool,
     /// When the reconciliation ran (unix seconds).
     pub taken_at: i64,
 }
@@ -55,9 +90,66 @@ impl From<ReserveSnapshot> for ReserveProofResponse {
             drift: s.drift,
             in_tolerance: s.in_tolerance,
             peg_healthy: s.peg_healthy,
+            reserve_balance_checked: s.reserve_balance_checked,
             taken_at: s.taken_at,
         }
     }
+}
+
+/// One component row in `GET /api/status`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComponentStatus {
+    /// Component name (`attestation`, `minter:ethereum`, `releaser:bth`, ...).
+    pub component: String,
+    /// Whether the component is available.
+    pub healthy: bool,
+    /// Human-readable detail.
+    pub detail: String,
+}
+
+/// Response body of `GET /api/status`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusResponse {
+    /// Whether the circuit breaker / kill switch is engaged.
+    pub paused: bool,
+    /// Why, when paused.
+    pub paused_reason: Option<String>,
+    /// Order counts per status (`failed` folds all failure reasons).
+    pub orders: std::collections::BTreeMap<String, i64>,
+    /// Orders the engine still has to act on.
+    pub actionable_backlog: u64,
+    /// Post-deposit orders that have not advanced within the threshold.
+    pub stuck_orders: u64,
+    /// Signer / minter / releaser availability.
+    pub components: Vec<ComponentStatus>,
+    /// Latest reconciliation verdict (`null` until the first pass).
+    pub peg_healthy: Option<bool>,
+    /// When the latest reconciliation ran (unix seconds).
+    pub peg_checked_at: Option<i64>,
+}
+
+/// Request body of `POST /api/breaker`.
+#[derive(Debug, Deserialize)]
+pub struct BreakerRequest {
+    /// Desired pause state.
+    pub paused: bool,
+    /// Reason recorded with a pause (ignored on resume).
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Response body of `POST /api/breaker`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BreakerResponse {
+    /// The pause state after the request.
+    pub paused: bool,
+    /// The recorded reason, when paused.
+    pub paused_reason: Option<String>,
+    /// Whether this request changed the state.
+    pub changed: bool,
 }
 
 #[derive(Serialize)]
@@ -66,40 +158,210 @@ struct ErrorResponse {
 }
 
 /// Build the API router.
-pub fn router(db: Database) -> Router {
+pub fn router(state: ApiState) -> Router {
     Router::new()
         .route("/health", get(health))
+        .route("/metrics", get(metrics))
+        .route("/api/status", get(status))
+        .route("/api/breaker", post(breaker))
         .route("/api/reserve/proof", get(reserve_proof))
-        .with_state(db)
+        .with_state(state)
 }
 
 /// Serve the API until shutdown.
 pub async fn serve(
     addr: String,
     db: Database,
+    stuck_after_secs: i64,
     mut shutdown: broadcast::Receiver<()>,
 ) -> Result<(), String> {
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .map_err(|e| format!("bind {} failed: {}", addr, e))?;
-    info!("Proof-of-reserves API listening on {}", addr);
+    info!("Bridge API listening on {}", addr);
 
-    axum::serve(listener, router(db))
-        .with_graceful_shutdown(async move {
-            let _ = shutdown.recv().await;
-            info!("Proof-of-reserves API shutting down");
-        })
-        .await
-        .map_err(|e| format!("API server error: {}", e))
+    axum::serve(
+        listener,
+        router(ApiState {
+            db,
+            stuck_after_secs,
+        }),
+    )
+    .with_graceful_shutdown(async move {
+        let _ = shutdown.recv().await;
+        info!("Bridge API shutting down");
+    })
+    .await
+    .map_err(|e| format!("API server error: {}", e))
 }
 
-async fn health() -> impl IntoResponse {
-    "OK"
+/// Liveness + breaker state: 200 `OK` while operating, 503 when paused
+/// or the DB is unreachable.
+async fn health(State(state): State<ApiState>) -> axum::response::Response {
+    match state.db.is_paused() {
+        Ok(None) => (StatusCode::OK, "OK").into_response(),
+        Ok(Some(reason)) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("paused: {}", reason),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("db error: {}", e),
+        )
+            .into_response(),
+    }
+}
+
+fn collect_status(state: &ApiState) -> Result<StatusResponse, String> {
+    let paused_reason = state.db.is_paused()?;
+    let orders: std::collections::BTreeMap<String, i64> =
+        state.db.order_status_counts()?.into_iter().collect();
+    let actionable_backlog = state.db.actionable_backlog()?;
+    let stuck_orders = state.db.stuck_orders(state.stuck_after_secs)?.len() as u64;
+    let components = state
+        .db
+        .component_health()?
+        .into_iter()
+        .map(|(component, healthy, detail)| ComponentStatus {
+            component,
+            healthy,
+            detail,
+        })
+        .collect();
+    let snapshot = state.db.latest_reserve_snapshot()?;
+
+    Ok(StatusResponse {
+        paused: paused_reason.is_some(),
+        paused_reason,
+        orders,
+        actionable_backlog,
+        stuck_orders,
+        components,
+        peg_healthy: snapshot.as_ref().map(|s| s.peg_healthy),
+        peg_checked_at: snapshot.as_ref().map(|s| s.taken_at),
+    })
+}
+
+/// Operational status snapshot.
+async fn status(State(state): State<ApiState>) -> axum::response::Response {
+    match collect_status(&state) {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse { error: e }),
+        )
+            .into_response(),
+    }
+}
+
+/// Prometheus text exposition of the status snapshot.
+async fn metrics(State(state): State<ApiState>) -> axum::response::Response {
+    let status = match collect_status(&state) {
+        Ok(s) => s,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("# error: {}", e)).into_response()
+        }
+    };
+    let locked = state.db.locked_reserve_total().unwrap_or(0);
+    let snapshot = state.db.latest_reserve_snapshot().ok().flatten();
+
+    let mut out = String::new();
+    out.push_str("# TYPE bridge_paused gauge\n");
+    out.push_str(&format!("bridge_paused {}\n", status.paused as u8));
+    out.push_str("# TYPE bridge_orders gauge\n");
+    for (bucket, count) in &status.orders {
+        out.push_str(&format!(
+            "bridge_orders{{status=\"{}\"}} {}\n",
+            bucket, count
+        ));
+    }
+    out.push_str("# TYPE bridge_actionable_backlog gauge\n");
+    out.push_str(&format!(
+        "bridge_actionable_backlog {}\n",
+        status.actionable_backlog
+    ));
+    out.push_str("# TYPE bridge_stuck_orders gauge\n");
+    out.push_str(&format!("bridge_stuck_orders {}\n", status.stuck_orders));
+    out.push_str("# TYPE bridge_component_healthy gauge\n");
+    for component in &status.components {
+        out.push_str(&format!(
+            "bridge_component_healthy{{component=\"{}\"}} {}\n",
+            component.component, component.healthy as u8
+        ));
+    }
+    out.push_str("# TYPE bridge_reserve_locked_picocredits gauge\n");
+    out.push_str(&format!("bridge_reserve_locked_picocredits {}\n", locked));
+    if let Some(s) = snapshot {
+        out.push_str("# TYPE bridge_peg_healthy gauge\n");
+        out.push_str(&format!("bridge_peg_healthy {}\n", s.peg_healthy as u8));
+        out.push_str("# TYPE bridge_reserve_drift_picocredits gauge\n");
+        out.push_str(&format!("bridge_reserve_drift_picocredits {}\n", s.drift));
+        out.push_str("# TYPE bridge_reserve_balance_checked gauge\n");
+        out.push_str(&format!(
+            "bridge_reserve_balance_checked {}\n",
+            s.reserve_balance_checked as u8
+        ));
+    }
+
+    (StatusCode::OK, out).into_response()
+}
+
+/// Runtime kill-switch toggle.
+async fn breaker(
+    State(state): State<ApiState>,
+    Json(request): Json<BreakerRequest>,
+) -> axum::response::Response {
+    let reason = request
+        .reason
+        .clone()
+        .unwrap_or_else(|| "manual operator action via /api/breaker".to_string());
+
+    let changed = match state.db.set_paused(request.paused, Some(&reason)) {
+        Ok(changed) => changed,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse { error: e }),
+            )
+                .into_response()
+        }
+    };
+
+    if changed {
+        let action = if request.paused {
+            "breaker_tripped"
+        } else {
+            "breaker_resumed"
+        };
+        if let Err(e) = state
+            .db
+            .log_audit(None, action, &format!("via /api/breaker: {}", reason))
+        {
+            warn!("breaker audit log failed: {}", e);
+        }
+        warn!(
+            "Circuit breaker {} via API ({})",
+            if request.paused { "PAUSED" } else { "RESUMED" },
+            reason
+        );
+    }
+
+    let paused_reason = state.db.is_paused().unwrap_or(None);
+    (
+        StatusCode::OK,
+        Json(BreakerResponse {
+            paused: paused_reason.is_some(),
+            paused_reason,
+            changed,
+        }),
+    )
+        .into_response()
 }
 
 /// Serve the latest proof-of-reserves snapshot.
-async fn reserve_proof(State(db): State<Database>) -> axum::response::Response {
-    match db.latest_reserve_snapshot() {
+async fn reserve_proof(State(state): State<ApiState>) -> axum::response::Response {
+    match state.db.latest_reserve_snapshot() {
         Ok(Some(snapshot)) => {
             (StatusCode::OK, Json(ReserveProofResponse::from(snapshot))).into_response()
         }
@@ -121,6 +383,7 @@ async fn reserve_proof(State(db): State<Database>) -> axum::response::Response {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bth_bridge_core::{BridgeOrder, Chain, OrderStatus};
 
     fn snapshot() -> ReserveSnapshot {
         ReserveSnapshot {
@@ -131,13 +394,26 @@ mod tests {
             drift: -500,
             in_tolerance: true,
             peg_healthy: true,
+            reserve_balance_checked: false,
         }
+    }
+
+    fn test_state() -> (ApiState, Database) {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        (
+            ApiState {
+                db: db.clone(),
+                stuck_after_secs: 3_600,
+            },
+            db,
+        )
     }
 
     #[test]
     fn test_response_contract_field_names() {
         // The exact JSON keys the metrics-daemon / dashboard hook consume
-        // (issue #825 API contract).
+        // (issue #825 API contract; #846 adds reserveBalanceChecked).
         let response = ReserveProofResponse::from(snapshot());
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&response).unwrap()).unwrap();
@@ -150,6 +426,7 @@ mod tests {
             "drift",
             "inTolerance",
             "pegHealthy",
+            "reserveBalanceChecked",
             "takenAt",
         ] {
             assert!(json.get(key).is_some(), "missing contract field {}", key);
@@ -160,6 +437,10 @@ mod tests {
         assert_eq!(json["totalWrapped"], 1_000);
         assert_eq!(json["drift"], -500);
         assert_eq!(json["pegHealthy"], true);
+        assert_eq!(
+            json["reserveBalanceChecked"], false,
+            "pegHealthy without custody verification must be distinguishable (#846)"
+        );
     }
 
     #[test]
@@ -176,15 +457,17 @@ mod tests {
         assert_eq!(response.total_wrapped, Some(1_500));
     }
 
-    #[tokio::test]
-    async fn test_endpoint_serves_latest_snapshot_over_http() {
-        let db = Database::open_in_memory().unwrap();
-        db.migrate().unwrap();
-
+    async fn spawn_server(
+        state: ApiState,
+    ) -> (
+        std::net::SocketAddr,
+        broadcast::Sender<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
         let (shutdown_tx, _) = broadcast::channel(1);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let app = router(db.clone());
+        let app = router(state);
         let mut shutdown_rx = shutdown_tx.subscribe();
         let server = tokio::spawn(async move {
             axum::serve(listener, app)
@@ -194,44 +477,169 @@ mod tests {
                 .await
                 .unwrap();
         });
+        (addr, shutdown_tx, server)
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_serves_latest_snapshot_over_http() {
+        let (state, db) = test_state();
+        let (addr, shutdown_tx, server) = spawn_server(state).await;
 
         // Before any reconciliation: 503.
-        let status = http_get(addr, "/api/reserve/proof").await.0;
+        let status = http_request(addr, "GET", "/api/reserve/proof", None)
+            .await
+            .0;
         assert_eq!(status, 503);
 
-        // Health always answers.
-        let (status, body) = http_get(addr, "/health").await;
+        // Health answers while unpaused.
+        let (status, body) = http_request(addr, "GET", "/health", None).await;
         assert_eq!(status, 200);
         assert_eq!(body, "OK");
 
         // After a snapshot: 200 with the contract body.
         db.insert_reserve_snapshot(&snapshot()).unwrap();
-        let (status, body) = http_get(addr, "/api/reserve/proof").await;
+        let (status, body) = http_request(addr, "GET", "/api/reserve/proof", None).await;
         assert_eq!(status, 200);
         let json: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(json["lockedReserve"], 1_500);
         assert_eq!(json["inTolerance"], true);
+        assert_eq!(json["reserveBalanceChecked"], false);
 
         let _ = shutdown_tx.send(());
         server.await.unwrap();
     }
 
-    /// Minimal HTTP/1.1 GET over a raw socket (avoids an HTTP-client
+    #[tokio::test]
+    async fn test_breaker_toggle_and_health_reflect_pause() {
+        let (state, db) = test_state();
+        let (addr, shutdown_tx, server) = spawn_server(state).await;
+
+        // Trip the breaker over the API.
+        let (status, body) = http_request(
+            addr,
+            "POST",
+            "/api/breaker",
+            Some(r#"{"paused": true, "reason": "incident drill"}"#),
+        )
+        .await;
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["paused"], true);
+        assert_eq!(json["changed"], true);
+        assert_eq!(db.is_paused().unwrap().as_deref(), Some("incident drill"));
+        assert_eq!(db.count_audit_action("breaker_tripped").unwrap(), 1);
+
+        // /health now reports unhealthy (alert trigger: breaker tripped).
+        let (status, body) = http_request(addr, "GET", "/health", None).await;
+        assert_eq!(status, 503);
+        assert!(body.contains("incident drill"), "{}", body);
+
+        // /metrics exposes the breaker gauge for alerting.
+        let (status, body) = http_request(addr, "GET", "/metrics", None).await;
+        assert_eq!(status, 200);
+        assert!(body.contains("bridge_paused 1"), "{}", body);
+
+        // Resume.
+        let (status, body) =
+            http_request(addr, "POST", "/api/breaker", Some(r#"{"paused": false}"#)).await;
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["paused"], false);
+        assert_eq!(db.count_audit_action("breaker_resumed").unwrap(), 1);
+        let (status, _) = http_request(addr, "GET", "/health", None).await;
+        assert_eq!(status, 200);
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_status_and_metrics_expose_backlog_stuck_and_components() {
+        let (state, db) = test_state();
+
+        // A fresh actionable order + one stuck for 3 hours.
+        let mut fresh = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000,
+            0,
+            "bth".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        fresh.set_status(OrderStatus::DepositConfirmed);
+        db.insert_order(&fresh).unwrap();
+
+        let mut stuck = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            2_000,
+            0,
+            "bth".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        stuck.set_status(OrderStatus::MintPending);
+        stuck.updated_at = chrono::Utc::now() - chrono::Duration::hours(3);
+        db.insert_order(&stuck).unwrap();
+
+        db.set_component_health("attestation", false, "federation misconfigured")
+            .unwrap();
+
+        let (addr, shutdown_tx, server) = spawn_server(state).await;
+
+        let (status, body) = http_request(addr, "GET", "/api/status", None).await;
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["paused"], false);
+        assert_eq!(json["orders"]["deposit_confirmed"], 1);
+        assert_eq!(json["orders"]["mint_pending"], 1);
+        assert_eq!(json["actionableBacklog"], 2);
+        assert_eq!(json["stuckOrders"], 1, "stuck-order alert trigger");
+        assert_eq!(json["components"][0]["component"], "attestation");
+        assert_eq!(
+            json["components"][0]["healthy"], false,
+            "signer-down alert trigger"
+        );
+        assert_eq!(json["pegHealthy"], serde_json::Value::Null);
+
+        let (status, body) = http_request(addr, "GET", "/metrics", None).await;
+        assert_eq!(status, 200);
+        assert!(body.contains("bridge_actionable_backlog 2"), "{}", body);
+        assert!(body.contains("bridge_stuck_orders 1"), "{}", body);
+        assert!(
+            body.contains("bridge_component_healthy{component=\"attestation\"} 0"),
+            "{}",
+            body
+        );
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    /// Minimal HTTP/1.1 request over a raw socket (avoids an HTTP-client
     /// dev-dependency). Returns (status, body).
-    async fn http_get(addr: std::net::SocketAddr, path: &str) -> (u16, String) {
+    async fn http_request(
+        addr: std::net::SocketAddr,
+        method: &str,
+        path: &str,
+        json_body: Option<&str>,
+    ) -> (u16, String) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
         let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        stream
-            .write_all(
-                format!(
-                    "GET {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
-                    path, addr
-                )
-                .as_bytes(),
-            )
-            .await
-            .unwrap();
+        let request = match json_body {
+            Some(body) => format!(
+                "{} {} HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                method,
+                path,
+                addr,
+                body.len(),
+                body
+            ),
+            None => format!(
+                "{} {} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
+                method, path, addr
+            ),
+        };
+        stream.write_all(request.as_bytes()).await.unwrap();
         let mut response = Vec::new();
         stream.read_to_end(&mut response).await.unwrap();
         let text = String::from_utf8_lossy(&response).to_string();

--- a/bridge/service/src/chaos_tests.rs
+++ b/bridge/service/src/chaos_tests.rs
@@ -1,0 +1,829 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Chaos / restart tests for the bridge order engine (#827 DoD).
+//!
+//! Every order transition is a SQLite commit boundary, so "kill -9 after
+//! commit K" is exactly equivalent to "perform the writes of commits
+//! 1..=K, then drop the engine and the DB handle". These tests drive
+//! orders through the FULL lifecycle over a file-backed database, crash
+//! the engine at EVERY durable state-transition boundary (by performing
+//! the partial writes of that boundary and reconstructing the engine +
+//! `Database` over the same file, via the real startup path including
+//! `recover_on_startup`), and assert exactly-once outcomes:
+//!
+//! - the destination chain minted exactly ONE transaction per order (the mock
+//!   chain enforces the #826 contract-side order-id guard and counts violation
+//!   attempts);
+//! - the BTH chain saw exactly ONE landed release per order (BTH has no
+//!   on-chain guard — a second landed tx IS the double-release bug);
+//! - every order reaches its terminal state (no stuck unrecoverable state),
+//!   with the reserve ledger arithmetically exact.
+//!
+//! The mock chains are `Arc`-shared across "restarts": they are the
+//! external world, which survives an engine crash.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use async_trait::async_trait;
+use bth_bridge_core::{
+    BridgeConfig, BridgeOrder, Chain, MintAuthorization, OrderStatus, ReleaseAuthorization,
+};
+use uuid::Uuid;
+
+use crate::{
+    attestation::{AttestationProvider, StubAttestationProvider},
+    db::Database,
+    engine::OrderProcessor,
+    mint::{ConfirmationStatus, MintError, Minter, PreparedMint},
+    release::{PreparedRelease, ReleaseConfirmation, ReleaseError, Releaser},
+};
+
+/// The external world: destination-chain and BTH-chain state that
+/// survives engine crashes.
+struct ChainWorld {
+    /// order_id_hash -> the ONE landed mint tx (the #826 contract-side
+    /// duplicate-order guard).
+    minted: Mutex<HashMap<String, String>>,
+    /// order_id_hash -> every DISTINCT landed release tx. BTH has no
+    /// on-chain order-id guard, so a second entry is a real double
+    /// release — the violation these tests hunt.
+    released: Mutex<HashMap<String, Vec<String>>>,
+    /// mint tx id -> order hash (set at signing time).
+    mint_tx_orders: Mutex<HashMap<String, String>>,
+    /// release tx hash -> order hash (set at signing time).
+    release_tx_orders: Mutex<HashMap<String, String>>,
+    /// Rejected duplicate-mint broadcasts (contract reverts). Must stay 0:
+    /// the service-side guards should never even ATTEMPT one.
+    double_mint_attempts: AtomicU32,
+    seq: AtomicU32,
+}
+
+impl ChainWorld {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            minted: Mutex::new(HashMap::new()),
+            released: Mutex::new(HashMap::new()),
+            mint_tx_orders: Mutex::new(HashMap::new()),
+            release_tx_orders: Mutex::new(HashMap::new()),
+            double_mint_attempts: AtomicU32::new(0),
+            seq: AtomicU32::new(0),
+        })
+    }
+
+    fn mint_count(&self, order: &BridgeOrder) -> usize {
+        let hash = hex::encode(order.order_id_bytes());
+        self.minted.lock().unwrap().contains_key(&hash) as usize
+    }
+
+    fn release_count(&self, order: &BridgeOrder) -> usize {
+        let hash = hex::encode(order.order_id_bytes());
+        self.released
+            .lock()
+            .unwrap()
+            .get(&hash)
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
+}
+
+/// Chaos minter: exactly-once at the chain level, auto-confirming once a
+/// tx has landed.
+///
+/// `aggressive_drop` controls what an unlanded tx reports: the chaos
+/// harness uses `true` (a never-broadcast tx is PROVABLY dropped in the
+/// deterministic single-writer world, driving the unwind/resubmit path);
+/// the concurrent load test uses `false` (`Pending`, mirroring the
+/// production rule that an implementation must never report a
+/// merely-unseen transaction as dropped — under concurrency another tick
+/// may broadcast it a moment later).
+struct ChaosMinter {
+    world: Arc<ChainWorld>,
+    prepare_calls: AtomicU32,
+    aggressive_drop: bool,
+}
+
+impl ChaosMinter {
+    async fn sign(&self, order: &BridgeOrder) -> PreparedMint {
+        let auth = StubAttestationProvider.authorize_mint(order).await.unwrap();
+        self.prepare_mint(order, &auth).await.unwrap()
+    }
+}
+
+#[async_trait]
+impl Minter for ChaosMinter {
+    fn chain(&self) -> Chain {
+        Chain::Ethereum
+    }
+
+    async fn prepare_mint(
+        &self,
+        order: &BridgeOrder,
+        _auth: &MintAuthorization,
+    ) -> Result<PreparedMint, MintError> {
+        self.prepare_calls.fetch_add(1, Ordering::SeqCst);
+        let tx_id = format!("0xtx{}", self.world.seq.fetch_add(1, Ordering::SeqCst));
+        self.world
+            .mint_tx_orders
+            .lock()
+            .unwrap()
+            .insert(tx_id.clone(), hex::encode(order.order_id_bytes()));
+        Ok(PreparedMint {
+            tx_id,
+            raw: vec![0xde],
+        })
+    }
+
+    async fn broadcast(&self, prepared: &PreparedMint) -> Result<(), MintError> {
+        let hash = self
+            .world
+            .mint_tx_orders
+            .lock()
+            .unwrap()
+            .get(&prepared.tx_id)
+            .cloned()
+            .expect("broadcast of a never-signed tx");
+        let mut minted = self.world.minted.lock().unwrap();
+        match minted.get(&hash) {
+            // Idempotent re-broadcast of the landed tx.
+            Some(landed) if *landed == prepared.tx_id => Ok(()),
+            // Contract-side order-id guard (#826): duplicate mint reverts.
+            Some(_) => {
+                self.world
+                    .double_mint_attempts
+                    .fetch_add(1, Ordering::SeqCst);
+                Err(MintError::Rpc(
+                    "execution reverted: order already minted".to_string(),
+                ))
+            }
+            None => {
+                minted.insert(hash, prepared.tx_id.clone());
+                Ok(())
+            }
+        }
+    }
+
+    async fn check_confirmation(
+        &self,
+        order: &BridgeOrder,
+        dest_tx: &str,
+    ) -> Result<ConfirmationStatus, MintError> {
+        let hash = hex::encode(order.order_id_bytes());
+        match self.world.minted.lock().unwrap().get(&hash) {
+            Some(landed) if landed == dest_tx => Ok(ConfirmationStatus::Confirmed),
+            _ if self.aggressive_drop => Ok(ConfirmationStatus::Reorged),
+            _ => Ok(ConfirmationStatus::Pending { confirmations: 0 }),
+        }
+    }
+}
+
+/// Chaos releaser: every broadcast tx lands (BTH has NO on-chain guard),
+/// auto-confirming a landed tx. See [`ChaosMinter`] for the
+/// `aggressive_drop` semantics.
+struct ChaosReleaser {
+    world: Arc<ChainWorld>,
+    prepare_calls: AtomicU32,
+    aggressive_drop: bool,
+}
+
+impl ChaosReleaser {
+    async fn sign(&self, order: &BridgeOrder) -> PreparedRelease {
+        let auth = StubAttestationProvider
+            .authorize_release(order)
+            .await
+            .unwrap();
+        self.prepare_release(order, &auth).await.unwrap()
+    }
+}
+
+#[async_trait]
+impl Releaser for ChaosReleaser {
+    async fn prepare_release(
+        &self,
+        order: &BridgeOrder,
+        _auth: &ReleaseAuthorization,
+    ) -> Result<PreparedRelease, ReleaseError> {
+        self.prepare_calls.fetch_add(1, Ordering::SeqCst);
+        let tx_hash = format!("bth_tx{}", self.world.seq.fetch_add(1, Ordering::SeqCst));
+        self.world
+            .release_tx_orders
+            .lock()
+            .unwrap()
+            .insert(tx_hash.clone(), hex::encode(order.order_id_bytes()));
+        Ok(PreparedRelease {
+            tx_hash,
+            raw: vec![0xca],
+        })
+    }
+
+    async fn broadcast(&self, prepared: &PreparedRelease) -> Result<(), ReleaseError> {
+        let hash = self
+            .world
+            .release_tx_orders
+            .lock()
+            .unwrap()
+            .get(&prepared.tx_hash)
+            .cloned()
+            .expect("broadcast of a never-signed tx");
+        let mut released = self.world.released.lock().unwrap();
+        let landed = released.entry(hash).or_default();
+        // Re-broadcast of the same tx is idempotent; a DIFFERENT tx for
+        // the same order LANDS (no on-chain guard) — recording the double
+        // release these tests assert never happens.
+        if !landed.contains(&prepared.tx_hash) {
+            landed.push(prepared.tx_hash.clone());
+        }
+        Ok(())
+    }
+
+    async fn check_confirmation(
+        &self,
+        order: &BridgeOrder,
+        dest_tx: &str,
+    ) -> Result<ReleaseConfirmation, ReleaseError> {
+        let hash = hex::encode(order.order_id_bytes());
+        let landed = self
+            .world
+            .released
+            .lock()
+            .unwrap()
+            .get(&hash)
+            .map(|v| v.contains(&dest_tx.to_string()))
+            .unwrap_or(false);
+        if landed {
+            Ok(ReleaseConfirmation::Confirmed)
+        } else if self.aggressive_drop {
+            // Never-broadcast tx: provably dead in the deterministic
+            // single-writer world (its inputs were never committed
+            // anywhere).
+            Ok(ReleaseConfirmation::Dropped)
+        } else {
+            Ok(ReleaseConfirmation::Pending { confirmations: 0 })
+        }
+    }
+}
+
+/// One "deployment": a DB file plus the external chain world. `boot()`
+/// simulates a process start (open DB, migrate, startup recovery);
+/// dropping the returned handles simulates a crash at the last commit.
+struct Harness {
+    _dir: tempfile::TempDir,
+    db_path: String,
+    world: Arc<ChainWorld>,
+    minter: Arc<ChaosMinter>,
+    releaser: Arc<ChaosReleaser>,
+    config: BridgeConfig,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir
+            .path()
+            .join("bridge-chaos.db")
+            .to_string_lossy()
+            .to_string();
+        let world = ChainWorld::new();
+        Self {
+            db_path,
+            minter: Arc::new(ChaosMinter {
+                world: world.clone(),
+                prepare_calls: AtomicU32::new(0),
+                aggressive_drop: true,
+            }),
+            releaser: Arc::new(ChaosReleaser {
+                world: world.clone(),
+                prepare_calls: AtomicU32::new(0),
+                aggressive_drop: true,
+            }),
+            world,
+            config: BridgeConfig::default(),
+            _dir: dir,
+        }
+    }
+
+    fn boot(&self) -> (OrderProcessor, Database) {
+        let db = Database::open(&self.db_path).unwrap();
+        db.migrate().unwrap();
+        let mut minters: HashMap<Chain, Arc<dyn Minter>> = HashMap::new();
+        minters.insert(Chain::Ethereum, self.minter.clone());
+        let processor = OrderProcessor::new(
+            self.config.clone(),
+            db.clone(),
+            minters,
+            Some(self.releaser.clone()),
+            Arc::new(StubAttestationProvider),
+        );
+        processor.recover_on_startup().unwrap();
+        (processor, db)
+    }
+}
+
+/// Tick until the order reaches a terminal state (bounded).
+async fn settle(processor: &OrderProcessor, db: &Database, order_id: &Uuid) -> OrderStatus {
+    for _ in 0..12 {
+        let status = db.get_order(order_id).unwrap().unwrap().status;
+        if status.is_terminal() {
+            return status;
+        }
+        processor.process_pending_orders().await.unwrap();
+    }
+    db.get_order(order_id).unwrap().unwrap().status
+}
+
+fn mint_order() -> BridgeOrder {
+    let mut order = BridgeOrder::new_mint(
+        Chain::Ethereum,
+        1_000_000_000_000,
+        1_000_000_000,
+        "bth_bridge_addr".to_string(),
+        "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+    );
+    order.set_status(OrderStatus::DepositConfirmed);
+    order
+}
+
+fn burn_order() -> BridgeOrder {
+    let mut order = BridgeOrder::new_burn(
+        Chain::Ethereum,
+        1_000_000_000_000,
+        1_000_000_000,
+        "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        "bth_user_stealth_addr".to_string(),
+        "0xburntx".to_string(),
+    );
+    order.set_status(OrderStatus::BurnConfirmed);
+    order
+}
+
+// === Mint-path crash points ===
+
+/// Every durable boundary of the mint submit/confirm pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum MintCrash {
+    /// Baseline: crash before any engine write.
+    BeforeAnything,
+    /// After the reserve backing was locked, before the mint record.
+    AfterReserveLock,
+    /// After the signed tx was persisted to `mints`, before the status
+    /// update and before broadcast.
+    AfterMintRecorded,
+    /// After the order advanced to `MintPending`, before broadcast.
+    AfterStatusMintPending,
+    /// After the tx was broadcast, before confirmation was recorded.
+    AfterBroadcast,
+    /// After `mark_mint_confirmed` (terminal): restart must be a no-op.
+    AfterConfirmed,
+}
+
+async fn run_mint_chaos(point: MintCrash) {
+    let harness = Harness::new();
+    let order = mint_order();
+    let hash = hex::encode(order.order_id_bytes());
+
+    // Engine instance 1: perform the writes up to the crash point, in the
+    // exact order the engine performs them, then crash.
+    {
+        let (_processor, db) = harness.boot();
+        db.insert_order(&order).unwrap();
+
+        if point >= MintCrash::AfterReserveLock {
+            db.record_locked_output(
+                &format!("dep:{}", order.id),
+                order.dest_chain,
+                order.net_amount(),
+                &order.id,
+            )
+            .unwrap();
+        }
+        if point >= MintCrash::AfterMintRecorded {
+            let prepared = harness.minter.sign(&order).await;
+            db.record_mint_submitted(&order.id, &hash, order.dest_chain, &prepared.tx_id)
+                .unwrap();
+            if point >= MintCrash::AfterStatusMintPending {
+                db.update_order_status(&order.id, &OrderStatus::MintPending, Some(&prepared.tx_id))
+                    .unwrap();
+            }
+            if point >= MintCrash::AfterBroadcast {
+                harness.minter.broadcast(&prepared).await.unwrap();
+            }
+            if point >= MintCrash::AfterConfirmed {
+                db.mark_mint_confirmed(&order.id).unwrap();
+            }
+        }
+        // Crash: processor + db handles dropped here.
+    }
+
+    // Engine instance 2: restart over the same file and settle.
+    let (processor, db) = harness.boot();
+    let status = settle(&processor, &db, &order.id).await;
+
+    // Exactly-once outcomes, regardless of where the crash hit.
+    assert_eq!(
+        status,
+        OrderStatus::Completed,
+        "{:?}: order must settle after restart",
+        point
+    );
+    assert_eq!(
+        harness.world.mint_count(&order),
+        1,
+        "{:?}: the chain must see exactly one mint",
+        point
+    );
+    assert_eq!(
+        harness.world.double_mint_attempts.load(Ordering::SeqCst),
+        0,
+        "{:?}: no duplicate mint may even be attempted",
+        point
+    );
+    let mint = db.get_mint_by_order(&order.id).unwrap().unwrap();
+    assert!(mint.confirmed_at.is_some());
+    assert_eq!(
+        Some(mint.dest_tx),
+        db.get_order(&order.id).unwrap().unwrap().dest_tx,
+        "{:?}: recorded and order-visible tx must agree",
+        point
+    );
+    // Reserve ledger exact: the completed mint's net backing is locked
+    // exactly once.
+    assert_eq!(
+        db.locked_reserve_total().unwrap(),
+        order.net_amount(),
+        "{:?}: backing must be locked exactly once",
+        point
+    );
+    // Further restarts + ticks change nothing (terminal is stable).
+    drop((processor, db));
+    let (processor, db) = harness.boot();
+    processor.process_pending_orders().await.unwrap();
+    assert_eq!(harness.world.mint_count(&order), 1);
+    assert_eq!(
+        db.get_order(&order.id).unwrap().unwrap().status,
+        OrderStatus::Completed
+    );
+}
+
+#[tokio::test]
+async fn chaos_mint_crash_at_every_transition_boundary() {
+    for point in [
+        MintCrash::BeforeAnything,
+        MintCrash::AfterReserveLock,
+        MintCrash::AfterMintRecorded,
+        MintCrash::AfterStatusMintPending,
+        MintCrash::AfterBroadcast,
+        MintCrash::AfterConfirmed,
+    ] {
+        run_mint_chaos(point).await;
+    }
+}
+
+// === Deposit-detection crash window (#843) ===
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum DepositCrash {
+    /// Between the detect write and the idempotency row (watcher step 1→2).
+    AfterDetect,
+    /// Between the idempotency row and the confirm write (step 2→4).
+    AfterDetectMarked,
+}
+
+async fn run_deposit_chaos(point: DepositCrash) {
+    let harness = Harness::new();
+    let mut order = BridgeOrder::new_mint(
+        Chain::Ethereum,
+        1_000_000_000_000,
+        1_000_000_000,
+        "bth_bridge_addr".to_string(),
+        "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+    );
+    order.generate_memo();
+
+    {
+        let (_processor, db) = harness.boot();
+        db.insert_order(&order).unwrap();
+        assert!(db
+            .record_deposit_detected(&order.id, "0xdeposit", order.amount)
+            .unwrap());
+        if point >= DepositCrash::AfterDetectMarked {
+            db.mark_deposit_processed("0xdeposit", &order.id).unwrap();
+        }
+        // Crash before the confirm write: without recovery this order is
+        // stranded at DepositDetected forever (#843).
+    }
+
+    let (processor, db) = harness.boot();
+    // Startup recovery already ran inside boot(); both crash halves must
+    // be closed.
+    assert_eq!(
+        db.get_order(&order.id).unwrap().unwrap().status,
+        OrderStatus::DepositConfirmed,
+        "{:?}: recovery must roll the stranded order forward",
+        point
+    );
+    assert!(db.is_deposit_processed("0xdeposit").unwrap());
+
+    let status = settle(&processor, &db, &order.id).await;
+    assert_eq!(status, OrderStatus::Completed, "{:?}", point);
+    assert_eq!(harness.world.mint_count(&order), 1, "{:?}", point);
+    assert_eq!(db.count_audit_action("deposit_recovered").unwrap(), 1);
+}
+
+#[tokio::test]
+async fn chaos_deposit_detected_crash_window_recovers() {
+    run_deposit_chaos(DepositCrash::AfterDetect).await;
+    run_deposit_chaos(DepositCrash::AfterDetectMarked).await;
+}
+
+// === Release-path crash points ===
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ReleaseCrash {
+    /// Baseline: crash before any engine write.
+    BeforeAnything,
+    /// After the durable claim, before signing.
+    AfterClaim,
+    /// After the signed tx (hash + raw bytes) was persisted, before the
+    /// status update and before broadcast.
+    AfterTxRecorded,
+    /// After the order advanced to `ReleasePending`, before broadcast.
+    AfterStatusReleasePending,
+    /// After the tx was broadcast, before confirmation was recorded.
+    AfterBroadcast,
+    /// After the reserve spend was applied, before `mark_release_confirmed`.
+    AfterReserveSpend,
+}
+
+/// Reserve seeded well above the burn amount.
+const RELEASE_SEED: u64 = 5_000_000_000_000;
+
+async fn run_release_chaos(point: ReleaseCrash) {
+    let harness = Harness::new();
+    let order = burn_order();
+    let hash = hex::encode(order.order_id_bytes());
+
+    {
+        let (_processor, db) = harness.boot();
+        db.record_locked_output("dep:seed", Chain::Ethereum, RELEASE_SEED, &Uuid::new_v4())
+            .unwrap();
+        db.insert_order(&order).unwrap();
+
+        if point >= ReleaseCrash::AfterClaim {
+            db.try_claim_release(&order.id, &hash).unwrap();
+        }
+        if point >= ReleaseCrash::AfterTxRecorded {
+            let prepared = harness.releaser.sign(&order).await;
+            db.record_release_tx(&order.id, &prepared.tx_hash, &prepared.raw)
+                .unwrap();
+            if point >= ReleaseCrash::AfterStatusReleasePending {
+                db.update_order_status(
+                    &order.id,
+                    &OrderStatus::ReleasePending,
+                    Some(&prepared.tx_hash),
+                )
+                .unwrap();
+            }
+            if point >= ReleaseCrash::AfterBroadcast {
+                harness.releaser.broadcast(&prepared).await.unwrap();
+            }
+            if point >= ReleaseCrash::AfterReserveSpend {
+                assert!(db
+                    .apply_release_spend(&order.id, order.source_chain, order.amount)
+                    .unwrap());
+            }
+        }
+        // Crash.
+    }
+
+    let (processor, db) = harness.boot();
+    let status = settle(&processor, &db, &order.id).await;
+
+    assert_eq!(
+        status,
+        OrderStatus::Released,
+        "{:?}: burn must settle after restart",
+        point
+    );
+    assert_eq!(
+        harness.world.release_count(&order),
+        1,
+        "{:?}: exactly one release may land on BTH (no on-chain guard!)",
+        point
+    );
+    let claim = db.get_release_by_order(&order.id).unwrap().unwrap();
+    assert!(claim.confirmed_at.is_some());
+    assert_eq!(
+        claim.release_tx_hash,
+        db.get_order(&order.id).unwrap().unwrap().dest_tx,
+        "{:?}: recorded and order-visible tx must agree",
+        point
+    );
+    // Reserve ledger exact: the GROSS burn left the ledger exactly once.
+    assert_eq!(
+        db.locked_reserve_total().unwrap(),
+        RELEASE_SEED - order.amount,
+        "{:?}: reserve must be spent exactly once",
+        point
+    );
+
+    // Further restarts + ticks change nothing.
+    drop((processor, db));
+    let (processor, db) = harness.boot();
+    processor.process_pending_orders().await.unwrap();
+    assert_eq!(harness.world.release_count(&order), 1);
+    assert_eq!(
+        db.locked_reserve_total().unwrap(),
+        RELEASE_SEED - order.amount
+    );
+    assert_eq!(
+        db.get_order(&order.id).unwrap().unwrap().status,
+        OrderStatus::Released
+    );
+}
+
+#[tokio::test]
+async fn chaos_release_crash_at_every_transition_boundary() {
+    for point in [
+        ReleaseCrash::BeforeAnything,
+        ReleaseCrash::AfterClaim,
+        ReleaseCrash::AfterTxRecorded,
+        ReleaseCrash::AfterStatusReleasePending,
+        ReleaseCrash::AfterBroadcast,
+        ReleaseCrash::AfterReserveSpend,
+    ] {
+        run_release_chaos(point).await;
+    }
+}
+
+/// Restart the engine after EVERY tick of a normal lifecycle (a rolling
+/// crash-loop deployment) — both flows must still settle exactly once.
+#[tokio::test]
+async fn chaos_restart_after_every_tick() {
+    let harness = Harness::new();
+    let mint = mint_order();
+    let burn = burn_order();
+
+    {
+        let (_processor, db) = harness.boot();
+        db.record_locked_output("dep:seed", Chain::Ethereum, RELEASE_SEED, &Uuid::new_v4())
+            .unwrap();
+        db.insert_order(&mint).unwrap();
+        db.insert_order(&burn).unwrap();
+    }
+
+    for _ in 0..8 {
+        let (processor, db) = harness.boot();
+        processor.process_pending_orders().await.unwrap();
+        let m = db.get_order(&mint.id).unwrap().unwrap().status;
+        let b = db.get_order(&burn.id).unwrap().unwrap().status;
+        if m.is_terminal() && b.is_terminal() {
+            break;
+        }
+        // Crash after every single tick.
+    }
+
+    let (_processor, db) = harness.boot();
+    assert_eq!(
+        db.get_order(&mint.id).unwrap().unwrap().status,
+        OrderStatus::Completed
+    );
+    assert_eq!(
+        db.get_order(&burn.id).unwrap().unwrap().status,
+        OrderStatus::Released
+    );
+    assert_eq!(harness.world.mint_count(&mint), 1);
+    assert_eq!(harness.world.release_count(&burn), 1);
+    assert_eq!(harness.world.double_mint_attempts.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        db.locked_reserve_total().unwrap(),
+        RELEASE_SEED + mint.net_amount() - burn.amount
+    );
+}
+
+// === Load test: high-volume concurrent pipeline ===
+
+/// Hundreds of concurrent orders through the mock pipeline with several
+/// engine ticks running CONCURRENTLY over the shared connection: no
+/// deadlocks, no lost orders, chain-level exactly-once throughout.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn load_test_concurrent_orders_exactly_once() {
+    const MINTS: usize = 120;
+    const BURNS: usize = 120;
+    const AMOUNT: u64 = 1_000_000_000_000; // 1 BTH
+
+    let db = Database::open_in_memory().unwrap();
+    db.migrate().unwrap();
+    let world = ChainWorld::new();
+    let minter = Arc::new(ChaosMinter {
+        world: world.clone(),
+        prepare_calls: AtomicU32::new(0),
+        aggressive_drop: false,
+    });
+    let releaser = Arc::new(ChaosReleaser {
+        world: world.clone(),
+        prepare_calls: AtomicU32::new(0),
+        aggressive_drop: false,
+    });
+    let mut minters: HashMap<Chain, Arc<dyn Minter>> = HashMap::new();
+    minters.insert(Chain::Ethereum, minter.clone());
+    let processor = Arc::new(OrderProcessor::new(
+        BridgeConfig::default(),
+        db.clone(),
+        minters,
+        Some(releaser.clone()),
+        Arc::new(StubAttestationProvider),
+    ));
+
+    // Seed reserve to cover every burn.
+    db.record_locked_output(
+        "dep:seed",
+        Chain::Ethereum,
+        AMOUNT * BURNS as u64,
+        &Uuid::new_v4(),
+    )
+    .unwrap();
+
+    let mut mint_ids = Vec::with_capacity(MINTS);
+    for i in 0..MINTS {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            AMOUNT,
+            0,
+            "bth_bridge_addr".to_string(),
+            format!("0xuser{:040}", i), // distinct per-address windows
+        );
+        order.set_status(OrderStatus::DepositConfirmed);
+        db.insert_order(&order).unwrap();
+        mint_ids.push(order.id);
+    }
+    let mut burn_ids = Vec::with_capacity(BURNS);
+    for i in 0..BURNS {
+        let mut order = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            AMOUNT,
+            0,
+            format!("0xburner{:038}", i),
+            "bth_user_stealth_addr".to_string(),
+            format!("0xburntx{}", i),
+        );
+        order.set_status(OrderStatus::BurnConfirmed);
+        db.insert_order(&order).unwrap();
+        burn_ids.push(order.id);
+    }
+
+    // 4 concurrent tick loops hammer the shared connection.
+    let mut tasks = Vec::new();
+    for _ in 0..4 {
+        let p = processor.clone();
+        tasks.push(tokio::spawn(async move {
+            for _ in 0..6 {
+                p.process_pending_orders().await.unwrap();
+            }
+        }));
+    }
+    for task in tasks {
+        task.await.unwrap();
+    }
+    // Drain any stragglers single-threaded (bounded).
+    for _ in 0..10 {
+        if db.actionable_backlog().unwrap() == 0 {
+            break;
+        }
+        processor.process_pending_orders().await.unwrap();
+    }
+
+    // No lost orders: every order reached its terminal state.
+    for id in &mint_ids {
+        let order = db.get_order(id).unwrap().unwrap();
+        assert_eq!(order.status, OrderStatus::Completed, "mint {} lost", id);
+        assert_eq!(world.mint_count(&order), 1, "mint {} not exactly-once", id);
+    }
+    for id in &burn_ids {
+        let order = db.get_order(id).unwrap().unwrap();
+        assert_eq!(order.status, OrderStatus::Released, "burn {} lost", id);
+        assert_eq!(
+            world.release_count(&order),
+            1,
+            "burn {} released a wrong number of times",
+            id
+        );
+    }
+    assert_eq!(
+        world.double_mint_attempts.load(Ordering::SeqCst),
+        0,
+        "no duplicate mint may even be attempted under concurrency"
+    );
+
+    // Reserve ledger arithmetic holds under the full concurrent volume.
+    assert_eq!(
+        db.locked_reserve_total().unwrap(),
+        AMOUNT * BURNS as u64 + AMOUNT * MINTS as u64 - AMOUNT * BURNS as u64,
+        "locked reserve must equal seeded + minted-net - burned-gross"
+    );
+    assert_eq!(db.actionable_backlog().unwrap(), 0);
+}

--- a/bridge/service/src/db.rs
+++ b/bridge/service/src/db.rs
@@ -159,6 +159,49 @@ pub struct ReserveSnapshot {
     /// `in_tolerance` AND the on-Botho reserve balance covered the ledger
     /// (when checkable). The dashboard's red/green peg state.
     pub peg_healthy: bool,
+    /// Whether the on-Botho reserve balance custody leg was actually
+    /// checked this pass (#846: consumers must be able to distinguish
+    /// "custody checked OK" from "custody never checked").
+    pub reserve_balance_checked: bool,
+}
+
+/// Outcome of an atomic rate-limit reservation
+/// ([`Database::check_and_reserve_limits`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LimitCheck {
+    /// The order's volume was reserved against the daily windows.
+    Reserved,
+    /// A reservation for this order already exists (crash/tick replay) —
+    /// the volume was counted exactly once.
+    AlreadyReserved,
+    /// The order violates a limit and must not proceed this window.
+    Rejected(LimitViolation),
+}
+
+/// Which limit a rejected order violated.
+// The shared `Cap` postfix is the point: each variant names WHICH cap.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitViolation {
+    /// `amount > max_order_amount`: can never pass — permanent for this
+    /// order.
+    PerOrderCap,
+    /// The counterparty address's daily volume window is exhausted;
+    /// retryable next window.
+    AddressDailyCap,
+    /// The bridge-wide daily volume window is exhausted; retryable next
+    /// window (and an anomaly signal — callers trip the circuit breaker).
+    GlobalDailyCap,
+}
+
+impl std::fmt::Display for LimitViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LimitViolation::PerOrderCap => write!(f, "per-order amount cap"),
+            LimitViolation::AddressDailyCap => write!(f, "per-address daily volume cap"),
+            LimitViolation::GlobalDailyCap => write!(f, "global daily volume cap"),
+        }
+    }
 }
 
 /// Database wrapper for thread-safe access.
@@ -313,6 +356,35 @@ impl Database {
 
             CREATE INDEX IF NOT EXISTS idx_reserve_snapshots_taken
                 ON reserve_snapshots(taken_at);
+
+            CREATE TABLE IF NOT EXISTS bridge_state (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                paused INTEGER NOT NULL DEFAULT 0,
+                paused_reason TEXT,
+                paused_at INTEGER
+            );
+
+            INSERT OR IGNORE INTO bridge_state (id, paused) VALUES (1, 0);
+
+            CREATE TABLE IF NOT EXISTS limit_reservations (
+                order_id TEXT PRIMARY KEY REFERENCES bridge_orders(id),
+                address TEXT NOT NULL,
+                amount INTEGER NOT NULL,
+                day_bucket INTEGER NOT NULL,
+                created_at INTEGER NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_limit_res_addr
+                ON limit_reservations(address, day_bucket);
+            CREATE INDEX IF NOT EXISTS idx_limit_res_day
+                ON limit_reservations(day_bucket);
+
+            CREATE TABLE IF NOT EXISTS component_health (
+                component TEXT PRIMARY KEY,
+                healthy INTEGER NOT NULL,
+                detail TEXT,
+                updated_at INTEGER NOT NULL
+            );
             "#,
         )
         .map_err(|e| format!("Migration failed: {}", e))?;
@@ -322,6 +394,14 @@ impl Database {
         // databases, so guard each with a pragma check.
         Self::ensure_column(&conn, "bridge_orders", "mint_authorization", "TEXT")?;
         Self::ensure_column(&conn, "bridge_orders", "dest_confirmed_at", "INTEGER")?;
+        // #846: persist whether the custody leg was checked, so the proof
+        // API can distinguish "checked OK" from "never checked".
+        Self::ensure_column(
+            &conn,
+            "reserve_snapshots",
+            "reserve_balance_checked",
+            "INTEGER",
+        )?;
 
         Ok(())
     }
@@ -450,14 +530,44 @@ impl Database {
         Ok(orders)
     }
 
-    /// Update order status.
+    /// Update order status, enforcing the state machine at the DB layer
+    /// (#839).
+    ///
+    /// The current status is read and validated inside the same
+    /// transaction: the write is rejected unless
+    /// [`OrderStatus::can_transition_to`] allows the edge. A same-status
+    /// write is treated as an idempotent refresh (replayed ticks may
+    /// re-assert a status, optionally updating the tx hash), never as a
+    /// transition. No writer can bypass the state machine or clobber a
+    /// terminal state through this path.
     pub fn update_order_status(
         &self,
         id: &Uuid,
         status: &OrderStatus,
         tx_hash: Option<&str>,
     ) -> Result<(), String> {
-        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let mut conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| format!("Transaction failed: {}", e))?;
+
+        let (current_str, current_err): (String, Option<String>) = tx
+            .query_row(
+                "SELECT status, error_message FROM bridge_orders WHERE id = ?1",
+                params![id.to_string()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .map_err(|e| format!("Order {} not found for status update: {}", id, e))?;
+        let current = parse_status(&current_str, current_err);
+
+        let same_status = std::mem::discriminant(&current) == std::mem::discriminant(status);
+        if !same_status && !current.can_transition_to(status) {
+            return Err(format!(
+                "illegal order status transition for {}: {} -> {}",
+                id, current, status
+            ));
+        }
 
         let now = Utc::now().timestamp();
         let status_str = status.to_string();
@@ -468,7 +578,7 @@ impl Database {
 
         if let Some(hash) = tx_hash {
             // Update with transaction hash
-            conn.execute(
+            tx.execute(
                 r#"
                 UPDATE bridge_orders
                 SET status = ?1, dest_tx = ?2, error_message = ?3, updated_at = ?4
@@ -478,7 +588,7 @@ impl Database {
             )
             .map_err(|e| format!("Update failed: {}", e))?;
         } else {
-            conn.execute(
+            tx.execute(
                 r#"
                 UPDATE bridge_orders
                 SET status = ?1, error_message = ?2, updated_at = ?3
@@ -489,7 +599,7 @@ impl Database {
             .map_err(|e| format!("Update failed: {}", e))?;
         }
 
-        Ok(())
+        tx.commit().map_err(|e| format!("Commit failed: {}", e))
     }
 
     /// Check if a deposit has been processed.
@@ -1180,25 +1290,159 @@ impl Database {
         .map_err(|e| format!("Update failed: {}", e))
     }
 
-    /// Unlock the locked output(s) recorded by `order_id` (a mint that
-    /// failed after its deposit was locked: the funds sit in the bridge
-    /// address but no longer back wrapped supply — they are owed back to
-    /// the depositor). Returns whether anything was unlocked.
-    pub fn unlock_outputs_for_order(&self, order_id: &Uuid) -> Result<bool, String> {
-        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+    /// Unlock `net_amount` of backing for a mint that failed after its
+    /// deposit was locked: the funds sit in the bridge address but no
+    /// longer back wrapped supply — they are owed back to the depositor.
+    ///
+    /// Value-based (#846): the order's own locked `dep:` output is
+    /// unlocked first, but if a release's FIFO spend already consumed it
+    /// (its residual value now lives in a `chg:` output attributed to the
+    /// release), the remainder is unlocked by VALUE from the chain's
+    /// locked outputs FIFO — mirroring [`Database::apply_release_spend`],
+    /// change semantics included — so the ledger never permanently
+    /// overcounts by the failed mint's amount.
+    ///
+    /// Exactly-once by attribution: a replay finds outputs already
+    /// unlocked with `spent_order_id == order_id` and returns `Ok(false)`.
+    /// Fails (rolling back) if the locked reserve cannot cover the
+    /// amount — an invariant violation the caller must surface.
+    pub fn unlock_backing_for_order(
+        &self,
+        order_id: &Uuid,
+        chain: Chain,
+        net_amount: u64,
+    ) -> Result<bool, String> {
+        let mut conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
 
-        let changed = conn
-            .execute(
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| format!("Transaction failed: {}", e))?;
+
+        // Idempotency: any output already attributed to this failed mint
+        // means the unlock was already applied.
+        let already: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM reserve_ledger WHERE spent_order_id = ?1",
+                params![order_id.to_string()],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Query failed: {}", e))?;
+        if already > 0 {
+            return Ok(false);
+        }
+
+        let now = Utc::now().timestamp();
+        let mut remaining = net_amount as u128;
+
+        // Pass 1: the order's own locked outputs (the common case — the
+        // `dep:` output is untouched and matches the net amount exactly).
+        let own: Vec<(String, u64)> = Self::locked_rows(
+            &tx,
+            r#"
+            SELECT bridge_output_id, amount_picocredits FROM reserve_ledger
+            WHERE order_id = ?1 AND locked = 1
+            ORDER BY created_at ASC, rowid ASC
+            "#,
+            params![order_id.to_string()],
+        )?;
+        for (output_id, output_amount) in own {
+            tx.execute(
                 r#"
                 UPDATE reserve_ledger
                 SET locked = 0, spent_order_id = ?1, spent_at = ?2
-                WHERE order_id = ?1 AND locked = 1
+                WHERE bridge_output_id = ?3 AND locked = 1
                 "#,
-                params![order_id.to_string(), Utc::now().timestamp()],
+                params![order_id.to_string(), now, output_id],
             )
             .map_err(|e| format!("Update failed: {}", e))?;
+            remaining = remaining.saturating_sub(output_amount as u128);
+        }
 
-        Ok(changed > 0)
+        // Pass 2: FIFO by value over the chain's other locked outputs
+        // (the failed mint's own output was consumed by a release spend
+        // and its value carried into change).
+        if remaining > 0 {
+            let rows: Vec<(String, u64)> = Self::locked_rows(
+                &tx,
+                r#"
+                SELECT bridge_output_id, amount_picocredits FROM reserve_ledger
+                WHERE chain = ?1 AND locked = 1
+                ORDER BY created_at ASC, rowid ASC
+                "#,
+                params![chain.to_string()],
+            )?;
+
+            for (output_id, output_amount) in rows {
+                if remaining == 0 {
+                    break;
+                }
+                tx.execute(
+                    r#"
+                    UPDATE reserve_ledger
+                    SET locked = 0, spent_order_id = ?1, spent_at = ?2
+                    WHERE bridge_output_id = ?3 AND locked = 1
+                    "#,
+                    params![order_id.to_string(), now, output_id],
+                )
+                .map_err(|e| format!("Update failed: {}", e))?;
+
+                let output_amount = output_amount as u128;
+                if output_amount >= remaining {
+                    let change = output_amount - remaining;
+                    remaining = 0;
+                    if change > 0 {
+                        tx.execute(
+                            r#"
+                            INSERT INTO reserve_ledger (
+                                bridge_output_id, chain, amount_picocredits, locked,
+                                order_id, spent_order_id, created_at, spent_at
+                            ) VALUES (?1, ?2, ?3, 1, ?4, NULL, ?5, NULL)
+                            "#,
+                            params![
+                                format!("chg:{}", order_id),
+                                chain.to_string(),
+                                change as i64,
+                                order_id.to_string(),
+                                now,
+                            ],
+                        )
+                        .map_err(|e| format!("Insert change failed: {}", e))?;
+                    }
+                } else {
+                    remaining -= output_amount;
+                }
+            }
+        }
+
+        if remaining > 0 {
+            // Dropping the transaction rolls everything back.
+            return Err(format!(
+                "insufficient locked reserve on {}: short {} picocredits unlocking failed mint {}",
+                chain, remaining, order_id
+            ));
+        }
+
+        tx.commit().map_err(|e| format!("Commit failed: {}", e))?;
+        Ok(true)
+    }
+
+    /// Collect `(bridge_output_id, amount)` rows for a locked-output query.
+    fn locked_rows(
+        conn: &Connection,
+        sql: &str,
+        args: impl rusqlite::Params,
+    ) -> Result<Vec<(String, u64)>, String> {
+        let mut stmt = conn
+            .prepare(sql)
+            .map_err(|e| format!("Prepare failed: {}", e))?;
+        let rows = stmt
+            .query_map(args, |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)? as u64))
+            })
+            .map_err(|e| format!("Query failed: {}", e))?
+            .collect::<SqliteResult<Vec<_>>>()
+            .map_err(|e| format!("Collect failed: {}", e))?;
+        Ok(rows)
     }
 
     /// Apply a confirmed release to the reserve ledger: spend locked
@@ -1430,8 +1674,8 @@ impl Database {
             r#"
             INSERT INTO reserve_snapshots (
                 taken_at, locked_reserve, eth_supply, sol_supply,
-                drift, in_tolerance, peg_healthy
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                drift, in_tolerance, peg_healthy, reserve_balance_checked
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
             "#,
             params![
                 snapshot.taken_at,
@@ -1441,11 +1685,31 @@ impl Database {
                 snapshot.drift,
                 snapshot.in_tolerance as i64,
                 snapshot.peg_healthy as i64,
+                snapshot.reserve_balance_checked as i64,
             ],
         )
         .map_err(|e| format!("Insert failed: {}", e))?;
 
         Ok(())
+    }
+
+    /// Delete reconciliation snapshots older than `retain_secs`, always
+    /// keeping the most recent row (#846: the tables are otherwise
+    /// unbounded — one row per pass, ~525k rows/yr at the default 60s
+    /// cadence). Returns the number of pruned rows.
+    pub fn prune_reserve_snapshots(&self, retain_secs: i64) -> Result<usize, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let cutoff = Utc::now().timestamp() - retain_secs;
+
+        conn.execute(
+            r#"
+            DELETE FROM reserve_snapshots
+            WHERE taken_at < ?1
+              AND id != (SELECT MAX(id) FROM reserve_snapshots)
+            "#,
+            params![cutoff],
+        )
+        .map_err(|e| format!("Prune failed: {}", e))
     }
 
     /// Latest reconciliation snapshot, if any pass has run.
@@ -1456,7 +1720,8 @@ impl Database {
             .prepare(
                 r#"
                 SELECT taken_at, locked_reserve, eth_supply, sol_supply,
-                       drift, in_tolerance, peg_healthy
+                       drift, in_tolerance, peg_healthy,
+                       COALESCE(reserve_balance_checked, 0)
                 FROM reserve_snapshots ORDER BY id DESC LIMIT 1
                 "#,
             )
@@ -1471,10 +1736,314 @@ impl Database {
                 drift: row.get(4)?,
                 in_tolerance: row.get::<_, i64>(5)? != 0,
                 peg_healthy: row.get::<_, i64>(6)? != 0,
+                reserve_balance_checked: row.get::<_, i64>(7)? != 0,
             })
         })
         .optional()
         .map_err(|e| format!("Query failed: {}", e))
+    }
+
+    // === Circuit breaker (bridge_state singleton) ===
+
+    /// Whether the bridge is paused. Returns the pause reason when paused.
+    pub fn is_paused(&self) -> Result<Option<String>, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        conn.query_row(
+            "SELECT paused, paused_reason FROM bridge_state WHERE id = 1",
+            [],
+            |row| {
+                let paused: i64 = row.get(0)?;
+                let reason: Option<String> = row.get(1)?;
+                Ok((paused != 0)
+                    .then(|| reason.unwrap_or_else(|| "paused (no reason recorded)".to_string())))
+            },
+        )
+        .map_err(|e| format!("Query failed: {}", e))
+    }
+
+    /// Set the global pause flag (the circuit breaker / kill switch).
+    ///
+    /// Returns whether the state CHANGED — callers audit-log the trip
+    /// exactly once, so an already-tripped breaker is not re-audited every
+    /// tick.
+    pub fn set_paused(&self, paused: bool, reason: Option<&str>) -> Result<bool, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let changed = conn
+            .execute(
+                r#"
+                UPDATE bridge_state
+                SET paused = ?1, paused_reason = ?2, paused_at = ?3
+                WHERE id = 1 AND paused != ?1
+                "#,
+                params![
+                    paused as i64,
+                    if paused { reason } else { None },
+                    if paused {
+                        Some(Utc::now().timestamp())
+                    } else {
+                        None
+                    },
+                ],
+            )
+            .map_err(|e| format!("Update failed: {}", e))?;
+
+        Ok(changed > 0)
+    }
+
+    // === Rate limits (per-order cap + daily rolling windows) ===
+
+    /// Atomically check and reserve an order's volume against the limits,
+    /// exactly once per order.
+    ///
+    /// In a single `BEGIN IMMEDIATE` transaction: an existing reservation
+    /// for `order_id` short-circuits to [`LimitCheck::AlreadyReserved`]
+    /// (a crashed or replayed tick never double-counts); otherwise the
+    /// per-order cap, the address's daily window, and the global daily
+    /// window are checked and — only if all pass — the volume is reserved
+    /// against the current UTC day bucket. A limit of 0 disables that
+    /// check. `Rejected` reserves nothing.
+    #[allow(clippy::too_many_arguments)]
+    pub fn check_and_reserve_limits(
+        &self,
+        order_id: &Uuid,
+        address: &str,
+        amount: u64,
+        max_order_amount: u64,
+        daily_limit_per_address: u64,
+        global_daily_limit: u64,
+        now: i64,
+    ) -> Result<LimitCheck, String> {
+        let mut conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|e| format!("Transaction failed: {}", e))?;
+
+        let existing: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM limit_reservations WHERE order_id = ?1",
+                params![order_id.to_string()],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Query failed: {}", e))?;
+        if existing > 0 {
+            return Ok(LimitCheck::AlreadyReserved);
+        }
+
+        if max_order_amount > 0 && amount > max_order_amount {
+            return Ok(LimitCheck::Rejected(LimitViolation::PerOrderCap));
+        }
+
+        let day_bucket = now.div_euclid(86_400);
+
+        if daily_limit_per_address > 0 {
+            let addr_volume: i64 = tx
+                .query_row(
+                    r#"
+                    SELECT COALESCE(SUM(amount), 0) FROM limit_reservations
+                    WHERE address = ?1 AND day_bucket = ?2
+                    "#,
+                    params![address, day_bucket],
+                    |row| row.get(0),
+                )
+                .map_err(|e| format!("Query failed: {}", e))?;
+            if (addr_volume.max(0) as u128).saturating_add(amount as u128)
+                > daily_limit_per_address as u128
+            {
+                return Ok(LimitCheck::Rejected(LimitViolation::AddressDailyCap));
+            }
+        }
+
+        if global_daily_limit > 0 {
+            let global_volume: i64 = tx
+                .query_row(
+                    r#"
+                    SELECT COALESCE(SUM(amount), 0) FROM limit_reservations
+                    WHERE day_bucket = ?1
+                    "#,
+                    params![day_bucket],
+                    |row| row.get(0),
+                )
+                .map_err(|e| format!("Query failed: {}", e))?;
+            if (global_volume.max(0) as u128).saturating_add(amount as u128)
+                > global_daily_limit as u128
+            {
+                return Ok(LimitCheck::Rejected(LimitViolation::GlobalDailyCap));
+            }
+        }
+
+        tx.execute(
+            r#"
+            INSERT INTO limit_reservations (order_id, address, amount, day_bucket, created_at)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+            params![
+                order_id.to_string(),
+                address,
+                amount as i64,
+                day_bucket,
+                now
+            ],
+        )
+        .map_err(|e| format!("Insert failed: {}", e))?;
+
+        tx.commit().map_err(|e| format!("Commit failed: {}", e))?;
+        Ok(LimitCheck::Reserved)
+    }
+
+    /// Total volume reserved against the daily window containing `now`
+    /// (monitoring / anomaly detection).
+    pub fn daily_reserved_volume(&self, now: i64) -> Result<u64, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let volume: i64 = conn
+            .query_row(
+                "SELECT COALESCE(SUM(amount), 0) FROM limit_reservations WHERE day_bucket = ?1",
+                params![now.div_euclid(86_400)],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Query failed: {}", e))?;
+        Ok(volume.max(0) as u64)
+    }
+
+    // === Monitoring queries (#827) ===
+
+    /// Order counts grouped by status (`failed: <reason>` variants are
+    /// folded into a single `failed` bucket).
+    pub fn order_status_counts(&self) -> Result<Vec<(String, i64)>, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT CASE WHEN status LIKE 'failed%' THEN 'failed' ELSE status END AS bucket,
+                       COUNT(*)
+                FROM bridge_orders GROUP BY bucket ORDER BY bucket
+                "#,
+            )
+            .map_err(|e| format!("Prepare failed: {}", e))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .map_err(|e| format!("Query failed: {}", e))?
+            .collect::<SqliteResult<Vec<_>>>()
+            .map_err(|e| format!("Collect failed: {}", e))?;
+        Ok(rows)
+    }
+
+    /// Number of orders the engine still has to act on (the backlog the
+    /// circuit breaker trips on).
+    pub fn actionable_backlog(&self) -> Result<u64, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let count: i64 = conn
+            .query_row(
+                r#"
+                SELECT COUNT(*) FROM bridge_orders
+                WHERE status IN ('deposit_confirmed', 'mint_pending',
+                                 'burn_confirmed', 'release_pending')
+                "#,
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Query failed: {}", e))?;
+        Ok(count.max(0) as u64)
+    }
+
+    /// Orders past the settlement stages that have not advanced within
+    /// `older_than_secs` — stuck orders needing operator attention. Covers
+    /// every non-terminal status past `awaiting_deposit` (which expires
+    /// instead: no funds have moved yet).
+    pub fn stuck_orders(&self, older_than_secs: i64) -> Result<Vec<BridgeOrder>, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let cutoff = Utc::now().timestamp() - older_than_secs;
+
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT id, order_type, source_chain, dest_chain, amount, fee,
+                       source_tx, dest_tx, source_address, dest_address,
+                       status, error_message, memo, mint_authorization,
+                       dest_confirmed_at, created_at, updated_at
+                FROM bridge_orders
+                WHERE status IN ('deposit_detected', 'deposit_confirmed', 'mint_pending',
+                                 'burn_detected', 'burn_confirmed', 'release_pending')
+                  AND updated_at < ?1
+                ORDER BY updated_at ASC
+                "#,
+            )
+            .map_err(|e| format!("Prepare failed: {}", e))?;
+
+        let rows = stmt
+            .query_map(params![cutoff], Self::row_to_order)
+            .map_err(|e| format!("Query failed: {}", e))?
+            .collect::<SqliteResult<Vec<_>>>()
+            .map_err(|e| format!("Collect failed: {}", e))?;
+        Ok(rows)
+    }
+
+    /// Whether an audit entry with this action exists for the order
+    /// (used to emit alerts exactly once per order).
+    pub fn has_audit_for_order(&self, order_id: &Uuid, action: &str) -> Result<bool, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM audit_log WHERE order_id = ?1 AND action = ?2",
+                params![order_id.to_string(), action],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Query failed: {}", e))?;
+        Ok(count > 0)
+    }
+
+    // === Component health (signer / minter / releaser availability) ===
+
+    /// Record a component's availability (engine startup + runtime checks).
+    pub fn set_component_health(
+        &self,
+        component: &str,
+        healthy: bool,
+        detail: &str,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        conn.execute(
+            r#"
+            INSERT OR REPLACE INTO component_health (component, healthy, detail, updated_at)
+            VALUES (?1, ?2, ?3, ?4)
+            "#,
+            params![component, healthy as i64, detail, Utc::now().timestamp()],
+        )
+        .map_err(|e| format!("Insert failed: {}", e))?;
+
+        Ok(())
+    }
+
+    /// All recorded component health rows: `(component, healthy, detail)`.
+    pub fn component_health(&self) -> Result<Vec<(String, bool, String)>, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+
+        let mut stmt = conn
+            .prepare("SELECT component, healthy, detail FROM component_health ORDER BY component")
+            .map_err(|e| format!("Prepare failed: {}", e))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)? != 0,
+                    row.get::<_, Option<String>>(2)?.unwrap_or_default(),
+                ))
+            })
+            .map_err(|e| format!("Query failed: {}", e))?
+            .collect::<SqliteResult<Vec<_>>>()
+            .map_err(|e| format!("Collect failed: {}", e))?;
+        Ok(rows)
     }
 
     /// Log an audit event.
@@ -1622,12 +2191,81 @@ mod tests {
         assert_eq!(retrieved.id, order.id);
         assert_eq!(retrieved.amount, order.amount);
 
-        // Update status
-        db.update_order_status(&order.id, &OrderStatus::DepositConfirmed, None)
+        // Update status along a legal edge.
+        db.update_order_status(&order.id, &OrderStatus::DepositDetected, None)
             .unwrap();
 
         let updated = db.get_order(&order.id).unwrap().unwrap();
-        assert_eq!(updated.status, OrderStatus::DepositConfirmed);
+        assert_eq!(updated.status, OrderStatus::DepositDetected);
+    }
+
+    #[test]
+    fn test_update_order_status_enforces_state_machine() {
+        // #839: the DB layer itself rejects illegal transitions, so no
+        // future writer can bypass the state machine.
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            0,
+            "bth_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        db.insert_order(&order).unwrap();
+
+        // Illegal jump: AwaitingDeposit -> Completed.
+        let err = db
+            .update_order_status(&order.id, &OrderStatus::Completed, None)
+            .unwrap_err();
+        assert!(err.contains("illegal order status transition"), "{}", err);
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::AwaitingDeposit
+        );
+
+        // Terminal states are frozen even through the raw update path.
+        db.update_order_status(&order.id, &OrderStatus::Expired, None)
+            .unwrap();
+        assert!(db
+            .update_order_status(&order.id, &OrderStatus::DepositDetected, None)
+            .is_err());
+        assert!(db
+            .update_order_status(
+                &order.id,
+                &OrderStatus::Failed {
+                    reason: "cannot clobber terminal".to_string()
+                },
+                None
+            )
+            .is_err());
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::Expired
+        );
+
+        // Unknown order id is an error, not a silent no-op.
+        assert!(db
+            .update_order_status(&Uuid::new_v4(), &OrderStatus::Expired, None)
+            .is_err());
+    }
+
+    #[test]
+    fn test_update_order_status_same_status_is_idempotent_refresh() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_mint_order(&db);
+
+        db.update_order_status(&order.id, &OrderStatus::MintPending, Some("0xtx"))
+            .unwrap();
+        // A replayed tick re-asserting the same status must not error.
+        db.update_order_status(&order.id, &OrderStatus::MintPending, Some("0xtx"))
+            .unwrap();
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::MintPending
+        );
     }
 
     #[test]
@@ -2151,7 +2789,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unlock_outputs_for_failed_mint() {
+    fn test_unlock_backing_for_failed_mint() {
         let db = reserve_db();
         let mint = Uuid::new_v4();
 
@@ -2159,10 +2797,250 @@ mod tests {
             .unwrap();
         assert_eq!(db.locked_reserve_total().unwrap(), 500);
 
-        assert!(db.unlock_outputs_for_order(&mint).unwrap());
+        assert!(db
+            .unlock_backing_for_order(&mint, Chain::Ethereum, 500)
+            .unwrap());
         assert_eq!(db.locked_reserve_total().unwrap(), 0);
         // Idempotent.
-        assert!(!db.unlock_outputs_for_order(&mint).unwrap());
+        assert!(!db
+            .unlock_backing_for_order(&mint, Chain::Ethereum, 500)
+            .unwrap());
+    }
+
+    #[test]
+    fn test_unlock_backing_by_value_after_fifo_consumed_dep_output() {
+        // #846 item 1: a release's FIFO spend consumed the failed mint's
+        // dep: output (its residual value lives in a chg: output). The
+        // unlock must still remove the failed mint's net amount from the
+        // locked ledger — by value — or the ledger overcounts forever.
+        let db = reserve_db();
+        let failed_mint = Uuid::new_v4();
+        let other_mint = Uuid::new_v4();
+        let release = Uuid::new_v4();
+
+        // FIFO order: the failed mint's output first (600), then another
+        // deposit (1_000).
+        db.record_locked_output(
+            &format!("dep:{}", failed_mint),
+            Chain::Ethereum,
+            600,
+            &failed_mint,
+        )
+        .unwrap();
+        db.record_locked_output(
+            &format!("dep:{}", other_mint),
+            Chain::Ethereum,
+            1_000,
+            &other_mint,
+        )
+        .unwrap();
+
+        // A release spends 700: consumes the failed mint's 600 entirely +
+        // 100 of the other output, change 900 attributed to the release.
+        assert!(db
+            .apply_release_spend(&release, Chain::Ethereum, 700)
+            .unwrap());
+        assert_eq!(db.locked_reserve_total().unwrap(), 900);
+
+        // Now the mint fails. Its dep: output is gone (locked = 0), so an
+        // id-based unlock would find nothing. The value-based unlock
+        // removes 600 from the remaining locked outputs FIFO.
+        assert!(db
+            .unlock_backing_for_order(&failed_mint, Chain::Ethereum, 600)
+            .unwrap());
+        assert_eq!(db.locked_reserve_total().unwrap(), 300);
+
+        // Change semantics: the 900 change output was consumed, and a new
+        // 300 change output attributed to the failed mint remains locked.
+        let change = db
+            .get_reserve_output(&format!("chg:{}", failed_mint))
+            .unwrap()
+            .unwrap();
+        assert!(change.locked);
+        assert_eq!(change.amount, 300);
+
+        // Replay is a no-op.
+        assert!(!db
+            .unlock_backing_for_order(&failed_mint, Chain::Ethereum, 600)
+            .unwrap());
+        assert_eq!(db.locked_reserve_total().unwrap(), 300);
+    }
+
+    #[test]
+    fn test_unlock_backing_insufficient_rolls_back() {
+        let db = reserve_db();
+        let mint = Uuid::new_v4();
+        db.record_locked_output("dep:other", Chain::Ethereum, 100, &Uuid::new_v4())
+            .unwrap();
+
+        // 500 > 100 locked: the whole unlock must fail and roll back.
+        let err = db
+            .unlock_backing_for_order(&mint, Chain::Ethereum, 500)
+            .unwrap_err();
+        assert!(err.contains("insufficient locked reserve"), "{}", err);
+        assert_eq!(db.locked_reserve_total().unwrap(), 100);
+    }
+
+    // === Circuit breaker + rate limits (#827) ===
+
+    #[test]
+    fn test_pause_state_roundtrip_and_change_detection() {
+        let db = reserve_db();
+
+        assert!(db.is_paused().unwrap().is_none());
+
+        // Trip: state changes exactly once.
+        assert!(db.set_paused(true, Some("drift alert")).unwrap());
+        assert_eq!(db.is_paused().unwrap().as_deref(), Some("drift alert"));
+        assert!(!db.set_paused(true, Some("drift alert")).unwrap());
+
+        // Resume clears the reason.
+        assert!(db.set_paused(false, None).unwrap());
+        assert!(db.is_paused().unwrap().is_none());
+        assert!(!db.set_paused(false, None).unwrap());
+    }
+
+    #[test]
+    fn test_limits_per_order_cap() {
+        let db = reserve_db();
+        let order = setup_mint_order(&db);
+
+        let check = db
+            .check_and_reserve_limits(&order.id, "0xuser", 1_001, 1_000, 0, 0, 1_000_000)
+            .unwrap();
+        assert_eq!(check, LimitCheck::Rejected(LimitViolation::PerOrderCap));
+        // Nothing was reserved.
+        assert_eq!(db.daily_reserved_volume(1_000_000).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_limits_daily_windows_and_day_boundary() {
+        let db = reserve_db();
+        let a = setup_mint_order(&db);
+        let b = setup_mint_order(&db);
+        let c = setup_mint_order(&db);
+        let now = 86_400 * 100 + 10; // some day bucket
+
+        // Address cap 1_000: first 700 passes...
+        assert_eq!(
+            db.check_and_reserve_limits(&a.id, "0xuser", 700, 0, 1_000, 10_000, now)
+                .unwrap(),
+            LimitCheck::Reserved
+        );
+        // ... a second 700 for the same address exceeds the window ...
+        assert_eq!(
+            db.check_and_reserve_limits(&b.id, "0xuser", 700, 0, 1_000, 10_000, now)
+                .unwrap(),
+            LimitCheck::Rejected(LimitViolation::AddressDailyCap)
+        );
+        // ... but passes at the next day boundary.
+        assert_eq!(
+            db.check_and_reserve_limits(&b.id, "0xuser", 700, 0, 1_000, 10_000, now + 86_400)
+                .unwrap(),
+            LimitCheck::Reserved
+        );
+
+        // Global cap: a different address is refused once the bridge-wide
+        // window is exhausted.
+        assert_eq!(
+            db.check_and_reserve_limits(&c.id, "0xother", 9_500, 0, 10_000, 10_000, now + 86_400)
+                .unwrap(),
+            LimitCheck::Rejected(LimitViolation::GlobalDailyCap)
+        );
+    }
+
+    #[test]
+    fn test_limits_reservation_is_exactly_once_per_order() {
+        let db = reserve_db();
+        let order = setup_mint_order(&db);
+        let now = 86_400 * 100;
+
+        assert_eq!(
+            db.check_and_reserve_limits(&order.id, "0xuser", 600, 0, 1_000, 0, now)
+                .unwrap(),
+            LimitCheck::Reserved
+        );
+        // A replayed tick (crash between reservation and mint) must not
+        // double-count the volume.
+        assert_eq!(
+            db.check_and_reserve_limits(&order.id, "0xuser", 600, 0, 1_000, 0, now)
+                .unwrap(),
+            LimitCheck::AlreadyReserved
+        );
+        assert_eq!(db.daily_reserved_volume(now).unwrap(), 600);
+    }
+
+    #[test]
+    fn test_monitoring_counts_backlog_stuck_and_health() {
+        let db = reserve_db();
+
+        let confirmed = setup_mint_order(&db); // deposit_confirmed
+        let mut stale = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000,
+            0,
+            "bth".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        stale.set_status(OrderStatus::MintPending);
+        stale.updated_at = Utc::now() - chrono::Duration::hours(3);
+        db.insert_order(&stale).unwrap();
+
+        let counts = db.order_status_counts().unwrap();
+        assert!(counts.contains(&("deposit_confirmed".to_string(), 1)));
+        assert!(counts.contains(&("mint_pending".to_string(), 1)));
+        assert_eq!(db.actionable_backlog().unwrap(), 2);
+
+        // Only the stale order is stuck past a 1-hour threshold.
+        let stuck = db.stuck_orders(3_600).unwrap();
+        assert_eq!(stuck.len(), 1);
+        assert_eq!(stuck[0].id, stale.id);
+        let _ = confirmed;
+
+        // Component health roundtrip.
+        db.set_component_health("attestation", false, "federation misconfigured")
+            .unwrap();
+        db.set_component_health("releaser:bth", true, "").unwrap();
+        let health = db.component_health().unwrap();
+        assert_eq!(
+            health,
+            vec![
+                (
+                    "attestation".to_string(),
+                    false,
+                    "federation misconfigured".to_string()
+                ),
+                ("releaser:bth".to_string(), true, String::new()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_prune_reserve_snapshots_keeps_latest() {
+        let db = reserve_db();
+        let old = ReserveSnapshot {
+            taken_at: 1_000, // far in the past
+            locked_reserve: 1,
+            eth_supply: None,
+            sol_supply: None,
+            drift: 0,
+            in_tolerance: true,
+            peg_healthy: true,
+            reserve_balance_checked: false,
+        };
+        db.insert_reserve_snapshot(&old).unwrap();
+        db.insert_reserve_snapshot(&ReserveSnapshot {
+            taken_at: 2_000,
+            ..old.clone()
+        })
+        .unwrap();
+
+        // Both are ancient, but the latest row always survives pruning.
+        let pruned = db.prune_reserve_snapshots(86_400).unwrap();
+        assert_eq!(pruned, 1);
+        let latest = db.latest_reserve_snapshot().unwrap().unwrap();
+        assert_eq!(latest.taken_at, 2_000);
+        assert_eq!(db.prune_reserve_snapshots(86_400).unwrap(), 0);
     }
 
     #[test]
@@ -2221,6 +3099,7 @@ mod tests {
             drift: 0,
             in_tolerance: true,
             peg_healthy: true,
+            reserve_balance_checked: false,
         };
         db.insert_reserve_snapshot(&first).unwrap();
 
@@ -2232,6 +3111,7 @@ mod tests {
             drift: 1_000,
             in_tolerance: false,
             peg_healthy: false,
+            reserve_balance_checked: true,
         };
         db.insert_reserve_snapshot(&second).unwrap();
 

--- a/bridge/service/src/engine.rs
+++ b/bridge/service/src/engine.rs
@@ -13,7 +13,7 @@ use crate::{
         AttestationProvider, DisabledAttestationProvider, FederationAttestationProvider,
         StubAttestationProvider,
     },
-    db::Database,
+    db::{Database, LimitCheck, LimitViolation},
     mint::{ethereum::EthMinter, solana::SolMinter, ConfirmationStatus, Minter},
     release::{bth::BthReleaser, PreparedRelease, ReleaseConfirmation, Releaser},
     reserve::Reconciler,
@@ -87,7 +87,8 @@ impl BridgeEngine {
         }
     }
 
-    /// Build the attestation provider (#824).
+    /// Build the attestation provider (#824), plus an availability verdict
+    /// for the health surface.
     ///
     /// - Federation configured and valid → the real
     ///   [`FederationAttestationProvider`].
@@ -95,18 +96,28 @@ impl BridgeEngine {
     ///   (fail-closed: authorizations error, orders stay retryable). Never
     ///   silently downgrades to the permissive stub.
     /// - No federation configured → the development stub.
-    fn build_attestation_provider(config: &BridgeConfig) -> Arc<dyn AttestationProvider> {
+    fn build_attestation_provider(
+        config: &BridgeConfig,
+    ) -> (Arc<dyn AttestationProvider>, bool, String) {
         match FederationAttestationProvider::from_config(config) {
             Ok(Some(provider)) => {
                 info!("federation attestation provider active (ADR 0002 t-of-n custody)");
-                Arc::new(provider)
+                (
+                    Arc::new(provider),
+                    true,
+                    "federation provider active".to_string(),
+                )
             }
             Ok(None) => {
                 warn!(
                     "no attestation federation configured; using the development stub \
                      provider (threshold 0 — production authorities reject its output)"
                 );
-                Arc::new(StubAttestationProvider)
+                (
+                    Arc::new(StubAttestationProvider),
+                    true,
+                    "development stub provider (no federation configured)".to_string(),
+                )
             }
             Err(e) => {
                 error!(
@@ -114,7 +125,8 @@ impl BridgeEngine {
                      mint or release until the configuration is fixed",
                     e
                 );
-                Arc::new(DisabledAttestationProvider::new(e))
+                let detail = format!("disabled: {}", e);
+                (Arc::new(DisabledAttestationProvider::new(e)), false, detail)
             }
         }
     }
@@ -122,6 +134,60 @@ impl BridgeEngine {
     /// Run the bridge engine.
     pub async fn run(self) -> Result<(), String> {
         info!("Starting bridge engine");
+
+        // Config-level kill switch: start paused until an operator resumes
+        // (the runtime state lives in the DB and otherwise survives
+        // restarts on its own).
+        if self.config.bridge.paused && self.db.set_paused(true, Some("paused via config"))? {
+            self.db.log_audit(
+                None,
+                "breaker_tripped",
+                "bridge.paused = true in configuration",
+            )?;
+            warn!("Bridge starting PAUSED (bridge.paused = true in config)");
+        }
+
+        let minters = Self::build_minters(&self.config);
+        let releaser = Self::build_releaser(&self.config);
+        let (attestation, attestation_ok, attestation_detail) =
+            Self::build_attestation_provider(&self.config);
+
+        // Record component availability for the health surface
+        // (`/api/status`, `/metrics`). The engine already fails closed on
+        // each unavailable component (orders stay retryable); this makes
+        // the degradation observable instead of silent.
+        self.db
+            .set_component_health("attestation", attestation_ok, &attestation_detail)?;
+        for chain in [Chain::Ethereum, Chain::Solana] {
+            let configured = minters.contains_key(&chain);
+            self.db.set_component_health(
+                &format!("minter:{}", chain),
+                configured,
+                if configured { "configured" } else { "disabled" },
+            )?;
+        }
+        self.db.set_component_health(
+            "releaser:bth",
+            releaser.is_some(),
+            if releaser.is_some() {
+                "configured"
+            } else {
+                "disabled"
+            },
+        )?;
+
+        let processor = OrderProcessor::new(
+            self.config.clone(),
+            self.db.clone(),
+            minters,
+            releaser,
+            attestation,
+        );
+
+        // Startup reconciliation (#843): roll stranded orders forward
+        // exactly once BEFORE any watcher or processing loop runs (no
+        // writer races while recovering).
+        processor.recover_on_startup()?;
 
         // Spawn the BTH watcher
         let bth_watcher = BthWatcher::new(
@@ -163,16 +229,6 @@ impl BridgeEngine {
         });
 
         // Spawn the order processing loop
-        let minters = Self::build_minters(&self.config);
-        let releaser = Self::build_releaser(&self.config);
-        let attestation = Self::build_attestation_provider(&self.config);
-        let processor = OrderProcessor::new(
-            self.config.clone(),
-            self.db.clone(),
-            minters,
-            releaser,
-            attestation,
-        );
         let mut shutdown_rx = self.shutdown_tx.subscribe();
 
         let process_handle = tokio::spawn(async move {
@@ -201,26 +257,43 @@ impl BridgeEngine {
             reconciler.run(reconcile_interval, reconcile_shutdown).await;
         });
 
-        // Spawn the proof-of-reserves HTTP API (#825); empty listen
-        // address disables it.
+        // Spawn the bridge HTTP API (#825 proof-of-reserves + #827
+        // monitoring/breaker surface); empty listen address disables it.
         let api_handle = if self.config.reserve.api_listen.is_empty() {
             None
         } else {
             let addr = self.config.reserve.api_listen.clone();
             let api_db = self.db.clone();
             let api_shutdown = self.shutdown_tx.subscribe();
+            let stuck_after_secs = self.config.bridge.order_expiry_minutes.max(1) * 60;
             Some(tokio::spawn(async move {
-                if let Err(e) = api::serve(addr, api_db, api_shutdown).await {
-                    error!("Proof-of-reserves API error: {}", e);
+                if let Err(e) = api::serve(addr, api_db, stuck_after_secs, api_shutdown).await {
+                    error!("Bridge API error: {}", e);
                 }
             }))
         };
 
-        // Handle shutdown signals
-        tokio::select! {
-            _ = tokio::signal::ctrl_c() => {
-                info!("Received shutdown signal");
+        // Handle shutdown signals: SIGINT (ctrl-c) and, on unix, SIGTERM
+        // (what systemd sends). Both trigger the same graceful drain:
+        // every component gets the broadcast and is joined below.
+        #[cfg(unix)]
+        {
+            let mut sigterm =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                    .map_err(|e| format!("failed to install SIGTERM handler: {}", e))?;
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {
+                    info!("Received SIGINT; shutting down gracefully");
+                }
+                _ = sigterm.recv() => {
+                    info!("Received SIGTERM; shutting down gracefully");
+                }
             }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+            info!("Received shutdown signal");
         }
 
         // Send shutdown signal to all components
@@ -244,7 +317,7 @@ impl BridgeEngine {
 }
 
 /// Order processor handles pending orders.
-struct OrderProcessor {
+pub(crate) struct OrderProcessor {
     config: BridgeConfig,
     db: Database,
     minters: HashMap<Chain, Arc<dyn Minter>>,
@@ -253,7 +326,7 @@ struct OrderProcessor {
 }
 
 impl OrderProcessor {
-    fn new(
+    pub(crate) fn new(
         config: BridgeConfig,
         db: Database,
         minters: HashMap<Chain, Arc<dyn Minter>>,
@@ -269,18 +342,98 @@ impl OrderProcessor {
         }
     }
 
+    /// Startup reconciliation, run BEFORE any watcher or processing loop.
+    ///
+    /// #843: a crash between the BTH watcher's detect step and its confirm
+    /// step strands an order at `DepositDetected` forever — the watcher's
+    /// replay skips it ("not awaiting a deposit") and the processor only
+    /// picks up orders from `deposit_confirmed` onward. Detection implies
+    /// finality in the BTH watcher (scanned blocks always meet the
+    /// finality requirement), so any `DepositDetected` order with a
+    /// durably recorded `source_tx` is rolled forward to
+    /// `DepositConfirmed` (and its deposit marked processed — the other
+    /// half of the same crash window), exactly once, with an audit entry.
+    ///
+    /// Orders stranded at `MintPending` / `ReleasePending` /
+    /// `DepositConfirmed` / `BurnConfirmed` need no startup action: the
+    /// processing stages resume them via the `mints` / `release_claims`
+    /// exactly-once tables.
+    pub(crate) fn recover_on_startup(&self) -> Result<(), String> {
+        let detected = self.db.get_orders_by_status("deposit_detected")?;
+        for order in detected {
+            let Some(source_tx) = order.source_tx.clone() else {
+                // DepositDetected without a recorded tx should be
+                // unreachable (the detect write records both atomically);
+                // surface it rather than guess.
+                warn!(
+                    "Order {} is DepositDetected with no recorded source_tx; leaving for triage",
+                    order.id
+                );
+                continue;
+            };
+
+            // Crash-between-detect-and-mark window: the idempotency row
+            // may be missing; write it so the watcher's replay of the
+            // block short-circuits cleanly.
+            self.db.mark_deposit_processed(&source_tx, &order.id)?;
+            self.db
+                .update_order_status(&order.id, &OrderStatus::DepositConfirmed, None)?;
+            self.db.log_audit(
+                Some(&order.id),
+                "deposit_recovered",
+                &format!(
+                    "tx={} recovered DepositDetected -> DepositConfirmed on startup (#843)",
+                    source_tx
+                ),
+            )?;
+            info!(
+                "Recovered stranded order {} (DepositDetected -> DepositConfirmed, tx {})",
+                order.id, source_tx
+            );
+        }
+
+        Ok(())
+    }
+
     /// Process all pending orders.
     ///
     /// Submission (`DepositConfirmed -> MintPending`) and confirmation
     /// (`MintPending -> Completed`) are driven as separate retryable stages
     /// so a crash or RPC failure between them never loses (or duplicates)
     /// a mint.
-    async fn process_pending_orders(&self) -> Result<(), String> {
-        // Stage 1: confirmed deposits need a mint submitted.
-        let deposit_orders = self.db.get_orders_by_status("deposit_confirmed")?;
-        for order in deposit_orders {
-            if let Err(e) = self.submit_mint(&order).await {
-                warn!("Failed to submit mint for order {}: {}", order.id, e);
+    ///
+    /// Circuit breaker: when the bridge is paused (kill switch or
+    /// auto-trip) the SUBMIT stages are halted — no new value leaves the
+    /// bridge — while the CONFIRM stages keep running so already-broadcast
+    /// transactions settle to a durable terminal state.
+    pub(crate) async fn process_pending_orders(&self) -> Result<(), String> {
+        // Automatic breaker conditions (fail closed) are evaluated before
+        // any submission.
+        self.check_breaker_conditions()?;
+
+        match self.db.is_paused()? {
+            None => {
+                // Stage 1: confirmed deposits need a mint submitted.
+                let deposit_orders = self.db.get_orders_by_status("deposit_confirmed")?;
+                for order in deposit_orders {
+                    if let Err(e) = self.submit_mint(&order).await {
+                        warn!("Failed to submit mint for order {}: {}", order.id, e);
+                    }
+                }
+
+                // Stage 3: confirmed burns need a BTH release submitted.
+                let burn_orders = self.db.get_orders_by_status("burn_confirmed")?;
+                for order in burn_orders {
+                    if let Err(e) = self.submit_release(&order).await {
+                        warn!("Failed to submit release for order {}: {}", order.id, e);
+                    }
+                }
+            }
+            Some(reason) => {
+                debug!(
+                    "Bridge paused ({}); submit stages halted, confirm stages continue",
+                    reason
+                );
             }
         }
 
@@ -289,14 +442,6 @@ impl OrderProcessor {
         for order in pending_mints {
             if let Err(e) = self.confirm_mint(&order).await {
                 warn!("Failed to confirm mint for order {}: {}", order.id, e);
-            }
-        }
-
-        // Stage 3: confirmed burns need a BTH release submitted.
-        let burn_orders = self.db.get_orders_by_status("burn_confirmed")?;
-        for order in burn_orders {
-            if let Err(e) = self.submit_release(&order).await {
-                warn!("Failed to submit release for order {}: {}", order.id, e);
             }
         }
 
@@ -311,6 +456,125 @@ impl OrderProcessor {
         // Check for expired orders
         self.expire_stale_orders()?;
 
+        // Alert on orders stuck past the age threshold (funds have moved;
+        // they must never auto-expire — an operator has to act).
+        self.alert_stuck_orders()?;
+
+        Ok(())
+    }
+
+    /// Evaluate the automatic circuit-breaker conditions and trip the
+    /// breaker (fail closed) when one fires. The reconciler additionally
+    /// trips it on any peg-drift alert (see `reserve::Reconciler`).
+    fn check_breaker_conditions(&self) -> Result<(), String> {
+        if self.db.is_paused()?.is_some() {
+            return Ok(());
+        }
+
+        let max_pending = self.config.bridge.max_pending_orders;
+        if max_pending > 0 {
+            let backlog = self.db.actionable_backlog()?;
+            if backlog > max_pending {
+                self.trip_breaker(&format!(
+                    "actionable backlog {} exceeds max_pending_orders {}",
+                    backlog, max_pending
+                ))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Trip the circuit breaker: pause the submit stages, audit-log the
+    /// trip exactly once.
+    fn trip_breaker(&self, reason: &str) -> Result<(), String> {
+        if self.db.set_paused(true, Some(reason))? {
+            self.db.log_audit(None, "breaker_tripped", reason)?;
+            error!(
+                "CIRCUIT BREAKER TRIPPED: {}; submit stages halted (confirm stages continue). \
+                 Resume via POST /api/breaker after triage — see \
+                 docs/operations/runbooks/bridge-order-engine-recovery.md",
+                reason
+            );
+        }
+        Ok(())
+    }
+
+    /// Rate-limit gate for a submit stage: reserve the order's volume
+    /// against the per-order cap and the daily windows, exactly once per
+    /// order. Returns `Ok(true)` when the order may proceed.
+    ///
+    /// A daily-window rejection defers the order (retryable next window);
+    /// exhausting the GLOBAL window additionally trips the circuit
+    /// breaker — bridge-wide volume at the cap is an anomaly signal.
+    fn reserve_order_limits(&self, order: &BridgeOrder) -> Result<bool, String> {
+        use bth_bridge_core::OrderType;
+
+        // The counterparty whose daily window this order consumes: the
+        // wBTH recipient for mints, the wBTH burner for burns.
+        let address = match order.order_type {
+            OrderType::Mint => &order.dest_address,
+            OrderType::Burn => &order.source_address,
+        };
+
+        match self.db.check_and_reserve_limits(
+            &order.id,
+            address,
+            order.amount,
+            self.config.bridge.max_order_amount,
+            self.config.bridge.daily_limit_per_address,
+            self.config.bridge.global_daily_limit,
+            chrono::Utc::now().timestamp(),
+        )? {
+            LimitCheck::Reserved | LimitCheck::AlreadyReserved => Ok(true),
+            LimitCheck::Rejected(violation) => {
+                if !self.db.has_audit_for_order(&order.id, "rate_limited")? {
+                    self.db.log_audit(
+                        Some(&order.id),
+                        "rate_limited",
+                        &format!("violation={} amount={}", violation, order.amount),
+                    )?;
+                }
+                warn!(
+                    "Order {} deferred by rate limit ({}; amount {})",
+                    order.id, violation, order.amount
+                );
+                if violation == LimitViolation::GlobalDailyCap {
+                    self.trip_breaker(&format!(
+                        "global daily volume cap reached (order {} amount {})",
+                        order.id, order.amount
+                    ))?;
+                }
+                Ok(false)
+            }
+        }
+    }
+
+    /// Audit-log (exactly once per order) any order stuck past the age
+    /// threshold in a post-deposit stage.
+    fn alert_stuck_orders(&self) -> Result<(), String> {
+        let threshold_secs = self.config.bridge.order_expiry_minutes.max(1) * 60;
+        for order in self.db.stuck_orders(threshold_secs)? {
+            if self
+                .db
+                .has_audit_for_order(&order.id, "stuck_order_alert")?
+            {
+                continue;
+            }
+            let age_secs = (chrono::Utc::now() - order.updated_at).num_seconds();
+            self.db.log_audit(
+                Some(&order.id),
+                "stuck_order_alert",
+                &format!(
+                    "status={} age_secs={} threshold_secs={}",
+                    order.status, age_secs, threshold_secs
+                ),
+            )?;
+            warn!(
+                "Order {} stuck in {} for {}s (threshold {}s) — operator attention needed",
+                order.id, order.status, age_secs, threshold_secs
+            );
+        }
         Ok(())
     }
 
@@ -334,6 +598,13 @@ impl OrderProcessor {
                 },
                 None,
             )?;
+            return Ok(());
+        }
+
+        // Rate limits (#827): mirror the contract-side caps service-side.
+        // A deferred order stays DepositConfirmed and retries next window
+        // (the deposit already happened — never dropped).
+        if !self.reserve_order_limits(order)? {
             return Ok(());
         }
 
@@ -554,16 +825,36 @@ impl OrderProcessor {
                     .update_order_status(&order.id, &OrderStatus::Failed { reason }, None)?;
                 // Reserve accounting (#825): a failed mint's deposit no
                 // longer backs wrapped supply — it is owed back to the
-                // depositor. Unlock it so the peg ledger stays exact.
-                if self.db.unlock_outputs_for_order(&order.id)? {
-                    self.db.log_audit(
-                        Some(&order.id),
-                        "reserve_unlocked",
-                        &format!(
-                            "chain={} mint failed; deposit no longer backs supply",
-                            order.dest_chain
-                        ),
-                    )?;
+                // depositor. Unlock its VALUE (#846: the specific dep:
+                // output may already have been consumed by a release's
+                // FIFO spend) so the peg ledger stays exact. A shortfall
+                // is audited and surfaces as drift — never blocks the
+                // failure transition (already durably recorded above).
+                match self.db.unlock_backing_for_order(
+                    &order.id,
+                    order.dest_chain,
+                    order.net_amount(),
+                ) {
+                    Ok(true) => {
+                        self.db.log_audit(
+                            Some(&order.id),
+                            "reserve_unlocked",
+                            &format!(
+                                "chain={} amount={} mint failed; deposit no longer backs supply",
+                                order.dest_chain,
+                                order.net_amount()
+                            ),
+                        )?;
+                    }
+                    Ok(false) => {} // replay: already unlocked
+                    Err(e) => {
+                        error!(
+                            "Reserve unlock for failed mint order {} failed: {}",
+                            order.id, e
+                        );
+                        self.db
+                            .log_audit(Some(&order.id), "reserve_unlock_failed", &e)?;
+                    }
                 }
             }
         }
@@ -609,6 +900,13 @@ impl OrderProcessor {
             // the configuration.
             return Err("BTH release not configured".to_string());
         };
+
+        // Rate limits (#827): a deferred burn stays BurnConfirmed and
+        // retries next window — a confirmed burn is owed BTH and is never
+        // failed by a limit, only delayed and surfaced as stuck.
+        if !self.reserve_order_limits(order)? {
+            return Ok(());
+        }
 
         // Durable exactly-once claim, taken BEFORE any signing/submission.
         let claim = self
@@ -1549,5 +1847,242 @@ mod tests {
         );
         assert_eq!(db.count_audit_action("reserve_spend_failed").unwrap(), 1);
         assert_eq!(db.count_audit_action("reserve_spent").unwrap(), 0);
+    }
+
+    // === Circuit breaker + rate limits + monitoring (#827) ===
+
+    #[tokio::test]
+    async fn test_kill_switch_halts_submits_but_confirms_settle() {
+        let (processor, minter, releaser, db) = setup_full();
+
+        // An in-flight mint (already broadcast) and a not-yet-submitted
+        // deposit.
+        let inflight = insert_confirmed_deposit(&db);
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(
+            db.get_order(&inflight.id).unwrap().unwrap().status,
+            OrderStatus::MintPending
+        );
+        let waiting = insert_confirmed_deposit(&db);
+        let burn = insert_confirmed_burn(&db);
+
+        // Trip the kill switch.
+        assert!(db.set_paused(true, Some("manual")).unwrap());
+
+        // Confirm stage still settles the in-flight order...
+        minter.set_confirmation(ConfirmationStatus::Confirmed);
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(
+            db.get_order(&inflight.id).unwrap().unwrap().status,
+            OrderStatus::Completed,
+            "confirm stages must keep running while paused"
+        );
+
+        // ...but no NEW value leaves the bridge: the waiting deposit and
+        // the confirmed burn are untouched.
+        assert_eq!(
+            db.get_order(&waiting.id).unwrap().unwrap().status,
+            OrderStatus::DepositConfirmed,
+            "submit stages must halt while paused"
+        );
+        assert_eq!(
+            db.get_order(&burn.id).unwrap().unwrap().status,
+            OrderStatus::BurnConfirmed
+        );
+        assert_eq!(releaser.prepare_calls.load(Ordering::SeqCst), 0);
+
+        // Resume: everything proceeds.
+        assert!(db.set_paused(false, None).unwrap());
+        minter.set_confirmation(ConfirmationStatus::Pending { confirmations: 0 });
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(
+            db.get_order(&waiting.id).unwrap().unwrap().status,
+            OrderStatus::MintPending
+        );
+        assert_eq!(
+            db.get_order(&burn.id).unwrap().unwrap().status,
+            OrderStatus::ReleasePending
+        );
+    }
+
+    #[tokio::test]
+    async fn test_breaker_auto_trips_on_backlog() {
+        let (mut config, db) = (BridgeConfig::default(), {
+            let db = Database::open_in_memory().unwrap();
+            db.migrate().unwrap();
+            db
+        });
+        config.bridge.max_pending_orders = 2;
+
+        let minter = Arc::new(MockMinter::new(Chain::Ethereum));
+        let mut minters: HashMap<Chain, Arc<dyn Minter>> = HashMap::new();
+        minters.insert(Chain::Ethereum, minter.clone());
+        let processor = OrderProcessor::new(
+            config,
+            db.clone(),
+            minters,
+            None,
+            Arc::new(StubAttestationProvider),
+        );
+
+        // Backlog of 3 actionable orders > max_pending_orders of 2.
+        for _ in 0..3 {
+            insert_confirmed_deposit(&db);
+        }
+
+        processor.process_pending_orders().await.unwrap();
+
+        let reason = db.is_paused().unwrap().expect("breaker must trip");
+        assert!(reason.contains("backlog"), "{}", reason);
+        assert_eq!(db.count_audit_action("breaker_tripped").unwrap(), 1);
+        // Fail closed: nothing was submitted this tick.
+        assert_eq!(minter.prepare_calls.load(Ordering::SeqCst), 0);
+
+        // The trip is audited exactly once across further ticks.
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(db.count_audit_action("breaker_tripped").unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_per_order_cap_defers_mint() {
+        let (mut config, db) = (BridgeConfig::default(), {
+            let db = Database::open_in_memory().unwrap();
+            db.migrate().unwrap();
+            db
+        });
+        // Cap below the order amount.
+        config.bridge.max_order_amount = 1_000;
+
+        let minter = Arc::new(MockMinter::new(Chain::Ethereum));
+        let mut minters: HashMap<Chain, Arc<dyn Minter>> = HashMap::new();
+        minters.insert(Chain::Ethereum, minter.clone());
+        let processor = OrderProcessor::new(
+            config,
+            db.clone(),
+            minters,
+            None,
+            Arc::new(StubAttestationProvider),
+        );
+
+        let order = insert_confirmed_deposit(&db); // amount 1 BTH >> 1_000
+        processor.process_pending_orders().await.unwrap();
+
+        // Deferred, not failed, and never submitted.
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::DepositConfirmed
+        );
+        assert_eq!(minter.prepare_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(db.count_audit_action("rate_limited").unwrap(), 1);
+        // The rejection is audited exactly once per order.
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(db.count_audit_action("rate_limited").unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_global_cap_trips_breaker() {
+        let (mut config, db) = (BridgeConfig::default(), {
+            let db = Database::open_in_memory().unwrap();
+            db.migrate().unwrap();
+            db
+        });
+        config.bridge.global_daily_limit = 1_000; // below one order
+
+        let minter = Arc::new(MockMinter::new(Chain::Ethereum));
+        let mut minters: HashMap<Chain, Arc<dyn Minter>> = HashMap::new();
+        minters.insert(Chain::Ethereum, minter.clone());
+        let processor = OrderProcessor::new(
+            config,
+            db.clone(),
+            minters,
+            None,
+            Arc::new(StubAttestationProvider),
+        );
+
+        insert_confirmed_deposit(&db);
+        processor.process_pending_orders().await.unwrap();
+
+        // Anomalous volume: the global window exhausting trips the
+        // breaker (fail closed).
+        let reason = db.is_paused().unwrap().expect("breaker must trip");
+        assert!(reason.contains("global daily volume"), "{}", reason);
+        assert_eq!(minter.prepare_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_stuck_order_alert_fires_once() {
+        let (processor, _minter, db) = setup();
+
+        // A MintPending order that has not advanced for 3 hours (default
+        // expiry threshold is 60 minutes). Funds moved: it must alert,
+        // never auto-expire.
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            0,
+            "bth_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        order.set_status(OrderStatus::MintPending);
+        // Submitted tx that the (mock) chain keeps reporting as Pending —
+        // without it confirm_mint would unwind the order instead.
+        order.dest_tx = Some("0xstuck_mint_tx".to_string());
+        order.updated_at = chrono::Utc::now() - chrono::Duration::hours(3);
+        db.insert_order(&order).unwrap();
+
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(db.count_audit_action("stuck_order_alert").unwrap(), 1);
+        assert!(!db
+            .get_order(&order.id)
+            .unwrap()
+            .unwrap()
+            .status
+            .is_terminal());
+
+        // Exactly once per order, not per tick.
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(db.count_audit_action("stuck_order_alert").unwrap(), 1);
+    }
+
+    // === Startup recovery (#843) ===
+
+    #[tokio::test]
+    async fn test_recover_stranded_deposit_detected_order() {
+        let (processor, minter, db) = setup();
+
+        // Simulate the #843 crash window: the watcher recorded the detect
+        // (status + amount + source_tx durably written) and died before
+        // marking the deposit processed or confirming.
+        let order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bridge_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        db.insert_order(&order).unwrap();
+        assert!(db
+            .record_deposit_detected(&order.id, "0xdeposit", 999_000_000_000)
+            .unwrap());
+
+        // Startup recovery rolls it forward and closes both crash halves.
+        processor.recover_on_startup().unwrap();
+        let stored = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(stored.status, OrderStatus::DepositConfirmed);
+        assert!(db.is_deposit_processed("0xdeposit").unwrap());
+        assert_eq!(db.count_audit_action("deposit_recovered").unwrap(), 1);
+
+        // Recovery is idempotent and the order then completes exactly once.
+        processor.recover_on_startup().unwrap();
+        assert_eq!(db.count_audit_action("deposit_recovered").unwrap(), 1);
+
+        processor.process_pending_orders().await.unwrap();
+        minter.set_confirmation(ConfirmationStatus::Confirmed);
+        processor.process_pending_orders().await.unwrap();
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::Completed
+        );
+        assert_eq!(minter.prepare_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/bridge/service/src/main.rs
+++ b/bridge/service/src/main.rs
@@ -12,6 +12,8 @@ use tracing_subscriber::FmtSubscriber;
 
 mod api;
 mod attestation;
+#[cfg(test)]
+mod chaos_tests;
 mod db;
 mod engine;
 mod mint;

--- a/bridge/service/src/reserve.rs
+++ b/bridge/service/src/reserve.rs
@@ -96,7 +96,7 @@ pub enum ReserveError {
     /// RPC / network failure (retryable next pass).
     Rpc(String),
     /// Transport not yet wired up (Solana supply / BTH reserve balance,
-    /// see #828). Fail-safe: the chain is reported unverified, never
+    /// see #853). Fail-safe: the chain is reported unverified, never
     /// silently healthy.
     NotImplemented(String),
 }
@@ -173,7 +173,7 @@ impl SupplySource for EthSupplySource {
 /// Solana supply source: wBTH SPL `Mint.supply` via `getTokenSupply`
 /// (12-decimal mint, 1:1 with picocredits).
 ///
-/// TODO(#828): implement against `SolanaConfig::rpc_url`. Until then this
+/// TODO(#853): implement against `SolanaConfig::rpc_url`. Until then this
 /// is a fail-safe stub: the reconciler reports Solana as UNVERIFIED (its
 /// DB-expected backing is excluded from drift math) rather than silently
 /// healthy.
@@ -197,7 +197,7 @@ impl SupplySource for SolSupplySource {
 
     async fn wrapped_supply(&self) -> Result<u128, ReserveError> {
         Err(ReserveError::NotImplemented(
-            "Solana getTokenSupply transport pending #828".to_string(),
+            "Solana getTokenSupply transport pending #853".to_string(),
         ))
     }
 }
@@ -215,7 +215,7 @@ pub trait ReserveBalanceSource: Send + Sync {
 
 /// Live BTH reserve-balance source.
 ///
-/// TODO(#828): implement against the BTH node transport (view-key scan of
+/// TODO(#853): implement against the BTH node transport (view-key scan of
 /// reserve-address outputs, the same wiring as `watchers::bth`). Until
 /// then this is a fail-safe stub: the custody check is SKIPPED and
 /// `reserveBalanceChecked` stays false — never a silent pass.
@@ -235,7 +235,7 @@ impl NodeReserveBalanceSource {
 impl ReserveBalanceSource for NodeReserveBalanceSource {
     async fn reserve_balance(&self) -> Result<u128, ReserveError> {
         Err(ReserveError::NotImplemented(
-            "BTH reserve-address balance transport pending #828".to_string(),
+            "BTH reserve-address balance transport pending #853".to_string(),
         ))
     }
 }
@@ -270,7 +270,7 @@ pub struct ReserveProof {
     pub locked_reserve: u64,
     /// Verified wBTH totalSupply on Ethereum, picocredits.
     pub eth_supply: Option<u64>,
-    /// Verified wBTH supply on Solana, picocredits (pending #828).
+    /// Verified wBTH supply on Solana, picocredits (pending #853).
     pub sol_supply: Option<u64>,
     /// Σ of the verified supplies, picocredits.
     pub total_wrapped: Option<u64>,
@@ -282,7 +282,7 @@ pub struct ReserveProof {
     /// (when checkable). The dashboard's red/green peg state.
     pub peg_healthy: bool,
     /// Whether the on-Botho reserve balance was actually checked (false
-    /// until the #828 transport lands).
+    /// until the #853 transport lands).
     pub reserve_balance_checked: bool,
     /// When the reconciliation ran (unix seconds).
     pub taken_at: i64,
@@ -297,6 +297,9 @@ pub struct Reconciler {
     supplies: Vec<Arc<dyn SupplySource>>,
     reserve_balance: Option<Arc<dyn ReserveBalanceSource>>,
     tolerance: u64,
+    /// Snapshot retention window in seconds (#846 pruning); `None`
+    /// disables pruning.
+    snapshot_retention_secs: Option<i64>,
 }
 
 impl Reconciler {
@@ -312,6 +315,7 @@ impl Reconciler {
             supplies,
             reserve_balance,
             tolerance,
+            snapshot_retention_secs: None,
         }
     }
 
@@ -326,12 +330,17 @@ impl Reconciler {
         }
         supplies.push(Arc::new(SolSupplySource::new(config.solana.clone())));
 
-        Self::new(
+        let mut reconciler = Self::new(
             db,
             supplies,
             Some(Arc::new(NodeReserveBalanceSource::new(config.bth.clone()))),
             config.reserve.tolerance_picocredits,
-        )
+        );
+        if config.reserve.snapshot_retention_days > 0 {
+            reconciler.snapshot_retention_secs =
+                Some(config.reserve.snapshot_retention_days as i64 * 86_400);
+        }
+        reconciler
     }
 
     /// One reconciliation pass: compute, persist, and (on violation)
@@ -447,7 +456,13 @@ impl Reconciler {
             drift,
             in_tolerance: all_in_tolerance,
             peg_healthy: proof.peg_healthy,
+            reserve_balance_checked,
         })?;
+        if let Some(retention) = self.snapshot_retention_secs {
+            if let Err(e) = self.db.prune_reserve_snapshots(retention) {
+                warn!("reserve snapshot pruning failed (will retry): {}", e);
+            }
+        }
         let details =
             serde_json::to_string(&proof).map_err(|e| format!("serialize proof: {}", e))?;
         self.db.log_audit(None, "reserve_reconcile", &details)?;
@@ -462,6 +477,24 @@ impl Reconciler {
                  custody incident (#825)",
                 locked_reserve, proof.total_wrapped, drift, all_in_tolerance, reserve_covered
             );
+            // Circuit breaker (#827): a peg incident halts the submit
+            // stages (fail closed) until an operator triages and resumes.
+            // Event-driven — a manual resume holds until the NEXT
+            // unhealthy pass, so recovery is never fought by stale state.
+            if self
+                .db
+                .set_paused(true, Some("reserve drift alert (peg unhealthy)"))?
+            {
+                self.db.log_audit(
+                    None,
+                    "breaker_tripped",
+                    "reserve drift alert (peg unhealthy)",
+                )?;
+                error!(
+                    "CIRCUIT BREAKER TRIPPED by reserve drift alert; submit stages halted. \
+                     See docs/operations/runbooks/bridge-order-engine-recovery.md"
+                );
+            }
         } else {
             debug!(
                 "reserve reconciled: locked={} wrapped={:?} drift={}",
@@ -708,7 +741,7 @@ mod tests {
 
         let eth = MockSupply::new(Chain::Ethereum, 1_000);
         let sol = MockSupply::new(Chain::Solana, 0);
-        sol.set_err(ReserveError::NotImplemented("pending #828".to_string()));
+        sol.set_err(ReserveError::NotImplemented("pending #853".to_string()));
         let reconciler = Reconciler::new(db.clone(), vec![eth, sol], None, 0);
 
         let proof = reconciler.reconcile_once().await.unwrap();
@@ -753,6 +786,60 @@ mod tests {
             "custody shortfall must flip the peg state"
         );
         assert_eq!(db.count_audit_action("reserve_drift_alert").unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_drift_alert_trips_circuit_breaker() {
+        let db = setup_db();
+        lock(&db, Chain::Ethereum, 1_000);
+
+        let eth = MockSupply::new(Chain::Ethereum, 1_000);
+        let reconciler = Reconciler::new(db.clone(), vec![eth.clone()], None, 0);
+
+        // Healthy pass: breaker stays closed.
+        assert!(reconciler.reconcile_once().await.unwrap().peg_healthy);
+        assert!(db.is_paused().unwrap().is_none());
+
+        // Drift: the alert trips the breaker (fail closed), audited once.
+        eth.set(1_001);
+        assert!(!reconciler.reconcile_once().await.unwrap().peg_healthy);
+        let reason = db.is_paused().unwrap().expect("breaker must trip");
+        assert!(reason.contains("drift"), "{}", reason);
+        assert_eq!(db.count_audit_action("breaker_tripped").unwrap(), 1);
+
+        // A second unhealthy pass does not re-audit the trip.
+        assert!(!reconciler.reconcile_once().await.unwrap().peg_healthy);
+        assert_eq!(db.count_audit_action("breaker_tripped").unwrap(), 1);
+
+        // Manual resume holds while passes are healthy again.
+        db.set_paused(false, None).unwrap();
+        eth.set(1_000);
+        assert!(reconciler.reconcile_once().await.unwrap().peg_healthy);
+        assert!(db.is_paused().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_persists_custody_verification_flag() {
+        // #846: a consumer must be able to distinguish "custody checked
+        // OK" from "custody never checked" from the persisted snapshot.
+        let db = setup_db();
+        lock(&db, Chain::Ethereum, 1_000);
+        let eth = MockSupply::new(Chain::Ethereum, 1_000);
+
+        // No balance source: pegHealthy but custody UNCHECKED.
+        let reconciler = Reconciler::new(db.clone(), vec![eth.clone()], None, 0);
+        reconciler.reconcile_once().await.unwrap();
+        let snapshot = db.latest_reserve_snapshot().unwrap().unwrap();
+        assert!(snapshot.peg_healthy);
+        assert!(!snapshot.reserve_balance_checked);
+
+        // With a balance source: custody CHECKED.
+        let balance = MockBalance::new(1_000);
+        let reconciler = Reconciler::new(db.clone(), vec![eth], Some(balance), 0);
+        reconciler.reconcile_once().await.unwrap();
+        let snapshot = db.latest_reserve_snapshot().unwrap().unwrap();
+        assert!(snapshot.peg_healthy);
+        assert!(snapshot.reserve_balance_checked);
     }
 
     #[tokio::test]

--- a/docs/operations/runbooks/bridge-order-engine-recovery.md
+++ b/docs/operations/runbooks/bridge-order-engine-recovery.md
@@ -1,0 +1,266 @@
+# Runbook: Bridge Order Engine Recovery
+
+Procedures for operating the BTH bridge service (`bth-bridge`): the circuit
+breaker / kill switch, crash and restart behavior, stuck-order triage,
+peg-drift incident response, signer outages, key rotation, and backup/restore
+of the bridge database.
+
+**Target RTO:** 5-30 minutes
+**Severity:** Critical (custody of the locked BTH reserve)
+**Owner:** Infrastructure
+
+---
+
+## Scope and design recap
+
+The bridge engine (#816) drives orders through a strict state machine,
+enforced at the database layer (#839 — no writer can skip a state or clobber
+a terminal state):
+
+```
+Mint (BTH -> wBTH):  awaiting_deposit -> deposit_detected -> deposit_confirmed
+                     -> mint_pending -> completed
+Burn (wBTH -> BTH):  burn_detected -> burn_confirmed -> release_pending -> released
+Error states:        failed (any non-terminal), expired (pre-deposit only)
+```
+
+Exactly-once machinery (all in the SQLite bridge DB):
+
+- `mints` — one row per order that ever had a mint tx prepared; written
+  BEFORE first broadcast. The contract-side order-id guard (#826) is the
+  on-chain backstop.
+- `release_claims` — claim taken before signing; signed tx hash + raw bytes
+  recorded before first broadcast. BTH has **no on-chain guard**: this table
+  is the only double-release protection. Never delete rows from it.
+- `processed_deposits` / `processed_burns` / `watcher_cursors` — watcher
+  idempotency + resume points.
+- `reserve_ledger` — the locked reserve, derived from outputs (never a
+  mutable counter); reconciled against on-chain supply every
+  `reserve.reconcile_interval_secs` (#825).
+
+**Crash-safety guarantee (verified by the chaos suite in
+`bridge/service/src/chaos_tests.rs`):** killing the service at ANY point and
+restarting never double-mints, never double-releases, and never strands an
+order — startup recovery (`recover_on_startup`) rolls forward orders caught
+in the deposit-detection window (#843), and the submit stages resume from
+the idempotency tables. **A plain restart is therefore always safe** and is
+the first response to most anomalies.
+
+---
+
+## Monitoring surface
+
+All endpoints on `[reserve] api_listen` (default `127.0.0.1:9741` —
+localhost-only; reaching it means you are an operator):
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /health` | `200 OK` operating; `503 paused: <reason>` when the breaker is tripped |
+| `GET /api/status` | Pause state, order counts per status, actionable backlog, stuck-order count, component health, latest peg verdict |
+| `GET /metrics` | Prometheus text for `bridge/service/alerts.yml` |
+| `POST /api/breaker` | Kill-switch toggle (below) |
+| `GET /api/reserve/proof` | Latest proof-of-reserves snapshot (`pegHealthy`, `reserveBalanceChecked`, drift) |
+
+```bash
+curl -s http://127.0.0.1:9741/api/status | jq
+```
+
+The audit trail lives in the `audit_log` table; key alert actions:
+`breaker_tripped`, `breaker_resumed`, `stuck_order_alert`, `rate_limited`,
+`reserve_drift_alert`, `deposit_recovered`.
+
+---
+
+## Kill switch / circuit breaker
+
+Pausing halts the **submit** stages (no new mint or release leaves the
+bridge). **Confirm** stages keep running so already-broadcast transactions
+settle to a durable terminal state. The pause state persists in the DB
+(`bridge_state`) across restarts.
+
+### Pause (freeze the bridge)
+
+```bash
+curl -s -X POST http://127.0.0.1:9741/api/breaker \
+  -H "Content-Type: application/json" \
+  -d '{"paused": true, "reason": "incident <ticket>"}'
+```
+
+Alternatives when the API is unreachable:
+
+- Config: set `paused = true` under `[bridge]` and restart — the service
+  starts paused.
+- On-chain (strongest, mint side): pause the `WrappedBTH` contract itself
+  (`pause()` via the Gnosis Safe, #826) — stops mints even if the service
+  host is compromised. Contract pause and service pause are independent
+  layers; for a custody incident engage **both**.
+
+### Automatic trips (fail closed)
+
+| Trigger | Source |
+|---|---|
+| Reserve drift alert (`pegHealthy = false`) | reconciler, every pass |
+| Actionable backlog > `bridge.max_pending_orders` (default 1000) | engine tick |
+| Global daily volume cap reached (`bridge.global_daily_limit`) | rate limiter |
+| `bridge.paused = true` in config | startup |
+
+Trips are audited (`breaker_tripped`) exactly once. Per-address and
+per-order rate-limit rejections do **not** trip the breaker; they defer the
+individual order (audited `rate_limited`).
+
+### Resume — safety checklist
+
+1. Root cause identified and fixed (see the incident sections below).
+2. `GET /api/reserve/proof` shows `pegHealthy: true` on a FRESH pass
+   (`takenAt` newer than the fix). The reconciler re-trips on the next
+   unhealthy pass, so resuming with a bad peg just re-pauses.
+3. `GET /api/status` shows the expected backlog and no unexplained
+   `stuckOrders`.
+4. Resume:
+
+```bash
+curl -s -X POST http://127.0.0.1:9741/api/breaker -d '{"paused": false}' \
+  -H "Content-Type: application/json"
+```
+
+5. Watch `bridge_actionable_backlog` drain and the first orders complete.
+
+---
+
+## Incident: peg drift alert (`reserve_drift_alert`)
+
+The reconciler compares on-chain wBTH supply vs the ledger-locked reserve vs
+(when the transport is wired) the actual reserve-address balance.
+
+1. **Freeze.** The breaker trips automatically; verify with `GET /health`.
+   For positive drift (unbacked supply — possible mint-authority
+   compromise) ALSO pause the `WrappedBTH` contract via the Safe.
+2. **Read the evidence.** The full per-chain detail is in the audit log:
+
+   ```bash
+   sqlite3 bridge.db \
+     "SELECT created_at, details FROM audit_log
+      WHERE action IN ('reserve_drift_alert','reserve_reconcile')
+      ORDER BY id DESC LIMIT 5;"
+   ```
+
+   - `drift > 0` (supply > locked): unbacked wBTH. Suspect an unauthorized
+     mint (check the wBTH contract's event log against the `mints` table)
+     or a missed deposit unlock. Custody/key incident until proven
+     otherwise — see key rotation below.
+   - `drift < 0` beyond the in-flight allowance: supply that should exist
+     does not, or the ledger overcounts (e.g. a failed-mint unlock that
+     could not cover — audited as `reserve_unlock_failed`).
+   - `reserveBalanceChecked: true` with a shortfall: BTH left the reserve
+     address without a burn — custody incident, rotate reserve keys.
+3. **Reconcile.** Fix the ledger only with recorded evidence (every ledger
+   mutation is audited: `reserve_locked`, `reserve_spent`,
+   `reserve_unlocked`, `reserve_spend_failed`, `reserve_unlock_failed`).
+4. **Resume** per the checklist above (fresh healthy pass required).
+
+---
+
+## Incident: stuck orders (`stuck_order_alert`)
+
+Orders past `deposit_detected` never auto-expire — funds have moved, an
+operator must act. Only `awaiting_deposit` orders expire automatically.
+
+| Stuck status | Meaning | Action |
+|---|---|---|
+| `deposit_detected` | #843 crash window (should be recovered at startup) | Restart the service — `recover_on_startup` rolls it forward; check `deposit_recovered` in the audit log |
+| `deposit_confirmed` | Mint submission failing | Check `minter:*` in `/api/status` components (config), attestation health, and `rate_limited` audits (deferred by a cap: passes at the next UTC day window) |
+| `mint_pending` | Mint tx not confirming | Check the tx on the destination chain. Dropped/reorged txs unwind automatically; a tx that reverted marks the order `failed` and unlocks its backing |
+| `burn_confirmed` | Release submission failing | Check `releaser:bth` component health, attestation health, `rate_limited` audits |
+| `release_pending` | Release tx not confirming | Check the BTH tx. **Never** delete the `release_claims` row to force a re-sign — a merely-unseen tx can still land; only the engine's provably-dropped path may unwind it |
+| `failed` releases | Landed-but-wrong release tx | Manual review; the claim is kept deliberately so any retry reuses the recorded tx |
+
+A stuck order alerts exactly once (audit `stuck_order_alert`); the
+`bridge_stuck_orders` gauge stays up until resolved.
+
+---
+
+## Incident: signer / component outage
+
+`/api/status` `components` reports `attestation`, `minter:ethereum`,
+`minter:solana`, `releaser:bth`. The engine fails closed: affected orders
+stay retryable in their current state — nothing is dropped or failed.
+
+- `attestation` unhealthy: the federation config is invalid
+  (`[bridge] attestation_*_key_file`, `mint_signers` / `release_signers` /
+  thresholds). No mint or release is authorized until fixed. Fix config,
+  restart, confirm the component turns healthy.
+- `minter:*` / `releaser:bth` unhealthy: missing Safe address / contract
+  address / reserve address. Same treatment.
+
+---
+
+## Key rotation
+
+Bridge-relevant keys and where they live:
+
+| Key | Location | Rotation |
+|---|---|---|
+| Attestation Ed25519 (BTH release + Solana mint federation) | `[bridge] attestation_ed25519_key_file`; pubkeys in every node's `release_signers` / `mint_signers` | Two-step overlap: add the new pubkey to the signer lists fleet-wide, restart, verify a release authorizes, then remove the old key. Thresholds must hold at every step |
+| Attestation secp256k1 (Ethereum mint / Safe owner) | `[bridge] attestation_secp256k1_key_file`; owner set on the Gnosis Safe | Rotate via the Safe's owner-management transactions (`addOwnerWithThreshold` / `removeOwner`), then update `ethereum.mint_signers` |
+| Reserve wallet spend key | `[bth] spend_key_file` | A compromise is a custody incident: **pause first**, move the reserve to a fresh address, update `reserve_address`, reconcile the ledger before resuming |
+| Ethereum submitter key | `[ethereum] private_key_file` | Low privilege (pays gas); rotate freely |
+
+After any rotation: restart, check `/api/status` components, and run one
+end-to-end testnet order in each direction before resuming mainnet flow.
+
+---
+
+## Backup / restore of the bridge DB
+
+The bridge DB is the custody-critical state: the reserve ledger, the
+exactly-once tables, and the audit log. Losing `release_claims` in
+particular could allow a double release on restore-then-resume.
+
+**Backup** (safe while the service runs — SQLite online backup):
+
+```bash
+sqlite3 bridge.db ".backup 'bridge-$(date -u +%Y%m%dT%H%M%SZ).db'"
+# Also back up the attestation nonce store (replay protection):
+cp bridge.db.attestation-nonces.json bridge-nonces-$(date -u +%Y%m%dT%H%M%SZ).json
+```
+
+Schedule at least hourly in production and before every deploy.
+
+**Restore procedure:**
+
+1. Stop the service; keep the corrupt DB aside for forensics.
+2. Restore the newest backup pair (DB + nonce store).
+3. Start the service **paused** (`paused = true` in `[bridge]`).
+4. The watchers rescan from the persisted cursors; the idempotency tables
+   absorb the replay. Startup recovery rolls stranded orders forward.
+5. **Cross-check before resuming:** for every `release_pending` /
+   `mint_pending` order, compare the recorded tx against the chain. A
+   release broadcast AFTER the backup was taken will not be in the restored
+   `release_claims` — this is the one restore hazard. Reconcile manually
+   (insert the claim row from chain evidence) before resuming.
+6. Wait for a fresh `pegHealthy: true` reconciliation, then resume.
+
+> Testnet deployments are ephemeral — skip the backup ceremony there.
+
+---
+
+## Symptom → Action map
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `/health` returns `503 paused: reserve drift alert...` | Peg incident | Drift incident procedure above |
+| `/health` returns `503 paused: actionable backlog...` | Order flood / settlement stall | Check destination-chain RPC health; drain or raise `max_pending_orders`; resume |
+| `bridge_stuck_orders > 0` | See stuck-order table | Per-status triage above |
+| Order stuck at `deposit_detected` | #843 window (pre-recovery build or recovery failed) | Restart; verify `deposit_recovered` audit |
+| `rate_limited` audits accumulating | Caps sized below real traffic | Raise `[bridge]` caps deliberately; per-order-cap mints can never pass — refund path via operator |
+| Service crash-loops | Bad config / DB corruption | `bth-bridge --migrate` to test the DB; restore-from-backup procedure |
+| Repeated `breaker_tripped` right after resume | Root cause not fixed (reconciler re-trips on every unhealthy pass) | Fix first; the breaker is doing its job |
+
+---
+
+## Related documentation
+
+- `bridge/service/alerts.yml` — Prometheus alert rules for this runbook
+- `docs/decisions/` ADR 0002 (custody), 0003 (peg/reserve), 0005 (per-chain invariant)
+- [Quorum Edit Recovery](quorum-edit-recovery.md) — operator-signed-action recovery pattern this runbook mirrors
+- [Disaster Recovery](../disaster-recovery.md) — node-level procedures


### PR DESCRIPTION
Closes #827
Closes #839
Closes #843
Closes #846

Part of the bridge epic #816. Makes the `bridge/service` order engine production-operable on top of the exactly-once machinery from #838/#840/#841/#844/#847.

## What's implemented

**Chaos/restart suite (DoD centerpiece)** — `bridge/service/src/chaos_tests.rs`
- Drives mint and burn orders through the full lifecycle over a file-backed SQLite DB with mocked chains, crashing (dropping engine + DB handles) and rebooting via the real startup path (`recover_on_startup`) at **every** durable transition boundary: 6 mint crash points, 2 deposit-detection crash points (#843), 6 release crash points, plus a rolling restart-after-every-tick run.
- Asserts exactly-once everywhere: the mock Ethereum chain enforces the #826 contract order-id guard and counts duplicate-mint *attempts* (must stay 0); BTH deliberately has **no** on-chain guard, so a second landed release tx is the double-release bug the suite hunts; the reserve ledger must be arithmetically exact after every scenario; terminal states are stable across further restarts.
- Load test: 240 concurrent orders with 4 engine tick loops hammering the shared connection — no deadlocks, no lost orders, chain-level exactly-once, exact reserve arithmetic. Runs in ~1s (not `#[ignore]`d).

**DB-layer state machine (#839)** — `update_order_status` reads the current status inside the same immediate transaction and rejects any edge `OrderStatus::can_transition_to` disallows; same-status writes are idempotent refreshes; terminal states cannot be clobbered by any writer through this path.

**Startup recovery (#843)** — `recover_on_startup` (run before any watcher/loop) rolls `DepositDetected` orders with a durable `source_tx` forward to `DepositConfirmed` exactly once (audited `deposit_recovered`), also writing the idempotency row so the watcher's block replay short-circuits — both halves of the crash window closed. Covered by unit + chaos tests.

**Rate limits + circuit breaker**
- Config-driven per-order (`max_order_amount`), per-address daily and global daily volume caps, reserved exactly-once per order in `limit_reservations` (crash/tick replay counts each order once). Daily-window rejections defer (retry next window); rejections are audited `rate_limited` exactly once per order.
- Breaker auto-trips (fail closed) on: reserve drift alert from the reconciler (#825/#844 peg incident), actionable backlog above `max_pending_orders`, and global-daily-cap exhaustion (anomalous volume).
- Kill switch: `bridge.paused = true` config (start paused) + runtime `POST /api/breaker` toggle. Pausing halts the **submit** stages only; **confirm** stages keep running so in-flight orders settle to durable terminal states. Pause state persists in the DB across restarts.

**Monitoring / alerting**
- `GET /health` (503 with reason when paused/DB-down), `GET /api/status` (pause state, per-status order counts, actionable backlog, stuck orders, component health, latest peg verdict), `GET /metrics` (hand-rolled Prometheus text — no new dependency), `POST /api/breaker`.
- Component availability (attestation signer, per-chain minters, releaser) recorded at startup and surfaced.
- Stuck-order alerts: post-deposit orders never auto-expire (funds moved); they alert exactly once per order (`stuck_order_alert`) and stay on the `bridge_stuck_orders` gauge until resolved.
- `bridge/service/alerts.yml`: Prometheus rules (breaker tripped, peg unhealthy, backlog, stuck orders, component down, API down), each pointing at the runbook.
- Alerting tests: every alert fires on its trigger (drift→trip, backlog→trip, global cap→trip, stuck order→audit-once, breaker toggle→health 503, component health surface).

**Reserve follow-ups (#846) — all four items**
1. Value-based unlock for failed mints: `unlock_backing_for_order` unlocks the order's own outputs first, then FIFO-by-value with change-output semantics (mirroring `apply_release_spend`) when a release's FIFO spend already consumed the `dep:` output — no more permanent overcount / forever-red drift alarm. Idempotent by attribution.
2. `reserve_balance_checked` persisted in `reserve_snapshots` and exposed via `GET /api/reserve/proof` (`reserveBalanceChecked`) and `/metrics`, so "peg healthy (custody unverified)" is honestly distinguishable.
3. Snapshot pruning: `reserve.snapshot_retention_days` (default 30, 0 disables), pruned each reconcile pass, latest snapshot always survives.
4. Transport homes: the Solana `getTokenSupply` and BTH reserve-balance stubs are re-homed from the test-infra issue #828 to the new dedicated implementation issue #853.

**Ops runbook** — `docs/operations/runbooks/bridge-order-engine-recovery.md`: breaker/kill-switch operation (API + config + contract-level pause layers), automatic-trip table, resume safety checklist, peg-drift / stuck-order / signer-outage incident response, key rotation (attestation Ed25519 + secp256k1/Safe, reserve spend key, submitter key), SQLite online backup + restore procedure with the one restore hazard called out (post-backup release claims), symptom→action map.

## Deferred (with homes)
- Live reserve transports (Solana supply, BTH reserve balance): #853 (new, split out of #846 item 4).
- Federation envelope transport / live RPC wiring: #828 as before.

## Test Plan
- [x] `cargo test -p bth-bridge-core -p bth-bridge-service` — 169 passed, 0 failed (42 core + 127 service, including the 5 chaos/load tests)
- [x] `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets` — 0 warnings
- [x] `cargo +nightly-2025-12-03 fmt --check` — clean
- [x] `cargo deny` — n/a (no dependency changes)
- [x] Chaos suite: `cargo test -p bth-bridge-service chaos` (mint/deposit/release crash matrices + restart-per-tick) and `load_test_concurrent_orders_exactly_once`

🤖 Generated with [Claude Code](https://claude.com/claude-code)