### PR TITLE
feat(bridge): federation attestation envelope transport between validator bridge nodes (#858)

### DIFF
--- a/bridge/core/src/attestation.rs
+++ b/bridge/core/src/attestation.rs
@@ -17,9 +17,12 @@
 //! envelopes mirroring the operator-signed-action machinery
 //! (`botho/src/operator_action.rs`, P4.4), aggregated to the federation
 //! threshold by [`AttestationSet`]. Signature *collection over the network*
-//! between federation members is TODO(#858); everything cryptographic —
-//! signing, verification, replay rejection, order binding, thresholding —
-//! is implemented here and in `bridge/service/src/attestation.rs`.
+//! between federation members is the #858 transport in
+//! `bridge/service/src/federation.rs` (an authenticated `POST /api/attest`
+//! endpoint in front of this pipeline, plus outbound peer push); everything
+//! cryptographic — signing, verification, replay rejection, order binding,
+//! thresholding — is implemented here and in
+//! `bridge/service/src/attestation.rs`.
 
 use ed25519_dalek::{Signature as Ed25519Signature, SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
@@ -841,6 +844,33 @@ pub fn peek_target_chain(envelope: &str) -> Result<Chain, AttestationRejectReaso
             "action `{other}` is not in the v1 allowlist"
         ))),
     }
+}
+
+/// Peek the bound order UUID out of the (still-unverified) envelope bytes,
+/// ONLY to route the received envelope to the on-record order the ingest
+/// pipeline then binds it against (#858 transport). Like [`peek_signer_key_id`]
+/// this is a hint that drives no security decision on its own: the routed
+/// order is re-checked field-by-field by `check_order_binding` AFTER the
+/// signature verifies, so a lying `orderId` selects an order the signature —
+/// or the order binding — then rejects.
+pub fn peek_order_id(envelope: &str) -> Result<Uuid, AttestationRejectReason> {
+    let value: Value = serde_json::from_str(envelope).map_err(|_| {
+        AttestationRejectReason::Malformed("envelope is not valid JSON".to_string())
+    })?;
+    let order_id = value
+        .as_object()
+        .and_then(|o| o.get("params"))
+        .and_then(|p| p.as_object())
+        .and_then(|p| p.get("orderId"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            AttestationRejectReason::Malformed(
+                "envelope missing string `params.orderId`".to_string(),
+            )
+        })?;
+    Uuid::parse_str(order_id).map_err(|_| {
+        AttestationRejectReason::Malformed("`params.orderId` is not a valid UUID".to_string())
+    })
 }
 
 /// Parse a chain from its canonical wire string ONLY (`ethereum` /

--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -22,6 +22,83 @@ pub struct BridgeConfig {
     /// Reserve reconciliation / proof-of-reserves settings (#825).
     #[serde(default)]
     pub reserve: ReserveSettings,
+
+    /// Federation attestation transport settings (#858): how this node
+    /// exchanges signed attestation envelopes with the other validator
+    /// bridge nodes.
+    #[serde(default)]
+    pub federation: FederationSettings,
+}
+
+/// Federation attestation envelope transport settings (#858).
+///
+/// The #824 attestation pipeline verifies, replay-checks, order-binds, and
+/// thresholds signed envelopes, but each node only ever sees its OWN local
+/// signer's envelope until they are exchanged over the network. This section
+/// configures that exchange between the t-of-n validator bridge nodes (per
+/// ADR 0002 the SCP validator set doubles as the federation).
+///
+/// Envelopes are self-authenticating — every envelope carries a signature
+/// over domain-separated bytes plus a single-use replay nonce, verified
+/// fail-closed by the ingest pipeline regardless of how it arrived. The
+/// transport therefore needs integrity / anti-DoS but NOT confidentiality: a
+/// shared-secret bearer token gates the inbound endpoint (rejecting
+/// unauthenticated floods before any signature work) and authenticates
+/// outbound pushes to peers. The endpoint is pure transport in front of the
+/// existing verify pipeline; it never weakens verification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FederationSettings {
+    /// Base URLs of the OTHER federation members' bridge services (e.g.
+    /// `https://bridge-2.example:9742`). When a node self-attests it pushes
+    /// its envelope to each peer's `/api/attest` endpoint. Empty disables
+    /// outbound push (single-node development, or threshold 1).
+    #[serde(default)]
+    pub peers: Vec<String>,
+
+    /// Listen address for the inbound attestation endpoint
+    /// (`POST /api/attest`). Empty string disables the inbound endpoint —
+    /// this node then only ever counts its own local signer, so any
+    /// threshold above 1 never authorizes (fail-safe). Distinct from the
+    /// proof-of-reserves API so the two surfaces can bind separately.
+    #[serde(default)]
+    pub attest_listen: String,
+
+    /// Shared bearer secret a peer must present (HTTP `Authorization:
+    /// Bearer <token>`) to submit an envelope to THIS node's inbound
+    /// endpoint. Empty disables the auth gate — acceptable only on a
+    /// trusted private network, since envelopes are self-authenticating,
+    /// but leaves the endpoint open to unauthenticated verification-work
+    /// floods. Set it in any exposed deployment.
+    #[serde(default)]
+    pub inbound_auth_token: Option<String>,
+
+    /// Bearer secret this node presents when pushing envelopes OUTBOUND to
+    /// peers (their `inbound_auth_token`). `None` sends no `Authorization`
+    /// header. In a symmetric federation every node shares one secret, so
+    /// this typically equals `inbound_auth_token`.
+    #[serde(default)]
+    pub peer_auth_token: Option<String>,
+
+    /// Per-request timeout (seconds) for an outbound push to a peer. A slow
+    /// or unreachable peer must never wedge the local self-attestation path.
+    #[serde(default = "default_peer_push_timeout_secs")]
+    pub peer_push_timeout_secs: u64,
+}
+
+fn default_peer_push_timeout_secs() -> u64 {
+    5
+}
+
+impl Default for FederationSettings {
+    fn default() -> Self {
+        Self {
+            peers: Vec::new(),
+            attest_listen: String::new(),
+            inbound_auth_token: None,
+            peer_auth_token: None,
+            peer_push_timeout_secs: default_peer_push_timeout_secs(),
+        }
+    }
 }
 
 /// Reserve reconciliation / proof-of-reserves settings (#825).
@@ -414,6 +491,7 @@ impl Default for BridgeConfig {
                 attestation_nonce_file: None,
             },
             reserve: ReserveSettings::default(),
+            federation: FederationSettings::default(),
         }
     }
 }
@@ -510,6 +588,40 @@ mod tests {
         assert_eq!(configured.release_signers.len(), 2);
         assert_eq!(configured.release_threshold, 3);
         assert_eq!(configured.release_confirmations_required, 2);
+    }
+
+    #[test]
+    fn test_federation_settings_default_and_parse() {
+        // Defaults (#858): no peers, inbound endpoint disabled, no auth,
+        // 5s push timeout — a single-node / threshold-1 deployment.
+        let config = BridgeConfig::default();
+        assert!(config.federation.peers.is_empty());
+        assert!(config.federation.attest_listen.is_empty());
+        assert!(config.federation.inbound_auth_token.is_none());
+        assert!(config.federation.peer_auth_token.is_none());
+        assert_eq!(config.federation.peer_push_timeout_secs, 5);
+
+        // A pre-existing config without a [federation] section still parses.
+        let legacy: FederationSettings = toml::from_str("").unwrap();
+        assert!(legacy.peers.is_empty());
+        assert_eq!(legacy.peer_push_timeout_secs, 5);
+
+        // The knobs round-trip from TOML.
+        let configured: FederationSettings = toml::from_str(
+            r#"
+            peers = ["http://bridge-2:9742", "http://bridge-3:9742"]
+            attest_listen = "0.0.0.0:9742"
+            inbound_auth_token = "in-secret"
+            peer_auth_token = "out-secret"
+            peer_push_timeout_secs = 3
+            "#,
+        )
+        .unwrap();
+        assert_eq!(configured.peers.len(), 2);
+        assert_eq!(configured.attest_listen, "0.0.0.0:9742");
+        assert_eq!(configured.inbound_auth_token.as_deref(), Some("in-secret"));
+        assert_eq!(configured.peer_auth_token.as_deref(), Some("out-secret"));
+        assert_eq!(configured.peer_push_timeout_secs, 3);
     }
 
     #[test]

--- a/bridge/core/src/lib.rs
+++ b/bridge/core/src/lib.rs
@@ -25,17 +25,17 @@ mod adversarial_tests;
 pub use attestation::{
     attestation_domain, attestation_signed_message, canonical_attestation_envelope,
     check_attestation_freshness, check_order_binding, mint_payload_digest,
-    parse_attestation_envelope, peek_signer_key_id, peek_target_chain, release_payload_digest,
-    sign_attestation_ed25519, AttestationEnvelope, AttestationKind, AttestationOutcome,
-    AttestationRejectReason, AttestationSet, AttestationSignature, MintAuthorization,
-    ParsedAttestation, ReleaseAuthorization, SignatureScheme, ATTESTATION_ENVELOPE_VERSION,
-    ATTEST_DOMAIN_BTH, ATTEST_DOMAIN_ETH, ATTEST_DOMAIN_SOL, MAX_ATTESTATION_LIFETIME_SECS,
-    RELEASE_ATTESTATION_DOMAIN_TAG,
+    parse_attestation_envelope, peek_order_id, peek_signer_key_id, peek_target_chain,
+    release_payload_digest, sign_attestation_ed25519, AttestationEnvelope, AttestationKind,
+    AttestationOutcome, AttestationRejectReason, AttestationSet, AttestationSignature,
+    MintAuthorization, ParsedAttestation, ReleaseAuthorization, SignatureScheme,
+    ATTESTATION_ENVELOPE_VERSION, ATTEST_DOMAIN_BTH, ATTEST_DOMAIN_ETH, ATTEST_DOMAIN_SOL,
+    MAX_ATTESTATION_LIFETIME_SECS, RELEASE_ATTESTATION_DOMAIN_TAG,
 };
 pub use chains::{Chain, ChainAddress};
 pub use config::{
-    BridgeConfig, BthConfig, EthereumConfig, GasPriceStrategy, ReserveSettings, SolanaCommitment,
-    SolanaConfig,
+    BridgeConfig, BthConfig, EthereumConfig, FederationSettings, GasPriceStrategy, ReserveSettings,
+    SolanaCommitment, SolanaConfig,
 };
 pub use nonce::{NonceStore, ReserveOutcome};
 pub use order::{derive_order_id, BridgeOrder, OrderStatus, OrderType};

--- a/bridge/service/src/attestation.rs
+++ b/bridge/service/src/attestation.rs
@@ -23,9 +23,17 @@
 //!   `Safe.execTransaction`.
 //! - **Local signing**: the bridge node self-attests with its own federation
 //!   keys through the SAME ingest pipeline (its own envelopes get no special
-//!   trust). Envelope transport between federation members is `TODO(#858)`;
-//!   until then a threshold above 1 simply never authorizes — fail-safe, orders
-//!   stay in their confirmed state.
+//!   trust). Immediately after a self-attestation is accepted locally, the
+//!   envelope is pushed to the other federation members over the #858 transport
+//!   (an [`EnvelopePush`] broadcaster, wired to the peers' inbound `POST
+//!   /api/attest` endpoints); inbound peer envelopes arrive at THIS node's
+//!   endpoint and flow through [`submit_attestation`] — the same fail-closed
+//!   pipeline as any local envelope. When no broadcaster is configured
+//!   (single-node development, or threshold 1) a threshold above the
+//!   locally-signable count simply never authorizes — fail-safe, orders stay in
+//!   their confirmed state.
+//!
+//! [`submit_attestation`]: FederationAttestationProvider::submit_attestation
 //!
 //! [`StubAttestationProvider`] remains the development fallback when no
 //! federation is configured, and [`DisabledAttestationProvider`] is the
@@ -67,6 +75,22 @@ use crate::mint::ethereum::{encode_bridge_mint_calldata, safe_tx_hash, IGnosisSa
 
 /// Validity window the local signer stamps on its own attestations.
 const SELF_ATTESTATION_LIFETIME_SECS: u64 = 120;
+
+/// Outbound transport for freshly-signed local attestation envelopes (#858).
+///
+/// When this node self-attests (mint or release) it hands the accepted
+/// envelope to the broadcaster, which pushes it to the other federation
+/// members' inbound endpoints. Implementations are fire-and-forget with
+/// respect to the local authorization path: a slow or unreachable peer must
+/// never wedge or fail the local self-attestation (the peer will still
+/// self-attest and push its own envelope back). The envelope is
+/// self-authenticating, so the transport carries no trust — a dropped push
+/// only delays reaching threshold, and re-authorization re-pushes.
+pub trait EnvelopePush: Send + Sync {
+    /// Push one signed envelope to every configured peer. Errors are the
+    /// implementation's to log/absorb; the return is advisory.
+    fn broadcast(&self, envelope: &AttestationEnvelope);
+}
 
 /// Source of threshold mint and release authorizations.
 #[async_trait]
@@ -246,6 +270,11 @@ pub struct FederationAttestationProvider {
     local_ed25519: Option<SigningKey>,
     local_secp256k1: Option<PrivateKeySigner>,
     tracker: Mutex<Tracker>,
+    /// #858 outbound transport: pushes each accepted local envelope to the
+    /// other federation members. `None` disables outbound push (single-node
+    /// development / threshold 1) — the node then only ever counts its own
+    /// signer, which is fail-safe.
+    peer_push: Option<Arc<dyn EnvelopePush>>,
 }
 
 /// Parse a hex-encoded 32-byte Ed25519 public key list into verifying keys.
@@ -417,7 +446,95 @@ impl FederationAttestationProvider {
                 nonces,
                 sets: HashMap::new(),
             }),
+            peer_push: None,
         }))
+    }
+
+    /// Attach the #858 outbound transport: every accepted local
+    /// self-attestation envelope is pushed to the other federation members.
+    /// Consuming builder so the provider can be wrapped in an `Arc` after
+    /// wiring (the transport is set once, at engine start).
+    pub fn with_peer_push(mut self, push: Arc<dyn EnvelopePush>) -> Self {
+        self.peer_push = Some(push);
+        self
+    }
+
+    /// Test-support constructor for the #858 transport harness: a BTH-release
+    /// federation (Ed25519) with an in-memory nonce store and no peer push
+    /// (the caller attaches a real [`PeerBroadcaster`] via [`with_peer_push`]
+    /// so envelopes travel over the wire, not by direct injection).
+    #[cfg(test)]
+    pub(crate) fn new_bth_for_test(
+        signers: &[VerifyingKey],
+        threshold: u32,
+        local: SigningKey,
+    ) -> Self {
+        Self {
+            eth: None,
+            sol: None,
+            bth: Some(Ed25519Federation {
+                signers: signers.to_vec(),
+                threshold,
+            }),
+            local_ed25519: Some(local),
+            local_secp256k1: None,
+            tracker: Mutex::new(Tracker {
+                nonces: NonceStore::in_memory(),
+                sets: HashMap::new(),
+            }),
+            peer_push: None,
+        }
+    }
+
+    /// Test-support constructor for the #858 transport harness: an
+    /// Ethereum-mint federation (secp256k1 Safe owners) reading the Safe
+    /// nonce from a fixed source, with no peer push (the caller attaches a
+    /// real [`PeerBroadcaster`]).
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_eth_for_test(
+        owners: &[Address],
+        threshold: u32,
+        chain_id: u64,
+        safe: Address,
+        wbth: Address,
+        nonce_source: Arc<dyn SafeNonceSource>,
+        local: PrivateKeySigner,
+    ) -> Self {
+        Self {
+            eth: Some(EthFederation {
+                owners: owners.to_vec(),
+                threshold,
+                chain_id,
+                safe,
+                wbth,
+                nonce_source,
+            }),
+            sol: None,
+            bth: None,
+            local_ed25519: None,
+            local_secp256k1: Some(local),
+            tracker: Mutex::new(Tracker {
+                nonces: NonceStore::in_memory(),
+                sets: HashMap::new(),
+            }),
+            peer_push: None,
+        }
+    }
+
+    /// Distinct signers collected so far for `(order, action)` — test-only
+    /// observation of an [`AttestationSet`]'s progress WITHOUT touching it
+    /// (the #858 harness asserts a wired envelope actually reached a node).
+    #[cfg(test)]
+    pub(crate) fn distinct_signers_for_test(&self, order_id: Uuid, action: &'static str) -> u32 {
+        self.progress(order_id, action)
+    }
+
+    /// Build a release [`AttestationKind`] for `order` (test-only; the real
+    /// path is `release_kind`, which is private).
+    #[cfg(test)]
+    pub(crate) fn release_kind_for_test(order: &BridgeOrder) -> AttestationKind {
+        Self::release_kind(order).unwrap()
     }
 
     /// The configured threshold for a target chain's federation.
@@ -441,10 +558,11 @@ impl FederationAttestationProvider {
     }
 
     /// Ingest one federation attestation for `order` at the current wall
-    /// clock. This is the RPC seam validators will submit envelopes through
-    /// once inter-node transport lands (`TODO(#858)` — the endpoint routes
-    /// the peeked order id to the on-record order, then calls this).
-    #[allow(dead_code)] // the #858 transport endpoint's entry point
+    /// clock. This is the RPC seam validators submit envelopes through: the
+    /// #858 inbound endpoint (`POST /api/attest`) peeks the envelope's order
+    /// id, routes it to the on-record order, then calls this — which runs the
+    /// full fail-closed verify pipeline (the endpoint is pure transport in
+    /// front of verification, never a trusted inject).
     pub fn submit_attestation(
         &self,
         envelope: &AttestationEnvelope,
@@ -682,7 +800,19 @@ impl FederationAttestationProvider {
                 outcome.tag, outcome.message
             ));
         }
+        // #858: push our accepted envelope to the other federation members
+        // so their nodes reach threshold. Fire-and-forget — a peer failure
+        // never fails our local authorization path.
+        self.push_to_peers(&envelope);
         Ok(())
+    }
+
+    /// Hand a freshly-accepted local envelope to the #858 outbound transport
+    /// (no-op when no broadcaster is wired).
+    fn push_to_peers(&self, envelope: &AttestationEnvelope) {
+        if let Some(push) = &self.peer_push {
+            push.broadcast(envelope);
+        }
     }
 
     fn set_contains(&self, order_id: Uuid, action: &'static str, signer_key_id: &str) -> bool {
@@ -898,13 +1028,18 @@ impl AttestationProvider for FederationAttestationProvider {
                                 outcome.tag, outcome.message
                             ));
                         }
+                        // #858: push our Safe-owner envelope (bound to the
+                        // set's Safe nonce, so peers bind the SAME nonce) to
+                        // the other members. Fire-and-forget.
+                        self.push_to_peers(&envelope);
                     }
                 }
 
-                // TODO(#858): request + ingest envelopes from the other
-                // federation members. Until that transport exists a
-                // threshold above the locally-signable count simply never
-                // authorizes — fail-safe.
+                // #858: peer envelopes arrive asynchronously at this node's
+                // inbound endpoint and flow through submit_attestation into
+                // the same set. If the threshold is not yet met we fail-safe
+                // (the order stays retryable and re-authorizes on the next
+                // pass, re-pushing our envelope).
                 let collected = self.progress(order.id, "bridge.mint_wbth");
                 match self.take_if_threshold_met(order.id, "bridge.mint_wbth", fed.threshold) {
                     Some(signatures) => Ok(MintAuthorization {
@@ -915,7 +1050,7 @@ impl AttestationProvider for FederationAttestationProvider {
                     }),
                     None => Err(format!(
                         "attestation threshold not met ({}/{} distinct signers); \
-                         federation transport pending #858",
+                         awaiting peer envelopes (#858 transport)",
                         collected, fed.threshold
                     )),
                 }
@@ -928,7 +1063,9 @@ impl AttestationProvider for FederationAttestationProvider {
                 let kind = Self::mint_kind(order, None)?;
                 self.self_attest_ed25519(&kind, order)?;
 
-                // TODO(#858): federation transport (see the Ethereum arm).
+                // #858: self_attest_ed25519 already pushed our envelope to
+                // peers; peer envelopes arrive at the inbound endpoint. Below
+                // threshold is fail-safe (retries + re-pushes next pass).
                 let collected = self.progress(order.id, "bridge.mint_wbth");
                 match self.take_if_threshold_met(order.id, "bridge.mint_wbth", fed.threshold) {
                     Some(signatures) => Ok(MintAuthorization {
@@ -955,7 +1092,9 @@ impl AttestationProvider for FederationAttestationProvider {
         let kind = Self::release_kind(order)?;
         self.self_attest_ed25519(&kind, order)?;
 
-        // TODO(#858): federation transport (see authorize_mint).
+        // #858: self_attest_ed25519 already pushed our envelope to peers;
+        // peer envelopes arrive at the inbound endpoint. Below threshold is
+        // fail-safe (retries + re-pushes next pass).
         let collected = self.progress(order.id, "bridge.release_bth");
         match self.take_if_threshold_met(order.id, "bridge.release_bth", fed.threshold) {
             Some(signatures) => Ok(ReleaseAuthorization {
@@ -1013,6 +1152,7 @@ mod tests {
             local_ed25519: local,
             local_secp256k1: None,
             tracker: empty_tracker(),
+            peer_push: None,
         }
     }
 
@@ -1057,6 +1197,7 @@ mod tests {
             local_ed25519: None,
             local_secp256k1: local,
             tracker: empty_tracker(),
+            peer_push: None,
         }
     }
 

--- a/bridge/service/src/engine.rs
+++ b/bridge/service/src/engine.rs
@@ -14,6 +14,7 @@ use crate::{
         StubAttestationProvider,
     },
     db::{Database, LimitCheck, LimitViolation},
+    federation::{self, AttestState, PeerBroadcaster},
     mint::{ethereum::EthMinter, solana::SolMinter, ConfirmationStatus, Minter},
     release::{bth::BthReleaser, PreparedRelease, ReleaseConfirmation, Releaser},
     reserve::Reconciler,
@@ -91,19 +92,51 @@ impl BridgeEngine {
     /// for the health surface.
     ///
     /// - Federation configured and valid → the real
-    ///   [`FederationAttestationProvider`].
+    ///   [`FederationAttestationProvider`], with the #858 outbound transport
+    ///   ([`PeerBroadcaster`]) attached when peers are configured. The concrete
+    ///   provider is returned so the inbound `/api/attest` endpoint can route
+    ///   received envelopes into the SAME set (the endpoint needs the concrete
+    ///   type, not the trait object).
     /// - Federation configured but INVALID → [`DisabledAttestationProvider`]
     ///   (fail-closed: authorizations error, orders stay retryable). Never
     ///   silently downgrades to the permissive stub.
     /// - No federation configured → the development stub.
     fn build_attestation_provider(
         config: &BridgeConfig,
-    ) -> (Arc<dyn AttestationProvider>, bool, String) {
+    ) -> (
+        Arc<dyn AttestationProvider>,
+        Option<Arc<FederationAttestationProvider>>,
+        bool,
+        String,
+    ) {
         match FederationAttestationProvider::from_config(config) {
             Ok(Some(provider)) => {
                 info!("federation attestation provider active (ADR 0002 t-of-n custody)");
+                // #858 outbound: push each accepted local envelope to peers.
+                let provider = match PeerBroadcaster::new(
+                    &config.federation.peers,
+                    config.federation.peer_auth_token.clone(),
+                    Duration::from_secs(config.federation.peer_push_timeout_secs.max(1)),
+                ) {
+                    Some(broadcaster) => {
+                        info!(
+                            "federation transport active: pushing envelopes to {} peer(s) (#858)",
+                            config.federation.peers.len()
+                        );
+                        provider.with_peer_push(Arc::new(broadcaster))
+                    }
+                    None => {
+                        info!(
+                            "no federation peers configured; outbound envelope push disabled \
+                             (a threshold above the locally-signable count will not authorize)"
+                        );
+                        provider
+                    }
+                };
+                let concrete = Arc::new(provider);
                 (
-                    Arc::new(provider),
+                    concrete.clone(),
+                    Some(concrete),
                     true,
                     "federation provider active".to_string(),
                 )
@@ -115,6 +148,7 @@ impl BridgeEngine {
                 );
                 (
                     Arc::new(StubAttestationProvider),
+                    None,
                     true,
                     "development stub provider (no federation configured)".to_string(),
                 )
@@ -126,7 +160,12 @@ impl BridgeEngine {
                     e
                 );
                 let detail = format!("disabled: {}", e);
-                (Arc::new(DisabledAttestationProvider::new(e)), false, detail)
+                (
+                    Arc::new(DisabledAttestationProvider::new(e)),
+                    None,
+                    false,
+                    detail,
+                )
             }
         }
     }
@@ -149,7 +188,7 @@ impl BridgeEngine {
 
         let minters = Self::build_minters(&self.config);
         let releaser = Self::build_releaser(&self.config);
-        let (attestation, attestation_ok, attestation_detail) =
+        let (attestation, federation_provider, attestation_ok, attestation_detail) =
             Self::build_attestation_provider(&self.config);
 
         // Record component availability for the health surface
@@ -273,6 +312,41 @@ impl BridgeEngine {
             }))
         };
 
+        // Spawn the inbound federation attestation endpoint (#858):
+        // authenticated `POST /api/attest` that routes received envelopes
+        // into the same #824 verify pipeline. Enabled only when a concrete
+        // federation provider exists AND a listen address is configured
+        // (empty address = fail-safe: peers cannot reach us, threshold > 1
+        // never authorizes).
+        let attest_handle = match (
+            &federation_provider,
+            self.config.federation.attest_listen.is_empty(),
+        ) {
+            (Some(provider), false) => {
+                let addr = self.config.federation.attest_listen.clone();
+                let state = AttestState {
+                    provider: provider.clone(),
+                    db: self.db.clone(),
+                    inbound_auth_token: self.config.federation.inbound_auth_token.clone(),
+                };
+                let attest_shutdown = self.shutdown_tx.subscribe();
+                Some(tokio::spawn(async move {
+                    if let Err(e) = federation::serve(addr, state, attest_shutdown).await {
+                        error!("Bridge attestation endpoint error: {}", e);
+                    }
+                }))
+            }
+            (Some(_), true) => {
+                warn!(
+                    "federation provider active but federation.attest_listen is empty; \
+                     inbound peer attestations disabled (threshold above the locally-signable \
+                     count will not authorize — fail-safe)"
+                );
+                None
+            }
+            (None, _) => None,
+        };
+
         // Handle shutdown signals: SIGINT (ctrl-c) and, on unix, SIGTERM
         // (what systemd sends). Both trigger the same graceful drain:
         // every component gets the broadcast and is joined below.
@@ -308,6 +382,9 @@ impl BridgeEngine {
             reconcile_handle
         );
         if let Some(handle) = api_handle {
+            let _ = handle.await;
+        }
+        if let Some(handle) = attest_handle {
             let _ = handle.await;
         }
 

--- a/bridge/service/src/federation.rs
+++ b/bridge/service/src/federation.rs
@@ -1,0 +1,985 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Federation attestation envelope transport (#858).
+//!
+//! The #824 attestation pipeline
+//! ([`FederationAttestationProvider`](crate::attestation::FederationAttestationProvider))
+//! verifies, replay-checks, order-binds, and thresholds signed envelopes —
+//! but each validator bridge node only ever sees its OWN local signer's
+//! envelope until they are exchanged over the network. Without that exchange
+//! any threshold above 1 never authorizes in production (fail-safe by
+//! design). This module is that exchange, per ADR 0002 (the SCP validator set
+//! doubles as the t-of-n bridge federation):
+//!
+//! - **Inbound** ([`attest`]): an authenticated `POST /api/attest` endpoint
+//!   that accepts an [`AttestationEnvelope`] (JSON), peeks its bound order id,
+//!   routes it to the on-record order, and calls
+//!   [`FederationAttestationProvider::submit_attestation`]. It is PURE
+//!   TRANSPORT in front of the existing fail-closed verify pipeline — it never
+//!   weakens verification. Adversarial envelopes (replayed nonce, wrong order,
+//!   unknown signer) are rejected by that pipeline with the existing
+//!   [`AttestationRejectReason`](bth_bridge_core::AttestationRejectReason)
+//!   refuse reasons, surfaced as HTTP status codes.
+//! - **Outbound** ([`PeerBroadcaster`]): when a node self-attests it pushes the
+//!   accepted envelope to every configured peer's inbound endpoint.
+//!
+//! **Transport security.** Envelopes are self-authenticating (a signature
+//! over domain-separated bytes plus a single-use replay nonce), so the
+//! transport needs integrity / anti-DoS but NOT confidentiality. A shared
+//! bearer secret gates the inbound endpoint — rejecting unauthenticated
+//! floods BEFORE any signature work — and authenticates outbound pushes. The
+//! raw envelope signature remains the only thing that authorizes an
+//! attestation; the bearer token is a DoS fence, not a trust anchor (a
+//! stolen token still cannot forge a federation signature).
+//!
+//! **Ethereum Safe nonce.** For Ethereum mints every collected payload
+//! signature must bind the SAME Gnosis Safe nonce (signatures over different
+//! nonces cannot share one `execTransaction`). The provider stamps its
+//! self-attestation with the set's
+//! [`safe_nonce`](bth_bridge_core::AttestationSet::safe_nonce) and pushes THAT
+//! envelope, so peers ingesting it bind the same nonce; a peer whose set
+//! already pinned a different nonce refuses the envelope
+//! (`refused:invalid_payload`) rather than mixing incompatible signatures.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    Json,
+};
+use bth_bridge_core::{peek_order_id, AttestationEnvelope};
+use serde::Serialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tracing::{debug, warn};
+
+use crate::{
+    attestation::{EnvelopePush, FederationAttestationProvider},
+    db::Database,
+};
+
+/// Shared state of the inbound `POST /api/attest` endpoint.
+#[derive(Clone)]
+pub struct AttestState {
+    /// The #824 provider whose fail-closed ingest pipeline every received
+    /// envelope flows through.
+    pub provider: Arc<FederationAttestationProvider>,
+    /// Order lookup: the peeked order id is routed to this on-record order,
+    /// then re-bound field-by-field by the verify pipeline.
+    pub db: Database,
+    /// Shared bearer secret a peer must present. `None` disables the auth
+    /// gate (trusted private network only).
+    pub inbound_auth_token: Option<String>,
+}
+
+/// The JSON body returned by the inbound endpoint (both accept and refuse).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttestResponse {
+    /// Whether the envelope was accepted into its threshold set.
+    pub accepted: bool,
+    /// Stable machine tag: `accepted` or `refused:<reason-tag>`.
+    pub tag: String,
+    /// Human-facing detail (safe to return to the submitter).
+    pub message: String,
+    /// Distinct valid signers collected for this `(order, action)` so far.
+    pub signers: u32,
+    /// The configured federation threshold `t`.
+    pub threshold: u32,
+}
+
+/// Extract the bearer token from an `Authorization: Bearer <token>` header.
+fn bearer(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(|s| s.trim().to_string())
+}
+
+/// Constant-time-ish comparison for the shared bearer secret. Envelopes are
+/// self-authenticating so this token is a DoS fence, not the security
+/// boundary; a length-independent compare still avoids a trivial timing
+/// oracle on the secret.
+fn token_matches(expected: &str, presented: &str) -> bool {
+    let a = expected.as_bytes();
+    let b = presented.as_bytes();
+    let mut diff = a.len() ^ b.len();
+    for i in 0..a.len().max(b.len()) {
+        let x = a.get(i).copied().unwrap_or(0);
+        let y = b.get(i).copied().unwrap_or(0);
+        diff |= (x ^ y) as usize;
+    }
+    diff == 0
+}
+
+/// Inbound attestation endpoint: `POST /api/attest`.
+///
+/// Pure transport in front of the #824 verify pipeline. The flow is:
+/// 1. bearer-auth gate (anti-DoS; rejected BEFORE any signature work);
+/// 2. peek the (unverified) order id purely to route to the on-record order — a
+///    lying id selects an order the signature/order-binding then rejects;
+/// 3. hand the RECEIVED envelope + order to `submit_attestation`, which runs
+///    the full fail-closed pipeline (signer selection → signature → parse →
+///    freshness → durable nonce reserve → order binding → aggregation).
+///
+/// The verdict maps to HTTP status so a peer can distinguish transport
+/// failures from attestation refusals: `200` accepted, `202` a valid-but-
+/// not-yet-threshold or benign refusal, `401` bad bearer, `400` malformed /
+/// bad-signature / unknown-signer, `404` no such order, `409` a replay /
+/// wrong-order / stale post-signature refusal, `503` an internal error.
+pub async fn attest(
+    State(state): State<AttestState>,
+    headers: HeaderMap,
+    Json(envelope): Json<AttestationEnvelope>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    // 1. Bearer-auth gate (anti-DoS). Only enforced when configured.
+    if let Some(expected) = &state.inbound_auth_token {
+        match bearer(&headers) {
+            Some(presented) if token_matches(expected, &presented) => {}
+            _ => {
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(AttestResponse {
+                        accepted: false,
+                        tag: "refused:unauthorized".to_string(),
+                        message: "missing or invalid bearer token".to_string(),
+                        signers: 0,
+                        threshold: 0,
+                    }),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    // 2. Route the peeked (unverified) order id to the on-record order.
+    let order_id = match peek_order_id(&envelope.envelope) {
+        Ok(id) => id,
+        Err(r) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(AttestResponse {
+                    accepted: false,
+                    tag: format!("refused:{}", r.tag()),
+                    message: r.message(),
+                    signers: 0,
+                    threshold: 0,
+                }),
+            )
+                .into_response();
+        }
+    };
+    let order = match state.db.get_order(&order_id) {
+        Ok(Some(order)) => order,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(AttestResponse {
+                    accepted: false,
+                    tag: "refused:unknown_order".to_string(),
+                    message: format!("no order on record for {order_id}"),
+                    signers: 0,
+                    threshold: 0,
+                }),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            warn!("attest endpoint: order lookup failed: {e}");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(AttestResponse {
+                    accepted: false,
+                    tag: "refused:internal".to_string(),
+                    message: "order lookup failed".to_string(),
+                    signers: 0,
+                    threshold: 0,
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    // 3. Full fail-closed verify pipeline (the endpoint adds NO trust).
+    let outcome = state.provider.submit_attestation(&envelope, &order);
+    let status = if outcome.accepted {
+        StatusCode::OK
+    } else {
+        match outcome.tag.as_str() {
+            "refused:malformed" | "refused:bad_signature" | "refused:unknown_signer" => {
+                StatusCode::BAD_REQUEST
+            }
+            "refused:replayed_nonce"
+            | "refused:wrong_order"
+            | "refused:stale"
+            | "refused:invalid_payload" => StatusCode::CONFLICT,
+            "refused:internal" => StatusCode::SERVICE_UNAVAILABLE,
+            // not_configured / below_threshold / anything else: the envelope
+            // was structurally fine, it just did not advance a set here.
+            _ => StatusCode::ACCEPTED,
+        }
+    };
+    (
+        status,
+        Json(AttestResponse {
+            accepted: outcome.accepted,
+            tag: outcome.tag,
+            message: outcome.message,
+            signers: outcome.signers,
+            threshold: outcome.threshold,
+        }),
+    )
+        .into_response()
+}
+
+/// Build the inbound attestation router (`POST /api/attest`).
+pub fn router(state: AttestState) -> axum::Router {
+    axum::Router::new()
+        .route("/api/attest", axum::routing::post(attest))
+        .with_state(state)
+}
+
+/// Serve the inbound attestation endpoint until shutdown. Empty `addr`
+/// disables the endpoint (the caller checks this before spawning).
+pub async fn serve(
+    addr: String,
+    state: AttestState,
+    mut shutdown: tokio::sync::broadcast::Receiver<()>,
+) -> Result<(), String> {
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .map_err(|e| format!("bind {addr} (attest) failed: {e}"))?;
+    tracing::info!("Bridge attestation endpoint listening on {addr}");
+    axum::serve(listener, router(state))
+        .with_graceful_shutdown(async move {
+            let _ = shutdown.recv().await;
+            tracing::info!("Bridge attestation endpoint shutting down");
+        })
+        .await
+        .map_err(|e| format!("attest server error: {e}"))
+}
+
+/// Outbound transport ([`EnvelopePush`]): pushes each accepted local envelope
+/// to every configured peer's inbound `POST /api/attest` endpoint.
+///
+/// Fire-and-forget with respect to the local authorization path: each push
+/// is spawned onto the tokio runtime and its result only logged. A slow or
+/// unreachable peer never wedges or fails the local self-attestation — the
+/// peer will self-attest and push its own envelope back, and re-authorization
+/// re-pushes. Uses a minimal raw-socket HTTP/1.1 POST (no HTTP-client
+/// dependency; the envelope is self-authenticating so plain HTTP integrity +
+/// the bearer fence suffice for v1 — mTLS can wrap it at the transport layer).
+pub struct PeerBroadcaster {
+    peers: Vec<PeerEndpoint>,
+    auth_token: Option<String>,
+    timeout: std::time::Duration,
+}
+
+/// A parsed peer base URL split into the pieces the raw-socket client needs.
+#[derive(Clone)]
+struct PeerEndpoint {
+    /// `host:port` connect target.
+    authority: String,
+    /// The `Host:` header value (authority without any userinfo).
+    host_header: String,
+    /// Request path (base path + `/api/attest`).
+    path: String,
+}
+
+impl PeerBroadcaster {
+    /// Build from configured peer base URLs (e.g.
+    /// `http://bridge-2.internal:9742`). Unparseable peers are skipped with a
+    /// warning rather than failing construction (a bad peer entry must not
+    /// disable the whole node's outbound path). Returns `None` when no peer
+    /// parses (nothing to broadcast to).
+    pub fn new(
+        peers: &[String],
+        auth_token: Option<String>,
+        timeout: std::time::Duration,
+    ) -> Option<Self> {
+        let parsed: Vec<PeerEndpoint> = peers
+            .iter()
+            .filter_map(|p| match parse_peer(p) {
+                Ok(ep) => Some(ep),
+                Err(e) => {
+                    warn!("federation peer `{p}` ignored: {e}");
+                    None
+                }
+            })
+            .collect();
+        if parsed.is_empty() {
+            return None;
+        }
+        Some(Self {
+            peers: parsed,
+            auth_token,
+            timeout,
+        })
+    }
+
+    /// Send one envelope to one peer over a raw HTTP/1.1 connection.
+    async fn push_one(
+        peer: PeerEndpoint,
+        body: String,
+        auth_token: Option<String>,
+        timeout: std::time::Duration,
+    ) {
+        let attempt = async {
+            let mut stream = tokio::net::TcpStream::connect(&peer.authority)
+                .await
+                .map_err(|e| format!("connect {}: {e}", peer.authority))?;
+            let auth = match &auth_token {
+                Some(t) => format!("Authorization: Bearer {t}\r\n"),
+                None => String::new(),
+            };
+            let request = format!(
+                "POST {} HTTP/1.1\r\nHost: {}\r\nContent-Type: application/json\r\n\
+                 {}Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                peer.path,
+                peer.host_header,
+                auth,
+                body.len(),
+                body
+            );
+            stream
+                .write_all(request.as_bytes())
+                .await
+                .map_err(|e| format!("write {}: {e}", peer.authority))?;
+            let mut response = Vec::new();
+            stream
+                .read_to_end(&mut response)
+                .await
+                .map_err(|e| format!("read {}: {e}", peer.authority))?;
+            let text = String::from_utf8_lossy(&response);
+            let status: u16 = text
+                .split_whitespace()
+                .nth(1)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            Ok::<u16, String>(status)
+        };
+
+        match tokio::time::timeout(timeout, attempt).await {
+            Ok(Ok(status)) => {
+                debug!("pushed attestation to {} -> HTTP {status}", peer.authority);
+            }
+            Ok(Err(e)) => warn!("attestation push to {} failed: {e}", peer.authority),
+            Err(_) => warn!(
+                "attestation push to {} timed out after {:?}",
+                peer.authority, timeout
+            ),
+        }
+    }
+}
+
+impl EnvelopePush for PeerBroadcaster {
+    fn broadcast(&self, envelope: &AttestationEnvelope) {
+        let body = match serde_json::to_string(envelope) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("cannot serialize envelope for peer push: {e}");
+                return;
+            }
+        };
+        for peer in &self.peers {
+            let peer = peer.clone();
+            let body = body.clone();
+            let auth_token = self.auth_token.clone();
+            let timeout = self.timeout;
+            // Fire-and-forget: never block or fail the local authorize path.
+            tokio::spawn(Self::push_one(peer, body, auth_token, timeout));
+        }
+    }
+}
+
+/// Parse a peer base URL into a raw-socket target. Accepts `http://` and
+/// `https://` schemes (the scheme only informs the default port here — TLS
+/// termination for `https` peers is expected at a reverse proxy / mTLS layer
+/// in front of the plain endpoint for v1). Rejects anything without a host.
+fn parse_peer(url: &str) -> Result<PeerEndpoint, String> {
+    let url = url.trim();
+    let (scheme, rest) = match url.split_once("://") {
+        Some((s, r)) => (s, r),
+        None => ("http", url),
+    };
+    let default_port = match scheme {
+        "http" => 80,
+        "https" => 443,
+        other => return Err(format!("unsupported scheme `{other}`")),
+    };
+    // Split authority from path.
+    let (authority, base_path) = match rest.find('/') {
+        Some(i) => (&rest[..i], rest[i..].trim_end_matches('/')),
+        None => (rest, ""),
+    };
+    if authority.is_empty() {
+        return Err("empty host".to_string());
+    }
+    // The connect target needs an explicit port; the Host header keeps the
+    // authority verbatim.
+    let connect = if authority.contains(':') {
+        authority.to_string()
+    } else {
+        format!("{authority}:{default_port}")
+    };
+    let path = format!("{base_path}/api/attest");
+    Ok(PeerEndpoint {
+        authority: connect,
+        host_header: authority.to_string(),
+        path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_peer_defaults_port_and_appends_path() {
+        let ep = parse_peer("http://bridge-2.internal:9742").unwrap();
+        assert_eq!(ep.authority, "bridge-2.internal:9742");
+        assert_eq!(ep.host_header, "bridge-2.internal:9742");
+        assert_eq!(ep.path, "/api/attest");
+
+        // No port -> default 80 for http, 443 for https.
+        let ep = parse_peer("http://peer.example").unwrap();
+        assert_eq!(ep.authority, "peer.example:80");
+        let ep = parse_peer("https://peer.example").unwrap();
+        assert_eq!(ep.authority, "peer.example:443");
+
+        // A base path is preserved and the endpoint path appended.
+        let ep = parse_peer("http://gw.example:8080/bridge/").unwrap();
+        assert_eq!(ep.authority, "gw.example:8080");
+        assert_eq!(ep.path, "/bridge/api/attest");
+
+        // Scheme-less is treated as http.
+        let ep = parse_peer("127.0.0.1:9742").unwrap();
+        assert_eq!(ep.authority, "127.0.0.1:9742");
+    }
+
+    #[test]
+    fn parse_peer_rejects_bad_input() {
+        assert!(parse_peer("ftp://x").is_err());
+        assert!(parse_peer("http://").is_err());
+    }
+
+    #[test]
+    fn token_matches_is_exact() {
+        assert!(token_matches("s3cret", "s3cret"));
+        assert!(!token_matches("s3cret", "s3cre"));
+        assert!(!token_matches("s3cret", "s3crett"));
+        assert!(!token_matches("s3cret", "wrong"));
+        assert!(token_matches("", ""));
+    }
+
+    #[test]
+    fn bearer_extracts_token() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            axum::http::header::AUTHORIZATION,
+            "Bearer abc123".parse().unwrap(),
+        );
+        assert_eq!(bearer(&h), Some("abc123".to_string()));
+
+        let empty = HeaderMap::new();
+        assert_eq!(bearer(&empty), None);
+    }
+}
+
+/// Two-node federation transport tests (#858 DoD): envelopes travel through
+/// the real `POST /api/attest` endpoint over the wire — NO direct injection
+/// into any node's `AttestationSet`. Each node runs its own provider + DB +
+/// inbound endpoint, and pushes its self-attestation to the OTHER node via a
+/// real [`PeerBroadcaster`].
+#[cfg(test)]
+#[allow(clippy::type_complexity)]
+mod federation_transport_tests {
+    use super::*;
+    use crate::attestation::{AttestationProvider, FederationAttestationProvider, SafeNonceSource};
+    use alloy::{
+        primitives::{Address, B256},
+        signers::local::PrivateKeySigner,
+    };
+    use async_trait::async_trait;
+    use bth_bridge_core::{BridgeOrder, Chain, OrderStatus, OrderType};
+    use ed25519_dalek::SigningKey;
+    use std::time::Duration;
+    use tokio::sync::broadcast;
+
+    const AUTH: &str = "shared-federation-secret";
+
+    fn ed_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn eth_key(seed: u8) -> PrivateKeySigner {
+        PrivateKeySigner::from_bytes(&B256::from([seed; 32])).unwrap()
+    }
+
+    struct FixedNonce(u64);
+    #[async_trait]
+    impl SafeNonceSource for FixedNonce {
+        async fn safe_nonce(&self) -> Result<u64, String> {
+            Ok(self.0)
+        }
+    }
+
+    /// A node whose inbound endpoint is bound (port known) but not yet
+    /// serving — so we can wire each node's outbound push to the OTHER
+    /// node's URL before either starts serving, breaking the circular
+    /// endpoint/provider dependency.
+    struct PendingNode {
+        listener: tokio::net::TcpListener,
+        url: String,
+        db: Database,
+    }
+
+    async fn pending_node(order: &BridgeOrder) -> PendingNode {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        PendingNode {
+            listener,
+            url: format!("http://{addr}"),
+            db: db_with_order(order),
+        }
+    }
+
+    /// A broadcaster pushing to one peer URL with the shared bearer secret.
+    fn push_to(url: &str) -> Arc<PeerBroadcaster> {
+        Arc::new(
+            PeerBroadcaster::new(
+                &[url.to_string()],
+                Some(AUTH.to_string()),
+                Duration::from_secs(5),
+            )
+            .unwrap(),
+        )
+    }
+
+    /// Start serving `provider` on a pre-bound listener; returns the shutdown
+    /// sender + task handle.
+    fn serve_pending(
+        node: PendingNode,
+        provider: Arc<FederationAttestationProvider>,
+    ) -> (broadcast::Sender<()>, tokio::task::JoinHandle<()>) {
+        let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
+        let state = AttestState {
+            provider,
+            db: node.db,
+            inbound_auth_token: Some(AUTH.to_string()),
+        };
+        let app = router(state);
+        let handle = tokio::spawn(async move {
+            axum::serve(node.listener, app)
+                .with_graceful_shutdown(async move {
+                    let mut rx = shutdown_rx;
+                    let _ = rx.recv().await;
+                })
+                .await
+                .unwrap();
+        });
+        (shutdown_tx, handle)
+    }
+
+    fn burn_order() -> BridgeOrder {
+        let mut order = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+            "bth_user_stealth_addr".to_string(),
+            "0xburntx".to_string(),
+        );
+        order.set_status(OrderStatus::BurnConfirmed);
+        order
+    }
+
+    fn eth_mint_order() -> BridgeOrder {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bth_deposit_addr".to_string(),
+            format!("0x{}", hex::encode([0x11u8; 20])),
+        );
+        order.source_tx = Some("bth_deposit_tx".to_string());
+        order.set_status(OrderStatus::DepositConfirmed);
+        order
+    }
+
+    /// Persist `order` into a fresh in-memory DB (each node has its own; the
+    /// endpoint looks the routed order up here).
+    fn db_with_order(order: &BridgeOrder) -> Database {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        db.insert_order(order).unwrap();
+        db
+    }
+
+    /// Bind an endpoint on an ephemeral port and start serving `provider`
+    /// immediately (for single-node adversarial tests). Returns the base URL,
+    /// shutdown sender, and task handle.
+    async fn spawn_endpoint(
+        provider: Arc<FederationAttestationProvider>,
+        db: Database,
+    ) -> (String, broadcast::Sender<()>, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let node = PendingNode {
+            listener,
+            url: url.clone(),
+            db,
+        };
+        let (sd, handle) = serve_pending(node, provider);
+        (url, sd, handle)
+    }
+
+    /// Poll until `cond` holds or the deadline elapses (peer pushes are
+    /// fire-and-forget over the network, so propagation is asynchronous).
+    async fn wait_for(mut cond: impl FnMut() -> bool) {
+        for _ in 0..200 {
+            if cond() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("condition not met within timeout (envelope did not propagate over the wire)");
+    }
+
+    #[tokio::test]
+    async fn two_node_release_authorizes_over_the_wire_no_injection() {
+        // Federation {A, B}, threshold 2. Each node self-attests with its
+        // OWN key and pushes to the other's endpoint over the wire; neither
+        // ever inserts into the other's set directly.
+        let (ka, kb) = (ed_key(11), ed_key(22));
+        let federation = vec![ka.verifying_key(), kb.verifying_key()];
+        let order = burn_order();
+
+        // Bind both endpoints (ports known) BEFORE wiring push, so each
+        // node's outbound broadcaster targets the other's real URL.
+        let pending_a = pending_node(&order).await;
+        let pending_b = pending_node(&order).await;
+
+        let node_a = Arc::new(
+            FederationAttestationProvider::new_bth_for_test(&federation, 2, ka)
+                .with_peer_push(push_to(&pending_b.url)),
+        );
+        let node_b = Arc::new(
+            FederationAttestationProvider::new_bth_for_test(&federation, 2, kb)
+                .with_peer_push(push_to(&pending_a.url)),
+        );
+
+        let (sd_a, srv_a) = serve_pending(pending_a, node_a.clone());
+        let (sd_b, srv_b) = serve_pending(pending_b, node_b.clone());
+
+        // -- Drive the protocol --------------------------------------------
+        // A self-attests (1/2 locally) and pushes A's envelope to B's wire.
+        assert!(
+            node_a.authorize_release(&order).await.is_err(),
+            "A alone is 1/2"
+        );
+        // B receives A's envelope over the wire -> B set reaches 1/2.
+        wait_for(|| node_b.distinct_signers_for_test(order.id, "bridge.release_bth") == 1).await;
+
+        // B self-attests (now 2/2 at B) and returns a full authorization;
+        // B also pushes B's envelope back to A's wire.
+        let auth_b = node_b
+            .authorize_release(&order)
+            .await
+            .expect("B reaches threshold via A's wired envelope + its own");
+        assert_eq!(auth_b.signatures.len(), 2);
+        assert!(auth_b.meets_threshold());
+
+        // A receives B's envelope over the wire -> A set reaches 2/2.
+        wait_for(|| node_a.distinct_signers_for_test(order.id, "bridge.release_bth") == 2).await;
+        let auth_a = node_a
+            .authorize_release(&order)
+            .await
+            .expect("A reaches threshold via B's wired envelope + its own");
+        assert_eq!(auth_a.signatures.len(), 2);
+
+        // Both authorizations verify against the pinned federation — proof
+        // the wired envelopes carry real federation signatures.
+        crate::release::bth::validate_release_attestation(&order, &auth_a, &federation, 2)
+            .expect("A's collected authorization must satisfy the release validator");
+        crate::release::bth::validate_release_attestation(&order, &auth_b, &federation, 2)
+            .expect("B's collected authorization must satisfy the release validator");
+
+        let _ = sd_a.send(());
+        let _ = sd_b.send(());
+        let _ = srv_a.await;
+        let _ = srv_b.await;
+    }
+
+    #[tokio::test]
+    async fn two_node_eth_mint_authorizes_over_the_wire_no_injection() {
+        // Federation {A, B} Safe owners, threshold 2, both binding Safe
+        // nonce 7 (the #848/#849 nonce-agreement seam: peers must sign the
+        // SAME nonce or the set refuses to mix them).
+        const NONCE: u64 = 7;
+        let (oa, ob) = (eth_key(11), eth_key(22));
+        let owners = vec![oa.address(), ob.address()];
+        let safe = Address::repeat_byte(0x5a);
+        let wbth = Address::repeat_byte(0xeb);
+        let chain_id = 1u64;
+        let order = eth_mint_order();
+
+        let mk = |local: PrivateKeySigner| {
+            FederationAttestationProvider::new_eth_for_test(
+                &owners,
+                2,
+                chain_id,
+                safe,
+                wbth,
+                Arc::new(FixedNonce(NONCE)),
+                local,
+            )
+        };
+
+        let pending_a = pending_node(&order).await;
+        let pending_b = pending_node(&order).await;
+        let node_a = Arc::new(mk(oa).with_peer_push(push_to(&pending_b.url)));
+        let node_b = Arc::new(mk(ob).with_peer_push(push_to(&pending_a.url)));
+        let (sd_a, srv_a) = serve_pending(pending_a, node_a.clone());
+        let (sd_b, srv_b) = serve_pending(pending_b, node_b.clone());
+
+        // A self-attests (1/2) and pushes to B.
+        assert!(
+            node_a.authorize_mint(&order).await.is_err(),
+            "A alone is 1/2"
+        );
+        wait_for(|| node_b.distinct_signers_for_test(order.id, "bridge.mint_wbth") == 1).await;
+
+        // B self-attests -> 2/2, returns a full authorization.
+        let auth = node_b
+            .authorize_mint(&order)
+            .await
+            .expect("B reaches threshold via A's wired envelope + its own");
+        assert_eq!(auth.signatures.len(), 2);
+        assert!(auth.meets_threshold());
+
+        // Every payload signature is a Safe owner signature over THIS order's
+        // SafeTx digest at the SAME nonce 7 — directly execTransaction-ready.
+        let digest = {
+            use alloy::primitives::U256;
+            let to: Address = order.dest_address.parse().unwrap();
+            let calldata = crate::mint::ethereum::encode_bridge_mint_calldata(
+                to,
+                U256::from(order.net_amount()),
+                order.order_id_bytes(),
+            );
+            crate::mint::ethereum::safe_tx_hash(chain_id, safe, wbth, &calldata, U256::from(NONCE))
+        };
+        for sig in &auth.signatures {
+            use alloy::primitives::Signature;
+            let ecdsa = Signature::from_raw(&sig.signature).unwrap();
+            let recovered = ecdsa.recover_address_from_prehash(&digest).unwrap();
+            assert!(owners.contains(&recovered), "signature binds a Safe owner");
+        }
+        assert_eq!(order.order_type, OrderType::Mint);
+
+        let _ = sd_a.send(());
+        let _ = sd_b.send(());
+        let _ = srv_a.await;
+        let _ = srv_b.await;
+    }
+
+    // -- Adversarial endpoint tests (rejected by the verify pipeline) -------
+
+    /// Send a raw JSON body to a node's `/api/attest` and return (status,
+    /// body). Mirrors the api.rs test client (no HTTP-client dep).
+    async fn post_attest(base_url: &str, auth: Option<&str>, body: &str) -> (u16, String) {
+        let addr = base_url.trim_start_matches("http://");
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let auth_hdr = match auth {
+            Some(t) => format!("Authorization: Bearer {t}\r\n"),
+            None => String::new(),
+        };
+        let request = format!(
+            "POST /api/attest HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\n\
+             {auth_hdr}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let text = String::from_utf8_lossy(&response).to_string();
+        let status: u16 = text
+            .split_whitespace()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        let body = text
+            .split_once("\r\n\r\n")
+            .map(|(_, b)| b.to_string())
+            .unwrap_or_default();
+        (status, body)
+    }
+
+    /// Build a single node with an endpoint for adversarial tests.
+    async fn single_node_endpoint(
+        order: &BridgeOrder,
+    ) -> (
+        String,
+        Arc<FederationAttestationProvider>,
+        broadcast::Sender<()>,
+        tokio::task::JoinHandle<()>,
+        SigningKey,
+        SigningKey,
+    ) {
+        let (ka, kb) = (ed_key(11), ed_key(22));
+        let federation = vec![ka.verifying_key(), kb.verifying_key()];
+        let provider = Arc::new(FederationAttestationProvider::new_bth_for_test(
+            &federation,
+            2,
+            ka.clone(),
+        ));
+        let (url, sd, srv) = spawn_endpoint(provider.clone(), db_with_order(order)).await;
+        (url, provider, sd, srv, ka, kb)
+    }
+
+    #[tokio::test]
+    async fn endpoint_rejects_unknown_signer() {
+        let order = burn_order();
+        let (url, provider, sd, srv, _ka, _kb) = single_node_endpoint(&order).await;
+
+        // An envelope from a non-member key: rejected pre-signature.
+        let byz = ed_key(99);
+        let kind = FederationAttestationProvider::release_kind_for_test(&order);
+        let now = chrono::Utc::now().timestamp().max(0) as u64;
+        let env =
+            bth_bridge_core::sign_attestation_ed25519(&kind, &byz, "adv-unknown", now, now + 120)
+                .unwrap();
+        let (status, body) =
+            post_attest(&url, Some(AUTH), &serde_json::to_string(&env).unwrap()).await;
+        assert_eq!(status, 400, "{body}");
+        assert!(body.contains("unknown_signer"), "{body}");
+        assert_eq!(
+            provider.distinct_signers_for_test(order.id, "bridge.release_bth"),
+            0
+        );
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+
+    #[tokio::test]
+    async fn endpoint_rejects_wrong_order() {
+        // Sign a valid envelope for `order`, but the DB record under that
+        // same order id has a DIFFERENT net amount — the peeked id routes to
+        // it, the signature verifies, and order binding then rejects the
+        // amount mismatch (post-signature `wrong_order`).
+        let order = burn_order();
+        let (ka, kb) = (ed_key(11), ed_key(22));
+        let federation = vec![ka.verifying_key(), kb.verifying_key()];
+        let provider = Arc::new(FederationAttestationProvider::new_bth_for_test(
+            &federation,
+            2,
+            ka.clone(),
+        ));
+
+        let kind = FederationAttestationProvider::release_kind_for_test(&order);
+        let now = chrono::Utc::now().timestamp().max(0) as u64;
+        let env =
+            bth_bridge_core::sign_attestation_ed25519(&kind, &ka, "adv-wrong", now, now + 120)
+                .unwrap();
+
+        // Persist a tampered copy under the same order id (fee changed so the
+        // net amount differs from the signed envelope).
+        let mut tampered = order.clone();
+        tampered.fee = order.fee + 1;
+        assert_ne!(tampered.net_amount(), order.net_amount());
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        db.insert_order(&tampered).unwrap();
+        let (url, sd, srv) = spawn_endpoint(provider.clone(), db).await;
+
+        let (status, body) =
+            post_attest(&url, Some(AUTH), &serde_json::to_string(&env).unwrap()).await;
+        assert_eq!(status, 409, "{body}");
+        assert!(body.contains("wrong_order"), "{body}");
+        assert_eq!(
+            provider.distinct_signers_for_test(order.id, "bridge.release_bth"),
+            0
+        );
+
+        // A completely absent order id routes to a 404 (unknown_order).
+        let absent = burn_order();
+        let kind2 = FederationAttestationProvider::release_kind_for_test(&absent);
+        let env2 =
+            bth_bridge_core::sign_attestation_ed25519(&kind2, &ka, "adv-absent", now, now + 120)
+                .unwrap();
+        let (status, body) =
+            post_attest(&url, Some(AUTH), &serde_json::to_string(&env2).unwrap()).await;
+        assert_eq!(status, 404, "{body}");
+        assert!(body.contains("unknown_order"), "{body}");
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+
+    #[tokio::test]
+    async fn endpoint_rejects_replayed_envelope() {
+        let order = burn_order();
+        let (url, provider, sd, srv, ka, _kb) = single_node_endpoint(&order).await;
+
+        let kind = FederationAttestationProvider::release_kind_for_test(&order);
+        let now = chrono::Utc::now().timestamp().max(0) as u64;
+        let env =
+            bth_bridge_core::sign_attestation_ed25519(&kind, &ka, "adv-replay", now, now + 120)
+                .unwrap();
+        let body = serde_json::to_string(&env).unwrap();
+
+        // First submission accepted.
+        let (status, resp) = post_attest(&url, Some(AUTH), &body).await;
+        assert_eq!(status, 200, "{resp}");
+        assert!(resp.contains("accepted"), "{resp}");
+        assert_eq!(
+            provider.distinct_signers_for_test(order.id, "bridge.release_bth"),
+            1
+        );
+
+        // The SAME envelope again: the durable nonce reserve rejects it.
+        let (status, resp) = post_attest(&url, Some(AUTH), &body).await;
+        assert_eq!(status, 409, "{resp}");
+        assert!(resp.contains("replayed_nonce"), "{resp}");
+        // Still exactly one distinct signer — the replay never double-counts.
+        assert_eq!(
+            provider.distinct_signers_for_test(order.id, "bridge.release_bth"),
+            1
+        );
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+
+    #[tokio::test]
+    async fn endpoint_rejects_bad_bearer() {
+        let order = burn_order();
+        let (url, provider, sd, srv, ka, _kb) = single_node_endpoint(&order).await;
+
+        let kind = FederationAttestationProvider::release_kind_for_test(&order);
+        let now = chrono::Utc::now().timestamp().max(0) as u64;
+        let env = bth_bridge_core::sign_attestation_ed25519(&kind, &ka, "adv-auth", now, now + 120)
+            .unwrap();
+        let body = serde_json::to_string(&env).unwrap();
+
+        // Wrong token: 401 BEFORE any signature work.
+        let (status, resp) = post_attest(&url, Some("wrong"), &body).await;
+        assert_eq!(status, 401, "{resp}");
+        // No token at all: 401.
+        let (status, _resp) = post_attest(&url, None, &body).await;
+        assert_eq!(status, 401);
+        // Nothing was ingested.
+        assert_eq!(
+            provider.distinct_signers_for_test(order.id, "bridge.release_bth"),
+            0
+        );
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+}

--- a/bridge/service/src/main.rs
+++ b/bridge/service/src/main.rs
@@ -18,6 +18,7 @@ mod attestation;
 mod chaos_tests;
 mod db;
 mod engine;
+mod federation;
 #[cfg(test)]
 mod fork_tests;
 mod mint;


### PR DESCRIPTION
Closes #858

The KEYSTONE of the Phase-4 bridge milestone (#865): the #824 attestation pipeline was complete and tested, but envelopes only ever reached a node from its OWN local signer (peers were injected directly in tests), so any threshold > 1 never authorized in production. This wires envelope exchange between the t-of-n validator bridge nodes (ADR 0002) over a real, authenticated transport.

Envelopes are self-authenticating — a signature over domain-separated bytes plus a single-use replay nonce, verified fail-closed regardless of how they arrive — so the transport adds integrity/anti-DoS but NOT confidentiality. The endpoint is pure transport in front of the existing verify pipeline; it never weakens verification.

## Implemented

- **Inbound endpoint** (`bridge/service/src/federation.rs`): authenticated `POST /api/attest` that
  1. gates on a shared bearer secret (anti-DoS, before any signature work),
  2. peeks the (unverified) order id purely to route to the on-record order (new `peek_order_id` in `bridge/core/src/attestation.rs`),
  3. hands the RECEIVED envelope + order to `FederationAttestationProvider::submit_attestation` — the full fail-closed pipeline (signer selection → signature → parse-after-verify → freshness → durable nonce reserve → order binding → aggregation).
  The verdict maps to HTTP status (200 accepted / 202 benign / 400 malformed·bad-sig·unknown-signer / 401 bad bearer / 404 unknown order / 409 replay·wrong-order·stale / 503 internal).
- **Outbound push** (`PeerBroadcaster`): when a node self-attests (mint or release) it pushes the accepted envelope to every configured peer's inbound endpoint. Fire-and-forget — a slow/unreachable peer never wedges or fails the local authorize path (the peer self-attests and pushes back; re-authorization re-pushes). Minimal raw-socket HTTP/1.1 client (no new dependency).
- **Ethereum Safe nonce**: the provider stamps its Ethereum self-attestation with the set's `safe_nonce()` and pushes THAT envelope, so peers bind the SAME Safe nonce; a peer whose set already pinned a different nonce refuses (`refused:invalid_payload`) rather than mixing incompatible signatures. Coordinates with the #848/#849 stale-nonce seam without regressing it.
- **Config**: new `[federation]` section (`peers`, `attest_listen`, `inbound_auth_token`, `peer_auth_token`, `peer_push_timeout_secs`). Legacy configs parse with safe defaults (transport disabled → fail-safe).
- **Engine wiring** (`bridge/service/src/engine.rs`): the concrete provider is shared between the `OrderProcessor` and the inbound endpoint; `PeerBroadcaster` is attached when peers are configured; the endpoint is spawned when a listen address is set. Empty listen / no peers = fail-safe (threshold > 1 never authorizes).
- Retired the `TODO(#858)` / `TODO(federation transport)` markers.

## Deferred

- BTH / Solana chain transports for the payload SUBMISSION side remain stubbed elsewhere (#856/#857/#853) — out of scope; this issue is envelope transport between federation nodes, which is chain-agnostic and covers Ethereum + BTH + Solana attestations uniformly.
- mTLS is left to a reverse-proxy / transport layer in front of the plain endpoint for v1 (the doc comments call this out); the bearer fence + self-authenticating envelopes are the v1 posture the issue explicitly permits.
- Pull-based "request missing envelopes on a threshold miss" is not implemented; push + periodic re-authorization (which re-pushes) already converges to threshold. Noted as an optional follow-up.

## Test Plan

- `cargo test -p bth-bridge-core -p bth-bridge-service` — 66 core + 140 service tests pass (0 failed).
- **2-node no-injection DoD** (`federation_transport_tests`): two providers, each with its own DB + real inbound endpoint + real `PeerBroadcaster` to the other; envelopes travel over the wire (bound listeners break the endpoint/provider cycle). `two_node_release_authorizes_over_the_wire_no_injection` and `two_node_eth_mint_authorizes_over_the_wire_no_injection` both reach threshold 2 and produce authorizations that satisfy the downstream release validator / are Safe-owner signatures over the shared-nonce SafeTx digest. No test calls `AttestationSet::insert` across nodes.
- **Adversarial endpoint tests**: replayed envelope (409 `replayed_nonce`, never double-counts), wrong-order (409 `wrong_order`) + unknown-order (404), unknown signer (400 `unknown_signer`, not counted), bad/missing bearer (401 before any signature work).
- `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets` — clean.
- `cargo +nightly-2025-12-03 fmt --check` — clean.
- No new dependencies → `Cargo.lock` / `deny.toml` untouched (`cargo deny` not required).

Scope: `bridge/` only. Does not modify the main worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)