### PR TITLE
docs(security): internal bridge security audit (#830)

### DIFF
--- a/audits/2026-07-13-bridge.md
+++ b/audits/2026-07-13-bridge.md
@@ -1,0 +1,185 @@
+# Internal Security Audit Report — BTH↔Ethereum wBTH Bridge
+
+**Date**: 2026-07-13
+**Auditor**: Claude (loom:sweep, main-session review)
+**Scope**: The entire bridge surface — `bridge/core`, `bridge/service`, `contracts/ethereum/contracts/WrappedBTH.sol`, and the four bridge ADRs (0002–0005). This is the dedicated bridge audit required by #830 (Phase 3 of epic #816), the internal half of the sign-off gate.
+**Commit**: `d5ba4d0b` (bridge complete through PRs #838, #840, #841, #844, #847, #851, #854, #860, #861)
+
+---
+
+## Executive Summary
+
+The bridge was implemented and hardened over a single sweep (#821–#829) in which **every** PR received an adversarial Judge review before merge, and #829 shipped a dedicated threat model (`docs/security/bridge-threat-model.md`) mapping ten named threats to covering tests. This audit re-reviews the merged surface as a whole, reads the two highest-risk components (the attestation envelope protocol and `WrappedBTH.sol`) line-by-line, and confirms the security architecture end-to-end.
+
+**No unresolved Critical or High findings exist in the merged bridge code.** The exactly-once guarantee (the property bridges most often lose) is enforced redundantly at three layers: the on-chain `processedOrders` order-id replay guard, the service-side `mints`/`release_claims` idempotency tables with record-before-broadcast semantics, and the order state machine's guarded transitions. The attestation protocol has correct domain separation (per chain × per action), parse-after-verify with duplicate-key rejection, order binding, bounded freshness, and distinct-signer thresholding that rejects a zero threshold. The proof-of-reserves reconciler enforces the ADR 0003 exact-peg invariant with a one-sided in-flight allowance that cannot mask unbacked supply.
+
+The bridge is **not yet safe to custody real value**, but for a reason outside the merged code: several **live chain transports are deliberately unimplemented** (fail-safe `TODO` stubs — #853/#856/#857/#858) and the **external audit** the acceptance criteria require has not been commissioned (operator action, gated on the external-audit budget #616). Those are completeness gaps, not vulnerabilities. This report closes the *internal* half of #830; #830 itself remains open pending the external audit and the mainnet sign-off gate.
+
+**Overall Status**: Clean (internal) — no Critical/High; open items are tracked completeness follow-ups.
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High | 0 |
+| Medium | 3 (all tracked, open follow-ups) |
+| Low | 3 (all tracked, open follow-ups) |
+| Info | 4 |
+
+---
+
+## Bridge Sections Reviewed
+
+- [x] **B1. Custody / key management** (ADR 0002, #817) — clean
+- [x] **B2. Attestation / authorization protocol** (#824) — clean; read in full
+- [x] **B3. `WrappedBTH.sol`** (#826, #851) — clean; read in full
+- [x] **B4. Watchers + engine: reorg safety, exactly-once, crash-safety** (#823/#827) — clean
+- [x] **B5. Reserve accounting / peg invariant** (#825, ADR 0003) — clean
+- [x] **B6. Privacy boundary** (ADR 0004, #819) — accepted-risk, documented
+- [x] **B7. Dependencies & build** — clean (`cargo deny` advisories ok)
+
+---
+
+## B1. Custody / Key Management (ADR 0002)
+
+**Reviewed**: `docs/decisions/0002-bridge-custody-scp-validator-federation.md`, `WrappedBTH.sol` constructor, `bridge/core/src/config.rs`.
+
+The custody model reuses the SCP validator set as the t-of-n federation. On Ethereum, `MINTER_ROLE` is held by a validator **Gnosis Safe** (secp256k1 owner keys); threshold enforcement lives in the Safe, not the token. The constructor grants three **distinct** Safes: `DEFAULT_ADMIN_ROLE` (governance), `MINTER_ROLE` (validators), `PAUSER_ROLE` (guardian). The deployer receives no roles. Separating the admin quorum from the mint quorum means configuration changes and minting cannot be authorized by the same signers — a sound separation-of-duties.
+
+**Confirmed**: no single-EOA mint path exists in the deployed configuration; the bridge threshold is documented as ≥ the SCP safety threshold; key storage/HSM, rotation, and quorum-loss handling are operator procedures documented in the ops runbook (`docs/operations/runbooks/bridge-order-engine-recovery.md`) and `contracts/ethereum/README.md`. Live key management (HSM, ceremony) is an operational concern for the external audit and the mainnet key ceremony, not merged code.
+
+**Finding B1 (Info)** — Custody correctness ultimately depends on Safe deployment parameters (which addresses, what threshold) that live outside this repo. The audit verifies the *contract enforces role separation*; it cannot verify the *deployed Safe thresholds*. This is inherent and belongs in the external audit + key-ceremony sign-off.
+
+---
+
+## B2. Attestation / Authorization Protocol (#824)
+
+**Reviewed in full**: `bridge/core/src/attestation.rs` (envelope protocol, digests, `AttestationSet`), `bridge/service/src/attestation.rs` (federation provider), `bridge/core/src/nonce.rs` (durable nonce store). This is the highest-risk component; it received a dedicated adversarial Judge review at #847 and a further adversarial test pass at #829.
+
+**Replay / order binding** — verified sound:
+- `release_payload_digest` / `mint_payload_digest` bind `sha256(domain_tag ‖ order_id ‖ amount_le ‖ recipient_len_le ‖ recipient)`. The length-prefixed recipient makes the encoding unambiguous (no concatenation ambiguity).
+- **Domain separation is per-chain × per-action**: distinct tags for release (`botho-bridge-release-v1`), Solana mint (`…-mint-sol-v1`), Ethereum mint (`…-mint-eth-v1`), and the envelope domains (`…-attest-{eth,sol,bth}-v1`). A signature over one chain's mint can never verify as another chain's, and a mint signature can never be replayed as a release. The tags are also provably distinct from `botho/src/operator_action.rs`'s domain (verified by the #829 cross-domain test), so an operator-action signature cannot be presented as a bridge authorization.
+- `check_order_binding` re-binds every attested field (order UUID, net amount, recipient, source tx, order type, chain) to the on-record `BridgeOrder`. A validly-signed attestation for order A presented against order B is rejected even with a fresh nonce.
+- Single-use nonces are consumed through the durable reserve-then-apply `NonceStore` (0600 file, atomic persist, rollback on write failure).
+
+**Parse-after-verify** — verified: `verify_and_parse_ed25519` verifies the signature over the *received bytes* (with the domain prefix) *before* parsing. The parser (`parse_attestation_envelope`) rejects unknown keys, unknown versions (no downgrade), non-integer numerics (`5.0` fails `as_u64`), and — critically — **duplicate keys at every nesting level** (`reject_duplicate_keys`), so one signed byte string can never carry two logical attestations. `verify_strict` rejects malleable/low-order Ed25519 signatures.
+
+**Aggregation / thresholding** — verified: `AttestationSet` deduplicates by signer identity (a member signing twice counts once), rejects attestations that don't match the set's `(order, action, chain, safe_nonce)`, and `is_threshold_met` requires `threshold >= 1` — **a zero threshold never authorizes**. Ethereum sets pin a single Safe nonce so signatures over different nonces cannot be combined into one `execTransaction`.
+
+**Freshness** — verified: `check_attestation_freshness` uses saturating arithmetic (crafted timestamps cannot panic), enforces `expiresAt >= issuedAt`, a `MAX_ATTESTATION_LIFETIME_SECS = 300` bound, and a 30s skew allowance.
+
+**Finding B2 (Low, tracked → #859)** — Equivocation (a signer attesting two conflicting payloads for the same order) is *neutralized* — order binding + per-signer dedup mean an equivocating signer cannot move funds — but not *actively detected/alerted*. A malicious federation member is contained but not surfaced. Follow-up #859 tracks active detection. Not exploitable for fund movement.
+
+**Finding B3 (Low, tracked → #849/#848)** — A partially-filled Ethereum `AttestationSet` pinned to a stale Safe nonce is never evicted; a wedged in-memory set is a **liveness** concern only, and is reachable solely once the #858 network transport lands. No safety impact.
+
+---
+
+## B3. WrappedBTH.sol (#826, #851)
+
+**Reviewed in full**: `contracts/ethereum/contracts/WrappedBTH.sol` (306 lines). External contract audit is still required (#616); this is the internal pass.
+
+**Access control** — sound: `MINTER_ROLE`/`PAUSER_ROLE`/`DEFAULT_ADMIN_ROLE` on distinct Safes; deployer gets nothing; role admin is the governance Safe. No EOA mint path.
+
+**Replay guard** — sound: `bridgeMint` requires a non-zero `orderId`, rejects `processedOrders[orderId]`, and sets the flag **before** `_mint` (checks-effects-interactions). This is the on-chain backstop that closes the residual double-mint window even if the off-chain service is compromised into re-submitting.
+
+**Rate limits / breaker** — sound: `maxMintPerTx` and a per-UTC-day `dailyMintLimit` with a lazy strictly-greater day-rollover reset (multi-day gaps reset correctly); the auto-pause breaker halts the contract when cumulative daily mints reach `autoPauseThreshold` (the triggering mint, being within the daily cap, still succeeds — intended). The removed per-recipient cooldown was correctly judged security-theatre (recipient-rotation bypass, griefs honest throughput).
+
+**Burn path** — sound: `bridgeBurn` is the *only* burn path and emits the `BridgeBurn(from, amount, bthAddress)` event the watchers rely on; `ERC20Burnable` was removed so a plain burn cannot silently strand reserve.
+
+**Reentrancy** — sound: OZ v5 `_mint`/`_burn` have no external calls; strict CEI plus `ReentrancyGuard` on both entrypoints as defense-in-depth.
+
+**Decimals** — sound: `DECIMALS = 12`, 1 base unit == 1 picocredit, no scaling across the boundary; pinned by a cross-language EIP-712 digest test (Rust == ethers == on-chain) in #861.
+
+**Finding B4 (Info)** — The `SafeStub.sol` test double reverts differently from a real Safe (`ExecutionFailure` vs `GS013`) when `safeTxGas == 0 && gasPrice == 0` — both fail-safe for `check_confirmation`, but the fork tests should be re-run against a canonical Safe deployment during the external audit for full fidelity. Noted at the #861 review.
+
+**Finding B5 (Info)** — A compromised *minter quorum* can still mint up to `dailyMintLimit` per day until the guardian pauses (the breaker converts anomalous volume to a hard stop but the first `autoPauseThreshold` of minting lands). This is the intended trust boundary of a t-of-n federation, documented; residual exposure is bounded by the daily cap and the guardian's response time. Belongs in the external audit's trust-model assessment.
+
+---
+
+## B4. Watchers + Engine — Reorg Safety, Exactly-Once, Crash-Safety (#823, #827)
+
+**Reviewed**: `bridge/service/src/watchers/{bth,ethereum,solana}.rs`, `engine.rs`, `db.rs`, `chaos_tests.rs`.
+
+**Exactly-once** — verified across the accumulated Judge reviews and the #827 chaos matrix: mints and releases persist the tx (hash + raw bytes) **before** broadcast; a duplicate order-id returns the prior row; the resume path re-broadcasts recorded bytes without re-signing. The #827 chaos tests reconstruct the engine over the *same SQLite file* (running the production `recover_on_startup` path) at every mint/deposit/release transition boundary and assert chain-level exactly-once (`double_mint_attempts == 0`, one landed release), not merely "no panic."
+
+**Reorg safety** — verified: watcher cursors advance only after a block is fully processed; the `processed_burns` idempotency key `<source_tx>#<ordinal>` is reorg-stable; Ethereum confirmation requires depth **and** a canonical-hash re-check; reorg re-adds relocate and confirm the same order exactly once; an `orphaned` flag holds reorged-out burns short of release. The #829 reorg/finality fuzz drives the real `EthereumWatcher::scan_once` over a mock chain. Reorgs at/beyond `confirmations_required` are a documented model boundary (that depth *is* the stated safety assumption), not a covered regime.
+
+**Crash-safety / state machine** — verified: `update_order_status` enforces `can_transition_to` inside a `BEGIN IMMEDIATE` transaction; all raw status updates are `WHERE status='<from>'`-guarded (audited, #839 closed). Circuit breaker halts submit stages while confirm stages settle in-flight orders; trips on reconciler drift, backlog, and volume.
+
+**Finding B6 (Medium, tracked → #856/#857)** — The **live BTH and Solana transports are unimplemented** fail-safe stubs (`TODO(#856)`×9, `TODO(#857)`×4): the BTH deposit websocket scan / release construction-submission-confirmation, and the Solana mint tx assembly / burn watcher RPC bodies. They return `NotImplemented` and leave orders retryable — no silent success, no fund exposure — but the bridge **cannot process real BTH↔Solana value until these land**. This is the single largest gap to a functional bridge and is the correct place to spend the next implementation effort. The Ethereum path *is* fully wired (verified by the #861 fork test running the real pipeline).
+
+---
+
+## B5. Reserve Accounting / Peg Invariant (#825, ADR 0003)
+
+**Reviewed**: `bridge/service/src/reserve.rs`, `db.rs` (reserve ledger), `api.rs`.
+
+ADR 0003's factor-1-only wrapping makes the reserve peg-stable by construction (background coins pay zero demurrage), so the invariant is exact: `Σ(wBTH outstanding) == locked BTH reserve`. The three-leg reconciler compares the DB ledger, on-chain `totalSupply` per chain, and the actual reserve balance, with a two-sided tolerance rule defaulting to 0. The in-flight allowance is **one-sided** — it can only excuse `locked > supply` (the over-collateralized, safe direction); unbacked supply always trips `reserve_drift_alert` and flips `pegHealthy`. The peg-invariant proptest (extended with interleaved reorgs in #829) and three drift-injection variants confirm the alert fires.
+
+**Finding B7 (Medium, tracked → #853)** — The Solana `getTokenSupply` and BTH reserve-balance transports are `TODO(#853)` stubs reported as **unverified** (never silently healthy — a stubbed leg is excluded from drift math and does not fabricate a green status). Proof-of-reserves is therefore only end-to-end verifiable for the Ethereum leg today.
+
+**Finding B8 (Low, tracked → #855)** — `reserve.api_listen` (proof/health/breaker endpoints) is unauthenticated but binds `127.0.0.1` by default; an operator who rebinds it to a non-loopback address without a fronting auth proxy would expose an unauthenticated pause/unpause switch. #855 tracks a non-loopback bind warning/refusal.
+
+---
+
+## B6. Privacy Boundary (ADR 0004, #819)
+
+**Reviewed**: `docs/decisions/0004-bridge-privacy-semantics.md`, release path stealth-output handling.
+
+Per ADR 0004, releases pay a **fresh one-time stealth output** derived from the burn's `bthAddress` — never a static payout key. The residual amount/timing correlation at the wrap/unwrap boundary (the bridge inherently reveals the wrapped amount on Ethereum) is **documented and accepted for v1** (#819). This is a design decision, not a defect.
+
+**Finding B9 (Info)** — The privacy boundary is an accepted-risk item; the external audit should confirm the on-BTH release re-shielding matches the mainnet privacy claims and that no additional linkage (e.g. dust-amount fingerprinting) is introduced beyond the documented amount revelation.
+
+---
+
+## B7. Dependencies & Build
+
+`cargo deny check advisories` → **ok** on the bridge crates. The bridge adds `alloy` (Ethereum), `axum` (proof API), and Ed25519/secp256k1 crypto; one build-time-only advisory (`RUSTSEC-2026-0173`, `proc-macro-error2` via `alloy-sol-macro`) is justified-ignored. The `--cfg=feature="precomputed-tables"` global rustflag bit CI twice (#361, #861) and is tracked for removal in #863 — a build-hygiene issue, not a runtime vulnerability.
+
+---
+
+## Findings Summary
+
+| ID | Severity | Area | Status | Tracker |
+|----|----------|------|--------|---------|
+| B2 | Low | Attestation: equivocation not actively detected (neutralized) | Open | #859 |
+| B3 | Low | Attestation: stale Safe-nonce set eviction (liveness) | Open | #849/#848 |
+| B6 | Medium | Live BTH/Solana transports unimplemented (fail-safe stubs) | Open | #856/#857 |
+| B7 | Medium | Reserve Solana/BTH supply legs unverified (fail-safe) | Open | #853 |
+| B8 | Low | Unauthenticated ops API safe only on loopback bind | Open | #855 |
+| B1/B4/B5/B9 | Info | External-audit / key-ceremony / fidelity items | Open | #616, #830 |
+
+Plus one Medium spanning the whole issue: **the external audit itself is not done** (#616, operator action).
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `cargo test -p bth-bridge-core -p bth-bridge-service` | 130 passed, 0 failed, 1 ignored |
+| `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets` | 0 warnings |
+| `cargo deny check advisories` | advisories ok |
+| Hardhat suite (`contracts/ethereum`, per #861) | 38 passing |
+| Ethereum fork e2e (`bridge-e2e-local.sh`, per #861) | passes against a real node |
+
+---
+
+## Sign-off Gate Status (#830 acceptance criteria)
+
+| Criterion | Status |
+|-----------|--------|
+| Internal audit, no unresolved Critical/High | ✅ **Done (this report)** |
+| External audit, no unresolved Critical/High | ❌ Not commissioned — **operator action, gated on #616** |
+| Published threat model + audit report under `audits/`/`docs/security/` | ✅ `docs/security/bridge-threat-model.md` (#829) + this report |
+| Explicit sign-off gate: no mainnet bridge value until this closes | ⏳ **Gate holds** — #830 stays OPEN |
+
+**#830 must not be closed by this report.** The internal half is complete; the external audit + mainnet key ceremony remain, and both are operator actions tied to #616. This audit adds the bridge to the internal audit cadence (next cycle should re-review once the #856/#857 live transports land, since those are the largest untested surface).
+
+---
+
+## Recommendations for Next Audit
+
+1. **Re-audit once #856/#857/#858 live transports land** — they are the largest currently-stubbed surface and carry the real reserve-key and RPC handling.
+2. **Commission the external contract audit** (`WrappedBTH.sol` + the Safe deployment) as the first spend of the #616 budget, per ADR / issue guidance.
+3. **Confirm the deployed Safe thresholds** at the mainnet key ceremony — the contract enforces role *separation* but not the *quorum values*.
+4. Resolve the tracked Mediums (#853 reserve legs) and Lows (#855, #859, #849) before mainnet value.

--- a/audits/README.md
+++ b/audits/README.md
@@ -45,6 +45,7 @@ Security auditing is iterative. Each internal audit:
 
 | Date | Auditor | Scope | Critical | High | Medium | Low | Status |
 |------|---------|-------|----------|------|--------|-----|--------|
+| 2026-07-13 (bridge) | Internal | Dedicated - BTH↔Ethereum wBTH bridge (#830) | **0** | **0** | 3 | 3 | **Clean (internal); external audit pending #616** |
 | 2026-07-12 (c8) | Internal | Delta - Operator write path + consensus/BaaS | **0** | **0** | 1 new | 3 | **Healthy** |
 | 2026-07-05 (c7) | Internal | Delta - Verification (block-acceptance + BaaS + u128) | **0** | **0** | 1 new | 3 | **Healthy** |
 | 2026-06-11 (c6) | Internal | Delta - Block-acceptance path + consensus economics | **5** | 6 | 8 | 4 | Issues Found (all Criticals fixed by c7) |
@@ -66,6 +67,7 @@ External audit will be commissioned when:
 
 ## Report Index
 
+- [2026-07-13 Bridge](2026-07-13-bridge.md) - Dedicated BTH↔Ethereum wBTH bridge audit (#830): custody, attestation protocol, WrappedBTH.sol, watchers/engine exactly-once, reserve peg invariant, privacy boundary; 0 Critical/High, external audit + mainnet gate remain (operator, #616)
 - [2026-07-12 Cycle 8](2026-07-12-cycle8.md) - Operator-signed quorum-curation write path (P4.4), consensus deltas, BaaS status-link; cycle-7 findings closed
 - [2026-07-05 Cycle 7](2026-07-05-cycle7.md) - Verification cycle: block-acceptance C1–C7 confirmed, BaaS worker, u128 widening, dep advisories
 - [2026-06-11 Cycle 6](2026-06-11-cycle6.md) - Block-acceptance hardening, 5 Criticals + Highs


### PR DESCRIPTION
## Summary

Dedicated **internal** security audit of the BTH↔Ethereum wBTH bridge — the internal half of the #830 sign-off gate (Phase 3 of epic #816). Adds `audits/2026-07-13-bridge.md` and updates the audit history index.

Scope (all seven bridge sections reviewed):
- **B1 Custody** (ADR 0002, #817) — Safe-held MINTER_ROLE, three distinct Safes, no EOA mint path
- **B2 Attestation protocol** (#824) — read in full: domain separation per chain×action, parse-after-verify + duplicate-key rejection, order binding, bounded freshness, distinct-signer thresholding (zero-threshold never authorizes)
- **B3 WrappedBTH.sol** (#826) — read in full: on-chain orderId replay guard (CEI), role separation, rate-limit/auto-pause, burn-only redemption, reentrancy posture, 12-decimal peg
- **B4 Watchers + engine** (#823/#827) — exactly-once (record-before-broadcast + chaos matrix), reorg safety (canonical-hash re-check, orphan flag), DB-layer transition enforcement
- **B5 Reserve peg** (#825, ADR 0003) — exact invariant, one-sided in-flight allowance, drift alert fail-closed
- **B6 Privacy boundary** (ADR 0004) — fresh stealth output on release; amount revelation accepted for v1
- **B7 Dependencies/build** — `cargo deny` advisories ok

## Verdict

**0 Critical / 0 High.** Three Mediums + three Lows, all already tracked as open follow-ups (#853/#855/#856/#857/#858/#859/#849). The bridge is not yet safe for real value — but because live BTH/Solana transports are deliberately unimplemented fail-safe stubs and the **external audit has not been commissioned** (operator action, gated on #616), not because of a defect in merged code.

## Why this does NOT close #830

The issue's acceptance criteria require **both** internal and external audits plus the mainnet sign-off gate. This PR completes the internal half; the external audit + key ceremony are operator actions tied to #616. **#830 stays OPEN** — hence "Part of #830", not "Closes".

## Test Plan

Docs-only. Verification recorded in the report:
- `cargo test -p bth-bridge-core -p bth-bridge-service` → 130 passed, 0 failed, 1 ignored
- `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets` → 0 warnings
- `cargo deny check advisories` → ok

Part of #830. Part of #816.

🤖 Generated with [Claude Code](https://claude.com/claude-code)