### PR TITLE
bridge: live reserve transports — Solana getTokenSupply + BTH reserve-address balance (#853)

### DIFF
--- a/bridge/service/src/bth_fork_tests.rs
+++ b/bridge/service/src/bth_fork_tests.rs
@@ -142,3 +142,29 @@ async fn bth_node_rpc_round_trips() {
         .expect("chain_areKeyImagesSpent");
     assert!(statuses.is_empty());
 }
+
+/// #853: the production [`crate::reserve::NodeReserveBalanceSource`] scans the
+/// live reserve window, drops spent/pending outputs, and sums the actual
+/// spendable factor-1 reserve balance — the custody leg of the reconciler.
+/// Proves `reserve_balance()` runs end-to-end against a real node without a
+/// mock (the sum depends on the funded reserve state the operator drives).
+#[tokio::test]
+#[ignore = "requires a live BTH node (set BRIDGE_BTH_RPC_URL + reserve key files)"]
+async fn bth_node_reserve_balance_reads_live_reserve() {
+    use crate::reserve::{NodeReserveBalanceSource, ReserveBalanceSource};
+
+    let Some(config) = live_config() else {
+        eprintln!(
+            "SKIP: set BRIDGE_BTH_RPC_URL, BRIDGE_BTH_RESERVE_VIEW_KEY, \
+             BRIDGE_BTH_RESERVE_SPEND_KEY to run this live-node test"
+        );
+        return;
+    };
+
+    let source = NodeReserveBalanceSource::new(config);
+    let balance = source
+        .reserve_balance()
+        .await
+        .expect("reserve_balance scans the live reserve window without error");
+    eprintln!("live reserve balance: {balance} picocredits (unspent factor-1)");
+}

--- a/bridge/service/src/mint/solana.rs
+++ b/bridge/service/src/mint/solana.rs
@@ -179,7 +179,7 @@ pub fn build_bridge_mint_instruction(
 /// Byte offset of the `mint: Pubkey` field inside the `Bridge` account:
 /// 8-byte Anchor discriminator + mint_authority(32) + admin_authority(32) +
 /// pauser_authority(32).
-const BRIDGE_MINT_OFFSET: usize = 8 + 32 + 32 + 32;
+pub const BRIDGE_MINT_OFFSET: usize = 8 + 32 + 32 + 32;
 
 /// Extract the wBTH mint pubkey from raw `Bridge` account data (#850 layout).
 pub fn parse_bridge_mint(data: &[u8]) -> Result<Pubkey, MintError> {

--- a/bridge/service/src/reserve.rs
+++ b/bridge/service/src/reserve.rs
@@ -77,7 +77,14 @@ use std::{sync::Arc, time::Duration};
 use tokio::sync::broadcast;
 use tracing::{debug, error, info, warn};
 
-use crate::db::{Database, ReserveSnapshot};
+use crate::{
+    bth_keys::ReserveKeys,
+    bth_rpc::BthNodeRpc,
+    bth_scan::{scan_deposit_output, OwnedOutput},
+    db::{Database, ReserveSnapshot},
+    mint::solana::{parse_bridge_mint, BRIDGE_PDA_SEED},
+    solana_rpc::{HttpSolanaRpc, Pubkey, SolanaRpc},
+};
 
 sol! {
     /// ERC-20 supply surface of the wBTH token
@@ -170,22 +177,75 @@ impl SupplySource for EthSupplySource {
     }
 }
 
-/// Solana supply source: wBTH SPL `Mint.supply` via `getTokenSupply`
-/// (12-decimal mint, 1:1 with picocredits).
+/// Solana supply source: wBTH SPL `Mint.supply` via `getTokenSupply` (#853).
 ///
-/// TODO(#853): implement against `SolanaConfig::rpc_url`. Until then this
-/// is a fail-safe stub: the reconciler reports Solana as UNVERIFIED (its
-/// DB-expected backing is excluded from drift math) rather than silently
-/// healthy.
+/// The wBTH SPL mint carries 12 decimals, so its raw supply (the
+/// `getTokenSupply` `amount`) is already in picocredits, 1:1 with the
+/// Ethereum leg. The mint address is not configured directly; it is the
+/// `mint` field of the on-chain `Bridge` PDA (`seeds = [b"bridge"]` under
+/// `solana.wbth_program`), the same source of truth [`crate::mint::solana`]
+/// resolves before every mint. Any transport/RPC failure surfaces as
+/// [`ReserveError::Rpc`], leaving the Solana leg UNVERIFIED (excluded from
+/// drift math) rather than reporting a false-healthy peg.
 pub struct SolSupplySource {
-    #[allow(dead_code)]
-    config: SolanaConfig,
+    rpc: Arc<dyn SolanaRpc>,
+    /// The bridge state PDA whose `mint` field names the wBTH mint.
+    bridge_pda: Pubkey,
+    commitment: String,
 }
 
 impl SolSupplySource {
-    /// Build a source from configuration. Does not perform network I/O.
-    pub fn new(config: SolanaConfig) -> Self {
-        Self { config }
+    /// Build a source from configuration. Does not perform network I/O. A
+    /// misconfiguration (empty/invalid `wbth_program`, unreachable-URL parse)
+    /// surfaces as [`ReserveError::Config`]; `from_config` maps that onto an
+    /// UNVERIFIED Solana leg (fail-safe), never a silent pass.
+    pub fn new(config: &SolanaConfig) -> Result<Self, ReserveError> {
+        if config.wbth_program.is_empty() {
+            return Err(ReserveError::Config(
+                "solana.wbth_program is empty".to_string(),
+            ));
+        }
+        let program_id = Pubkey::from_base58(&config.wbth_program)
+            .map_err(|e| ReserveError::Config(format!("invalid solana.wbth_program: {}", e)))?;
+        let (bridge_pda, _bump) = Pubkey::find_program_address(&[BRIDGE_PDA_SEED], &program_id)
+            .ok_or_else(|| ReserveError::Config("could not derive bridge PDA".to_string()))?;
+        let rpc: Arc<dyn SolanaRpc> = Arc::new(
+            HttpSolanaRpc::new(config.rpc_url.clone())
+                .map_err(|e| ReserveError::Config(format!("invalid solana rpc_url: {}", e)))?,
+        );
+        Ok(Self {
+            rpc,
+            bridge_pda,
+            commitment: commitment_str(config.commitment).to_string(),
+        })
+    }
+
+    /// Test/DI constructor: inject a mock transport and an already-derived
+    /// bridge PDA.
+    #[cfg(test)]
+    pub fn with_rpc(rpc: Arc<dyn SolanaRpc>, bridge_pda: Pubkey, commitment: String) -> Self {
+        Self {
+            rpc,
+            bridge_pda,
+            commitment,
+        }
+    }
+
+    /// Resolve the wBTH mint address from the on-chain `Bridge` account (its
+    /// `mint` field is the source of truth, set at `initialize`).
+    async fn resolve_mint(&self) -> Result<Pubkey, ReserveError> {
+        let data = self
+            .rpc
+            .get_account_data(&self.bridge_pda.to_base58(), &self.commitment)
+            .await
+            .map_err(ReserveError::Rpc)?
+            .ok_or_else(|| {
+                ReserveError::Rpc(format!(
+                    "bridge account {} not found — is the program initialized?",
+                    self.bridge_pda.to_base58()
+                ))
+            })?;
+        parse_bridge_mint(&data).map_err(|e| ReserveError::Rpc(e.to_string()))
     }
 }
 
@@ -196,9 +256,11 @@ impl SupplySource for SolSupplySource {
     }
 
     async fn wrapped_supply(&self) -> Result<u128, ReserveError> {
-        Err(ReserveError::NotImplemented(
-            "Solana getTokenSupply transport pending #853".to_string(),
-        ))
+        let mint = self.resolve_mint().await?;
+        self.rpc
+            .get_token_supply(&mint.to_base58(), &self.commitment)
+            .await
+            .map_err(ReserveError::Rpc)
     }
 }
 
@@ -213,31 +275,190 @@ pub trait ReserveBalanceSource: Send + Sync {
     async fn reserve_balance(&self) -> Result<u128, ReserveError>;
 }
 
-/// Live BTH reserve-balance source.
+/// How many recent blocks to scan for reserve-owned outputs. Mirrors
+/// [`crate::release::bth`]'s reserve window: the reserve holds a bounded set
+/// of factor-1 outputs and this covers realistic reserve depth cheaply.
+const RESERVE_SCAN_WINDOW: u64 = 10_000;
+
+/// Live BTH reserve-balance source (#853).
 ///
-/// TODO(#853): implement against the BTH node transport (view-key scan of
-/// reserve-address outputs, the same wiring as `watchers::bth`). Until
-/// then this is a fail-safe stub: the custody check is SKIPPED and
-/// `reserveBalanceChecked` stays false — never a silent pass.
+/// View-key-scans the recent reserve window (`chain_getOutputs` over
+/// `BthConfig::rpc_url`) for factor-1, reserve-owned outputs — the exact
+/// [`crate::bth_scan::scan_deposit_output`] primitive the deposit watcher and
+/// the [`crate::release::bth::BthReleaser`] use — drops any output whose key
+/// image is already spent/pending (`chain_areKeyImagesSpent`), and sums the
+/// remaining unspent amounts. That sum is the ACTUAL spendable reserve
+/// balance the reconciler's custody leg compares against the ledger.
+///
+/// Only factor-1 outputs count: a factor-1-only reserve is the peg backing
+/// (ADR 0003), and only factor-1 outputs are ever releasable, so this is the
+/// balance that must cover outstanding wBTH.
+///
+/// Without configured reserve keys (`view_key_file` / `spend_key_file`), or
+/// on any RPC failure, the source returns `NotImplemented` / `Rpc` and the
+/// custody leg stays UNVERIFIED (`reserveBalanceChecked` false) — never a
+/// silent healthy pass.
 pub struct NodeReserveBalanceSource {
-    #[allow(dead_code)]
-    config: BthConfig,
+    rpc: Arc<BthNodeRpc>,
+    reserve: Option<ReserveKeys>,
+    build_error: Option<String>,
 }
 
 impl NodeReserveBalanceSource {
     /// Build a source from configuration. Does not perform network I/O.
+    ///
+    /// A malformed `rpc_url` or key file is remembered and surfaced as
+    /// `Config` on every poll (the leg stays unverified) rather than
+    /// panicking or silently passing.
     pub fn new(config: BthConfig) -> Self {
-        Self { config }
+        let (rpc, build_error) = match BthNodeRpc::new(config.rpc_url.clone()) {
+            Ok(rpc) => (Arc::new(rpc), None),
+            Err(e) => (
+                // A placeholder client that will never be used (build_error is
+                // set, so every poll short-circuits before touching it).
+                Arc::new(BthNodeRpc::new("http://invalid.invalid").expect("static url")),
+                Some(e.to_string()),
+            ),
+        };
+        let reserve = match ReserveKeys::load(
+            config.view_key_file.as_deref(),
+            config.spend_key_file.as_deref(),
+        ) {
+            Ok(keys) => keys,
+            Err(e) => {
+                return Self {
+                    rpc,
+                    reserve: None,
+                    build_error: Some(build_error.unwrap_or(e)),
+                }
+            }
+        };
+        Self {
+            rpc,
+            reserve,
+            build_error,
+        }
+    }
+
+    /// Test/DI constructor: inject a client and reserve keys directly.
+    #[cfg(test)]
+    pub fn with_parts(rpc: Arc<BthNodeRpc>, reserve: Option<ReserveKeys>) -> Self {
+        Self {
+            rpc,
+            reserve,
+            build_error: None,
+        }
     }
 }
 
 #[async_trait]
 impl ReserveBalanceSource for NodeReserveBalanceSource {
     async fn reserve_balance(&self) -> Result<u128, ReserveError> {
-        Err(ReserveError::NotImplemented(
-            "BTH reserve-address balance transport pending #853".to_string(),
-        ))
+        if let Some(e) = &self.build_error {
+            return Err(ReserveError::Config(e.clone()));
+        }
+        // Watch-only (no reserve keys): the custody leg is genuinely
+        // uncheckable, so report NotImplemented (leg stays unverified).
+        let Some(reserve) = self.reserve.as_ref() else {
+            return Err(ReserveError::NotImplemented(
+                "BTH reserve-balance check disabled: bth.view_key_file / spend_key_file \
+                 not configured"
+                    .to_string(),
+            ));
+        };
+        let account = reserve.account();
+
+        let tip = self
+            .rpc
+            .chain_tip()
+            .await
+            .map_err(|e| ReserveError::Rpc(e.to_string()))?;
+        let start = tip.saturating_sub(RESERVE_SCAN_WINDOW);
+        let blocks = self
+            .rpc
+            .get_outputs(start, tip)
+            .await
+            .map_err(|e| ReserveError::Rpc(e.to_string()))?;
+
+        // Reserve-owned, factor-1 outputs (the peg backing, ADR 0003).
+        let mut owned: Vec<OwnedOutput> = Vec::new();
+        for block in &blocks {
+            for out in &block.outputs {
+                match scan_deposit_output(out, account).map_err(ReserveError::Config)? {
+                    Some(scanned) if scanned.owned.factor_one => owned.push(scanned.owned),
+                    _ => {}
+                }
+            }
+        }
+
+        if owned.is_empty() {
+            return Ok(0);
+        }
+
+        // Drop already-spent / pending outputs so the balance reflects only
+        // UNSPENT reserve value (the same double-spend guard the releaser
+        // uses before selecting inputs).
+        let key_images: Vec<String> = owned
+            .iter()
+            .map(|o| reserve_output_key_image(account, o))
+            .collect::<Result<_, _>>()?;
+        let statuses = self
+            .rpc
+            .are_key_images_spent(&key_images)
+            .await
+            .map_err(|e| ReserveError::Rpc(e.to_string()))?;
+
+        Ok(sum_unspent_reserve_balance(&owned, &statuses))
     }
+}
+
+/// Sum the amounts of `owned` reserve outputs whose key-image `statuses`
+/// (positionally aligned) report neither spent nor pending. The pure core of
+/// [`NodeReserveBalanceSource::reserve_balance`], unit-testable without a live
+/// node. A status shorter than `owned` conservatively treats the missing
+/// entries as spent (excluded), never overcounting the reserve.
+fn sum_unspent_reserve_balance(
+    owned: &[OwnedOutput],
+    statuses: &[crate::bth_rpc::KeyImageStatus],
+) -> u128 {
+    owned
+        .iter()
+        .zip(statuses)
+        .filter(|(_, s)| !s.spent && !s.pending)
+        .map(|(o, _)| o.amount as u128)
+        .sum()
+}
+
+/// Derive the key image of a reserve-owned output (node-identical), for the
+/// spent-status query. Reuses `recover_spend_key` + `KeyImage::from`, exactly
+/// what the node records in its double-spend set (mirrors the releaser's
+/// `release_input_key_image`).
+fn reserve_output_key_image(
+    account: &bth_account_keys::AccountKey,
+    owned: &OwnedOutput,
+) -> Result<String, ReserveError> {
+    use bth_crypto_ring_signature::KeyImage;
+    use bth_transaction_clsag::TxOutput;
+
+    let target_key: [u8; 32] = hex::decode(&owned.target_key)
+        .ok()
+        .and_then(|b| b.try_into().ok())
+        .ok_or_else(|| ReserveError::Config("owned output target_key not 32 bytes".into()))?;
+    let public_key: [u8; 32] = hex::decode(&owned.public_key)
+        .ok()
+        .and_then(|b| b.try_into().ok())
+        .ok_or_else(|| ReserveError::Config("owned output public_key not 32 bytes".into()))?;
+    let tx_out = TxOutput {
+        amount: owned.amount,
+        target_key,
+        public_key,
+        e_memo: None,
+        cluster_tags: Default::default(),
+    };
+    let onetime = tx_out
+        .recover_spend_key(account, owned.subaddress_index)
+        .ok_or_else(|| ReserveError::Config("cannot recover reserve one-time key".into()))?;
+    Ok(hex::encode(KeyImage::from(&onetime).as_bytes()))
 }
 
 /// Per-chain reconciliation detail in a [`ReserveProof`].
@@ -328,7 +549,13 @@ impl Reconciler {
             Ok(source) => supplies.push(Arc::new(source)),
             Err(e) => warn!("Ethereum supply polling disabled: {}", e),
         }
-        supplies.push(Arc::new(SolSupplySource::new(config.solana.clone())));
+        match SolSupplySource::new(&config.solana) {
+            Ok(source) => supplies.push(Arc::new(source)),
+            // A misconfigured Solana source is simply absent this pass; the
+            // Solana leg is then reported unverified (its DB-expected backing
+            // excluded from drift math), never silently healthy.
+            Err(e) => warn!("Solana supply polling disabled: {}", e),
+        }
 
         let mut reconciler = Self::new(
             db,
@@ -541,6 +768,17 @@ fn unverified_status(chain: Chain, locked: u64, in_flight: u64) -> ChainReserveS
 
 fn clamp_i64(v: i128) -> i64 {
     i64::try_from(v).unwrap_or(if v < 0 { i64::MIN } else { i64::MAX })
+}
+
+/// The JSON-RPC commitment string for a [`SolanaCommitment`] (the wire value
+/// `getTokenSupply` / `getAccountInfo` expect).
+fn commitment_str(commitment: bth_bridge_core::SolanaCommitment) -> &'static str {
+    use bth_bridge_core::SolanaCommitment::*;
+    match commitment {
+        Processed => "processed",
+        Confirmed => "confirmed",
+        Finalized => "finalized",
+    }
 }
 
 #[cfg(test)]
@@ -953,6 +1191,230 @@ mod tests {
                 .apply_release_spend(&Uuid::new_v4(), Chain::Ethereum, over)
                 .is_err());
         }
+    }
+
+    // === #853: live-transport source tests against mocked RPC ===
+
+    use crate::{
+        bth_rpc::KeyImageStatus,
+        mint::solana::BRIDGE_MINT_OFFSET,
+        solana_rpc::{SignatureState, SolanaRpc},
+    };
+    use bth_account_keys::AccountKey;
+    use bth_transaction_clsag::TxOutput;
+
+    /// A mock Solana RPC that serves a `Bridge` account (naming the wBTH mint)
+    /// and a programmable `getTokenSupply`.
+    struct MockSolanaRpc {
+        bridge_account: Mutex<Option<Vec<u8>>>,
+        token_supply: Mutex<Result<u128, String>>,
+    }
+
+    impl MockSolanaRpc {
+        fn new(mint: Pubkey, supply: u128) -> Arc<Self> {
+            let mut data = vec![0u8; BRIDGE_MINT_OFFSET];
+            data.extend_from_slice(&mint.0);
+            data.extend_from_slice(&[0u8; 100]);
+            Arc::new(Self {
+                bridge_account: Mutex::new(Some(data)),
+                token_supply: Mutex::new(Ok(supply)),
+            })
+        }
+
+        fn set_supply_err(&self, e: &str) {
+            *self.token_supply.lock().unwrap() = Err(e.to_string());
+        }
+
+        fn clear_bridge_account(&self) {
+            *self.bridge_account.lock().unwrap() = None;
+        }
+    }
+
+    #[async_trait]
+    impl SolanaRpc for MockSolanaRpc {
+        async fn get_latest_blockhash(&self) -> Result<([u8; 32], u64), String> {
+            Ok(([0u8; 32], 0))
+        }
+        async fn send_transaction(&self, _raw: &[u8]) -> Result<String, String> {
+            Err("unused".to_string())
+        }
+        async fn get_signature_status(&self, _s: &str) -> Result<SignatureState, String> {
+            Ok(SignatureState::Unknown)
+        }
+        async fn get_account_data(
+            &self,
+            _address: &str,
+            _commitment: &str,
+        ) -> Result<Option<Vec<u8>>, String> {
+            Ok(self.bridge_account.lock().unwrap().clone())
+        }
+        async fn get_signatures_for_address(
+            &self,
+            _a: &str,
+            _u: Option<&str>,
+            _c: &str,
+        ) -> Result<Vec<(String, u64)>, String> {
+            Ok(vec![])
+        }
+        async fn get_transaction_logs(
+            &self,
+            _s: &str,
+            _c: &str,
+        ) -> Result<Option<(Vec<String>, u64)>, String> {
+            Ok(None)
+        }
+        async fn get_token_supply(&self, _mint: &str, _commitment: &str) -> Result<u128, String> {
+            self.token_supply.lock().unwrap().clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sol_supply_source_resolves_mint_and_reports_supply() {
+        // The source resolves the wBTH mint from the Bridge account then reads
+        // getTokenSupply (raw base units == picocredits at 12 decimals).
+        let mint = Pubkey([7u8; 32]);
+        let rpc = MockSolanaRpc::new(mint, 4_200_000_000_000);
+        let source =
+            SolSupplySource::with_rpc(rpc.clone(), Pubkey([1u8; 32]), "finalized".to_string());
+
+        assert_eq!(source.chain(), Chain::Solana);
+        assert_eq!(source.wrapped_supply().await.unwrap(), 4_200_000_000_000);
+
+        // getTokenSupply RPC failure -> Rpc error (leg left unverified, never
+        // a false zero).
+        rpc.set_supply_err("connection reset");
+        assert!(matches!(
+            source.wrapped_supply().await,
+            Err(ReserveError::Rpc(_))
+        ));
+
+        // A missing Bridge account (program not initialized) is also an Rpc
+        // error, not a silent supply.
+        let rpc2 = MockSolanaRpc::new(mint, 1);
+        rpc2.clear_bridge_account();
+        let source2 = SolSupplySource::with_rpc(rpc2, Pubkey([1u8; 32]), "finalized".to_string());
+        assert!(matches!(
+            source2.wrapped_supply().await,
+            Err(ReserveError::Rpc(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_sol_supply_source_verifies_solana_leg_in_reconciler() {
+        // A live (mocked) Solana source makes the Solana leg VERIFY instead of
+        // being reported unverified: an exact match is healthy.
+        let db = setup_db();
+        lock(&db, Chain::Solana, 2_000);
+
+        let mint = Pubkey([9u8; 32]);
+        let rpc = MockSolanaRpc::new(mint, 2_000);
+        let sol: Arc<dyn SupplySource> = Arc::new(SolSupplySource::with_rpc(
+            rpc,
+            Pubkey([1u8; 32]),
+            "finalized".to_string(),
+        ));
+        let reconciler = Reconciler::new(db.clone(), vec![sol], None, 0);
+
+        let proof = reconciler.reconcile_once().await.unwrap();
+        assert_eq!(proof.sol_supply, Some(2_000));
+        assert_eq!(proof.total_wrapped, Some(2_000));
+        assert_eq!(proof.drift, 0);
+        assert!(proof.peg_healthy);
+        let sol_status = proof.chains.iter().find(|c| c.chain == "solana").unwrap();
+        assert!(sol_status.verified, "Solana leg must now VERIFY");
+    }
+
+    /// Build a reserve `OwnedOutput` (via the real scan path) for a factor-1
+    /// output the reserve owns, so its key-image derivation matches the node.
+    fn reserve_owned(reserve: &AccountKey, amount: u64, tag: &str) -> OwnedOutput {
+        use crate::bth_rpc::RpcOutput;
+        let out = TxOutput::new(amount, &reserve.default_subaddress());
+        let rpc = RpcOutput {
+            tx_hash: tag.to_string(),
+            output_index: 0,
+            target_key: hex::encode(out.target_key),
+            public_key: hex::encode(out.public_key),
+            amount,
+            cluster_tags: vec![],
+            e_memo: None,
+        };
+        scan_deposit_output(&rpc, reserve).unwrap().unwrap().owned
+    }
+
+    #[test]
+    fn test_sum_unspent_reserve_balance_excludes_spent_and_pending() {
+        use rand::SeedableRng;
+        let mut rng = rand::rngs::StdRng::from_seed([31u8; 32]);
+        let reserve = AccountKey::random(&mut rng);
+
+        let owned = vec![
+            reserve_owned(&reserve, 1_000, "a"),
+            reserve_owned(&reserve, 2_000, "b"),
+            reserve_owned(&reserve, 4_000, "c"),
+        ];
+        let unspent = KeyImageStatus {
+            spent: false,
+            pending: false,
+        };
+        let spent = KeyImageStatus {
+            spent: true,
+            pending: false,
+        };
+        let pending = KeyImageStatus {
+            spent: false,
+            pending: true,
+        };
+
+        // All unspent: full sum.
+        assert_eq!(
+            sum_unspent_reserve_balance(&owned, &[unspent, unspent, unspent]),
+            7_000
+        );
+        // The 2_000 output is spent, the 4_000 is pending: only 1_000 counts.
+        assert_eq!(
+            sum_unspent_reserve_balance(&owned, &[unspent, spent, pending]),
+            1_000
+        );
+        // A short status vector never overcounts (missing entries excluded).
+        assert_eq!(sum_unspent_reserve_balance(&owned, &[unspent]), 1_000);
+    }
+
+    #[test]
+    fn test_reserve_output_key_image_is_deterministic_and_node_identical() {
+        use rand::SeedableRng;
+        let mut rng = rand::rngs::StdRng::from_seed([37u8; 32]);
+        let reserve = AccountKey::random(&mut rng);
+        let owned = reserve_owned(&reserve, 5_000, "ki");
+
+        let ki1 = reserve_output_key_image(&reserve, &owned).unwrap();
+        let ki2 = reserve_output_key_image(&reserve, &owned).unwrap();
+        assert_eq!(ki1, ki2, "key image derivation must be deterministic");
+        assert_eq!(ki1.len(), 64, "32-byte key image, hex-encoded");
+    }
+
+    #[tokio::test]
+    async fn test_node_reserve_balance_source_watch_only_is_unverified() {
+        // No reserve keys configured: the custody leg is genuinely uncheckable
+        // and must report NotImplemented (leg stays unverified) — never a
+        // silent healthy pass.
+        let source = NodeReserveBalanceSource::with_parts(
+            Arc::new(BthNodeRpc::new("http://127.0.0.1:1/").unwrap()),
+            None,
+        );
+        assert!(matches!(
+            source.reserve_balance().await,
+            Err(ReserveError::NotImplemented(_))
+        ));
+
+        // Wired into the reconciler, a NotImplemented balance source leaves
+        // reserve_balance_checked false (custody UNCHECKED, not false-healthy).
+        let db = setup_db();
+        lock(&db, Chain::Ethereum, 1_000);
+        let eth = MockSupply::new(Chain::Ethereum, 1_000);
+        let reconciler = Reconciler::new(db.clone(), vec![eth], Some(Arc::new(source)), 0);
+        let proof = reconciler.reconcile_once().await.unwrap();
+        assert!(!proof.reserve_balance_checked);
+        assert!(proof.peg_healthy);
     }
 
     #[test]

--- a/bridge/service/src/solana_devnet_tests.rs
+++ b/bridge/service/src/solana_devnet_tests.rs
@@ -138,3 +138,25 @@ async fn solana_devnet_prepare_mint_against_live_pdas() {
         eprintln!("devnet mint {} status: {:?}", prepared.tx_id, status);
     }
 }
+
+/// Drill (#853): resolve the wBTH mint from the live `Bridge` account and read
+/// its outstanding SPL supply via `getTokenSupply` through the production
+/// [`crate::reserve::SolSupplySource`] — the exact path the reserve reconciler
+/// runs. Proves the Solana leg VERIFIES against a real cluster (12-decimal
+/// mint => picocredits).
+#[tokio::test]
+#[ignore = "requires a live cluster with an initialized wbth program"]
+async fn solana_devnet_reserve_supply_source() {
+    use crate::reserve::{SolSupplySource, SupplySource};
+
+    let Some(config) = config_from_env() else {
+        eprintln!("BRIDGE_SOLANA_RPC_URL unset — skipping");
+        return;
+    };
+    let source = SolSupplySource::new(&config).expect("construct supply source");
+    let supply = source
+        .wrapped_supply()
+        .await
+        .expect("read wBTH supply via getTokenSupply against the live cluster");
+    eprintln!("live wBTH Solana supply: {supply} picocredits");
+}

--- a/bridge/service/src/solana_rpc.rs
+++ b/bridge/service/src/solana_rpc.rs
@@ -398,6 +398,18 @@ pub trait SolanaRpc: Send + Sync {
         signature: &str,
         commitment: &str,
     ) -> Result<Option<(Vec<String>, u64)>, String>;
+
+    /// `getTokenSupply(mint)` at `commitment`, returning the SPL mint's total
+    /// supply in its RAW base units (the `amount` field — an integer scaled by
+    /// the mint's decimals). The wBTH mint carries 12 decimals, matching the
+    /// picocredit base unit, so the raw amount is already in picocredits
+    /// (#853).
+    ///
+    /// A default `NotImplemented`-style error keeps the many mock transports
+    /// in the codebase compiling; the live [`HttpSolanaRpc`] overrides it.
+    async fn get_token_supply(&self, _mint: &str, _commitment: &str) -> Result<u128, String> {
+        Err("getTokenSupply not implemented for this transport".to_string())
+    }
 }
 
 /// A live JSON-RPC client over `reqwest`.
@@ -541,6 +553,13 @@ impl SolanaRpc for HttpSolanaRpc {
             .await?;
         parse_transaction_logs(&result)
     }
+
+    async fn get_token_supply(&self, mint: &str, commitment: &str) -> Result<u128, String> {
+        let result = self
+            .call("getTokenSupply", json!([mint, {"commitment": commitment}]))
+            .await?;
+        parse_token_supply(&result)
+    }
 }
 
 /// Marker string used to signal an idempotent "already processed" broadcast
@@ -656,6 +675,22 @@ pub fn parse_transaction_logs(result: &Value) -> Result<Option<(Vec<String>, u64
         })
         .unwrap_or_default();
     Ok(Some((logs, slot)))
+}
+
+/// Parse a `getTokenSupply` result into the RAW supply (base units), reading
+/// the `value.amount` string (a decimal integer already scaled by the mint's
+/// decimals). The wBTH mint's 12 decimals make this value picocredits (#853).
+pub fn parse_token_supply(result: &Value) -> Result<u128, String> {
+    let value = result
+        .get("value")
+        .ok_or_else(|| "getTokenSupply missing value".to_string())?;
+    let amount = value
+        .get("amount")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "getTokenSupply missing value.amount".to_string())?;
+    amount
+        .parse::<u128>()
+        .map_err(|e| format!("getTokenSupply amount {amount:?} is not a u128: {e}"))
 }
 
 /// Parse a `getAccountInfo` result into the raw account data.
@@ -942,6 +977,30 @@ mod tests {
             pairs,
             vec![("sigA".to_string(), 10), ("sigC".to_string(), 12)]
         );
+    }
+
+    #[test]
+    fn test_parse_token_supply() {
+        // The RPC returns the raw supply as a decimal string under
+        // value.amount (12-decimal wBTH mint => picocredits).
+        let result = json!({
+            "context": {"slot": 100},
+            "value": {"amount": "1500000000000", "decimals": 12, "uiAmount": 1.5, "uiAmountString": "1.5"}
+        });
+        assert_eq!(parse_token_supply(&result).unwrap(), 1_500_000_000_000);
+
+        // Zero supply.
+        let zero = json!({"value": {"amount": "0", "decimals": 12}});
+        assert_eq!(parse_token_supply(&zero).unwrap(), 0);
+
+        // A very large supply still fits u128 (u64::MAX * scale).
+        let big = json!({"value": {"amount": "340282366920938463463374607431768211455"}});
+        assert_eq!(parse_token_supply(&big).unwrap(), u128::MAX);
+
+        // Missing / malformed shapes are errors, never a silent zero.
+        assert!(parse_token_supply(&json!({})).is_err());
+        assert!(parse_token_supply(&json!({"value": {}})).is_err());
+        assert!(parse_token_supply(&json!({"value": {"amount": "not-a-number"}})).is_err());
     }
 
     #[test]


### PR DESCRIPTION
Closes #853

Final Stage-A transport of the Phase-4 bridge milestone (#865): both reconciler legs now verify against a real endpoint instead of returning a fail-safe `NotImplemented` stub. Scope is `bridge/` only.

## Implemented (vs live-gated)

**`SolSupplySource` (implemented, unit-tested against mocked RPC)**
- Reuses the merged #857 `bridge/service/src/solana_rpc.rs` client. Added one method to its `SolanaRpc` trait — `get_token_supply(mint, commitment)` — with a default `NotImplemented`-style body (so the codebase's existing mock transports keep compiling) plus the live `HttpSolanaRpc` override and a pure `parse_token_supply` parser (reads `value.amount` as raw base units).
- Resolves the wBTH mint from the on-chain `Bridge` PDA (`seeds = [b"bridge"]` under `solana.wbth_program`) via `get_account_data` + the reused `parse_bridge_mint` — the same source of truth `mint::solana` resolves before every mint. The 12-decimal mint's raw supply is picocredits, 1:1 with the Ethereum leg.

**`NodeReserveBalanceSource` (implemented, unit-tested against mocked RPC + pure core)**
- Reuses the merged #856 `bth_rpc` + `bth_scan` + `bth_keys`: view-key-scans the recent reserve window with the same `scan_deposit_output` primitive the deposit watcher and `BthReleaser` use, drops spent/pending outputs via `chain_areKeyImagesSpent` (node-identical key-image derivation, mirroring the releaser), and sums the unspent factor-1 reserve balance. The reconciler's custody leg (`reserve_balance_checked`) now verifies actual reserve instead of being skipped.

**Fail-safe preserved (#846):** any RPC/config failure, a missing/uninitialized `Bridge` account, or watch-only mode (no reserve key files) leaves the leg UNVERIFIED — nullable supplies / `reserveBalanceChecked: false` — never a false-healthy peg.

**Live-gated:** end-to-end `getTokenSupply` and reserve-balance drills added `#[ignore]`d and self-skipping in `solana_devnet_tests.rs` / `bth_fork_tests.rs` (run against a real cluster/node per their module docs). The dev environment has no live endpoints, so these were validated by construction + the mocked suites only.

## Test Plan
- `cargo test -p bth-bridge-core -p bth-bridge-service` — 187 + 66 pass, 7 ignored (the two new live drills included). New tests: `parse_token_supply`; `SolSupplySource` resolves mint + reports supply and RPC/missing-account failures surface as `Rpc`; reconciler now VERIFIES the Solana leg against a mock (`sol_status.verified`); `sum_unspent_reserve_balance` excludes spent/pending and never overcounts; `reserve_output_key_image` deterministic + 32-byte; watch-only reserve source stays `reserve_balance_checked: false` + peg_healthy. The existing three-leg + drift + circuit-breaker tests are unchanged and green.
- `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets -- -D warnings` — clean (includes the bth crypto crates).
- `cargo +nightly-2025-12-03 fmt --check` — clean.
- `cargo deny check advisories` — ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)