### PR TITLE
fix(bridge): recover Ethereum mints wedged behind a stale Safe nonce

### DIFF
--- a/bridge/core/src/attestation.rs
+++ b/bridge/core/src/attestation.rs
@@ -89,6 +89,21 @@ pub struct MintAuthorization {
     /// Collected validator signatures. Must contain at least `threshold`
     /// entries from distinct signers to be usable.
     pub signatures: Vec<AttestationSignature>,
+
+    /// The Gnosis Safe nonce every collected Ethereum payload signature is
+    /// bound to (`None` for Ed25519 / Solana mints, which are blockhash-bound
+    /// rather than nonce-bound).
+    ///
+    /// The Safe owner signatures were produced over a SafeTx digest that
+    /// includes this nonce; `Safe.execTransaction` only accepts them while it
+    /// is the Safe's *current* on-chain nonce. Carrying it here lets the
+    /// minter cross-check the live nonce **before broadcast** and trigger a
+    /// deliberate re-collection at the fresh nonce instead of broadcasting
+    /// signatures the Safe will reject (see #848). `#[serde(default)]` keeps
+    /// authorizations persisted before this field was added deserializable
+    /// (they decode as `None`).
+    #[serde(default)]
+    pub safe_nonce: Option<u64>,
 }
 
 impl MintAuthorization {
@@ -1388,6 +1403,7 @@ mod tests {
             scheme: SignatureScheme::Secp256k1,
             threshold: 2,
             signatures: vec![sig(1)],
+            safe_nonce: Some(7),
         };
         assert!(!auth.meets_threshold());
 
@@ -1406,10 +1422,30 @@ mod tests {
             scheme: SignatureScheme::Ed25519,
             threshold: 3,
             signatures: vec![sig(1), sig(2)],
+            safe_nonce: None,
         };
         let json = serde_json::to_string(&auth).unwrap();
         let back: MintAuthorization = serde_json::from_str(&json).unwrap();
         assert_eq!(auth, back);
+
+        // Ethereum mint authorizations carry the bound Safe nonce.
+        let eth_auth = MintAuthorization {
+            order_id: [3u8; 32],
+            scheme: SignatureScheme::Secp256k1,
+            threshold: 2,
+            signatures: vec![sig(1), sig(2)],
+            safe_nonce: Some(42),
+        };
+        let json = serde_json::to_string(&eth_auth).unwrap();
+        let back: MintAuthorization = serde_json::from_str(&json).unwrap();
+        assert_eq!(eth_auth, back);
+        assert_eq!(back.safe_nonce, Some(42));
+
+        // Authorizations persisted before `safe_nonce` existed still
+        // deserialize (the field defaults to `None`).
+        let legacy = r#"{"order_id":"0909090909090909090909090909090909090909090909090909090909090909","scheme":"ed25519","threshold":3,"signatures":[]}"#;
+        let back: MintAuthorization = serde_json::from_str(legacy).unwrap();
+        assert_eq!(back.safe_nonce, None);
     }
 
     #[test]

--- a/bridge/service/src/attestation.rs
+++ b/bridge/service/src/attestation.rs
@@ -133,6 +133,7 @@ impl AttestationProvider for StubAttestationProvider {
             scheme,
             threshold: 0,
             signatures: vec![],
+            safe_nonce: None,
         })
     }
 
@@ -314,6 +315,32 @@ fn check_threshold(threshold: u32, n: usize, what: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Reject a federation configured with duplicate signer identities.
+///
+/// Duplicate owner addresses / signer pubkeys inflate the raw list length
+/// `n` used by [`check_threshold`], so a `threshold == padded_n` config would
+/// pass construction yet be unsatisfiable at runtime: the aggregator dedups
+/// by signer identity ([`AttestationSet::insert`]), so the *effective*
+/// federation is smaller than `n` and the threshold can never be reached —
+/// the order wedges forever, fail-safe but silent. Rejecting the misconfig at
+/// construction surfaces it immediately (#848).
+///
+/// `identities` must already be normalized (parsed/trimmed) so that surface
+/// variants like `"0xAbc"` and `"0xabc"` collide on the same canonical bytes.
+fn reject_duplicate_signers<T: Ord + Clone>(identities: &[T], what: &str) -> Result<(), String> {
+    let mut seen = identities.to_vec();
+    seen.sort();
+    if seen.windows(2).any(|w| w[0] == w[1]) {
+        return Err(format!(
+            "{}: duplicate signer identities configured — every federation \
+             member must be distinct (a repeated signer inflates the \
+             configured count and makes a threshold equal to it unsatisfiable)",
+            what
+        ));
+    }
+    Ok(())
+}
+
 /// The signer identity string for an Ethereum owner address: lowercase hex,
 /// no 0x prefix (40 chars).
 fn eth_signer_key_id(address: &Address) -> String {
@@ -333,11 +360,6 @@ impl FederationAttestationProvider {
         let eth = if eth_cfg.mint_signers.is_empty() {
             None
         } else {
-            check_threshold(
-                eth_cfg.mint_threshold,
-                eth_cfg.mint_signers.len(),
-                "ethereum.mint_threshold",
-            )?;
             let mut owners = Vec::with_capacity(eth_cfg.mint_signers.len());
             for s in &eth_cfg.mint_signers {
                 owners.push(
@@ -346,6 +368,14 @@ impl FederationAttestationProvider {
                         .map_err(|e| format!("bad ethereum mint signer {}: {}", s, e))?,
                 );
             }
+            // Dedup on the parsed 20-byte address (not the raw string), so
+            // checksummed / lowercase spellings of one owner collide.
+            reject_duplicate_signers(&owners, "ethereum.mint_signers")?;
+            check_threshold(
+                eth_cfg.mint_threshold,
+                owners.len(),
+                "ethereum.mint_threshold",
+            )?;
             let safe: Address = eth_cfg
                 .safe_address
                 .as_deref()
@@ -373,13 +403,18 @@ impl FederationAttestationProvider {
         let sol = if config.solana.mint_signers.is_empty() {
             None
         } else {
+            let signers = parse_ed25519_federation(&config.solana.mint_signers, "solana mint")?;
+            reject_duplicate_signers(
+                &signers.iter().map(|k| k.to_bytes()).collect::<Vec<_>>(),
+                "solana.mint_signers",
+            )?;
             check_threshold(
                 config.solana.mint_threshold,
-                config.solana.mint_signers.len(),
+                signers.len(),
                 "solana.mint_threshold",
             )?;
             Some(Ed25519Federation {
-                signers: parse_ed25519_federation(&config.solana.mint_signers, "solana mint")?,
+                signers,
                 threshold: config.solana.mint_threshold,
             })
         };
@@ -387,13 +422,18 @@ impl FederationAttestationProvider {
         let bth = if config.bth.release_signers.is_empty() {
             None
         } else {
+            let signers = parse_ed25519_federation(&config.bth.release_signers, "bth release")?;
+            reject_duplicate_signers(
+                &signers.iter().map(|k| k.to_bytes()).collect::<Vec<_>>(),
+                "bth.release_signers",
+            )?;
             check_threshold(
                 config.bth.release_threshold,
-                config.bth.release_signers.len(),
+                signers.len(),
                 "bth.release_threshold",
             )?;
             Some(Ed25519Federation {
-                signers: parse_ed25519_federation(&config.bth.release_signers, "bth release")?,
+                signers,
                 threshold: config.bth.release_threshold,
             })
         };
@@ -992,6 +1032,49 @@ impl AttestationProvider for FederationAttestationProvider {
                         .to_string()
                 })?;
 
+                // Stale-nonce eviction (#848 / #849). A partial set is pinned
+                // to the Safe nonce of its first attestation. If an unrelated
+                // Safe transaction executed while the set was below threshold,
+                // the Safe's on-chain nonce advances past the pinned nonce and
+                // every fresh-nonce attestation is (correctly) refused as a
+                // nonce mismatch — the set can never reach a usable threshold
+                // and the order wedges at DepositConfirmed until a restart.
+                //
+                // Read the live nonce OUTSIDE the tracker lock (RPC), then
+                // re-lock to evict only when the pinned nonce is STRICTLY
+                // behind. An equal nonce is the healthy case; a set pinned
+                // AHEAD of the read (a transient stale on-chain read) is left
+                // untouched — we never evict on a nonce that only appears to
+                // have moved. Dropping the set is safe: the collected
+                // signatures bind the stale nonce and are unusable anyway, and
+                // the durable nonce store forces each peer to re-sign with a
+                // fresh envelope nonce on re-collection (no replay risk).
+                let pinned_nonce = {
+                    let tracker = self.tracker.lock().expect("tracker lock poisoned");
+                    tracker
+                        .sets
+                        .get(&(order.id, "bridge.mint_wbth"))
+                        .and_then(|s| s.safe_nonce())
+                };
+                if let Some(pinned) = pinned_nonce {
+                    let live = fed.nonce_source.safe_nonce().await?;
+                    if pinned < live {
+                        let mut tracker = self.tracker.lock().expect("tracker lock poisoned");
+                        // Re-check under the lock: only evict if the set is
+                        // still pinned to the same stale nonce (it may have
+                        // been re-collected or taken between the RPC read and
+                        // re-acquiring the lock).
+                        if tracker
+                            .sets
+                            .get(&(order.id, "bridge.mint_wbth"))
+                            .and_then(|s| s.safe_nonce())
+                            == Some(pinned)
+                        {
+                            tracker.sets.remove(&(order.id, "bridge.mint_wbth"));
+                        }
+                    }
+                }
+
                 // Self-attest with the local Safe owner key, binding to the
                 // set's Safe nonce (or the current on-chain nonce for a
                 // fresh set) so all collected signatures share one SafeTx.
@@ -1041,12 +1124,24 @@ impl AttestationProvider for FederationAttestationProvider {
                 // (the order stays retryable and re-authorizes on the next
                 // pass, re-pushing our envelope).
                 let collected = self.progress(order.id, "bridge.mint_wbth");
+                // Snapshot the Safe nonce the set is pinned to BEFORE
+                // take_if_threshold_met removes the set, so the authorization
+                // can carry it for the minter's pre-broadcast cross-check
+                // (#848).
+                let collected_nonce = {
+                    let tracker = self.tracker.lock().expect("tracker lock poisoned");
+                    tracker
+                        .sets
+                        .get(&(order.id, "bridge.mint_wbth"))
+                        .and_then(|s| s.safe_nonce())
+                };
                 match self.take_if_threshold_met(order.id, "bridge.mint_wbth", fed.threshold) {
                     Some(signatures) => Ok(MintAuthorization {
                         order_id: order.order_id_bytes(),
                         scheme: SignatureScheme::Secp256k1,
                         threshold: fed.threshold,
                         signatures,
+                        safe_nonce: collected_nonce,
                     }),
                     None => Err(format!(
                         "attestation threshold not met ({}/{} distinct signers); \
@@ -1073,6 +1168,9 @@ impl AttestationProvider for FederationAttestationProvider {
                         scheme: SignatureScheme::Ed25519,
                         threshold: fed.threshold,
                         signatures,
+                        // Solana mints are blockhash-bound, not Safe-nonce
+                        // bound: no Safe nonce to cross-check.
+                        safe_nonce: None,
                     }),
                     None => Err(format!(
                         "attestation threshold not met ({}/{} distinct signers); \
@@ -1165,6 +1263,18 @@ mod tests {
         }
     }
 
+    /// A Safe nonce source whose reported value can be advanced mid-test, to
+    /// simulate an unrelated Safe transaction executing while a set is below
+    /// threshold (#848 eviction path).
+    struct MutableSafeNonce(std::sync::atomic::AtomicU64);
+
+    #[async_trait]
+    impl SafeNonceSource for MutableSafeNonce {
+        async fn safe_nonce(&self) -> Result<u64, String> {
+            Ok(self.0.load(std::sync::atomic::Ordering::SeqCst))
+        }
+    }
+
     const CHAIN_ID: u64 = 1;
 
     fn safe_addr() -> Address {
@@ -1191,6 +1301,32 @@ mod tests {
                 safe: safe_addr(),
                 wbth: wbth_addr(),
                 nonce_source: Arc::new(FixedSafeNonce(safe_nonce)),
+            }),
+            sol: None,
+            bth: None,
+            local_ed25519: None,
+            local_secp256k1: local,
+            tracker: empty_tracker(),
+            peer_push: None,
+        }
+    }
+
+    /// Like [`eth_provider`] but sharing a caller-held [`MutableSafeNonce`] so
+    /// the test can advance the on-chain nonce mid-run.
+    fn eth_provider_with_nonce_source(
+        owners: &[&PrivateKeySigner],
+        threshold: u32,
+        nonce_source: Arc<MutableSafeNonce>,
+        local: Option<PrivateKeySigner>,
+    ) -> FederationAttestationProvider {
+        FederationAttestationProvider {
+            eth: Some(EthFederation {
+                owners: owners.iter().map(|s| s.address()).collect(),
+                threshold,
+                chain_id: CHAIN_ID,
+                safe: safe_addr(),
+                wbth: wbth_addr(),
+                nonce_source,
             }),
             sol: None,
             bth: None,
@@ -1432,6 +1568,9 @@ mod tests {
         assert_eq!(auth.threshold, 2);
         assert_eq!(auth.signatures.len(), 2);
         assert!(auth.meets_threshold());
+        // The authorization carries the Safe nonce the signatures are bound
+        // to, so the minter can cross-check it pre-broadcast (#848).
+        assert_eq!(auth.safe_nonce, Some(7));
 
         // Every collected payload signature is a Safe owner signature over
         // THIS order's SafeTx digest at the attested Safe nonce — directly
@@ -1473,6 +1612,120 @@ mod tests {
         assert_eq!(provider.progress(order.id, "bridge.mint_wbth"), 1);
     }
 
+    #[tokio::test]
+    async fn authorize_mint_eth_evicts_a_set_pinned_behind_the_onchain_nonce() {
+        // A partial set is pinned to Safe nonce N (below threshold). An
+        // unrelated Safe transaction then advances the on-chain nonce to N+1.
+        // Without eviction, every fresh-nonce attestation is refused as a
+        // nonce mismatch and the order wedges forever (#848 / #849). The
+        // aggregator must drop the stale set and re-collect at N+1.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        let (o1, o2) = (eth_signer(1), eth_signer(2));
+        let source = Arc::new(MutableSafeNonce(AtomicU64::new(7)));
+        // The local Safe owner is o1: authorize_mint self-attests.
+        let provider =
+            eth_provider_with_nonce_source(&[&o1, &o2], 2, Arc::clone(&source), Some(o1.clone()));
+        let order = eth_mint_order();
+
+        // First pass at nonce 7: self-attest (o1) pins the set to 7, below
+        // threshold (needs 2), so authorize_mint fails safe.
+        assert!(provider.authorize_mint(&order).await.is_err());
+        assert_eq!(provider.progress(order.id, "bridge.mint_wbth"), 1);
+
+        // An unrelated Safe tx executes: the on-chain nonce advances to 8.
+        // The set is still pinned to 7. A peer envelope at the fresh nonce 8
+        // cannot join the stale set (correct within-set refusal).
+        source.0.store(8, Ordering::SeqCst);
+        let e2_at_8 = eth_mint_envelope(&order, &o2, 8, "nonce-evict-1");
+        let refused = provider.submit_attestation_at(&e2_at_8, &order, NOW);
+        assert!(
+            !refused.accepted,
+            "fresh-nonce attestation cannot join a stale set"
+        );
+
+        // Next authorize_mint pass evicts the stale (nonce-7) set and
+        // re-collects fresh at nonce 8: o1 self-attests at 8, then an o2
+        // envelope at 8 reaches threshold.
+        assert!(provider.authorize_mint(&order).await.is_err()); // evicted + re-self-attested (1/2)
+        let e2_fresh = eth_mint_envelope(&order, &o2, 8, "nonce-evict-2");
+        assert!(
+            provider
+                .submit_attestation_at(&e2_fresh, &order, NOW)
+                .accepted,
+            "after eviction the set is pinned to 8 and accepts the o2 envelope"
+        );
+
+        let auth = provider
+            .authorize_mint(&order)
+            .await
+            .expect("order recovers at the fresh nonce without a restart");
+        assert_eq!(auth.signatures.len(), 2);
+        assert_eq!(auth.safe_nonce, Some(8), "re-collected at the fresh nonce");
+    }
+
+    #[tokio::test]
+    async fn authorize_mint_eth_does_not_evict_on_equal_or_stale_read() {
+        // Guard the eviction: an EQUAL on-chain nonce is the healthy case and
+        // must not drop the set; a transient on-chain read reported BEHIND the
+        // pinned nonce must also never evict (#848 edge cases).
+        use std::sync::atomic::{AtomicU64, Ordering};
+        let (o1, o2) = (eth_signer(1), eth_signer(2));
+        let source = Arc::new(MutableSafeNonce(AtomicU64::new(7)));
+        let provider =
+            eth_provider_with_nonce_source(&[&o1, &o2], 2, Arc::clone(&source), Some(o1.clone()));
+        let order = eth_mint_order();
+
+        // Pin the set to nonce 7 (o1 self-attest, below threshold).
+        assert!(provider.authorize_mint(&order).await.is_err());
+        assert_eq!(provider.progress(order.id, "bridge.mint_wbth"), 1);
+
+        // Equal nonce: no eviction — the set survives (still 1/2 at nonce 7).
+        assert!(provider.authorize_mint(&order).await.is_err());
+        assert_eq!(provider.progress(order.id, "bridge.mint_wbth"), 1);
+
+        // A transient stale read reports the nonce BEHIND the pinned value:
+        // must not evict.
+        source.0.store(5, Ordering::SeqCst);
+        assert!(provider.authorize_mint(&order).await.is_err());
+        assert_eq!(
+            provider.progress(order.id, "bridge.mint_wbth"),
+            1,
+            "a behind-read must not drop the set"
+        );
+
+        // With the nonce back at 7, the o2 envelope completes the set.
+        source.0.store(7, Ordering::SeqCst);
+        let e2 = eth_mint_envelope(&order, &o2, 7, "nonce-equal-1");
+        assert!(provider.submit_attestation_at(&e2, &order, NOW).accepted);
+        let auth = provider.authorize_mint(&order).await.unwrap();
+        assert_eq!(auth.signatures.len(), 2);
+        assert_eq!(auth.safe_nonce, Some(7));
+    }
+
+    #[tokio::test]
+    async fn authorize_mint_solana_carries_no_safe_nonce() {
+        let (k1, k2) = (signing_key(10), signing_key(11));
+        let provider = FederationAttestationProvider {
+            eth: None,
+            sol: Some(Ed25519Federation {
+                signers: vec![k1.verifying_key(), k2.verifying_key()],
+                threshold: 1,
+            }),
+            bth: None,
+            local_ed25519: Some(k1.clone()),
+            local_secp256k1: None,
+            tracker: empty_tracker(),
+            peer_push: None,
+        };
+        let order = sol_mint_order();
+        let auth = provider.authorize_mint(&order).await.unwrap();
+        assert_eq!(auth.scheme, SignatureScheme::Ed25519);
+        assert_eq!(
+            auth.safe_nonce, None,
+            "Solana mints are not Safe-nonce bound"
+        );
+    }
+
     #[test]
     fn pipeline_rejects_eth_envelope_from_a_non_owner() {
         let (o1, byzantine) = (eth_signer(1), eth_signer(66));
@@ -1512,5 +1765,45 @@ mod tests {
             .err()
             .expect("threshold above n must be refused");
         assert!(err.contains("exceeds"), "{err}");
+    }
+
+    #[test]
+    fn from_config_rejects_duplicate_ed25519_signers() {
+        // A repeated signer inflates the configured count; the aggregator
+        // dedups by identity, so a threshold equal to the padded count is
+        // unsatisfiable. Reject the misconfig at construction (#848).
+        let key = hex::encode(signing_key(1).verifying_key().as_bytes());
+        let mut config = BridgeConfig::default();
+        config.solana.mint_signers = vec![key.clone(), key];
+        config.solana.mint_threshold = 2;
+        let err = FederationAttestationProvider::from_config(&config)
+            .err()
+            .expect("duplicate solana signers must be refused");
+        assert!(err.contains("duplicate signer identities"), "{err}");
+
+        // Distinct signers still construct.
+        let mut config = BridgeConfig::default();
+        config.solana.mint_signers = vec![
+            hex::encode(signing_key(1).verifying_key().as_bytes()),
+            hex::encode(signing_key(2).verifying_key().as_bytes()),
+        ];
+        config.solana.mint_threshold = 2;
+        assert!(FederationAttestationProvider::from_config(&config).is_ok());
+    }
+
+    #[test]
+    fn from_config_rejects_duplicate_eth_owners_checksum_insensitive() {
+        // The same owner spelled two ways (checksummed vs lowercase) must
+        // collide on the parsed 20-byte address, not the raw string (#848).
+        let addr = format!("0x{}", hex::encode([0x11u8; 20]));
+        let mut config = BridgeConfig::default();
+        config.ethereum.mint_signers = vec![addr.to_uppercase().replace("0X", "0x"), addr.clone()];
+        config.ethereum.mint_threshold = 2;
+        config.ethereum.safe_address = Some(format!("0x{}", hex::encode([0x22u8; 20])));
+        config.ethereum.wbth_contract = format!("0x{}", hex::encode([0x33u8; 20]));
+        let err = FederationAttestationProvider::from_config(&config)
+            .err()
+            .expect("duplicate eth owners must be refused");
+        assert!(err.contains("duplicate signer identities"), "{err}");
     }
 }

--- a/bridge/service/src/db.rs
+++ b/bridge/service/src/db.rs
@@ -2544,6 +2544,7 @@ mod tests {
             scheme: bth_bridge_core::SignatureScheme::Secp256k1,
             threshold: 2,
             signatures: vec![],
+            safe_nonce: Some(7),
         });
         db.insert_order(&order).unwrap();
 

--- a/bridge/service/src/mint/ethereum.rs
+++ b/bridge/service/src/mint/ethereum.rs
@@ -166,6 +166,33 @@ pub fn assemble_safe_signatures(auth: &MintAuthorization) -> Result<Bytes, MintE
     Ok(blob.into())
 }
 
+/// Pre-broadcast Safe-nonce cross-check (#848).
+///
+/// The collected Safe owner signatures on `auth` are bound to a specific Safe
+/// nonce (`auth.safe_nonce`). If an unrelated Safe transaction executed
+/// between attestation collection and mint submission, `on_chain_nonce` has
+/// advanced past it and `Safe.execTransaction` would revert. Detecting the
+/// mismatch here — before any transaction is persisted or broadcast — lets the
+/// engine re-authorize and re-collect at the fresh nonce instead of
+/// broadcasting a doomed transaction and silently discarding threshold
+/// signatures.
+///
+/// `Ok(())` when the authorization carries no nonce (Solana / legacy) or the
+/// attested nonce equals the on-chain nonce; a retryable
+/// [`MintError::StaleNonce`] otherwise.
+fn check_attested_nonce(auth: &MintAuthorization, on_chain_nonce: U256) -> Result<(), MintError> {
+    if let Some(attested_nonce) = auth.safe_nonce {
+        if U256::from(attested_nonce) != on_chain_nonce {
+            return Err(MintError::StaleNonce(format!(
+                "attestation bound to Safe nonce {} but Safe.nonce() is now {}; \
+                 re-authorizing to re-collect signatures at the current nonce",
+                attested_nonce, on_chain_nonce
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Map the configured [`GasPriceStrategy`] to EIP-1559 fee fields, given the
 /// next block's base fee and the observed priority-fee percentiles from
 /// `eth_feeHistory` (10th / 50th / 90th).
@@ -362,6 +389,13 @@ impl Minter for EthMinter {
 
         // Safe wrapper: execTransaction with the threshold owner signatures.
         let safe_nonce = self.safe_nonce().await?;
+
+        // Pre-broadcast nonce cross-check (#848): if the Safe's on-chain nonce
+        // advanced since the signatures were collected, fail with a distinct
+        // retryable error BEFORE persisting or broadcasting any tx, so the
+        // engine re-authorizes and re-collects at the fresh nonce.
+        check_attested_nonce(auth, safe_nonce)?;
+
         let signatures = assemble_safe_signatures(auth)?;
         debug!(
             "safe tx hash for order {}: {}",
@@ -586,6 +620,7 @@ mod tests {
             scheme: SignatureScheme::Secp256k1,
             threshold: 2,
             signatures: vec![sig(0xBB, 2), sig(0xAA, 1)],
+            safe_nonce: Some(0),
         };
 
         let blob = assemble_safe_signatures(&auth).unwrap();
@@ -604,11 +639,42 @@ mod tests {
                 signer: vec![1u8; 20],
                 signature: vec![0u8; 65],
             }],
+            safe_nonce: Some(0),
         };
         assert!(matches!(
             assemble_safe_signatures(&auth),
             Err(MintError::Attestation(_))
         ));
+    }
+
+    #[test]
+    fn test_check_attested_nonce_detects_mismatch_pre_broadcast() {
+        let auth = MintAuthorization {
+            order_id: [0u8; 32],
+            scheme: SignatureScheme::Secp256k1,
+            threshold: 1,
+            signatures: vec![AttestationSignature {
+                signer: vec![1u8; 20],
+                signature: vec![0u8; 65],
+            }],
+            safe_nonce: Some(7),
+        };
+
+        // Matching nonce: proceed.
+        assert!(check_attested_nonce(&auth, U256::from(7u64)).is_ok());
+
+        // Safe nonce advanced past the attested nonce: distinct stale-nonce
+        // error, so the engine re-authorizes instead of broadcasting.
+        let err = check_attested_nonce(&auth, U256::from(8u64)).unwrap_err();
+        assert!(matches!(err, MintError::StaleNonce(_)), "{err:?}");
+
+        // Authorizations without a Safe nonce (Solana / legacy) never trip the
+        // check.
+        let no_nonce = MintAuthorization {
+            safe_nonce: None,
+            ..auth
+        };
+        assert!(check_attested_nonce(&no_nonce, U256::from(999u64)).is_ok());
     }
 
     #[test]
@@ -618,6 +684,7 @@ mod tests {
             scheme: SignatureScheme::Ed25519,
             threshold: 0,
             signatures: vec![],
+            safe_nonce: None,
         };
         assert!(matches!(
             assemble_safe_signatures(&auth),

--- a/bridge/service/src/mint/mod.rs
+++ b/bridge/service/src/mint/mod.rs
@@ -31,6 +31,13 @@ pub enum MintError {
     Attestation(String),
     /// RPC / network failure (retryable).
     Rpc(String),
+    /// The Safe nonce the collected signatures are bound to no longer matches
+    /// the Safe's current on-chain nonce (an unrelated Safe transaction
+    /// executed between attestation collection and mint submission). Detected
+    /// **before broadcast** so the engine re-authorizes and re-collects at the
+    /// fresh nonce (#848) instead of broadcasting a transaction the Safe will
+    /// reject. Retryable via re-authorization.
+    StaleNonce(String),
 }
 
 impl std::fmt::Display for MintError {
@@ -39,6 +46,7 @@ impl std::fmt::Display for MintError {
             MintError::Config(m) => write!(f, "config error: {}", m),
             MintError::Attestation(m) => write!(f, "attestation error: {}", m),
             MintError::Rpc(m) => write!(f, "rpc error: {}", m),
+            MintError::StaleNonce(m) => write!(f, "stale safe nonce: {}", m),
         }
     }
 }

--- a/bridge/service/src/mint/solana.rs
+++ b/bridge/service/src/mint/solana.rs
@@ -531,6 +531,7 @@ mod tests {
                 signer: vec![1u8; 32],
                 signature: vec![2u8; 64],
             }],
+            safe_nonce: None,
         };
         (order, auth)
     }
@@ -749,6 +750,7 @@ mod tests {
                 signer: vec![1u8; 32],
                 signature: vec![2u8; 64],
             }],
+            safe_nonce: None,
         }
     }
 

--- a/bridge/service/src/solana_devnet_tests.rs
+++ b/bridge/service/src/solana_devnet_tests.rs
@@ -120,6 +120,7 @@ async fn solana_devnet_prepare_mint_against_live_pdas() {
             signer: vec![1u8; 32],
             signature: vec![2u8; 64],
         }],
+        safe_nonce: None,
     };
 
     let prepared = minter


### PR DESCRIPTION
## Summary

The #824 federation aggregator binds each Ethereum mint `AttestationSet` to the Safe nonce of its first attestation (correct — signatures over different SafeTx nonces cannot share one `execTransaction`). But sets were only removed via `take_if_threshold_met`, so once the Safe's on-chain nonce advanced past a below-threshold set's pinned nonce (an unrelated Safe tx executed), every fresh-nonce attestation was refused and the order wedged at `DepositConfirmed` until a process restart. A second window existed after threshold: `take_if_threshold_met` removed the set and `prepare_mint` re-read the live nonce with no cross-check, so a nonce move between collection and broadcast silently discarded threshold signatures.

This is a **liveness** fix. Every failure mode here was already fail-safe (fails closed); no nonce-mixing or threshold check is weakened — this adds recovery, a pre-broadcast cross-check, and a construction-time guard.

## Changes

- **Stale-nonce eviction (`bridge/service/src/attestation.rs`, `authorize_mint` Ethereum arm):** reads the live `Safe.nonce()` outside the tracker lock, and drops an `AttestationSet` pinned **strictly behind** it (re-checking under the lock before removal), letting it re-collect at the fresh nonce. An equal nonce (healthy) and a behind-read (transient stale RPC) never evict.
- **`MintAuthorization.safe_nonce: Option<u64>` (`bridge/core/src/attestation.rs`):** carries the Safe nonce the collected signatures are bound to (`None` for Ed25519 / Solana). `#[serde(default)]` keeps authorizations persisted before this field deserializable.
- **Pre-broadcast cross-check (`bridge/service/src/mint/ethereum.rs`):** `prepare_mint` compares `auth.safe_nonce` to the live `Safe.nonce()` via a pure `check_attested_nonce` helper and returns a new retryable `MintError::StaleNonce` **before** persisting or broadcasting any tx, so the engine re-authorizes and re-collects instead of broadcasting doomed signatures.
- **Duplicate-signer rejection at construction (`from_config`):** dedups eth owners by parsed `Address` (checksum-insensitive) and ed25519 signers by verifying-key bytes, so a `threshold == padded_n` misconfig fails at startup instead of wedging at runtime.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Stale set evicted + re-collected at fresh nonce, recovers without restart (closes #849) | ✅ | `authorize_mint_eth_evicts_a_set_pinned_behind_the_onchain_nonce` |
| `MintAuthorization` carries `safe_nonce` (`None` for Ed25519) | ✅ | assertions in `authorize_mint_eth_collects...` (`Some(7)`) and `authorize_mint_solana_carries_no_safe_nonce` (`None`) |
| `prepare_mint` detects mismatch pre-broadcast, returns a distinct error | ✅ | new `MintError::StaleNonce`; `test_check_attested_nonce_detects_mismatch_pre_broadcast` |
| Duplicate signer identities rejected at construction with a clear message | ✅ | `from_config_rejects_duplicate_ed25519_signers`, `from_config_rejects_duplicate_eth_owners_checksum_insensitive` |
| Existing attestation tests still pass | ✅ | `pipeline_rejects_eth_attestation_at_a_different_safe_nonce` + `authorize_mint_eth_collects_safe_owner_signatures_to_threshold` green |
| Edge cases: behind-read / equal nonce no-op; Solana unaffected | ✅ | `authorize_mint_eth_does_not_evict_on_equal_or_stale_read`, `authorize_mint_solana_carries_no_safe_nonce` |
| PR body includes both closes | ✅ | below |

## Test Plan

- `cargo test -p bth-bridge-service -p bth-bridge-core` — green (66 core + 197 service tests, 0 failures).
- `cargo clippy -p bth-bridge-service -p bth-bridge-core --all-targets` — clean.
- `cargo fmt` applied.

Closes #848
Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)