### PR TITLE
contracts(solana): harden wbth Anchor program (multisig, replay guard, limits, upgrade authority)

### DIFF
--- a/contracts/solana/README.md
+++ b/contracts/solana/README.md
@@ -1,0 +1,136 @@
+# wBTH — Wrapped BTH on Solana
+
+The `wbth` Anchor program (`programs/wbth`) mints the wBTH SPL token 1:1
+against BTH locked in the bridge reserve (epic #816). One wBTH base unit
+equals one picocredit (`mint::decimals = 12`); no scaling happens anywhere
+across the bridge boundary. This is the Solana counterpart to
+`contracts/ethereum/contracts/WrappedBTH.sol` and mirrors its hardening
+decisions (#826 → #850).
+
+## Security model (parity with #826, decided per ADR 0002 / 0005)
+
+### Custody — ADR 0002
+
+No single key can mint. The program stores three **authority pubkeys**, each
+of which is expected to be a **multisig** account — an SPL Token multisig or
+a [Squads](https://squads.so) multisig PDA whose members are the validators'
+**Ed25519** keys. Solana verifies Ed25519 natively, so the SCP validator
+federation signs Solana mint authorizations directly (no secp256k1/Gnosis
+detour like the Ethereum side). **Threshold `t`-of-`n` enforcement lives
+inside the multisig program, NOT in `wbth`** — exactly as the Gnosis Safe
+holds the threshold on Ethereum. The program only checks that the presented
+signer equals the configured authority pubkey.
+
+| Role (Bridge field) | Holder | Purpose |
+|---------------------|--------|---------|
+| `mint_authority` | Validator multisig (t-of-n Ed25519, owners = SCP validators; t ≥ SCP safety threshold) | The only mint path: signs `bridge_mint` |
+| `admin_authority` | Governance multisig (distinct from the validator multisig) | Rate-limit / breaker configuration, role rotation (`set_daily_limit`, `set_auto_pause_threshold`, `transfer_authority`, `transfer_admin`, `transfer_pauser`) |
+| `pauser_authority` | Guardian multisig (may be lower-threshold) | Fast `pause` / `unpause` — fail-safe only, cannot move funds |
+
+The mint-authority **PDA** (`seeds = [b"bridge"]`) is the SPL `MintTo` /
+freeze authority on the wBTH mint; the multisig only *authorizes* the
+`bridge_mint` instruction, while the PDA signs the CPI. `initialize` takes the
+three authority pubkeys explicitly; the payer receives no standing role.
+
+Record the concrete multisig addresses + thresholds here per deployment:
+
+| Network | Program ID | wBTH mint | Mint multisig | Admin multisig | Pauser multisig |
+|---------|-----------|-----------|---------------|----------------|-----------------|
+| (none deployed yet) | | | | | |
+
+### Replay-proof, order-bound minting
+
+`bridge_mint(amount, order_id)` takes a 32-byte `order_id` (the bridge order
+id from the attestation protocol, #824, `bridge_core::derive_order_id`) and
+creates a per-order marker PDA with `init` (`seeds = [b"order", order_id]`).
+A duplicate order id **fails at `init`** because the account already exists —
+the Solana equivalent of the Ethereum `processedOrders` mapping, closing the
+residual double-mint window even if the off-chain service retries or is
+compromised into re-submitting an authorization.
+
+The instruction name (`bridge_mint`) and the borsh **arg order**
+(`amount: u64` little-endian, then the raw 32-byte `order_id`) are pinned by
+`bridge/service/src/mint/solana.rs`
+(`encode_bridge_mint_instruction_data`) — **do not reorder or rename in a way
+that changes the discriminator or the encoded bytes** without updating the
+Rust side. (The Anchor discriminator hashes the instruction *name* only, so
+renaming the arg is safe; reordering the args is not.)
+
+### Upgradeability — immutable at deploy (BPF upgrade authority revoked)
+
+To match the Ethereum IMMUTABLE posture, the deployed program's BPF upgrade
+authority MUST be revoked at deploy time:
+
+```bash
+solana program set-upgrade-authority <PROGRAM_ID> --final
+```
+
+Rationale (mirrors the project's no-hard-forks / minimal-trust posture): a
+retained upgrade authority is a rug vector — whoever can upgrade the program
+can rewrite `bridge_mint` to mint at will or seize the mint-authority PDA,
+which negates the multisig custody model. Trade-off (accepted): bugs are
+handled by `pause`, deploying a corrected program + mint, and migrating
+balances through the bridge itself (burn on old, mint on new) — the same
+recovery path documented for the Ethereum token.
+
+**Testnet exception:** on devnet/testnet the upgrade authority MAY be retained
+for iteration. When it is, the holding key (ideally the governance multisig,
+never a lone EOA) MUST be recorded in the deployment table above, and it MUST
+be finalized before any mainnet value flows.
+
+### Rate limits + circuit breaker (picocredits)
+
+- `MAX_MINT_PER_TX` (1M BTH) caps a single `bridge_mint`; `daily_mint_limit`
+  (default 10M BTH) caps cumulative mints per UTC day. Both are the same raw
+  picocredit literals as the EVM contract.
+- The daily counter lazily resets on the first mint of a later UTC day, using
+  `Clock::unix_timestamp / 86_400` (parity with EVM `block.timestamp / 1 days`;
+  correct across multi-day gaps). The previous slot-based window was replaced
+  because slot time drifts and is not a wall-clock day.
+- **Auto-pause breaker:** when cumulative daily volume reaches
+  `auto_pause_threshold` (default = the daily limit; 0 disables), the program
+  sets `paused = true` and emits `AutoPausedEvent`. The triggering mint still
+  succeeds (it is within the daily limit); a guardian must investigate and
+  `unpause`. Converts anomalous volume from a soft revert into a hard stop.
+
+### Arithmetic safety
+
+Daily-total accumulation uses `checked_add(...).ok_or(BridgeError::MathOverflow)?`
+(no `.unwrap()` panic path). The release profile also sets
+`overflow-checks = true`.
+
+### Burn path
+
+`bridge_burn(amount, bth_address)` is the only burn path; it honors `paused`,
+requires `amount > 0` and a non-empty `bth_address` bounded to
+`MAX_BTH_ADDRESS_LEN` (128) bytes, then emits `BridgeBurnEvent` — the event the
+native-chain release watchers rely on. There is no open SPL burn surface on
+this program's authority: users burn their own tokens (they sign as `user`).
+
+### Mint-redirection guard
+
+`bridge_mint`'s `user_token_account` is constrained
+`associated_token::authority = user`, so a mint can only land in the
+recipient's own associated token account; a compromised or buggy caller cannot
+redirect minted wBTH to an arbitrary token account.
+
+## Development
+
+```bash
+npm install        # or: yarn
+anchor build       # compiles the program + generates target/types/wbth.ts
+anchor test        # spins up a local validator and runs the ts-mocha suite
+```
+
+The `tests/wbth.ts` suite covers: `initialize` (PDA mint authority + 12
+decimals + distinct roles), multisig-gated `bridge_mint`, order-id replay
+(same id fails at PDA `init`, distinct ids succeed), unit pinning (raw
+picocredits), the mint-redirection guard, `bridge_burn` redemption events +
+address bounds, admin-only limit/threshold/authority-rotation, guardian-only
+pause (mint + burn blocked while paused), and the daily-limit boundary +
+auto-pause breaker.
+
+> **Toolchain note:** running `anchor test` requires the Solana toolchain
+> (`solana`, `cargo build-sbf`) and Anchor CLI 0.29. The Rust program itself
+> compiles under a plain host `cargo build` (used in CI without the SBF
+> toolchain) via the Anchor host-side codegen.

--- a/contracts/solana/package.json
+++ b/contracts/solana/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "wbth-solana",
+  "version": "0.1.0",
+  "description": "Wrapped BTH (wBTH) Anchor program for Solana",
+  "scripts": {
+    "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
+    "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
+    "test": "anchor test"
+  },
+  "dependencies": {
+    "@coral-xyz/anchor": "^0.29.0",
+    "@solana/spl-token": "^0.4.0",
+    "@solana/web3.js": "^1.90.0"
+  },
+  "devDependencies": {
+    "@types/bn.js": "^5.1.0",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^10.0.0",
+    "chai": "^4.3.4",
+    "mocha": "^10.0.0",
+    "prettier": "^3.0.0",
+    "ts-mocha": "^10.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/contracts/solana/programs/wbth/Cargo.toml
+++ b/contracts/solana/programs/wbth/Cargo.toml
@@ -18,3 +18,4 @@ default = []
 [dependencies]
 anchor-lang = "0.29"
 anchor-spl = "0.29"
+hex = "0.4"

--- a/contracts/solana/programs/wbth/src/lib.rs
+++ b/contracts/solana/programs/wbth/src/lib.rs
@@ -6,55 +6,163 @@ declare_id!("wBTH111111111111111111111111111111111111111");
 /// Wrapped BTH (wBTH) SPL token bridge program.
 ///
 /// This program manages the wBTH token on Solana, allowing:
-/// - Bridge operator to mint wBTH when BTH is deposited
-/// - Users to burn wBTH to redeem BTH on the native chain
-/// - Rate limiting and pause functionality for security
+/// - The validator federation (via a multisig) to mint wBTH when BTH is locked
+///   on the native chain.
+/// - Users to burn wBTH to redeem BTH on the native chain.
+/// - Rate limiting, a circuit breaker, and pause functionality for security.
+///
+/// # Security model — parity with `WrappedBTH.sol` (#826, ADR 0002/0005)
+///
+/// The Ethereum side (`contracts/ethereum/contracts/WrappedBTH.sol`) was
+/// hardened in #826; this program mirrors those decisions on Solana:
+///
+/// - **No single-key mint (ADR 0002).** The `authority` fields are the ONLY
+///   privileged signers, and each is expected to be a *multisig* account — an
+///   SPL Token multisig or a Squads multisig PDA whose members are the
+///   validators' Ed25519 keys (which Solana verifies natively, so no secp256k1
+///   detour is needed). Threshold `t`-of-`n` enforcement lives inside that
+///   multisig program, NOT in this contract — exactly as the Gnosis Safe holds
+///   the threshold on the Ethereum side. The three roles are held by three
+///   DISTINCT multisigs so that minting, configuration, and pausing require
+///   different quorums:
+///     * `mint_authority`  — validator multisig (t ≥ SCP safety threshold).
+///     * `admin_authority` — governance multisig (limits / breaker / role
+///       rotation).
+///     * `pauser_authority`— guardian multisig (may be lower-threshold for fast
+///       incident response; pausing can only halt, never move funds).
+///   The mint-authority PDA (`seeds = [b"bridge"]`) remains the SPL
+///   `MintTo` signer; the multisig only *authorizes* the instruction.
+///
+/// - **Replay-proof, order-bound minting.** `bridge_mint` takes an `order_id:
+///   [u8; 32]` (the attestation-bound bridge order id, #824, from
+///   `bridge_core::derive_order_id`) and creates a per-order marker PDA
+///   (`init`, `seeds = [b"order", order_id]`). A duplicate order id fails at
+///   `init` (account already exists) — the Solana equivalent of Ethereum's
+///   `processedOrders` mapping. The instruction signature and borsh arg order
+///   (`amount: u64` then `order_id: [u8; 32]`) are pinned by the service side
+///   (`bridge/service/src/mint/solana.rs`,
+///   `encode_bridge_mint_instruction_data`); do not reorder them.
+///
+/// - **Immutable program (upgrade authority).** To match the Ethereum IMMUTABLE
+///   posture (a proxy/upgrade admin is a rug vector that negates the multisig
+///   custody model), the deployed program's BPF upgrade authority MUST be
+///   revoked at deploy time via `solana program set-upgrade-authority
+///   <PROGRAM_ID> --final`. This is a deploy-time operation (documented in
+///   `contracts/solana/README.md`), not something the program enforces. On
+///   testnet the upgrade authority MAY be retained for iteration; who holds it
+///   is recorded in the README.
+///
+/// - **Units / rate limits (picocredits).** `mint::decimals = 12` (1 base unit
+///   == 1 picocredit == 1:1 with native BTH). `MAX_MINT_PER_TX` (1M BTH) and
+///   the default `daily_mint_limit` (10M BTH) are the same raw picocredit
+///   literals as the EVM contract. The daily counter resets on a UTC-day
+///   boundary using `Clock::unix_timestamp` (parity with the EVM
+///   `block.timestamp / 1 days`), not slots.
+///
+/// - **Auto-pause circuit breaker.** When cumulative daily volume reaches
+///   `auto_pause_threshold` (default = the daily limit; 0 disables), the bridge
+///   pauses itself — the triggering mint still succeeds (it is within the daily
+///   limit) but a guardian must investigate and unpause.
 #[program]
 pub mod wbth_bridge {
     use super::*;
 
+    /// Maximum amount a single `bridge_mint` may mint (picocredits, 1M BTH).
+    /// Matches `WrappedBTH.maxMintPerTx`.
+    pub const MAX_MINT_PER_TX: u64 = 1_000_000 * 1_000_000_000_000;
+
+    /// Default cumulative daily mint limit (picocredits, 10M BTH).
+    /// Matches `WrappedBTH.dailyMintLimit`.
+    pub const DEFAULT_DAILY_MINT_LIMIT: u64 = 10_000_000 * 1_000_000_000_000;
+
+    /// Length of a UTC day in seconds (parity with EVM `1 days`).
+    pub const SECONDS_PER_DAY: i64 = 86_400;
+
+    /// Maximum accepted length of a native BTH destination address string.
+    /// Stealth-address strings are well under this; the bound prevents a
+    /// griefer from bloating the burn event / transaction.
+    pub const MAX_BTH_ADDRESS_LEN: usize = 128;
+
     /// Initialize the bridge with a new wBTH mint.
-    pub fn initialize(ctx: Context<Initialize>, bump: u8) -> Result<()> {
+    ///
+    /// `mint_authority`, `admin_authority`, and `pauser_authority` should each
+    /// be a distinct multisig account (SPL/Squads) per ADR 0002; the program
+    /// only checks that the presented signer matches the configured pubkey —
+    /// the multisig enforces the threshold.
+    pub fn initialize(
+        ctx: Context<Initialize>,
+        bump: u8,
+        mint_authority: Pubkey,
+        admin_authority: Pubkey,
+        pauser_authority: Pubkey,
+    ) -> Result<()> {
         let bridge = &mut ctx.accounts.bridge;
-        bridge.authority = ctx.accounts.authority.key();
+        bridge.mint_authority = mint_authority;
+        bridge.admin_authority = admin_authority;
+        bridge.pauser_authority = pauser_authority;
         bridge.mint = ctx.accounts.mint.key();
         bridge.bump = bump;
         bridge.paused = false;
-        bridge.daily_mint_limit = 10_000_000 * 1_000_000_000_000; // 10M BTH in picocredits
+        bridge.daily_mint_limit = DEFAULT_DAILY_MINT_LIMIT;
+        bridge.auto_pause_threshold = DEFAULT_DAILY_MINT_LIMIT;
         bridge.daily_minted = 0;
-        bridge.last_reset_slot = Clock::get()?.slot;
+        // UTC-day index of the last reset (parity with EVM lastResetDay).
+        bridge.last_reset_day = Clock::get()?.unix_timestamp / SECONDS_PER_DAY;
 
         msg!("Bridge initialized with mint: {}", bridge.mint);
+        msg!(
+            "Authorities — mint: {}, admin: {}, pauser: {}",
+            bridge.mint_authority,
+            bridge.admin_authority,
+            bridge.pauser_authority
+        );
         Ok(())
     }
 
-    /// Mint wBTH to a user when BTH is deposited to the bridge.
+    /// Mint wBTH to a user for a locked-BTH bridge order.
     ///
-    /// Only callable by the bridge authority.
-    pub fn bridge_mint(ctx: Context<BridgeMint>, amount: u64, bth_tx_hash: [u8; 32]) -> Result<()> {
+    /// Only callable by the `mint_authority` multisig. Replay-proof: the
+    /// per-order marker PDA (`seeds = [b"order", order_id]`) is created with
+    /// `init`, so a duplicate `order_id` fails here.
+    ///
+    /// Argument order (`amount` then `order_id`) and borsh encoding are pinned
+    /// by `bridge/service/src/mint/solana.rs`.
+    pub fn bridge_mint(ctx: Context<BridgeMint>, amount: u64, order_id: [u8; 32]) -> Result<()> {
         let bridge = &mut ctx.accounts.bridge;
 
         require!(!bridge.paused, BridgeError::Paused);
-        require!(
-            amount <= 1_000_000 * 1_000_000_000_000,
-            BridgeError::ExceedsMaxMint
-        );
+        require!(amount > 0, BridgeError::InvalidAmount);
+        require!(amount <= MAX_MINT_PER_TX, BridgeError::ExceedsMaxMint);
+        require!(order_id != [0u8; 32], BridgeError::InvalidOrderId);
 
-        // Reset daily limit if >24h since last reset (~216,000 slots at 400ms/slot)
+        // Lazily reset the daily counter on the first mint of a later UTC day
+        // (strictly-greater comparison, so multi-day gaps reset correctly —
+        // parity with the EVM contract).
         let clock = Clock::get()?;
-        let slots_per_day: u64 = 216_000;
-        if clock.slot > bridge.last_reset_slot + slots_per_day {
+        let today = clock.unix_timestamp / SECONDS_PER_DAY;
+        if today > bridge.last_reset_day {
             bridge.daily_minted = 0;
-            bridge.last_reset_slot = clock.slot;
+            bridge.last_reset_day = today;
         }
 
+        // Effects before interaction (checks-effects-interactions). Overflow
+        // is a hard error rather than a silent wrap / panic.
+        let new_daily = bridge
+            .daily_minted
+            .checked_add(amount)
+            .ok_or(BridgeError::MathOverflow)?;
         require!(
-            bridge.daily_minted.checked_add(amount).unwrap() <= bridge.daily_mint_limit,
+            new_daily <= bridge.daily_mint_limit,
             BridgeError::DailyLimitExceeded
         );
-        bridge.daily_minted = bridge.daily_minted.checked_add(amount).unwrap();
+        bridge.daily_minted = new_daily;
 
-        // Mint tokens using PDA signature
+        // Record the order id on the marker PDA for auditability. The replay
+        // guard itself is enforced by `init` on `order_marker` in the accounts
+        // struct; storing the id makes the account self-describing.
+        ctx.accounts.order_marker.order_id = order_id;
+
+        // Mint tokens using the bridge PDA as the SPL mint authority.
         let seeds = &[b"bridge".as_ref(), &[bridge.bump]];
         let signer = &[&seeds[..]];
 
@@ -72,29 +180,49 @@ pub mod wbth_bridge {
         emit!(BridgeMintEvent {
             user: ctx.accounts.user.key(),
             amount,
-            bth_tx_hash,
-            slot: clock.slot,
+            order_id,
+            timestamp: clock.unix_timestamp,
         });
 
         msg!(
-            "Minted {} wBTH to {} (BTH tx: {})",
+            "Minted {} wBTH to {} (order: {})",
             amount,
             ctx.accounts.user.key(),
-            hex::encode(&bth_tx_hash[..8])
+            hex::encode(&order_id[..8])
         );
+
+        // Circuit breaker: anomalous cumulative daily volume halts the bridge
+        // instead of merely reverting later mints (parity with EVM AutoPaused).
+        if bridge.auto_pause_threshold != 0 && bridge.daily_minted >= bridge.auto_pause_threshold {
+            bridge.paused = true;
+            emit!(AutoPausedEvent {
+                daily_minted: bridge.daily_minted,
+                threshold: bridge.auto_pause_threshold,
+            });
+            msg!(
+                "Auto-paused: daily volume {} reached threshold {}",
+                bridge.daily_minted,
+                bridge.auto_pause_threshold
+            );
+        }
 
         Ok(())
     }
 
     /// Burn wBTH to redeem BTH on the native chain.
     ///
-    /// The bridge service monitors these events and releases BTH.
+    /// This is the only burn path; the emitted `BridgeBurnEvent` is what the
+    /// bridge watchers rely on to release native BTH.
     pub fn bridge_burn(ctx: Context<BridgeBurn>, amount: u64, bth_address: String) -> Result<()> {
         let bridge = &ctx.accounts.bridge;
 
         require!(!bridge.paused, BridgeError::Paused);
         require!(amount > 0, BridgeError::InvalidAmount);
         require!(!bth_address.is_empty(), BridgeError::InvalidBthAddress);
+        require!(
+            bth_address.len() <= MAX_BTH_ADDRESS_LEN,
+            BridgeError::InvalidBthAddress
+        );
 
         let cpi_ctx = CpiContext::new(
             ctx.accounts.token_program.to_account_info(),
@@ -110,7 +238,7 @@ pub mod wbth_bridge {
             user: ctx.accounts.user.key(),
             amount,
             bth_address: bth_address.clone(),
-            slot: Clock::get()?.slot,
+            timestamp: Clock::get()?.unix_timestamp,
         });
 
         msg!(
@@ -123,31 +251,56 @@ pub mod wbth_bridge {
         Ok(())
     }
 
-    /// Pause the bridge (emergency only).
-    pub fn pause(ctx: Context<AdminOnly>) -> Result<()> {
+    /// Pause the bridge (emergency only). Callable by the pauser multisig.
+    pub fn pause(ctx: Context<PauserOnly>) -> Result<()> {
         ctx.accounts.bridge.paused = true;
-        msg!("Bridge paused by {}", ctx.accounts.authority.key());
+        msg!("Bridge paused by {}", ctx.accounts.pauser_authority.key());
         Ok(())
     }
 
-    /// Unpause the bridge.
-    pub fn unpause(ctx: Context<AdminOnly>) -> Result<()> {
+    /// Unpause the bridge. Callable by the pauser multisig.
+    pub fn unpause(ctx: Context<PauserOnly>) -> Result<()> {
         ctx.accounts.bridge.paused = false;
-        msg!("Bridge unpaused by {}", ctx.accounts.authority.key());
+        msg!("Bridge unpaused by {}", ctx.accounts.pauser_authority.key());
         Ok(())
     }
 
-    /// Update the daily mint limit.
+    /// Update the daily mint limit (picocredits). Admin multisig only.
     pub fn set_daily_limit(ctx: Context<AdminOnly>, new_limit: u64) -> Result<()> {
         ctx.accounts.bridge.daily_mint_limit = new_limit;
         msg!("Daily mint limit updated to {}", new_limit);
         Ok(())
     }
 
-    /// Transfer bridge authority to a new account.
+    /// Update the auto-pause breaker threshold (0 disables). Admin only.
+    pub fn set_auto_pause_threshold(ctx: Context<AdminOnly>, new_threshold: u64) -> Result<()> {
+        ctx.accounts.bridge.auto_pause_threshold = new_threshold;
+        msg!("Auto-pause threshold updated to {}", new_threshold);
+        Ok(())
+    }
+
+    /// Transfer the mint authority to a new multisig. Admin only.
+    ///
+    /// Mirrors the EVM role administration living under `DEFAULT_ADMIN_ROLE`:
+    /// the mint quorum cannot rotate itself; the (distinct) governance quorum
+    /// does.
     pub fn transfer_authority(ctx: Context<AdminOnly>, new_authority: Pubkey) -> Result<()> {
-        ctx.accounts.bridge.authority = new_authority;
-        msg!("Bridge authority transferred to {}", new_authority);
+        ctx.accounts.bridge.mint_authority = new_authority;
+        msg!("Mint authority transferred to {}", new_authority);
+        Ok(())
+    }
+
+    /// Transfer the admin authority to a new multisig. Admin only.
+    pub fn transfer_admin(ctx: Context<AdminOnly>, new_admin: Pubkey) -> Result<()> {
+        ctx.accounts.bridge.admin_authority = new_admin;
+        msg!("Admin authority transferred to {}", new_admin);
+        Ok(())
+    }
+
+    /// Transfer the pauser authority to a new multisig. Admin only.
+    pub fn transfer_pauser(ctx: Context<AdminOnly>, new_pauser: Pubkey) -> Result<()> {
+        ctx.accounts.bridge.pauser_authority = new_pauser;
+        msg!("Pauser authority transferred to {}", new_pauser);
         Ok(())
     }
 }
@@ -155,31 +308,54 @@ pub mod wbth_bridge {
 /// Bridge state account.
 #[account]
 pub struct Bridge {
-    /// The authority that can mint and manage the bridge
-    pub authority: Pubkey,
-    /// The wBTH mint address
+    /// Validator multisig authorized to mint (ADR 0002).
+    pub mint_authority: Pubkey,
+    /// Governance multisig authorized to change limits and rotate roles.
+    pub admin_authority: Pubkey,
+    /// Guardian multisig authorized to pause / unpause.
+    pub pauser_authority: Pubkey,
+    /// The wBTH mint address.
     pub mint: Pubkey,
-    /// PDA bump seed
+    /// PDA bump seed.
     pub bump: u8,
-    /// Whether the bridge is paused
+    /// Whether the bridge is paused.
     pub paused: bool,
-    /// Daily mint limit in picocredits
+    /// Daily mint limit in picocredits.
     pub daily_mint_limit: u64,
-    /// Amount minted today
+    /// Auto-pause circuit-breaker threshold in picocredits (0 disables).
+    pub auto_pause_threshold: u64,
+    /// Cumulative amount minted during the current UTC day.
     pub daily_minted: u64,
-    /// Slot when daily limit was last reset
-    pub last_reset_slot: u64,
+    /// UTC-day index (unix_timestamp / 86400) of the last reset.
+    pub last_reset_day: i64,
 }
 
 impl Bridge {
     pub const LEN: usize = 8 + // discriminator
-        32 + // authority
+        32 + // mint_authority
+        32 + // admin_authority
+        32 + // pauser_authority
         32 + // mint
         1 +  // bump
         1 +  // paused
         8 +  // daily_mint_limit
+        8 +  // auto_pause_threshold
         8 +  // daily_minted
-        8; // last_reset_slot
+        8; // last_reset_day
+}
+
+/// Per-order replay-guard marker. Created with `init` in `bridge_mint`; a
+/// duplicate `order_id` fails because the PDA already exists (the Solana
+/// analogue of the EVM `processedOrders` mapping).
+#[account]
+pub struct OrderMarker {
+    /// The order id this marker records (for auditability).
+    pub order_id: [u8; 32],
+}
+
+impl OrderMarker {
+    pub const LEN: usize = 8 + // discriminator
+        32; // order_id
 }
 
 // === Account Contexts ===
@@ -189,7 +365,7 @@ impl Bridge {
 pub struct Initialize<'info> {
     #[account(
         init,
-        payer = authority,
+        payer = payer,
         space = Bridge::LEN,
         seeds = [b"bridge"],
         bump
@@ -198,15 +374,15 @@ pub struct Initialize<'info> {
 
     #[account(
         init,
-        payer = authority,
-        mint::decimals = 12, // Match BTH's 12 decimals
+        payer = payer,
+        mint::decimals = 12, // Match BTH's 12 decimals (1 unit == 1 picocredit)
         mint::authority = bridge,
         mint::freeze_authority = bridge,
     )]
     pub mint: Account<'info, Mint>,
 
     #[account(mut)]
-    pub authority: Signer<'info>,
+    pub payer: Signer<'info>,
 
     pub token_program: Program<'info, Token>,
     pub system_program: Program<'info, System>,
@@ -214,19 +390,34 @@ pub struct Initialize<'info> {
 }
 
 #[derive(Accounts)]
+#[instruction(amount: u64, order_id: [u8; 32])]
 pub struct BridgeMint<'info> {
     #[account(
         mut,
         seeds = [b"bridge"],
         bump = bridge.bump,
-        has_one = authority,
         has_one = mint,
+        has_one = mint_authority,
     )]
     pub bridge: Account<'info, Bridge>,
+
+    /// Per-order replay guard. `init` fails if this order id was already
+    /// minted — mirrors the EVM `processedOrders` check.
+    #[account(
+        init,
+        payer = mint_authority,
+        space = OrderMarker::LEN,
+        seeds = [b"order", order_id.as_ref()],
+        bump,
+    )]
+    pub order_marker: Account<'info, OrderMarker>,
 
     #[account(mut)]
     pub mint: Account<'info, Mint>,
 
+    /// The recipient's associated token account. Constrained to
+    /// `associated_token::authority = user`, so a mint cannot be redirected to
+    /// an account the recipient does not own.
     #[account(
         mut,
         associated_token::mint = mint,
@@ -234,12 +425,19 @@ pub struct BridgeMint<'info> {
     )]
     pub user_token_account: Account<'info, TokenAccount>,
 
-    /// CHECK: Just used for event emission
+    /// CHECK: The recipient. Not a signer, but it is bound to
+    /// `user_token_account` via the `associated_token::authority = user`
+    /// constraint above, so mints can only land in the recipient's own ATA.
     pub user: UncheckedAccount<'info>,
 
-    pub authority: Signer<'info>,
+    /// The validator multisig authorized to mint (ADR 0002). Must sign and
+    /// equal `bridge.mint_authority`; the multisig program enforces the
+    /// t-of-n threshold. Also the rent payer for the order-marker PDA.
+    #[account(mut)]
+    pub mint_authority: Signer<'info>,
 
     pub token_program: Program<'info, Token>,
+    pub system_program: Program<'info, System>,
 }
 
 #[derive(Accounts)]
@@ -273,11 +471,26 @@ pub struct AdminOnly<'info> {
         mut,
         seeds = [b"bridge"],
         bump = bridge.bump,
-        has_one = authority,
+        has_one = admin_authority,
     )]
     pub bridge: Account<'info, Bridge>,
 
-    pub authority: Signer<'info>,
+    /// Governance multisig. Must sign and equal `bridge.admin_authority`.
+    pub admin_authority: Signer<'info>,
+}
+
+#[derive(Accounts)]
+pub struct PauserOnly<'info> {
+    #[account(
+        mut,
+        seeds = [b"bridge"],
+        bump = bridge.bump,
+        has_one = pauser_authority,
+    )]
+    pub bridge: Account<'info, Bridge>,
+
+    /// Guardian multisig. Must sign and equal `bridge.pauser_authority`.
+    pub pauser_authority: Signer<'info>,
 }
 
 // === Events ===
@@ -286,8 +499,8 @@ pub struct AdminOnly<'info> {
 pub struct BridgeMintEvent {
     pub user: Pubkey,
     pub amount: u64,
-    pub bth_tx_hash: [u8; 32],
-    pub slot: u64,
+    pub order_id: [u8; 32],
+    pub timestamp: i64,
 }
 
 #[event]
@@ -295,7 +508,13 @@ pub struct BridgeBurnEvent {
     pub user: Pubkey,
     pub amount: u64,
     pub bth_address: String,
-    pub slot: u64,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct AutoPausedEvent {
+    pub daily_minted: u64,
+    pub threshold: u64,
 }
 
 // === Errors ===
@@ -316,4 +535,10 @@ pub enum BridgeError {
 
     #[msg("Amount must be greater than zero")]
     InvalidAmount,
+
+    #[msg("Invalid order id")]
+    InvalidOrderId,
+
+    #[msg("Arithmetic overflow")]
+    MathOverflow,
 }

--- a/contracts/solana/tests/wbth.ts
+++ b/contracts/solana/tests/wbth.ts
@@ -1,0 +1,501 @@
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { Wbth } from "../target/types/wbth";
+import {
+  PublicKey,
+  Keypair,
+  SystemProgram,
+  SYSVAR_RENT_PUBKEY,
+  LAMPORTS_PER_SOL,
+} from "@solana/web3.js";
+import {
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountInstruction,
+  getMint,
+  getAccount,
+} from "@solana/spl-token";
+import { assert, expect } from "chai";
+
+/**
+ * wBTH Anchor program tests (#850).
+ *
+ * Parity target: contracts/ethereum/test/WrappedBTH.test.ts (#826).
+ *
+ * The multisig Safes from ADR 0002 are simulated here with single Keypairs:
+ * the on-chain program only checks that the presented signer equals the
+ * configured `*_authority` pubkey — t-of-n threshold enforcement lives in
+ * the SPL/Squads multisig program, not in this contract. So the properties
+ * under test are "only the configured authority may act" and "roles are
+ * distinct".
+ */
+
+const PICO = new anchor.BN(10).pow(new anchor.BN(12)); // 1 BTH = 10^12 picocredits
+const MAX_TX = new anchor.BN(1_000_000).mul(PICO); // 1M BTH
+const DAILY = new anchor.BN(10_000_000).mul(PICO); // 10M BTH
+
+function bthToPico(bth: number): anchor.BN {
+  return new anchor.BN(bth).mul(PICO);
+}
+
+/** Deterministic 32-byte order ids. */
+function oid(n: number): number[] {
+  const buf = Buffer.alloc(32);
+  buf.writeUInt32BE(n >>> 0, 28);
+  // Non-zero prefix so it can never collide with the all-zero rejected id.
+  buf[0] = 0xa5;
+  return Array.from(buf);
+}
+
+const ZERO_ORDER_ID: number[] = Array.from(Buffer.alloc(32));
+
+describe("wbth", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace.Wbth as Program<Wbth>;
+  const connection = provider.connection;
+
+  // Role signers (simulate three distinct multisigs).
+  const mintAuthority = Keypair.generate();
+  const adminAuthority = Keypair.generate();
+  const pauserAuthority = Keypair.generate();
+  const attacker = Keypair.generate();
+
+  // Users.
+  const user = Keypair.generate();
+  const otherUser = Keypair.generate();
+
+  const mint = Keypair.generate();
+
+  let bridgePda: PublicKey;
+  let bridgeBump: number;
+
+  function orderPda(orderId: number[]): PublicKey {
+    const [pda] = PublicKey.findProgramAddressSync(
+      [Buffer.from("order"), Buffer.from(orderId)],
+      program.programId
+    );
+    return pda;
+  }
+
+  async function airdrop(pubkey: PublicKey, sol = 5) {
+    const sig = await connection.requestAirdrop(pubkey, sol * LAMPORTS_PER_SOL);
+    await connection.confirmTransaction(sig, "confirmed");
+  }
+
+  async function ataFor(owner: PublicKey): Promise<PublicKey> {
+    return getAssociatedTokenAddressSync(mint.publicKey, owner);
+  }
+
+  /** Create the recipient's ATA (paid by the mint authority in tests). */
+  async function ensureAta(owner: PublicKey, payer: Keypair): Promise<PublicKey> {
+    const ata = getAssociatedTokenAddressSync(mint.publicKey, owner);
+    const info = await connection.getAccountInfo(ata);
+    if (info) return ata;
+    const ix = createAssociatedTokenAccountInstruction(
+      payer.publicKey,
+      ata,
+      owner,
+      mint.publicKey
+    );
+    const tx = new anchor.web3.Transaction().add(ix);
+    await provider.sendAndConfirm(tx, [payer]);
+    return ata;
+  }
+
+  async function bridge(): Promise<any> {
+    return program.account.bridge.fetch(bridgePda);
+  }
+
+  /** Mint helper honoring the pinned (amount, orderId) arg order. */
+  async function doMint(
+    amount: anchor.BN,
+    orderId: number[],
+    recipient: PublicKey,
+    recipientAta: PublicKey,
+    signer: Keypair = mintAuthority
+  ) {
+    return program.methods
+      .bridgeMint(amount, orderId)
+      .accounts({
+        bridge: bridgePda,
+        orderMarker: orderPda(orderId),
+        mint: mint.publicKey,
+        userTokenAccount: recipientAta,
+        user: recipient,
+        mintAuthority: signer.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([signer])
+      .rpc();
+  }
+
+  before(async () => {
+    [bridgePda, bridgeBump] = PublicKey.findProgramAddressSync(
+      [Buffer.from("bridge")],
+      program.programId
+    );
+
+    await Promise.all([
+      airdrop(mintAuthority.publicKey),
+      airdrop(adminAuthority.publicKey),
+      airdrop(pauserAuthority.publicKey),
+      airdrop(attacker.publicKey),
+      airdrop(user.publicKey),
+      airdrop(otherUser.publicKey),
+    ]);
+  });
+
+  describe("initialize", () => {
+    it("initializes with PDA mint authority + 12 decimals + distinct roles", async () => {
+      await program.methods
+        .initialize(
+          bridgeBump,
+          mintAuthority.publicKey,
+          adminAuthority.publicKey,
+          pauserAuthority.publicKey
+        )
+        .accounts({
+          bridge: bridgePda,
+          mint: mint.publicKey,
+          payer: adminAuthority.publicKey,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          systemProgram: SystemProgram.programId,
+          rent: SYSVAR_RENT_PUBKEY,
+        })
+        .signers([adminAuthority, mint])
+        .rpc();
+
+      const b = await bridge();
+      assert.strictEqual(b.paused, false);
+      assert.ok(b.mintAuthority.equals(mintAuthority.publicKey));
+      assert.ok(b.adminAuthority.equals(adminAuthority.publicKey));
+      assert.ok(b.pauserAuthority.equals(pauserAuthority.publicKey));
+      assert.ok(b.mint.equals(mint.publicKey));
+      assert.ok(b.dailyMintLimit.eq(DAILY));
+      assert.ok(b.autoPauseThreshold.eq(DAILY));
+      assert.ok(b.dailyMinted.isZero());
+
+      // The mint authority + freeze authority are the bridge PDA, decimals=12.
+      const mintInfo = await getMint(connection, mint.publicKey);
+      assert.strictEqual(mintInfo.decimals, 12);
+      assert.ok(mintInfo.mintAuthority?.equals(bridgePda));
+      assert.ok(mintInfo.freezeAuthority?.equals(bridgePda));
+    });
+  });
+
+  describe("bridge_mint — multisig gate + units", () => {
+    it("mints raw picocredits to the recipient ATA (5 BTH = 5 * 10^12)", async () => {
+      const ata = await ensureAta(user.publicKey, mintAuthority);
+      await doMint(bthToPico(5), oid(1), user.publicKey, ata);
+      const acct = await getAccount(connection, ata);
+      assert.strictEqual(acct.amount.toString(), bthToPico(5).toString());
+
+      const b = await bridge();
+      assert.ok(b.dailyMinted.eq(bthToPico(5)));
+    });
+
+    it("rejects a mint signed by a non-authority (multisig gate)", async () => {
+      const ata = await ataFor(user.publicKey);
+      try {
+        await doMint(bthToPico(1), oid(2), user.publicKey, ata, attacker);
+        assert.fail("attacker mint should have been rejected");
+      } catch (err: any) {
+        // has_one = mint_authority mismatch (ConstraintHasOne / ConstraintSeeds).
+        expect(String(err)).to.match(/HasOne|ConstraintHasOne|has_one|unknown signer|Signature/i);
+      }
+    });
+
+    it("rejects the all-zero order id", async () => {
+      const ata = await ataFor(user.publicKey);
+      try {
+        await doMint(bthToPico(1), ZERO_ORDER_ID, user.publicKey, ata);
+        assert.fail("zero order id should be rejected");
+      } catch (err: any) {
+        expect(String(err)).to.match(/InvalidOrderId/);
+      }
+    });
+
+    it("rejects a zero amount and an amount over the per-tx max", async () => {
+      const ata = await ataFor(user.publicKey);
+      try {
+        await doMint(new anchor.BN(0), oid(3), user.publicKey, ata);
+        assert.fail("zero amount should be rejected");
+      } catch (err: any) {
+        expect(String(err)).to.match(/InvalidAmount/);
+      }
+      try {
+        await doMint(MAX_TX.add(new anchor.BN(1)), oid(4), user.publicKey, ata);
+        assert.fail("over-max mint should be rejected");
+      } catch (err: any) {
+        expect(String(err)).to.match(/ExceedsMaxMint/);
+      }
+    });
+
+    it("cannot redirect a mint to an ATA the recipient does not own", async () => {
+      // ATA owned by otherUser, but claim user is the recipient => constraint fails.
+      const foreignAta = await ensureAta(otherUser.publicKey, mintAuthority);
+      try {
+        await doMint(bthToPico(1), oid(5), user.publicKey, foreignAta);
+        assert.fail("redirected mint should be rejected");
+      } catch (err: any) {
+        expect(String(err)).to.match(/ConstraintAssociated|associated|ConstraintTokenOwner/i);
+      }
+    });
+  });
+
+  describe("order-id replay guard", () => {
+    it("same order id twice fails at PDA init; distinct ids succeed", async () => {
+      const ata = await ataFor(user.publicKey);
+      const id = oid(100);
+      await doMint(bthToPico(1), id, user.publicKey, ata);
+
+      // Replay: same order id => order_marker init fails (account exists).
+      try {
+        await doMint(bthToPico(1), id, user.publicKey, ata);
+        assert.fail("duplicate order id should fail at init");
+      } catch (err: any) {
+        expect(String(err)).to.match(/already in use|custom program error: 0x0|Allocate/i);
+      }
+
+      // Distinct id succeeds.
+      await doMint(bthToPico(1), oid(101), user.publicKey, ata);
+    });
+  });
+
+  describe("bridge_burn", () => {
+    it("burns and emits a BridgeBurn redemption event", async () => {
+      const ata = await ensureAta(user.publicKey, mintAuthority);
+      await doMint(bthToPico(10), oid(200), user.publicKey, ata);
+
+      let captured: any = null;
+      const listener = program.addEventListener("bridgeBurnEvent", (ev) => {
+        captured = ev;
+      });
+
+      await program.methods
+        .bridgeBurn(bthToPico(4), "bth1qexampledestaddress")
+        .accounts({
+          bridge: bridgePda,
+          mint: mint.publicKey,
+          userTokenAccount: ata,
+          user: user.publicKey,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .signers([user])
+        .rpc();
+
+      await new Promise((r) => setTimeout(r, 500));
+      await program.removeEventListener(listener);
+
+      assert.ok(captured, "BridgeBurn event not emitted");
+      assert.ok(captured.amount.eq(bthToPico(4)));
+      assert.strictEqual(captured.bthAddress, "bth1qexampledestaddress");
+    });
+
+    it("rejects an empty and an over-long bth_address", async () => {
+      const ata = await ataFor(user.publicKey);
+      try {
+        await program.methods
+          .bridgeBurn(bthToPico(1), "")
+          .accounts({
+            bridge: bridgePda,
+            mint: mint.publicKey,
+            userTokenAccount: ata,
+            user: user.publicKey,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          })
+          .signers([user])
+          .rpc();
+        assert.fail("empty address should be rejected");
+      } catch (err: any) {
+        expect(String(err)).to.match(/InvalidBthAddress/);
+      }
+
+      try {
+        await program.methods
+          .bridgeBurn(bthToPico(1), "x".repeat(129))
+          .accounts({
+            bridge: bridgePda,
+            mint: mint.publicKey,
+            userTokenAccount: ata,
+            user: user.publicKey,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          })
+          .signers([user])
+          .rpc();
+        assert.fail("over-long address should be rejected");
+      } catch (err: any) {
+        expect(String(err)).to.match(/InvalidBthAddress/);
+      }
+    });
+  });
+
+  describe("admin-only controls", () => {
+    it("set_daily_limit / transfer_authority reject non-admin signers", async () => {
+      for (const bad of [mintAuthority, pauserAuthority, attacker]) {
+        try {
+          await program.methods
+            .setDailyLimit(DAILY)
+            .accounts({ bridge: bridgePda, adminAuthority: bad.publicKey })
+            .signers([bad])
+            .rpc();
+          assert.fail("non-admin should not set daily limit");
+        } catch (err: any) {
+          expect(String(err)).to.match(/HasOne|ConstraintHasOne|has_one/i);
+        }
+      }
+    });
+
+    it("admin can set the daily limit and auto-pause threshold", async () => {
+      const newLimit = bthToPico(20_000_000);
+      await program.methods
+        .setDailyLimit(newLimit)
+        .accounts({ bridge: bridgePda, adminAuthority: adminAuthority.publicKey })
+        .signers([adminAuthority])
+        .rpc();
+      let b = await bridge();
+      assert.ok(b.dailyMintLimit.eq(newLimit));
+
+      await program.methods
+        .setAutoPauseThreshold(new anchor.BN(0))
+        .accounts({ bridge: bridgePda, adminAuthority: adminAuthority.publicKey })
+        .signers([adminAuthority])
+        .rpc();
+      b = await bridge();
+      assert.ok(b.autoPauseThreshold.isZero());
+    });
+
+    it("admin can rotate the mint authority; the old one loses access", async () => {
+      const newMint = Keypair.generate();
+      await airdrop(newMint.publicKey);
+      await program.methods
+        .transferAuthority(newMint.publicKey)
+        .accounts({ bridge: bridgePda, adminAuthority: adminAuthority.publicKey })
+        .signers([adminAuthority])
+        .rpc();
+      let b = await bridge();
+      assert.ok(b.mintAuthority.equals(newMint.publicKey));
+
+      // Rotate back so later tests use the original mint authority.
+      await program.methods
+        .transferAuthority(mintAuthority.publicKey)
+        .accounts({ bridge: bridgePda, adminAuthority: adminAuthority.publicKey })
+        .signers([adminAuthority])
+        .rpc();
+      b = await bridge();
+      assert.ok(b.mintAuthority.equals(mintAuthority.publicKey));
+    });
+  });
+
+  describe("pause (guardian only) + burn/mint honoring paused", () => {
+    it("only the pauser can pause; mint and burn are blocked while paused", async () => {
+      // Non-pauser cannot pause.
+      try {
+        await program.methods
+          .pause()
+          .accounts({ bridge: bridgePda, pauserAuthority: attacker.publicKey })
+          .signers([attacker])
+          .rpc();
+        assert.fail("attacker should not pause");
+      } catch (err: any) {
+        expect(String(err)).to.match(/HasOne|ConstraintHasOne|has_one/i);
+      }
+
+      await program.methods
+        .pause()
+        .accounts({ bridge: bridgePda, pauserAuthority: pauserAuthority.publicKey })
+        .signers([pauserAuthority])
+        .rpc();
+      assert.strictEqual((await bridge()).paused, true);
+
+      const ata = await ataFor(user.publicKey);
+      try {
+        await doMint(bthToPico(1), oid(300), user.publicKey, ata);
+        assert.fail("mint should be blocked while paused");
+      } catch (err: any) {
+        expect(String(err)).to.match(/Paused/);
+      }
+      try {
+        await program.methods
+          .bridgeBurn(bthToPico(1), "bth1qdest")
+          .accounts({
+            bridge: bridgePda,
+            mint: mint.publicKey,
+            userTokenAccount: ata,
+            user: user.publicKey,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          })
+          .signers([user])
+          .rpc();
+        assert.fail("burn should be blocked while paused");
+      } catch (err: any) {
+        expect(String(err)).to.match(/Paused/);
+      }
+
+      // Unpause for later tests.
+      await program.methods
+        .unpause()
+        .accounts({ bridge: bridgePda, pauserAuthority: pauserAuthority.publicKey })
+        .signers([pauserAuthority])
+        .rpc();
+      assert.strictEqual((await bridge()).paused, false);
+    });
+  });
+
+  describe("rate limits + auto-pause breaker", () => {
+    // These tests initialize a SECOND bridge in a fresh program state is not
+    // possible (PDA is fixed), so they operate on tuned limits via admin.
+    it("enforces the daily limit boundary and auto-pauses at the threshold", async () => {
+      // Tighten the limit + breaker so we can exercise the boundary cheaply.
+      const limit = bthToPico(3);
+      await program.methods
+        .setDailyLimit(limit)
+        .accounts({ bridge: bridgePda, adminAuthority: adminAuthority.publicKey })
+        .signers([adminAuthority])
+        .rpc();
+      await program.methods
+        .setAutoPauseThreshold(limit)
+        .accounts({ bridge: bridgePda, adminAuthority: adminAuthority.publicKey })
+        .signers([adminAuthority])
+        .rpc();
+
+      // Force a daily reset by warping past a UTC-day boundary is only
+      // available on a test validator with `--warp-slot`; instead we rely on
+      // the current-day counter and read remaining capacity. Because earlier
+      // tests already minted on "today", we assert relative behavior:
+      const before = (await bridge()).dailyMinted;
+      const remaining = limit.sub(before);
+
+      const ata = await ensureAta(otherUser.publicKey, mintAuthority);
+      if (remaining.gt(new anchor.BN(0))) {
+        // Mint exactly up to the limit => should trip the auto-pause breaker.
+        await doMint(remaining, oid(400), otherUser.publicKey, ata);
+        assert.strictEqual((await bridge()).paused, true, "breaker should trip");
+        await program.methods
+          .unpause()
+          .accounts({ bridge: bridgePda, pauserAuthority: pauserAuthority.publicKey })
+          .signers([pauserAuthority])
+          .rpc();
+      }
+
+      // Now at/over the daily limit: a further mint must fail DailyLimitExceeded.
+      try {
+        await doMint(bthToPico(1), oid(401), otherUser.publicKey, ata);
+        assert.fail("mint past the daily limit should fail");
+      } catch (err: any) {
+        expect(String(err)).to.match(/DailyLimitExceeded|Paused/);
+      }
+
+      // Restore generous limits.
+      await program.methods
+        .setDailyLimit(DAILY)
+        .accounts({ bridge: bridgePda, adminAuthority: adminAuthority.publicKey })
+        .signers([adminAuthority])
+        .rpc();
+    });
+  });
+});

--- a/contracts/solana/tsconfig.json
+++ b/contracts/solana/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "types": ["mocha", "chai", "node"],
+    "typeRoots": ["./node_modules/@types"],
+    "lib": ["es2015", "es2019"],
+    "module": "commonjs",
+    "target": "es6",
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
Closes #850

Solana counterpart to the #826 Ethereum `WrappedBTH.sol` hardening (Phase-4 bridge milestone #865). Mirrors every decision made there, per ADR 0002 (validators' Ed25519 keys sign Solana mints natively) and ADR 0005.

## What changed (`contracts/solana/` only)

`programs/wbth/src/lib.rs`:

- **Multisig authority (ADR 0002).** The single-signer `authority` is replaced by three distinct authority pubkeys on `Bridge` — `mint_authority`, `admin_authority`, `pauser_authority` — each expected to be an SPL Token / Squads multisig of validator Ed25519 keys. `t`-of-`n` threshold enforcement lives inside the multisig program (like the Gnosis Safe on Ethereum), NOT in this contract; the program only checks the signer equals the configured pubkey via `has_one` on separate `BridgeMint` / `AdminOnly` / `PauserOnly` contexts. The mint-authority PDA (`seeds=[b"bridge"]`) still signs the `MintTo` CPI.
- **Order-id replay guard.** `bridge_mint` now takes `order_id: [u8;32]` and `init`s a per-order marker PDA (`seeds=[b"order", order_id]`); a duplicate fails at `init` — the Solana analogue of Ethereum's `processedOrders`. The instruction name and borsh arg order (`amount: u64` then `order_id`) match the pinned service encoding in `bridge/service/src/mint/solana.rs::encode_bridge_mint_instruction_data` and its `test_bridge_mint_instruction_data_layout`, so the bytes that land on-chain are unchanged.
- **Arithmetic + reset safety.** `.checked_add(amount).unwrap()` → `.ok_or(BridgeError::MathOverflow)?`; the 24h daily reset moved from slot-based to `Clock::unix_timestamp / 86_400` (UTC-day parity with EVM `block.timestamp / 1 days`, correct across multi-day gaps).
- **Burn / pause / redirection review.** `bridge_burn` honors `paused`, requires `amount > 0` and bounds `bth_address` to 128 bytes. `BridgeMint.user_token_account` is constrained `associated_token::authority = user` so a mint cannot be redirected to an account the recipient does not own.
- **Auto-pause breaker.** Daily volume `>= auto_pause_threshold` flips `paused` and emits `AutoPausedEvent` (default = daily limit; 0 disables) — the triggering mint still succeeds.
- **Units / config parity.** `mint::decimals = 12`; `MAX_MINT_PER_TX = 1M BTH`, `daily_mint_limit = 10M BTH` in picocredits (identical raw literals to the EVM contract); `Bridge::LEN` updated for the new fields.

`Cargo.toml`: declare `hex` explicitly (used by `msg!` order-id formatting).

New files: `tests/wbth.ts` (ts-mocha suite), `package.json`, `tsconfig.json`, `README.md`.

## Decisions

- **Multisig approach:** three distinct on-chain authority pubkeys, each a multisig account; threshold held off-contract in the SPL/Squads multisig. Chosen over an in-program t-of-n Ed25519 check because it (a) exactly mirrors the Ethereum "threshold lives in the Safe" model, (b) keeps the program minimal and audit-light, and (c) lets validators sign with existing tooling. Distinct multisigs for mint vs config vs pause so no single quorum can both mint and reconfigure.
- **Upgradeability: IMMUTABLE, matching Ethereum.** The deployed program's BPF upgrade authority MUST be revoked at deploy via `solana program set-upgrade-authority <PROGRAM_ID> --final` (a retained upgrade key is a rug vector that negates the multisig custody model). This is a deploy-time op — documented in `contracts/solana/README.md`, not enforced by code. Testnet may retain the authority for iteration provided the holder (a governance multisig, never a lone EOA) is recorded and finalized before mainnet.

## Test Plan

**Ran locally (host toolchain available):**
- `cargo build --lib -p wbth` in `contracts/solana` — compiles cleanly (only benign Anchor `anchor-debug` cfg warnings).
- `cargo clippy --lib -p wbth` — no errors.
- `cargo fmt --check` — clean.
- Verified the `bridge_mint` name + arg order + borsh layout match the pinned `bridge/service/src/mint/solana.rs` encoding and its unit test.

**NOT run — requires the Solana toolchain (not installed in this environment):**
- `anchor build` / `anchor test` (the full `tests/wbth.ts` ts-mocha suite) needs `solana`, `cargo build-sbf`, and Anchor CLI 0.29 plus a local test validator. These are **not installed here**, so the ts-mocha suite has **not been executed** — I am NOT claiming the tests pass. The suite is written against the standard `anchor.workspace.Wbth` harness (it loads `target/types/wbth.ts`, generated by `anchor build`) and covers: initialize (PDA mint authority + 12 decimals + distinct roles), multisig-gated mint, order-id replay (same id fails at PDA init, distinct ids succeed), unit pinning, mint-redirection guard, burn redemption event + address bounds, admin-only limit/threshold/authority rotation, guardian-only pause (mint + burn blocked while paused), and the daily-limit boundary + auto-pause breaker. A reviewer/auditor with the Solana toolchain should run `anchor test` to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)