### PR TITLE
test(bridge): adversarial / cross-domain + peg-invariant-with-reorg suite (#829)

### DIFF
--- a/bridge/core/src/adversarial_tests.rs
+++ b/bridge/core/src/adversarial_tests.rs
@@ -1,0 +1,351 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Adversarial / cross-domain attestation tests (bridge epic #816, Phase 3,
+//! issue #829).
+//!
+//! These tests actively try to break the attestation authorization layer.
+//! They complement the per-primitive negative tests already living in
+//! `attestation.rs` (replay, tamper, unknown signer, threshold, staleness —
+//! #847) by attacking the *domain-separation* and *aggregation* seams:
+//!
+//! - **Cross-domain signature confusion**: a signature produced for the
+//!   operator-signed-action machinery (`botho/src/operator_action.rs`), for a
+//!   wallet, or for a different bridge chain domain must NEVER verify as a
+//!   bridge attestation. This is the vector the issue calls out explicitly:
+//!   "verify domain tags actually differ from the operator_action domain".
+//! - **Equivocation / double-signing**: a single federation member cannot
+//!   inflate the distinct-signer count toward the threshold, and the
+//!   aggregation primitive is byte-stable about which of a signer's submissions
+//!   it keeps.
+//!
+//! Every domain tag in the bridge protocol is asserted pairwise-distinct and
+//! distinct from the operator-action domain, so cross-domain confusion is
+//! impossible by construction, not just by test.
+
+use ed25519_dalek::{Signer as _, SigningKey};
+
+use crate::{
+    attestation::{
+        attestation_signed_message, canonical_attestation_envelope, release_payload_digest,
+        sign_attestation_ed25519, AttestationEnvelope, AttestationKind, AttestationRejectReason,
+        AttestationSet, AttestationSignature, ATTEST_DOMAIN_BTH, ATTEST_DOMAIN_ETH,
+        ATTEST_DOMAIN_SOL, MINT_ATTESTATION_DOMAIN_TAG_ETH, MINT_ATTESTATION_DOMAIN_TAG_SOL,
+        RELEASE_ATTESTATION_DOMAIN_TAG,
+    },
+    chains::Chain,
+    order::BridgeOrder,
+};
+
+/// The domain separator the operator-signed-action machinery signs under
+/// (`botho/src/operator_action.rs` `DOMAIN_SEPARATOR`). Mirrored here as a
+/// literal — `bth-bridge-core` deliberately does NOT depend on the `botho`
+/// node crate — with an explicit assertion below that it differs from every
+/// bridge tag. If the node ever changes its separator, that is fine; the
+/// security property is only that the two families never COLLIDE.
+const OPERATOR_ACTION_DOMAIN_SEPARATOR: &[u8] = b"botho-operator-action-v1";
+
+fn signing_key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+fn now() -> u64 {
+    1_700_000_000
+}
+
+/// A confirmed burn order on Ethereum whose release pays out on BTH.
+fn burn_order() -> BridgeOrder {
+    BridgeOrder::new_burn(
+        Chain::Ethereum,
+        1_000_000_000_000,
+        1_000_000_000,
+        "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        "bth_user_stealth_addr".to_string(),
+        "0xburntx".to_string(),
+    )
+}
+
+fn release_kind(order: &BridgeOrder) -> AttestationKind {
+    AttestationKind::ReleaseBth {
+        source_chain: order.source_chain,
+        bth_address: order.dest_address.clone(),
+        amount: order.net_amount(),
+        order_id: order.id,
+        source_tx: order.source_tx.clone().unwrap(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Domain distinctness — cross-domain confusion is impossible by construction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_attestation_domain_tags_are_pairwise_distinct_and_differ_from_operator_action() {
+    // Every domain-separation tag the bridge signs under, plus the node's
+    // operator-action separator. If ANY two collide, a signature over one
+    // payload family could be replayed as another — the exact cross-domain
+    // confusion this suite exists to rule out.
+    let tags: &[(&str, &[u8])] = &[
+        ("attest-eth", ATTEST_DOMAIN_ETH),
+        ("attest-sol", ATTEST_DOMAIN_SOL),
+        ("attest-bth", ATTEST_DOMAIN_BTH),
+        ("release-payload", RELEASE_ATTESTATION_DOMAIN_TAG),
+        ("mint-payload-eth", MINT_ATTESTATION_DOMAIN_TAG_ETH),
+        ("mint-payload-sol", MINT_ATTESTATION_DOMAIN_TAG_SOL),
+        ("operator-action", OPERATOR_ACTION_DOMAIN_SEPARATOR),
+    ];
+
+    for (i, (name_a, a)) in tags.iter().enumerate() {
+        for (name_b, b) in tags.iter().skip(i + 1) {
+            assert_ne!(
+                a, b,
+                "domain tags `{name_a}` and `{name_b}` collide — cross-domain \
+                 signature confusion would be possible"
+            );
+            // Neither may be a prefix of the other: `verify(domain || bytes)`
+            // must not let a longer domain's suffix masquerade as payload.
+            assert!(
+                !a.starts_with(b) && !b.starts_with(a),
+                "domain tag `{name_a}` is a prefix of `{name_b}` (or vice \
+                 versa) — the domain boundary is ambiguous"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-domain signature confusion (#829 gap test a)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn operator_action_domain_signature_reused_as_bridge_attestation_is_rejected() {
+    // A federation validator's Ed25519 node key ALSO signs operator actions
+    // (`botho-operator-action-v1 || envelope`). If an attacker captures such
+    // a signature and wraps the same bytes as a bridge attestation, the
+    // bridge verifier — which signs `attestation_domain(chain) || bytes` —
+    // must reject it: the signed messages differ in their domain prefix.
+    let sk = signing_key(1);
+    let order = burn_order();
+    let kind = release_kind(&order); // target chain = Bth
+    let signer_key_id = hex::encode(sk.verifying_key().as_bytes());
+    let envelope = canonical_attestation_envelope(&kind, &signer_key_id, "n1", now(), now() + 120);
+
+    // Sign the SAME envelope bytes, but under the operator-action domain.
+    let mut operator_msg = OPERATOR_ACTION_DOMAIN_SEPARATOR.to_vec();
+    operator_msg.extend_from_slice(envelope.as_bytes());
+    let payload_digest = kind.ed25519_payload_digest().unwrap();
+
+    let forged = AttestationEnvelope {
+        envelope,
+        signature_hex: hex::encode(sk.sign(&operator_msg).to_bytes()),
+        payload_signature_hex: hex::encode(sk.sign(&payload_digest).to_bytes()),
+    };
+
+    assert_eq!(
+        forged.verify_and_parse_ed25519(&sk.verifying_key()),
+        Err(AttestationRejectReason::BadSignature),
+        "an operator-action-domain signature must not authorize a bridge release"
+    );
+}
+
+#[test]
+fn wallet_style_raw_signature_reused_as_bridge_attestation_is_rejected() {
+    // A validator key might also sign wallet/transaction payloads. A raw
+    // signature over arbitrary bytes (no bridge domain prefix at all) must
+    // never verify as an attestation envelope signature.
+    let sk = signing_key(2);
+    let order = burn_order();
+    let kind = release_kind(&order);
+    let signer_key_id = hex::encode(sk.verifying_key().as_bytes());
+    let envelope = canonical_attestation_envelope(&kind, &signer_key_id, "n2", now(), now() + 120);
+
+    // Sign the envelope bytes DIRECTLY (as a naive wallet would sign a blob),
+    // omitting the domain separator entirely.
+    let payload_digest = kind.ed25519_payload_digest().unwrap();
+    let forged = AttestationEnvelope {
+        signature_hex: hex::encode(sk.sign(envelope.as_bytes()).to_bytes()),
+        payload_signature_hex: hex::encode(sk.sign(&payload_digest).to_bytes()),
+        envelope,
+    };
+
+    assert_eq!(
+        forged.verify_and_parse_ed25519(&sk.verifying_key()),
+        Err(AttestationRejectReason::BadSignature),
+        "a domainless (wallet-style) signature must not authorize a bridge release"
+    );
+}
+
+#[test]
+fn release_payload_signature_reused_as_the_envelope_signature_is_rejected() {
+    // The two detached signatures cover DIFFERENT things (the envelope
+    // signature covers `domain || envelope_bytes`; the payload signature
+    // covers `release_payload_digest`). Swapping the payload signature into
+    // the envelope-signature slot — a within-protocol cross-domain reuse —
+    // must fail.
+    let sk = signing_key(3);
+    let order = burn_order();
+    let kind = release_kind(&order);
+    let good = sign_attestation_ed25519(&kind, &sk, "n3", now(), now() + 120).unwrap();
+
+    let swapped = AttestationEnvelope {
+        envelope: good.envelope.clone(),
+        // envelope slot now holds the PAYLOAD signature
+        signature_hex: good.payload_signature_hex.clone(),
+        payload_signature_hex: good.payload_signature_hex,
+    };
+    assert_eq!(
+        swapped.verify_and_parse_ed25519(&sk.verifying_key()),
+        Err(AttestationRejectReason::BadSignature),
+        "the payload signature must not double as the envelope signature"
+    );
+}
+
+#[test]
+fn a_release_attestation_never_verifies_under_a_mint_target_domain() {
+    // Bind-check the two mint payload domains against the release domain by
+    // signing a release envelope but selecting a mint chain's envelope
+    // domain. Verification derives the domain from the envelope's own
+    // action, so the mismatch fails closed.
+    let sk = signing_key(4);
+    let order = burn_order();
+    let kind = release_kind(&order);
+    let signer_key_id = hex::encode(sk.verifying_key().as_bytes());
+    let envelope = canonical_attestation_envelope(&kind, &signer_key_id, "n4", now(), now() + 120);
+
+    // Sign the release envelope but select the SOLANA (mint) envelope domain
+    // instead of BTH. Verification derives the domain from the envelope's own
+    // action, so the mismatch fails closed.
+    let wrong_msg = attestation_signed_message(Chain::Solana, envelope.as_bytes());
+    let payload = kind.ed25519_payload_digest().unwrap();
+    let forged = AttestationEnvelope {
+        envelope,
+        signature_hex: hex::encode(sk.sign(&wrong_msg).to_bytes()),
+        payload_signature_hex: hex::encode(sk.sign(&payload).to_bytes()),
+    };
+    assert_eq!(
+        forged.verify_and_parse_ed25519(&sk.verifying_key()),
+        Err(AttestationRejectReason::BadSignature),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Equivocation / double-signing (#829 gap test b)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn equivocating_signer_cannot_inflate_the_distinct_signer_count() {
+    // A Byzantine federation member signs TWO different valid attestations
+    // for the same (order, action) — the classic equivocation move to try to
+    // count as two toward the threshold. The aggregation primitive
+    // deduplicates by signer identity, so the second submission counts zero.
+    //
+    // NOTE ON DETECTION (follow-up filed): `AttestationSet` is *resistant* to
+    // equivocation (a single malicious signer can never move the threshold),
+    // but it does not *flag* the equivocation as an auditable event — it
+    // silently keeps the first submission. Active detection (raising an
+    // equivocation alarm when a signer presents conflicting bytes for the
+    // same order id) is tracked as a hardening follow-up. See the threat
+    // model doc: docs/security/bridge-threat-model.md.
+    let sk = signing_key(5);
+    let order = burn_order();
+    let kind = release_kind(&order);
+
+    // Two envelopes from the same signer, distinct nonces (both individually
+    // valid), for the same order/action.
+    let env_a = sign_attestation_ed25519(&kind, &sk, "eq-a", now(), now() + 120).unwrap();
+    let env_b = sign_attestation_ed25519(&kind, &sk, "eq-b", now(), now() + 120).unwrap();
+    let parsed_a = env_a.verify_and_parse_ed25519(&sk.verifying_key()).unwrap();
+    let parsed_b = env_b.verify_and_parse_ed25519(&sk.verifying_key()).unwrap();
+
+    let mut set = AttestationSet::for_attestation(&parsed_a);
+    let sig = |hex_str: &str| AttestationSignature {
+        signer: sk.verifying_key().as_bytes().to_vec(),
+        signature: hex::decode(hex_str).unwrap(),
+    };
+
+    assert_eq!(
+        set.insert(&parsed_a, sig(&env_a.payload_signature_hex)),
+        Ok(true),
+        "first submission from a signer counts"
+    );
+    assert_eq!(
+        set.insert(&parsed_b, sig(&env_b.payload_signature_hex)),
+        Ok(false),
+        "the SAME signer's second (equivocating) submission must not count again"
+    );
+    assert_eq!(set.distinct_signers(), 1);
+    assert!(
+        !set.is_threshold_met(2),
+        "a single equivocating signer can never satisfy a 2-of-n threshold"
+    );
+}
+
+#[test]
+fn a_zero_threshold_never_authorizes_even_with_signatures() {
+    // Defense in depth against a misconfigured federation: even a populated
+    // set must not be considered authorized at threshold 0 (a t-of-n
+    // federation always requires at least one signature).
+    let sk = signing_key(6);
+    let order = burn_order();
+    let kind = release_kind(&order);
+    let env = sign_attestation_ed25519(&kind, &sk, "z1", now(), now() + 120).unwrap();
+    let parsed = env.verify_and_parse_ed25519(&sk.verifying_key()).unwrap();
+
+    let mut set = AttestationSet::for_attestation(&parsed);
+    set.insert(
+        &parsed,
+        AttestationSignature {
+            signer: sk.verifying_key().as_bytes().to_vec(),
+            signature: hex::decode(&env.payload_signature_hex).unwrap(),
+        },
+    )
+    .unwrap();
+    assert!(set.distinct_signers() >= 1);
+    assert!(!set.is_threshold_met(0), "threshold 0 must never authorize");
+}
+
+#[test]
+fn conflicting_payload_for_the_same_order_cannot_cross_order_binding() {
+    // The *upstream* guard that makes equivocation moot: a signer cannot
+    // produce two binding-valid attestations for one order that differ in
+    // amount/recipient, because `check_order_binding` pins every field to the
+    // on-record order. Here a validly-signed release for a DIFFERENT amount
+    // is rejected against the real order before it can ever reach a set.
+    use crate::attestation::check_order_binding;
+
+    let sk = signing_key(7);
+    let order = burn_order();
+
+    // A validly-signed attestation that inflates the amount by 1 picocredit.
+    let inflated = AttestationKind::ReleaseBth {
+        source_chain: order.source_chain,
+        bth_address: order.dest_address.clone(),
+        amount: order.net_amount() + 1,
+        order_id: order.id,
+        source_tx: order.source_tx.clone().unwrap(),
+    };
+    let env = sign_attestation_ed25519(&inflated, &sk, "cb1", now(), now() + 120).unwrap();
+    let parsed = env.verify_and_parse_ed25519(&sk.verifying_key()).unwrap();
+
+    // On-record order carries a confirmed source tx so binding can run.
+    let mut on_record = order.clone();
+    on_record.source_tx = Some("0xburntx".to_string());
+
+    match check_order_binding(&parsed, &on_record) {
+        Err(AttestationRejectReason::WrongOrder(_)) => {}
+        other => panic!("expected WrongOrder for an amount-inflated attestation, got {other:?}"),
+    }
+    // Sanity: the digest an inflated attestation signs differs from the real
+    // order's release digest, so the two can never share a signature.
+    assert_ne!(
+        release_payload_digest(
+            &order.order_id_bytes(),
+            order.net_amount(),
+            &order.dest_address
+        ),
+        release_payload_digest(
+            &order.order_id_bytes(),
+            order.net_amount() + 1,
+            &order.dest_address
+        ),
+    );
+}

--- a/bridge/core/src/lib.rs
+++ b/bridge/core/src/lib.rs
@@ -16,6 +16,10 @@ pub mod config;
 pub mod nonce;
 pub mod order;
 
+/// Adversarial / cross-domain attestation tests (bridge epic #816, Phase 3).
+#[cfg(test)]
+mod adversarial_tests;
+
 pub use attestation::{
     attestation_domain, attestation_signed_message, canonical_attestation_envelope,
     check_attestation_freshness, check_order_binding, mint_payload_digest,

--- a/bridge/service/src/adversarial_tests.rs
+++ b/bridge/service/src/adversarial_tests.rs
@@ -1,0 +1,169 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Adversarial peg-invariant property tests (bridge epic #816, Phase 3,
+//! issue #829).
+//!
+//! The #825 property test
+//! (`reserve::tests::prop_invariant_holds_across_mint_burn_sequences`)
+//! drives randomized mint/burn sequences and asserts the reserve ledger's
+//! locked total tracks the expected wrapped supply. This module EXTENDS that
+//! coverage with the two chain events that test can't: **reorg-orphaned
+//! deposits** (a locked deposit whose mint never lands because its BTH
+//! deposit was reorged out — the backing must be released so the ledger does
+//! not permanently overcount) interleaved with mints and burns.
+//!
+//! The peg invariant under attack (ADR 0003 / ADR 0005):
+//!
+//! ```text
+//! locked_reserve_total() == Σ over chains of (locked backing value)
+//! ```
+//!
+//! must hold after EVERY settled operation — mint (lock), burn (FIFO
+//! release spend), and reorg-unwind (unlock the orphaned deposit's backing).
+//! No interleaving may drive the locked total negative, overcount, or
+//! undercount. All locked backing is fungible in the ledger, so the model
+//! tracks a single per-chain expected value and reconciles it against the
+//! ledger after each op.
+
+use bth_bridge_core::Chain;
+use proptest::prelude::*;
+use uuid::Uuid;
+
+use crate::db::Database;
+
+fn setup_db() -> Database {
+    let db = Database::open_in_memory().unwrap();
+    db.migrate().unwrap();
+    db
+}
+
+fn chain_of(ix: u8) -> Chain {
+    if ix == 0 {
+        Chain::Ethereum
+    } else {
+        Chain::Solana
+    }
+}
+
+/// One step in a randomized mint / burn / reorg sequence.
+#[derive(Debug, Clone)]
+enum Op {
+    /// A confirmed deposit is locked as backing for a pending mint.
+    Mint { chain_ix: u8, net: u64 },
+    /// A pending (not-yet-confirmed) deposit's mint is finalized — after
+    /// this the deposit is beyond the finality window and can never be
+    /// reorged out.
+    Confirm { pick: u8 },
+    /// A reorg orphans a still-pending deposit before its mint lands: the
+    /// locked backing must be unwound so the ledger stops counting it.
+    Reorg { pick: u8 },
+    /// A confirmed burn spends `fraction`% of a chain's locked backing FIFO.
+    Burn { chain_ix: u8, fraction: u8 },
+}
+
+fn op_strategy() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        3 => (0u8..2, 1u64..5_000_000).prop_map(|(chain_ix, net)| Op::Mint { chain_ix, net }),
+        1 => (0u8..255).prop_map(|pick| Op::Confirm { pick }),
+        1 => (0u8..255).prop_map(|pick| Op::Reorg { pick }),
+        2 => (0u8..2, 1u8..=100).prop_map(|(chain_ix, fraction)| Op::Burn { chain_ix, fraction }),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Peg invariant holds across randomized mint / burn / reorg sequences.
+    #[test]
+    fn prop_invariant_survives_reorg_interleaving(
+        ops in proptest::collection::vec(op_strategy(), 1..48)
+    ) {
+        let db = setup_db();
+        // Per-chain expected locked backing (the chain-side ground truth the
+        // ledger must equal). All locked backing is fungible.
+        let mut expected = [0u128; 2];
+        // Pending deposits that can still be reorged out: (order id, chain, net).
+        let mut pending: Vec<(Uuid, u8, u64)> = Vec::new();
+
+        for op in ops {
+            match op {
+                Op::Mint { chain_ix, net } => {
+                    let chain = chain_of(chain_ix);
+                    let order = Uuid::new_v4();
+                    let output_id = format!("dep:{}", order);
+                    prop_assert!(db
+                        .record_locked_output(&output_id, chain, net, &order)
+                        .unwrap());
+                    expected[chain_ix as usize] += net as u128;
+                    pending.push((order, chain_ix, net));
+                }
+                Op::Confirm { pick } => {
+                    // Finalize a pending deposit: it leaves the reorg-eligible
+                    // set (its backing stays locked and now backs real supply).
+                    if !pending.is_empty() {
+                        let idx = pick as usize % pending.len();
+                        pending.remove(idx);
+                    }
+                }
+                Op::Reorg { pick } => {
+                    // Orphan a still-pending deposit: unwind its backing.
+                    if pending.is_empty() {
+                        continue;
+                    }
+                    let idx = pick as usize % pending.len();
+                    let (order, chain_ix, net) = pending[idx];
+                    // Only unwind when the chain's locked backing can cover
+                    // the net (FIFO burns may already have consumed part of
+                    // this deposit's value; the value-based unlock needs the
+                    // remaining locked total to cover it).
+                    if expected[chain_ix as usize] >= net as u128 {
+                        let unlocked = db
+                            .unlock_backing_for_order(&order, chain_of(chain_ix), net)
+                            .unwrap();
+                        prop_assert!(unlocked, "first unwind of a deposit must apply");
+                        expected[chain_ix as usize] -= net as u128;
+                        pending.remove(idx);
+
+                        // A second unwind of the SAME orphaned deposit is a
+                        // no-op (exactly-once): a duplicated reorg signal can
+                        // never double-release the backing.
+                        let again = db
+                            .unlock_backing_for_order(&order, chain_of(chain_ix), net)
+                            .unwrap();
+                        prop_assert!(!again, "re-unwinding an orphaned deposit must be a no-op");
+                    }
+                }
+                Op::Burn { chain_ix, fraction } => {
+                    let outstanding = expected[chain_ix as usize];
+                    let amount = (outstanding * fraction as u128 / 100).min(outstanding) as u64;
+                    if amount == 0 {
+                        continue;
+                    }
+                    let chain = chain_of(chain_ix);
+                    let release = Uuid::new_v4();
+                    prop_assert!(db.apply_release_spend(&release, chain, amount).unwrap());
+                    expected[chain_ix as usize] -= amount as u128;
+                }
+            }
+
+            // The peg invariant after every settled op — per chain and total.
+            let expected_total: u128 = expected.iter().sum();
+            prop_assert_eq!(db.locked_reserve_total().unwrap() as u128, expected_total);
+            prop_assert_eq!(
+                db.locked_reserve_by_chain(Chain::Ethereum).unwrap() as u128,
+                expected[0]
+            );
+            prop_assert_eq!(
+                db.locked_reserve_by_chain(Chain::Solana).unwrap() as u128,
+                expected[1]
+            );
+        }
+
+        // Terminal safety: a burn exceeding the outstanding locked backing
+        // can never settle (no interleaving drives the total negative).
+        let over = db.locked_reserve_by_chain(Chain::Ethereum).unwrap() + 1;
+        prop_assert!(db
+            .apply_release_spend(&Uuid::new_v4(), Chain::Ethereum, over)
+            .is_err());
+    }
+}

--- a/bridge/service/src/main.rs
+++ b/bridge/service/src/main.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
+#[cfg(test)]
+mod adversarial_tests;
 mod api;
 mod attestation;
 #[cfg(test)]

--- a/bridge/service/src/watchers/adversarial_tests.rs
+++ b/bridge/service/src/watchers/adversarial_tests.rs
@@ -1,0 +1,293 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Reorg + finality fuzz for the Ethereum burn watcher (bridge epic #816,
+//! Phase 3, issue #829).
+//!
+//! `ethereum::tests` covers reorg orphan / re-add / restart as fixed
+//! scenarios. This module attacks the same watcher with RANDOMIZED reorg
+//! depths, re-add timing, and burn placements, asserting the two
+//! exactly-once safety properties that hold no matter how the chain wobbles:
+//!
+//! 1. **Exactly one order per burn transaction** — no reorg, re-add, or rescan
+//!    ever creates a second order (or a second `burn_detected`) for a tx, and
+//!    no tx is ever dropped.
+//! 2. **Confirm-once against a canonical block** — a burn only advances to
+//!    `BurnConfirmed` when its block is `confirmations_required` deep AND still
+//!    canonical; a confirmed order's recorded block is always the current
+//!    canonical hash, and confirmation never happens twice.
+//!
+//! Reorg depth is bounded by `confirmations_required` — a reorg deeper than
+//! the confirmation requirement is outside the bridge's stated safety model
+//! (the requirement is exactly the assumption that such reorgs do not
+//! happen), so fuzzing beyond it would test an unsupported regime.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Mutex,
+};
+
+use async_trait::async_trait;
+use bth_bridge_core::{BridgeOrder, EthereumConfig, OrderStatus};
+use proptest::prelude::*;
+use tokio::sync::broadcast;
+
+use super::{
+    ethereum::{BurnEvent, EthChainClient, EthereumWatcher},
+    WatchError,
+};
+use crate::db::Database;
+
+/// A canonical chain plus the burns ever emitted, with reorg support —
+/// modeled on `ethereum::tests::MockChain` but self-contained.
+struct MockChain {
+    /// height -> canonical block hash.
+    hashes: BTreeMap<u64, String>,
+    /// Every burn ever emitted; only those whose (height, hash) is still
+    /// canonical are visible via `burn_events`.
+    events: Vec<BurnEvent>,
+    /// Monotonic fork counter so each reorg mints fresh, distinct hashes.
+    fork_seq: u64,
+}
+
+struct MockEthClient {
+    chain: Mutex<MockChain>,
+}
+
+impl MockEthClient {
+    fn new() -> Self {
+        Self {
+            chain: Mutex::new(MockChain {
+                hashes: BTreeMap::new(),
+                events: Vec::new(),
+                fork_seq: 0,
+            }),
+        }
+    }
+
+    fn tip(&self) -> u64 {
+        *self
+            .chain
+            .lock()
+            .unwrap()
+            .hashes
+            .keys()
+            .next_back()
+            .unwrap_or(&0)
+    }
+
+    /// Extend the canonical chain by `n` blocks on the current fork.
+    fn extend(&self, n: u64) {
+        let mut chain = self.chain.lock().unwrap();
+        let fork = chain.fork_seq;
+        let start = chain.hashes.keys().next_back().map(|h| h + 1).unwrap_or(0);
+        for h in start..start + n {
+            chain.hashes.insert(h, format!("0x{}_{}", fork, h));
+        }
+    }
+
+    /// Reorg the top `depth` blocks onto a fresh fork of the same length,
+    /// orphaning any burns in that range. Returns the set of heights that
+    /// were rewritten.
+    fn reorg(&self, depth: u64) {
+        let mut chain = self.chain.lock().unwrap();
+        let tip = match chain.hashes.keys().next_back() {
+            Some(t) => *t,
+            None => return,
+        };
+        chain.fork_seq += 1;
+        let fork = chain.fork_seq;
+        let from = tip.saturating_sub(depth.saturating_sub(1));
+        for h in from..=tip {
+            chain.hashes.insert(h, format!("0x{}_{}", fork, h));
+        }
+    }
+
+    fn block_hash(&self, height: u64) -> Option<String> {
+        self.chain.lock().unwrap().hashes.get(&height).cloned()
+    }
+
+    /// Emit a single burn for `tx` in the CURRENT canonical block at the tip.
+    fn emit_burn(&self, tx: &str, amount: u64, height: u64) {
+        let hash = self.block_hash(height).expect("tip block must exist");
+        self.chain.lock().unwrap().events.push(BurnEvent {
+            tx_hash: tx.to_string(),
+            log_index: 0,
+            block_number: height,
+            block_hash: hash,
+            from: "0xburner".to_string(),
+            amount,
+            bth_address: "bth_dest".to_string(),
+        });
+    }
+
+    /// Whether `tx` currently has a canonical (visible, non-orphaned) burn.
+    fn has_canonical_burn(&self, tx: &str) -> bool {
+        let chain = self.chain.lock().unwrap();
+        chain
+            .events
+            .iter()
+            .any(|e| e.tx_hash == tx && chain.hashes.get(&e.block_number) == Some(&e.block_hash))
+    }
+}
+
+#[async_trait]
+impl EthChainClient for MockEthClient {
+    async fn latest_block(&self) -> Result<u64, WatchError> {
+        Ok(self.tip())
+    }
+
+    async fn block_hash_at(&self, number: u64) -> Result<Option<String>, WatchError> {
+        Ok(self.block_hash(number))
+    }
+
+    async fn burn_events(&self, from: u64, to: u64) -> Result<Vec<BurnEvent>, WatchError> {
+        let chain = self.chain.lock().unwrap();
+        Ok(chain
+            .events
+            .iter()
+            .filter(|e| {
+                e.block_number >= from
+                    && e.block_number <= to
+                    && chain.hashes.get(&e.block_number) == Some(&e.block_hash)
+            })
+            .cloned()
+            .collect())
+    }
+}
+
+fn watcher(confirmations_required: u32) -> (EthereumWatcher, Database) {
+    let db = Database::open_in_memory().unwrap();
+    db.migrate().unwrap();
+    let config = EthereumConfig {
+        rpc_url: "http://localhost:8545".to_string(),
+        wbth_contract: "0x00000000000000000000000000000000000000ee".to_string(),
+        safe_address: None,
+        chain_id: 1,
+        private_key_file: None,
+        confirmations_required,
+        gas_price_strategy: Default::default(),
+        mint_signers: Vec::new(),
+        mint_threshold: 0,
+    };
+    let (_tx, rx) = broadcast::channel(1);
+    (EthereumWatcher::new(config, db.clone(), rx), db)
+}
+
+fn burn_orders(db: &Database) -> Vec<BridgeOrder> {
+    db.get_orders_by_status("burn").unwrap()
+}
+
+/// A single fuzz step against the chain + watcher.
+#[derive(Debug, Clone)]
+enum Step {
+    /// Grow the canonical chain by 1..=4 blocks.
+    Grow(u8),
+    /// Emit a burn for tx `id` (0..4) at the tip, if that tx has no live burn.
+    Burn(u8),
+    /// Reorg the top `depth` blocks (bounded to confirmations elsewhere).
+    Reorg(u8),
+}
+
+fn step_strategy() -> impl Strategy<Value = Step> {
+    prop_oneof![
+        3 => (1u8..=4).prop_map(Step::Grow),
+        3 => (0u8..5).prop_map(Step::Burn),
+        1 => (1u8..=8).prop_map(Step::Reorg),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(48))]
+
+    #[test]
+    fn prop_reorg_finality_fuzz_is_exactly_once(
+        confirmations in 2u32..=4,
+        steps in proptest::collection::vec(step_strategy(), 1..40),
+    ) {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (watcher, db) = watcher(confirmations);
+            let client = MockEthClient::new();
+            // Seed a starting chain so the first scan has a tip.
+            client.extend(2);
+
+            // Every distinct tx we ever emit — the ground truth for
+            // "one order per tx, none dropped".
+            let mut distinct_txs: HashMap<String, ()> = HashMap::new();
+
+            for step in steps {
+                match step {
+                    Step::Grow(n) => client.extend(n as u64),
+                    Step::Burn(id) => {
+                        let tx = format!("0xburn{}", id);
+                        // Emit at most one LIVE burn per tx: re-emit only
+                        // after a reorg orphaned the previous location, so a
+                        // tx never has two canonical events at once (which
+                        // would be two logically distinct burns, not a
+                        // reorg re-add). Grow a fresh block first so the burn
+                        // lands ABOVE the watcher's forward-only cursor (a
+                        // burn buried below the cursor would never be
+                        // scanned — a test artifact, not a watcher property).
+                        if !client.has_canonical_burn(&tx) {
+                            client.extend(1);
+                            let height = client.tip();
+                            client.emit_burn(&tx, 1_000_000_000 + id as u64, height);
+                            distinct_txs.insert(tx, ());
+                        }
+                    }
+                    Step::Reorg(depth) => {
+                        // Reorg strictly SHALLOWER than the confirmation
+                        // window: a burn confirms only at `confirmations`
+                        // depth, so a reorg of depth < confirmations can
+                        // never orphan an already-confirmed burn. Reorgs at
+                        // or beyond the window are, by definition, outside
+                        // the bridge's stated safety assumption.
+                        let max_depth = (confirmations as u64).saturating_sub(1).max(1);
+                        let depth = (depth as u64).min(max_depth).max(1);
+                        client.reorg(depth);
+                    }
+                }
+
+                watcher.scan_once(&client).await.unwrap();
+
+                // Invariant 1: exactly one order (and one detection) per tx.
+                let orders = burn_orders(&db);
+                prop_assert_eq!(
+                    orders.len(),
+                    distinct_txs.len(),
+                    "every burn tx must map to exactly one order"
+                );
+                prop_assert_eq!(
+                    db.count_audit_action("burn_detected").unwrap() as usize,
+                    distinct_txs.len(),
+                    "each tx is detected exactly once"
+                );
+
+                // Invariant 2: confirmation is once, and only against a
+                // still-canonical block.
+                let confirmed: Vec<_> = orders
+                    .iter()
+                    .filter(|o| o.status == OrderStatus::BurnConfirmed)
+                    .collect();
+                prop_assert_eq!(
+                    db.count_audit_action("burn_confirmed").unwrap() as usize,
+                    confirmed.len(),
+                    "no order confirms twice"
+                );
+                for order in &confirmed {
+                    let record = db.get_burn_by_order(&order.id).unwrap().unwrap();
+                    prop_assert!(!record.orphaned, "a confirmed burn is never orphaned");
+                    let canonical = client.block_hash(record.block_number);
+                    prop_assert_eq!(
+                        canonical.as_deref(),
+                        record.block_hash.as_deref(),
+                        "a confirmed burn's block must be canonical"
+                    );
+                }
+            }
+            Ok(())
+        })?;
+    }
+}

--- a/bridge/service/src/watchers/mod.rs
+++ b/bridge/service/src/watchers/mod.rs
@@ -22,6 +22,11 @@ mod bth;
 mod ethereum;
 mod solana;
 
+/// Reorg + finality fuzz driving the Ethereum watcher (bridge epic #816,
+/// Phase 3, issue #829).
+#[cfg(test)]
+mod adversarial_tests;
+
 pub use bth::BthWatcher;
 pub use ethereum::EthereumWatcher;
 pub use solana::SolanaWatcher;

--- a/contracts/ethereum/test/WrappedBTH.test.ts
+++ b/contracts/ethereum/test/WrappedBTH.test.ts
@@ -539,4 +539,133 @@ describe("WrappedBTH", function () {
       expect(burned).to.be.gt(0n);
     });
   });
+
+  // Adversarial rate-limit accounting fuzz (bridge epic #816, Phase 3,
+  // issue #829). The #851 supply invariant above disables the breaker and
+  // only bounds `dailyMinted <= dailyMintLimit`. This test attacks the
+  // rate-limit ACCOUNTING itself with the breaker ARMED: it drives
+  // randomized mints and time-jumps across UTC-day boundaries and asserts,
+  // after every operation, that `dailyMinted`, `remainingDailyMint()`, and
+  // the auto-pause state exactly match an independent model — including the
+  // reset-is-rolled-back-on-revert and no-reset-on-unpause subtleties.
+  describe("rate-limit accounting fuzz (randomized, breaker armed)", function () {
+    it("dailyMinted / remainingDailyMint / auto-pause track a model under random ops", async function () {
+      const { wbth, admin, minter, pauser, user } = await loadFixture(
+        deployFixture
+      );
+
+      // A tight regime so a handful of max-size mints fill a day. The run
+      // has two phases: with the breaker ARMED below the cap (phase 1,
+      // exercises auto-pause + recovery) and with the breaker DISABLED
+      // (phase 2, lets the counter reach the cap so the daily-limit revert
+      // fires). `currentThreshold` mirrors the on-chain breaker setting.
+      const DAILY_LIMIT = 5n * MAX_TX;
+      let currentThreshold = 4n * MAX_TX;
+      const PHASE2_AT = 70;
+      await wbth.connect(admin).setDailyMintLimit(DAILY_LIMIT);
+      await wbth.connect(admin).setAutoPauseThreshold(currentThreshold);
+
+      // Deterministic PRNG (mulberry32) so failures reproduce.
+      let seed = 0x0829a11;
+      const rand = () => {
+        seed |= 0;
+        seed = (seed + 0x6d2b79f5) | 0;
+        let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+
+      // Independent model of the contract's rate-limit state.
+      let modelMinted = 0n;
+      let modelResetDay = BigInt(Math.floor((await time.latest()) / 86400));
+      let modelPaused = false;
+      let sawLimitRevert = false;
+      let sawAutoPause = false;
+      let orderNonce = 0;
+
+      for (let i = 0; i < 140; i++) {
+        // Enter phase 2: disable the breaker so the counter can reach the
+        // daily cap and exercise the "Daily limit exceeded" revert (which
+        // the breaker would otherwise pre-empt at the threshold).
+        if (i === PHASE2_AT && currentThreshold !== 0n) {
+          if (modelPaused) {
+            await wbth.connect(pauser).unpause();
+            modelPaused = false;
+          }
+          await wbth.connect(admin).setAutoPauseThreshold(0);
+          currentThreshold = 0n;
+        }
+
+        // Recover from an auto-pause: unpause (no reset happens) and jump a
+        // full day so the NEXT mint's lazy reset clears the counter.
+        if (modelPaused) {
+          await wbth.connect(pauser).unpause();
+          await time.increase(86400 + 3600);
+          modelPaused = false;
+        }
+
+        const roll = rand();
+        const nowTs = await time.latest();
+        const today = BigInt(Math.floor(nowTs / 86400));
+
+        if (roll < 0.72) {
+          // Attempt a mint of 1..maxMintPerTx picocredits.
+          const amount = (BigInt(Math.floor(rand() * 1_000_000)) + 1n) * PICO;
+          // The contract resets the counter at the top of bridgeMint, but a
+          // revert on the limit check rolls that reset back.
+          const base = today > modelResetDay ? 0n : modelMinted;
+
+          if (base + amount <= DAILY_LIMIT) {
+            await wbth
+              .connect(minter)
+              .bridgeMint(user.address, amount, oid(`rl-${orderNonce++}`));
+            modelMinted = base + amount;
+            modelResetDay = today;
+            if (currentThreshold !== 0n && modelMinted >= currentThreshold) {
+              modelPaused = true;
+              sawAutoPause = true;
+            }
+          } else {
+            await expect(
+              wbth
+                .connect(minter)
+                .bridgeMint(user.address, amount, oid(`rl-${orderNonce++}`))
+            ).to.be.revertedWith("Daily limit exceeded");
+            sawLimitRevert = true;
+            // State (including the day counter) is unchanged by the revert.
+          }
+        } else {
+          // Jump 1..48 hours (often crossing a UTC-day boundary).
+          await time.increase(3600 * (1 + Math.floor(rand() * 48)));
+        }
+
+        // Accounting invariants after every operation.
+        const tsAfter = await time.latest();
+        const todayAfter = BigInt(Math.floor(tsAfter / 86400));
+        expect(await wbth.dailyMinted()).to.equal(modelMinted);
+        expect(await wbth.paused()).to.equal(modelPaused);
+
+        // remainingDailyMint() folds in the pending (not-yet-persisted) reset.
+        let expectedRemaining: bigint;
+        if (todayAfter > modelResetDay) {
+          expectedRemaining = DAILY_LIMIT;
+        } else if (modelMinted >= DAILY_LIMIT) {
+          expectedRemaining = 0n;
+        } else {
+          expectedRemaining = DAILY_LIMIT - modelMinted;
+        }
+        expect(await wbth.remainingDailyMint()).to.equal(expectedRemaining);
+        expect(await wbth.dailyMinted()).to.be.lte(await wbth.dailyMintLimit());
+      }
+
+      // The run must have actually exercised the interesting branches.
+      expect(sawLimitRevert, "fuzz never hit the daily-limit revert").to.equal(
+        true
+      );
+      expect(
+        sawAutoPause,
+        "fuzz never tripped the auto-pause breaker"
+      ).to.equal(true);
+    });
+  });
 });

--- a/docs/security/bridge-threat-model.md
+++ b/docs/security/bridge-threat-model.md
@@ -1,0 +1,188 @@
+# BTH Bridge Threat Model & Adversarial Test Map
+
+_Part of bridge epic #816 (Phase 3, issue #829). Companion to
+[`docs/bridge/security.md`](../bridge/security.md), the ADRs
+[0002](../decisions/0002-bridge-custody-scp-validator-federation.md)–[0005](../decisions/0005-bridge-v1-chain-scope-ethereum-and-solana.md),
+and [`docs/security/threat-model.md`](./threat-model.md) (node/consensus)._
+
+Bridges are the most-attacked component in crypto: almost every large loss has
+come from a broken mint authorization, a replayed message, a reorg
+double-count, or a peg that silently drifted. This document enumerates the
+**named threats** against the BTH ↔ wBTH bridge and maps each to the specific
+test(s) that defend against it, so the adversarial suite is auditable against a
+concrete list rather than a vibe.
+
+The bridge's security rests on five load-bearing invariants:
+
+1. **Exactly-once mint** — one confirmed BTH deposit mints wBTH at most once.
+2. **Exactly-once release** — one confirmed wBTH burn releases reserve BTH at
+   most once.
+3. **Threshold authorization** — no privileged action (mint/release) happens
+   without a `t`-of-`n` federation signature set, domain-separated and
+   order-bound (ADR 0002).
+4. **Peg solvency** — `Σ(wBTH outstanding) == locked BTH reserve` within
+   tolerance at all times, and any drift trips the circuit breaker (ADR 0003).
+5. **Finality safety** — an action only fires against a block that is final on
+   its chain (SCP finality on BTH; `confirmations_required` depth + canonical
+   re-check on Ethereum; `Finalized` commitment on Solana).
+
+## Test surfaces
+
+| Surface | Location |
+| --- | --- |
+| Attestation crypto (envelopes, domains, thresholding) | `bridge/core/src/attestation.rs` |
+| Cross-domain / equivocation adversarial | `bridge/core/src/adversarial_tests.rs` |
+| Attestation ingest pipeline (service) | `bridge/service/src/attestation.rs` |
+| Peg reconciliation + drift/breaker | `bridge/service/src/reserve.rs` |
+| Peg-invariant + reorg property test | `bridge/service/src/adversarial_tests.rs` |
+| Ethereum watcher reorg/finality | `bridge/service/src/watchers/ethereum.rs` |
+| Reorg + finality fuzz (property test) | `bridge/service/src/watchers/adversarial_tests.rs` |
+| Order-engine chaos / restart / load | `bridge/service/src/chaos_tests.rs` |
+| Ledger exactly-once accounting | `bridge/service/src/db.rs` |
+| wBTH contract (supply + rate-limit) | `contracts/ethereum/test/WrappedBTH.test.ts` |
+
+## Threat → test map
+
+Each row is a named attack, the invariant it targets, and the test(s) that
+demonstrate the defense. "Pre-existing" = landed in an earlier Phase-3 wave
+(#841/#844/#847/#851/#854); "new (#829)" = added by this issue.
+
+### 1. Double-mint (replayed / duplicated deposit → mint)
+
+| Vector | Test | Wave |
+| --- | --- | --- |
+| Replayed attestation envelope (same nonce) | `attestation::pipeline_accepts_valid_release_attestation_then_rejects_replay` | #847 |
+| Nonce replay survives a service restart | `nonce::replay_protection_survives_a_restart_within_the_window` | #847 |
+| Duplicate deposit tx → one order | `db::test_mint_idempotency_duplicate_order_id_exactly_once`, `db::test_processed_deposits` | #854 |
+| On-chain duplicate `orderId` rejected | `WrappedBTH.test.ts › order-id replay guard` (both cases) | #851 |
+| Crash at any mint transition → one mint | `chaos_tests::chaos_mint_crash_at_every_transition_boundary` | #854 |
+| Concurrent orders each mint once | `chaos_tests::load_test_concurrent_orders_exactly_once` | #854 |
+
+### 2. Double-release (replayed / duplicated burn → release)
+
+| Vector | Test | Wave |
+| --- | --- | --- |
+| Replayed burn → single release | `engine::test_release_replayed_burn_single_release` | #854 |
+| Release claim is exactly-once | `db::test_release_claim_exactly_once` | #854 |
+| Crash at any release transition → one landed tx | `chaos_tests::chaos_release_crash_at_every_transition_boundary` | #854 |
+| Resume after crash reuses the recorded tx | `engine::test_release_resume_after_crash_reuses_recorded_tx` | #854 |
+| Crash after claim before sign is safe | `engine::test_release_crash_after_claim_before_sign_is_safe` | #854 |
+
+### 3. Attestation replay across domains
+
+| Vector | Test | Wave |
+| --- | --- | --- |
+| All bridge domain tags pairwise-distinct + differ from operator-action | `adversarial_tests::all_attestation_domain_tags_are_pairwise_distinct_and_differ_from_operator_action` | new (#829) |
+| A mint sig for chain C cannot authorize chain D | `attestation::test_mint_attestation_does_not_bind_to_other_chain_order`, `adversarial_tests::a_release_attestation_never_verifies_under_a_mint_target_domain` | #847 / new |
+| Expired / stale envelope rejected | `attestation::pipeline_rejects_expired_attestation`, `attestation::test_freshness_window` | #847 |
+
+### 4. Cross-domain signature confusion
+
+The keystone check the issue calls out: a validator's Ed25519 node key also
+signs **operator actions** (`botho/src/operator_action.rs`,
+`DOMAIN_SEPARATOR = "botho-operator-action-v1"`) and potentially wallet
+payloads. Those signatures must never authorize a bridge action. Verified by
+construction — every bridge domain tag is proven distinct from and non-prefixing
+of the operator-action tag — and by forged-signature tests.
+
+| Vector | Test | Wave |
+| --- | --- | --- |
+| Operator-action-domain signature reused as a bridge attestation | `adversarial_tests::operator_action_domain_signature_reused_as_bridge_attestation_is_rejected` | new (#829) |
+| Domainless (wallet-style) signature reused as an attestation | `adversarial_tests::wallet_style_raw_signature_reused_as_bridge_attestation_is_rejected` | new (#829) |
+| Payload signature reused in the envelope-signature slot | `adversarial_tests::release_payload_signature_reused_as_the_envelope_signature_is_rejected` | new (#829) |
+| Wrong-chain envelope domain fails | `attestation::test_cross_domain_signature_reuse_fails` | #847 |
+| Ethereum secp256k1 payload never accepted on the Ed25519 path | `attestation::test_ethereum_kind_rejected_on_ed25519_path` | #847 |
+
+**Domain tags in use** (all proven distinct):
+`botho-bridge-attest-{eth,sol,bth}-v1` (envelope),
+`botho-bridge-release-v1` (release payload),
+`botho-bridge-mint-{eth,sol}-v1` (mint payload) — versus the node's
+`botho-operator-action-v1`.
+
+### 5. Below-threshold authorization
+
+| Vector | Test | Wave |
+| --- | --- | --- |
+| `t`-of-`n` never satisfied below `t` distinct signers | `attestation::test_meets_threshold`, `release::bth::test_below_threshold_rejected` | #847 |
+| Threshold 0 never authorizes | `adversarial_tests::a_zero_threshold_never_authorizes_even_with_signatures`, `attestation::from_config_rejects_zero_or_unsatisfiable_threshold` | new / #847 |
+| Below-threshold release/mint is fail-safe (no partial action) | `attestation::authorize_release_meets_threshold_and_output_verifies_downstream`, `attestation::authorize_mint_eth_collects_safe_owner_signatures_to_threshold` | #847 |
+| On-chain Safe assembly rejects below-threshold | `mint::ethereum::test_safe_signature_assembly_rejects_below_threshold` | #847 |
+
+### 6. Single malicious signer moves funds
+
+| Vector | Test | Wave |
+| --- | --- | --- |
+| Unknown/byzantine signer not counted | `attestation::pipeline_rejects_unknown_signer_without_counting_it`, `attestation::pipeline_rejects_eth_envelope_from_a_non_owner` | #847 |
+| Non-federation signer rejected (release) | `release::bth::test_non_federation_signer_rejected` | #847 |
+| One signer cannot reach a `≥2` threshold alone | `adversarial_tests::equivocating_signer_cannot_inflate_the_distinct_signer_count` | new (#829) |
+
+### 7. Equivocation (a signer attests conflicting payloads for one order)
+
+| Vector | Test | Wave |
+| --- | --- | --- |
+| Same signer, two submissions → counts once (no threshold inflation) | `adversarial_tests::equivocating_signer_cannot_inflate_the_distinct_signer_count`, `attestation::pipeline_same_signer_with_fresh_nonces_counts_once_toward_threshold` | new / #847 |
+| Conflicting amount/recipient cannot pass order binding | `adversarial_tests::conflicting_payload_for_the_same_order_cannot_cross_order_binding`, `attestation::test_order_binding_rejects_field_mismatches` | new / #847 |
+
+**Residual / follow-up.** Equivocation is *neutralized* (order binding pins
+every field to the on-record order, and the aggregation set deduplicates by
+signer identity, so a single equivocating signer can neither move conflicting
+funds nor inflate the threshold), but it is **not actively detected**: the
+service does not raise an auditable "equivocation" alarm when a signer presents
+conflicting bytes for the same order id — it silently keeps the first valid
+submission and rejects the rest via the normal replay/binding paths. Active
+detection + alerting is filed as a hardening follow-up (see "Follow-ups").
+
+### 8. Reorg double-count (add / orphan / re-add on the source chain)
+
+| Vector | Test | Wave |
+| --- | --- | --- |
+| Reorg re-add processed exactly once | `watchers::ethereum::test_reorg_readd_processed_exactly_once` | #841 |
+| Orphaned burn never confirms | `watchers::ethereum::test_orphaned_burn_never_confirms` | #841 |
+| Cursor rewind / replay is a no-op | `watchers::ethereum::test_cursor_rewind_replay_is_noop`, `watchers::bth::test_cursor_rewind_replay_is_deduplicated` | #841 |
+| Solana only acts on `Finalized` commitment | `watchers::solana::test_only_finalized_commitment_is_a_reorg_guard` | #841 |
+| **Randomized** reorg depth / re-add → exactly-once confirmation | `watchers::adversarial_tests::prop_reorg_finality_fuzz_is_exactly_once` | new (#829) |
+| Engine reorg unwind + resubmit keeps one order id | `engine::test_reorg_unwinds_and_resubmits_same_order_id` | #854 |
+
+### 9. Peg break (unbacked mint / missing supply / custody theft)
+
+| Vector | Test | Wave |
+| --- | --- | --- |
+| Property: `locked == Σ supply` across random mint/burn | `reserve::prop_invariant_holds_across_mint_burn_sequences` | #844 |
+| **Property: invariant survives reorg-orphan interleaving** | `adversarial_tests::prop_invariant_survives_reorg_interleaving` | new (#829) |
+| Unbacked supply (unauthorized mint) trips alert | `reserve::test_drift_injection_unbacked_supply_trips_alert` | #844 |
+| Missing supply trips alert | `reserve::test_drift_injection_missing_supply_trips_alert` | #844 |
+| Custody theft (reserve moved w/o burn) flips peg state | `reserve::test_unauthorized_reserve_movement_trips_custody_alert` | #844 |
+| Contract supply invariant under random ops | `WrappedBTH.test.ts › supply accounting invariant (randomized)` | #851 |
+
+### 10. Breaker bypass (drift/anomaly should halt, not merely log)
+
+| Vector | Test | Wave |
+| --- | --- | --- |
+| Drift alert trips the circuit breaker (fail-closed) | `reserve::test_drift_alert_trips_circuit_breaker` | #844 |
+| Global/backlog caps trip the breaker | `engine::test_global_cap_trips_breaker`, `engine::test_breaker_auto_trips_on_backlog` | #854 |
+| Kill-switch halts submits, lets confirms settle | `engine::test_kill_switch_halts_submits_but_confirms_settle` | #854 |
+| On-chain auto-pause at anomalous cumulative volume | `WrappedBTH.test.ts › auto-pause circuit breaker` (3 cases) | #851 |
+| **Randomized rate-limit accounting + breaker** | `WrappedBTH.test.ts › rate-limit accounting fuzz (randomized, breaker armed)` | new (#829) |
+
+## Boundary of the model (accepted assumptions)
+
+- **Reorgs deeper than `confirmations_required`.** A burn confirms only at
+  `confirmations_required` depth against a canonical block; a reorg *deeper*
+  than that could orphan a confirmed burn. This is outside the safety model by
+  construction — `confirmations_required` **is** the assumption that such
+  reorgs do not occur — so the reorg fuzz bounds its depths strictly below the
+  confirmation window. Choosing `confirmations_required` larger than any
+  plausible reorg is an operational parameter, not a code defect.
+- **Signature transport between federation members** (#828) is out of scope
+  here; the tests inject peer envelopes directly. Everything cryptographic
+  (signing, verification, replay, binding, thresholding) is exercised.
+- **Solana / BTH live supply + reserve-balance transports** (#853) are
+  fail-safe stubs: an unverified chain is reported `verified: false` and
+  excluded from drift math — never silently counted as healthy
+  (`reserve::test_unverified_chain_is_flagged_not_alerted`).
+
+## Follow-ups filed
+
+- **Active equivocation detection & alerting** (#859) — raise an auditable
+  alarm when a federation member submits conflicting attestations for the same
+  order id (today: neutralized but silent). See threat #7.

--- a/docs/security/bridge-threat-model.md
+++ b/docs/security/bridge-threat-model.md
@@ -152,6 +152,7 @@ detection + alerting is filed as a hardening follow-up (see "Follow-ups").
 | Unbacked supply (unauthorized mint) trips alert | `reserve::test_drift_injection_unbacked_supply_trips_alert` | #844 |
 | Missing supply trips alert | `reserve::test_drift_injection_missing_supply_trips_alert` | #844 |
 | Custody theft (reserve moved w/o burn) flips peg state | `reserve::test_unauthorized_reserve_movement_trips_custody_alert` | #844 |
+| Demurrage decay of the reserve: a non-factor-1 (decaying) deposit never mints, so the reserve holds only zero-demurrage coins (ADR 0003) | `watchers::bth::test_non_factor1_deposit_rejected_with_audit` | #841 |
 | Contract supply invariant under random ops | `WrappedBTH.test.ts › supply accounting invariant (randomized)` | #851 |
 
 ### 10. Breaker bypass (drift/anomaly should halt, not merely log)


### PR DESCRIPTION
Closes #829. Phase 3 of the bridge epic (#816): the negative-path safety bar — the suite actively tries to break the peg and the exactly-once guarantees.

Substantial adversarial coverage already existed from prior waves (#841/#844/#847/#851/#854). This PR **consolidates** it under a threat-mapped document and **fills the gaps** that mapping surfaced, plus one contract fuzz addition. No production code changed — this is tests + docs only.

## Threat model (acceptance bar)
`docs/security/bridge-threat-model.md` enumerates ten named threats, each mapped to its covering test(s) by file + test name, with pre-existing vs new provenance:

| # | Threat | Coverage |
| --- | --- | --- |
| 1 | Double-mint (replay/dup deposit) | pre-existing (#847/#854/#851) |
| 2 | Double-release (replay/dup burn) | pre-existing (#854) |
| 3 | Attestation replay (per domain) | pre-existing + new domain-distinctness test |
| 4 | **Cross-domain signature confusion** | **new (#829)** + pre-existing wrong-chain test |
| 5 | Below-threshold authorization | pre-existing (#847) + new zero-threshold test |
| 6 | Single malicious signer | pre-existing (#847) |
| 7 | **Equivocation** | **new (#829)** — neutralized; detection → follow-up #859 |
| 8 | Reorg double-count | pre-existing (#841/#854) + **new randomized fuzz** |
| 9 | Peg break | pre-existing (#844/#851) + **new reorg-interleaved proptest** |
| 10 | Breaker bypass | pre-existing (#844/#854/#851) + **new rate-limit fuzz** |

## New gap tests
- **Cross-domain confusion** (`bridge/core/src/adversarial_tests.rs`): an operator-action-domain signature (`botho-operator-action-v1`), a domainless wallet-style signature, and the payload signature reused in the envelope slot are all rejected as bridge attestations. Every bridge domain tag is proven pairwise-distinct from — and non-prefixing of — the operator-action tag, so confusion is impossible by construction. Verified the tags actually differ per the issue's explicit ask.
- **Equivocation** (`bridge/core/src/adversarial_tests.rs`): a single signer's conflicting/duplicate submissions count once (no threshold inflation); order binding rejects any amount/recipient-inflated attestation. Equivocation is neutralized but not actively *detected* today — filed follow-up #859.
- **Reorg + finality fuzz** (`bridge/service/src/watchers/adversarial_tests.rs`): a proptest drives randomized reorg depths / re-add timing through the Ethereum watcher and asserts exactly-once confirmation against still-canonical blocks (reorgs bounded strictly below `confirmations_required`, the bridge's stated safety assumption).
- **Peg-invariant + reorg** (`bridge/service/src/adversarial_tests.rs`): extends the #844 mint/burn proptest with reorg-orphaned-deposit unwinds interleaved, asserting `locked_reserve_total == Σ backing` after every op and exactly-once unwind.
- **Contract rate-limit fuzz** (`contracts/ethereum/test/WrappedBTH.test.ts`): the #851 supply invariant disables the breaker; this adds a randomized rate-limit *accounting* fuzz with the breaker armed, tracking `dailyMinted` / `remainingDailyMint()` / auto-pause against an independent model (incl. reset-rolled-back-on-revert and no-reset-on-unpause).

All new proptests are tuned for CI speed (48–64 cases).

## Test Plan
- `cargo test -p bth-bridge-core -p bth-bridge-service` → 50 + 129 pass (incl. 8 new core, 2 new service proptests).
- `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets` → clean.
- `cargo +nightly-2025-12-03 fmt -- --check` → clean.
- `npx hardhat test` (contracts/ethereum) → 31 passing (incl. new rate-limit fuzz).

## Notes
- Tests only touch new distinctly-named files (`adversarial_tests.rs`) plus module registrations and one append to the Hardhat suite, to stay clear of the concurrent #828 (happy-path infra + CI) work.
- Boundary: reorgs deeper than `confirmations_required` are outside the safety model by construction (documented in the threat model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)