### PR TITLE
feat(bridge): startup guard against single-key Solana mint_authority

### DIFF
--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -291,6 +291,21 @@ pub struct SolanaConfig {
     pub mint_threshold: u32,
 }
 
+impl SolanaConfig {
+    /// Whether this Solana config is in a "production" custody posture: a
+    /// federation is configured (`mint_signers` non-empty AND a positive
+    /// `mint_threshold`), meaning ADR-0002 t-of-n custody is expected to be
+    /// enforced by an on-chain multisig `mint_authority`.
+    ///
+    /// The startup custody guard uses this as its strict-mode signal: in a
+    /// production posture a single-key `mint_authority` (equal to the local
+    /// `keypair_file` pubkey) is a HARD startup error; otherwise it is a
+    /// warning, so devnet/testnet single-key iteration is not bricked.
+    pub fn requires_multisig_authority(&self) -> bool {
+        !self.mint_signers.is_empty() && self.mint_threshold >= 1
+    }
+}
+
 /// Bridge-specific settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BridgeSettings {

--- a/bridge/service/src/engine.rs
+++ b/bridge/service/src/engine.rs
@@ -52,7 +52,14 @@ impl BridgeEngine {
     /// bad contract address, ...) is skipped with a warning: deposits to
     /// that chain stay in `DepositConfirmed` until the config is fixed —
     /// they are never dropped or failed.
-    fn build_minters(config: &BridgeConfig) -> HashMap<Chain, Arc<dyn Minter>> {
+    ///
+    /// Returns the trait-object map used by the [`OrderProcessor`], plus a
+    /// typed [`SolMinter`] handle (when Solana minting is enabled) so the
+    /// startup path can invoke its async ADR-0002 mint-authority custody guard
+    /// without downcasting the `Arc<dyn Minter>`.
+    fn build_minters(
+        config: &BridgeConfig,
+    ) -> (HashMap<Chain, Arc<dyn Minter>>, Option<Arc<SolMinter>>) {
         let mut minters: HashMap<Chain, Arc<dyn Minter>> = HashMap::new();
 
         match EthMinter::new(config.ethereum.clone()) {
@@ -62,14 +69,19 @@ impl BridgeEngine {
             Err(e) => warn!("Ethereum minting disabled: {}", e),
         }
 
-        match SolMinter::new(config.solana.clone()) {
+        let sol_minter = match SolMinter::new(config.solana.clone()) {
             Ok(minter) => {
-                minters.insert(Chain::Solana, Arc::new(minter));
+                let handle = Arc::new(minter);
+                minters.insert(Chain::Solana, handle.clone());
+                Some(handle)
             }
-            Err(e) => warn!("Solana minting disabled: {}", e),
-        }
+            Err(e) => {
+                warn!("Solana minting disabled: {}", e);
+                None
+            }
+        };
 
-        minters
+        (minters, sol_minter)
     }
 
     /// Build the BTH reserve-release backend from configuration.
@@ -186,7 +198,7 @@ impl BridgeEngine {
             warn!("Bridge starting PAUSED (bridge.paused = true in config)");
         }
 
-        let minters = Self::build_minters(&self.config);
+        let (minters, sol_minter) = Self::build_minters(&self.config);
         let releaser = Self::build_releaser(&self.config);
         let (attestation, federation_provider, attestation_ok, attestation_detail) =
             Self::build_attestation_provider(&self.config);
@@ -222,6 +234,22 @@ impl BridgeEngine {
             releaser,
             attestation,
         );
+
+        // ADR-0002 custody guard (#879): before any order flows, verify the
+        // on-chain Solana `bridge.mint_authority` is a distinct multisig, not
+        // this node's own key. Warn by default; hard-fail in a production
+        // posture (`solana.mint_signers`/`mint_threshold` configured). RPC
+        // failures are non-fatal (re-checked next boot) so they never wedge
+        // startup.
+        if let Some(sol_minter) = sol_minter.as_ref() {
+            if let Err(e) = sol_minter.verify_mint_authority_is_not_local_key().await {
+                error!(
+                    "Solana mint-authority custody check failed (ADR 0002): {}",
+                    e
+                );
+                return Err(format!("Solana mint-authority custody check failed: {}", e));
+            }
+        }
 
         // Startup reconciliation (#843): roll stranded orders forward
         // exactly once BEFORE any watcher or processing loop runs (no

--- a/bridge/service/src/mint/solana.rs
+++ b/bridge/service/src/mint/solana.rs
@@ -176,6 +176,10 @@ pub fn build_bridge_mint_instruction(
     }
 }
 
+/// Byte offset of the `mint_authority: Pubkey` field inside the `Bridge`
+/// account: it is the first field after the 8-byte Anchor discriminator.
+pub const BRIDGE_MINT_AUTHORITY_OFFSET: usize = 8;
+
 /// Byte offset of the `mint: Pubkey` field inside the `Bridge` account:
 /// 8-byte Anchor discriminator + mint_authority(32) + admin_authority(32) +
 /// pauser_authority(32).
@@ -193,6 +197,32 @@ pub fn parse_bridge_mint(data: &[u8]) -> Result<Pubkey, MintError> {
     let mut arr = [0u8; 32];
     arr.copy_from_slice(&data[BRIDGE_MINT_OFFSET..end]);
     Ok(Pubkey(arr))
+}
+
+/// Extract the `mint_authority` pubkey from raw `Bridge` account data
+/// (#850 layout). Bounds-checked exactly like [`parse_bridge_mint`] — never a
+/// truncated read.
+pub fn parse_bridge_mint_authority(data: &[u8]) -> Result<Pubkey, MintError> {
+    let end = BRIDGE_MINT_AUTHORITY_OFFSET + 32;
+    if data.len() < end {
+        return Err(MintError::Rpc(format!(
+            "bridge account too small ({} bytes) to hold the mint_authority field",
+            data.len()
+        )));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&data[BRIDGE_MINT_AUTHORITY_OFFSET..end]);
+    Ok(Pubkey(arr))
+}
+
+/// Pure comparison at the heart of the ADR-0002 startup custody guard: the
+/// on-chain `mint_authority` being byte-equal to this node's local signing
+/// key means the mint authority is a lone hot key, NOT a multisig — a single
+/// compromised relayer key could then mint, bypassing the federation.
+///
+/// Returns `true` when the configuration is unsafe (authority == local key).
+pub fn mint_authority_is_local_key(mint_authority: &Pubkey, local_signer: &Pubkey) -> bool {
+    mint_authority.0 == local_signer.0
 }
 
 /// Solana minting backend. Live-wired per #857 (see module docs).
@@ -282,6 +312,94 @@ impl SolMinter {
                 ))
             })?;
         parse_bridge_mint(&data)
+    }
+
+    /// ADR-0002 startup custody guard: read the on-chain `Bridge` account's
+    /// `mint_authority` and verify it is NOT this node's own local signing key.
+    ///
+    /// A single-key `mint_authority` (equal to the local `keypair_file` pubkey)
+    /// bypasses the whole federation custody model on Solana — a lone
+    /// compromised relayer key could mint, because the on-chain program only
+    /// checks that the presented signer *equals* `bridge.mint_authority` and
+    /// the `t`-of-`n` threshold lives inside the multisig. In production the
+    /// authority must be a distinct SPL/Squads multisig.
+    ///
+    /// Behavior:
+    /// - Watch-only mode (no local signer) → nothing to compare, returns `Ok`.
+    /// - RPC/parse failure → non-fatal: the guarded property is a static
+    ///   mis-init, re-checkable next boot, so a transient RPC blip must not
+    ///   wedge startup. Logs a warning and returns `Ok`.
+    /// - Authority == local key → single-key authority detected. In a
+    ///   production posture ([`SolanaConfig::requires_multisig_authority`])
+    ///   this is a HARD error; otherwise a prominent warning.
+    /// - Authority != local key → the safe path, returns `Ok` silently.
+    pub async fn verify_mint_authority_is_not_local_key(&self) -> Result<(), MintError> {
+        let local_signer = match self.signer.as_ref().map(|(_, pk)| pk) {
+            Some(pk) => pk,
+            None => {
+                debug!("solana mint-authority guard: watch-only mode (no keypair_file), skipping");
+                return Ok(());
+            }
+        };
+
+        // Reuse the exact fetch resolve_mint uses; treat any RPC/parse failure
+        // as non-fatal for the guard (log + continue).
+        let data = match self
+            .rpc
+            .get_account_data(&self.bridge_pda.to_base58(), "finalized")
+            .await
+        {
+            Ok(Some(data)) => data,
+            Ok(None) => {
+                warn!(
+                    "solana mint-authority guard: bridge account {} not found \
+                     (is the program initialized?); skipping the custody check",
+                    self.bridge_pda.to_base58()
+                );
+                return Ok(());
+            }
+            Err(e) => {
+                warn!(
+                    "solana mint-authority guard: could not fetch bridge account ({}); \
+                     skipping the custody check (re-checked next startup)",
+                    e
+                );
+                return Ok(());
+            }
+        };
+
+        let mint_authority = match parse_bridge_mint_authority(&data) {
+            Ok(pk) => pk,
+            Err(e) => {
+                warn!(
+                    "solana mint-authority guard: could not parse mint_authority ({}); \
+                     skipping the custody check",
+                    e
+                );
+                return Ok(());
+            }
+        };
+
+        if mint_authority_is_local_key(&mint_authority, local_signer) {
+            let msg = format!(
+                "solana bridge.mint_authority ({}) equals this node's local keypair_file key — \
+                 the mint authority is a SINGLE KEY, not a multisig. Per ADR 0002 it MUST be a \
+                 distinct SPL/Squads multisig; a lone compromised relayer key could otherwise \
+                 mint wBTH. Re-run `initialize` with a multisig mint_authority (see \
+                 contracts/solana/README.md deploy runbook).",
+                mint_authority.to_base58()
+            );
+            if self.config.requires_multisig_authority() {
+                return Err(MintError::Config(msg));
+            }
+            warn!("{}", msg);
+        } else {
+            debug!(
+                "solana mint-authority guard: on-chain mint_authority is distinct from the local \
+                 key (custody OK)"
+            );
+        }
+        Ok(())
     }
 }
 
@@ -655,9 +773,21 @@ mod tests {
 
     impl MockRpc {
         fn with_mint(mint: Pubkey) -> Self {
-            let mut data = vec![0u8; BRIDGE_MINT_OFFSET];
-            data.extend_from_slice(&mint.0);
+            Self::with_authorities(Pubkey([0u8; 32]), mint)
+        }
+
+        /// Build a mock seeding both the `mint_authority` (bytes [8..40]) and
+        /// the `mint` field of the on-chain `Bridge` account.
+        fn with_authorities(mint_authority: Pubkey, mint: Pubkey) -> Self {
+            // discriminator(8) || mint_authority(32) || admin(32) ||
+            // pauser(32) || mint(32) || tail
+            let mut data = vec![0u8; BRIDGE_MINT_AUTHORITY_OFFSET];
+            data.extend_from_slice(&mint_authority.0); // [8..40]
+            data.extend_from_slice(&[0u8; 32]); // admin_authority
+            data.extend_from_slice(&[0u8; 32]); // pauser_authority
+            data.extend_from_slice(&mint.0); // mint
             data.extend_from_slice(&[0u8; 100]);
+            debug_assert_eq!(data.len(), BRIDGE_MINT_OFFSET + 32 + 100);
             Self {
                 sent: Mutex::new(Vec::new()),
                 send_error: Mutex::new(None),
@@ -885,5 +1015,119 @@ mod tests {
     async fn test_send_transaction_base64_wire_is_standard() {
         // Guards the base64 encoding sendTransaction receives.
         assert_eq!(base64_encode(&[0, 0, 0]), "AAAA");
+    }
+
+    // ------------------------------------------------------------------
+    // ADR-0002 mint-authority custody guard (#879)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_bridge_mint_authority_well_formed() {
+        let authority = Pubkey([0x77u8; 32]);
+        let mut data = vec![0u8; BRIDGE_MINT_AUTHORITY_OFFSET];
+        data.extend_from_slice(&authority.0);
+        data.extend_from_slice(&[0u8; 200]);
+        assert_eq!(parse_bridge_mint_authority(&data).unwrap().0, authority.0);
+    }
+
+    #[test]
+    fn test_parse_bridge_mint_authority_rejects_truncated() {
+        // One byte short of the 40-byte minimum: must error, never truncate.
+        let data = vec![0u8; BRIDGE_MINT_AUTHORITY_OFFSET + 31];
+        assert!(matches!(
+            parse_bridge_mint_authority(&data),
+            Err(MintError::Rpc(_))
+        ));
+    }
+
+    #[test]
+    fn test_mint_authority_is_local_key_pure_comparison() {
+        let key = Pubkey([9u8; 32]);
+        let other = Pubkey([10u8; 32]);
+        // Equal bytes => single-key authority (unsafe).
+        assert!(mint_authority_is_local_key(&key, &key));
+        // Differing bytes => distinct authority (safe).
+        assert!(!mint_authority_is_local_key(&key, &other));
+    }
+
+    #[tokio::test]
+    async fn test_guard_flags_single_key_authority_warn_mode() {
+        // Authority == local key, non-production posture (no mint_signers):
+        // warn-only, so the guard returns Ok.
+        let (sk, pk) = test_signer();
+        let rpc = Arc::new(MockRpc::with_authorities(pk, Pubkey([0x33u8; 32])));
+        let minter = SolMinter::with_parts(test_config(), rpc, Some((sk, pk))).unwrap();
+        assert!(minter
+            .verify_mint_authority_is_not_local_key()
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_guard_hard_fails_single_key_authority_strict_mode() {
+        // Authority == local key AND a production posture (mint_signers +
+        // threshold configured): the guard must hard-fail.
+        let (sk, pk) = test_signer();
+        let rpc = Arc::new(MockRpc::with_authorities(pk, Pubkey([0x33u8; 32])));
+        let mut config = test_config();
+        config.mint_signers = vec![Pubkey([1u8; 32]).to_base58()];
+        config.mint_threshold = 1;
+        assert!(config.requires_multisig_authority());
+        let minter = SolMinter::with_parts(config, rpc, Some((sk, pk))).unwrap();
+        assert!(matches!(
+            minter.verify_mint_authority_is_not_local_key().await,
+            Err(MintError::Config(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_guard_passes_when_authority_differs() {
+        // Authority != local key: safe, even in strict mode.
+        let (sk, pk) = test_signer();
+        let multisig_authority = Pubkey([0x55u8; 32]);
+        let rpc = Arc::new(MockRpc::with_authorities(
+            multisig_authority,
+            Pubkey([0x33u8; 32]),
+        ));
+        let mut config = test_config();
+        config.mint_signers = vec![Pubkey([1u8; 32]).to_base58()];
+        config.mint_threshold = 1;
+        let minter = SolMinter::with_parts(config, rpc, Some((sk, pk))).unwrap();
+        assert!(minter
+            .verify_mint_authority_is_not_local_key()
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_guard_skips_in_watch_only_mode() {
+        // No local signer: nothing to compare, guard is a no-op even if the
+        // on-chain authority happens to match some key.
+        let rpc = Arc::new(MockRpc::with_authorities(
+            Pubkey([0x77u8; 32]),
+            Pubkey([0x33u8; 32]),
+        ));
+        let minter = SolMinter::with_parts(test_config(), rpc, None).unwrap();
+        assert!(minter
+            .verify_mint_authority_is_not_local_key()
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_guard_non_fatal_on_missing_bridge_account() {
+        // RPC returns no account: non-fatal (re-checked next boot), returns Ok
+        // even in strict mode.
+        let (sk, pk) = test_signer();
+        let rpc = Arc::new(MockRpc::with_authorities(pk, Pubkey([0x33u8; 32])));
+        *rpc.bridge_account.lock().unwrap() = None;
+        let mut config = test_config();
+        config.mint_signers = vec![Pubkey([1u8; 32]).to_base58()];
+        config.mint_threshold = 1;
+        let minter = SolMinter::with_parts(config, rpc, Some((sk, pk))).unwrap();
+        assert!(minter
+            .verify_mint_authority_is_not_local_key()
+            .await
+            .is_ok());
     }
 }

--- a/contracts/solana/README.md
+++ b/contracts/solana/README.md
@@ -38,6 +38,53 @@ Record the concrete multisig addresses + thresholds here per deployment:
 |---------|-----------|-----------|---------------|----------------|-----------------|
 | (none deployed yet) | | | | | |
 
+### Deploy / init runbook — checked custody gate (ADR 0002)
+
+The custody model above is a **deploy-time invariant** the on-chain program
+cannot self-enforce: `wbth` only checks that the presented signer *equals*
+`bridge.mint_authority`; the `t`-of-`n` threshold lives inside the multisig.
+So if `initialize` sets `mint_authority` to the relayer's own single key, a
+lone compromised key can mint. Turn the invariant into a step an operator ticks
+off at deploy:
+
+1. `[ ]` Create the **mint** multisig (distinct from admin/pauser). Its members
+   are the SCP validators' Ed25519 keys, threshold `t ≥ SCP safety threshold`.
+   - SPL Token multisig:
+     ```bash
+     spl-token create-multisig <THRESHOLD> <VALIDATOR_PUBKEY_1> <VALIDATOR_PUBKEY_2> ... <VALIDATOR_PUBKEY_N>
+     # → prints the mint multisig address; record it below.
+     ```
+   - or a [Squads](https://squads.so) multisig PDA (members = validator keys),
+     recording the resulting multisig PDA address.
+2. `[ ]` Create the **admin** and **pauser** multisigs the same way (each
+   distinct from the mint multisig and from each other).
+3. `[ ]` Call `initialize` passing the three authority pubkeys **explicitly**
+   (the payer receives no standing role):
+   ```bash
+   anchor run initialize -- \
+     --mint-authority   <MINT_MULTISIG>   \
+     --admin-authority  <ADMIN_MULTISIG>  \
+     --pauser-authority <PAUSER_MULTISIG>
+   # (or the equivalent `solana`/TS client call that invokes `initialize`
+   #  with those three pubkeys)
+   ```
+4. `[ ]` **Hard gate — verify before any value flows:** `mint_authority` is a
+   **DISTINCT multisig** (Squads PDA or SPL Token multisig), **NOT** the
+   relayer / `bridge.solana.keypair_file` key, **and NOT** `admin_authority`.
+   The bridge service also enforces this at startup: it reads the on-chain
+   `mint_authority` and, in a production posture
+   (`solana.mint_signers`/`mint_threshold` configured), **fails to start** if it
+   equals this node's local key (warns otherwise) — see
+   `bridge/service/src/mint/solana.rs`
+   (`verify_mint_authority_is_not_local_key`, #879).
+5. `[ ]` Record the resulting addresses + thresholds in the per-deployment table
+   above (Program ID / wBTH mint / Mint multisig / Admin multisig / Pauser
+   multisig).
+6. `[ ]` Finalize the BPF upgrade authority (`--final`) before mainnet value
+   flows — see [Upgradeability](#upgradeability--immutable-at-deploy-bpf-upgrade-authority-revoked)
+   below. This custody gate and the upgrade-authority gate are the two deploy
+   gates that must both be closed before mainnet.
+
 ### Replay-proof, order-bound minting
 
 `bridge_mint(amount, order_id)` takes a 32-byte `order_id` (the bridge order


### PR DESCRIPTION
## Summary

Per ADR 0002, the Solana `bridge.mint_authority` must be a distinct multisig, never a single hot key — the on-chain `wbth` program only checks the presented signer *equals* `mint_authority`, so the `t`-of-`n` threshold lives inside the multisig. The service could not enforce this deploy-time invariant, so a mis-init (`mint_authority` = the relayer's own key) would silently bypass Solana custody.

This adds (Item 1) an explicit checked deploy/init runbook and (Item 2) a startup/health custody guard that catches the mis-init before any order flows.

## Changes

- **`contracts/solana/README.md`** — new "Deploy / init runbook — checked custody gate" section: a checkbox checklist ending in a hard gate (`mint_authority` is a DISTINCT multisig, NOT the `keypair_file` key, NOT `admin_authority`), the concrete SPL/Squads multisig-creation + `initialize` commands, an instruction to record the addresses in the existing per-deployment table, and a cross-reference to the `--final` BPF upgrade-authority gate.
- **`bridge/service/src/mint/solana.rs`** — `BRIDGE_MINT_AUTHORITY_OFFSET` (= 8) + bounds-checked `parse_bridge_mint_authority` (mirrors `parse_bridge_mint`, never truncates); `mint_authority_is_local_key` pure comparison; async `SolMinter::verify_mint_authority_is_not_local_key` reusing the existing `get_account_data(bridge_pda, "finalized")` fetch. Watch-only mode skips; RPC/parse failures are non-fatal (re-checked next boot); authority == local key warns, or hard-errors in a production posture.
- **`bridge/service/src/engine.rs`** — `build_minters` now also returns a typed `Arc<SolMinter>` handle (no `dyn` downcast); `run()` invokes the guard once, right before `recover_on_startup`.
- **`bridge/core/src/config.rs`** — `SolanaConfig::requires_multisig_authority()` uses the existing `mint_signers`/`mint_threshold` production signal as the strict-mode switch (warn-by-default, fail-fast in production). No new config field, so no struct-literal churn.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Item 1: README checked runbook step (distinct multisig hard gate + init/multisig commands + points at table + cross-refs `--final`) | done | New runbook section in `contracts/solana/README.md` |
| Item 2: startup authority check reusing the `Bridge` fetch, compares to local signer | done | `verify_mint_authority_is_not_local_key` reuses `get_account_data`; wired in `engine.rs` before `recover_on_startup` |
| Warn-by-default with opt-in strict/fail switch | done | `requires_multisig_authority()` gates warn vs `MintError::Config`; tests cover both |
| Bounds-checked parser (never truncates) | done | `test_parse_bridge_mint_authority_rejects_truncated` |
| Watch-only skips; RPC/parse failure non-fatal | done | `test_guard_skips_in_watch_only_mode`, `test_guard_non_fatal_on_missing_bridge_account` |
| Unit test for single-key detection (pure comparison) | done | `test_mint_authority_is_local_key_pure_comparison` |
| Item 3 (devnet drill) left untouched | done | `solana_devnet_tests.rs` unchanged; 7 `#[ignore]`d drills still ignored |

## Test Plan

- `cargo test -p bth-bridge-service -p bth-bridge-core` → 208 passed, 0 failed, 7 ignored (the devnet drills, deliberately untouched). 9 new tests cover parser, pure comparison, warn mode, strict fail mode, authority-differs pass, watch-only skip, and non-fatal missing-account.
- `cargo clippy -p bth-bridge-service -p bth-bridge-core` → clean.
- `cargo fmt` applied.

**Item 3 (recording the live devnet drill in `solana_devnet_tests.rs`) remains deferred to #867** — it requires a running validator + deployed/initialized `wbth` program, which is operator-gated. The `#[ignore]` drill gates are left as-is; #867 is their validation gate.

Closes #879