### PR TITLE
build: enable curve25519-dalek precomputed-tables via cargo feature, not global rustc cfg

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,16 +5,16 @@
 # ...so instead we list all target triples (Tier 1 64-bit platforms)
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"']
 
 [target.x86_64-pc-windows-gnu]
-rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"']
 
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"']
 
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"', '--cfg=feature="precomputed-tables"']
+rustflags = ["-C", "target-cpu=skylake", '--cfg=curve25519_dalek_backend="simd"']
 
 [cargo-new]
 name = "Botho"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,7 +2054,6 @@ dependencies = [
  "clap",
  "ed25519-dalek",
  "hex",
- "k256",
  "proptest",
  "rand 0.8.7",
  "rand_core 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ crc = { version = "3", default-features = false }
 criterion = "0.5"
 crossbeam-channel = "0.5"
 ctr = "0.9"
-curve25519-dalek = { version = "4", default-features = false }
+curve25519-dalek = { version = "4", default-features = false, features = ["precomputed-tables"] }
 der = { version = "0.7", default-features = false }
 digest = { version = "0.10", default-features = false }
 dashmap = "6"

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -33,16 +33,6 @@ alloy = { workspace = true, features = [
     "sol-types",
 ] }
 
-# k256 reaches this crate through alloy; this edge exists ONLY to co-activate
-# `precomputed-tables` (+ its `std` gate) on the shared k256 build unit. The
-# workspace `.cargo/config.toml` injects `--cfg=feature="precomputed-tables"`
-# into every x86_64 build (a curve25519-dalek hack, see #361 and
-# crypto/secp256k1/Cargo.toml): without the REAL feature enabled, that injected
-# cfg makes k256 reference `once_cell` without linking it, so any
-# package-scoped build (`cargo test -p bth-bridge-service`, bridge-ci.yml)
-# fails to compile k256 on x86_64.
-k256 = { version = "0.13", default-features = false, features = ["ecdsa", "std", "precomputed-tables"] }
-
 # BTH release attestation verification (ADR 0002: federation Ed25519
 # signatures, mirroring the operator-signed-action machinery)
 ed25519-dalek = { workspace = true, features = ["std"] }

--- a/crypto/secp256k1/Cargo.toml
+++ b/crypto/secp256k1/Cargo.toml
@@ -14,21 +14,7 @@ default = ["std"]
 std = ["k256/std"]
 
 [dependencies]
-# `critical-section` is activated UNCONDITIONALLY (not behind our `std` feature)
-# on purpose. k256 0.13's `precomputed-tables` feature has a `compile_error!`
-# unless either `std` or `critical-section` is also active. On Linux,
-# `cargo build --workspace` (the #402 gate) pulls a k256 build unit with
-# `precomputed-tables` enabled through the full workspace graph (the Tauri
-# desktop crate's Linux-gated GUI subtree, via libp2p), and that build unit is
-# NOT reached through `bth-crypto-secp256k1`'s feature graph — so a feature we
-# gate behind `std`/`default` never lands on it (the workspace dep edge for this
-# crate is declared `default-features = false`, and resolver v2 does not unify
-# our `std` onto the libp2p-path k256 unit). Because resolver v2 still resolves a
-# single shared k256 build unit per (package, target, build-kind) group, putting
-# `critical-section` directly on this crate's k256 dependency edge co-activates
-# it on that shared unit, satisfying the `precomputed-tables` gate without
-# requiring `std` (so it is robust for no_std targets too). See #361.
-k256 = { version = "0.13", default-features = false, features = ["ecdsa", "schnorr", "alloc", "critical-section"] }
+k256 = { version = "0.13", default-features = false, features = ["ecdsa", "schnorr", "alloc"] }
 sha3 = { workspace = true }
 sha2 = { workspace = true }
 hmac = { workspace = true }


### PR DESCRIPTION
## Summary

`.cargo/config.toml` injected `--cfg=feature="precomputed-tables"` on all four x86_64 target triples — a curve25519-dalek tuning hack expressed as a raw, un-namespaced rustc cfg. That token flips `#[cfg(feature = "precomputed-tables")]` on for **every** crate on the target, including k256 (which has its own same-named feature). When cargo resolves a k256 build unit *without* the real feature (the alloy/libp2p paths), k256 references `once_cell` / requires a `std`|`critical-section` gate that was never linked, so compilation fails (`E0433 unresolved once_cell`). This broke package-scoped x86_64 CI twice (#361, #861), and is invisible on aarch64/macOS where no rustflags are configured.

This PR replaces the leaking rustc cfg with curve25519-dalek's **real cargo feature**, enabled on the workspace dependency edge, and removes the two downstream k256 workarounds it necessitated.

## Changes

- **`.cargo/config.toml`**: removed `--cfg=feature="precomputed-tables"` from all four `[target.x86_64-*]` rustflags. Kept `-C target-cpu=skylake` and the namespaced `--cfg=curve25519_dalek_backend="simd"` (dalek's documented backend knob — cannot collide).
- **`Cargo.toml`**: added `features = ["precomputed-tables"]` to the root `curve25519-dalek` edge (it had `default-features = false` — the root cause that stripped the default-on feature). Feature unification propagates it to every consumer.
- **`crypto/secp256k1/Cargo.toml`**: dropped the `critical-section` k256 co-activation workaround + its comment block (#361). Remaining features: `ecdsa`, `schnorr`, `alloc`.
- **`bridge/service/Cargo.toml`**: dropped the explicit `std`+`precomputed-tables` k256 pin + its comment (#861). k256 reaches this crate transitively via alloy; no direct `k256::` imports exist in its source, so the edge was removed entirely.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `--cfg=feature="precomputed-tables"` removed from all four x86_64 rustflags | ✅ | `.cargo/config.toml` diff — 4 occurrences removed |
| `target-cpu=skylake` + `curve25519_dalek_backend="simd"` remain | ✅ | Both retained on all four triples |
| `precomputed-tables` cargo feature enabled via a real dependency edge | ✅ | `cargo tree -p curve25519-dalek -e features -i` shows `curve25519-dalek feature "precomputed-tables"` active |
| `critical-section` workaround removed (#361) | ✅ | `crypto/secp256k1/Cargo.toml` diff |
| k256 `std`+`precomputed-tables` pin removed (#861) | ✅ | `bridge/service/Cargo.toml` diff |
| `cargo build --workspace` succeeds | ✅ | Green on aarch64 host (warnings only, pre-existing) — see note below |
| `cargo build -p bth-bridge-core -p bth-bridge-service` compiles (#861 selection) | ✅ | Finished clean |
| `cargo build -p bth-crypto-secp256k1` compiles (#361 selection) | ✅ | Finished clean |
| Crypto tests pass unchanged (behavior-preserving) | ✅ | `cargo test -p bth-crypto-secp256k1` — all pass |

## Test Plan

Run locally on this host (aarch64/macOS — **the x86_64 rustflags do not apply here**, so this validates the cargo-feature edge and that the workspace still builds; the x86_64 Linux CI path, especially bridge-ci.yml, is the real validation this fix targets):

- `cargo build --workspace` — succeeds (pre-existing dead-code warnings only)
- `cargo build -p bth-bridge-core -p bth-bridge-service` — compiles clean (the bridge-ci.yml selection from #861)
- `cargo build -p bth-crypto-secp256k1` — compiles clean (the #361 selection)
- `cargo test -p bth-crypto-secp256k1` — all tests pass (behavior-preserving; `precomputed-tables` is a speed/size trade-off, not a correctness feature)
- `cargo tree -p curve25519-dalek -e features -i` — confirms `precomputed-tables` is active on the real edge

**Note for reviewers**: the failure this fixes only manifests on x86_64 (where `.cargo/config.toml` rustflags apply). x86_64 Linux CI — the bridge-ci.yml run that first surfaced the k256/`once_cell` error — is the authoritative check.

Closes #863