### PR TITLE
feat(bridge): warn on non-loopback API bind; guard terminal dest_tx overwrite

### DIFF
--- a/bridge/service/src/api.rs
+++ b/bridge/service/src/api.rs
@@ -26,6 +26,8 @@
 //! to the `audit_log` by the reconciler; this surface serves the compact
 //! snapshots the dashboard renders.
 
+use std::net::ToSocketAddrs;
+
 use axum::{
     extract::State,
     http::StatusCode,
@@ -168,6 +170,35 @@ pub fn router(state: ApiState) -> Router {
         .with_state(state)
 }
 
+/// Classify a bind spec as reachable only from loopback.
+///
+/// Returns `true` when **every** resolved socket address is a loopback IP
+/// (`127.0.0.0/8` for IPv4, `::1` for IPv6) — i.e. the API is only reachable
+/// from the local host. Returns `false` when any resolved address is
+/// non-loopback (`0.0.0.0`, `::`, or a concrete external IP), meaning the
+/// unauthenticated breaker/status surface is exposed beyond localhost.
+///
+/// An address that cannot be resolved is treated as non-loopback (`false`)
+/// so callers err on the side of warning; in practice an unresolvable bind
+/// spec already fails earlier at `TcpListener::bind`, so this only runs on a
+/// successful bind.
+fn is_loopback_bind(addr: &str) -> bool {
+    match addr.to_socket_addrs() {
+        Ok(mut resolved) => {
+            let mut any = false;
+            for sa in resolved.by_ref() {
+                any = true;
+                if !sa.ip().is_loopback() {
+                    return false;
+                }
+            }
+            // No addresses resolved -> cannot confirm loopback -> warn.
+            any
+        }
+        Err(_) => false,
+    }
+}
+
 /// Serve the API until shutdown.
 pub async fn serve(
     addr: String,
@@ -179,6 +210,21 @@ pub async fn serve(
         .await
         .map_err(|e| format!("bind {} failed: {}", addr, e))?;
     info!("Bridge API listening on {}", addr);
+
+    // The breaker/status control surface is unauthenticated; its only defense
+    // is network placement (loopback by default). Warn loudly when the bind
+    // exposes it beyond localhost so an operator who set `0.0.0.0` to scrape
+    // /metrics remotely isn't silently exposing the un-pause kill switch.
+    if !is_loopback_bind(&addr) {
+        warn!(
+            "Bridge API bound to non-loopback address {} — POST /api/breaker is an \
+             UNAUTHENTICATED kill switch (pause/RESUME) and /api/status leaks operational \
+             detail. Anyone who can reach this address can defeat a fail-closed auto-trip \
+             during a peg incident. Put it behind a reverse proxy with auth or restrict access \
+             with firewall rules; see docs/operations/runbooks/bridge-order-engine-recovery.md",
+            addr
+        );
+    }
 
     axum::serve(
         listener,
@@ -408,6 +454,19 @@ mod tests {
             },
             db,
         )
+    }
+
+    #[test]
+    fn test_is_loopback_bind_classification() {
+        // #855: loopback binds must NOT warn.
+        assert!(is_loopback_bind("127.0.0.1:9741"));
+        assert!(is_loopback_bind("127.0.0.5:9741")); // 127.0.0.0/8
+        assert!(is_loopback_bind("[::1]:9741"));
+
+        // Non-loopback binds MUST warn (helper returns false).
+        assert!(!is_loopback_bind("0.0.0.0:9741"));
+        assert!(!is_loopback_bind("[::]:9741"));
+        assert!(!is_loopback_bind("192.0.2.10:9741")); // concrete external IP
     }
 
     #[test]

--- a/bridge/service/src/db.rs
+++ b/bridge/service/src/db.rs
@@ -576,7 +576,13 @@ impl Database {
             _ => None,
         };
 
-        if let Some(hash) = tx_hash {
+        // Defense-in-depth: a same-status write on a terminal order
+        // (`Completed -> Completed`, etc.) must not clobber the recorded
+        // `dest_tx`. `same_status` already passed the transition guard above,
+        // so without this a second call with a different `tx_hash` would
+        // overwrite the settled destination tx. Only refresh the tx hash while
+        // the order is still non-terminal.
+        if let (Some(hash), false) = (tx_hash, current.is_terminal()) {
             // Update with transaction hash
             tx.execute(
                 r#"
@@ -2265,6 +2271,59 @@ mod tests {
         assert_eq!(
             db.get_order(&order.id).unwrap().unwrap().status,
             OrderStatus::MintPending
+        );
+    }
+
+    #[test]
+    fn test_update_order_status_terminal_same_status_preserves_dest_tx() {
+        // #855 defense-in-depth: a `Completed -> Completed` write with a
+        // different tx_hash must NOT overwrite the settled dest_tx.
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_mint_order(&db); // DepositConfirmed
+
+        db.update_order_status(&order.id, &OrderStatus::MintPending, Some("0xtx"))
+            .unwrap();
+        db.update_order_status(&order.id, &OrderStatus::Completed, Some("A"))
+            .unwrap();
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().dest_tx.as_deref(),
+            Some("A")
+        );
+
+        // Same-status write on a terminal order with a different hash must be
+        // a no-op for dest_tx (the tx-hash refresh branch is gated off).
+        db.update_order_status(&order.id, &OrderStatus::Completed, Some("B"))
+            .unwrap();
+        let after = db.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(after.status, OrderStatus::Completed);
+        assert_eq!(
+            after.dest_tx.as_deref(),
+            Some("A"),
+            "terminal same-status write must not clobber the settled dest_tx"
+        );
+    }
+
+    #[test]
+    fn test_update_order_status_nonterminal_same_status_refreshes_dest_tx() {
+        // The terminal guard must not regress the legitimate non-terminal
+        // idempotent refresh: MintPending -> MintPending updates dest_tx.
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let order = setup_mint_order(&db);
+
+        db.update_order_status(&order.id, &OrderStatus::MintPending, Some("A"))
+            .unwrap();
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().dest_tx.as_deref(),
+            Some("A")
+        );
+        db.update_order_status(&order.id, &OrderStatus::MintPending, Some("B"))
+            .unwrap();
+        assert_eq!(
+            db.get_order(&order.id).unwrap().unwrap().dest_tx.as_deref(),
+            Some("B"),
+            "non-terminal same-status refresh must still update dest_tx"
         );
     }
 


### PR DESCRIPTION
## Summary

The bridge HTTP API mounts an **unauthenticated** `POST /api/breaker`
pause/RESUME kill switch alongside read-only monitoring endpoints; its entire
security model is loopback network placement (`api_listen` defaults to
`127.0.0.1:9741`). An operator who edits `reserve.api_listen` to `0.0.0.0:9741`
(a natural move to let a remote Prometheus scrape `/metrics`) previously
exposed the un-pause control to the whole network with **no warning** — the
most dangerous capability being a remote RESUME that defeats a fail-closed
auto-trip mid peg incident.

This PR adds a loud startup `warn!` when the API binds a non-loopback address,
and (defense-in-depth) prevents a terminal same-status write from clobbering
the settled `dest_tx`.

## Changes

- `bridge/service/src/api.rs`: added `is_loopback_bind(&str) -> bool`, a pure,
  unit-testable helper that resolves the bind spec and returns `true` only when
  every resolved address is loopback (`127.0.0.0/8`, `::1`). `serve()` calls it
  after a successful bind and emits a single `warn!` on a non-loopback bind that
  names the address, states the breaker/status endpoints are unauthenticated,
  recommends a reverse proxy with auth or firewall rules, and references
  `docs/operations/runbooks/bridge-order-engine-recovery.md`. The existing
  `info!` is unchanged; no routing/response behavior changes.
- `bridge/service/src/db.rs`: gated the `tx_hash`-refresh branch of
  `update_order_status` on `!current.is_terminal()` so a `Completed -> Completed`
  (or any terminal same-status) write with a different `tx_hash` no longer
  overwrites `dest_tx`. Non-terminal same-status refreshes and all legitimate
  transitions are unaffected.
- Added unit tests: loopback classification (loopback vs `0.0.0.0`/`::`/external
  IP, no socket opened); terminal same-status write preserves `dest_tx`;
  non-terminal same-status refresh still updates `dest_tx`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Non-loopback bind emits a single `warn!` naming the address, noting endpoints are unauthenticated, recommending proxy/firewall, referencing the runbook | ✅ | `warn!` in `serve()`; message reviewed |
| Loopback bind (`127.0.0.1`/`::1`) emits no warning (only existing `info!`) | ✅ | `is_loopback_bind` returns true → branch skipped |
| Classification factored into a small pure, socket-free unit-testable helper | ✅ | `is_loopback_bind` + `test_is_loopback_bind_classification` |
| No behavior change to bind success/failure, routing, or responses (warn-only) | ✅ | Only added a `warn!`; 194 unit tests + full suite pass |
| `update_order_status` no longer overwrites `dest_tx` on terminal same-status write; gated on `!current.is_terminal()` | ✅ | `test_update_order_status_terminal_same_status_preserves_dest_tx` |
| Non-terminal same-status refresh still updates `dest_tx` | ✅ | `test_update_order_status_nonterminal_same_status_refreshes_dest_tx` |

Out of scope (deferred per curator): `api_allow_remote` config flag and the
loopback peer-address restriction on `POST /api/breaker`.

## Test Plan

- `cargo test -p bth-bridge-service` — all pass (new tests included).
- `cargo clippy -p bth-bridge-service` — clean.
- `cargo fmt` applied.

Closes #855