### PR TITLE
feat(network): add Proof-of-Reserves panel to /network dashboard

### DIFF
--- a/web/packages/features/src/network/components/network-dashboard.test.tsx
+++ b/web/packages/features/src/network/components/network-dashboard.test.tsx
@@ -96,4 +96,54 @@ describe('NetworkDashboard', () => {
     // The live grid is unaffected.
     expect(screen.getByText('3/3')).toBeDefined()
   })
+
+  it('omits the reserve card entirely when reserveState is undefined', () => {
+    renderDash({ seed: live('seed'), eu: live('eu'), ap: live('ap') })
+    expect(screen.queryByText('Proof of Reserves')).toBeNull()
+  })
+
+  it('renders the reserve card with an ok proof', () => {
+    cleanup()
+    render(
+      <NetworkDashboard
+        nodes={NODES}
+        statuses={{ seed: live('seed'), eu: live('eu'), ap: live('ap') }}
+        avgBlockSeconds={20}
+        history={{}}
+        historyState="unavailable"
+        reserve={{
+          lockedReserve: 123_000_000_000_000,
+          ethSupply: 100_000_000_000_000,
+          solSupply: null,
+          totalWrapped: null,
+          drift: 0,
+          inTolerance: true,
+          pegHealthy: true,
+          takenAt: Math.floor(Date.now() / 1000) - 30,
+        }}
+        reserveState="ok"
+      />,
+    )
+    expect(screen.getByText('Proof of Reserves')).toBeDefined()
+    expect(screen.getByText('Peg healthy')).toBeDefined()
+    // The live grid is unaffected.
+    expect(screen.getByText('3/3')).toBeDefined()
+  })
+
+  it('hides the reserve card on the absent (404) state without breaking the grid', () => {
+    cleanup()
+    render(
+      <NetworkDashboard
+        nodes={NODES}
+        statuses={{ seed: live('seed'), eu: live('eu'), ap: live('ap') }}
+        avgBlockSeconds={20}
+        history={{}}
+        historyState="unavailable"
+        reserve={null}
+        reserveState="absent"
+      />,
+    )
+    expect(screen.queryByText('Proof of Reserves')).toBeNull()
+    expect(screen.getByText('3/3')).toBeDefined()
+  })
 })

--- a/web/packages/features/src/network/components/network-dashboard.tsx
+++ b/web/packages/features/src/network/components/network-dashboard.tsx
@@ -1,8 +1,15 @@
-import type { FleetNode, FleetNodeStatus, MetricsHistorySample } from '../types'
+import type {
+  FleetNode,
+  FleetNodeStatus,
+  MetricsHistorySample,
+  ReserveProof,
+  ReserveProofState,
+} from '../types'
 import { deriveFleetSummary } from '../fleet'
 import { FleetSummaryStrip } from './fleet-summary'
 import { NodeCard } from './node-card'
 import { HistoryChart } from './history-chart'
+import { ReserveProofCard } from './reserve-proof-card'
 
 export interface NetworkDashboardProps {
   nodes: FleetNode[]
@@ -12,6 +19,13 @@ export interface NetworkDashboardProps {
   /** History series per node id (may be empty). */
   history: Record<string, MetricsHistorySample[]>
   historyState: 'ok' | 'empty' | 'unavailable'
+  /**
+   * Latest bridge proof-of-reserves snapshot (#845). Optional so surfaces that
+   * don't wire the reserve hook simply omit the card.
+   */
+  reserve?: ReserveProof | null
+  /** Reserve fetch outcome; `undefined`/`absent` hides the card. */
+  reserveState?: ReserveProofState
   className?: string
 }
 
@@ -26,6 +40,8 @@ export function NetworkDashboard({
   avgBlockSeconds,
   history,
   historyState,
+  reserve,
+  reserveState,
   className,
 }: NetworkDashboardProps) {
   const statusList = nodes
@@ -41,6 +57,10 @@ export function NetworkDashboard({
   return (
     <div className={`space-y-4 ${className ?? ''}`}>
       <FleetSummaryStrip summary={displaySummary} avgBlockSeconds={avgBlockSeconds} />
+
+      {reserveState !== undefined && (
+        <ReserveProofCard proof={reserve ?? null} state={reserveState} />
+      )}
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {nodes.map((node) => (

--- a/web/packages/features/src/network/components/reserve-proof-card.test.tsx
+++ b/web/packages/features/src/network/components/reserve-proof-card.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Proof-of-Reserves card contract (#845): the peg indicator is driven solely
+ * by `pegHealthy`; null supply legs render "unverified" (never `0`, never
+ * green); a 404/`absent` state renders nothing; a non-404 failure degrades to
+ * a grayed placeholder without fabricating values (#541 lesson).
+ */
+import { describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { ReserveProofCard } from './reserve-proof-card'
+import type { ReserveProof } from '../types'
+
+function proof(over: Partial<ReserveProof> = {}): ReserveProof {
+  return {
+    lockedReserve: 123_000_000_000_000,
+    ethSupply: 100_000_000_000_000,
+    solSupply: null,
+    totalWrapped: null,
+    drift: 0,
+    inTolerance: true,
+    pegHealthy: true,
+    takenAt: Math.floor(Date.now() / 1000) - 30,
+    ...over,
+  }
+}
+
+describe('ReserveProofCard', () => {
+  it('shows a healthy peg and formatted BTH amounts', () => {
+    cleanup()
+    render(<ReserveProofCard proof={proof({ totalWrapped: 100_000_000_000_000 })} state="ok" />)
+    expect(screen.getByText('Peg healthy')).toBeDefined()
+    // 123_000_000_000_000 picocredits = 123 BTH; 100e12 = 100 BTH.
+    expect(screen.getByText(/123\.00 BTH/)).toBeDefined()
+    expect(screen.getAllByText(/100\.00 BTH/).length).toBeGreaterThan(0)
+  })
+
+  it('shows a red/unhealthy peg driven solely by pegHealthy', () => {
+    cleanup()
+    render(<ReserveProofCard proof={proof({ pegHealthy: false })} state="ok" />)
+    expect(screen.getByText('Peg unhealthy')).toBeDefined()
+    expect(screen.queryByText('Peg healthy')).toBeNull()
+  })
+
+  it('renders null supplies as "unverified", never 0 or green', () => {
+    cleanup()
+    render(<ReserveProofCard proof={proof({ solSupply: null, totalWrapped: null })} state="ok" />)
+    // Total wrapped is unverified.
+    expect(screen.getByText('unverified')).toBeDefined()
+    // Solana leg labeled explicitly as pending.
+    expect(screen.getByText('unverified (Solana pending)')).toBeDefined()
+    // Must NOT fabricate a zero figure for the unverified legs.
+    expect(screen.queryByText('0.00 BTH')).toBeNull()
+  })
+
+  it('renders negative drift with a leading minus sign', () => {
+    cleanup()
+    render(
+      <ReserveProofCard
+        proof={proof({ drift: -5_000_000_000_000, inTolerance: false })}
+        state="ok"
+      />,
+    )
+    expect(screen.getByText(/−5\.00 BTH/)).toBeDefined()
+    expect(screen.getByText('out of tolerance')).toBeDefined()
+  })
+
+  it('renders nothing when absent (404 — daemon not polling a bridge)', () => {
+    cleanup()
+    const { container } = render(<ReserveProofCard proof={null} state="absent" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a grayed placeholder (no fabricated values) when unavailable', () => {
+    cleanup()
+    render(<ReserveProofCard proof={null} state="unavailable" />)
+    expect(screen.getByText(/Reserve proof unavailable/)).toBeDefined()
+    expect(screen.queryByText('Peg healthy')).toBeNull()
+    expect(screen.queryByText(/BTH/)).toBeNull()
+  })
+
+  it('formats near-u64 reserves via the bigint path without precision loss', () => {
+    cleanup()
+    // 9_007_199_254_740_993 exceeds Number.MAX_SAFE_INTEGER (2^53); BigInt keeps it exact.
+    render(
+      <ReserveProofCard
+        proof={proof({ lockedReserve: 9_007_199_254_740_993, totalWrapped: 9_007_199_254_740_993 })}
+        state="ok"
+      />,
+    )
+    // Should not render NaN.
+    expect(screen.queryByText(/NaN/)).toBeNull()
+  })
+})

--- a/web/packages/features/src/network/components/reserve-proof-card.tsx
+++ b/web/packages/features/src/network/components/reserve-proof-card.tsx
@@ -1,0 +1,164 @@
+import { Card, CardContent } from '@botho/ui'
+import { AlertTriangle, Lock, ShieldAlert, ShieldCheck } from 'lucide-react'
+import { formatBTHWithSymbol, formatRelativeTime } from '@botho/core'
+import type { ReserveProof, ReserveProofState } from '../types'
+
+export interface ReserveProofCardProps {
+  /** Latest snapshot; ignored unless `state === 'ok'`. */
+  proof: ReserveProof | null
+  /** Fetch outcome from `useReserveProof`. */
+  state: ReserveProofState
+  className?: string
+}
+
+/**
+ * Proof-of-Reserves panel (#845): BTH locked in the bridge reserve vs total
+ * wBTH wrapped across chains, signed drift, and a red/green peg indicator.
+ *
+ * Pure presentation, mirroring `FleetSummaryStrip`. The peg color is driven
+ * SOLELY by `proof.pegHealthy` — the UI never re-derives health.
+ *
+ * Number contract: reserve/supply figures are `u64` picocredits (possibly
+ * beyond `Number.MAX_SAFE_INTEGER`) and `drift` is signed `i64`. We convert to
+ * `bigint` via `BigInt(...)` before formatting, never passing `Number`
+ * picocredits through the `bigint`-typed `formatBTH*`.
+ *
+ * `absent` (404 — daemon not polling a bridge yet) renders nothing so the rest
+ * of the dashboard is unaffected. `unavailable` (daemon down / non-404 error)
+ * renders a grayed placeholder rather than fabricating values (#541 lesson).
+ */
+export function ReserveProofCard({ proof, state, className }: ReserveProofCardProps) {
+  // 404: the daemon has no bridge poll yet — hide the card entirely.
+  if (state === 'absent') return null
+
+  if (state === 'unavailable' || proof === null) {
+    return (
+      <Card className={className}>
+        <CardContent className="p-4">
+          <div className="flex items-center gap-1.5 text-xs text-[--color-dim]">
+            <Lock className="h-4 w-4" />
+            Proof of Reserves
+          </div>
+          <div className="mt-1 text-sm text-[--color-dim]">
+            Reserve proof unavailable — the metrics daemon is not reachable.
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const healthy = proof.pegHealthy
+  const totalWrapped =
+    proof.totalWrapped === null
+      ? 'unverified'
+      : formatBTHWithSymbol(BigInt(proof.totalWrapped))
+  const ethSupply =
+    proof.ethSupply === null ? 'unverified' : formatBTHWithSymbol(BigInt(proof.ethSupply))
+  const solSupply =
+    proof.solSupply === null
+      ? 'unverified (Solana pending)'
+      : formatBTHWithSymbol(BigInt(proof.solSupply))
+
+  // Signed drift: branch on the bigint so very large magnitudes are exact.
+  const driftPico = BigInt(proof.drift)
+  const driftSign = driftPico < 0n ? '−' : '+'
+  const driftAbs = driftPico < 0n ? -driftPico : driftPico
+  const driftDisplay = `${driftSign}${formatBTHWithSymbol(driftAbs)}`
+
+  return (
+    <Card className={className}>
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5 text-xs text-[--color-dim]">
+            <Lock className="h-4 w-4" />
+            Proof of Reserves
+          </div>
+          <PegIndicator healthy={healthy} />
+        </div>
+
+        <div className="mt-3 grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <Metric label="Locked reserve" value={formatBTHWithSymbol(BigInt(proof.lockedReserve))} />
+          <Metric
+            label="Total wrapped"
+            value={totalWrapped}
+            unverified={proof.totalWrapped === null}
+          />
+          <Metric
+            label="Drift"
+            value={driftDisplay}
+            sub={proof.inTolerance ? 'within tolerance' : 'out of tolerance'}
+            warn={!proof.inTolerance}
+          />
+          <Metric
+            label="Snapshot"
+            value={formatRelativeTime(proof.takenAt)}
+            sub="metrics daemon poll"
+          />
+        </div>
+
+        <div className="mt-3 grid grid-cols-2 gap-4 text-xs text-[--color-dim] sm:grid-cols-4">
+          <div>
+            <span className="text-[--color-dim]">Ethereum wBTH</span>
+            <div className={proof.ethSupply === null ? 'text-[--color-dim]' : 'text-[--color-light]'}>
+              {ethSupply}
+            </div>
+          </div>
+          <div>
+            <span className="text-[--color-dim]">Solana wBTH</span>
+            <div className={proof.solSupply === null ? 'text-[--color-dim]' : 'text-[--color-light]'}>
+              {solSupply}
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Red/green peg badge — green iff `healthy`. Never re-derives health. */
+function PegIndicator({ healthy }: { healthy: boolean }) {
+  if (healthy) {
+    return (
+      <div className="flex items-center gap-1.5 text-xs font-medium text-emerald-400">
+        <ShieldCheck className="h-4 w-4" />
+        Peg healthy
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-center gap-1.5 text-xs font-medium text-[--color-danger]">
+      <ShieldAlert className="h-4 w-4" />
+      Peg unhealthy
+    </div>
+  )
+}
+
+function Metric({
+  label,
+  value,
+  sub,
+  warn,
+  unverified,
+}: {
+  label: string
+  value: string
+  sub?: string
+  warn?: boolean
+  unverified?: boolean
+}) {
+  const valueClass = unverified
+    ? 'text-[--color-dim]'
+    : warn
+      ? 'text-[--color-warning]'
+      : 'text-[--color-light]'
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-xs text-[--color-dim]">
+        {warn && <AlertTriangle className="h-4 w-4 text-[--color-warning]" />}
+        {label}
+      </div>
+      <div className={`mt-1 font-display text-lg font-semibold ${valueClass}`}>{value}</div>
+      {sub && <div className="text-xs text-[--color-dim]">{sub}</div>}
+    </div>
+  )
+}

--- a/web/packages/features/src/network/hooks.test.tsx
+++ b/web/packages/features/src/network/hooks.test.tsx
@@ -9,8 +9,8 @@
  */
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { useFleetHistory, useFleetStatus } from './hooks'
-import type { FleetNode } from './types'
+import { useFleetHistory, useFleetStatus, useReserveProof } from './hooks'
+import type { FleetNode, ReserveProof } from './types'
 
 const NODES: FleetNode[] = [
   { id: 'seed', name: 'Seed', rpcEndpoint: 'https://seed.test/rpc' },
@@ -79,6 +79,53 @@ describe('useFleetHistory', () => {
     )
     await waitFor(() => expect(result.current.historyState).toBe('ok'))
     expect(result.current.history.seed).toHaveLength(1)
+    unmount()
+  })
+})
+
+describe('useReserveProof', () => {
+  const PROOF: ReserveProof = {
+    lockedReserve: 123_000_000_000_000,
+    ethSupply: 100_000_000_000_000,
+    solSupply: null,
+    totalWrapped: null,
+    drift: 0,
+    inTolerance: true,
+    pegHealthy: true,
+    takenAt: 1_752_000_000,
+  }
+
+  it('reports ok with the parsed proof on 200', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => PROOF })),
+    )
+    const { result, unmount } = renderHook(() => useReserveProof('https://metrics.test'))
+    await waitFor(() => expect(result.current.state).toBe('ok'))
+    expect(result.current.proof).toEqual(PROOF)
+    unmount()
+  })
+
+  it('reports absent on 404 (daemon not polling a bridge yet)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404 })))
+    const { result, unmount } = renderHook(() => useReserveProof('https://metrics.test'))
+    await waitFor(() => expect(result.current.state).toBe('absent'))
+    expect(result.current.proof).toBeNull()
+    unmount()
+  })
+
+  it('degrades to unavailable on a non-404 failure without throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500 })))
+    const { result, unmount } = renderHook(() => useReserveProof('https://metrics.test'))
+    await waitFor(() => expect(result.current.state).toBe('unavailable'))
+    expect(result.current.proof).toBeNull()
+    unmount()
+  })
+
+  it('degrades to unavailable on a rejected fetch without throwing', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('down') }))
+    const { result, unmount } = renderHook(() => useReserveProof('https://metrics.test'))
+    await waitFor(() => expect(result.current.state).toBe('unavailable'))
     unmount()
   })
 })

--- a/web/packages/features/src/network/hooks.ts
+++ b/web/packages/features/src/network/hooks.ts
@@ -1,6 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { averageBlockSeconds, fetchFleetNodeStatus } from './fleet'
-import type { FleetNode, FleetNodeStatus, MetricsHistorySample } from './types'
+import type {
+  FleetNode,
+  FleetNodeStatus,
+  MetricsHistorySample,
+  ReserveProof,
+  ReserveProofState,
+} from './types'
 
 /**
  * Reusable polling/history hooks for the fleet dashboard (#706).
@@ -173,4 +179,69 @@ export function useFleetHistory(
   }, [nodes, metricsApiBase, refreshMs, windowSeconds])
 
   return { history, historyState }
+}
+
+export interface UseReserveProofOptions {
+  /** Reserve refresh cadence in ms. The daemon reconciles infrequently, so a
+   * slow poll (~2 min, same cadence as history) is right. */
+  refreshMs?: number
+}
+
+export interface UseReserveProofResult {
+  /** Latest snapshot, or null until the first successful poll. */
+  proof: ReserveProof | null
+  /** Discriminated fetch outcome (see {@link ReserveProofState}). */
+  state: ReserveProofState
+}
+
+/**
+ * Fetch the latest bridge proof-of-reserves snapshot from the metrics-daemon
+ * (#825), degrading gracefully when the endpoint is absent or the daemon is
+ * down. Mirrors {@link useFleetHistory}'s poll + `cancelled` cleanup structure.
+ *
+ * The endpoint returns 404 until the daemon has polled a bridge (no
+ * `--bridge-url` configured). That is NOT an error — it maps to `absent`, the
+ * "hide or gray the card" case. Any other non-OK response or a network error
+ * maps to `unavailable` (same graceful path as history-unavailable; never
+ * fabricate values — the #541 lesson).
+ */
+export function useReserveProof(
+  metricsApiBase: string,
+  { refreshMs = 120_000 }: UseReserveProofOptions = {},
+): UseReserveProofResult {
+  const [proof, setProof] = useState<ReserveProof | null>(null)
+  const [state, setState] = useState<ReserveProofState>('unavailable')
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const r = await fetch(`${metricsApiBase}/api/metrics/reserve`)
+        // 404 = daemon not polling a bridge yet → hide/gray the card. Check
+        // this before the generic non-OK path so it isn't treated as an error.
+        if (r.status === 404) {
+          if (!cancelled) {
+            setProof(null)
+            setState('absent')
+          }
+          return
+        }
+        if (!r.ok) throw new Error(`reserve ${r.status}`)
+        const data = (await r.json()) as ReserveProof
+        if (cancelled) return
+        setProof(data)
+        setState('ok')
+      } catch {
+        if (!cancelled) setState('unavailable')
+      }
+    }
+    load()
+    const id = setInterval(load, refreshMs)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [metricsApiBase, refreshMs])
+
+  return { proof, state }
 }

--- a/web/packages/features/src/network/index.ts
+++ b/web/packages/features/src/network/index.ts
@@ -5,6 +5,10 @@ export { NodeCard, type NodeCardProps } from './components/node-card'
 export { FleetSummaryStrip, type FleetSummaryStripProps } from './components/fleet-summary'
 export { HistoryChart, type HistoryChartProps } from './components/history-chart'
 export {
+  ReserveProofCard,
+  type ReserveProofCardProps,
+} from './components/reserve-proof-card'
+export {
   NetworkDashboard,
   type NetworkDashboardProps,
 } from './components/network-dashboard'

--- a/web/packages/features/src/network/types.ts
+++ b/web/packages/features/src/network/types.ts
@@ -82,6 +82,49 @@ export interface MetricsHistorySample {
   mempoolSize: number
 }
 
+/**
+ * Latest bridge proof-of-reserves snapshot, `GET /api/metrics/reserve` (#825).
+ *
+ * Backend source of truth: `ReserveProof` in
+ * `infra/faucet/metrics-daemon/src/db.rs` (`#[serde(rename_all = "camelCase")]`).
+ *
+ * Numeric contract: `lockedReserve`/`ethSupply`/`solSupply`/`totalWrapped` are
+ * Rust `u64` picocredits and `drift` is a signed `i64`, all serialized as bare
+ * JSON numbers. A full-supply value can exceed `Number.MAX_SAFE_INTEGER`, so we
+ * keep them as `number` on the wire type (that's how they arrive) and convert to
+ * `bigint` at format time via `BigInt(...)` — never pass `Number` picocredits
+ * through `formatBTH`, which takes a `bigint`.
+ *
+ * Nullable supplies mean the chain was unverified this pass (e.g. the Solana
+ * transport is still pending). `null` renders as "unverified", never `0`.
+ */
+export interface ReserveProof {
+  /** BTH locked in the bridge reserve (picocredits). */
+  lockedReserve: number
+  /** wBTH minted on Ethereum; null = chain unverified this pass. */
+  ethSupply: number | null
+  /** wBTH minted on Solana; null = transport pending / unverified. */
+  solSupply: number | null
+  /** ethSupply + solSupply; null if any leg is unverified. */
+  totalWrapped: number | null
+  /** Signed picocredits: lockedReserve − totalWrapped (can be negative). */
+  drift: number
+  /** Within the peg tolerance band. */
+  inTolerance: boolean
+  /** Authoritative red/green source for the peg indicator. */
+  pegHealthy: boolean
+  /** Unix SECONDS when the snapshot was taken. */
+  takenAt: number
+}
+
+/**
+ * `useReserveProof` state:
+ * - `ok`          — 200 with a parsed `ReserveProof`.
+ * - `absent`      — 404: daemon has not polled a bridge yet (hide/gray card).
+ * - `unavailable` — network error / non-404 non-OK (degrade gracefully, #541).
+ */
+export type ReserveProofState = 'ok' | 'absent' | 'unavailable'
+
 /** History fetcher the page injects (so components stay backend-agnostic). */
 export interface NetworkHistorySource {
   /** Per-node history samples, oldest first. Empty array = no data yet. */

--- a/web/packages/web-wallet/src/pages/network.tsx
+++ b/web/packages/web-wallet/src/pages/network.tsx
@@ -1,6 +1,11 @@
 import { Link } from 'react-router-dom'
 import { Logo } from '@botho/ui'
-import { NetworkDashboard, useFleetHistory, useFleetStatus } from '@botho/features'
+import {
+  NetworkDashboard,
+  useFleetHistory,
+  useFleetStatus,
+  useReserveProof,
+} from '@botho/features'
 import { ArrowLeft } from 'lucide-react'
 import { FLEET, METRICS_API_BASE } from '../config/fleet'
 
@@ -9,6 +14,7 @@ export function NetworkPage() {
   // /operator fleet tab shares this exact implementation — no forked copies.
   const { statuses, avgBlockSeconds } = useFleetStatus(FLEET)
   const { history, historyState } = useFleetHistory(FLEET, METRICS_API_BASE)
+  const { proof: reserve, state: reserveState } = useReserveProof(METRICS_API_BASE)
 
   return (
     <div className="min-h-screen">
@@ -47,6 +53,8 @@ export function NetworkPage() {
             avgBlockSeconds={avgBlockSeconds}
             history={history}
             historyState={historyState}
+            reserve={reserve}
+            reserveState={reserveState}
           />
         </div>
       </main>

--- a/web/packages/web-wallet/src/pages/operator.tsx
+++ b/web/packages/web-wallet/src/pages/operator.tsx
@@ -12,6 +12,7 @@ import {
   useFleetStatus,
   useOperatorAuditLog,
   useOperatorQuorumInfo,
+  useReserveProof,
   useTrustStatus,
   type SessionSigner,
 } from '@botho/features'
@@ -128,6 +129,7 @@ function TabButton({
 function FleetTab() {
   const { statuses, avgBlockSeconds } = useFleetStatus(FLEET)
   const { history, historyState } = useFleetHistory(FLEET, METRICS_API_BASE)
+  const { proof: reserve, state: reserveState } = useReserveProof(METRICS_API_BASE)
   return (
     <NetworkDashboard
       nodes={FLEET}
@@ -135,6 +137,8 @@ function FleetTab() {
       avgBlockSeconds={avgBlockSeconds}
       history={history}
       historyState={historyState}
+      reserve={reserve}
+      reserveState={reserveState}
     />
   )
 }


### PR DESCRIPTION
## Summary

Adds a Proof-of-Reserves panel to the `/network` (and `/operator`) fleet dashboard, consuming the metrics-daemon `GET /api/metrics/reserve` endpoint shipped in #825. The card shows BTH locked in the bridge reserve vs total wBTH wrapped across chains, signed drift, and an authoritative red/green peg indicator.

## Changes

- **`useReserveProof(metricsApiBase, opts?)` hook** (`network/hooks.ts`) — mirrors `useFleetHistory`: `setInterval` poll (~2 min) with `cancelled` cleanup. Returns `{ proof, state }` with `state` discriminating `ok` / `absent` (404) / `unavailable` (network error or other non-OK). Checks `r.status === 404` before the generic non-OK path so 404 is never treated as an error.
- **`ReserveProofCard`** (`network/components/reserve-proof-card.tsx`) — pure presentation, mirrors `FleetSummaryStrip`. `absent` renders nothing; `unavailable` renders a grayed placeholder (no fabricated values, #541). Peg color is driven **solely** by `pegHealthy`.
- **Number precision** — `lockedReserve`/`ethSupply`/`solSupply`/`totalWrapped` (`u64`) and `drift` (`i64`) are converted via `BigInt(...)` before the `bigint`-typed `formatBTHWithSymbol`; negative drift branches on the bigint (`< 0n`) and renders a leading "−".
- **Null supplies** render "unverified" (Solana labeled "unverified (Solana pending)"), never `0`, never green.
- **`ReserveProof` type + `ReserveProofState` union** added to `types.ts` (nullable supplies; kept as `number` on the wire, converted to `bigint` at format time — documented in a comment).
- **Wiring (Option A)** — `NetworkDashboard` accepts optional `reserve`/`reserveState` props and renders the card near the summary strip; `network.tsx` and `operator.tsx` (FleetTab) call `useReserveProof(METRICS_API_BASE)` and pass results down, reusing the existing `METRICS_API_BASE` (no new constant). Card exported from `network/index.ts`.
- `takenAt` rendered via `formatRelativeTime` (unix seconds, not divided).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `useReserveProof` polls the endpoint, discriminates ok/absent/unavailable | ✅ | `hooks.test.tsx`: 200→ok, 404→absent, 500→unavailable, reject→unavailable (no throw) |
| Card shows locked reserve vs total wrapped + signed drift via `formatBTH*` bigint path | ✅ | `reserve-proof-card.test.tsx` asserts formatted BTH + near-`u64` value has no `NaN` |
| Peg green iff `pegHealthy === true`, red otherwise, derived only from `pegHealthy` | ✅ | Card test: `pegHealthy:false` → "Peg unhealthy", no "Peg healthy" |
| Null supply legs render "unverified", never 0/green | ✅ | Card test asserts "unverified" / "unverified (Solana pending)" present, no `0.00 BTH` |
| 404 hides the card; rest of dashboard unaffected | ✅ | Dashboard test: `absent` → no "Proof of Reserves", `3/3` still shown |
| Non-404 failure degrades gracefully (no throw, no fabricated values) | ✅ | Hook + card tests (grayed placeholder, no `BTH` text) |
| Wired into `/network` and available to `/operator` via `METRICS_API_BASE` | ✅ | Both pages updated; Option A single composition point |
| `takenAt` rendered as relative time (unix seconds) | ✅ | Card passes `proof.takenAt` straight to `formatRelativeTime` |
| Exports + types added | ✅ | `index.ts` exports card; `types.ts` has `ReserveProof` + `ReserveProofState` |

**Placement note:** Chose **Option A** (props on `NetworkDashboard`) so `/operator` gets parity for free.

## Test Plan

- `pnpm -C web -r typecheck` — passes (all 8 projects).
- `pnpm -C web test:run` — 879 passed / 10 skipped; the 33 network tests (including new hook + card + dashboard cases) pass.
- `pnpm -C web build:web` — builds clean.

Closes #845