### PR TITLE
feat(bridge): detect + audit federation attestation equivocation

### DIFF
--- a/bridge/core/src/adversarial_tests.rs
+++ b/bridge/core/src/adversarial_tests.rs
@@ -28,7 +28,7 @@ use crate::{
     attestation::{
         attestation_signed_message, canonical_attestation_envelope, release_payload_digest,
         sign_attestation_ed25519, AttestationEnvelope, AttestationKind, AttestationRejectReason,
-        AttestationSet, AttestationSignature, ATTEST_DOMAIN_BTH, ATTEST_DOMAIN_ETH,
+        AttestationSet, AttestationSignature, InsertOutcome, ATTEST_DOMAIN_BTH, ATTEST_DOMAIN_ETH,
         ATTEST_DOMAIN_SOL, MINT_ATTESTATION_DOMAIN_TAG_ETH, MINT_ATTESTATION_DOMAIN_TAG_SOL,
         RELEASE_ATTESTATION_DOMAIN_TAG,
     },
@@ -238,13 +238,15 @@ fn equivocating_signer_cannot_inflate_the_distinct_signer_count() {
     // count as two toward the threshold. The aggregation primitive
     // deduplicates by signer identity, so the second submission counts zero.
     //
-    // NOTE ON DETECTION (follow-up filed): `AttestationSet` is *resistant* to
+    // NOTE ON DETECTION (#859): `AttestationSet` is *resistant* to
     // equivocation (a single malicious signer can never move the threshold),
-    // but it does not *flag* the equivocation as an auditable event — it
-    // silently keeps the first submission. Active detection (raising an
-    // equivocation alarm when a signer presents conflicting bytes for the
-    // same order id) is tracked as a hardening follow-up. See the threat
-    // model doc: docs/security/bridge-threat-model.md.
+    // and now also *classifies* it — `insert_classified` reports
+    // `Equivocation` when a counted signer re-sends CONFLICTING bytes so the
+    // service can raise an `attestation_equivocation` audit alarm. This test
+    // pins the funds-safe behavior (`insert` still returns `Ok(false)`, the
+    // count stays at 1);
+    // `equivocating_signer_is_classified_distinctly_from_a_benign_resend` below
+    // pins the new classification. See docs/security/bridge-threat-model.md.
     let sk = signing_key(5);
     let order = burn_order();
     let kind = release_kind(&order);
@@ -277,6 +279,59 @@ fn equivocating_signer_cannot_inflate_the_distinct_signer_count() {
         !set.is_threshold_met(2),
         "a single equivocating signer can never satisfy a 2-of-n threshold"
     );
+}
+
+#[test]
+fn equivocating_signer_is_classified_distinctly_from_a_benign_resend() {
+    // #859: the set must DETECT (not just neutralize) equivocation. A counted
+    // signer that re-sends IDENTICAL bytes is a benign duplicate; a counted
+    // signer that presents CONFLICTING payload bytes for the same
+    // (order, action) is an equivocation — a governance-relevant alarm. In
+    // BOTH cases the threshold is unchanged (still counts once): detection is
+    // observation only, so funds-safety is preserved.
+    let sk = signing_key(9);
+    let order = burn_order();
+    let kind = release_kind(&order);
+
+    let env = sign_attestation_ed25519(&kind, &sk, "eq-c", now(), now() + 120).unwrap();
+    let parsed = env.verify_and_parse_ed25519(&sk.verifying_key()).unwrap();
+
+    let mut set = AttestationSet::for_attestation(&parsed);
+    let real_sig = AttestationSignature {
+        signer: sk.verifying_key().as_bytes().to_vec(),
+        signature: hex::decode(&env.payload_signature_hex).unwrap(),
+    };
+
+    // First submission: a new distinct signer counts.
+    assert_eq!(
+        set.insert_classified(&parsed, real_sig.clone()),
+        Ok(InsertOutcome::NewSigner),
+    );
+    assert_eq!(set.distinct_signers(), 1);
+
+    // Benign re-send: same signer, IDENTICAL bytes. Not an alarm, counts once.
+    assert_eq!(
+        set.insert_classified(&parsed, real_sig.clone()),
+        Ok(InsertOutcome::DuplicateBenign),
+    );
+    assert_eq!(set.distinct_signers(), 1);
+
+    // Equivocation: same signer, CONFLICTING payload signature bytes.
+    let mut conflicting = real_sig.clone();
+    conflicting.signature[0] ^= 0xff;
+    assert_eq!(
+        set.insert_classified(&parsed, conflicting.clone()),
+        Ok(InsertOutcome::Equivocation),
+        "a counted signer presenting different payload bytes must be flagged as equivocation"
+    );
+
+    // Funds-safety invariant: the equivocation NEVER inflated the count and
+    // NEVER satisfied a 2-of-n threshold, and the funds-path `insert` still
+    // reports the neutralizing `Ok(false)` for the conflicting resubmission.
+    assert_eq!(set.distinct_signers(), 1);
+    assert!(!set.is_threshold_met(2));
+    assert_eq!(set.insert(&parsed, conflicting), Ok(false));
+    assert_eq!(set.distinct_signers(), 1);
 }
 
 #[test]

--- a/bridge/core/src/attestation.rs
+++ b/bridge/core/src/attestation.rs
@@ -648,6 +648,14 @@ pub struct AttestationOutcome {
     pub signers: u32,
     /// The configured federation threshold `t`.
     pub threshold: u32,
+    /// Detection-only flag: this VERIFIED envelope came from a signer that had
+    /// already attested this `(order, action)` with CONFLICTING bytes (a
+    /// different payload signature, or — for Ethereum mints — a different Safe
+    /// nonce). It is a governance-relevant equivocation signal the db-bearing
+    /// callsite audits (`attestation_equivocation`). It NEVER changes funds
+    /// behavior: the first submission already counted and an equivocating
+    /// resubmission still counts zero toward `t`.
+    pub equivocation: bool,
 }
 
 impl AttestationOutcome {
@@ -663,7 +671,15 @@ impl AttestationOutcome {
             order_id: Some(parsed.action.order_uuid()),
             signers,
             threshold,
+            equivocation: false,
         }
+    }
+
+    /// Flag this outcome as carrying an equivocation signal (detection only —
+    /// the threshold decision is unchanged). Chainable on `accept`/`refuse`.
+    pub fn with_equivocation(mut self) -> Self {
+        self.equivocation = true;
+        self
     }
 
     /// Build a refusal outcome. `parsed` is `Some` once the envelope parsed
@@ -684,6 +700,7 @@ impl AttestationOutcome {
             order_id: parsed.map(|p| p.action.order_uuid()),
             signers,
             threshold,
+            equivocation: false,
         }
     }
 }
@@ -1250,6 +1267,25 @@ pub fn check_order_binding(
     Ok(())
 }
 
+/// The classified result of inserting a verified attestation into an
+/// [`AttestationSet`]. The threshold decision is carried by the variant, and
+/// an already-counted signer is further split into a benign re-send vs. an
+/// equivocation so the ingest pipeline can raise a detection alarm WITHOUT
+/// changing what counts toward `t`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsertOutcome {
+    /// A new distinct signer was recorded and now counts once toward `t`.
+    NewSigner,
+    /// An already-counted signer re-sent IDENTICAL payload bytes (a benign
+    /// retry / duplicate delivery). Counts zero; not an alarm.
+    DuplicateBenign,
+    /// An already-counted signer presented CONFLICTING payload bytes for the
+    /// same `(order, action)` — an equivocation. Still counts zero (the
+    /// threshold is never inflated), but is a governance-relevant signal the
+    /// caller should audit.
+    Equivocation,
+}
+
 /// Collects verified per-signer attestations for ONE `(order, action)` and
 /// answers the threshold question. Deduplicates by signer identity: the
 /// same federation member attesting twice (even with distinct nonces)
@@ -1264,6 +1300,11 @@ pub struct AttestationSet {
     /// be combined into one `execTransaction`, so mismatches are rejected.
     safe_nonce: Option<u64>,
     entries: Vec<(String, AttestationSignature)>,
+    /// Signer key ids already flagged as equivocating, so the alarm fires at
+    /// most ONCE per signer even if that signer keeps re-submitting conflicting
+    /// bytes. Never affects threshold counting (an equivocating signer counts
+    /// once regardless of how many conflicts it presents).
+    flagged_equivocators: Vec<String>,
 }
 
 impl AttestationSet {
@@ -1279,6 +1320,7 @@ impl AttestationSet {
             target_chain: parsed.action.target_chain(),
             safe_nonce,
             entries: Vec::new(),
+            flagged_equivocators: Vec::new(),
         }
     }
 
@@ -1307,21 +1349,86 @@ impl AttestationSet {
     /// for a new distinct signer, `Ok(false)` if this signer already counted
     /// (double-count resistance), `Err` if the attestation does not belong
     /// to this set.
+    ///
+    /// This is the funds-path entry point: it answers only "did a new distinct
+    /// signer count?" and deliberately collapses the two already-counted cases
+    /// (benign re-send vs. equivocation) into a single `Ok(false)`. Callers
+    /// that need to DETECT equivocation (raise an audit alarm) must use
+    /// [`insert_classified`](Self::insert_classified) instead, which returns
+    /// the same threshold decision plus a conflict classification.
     pub fn insert(
         &mut self,
         parsed: &ParsedAttestation,
         signature: AttestationSignature,
     ) -> Result<bool, String> {
+        match self.insert_classified(parsed, signature)? {
+            InsertOutcome::NewSigner => Ok(true),
+            InsertOutcome::DuplicateBenign | InsertOutcome::Equivocation => Ok(false),
+        }
+    }
+
+    /// Insert a VERIFIED attestation's payload signature, classifying an
+    /// already-counted signer as either a benign re-send or an equivocation.
+    ///
+    /// The threshold decision is IDENTICAL to [`insert`](Self::insert): a new
+    /// distinct signer is recorded and counts once
+    /// ([`InsertOutcome::NewSigner`]); an already-counted signer is NOT
+    /// recorded and counts zero, whether it re-sent identical bytes
+    /// ([`InsertOutcome::DuplicateBenign`]) or CONFLICTING bytes
+    /// ([`InsertOutcome::Equivocation`]). The only added information is the
+    /// conflict signal — this method never inflates the distinct-signer count,
+    /// so funds-safety is unchanged (an equivocating signer still counts once).
+    ///
+    /// Conflict is decided by comparing the newly-presented payload signature
+    /// bytes against the entry already stored for that signer: identical bytes
+    /// are a benign retry, differing bytes are an equivocation (the signer has
+    /// signed two distinct payloads for one logical `(order, action)`). A
+    /// conflicting Safe nonce (Ethereum mints) is caught earlier by
+    /// [`matches`](Self::matches) and surfaces as `Err`; the pipeline treats
+    /// that separately (see the service layer's equivocation classifier).
+    pub fn insert_classified(
+        &mut self,
+        parsed: &ParsedAttestation,
+        signature: AttestationSignature,
+    ) -> Result<InsertOutcome, String> {
         self.matches(parsed)?;
-        if self
+        if let Some((_, stored)) = self
             .entries
             .iter()
-            .any(|(id, _)| *id == parsed.signer_key_id)
+            .find(|(id, _)| *id == parsed.signer_key_id)
         {
-            return Ok(false);
+            // Already counted. Distinguish a benign re-send (same signer, same
+            // payload signature bytes) from an equivocation (same signer,
+            // CONFLICTING payload signature — two distinct signed payloads for
+            // one logical order). Either way the signer still counts once.
+            if stored.signature == signature.signature {
+                return Ok(InsertOutcome::DuplicateBenign);
+            }
+            // Conflict. Flag it, but report `Equivocation` at most ONCE per
+            // signer so the audit alarm does not spam on repeated conflicts —
+            // subsequent conflicts from an already-flagged signer report as a
+            // benign duplicate (still counts zero).
+            if self.flag_equivocation(&parsed.signer_key_id) {
+                return Ok(InsertOutcome::Equivocation);
+            }
+            return Ok(InsertOutcome::DuplicateBenign);
         }
         self.entries.push((parsed.signer_key_id.clone(), signature));
-        Ok(true)
+        Ok(InsertOutcome::NewSigner)
+    }
+
+    /// Record that `signer_key_id` has equivocated, returning `true` only the
+    /// FIRST time (so the caller raises the alarm exactly once per signer).
+    /// Detection bookkeeping only — never touches threshold counting. Exposed
+    /// so the ingest pipeline can also dedup the Safe-nonce-conflict shape,
+    /// which `matches` rejects (as `Err`) before it reaches
+    /// [`insert_classified`](Self::insert_classified)'s entry comparison.
+    pub fn flag_equivocation(&mut self, signer_key_id: &str) -> bool {
+        if self.flagged_equivocators.iter().any(|s| s == signer_key_id) {
+            return false;
+        }
+        self.flagged_equivocators.push(signer_key_id.to_string());
+        true
     }
 
     /// Distinct signers collected so far.

--- a/bridge/core/src/lib.rs
+++ b/bridge/core/src/lib.rs
@@ -28,7 +28,7 @@ pub use attestation::{
     parse_attestation_envelope, peek_order_id, peek_signer_key_id, peek_target_chain,
     release_payload_digest, sign_attestation_ed25519, AttestationEnvelope, AttestationKind,
     AttestationOutcome, AttestationRejectReason, AttestationSet, AttestationSignature,
-    MintAuthorization, ParsedAttestation, ReleaseAuthorization, SignatureScheme,
+    InsertOutcome, MintAuthorization, ParsedAttestation, ReleaseAuthorization, SignatureScheme,
     ATTESTATION_ENVELOPE_VERSION, ATTEST_DOMAIN_BTH, ATTEST_DOMAIN_ETH, ATTEST_DOMAIN_SOL,
     MAX_ATTESTATION_LIFETIME_SECS, RELEASE_ATTESTATION_DOMAIN_TAG,
 };

--- a/bridge/service/src/attestation.rs
+++ b/bridge/service/src/attestation.rs
@@ -59,7 +59,7 @@ use bth_bridge_core::{
         canonical_attestation_envelope, check_attestation_freshness, check_order_binding,
         parse_attestation_envelope, peek_signer_key_id, peek_target_chain,
         sign_attestation_ed25519, AttestationEnvelope, AttestationKind, AttestationOutcome,
-        AttestationRejectReason, AttestationSet, ParsedAttestation,
+        AttestationRejectReason, AttestationSet, InsertOutcome, ParsedAttestation,
     },
     attestation_signed_message,
     nonce::{NonceStore, ReserveOutcome},
@@ -750,27 +750,58 @@ impl FederationAttestationProvider {
             .sets
             .entry((order.id, parsed.action.name()))
             .or_insert_with(|| AttestationSet::for_attestation(&parsed));
-        match set.insert(
+        // Whether this signer had already counted BEFORE this submission —
+        // needed to classify a set-mismatch (`Err`) as an equivocation
+        // (already-counted signer presenting a CONFLICTING Safe nonce) vs. a
+        // generic invalid payload (a signer that never counted for this set).
+        let already_counted = set.contains_signer(&parsed.signer_key_id);
+        match set.insert_classified(
             &parsed,
             AttestationSignature {
                 signer: signer_bytes,
                 signature: payload_sig,
             },
         ) {
-            Ok(_new_signer) => {
+            Ok(InsertOutcome::NewSigner | InsertOutcome::DuplicateBenign) => {
                 let signers = set.distinct_signers();
                 drop(tracker);
                 AttestationOutcome::accept(&parsed, signers, threshold)
             }
-            Err(e) => {
+            Ok(InsertOutcome::Equivocation) => {
+                // Shape 1: the already-counted signer presented a CONFLICTING
+                // payload signature for the same (order, action). Detection
+                // only — the first submission already counted, this one counts
+                // zero (funds-safety unchanged). Surface the equivocation so
+                // the db-bearing callsite raises the audit alarm; the outcome
+                // still reports as accepted (the set advanced on the first
+                // submission and this benign-shaped resubmission changes no
+                // funds decision).
                 let signers = set.distinct_signers();
                 drop(tracker);
-                AttestationOutcome::refuse(
+                AttestationOutcome::accept(&parsed, signers, threshold).with_equivocation()
+            }
+            Err(e) => {
+                // Shape 2 (Ethereum mints): `matches` rejected a CONFLICTING
+                // Safe nonce. When the signer had already counted for this
+                // set, that is an equivocation (two Safe nonces signed for one
+                // order), not a generic invalid payload — flag it for audit at
+                // most once per signer. Threshold counting is unchanged either
+                // way (this envelope never counts).
+                let is_equivocation =
+                    already_counted && set.flag_equivocation(&parsed.signer_key_id);
+                let signers = set.distinct_signers();
+                drop(tracker);
+                let refusal = AttestationOutcome::refuse(
                     &AttestationRejectReason::InvalidPayload(e),
                     Some(&parsed),
                     signers,
                     threshold,
-                )
+                );
+                if is_equivocation {
+                    refusal.with_equivocation()
+                } else {
+                    refusal
+                }
             }
         }
     }

--- a/bridge/service/src/federation.rs
+++ b/bridge/service/src/federation.rs
@@ -205,6 +205,32 @@ pub async fn attest(
 
     // 3. Full fail-closed verify pipeline (the endpoint adds NO trust).
     let outcome = state.provider.submit_attestation(&envelope, &order);
+
+    // 3a. Equivocation detection (detection-only; funds behavior unchanged).
+    // A VERIFIED envelope from a known signer that conflicts with what that
+    // signer already attested for this order (different payload digest / Safe
+    // nonce) is a governance-relevant Byzantine signal — audit it distinctly
+    // from replayed_nonce / wrong_order / invalid_payload. The threshold set
+    // is unchanged: an equivocating signer still counts once.
+    if outcome.equivocation {
+        let signer = outcome.signer_key_id.as_deref().unwrap_or("<unknown>");
+        let action = outcome.action.as_deref().unwrap_or("<unknown>");
+        let details = format!(
+            "federation signer equivocated: signer={signer} order={} action={action} \
+             (conflicting attestation bytes for one order; funds neutralized, still counts once)",
+            order.id
+        );
+        warn!("attestation equivocation detected: {details}");
+        if let Err(e) = state
+            .db
+            .log_audit(Some(&order.id), "attestation_equivocation", &details)
+        {
+            // Audit is observability; a failed insert must not change the
+            // funds-safe HTTP verdict below.
+            warn!("failed to log attestation_equivocation audit event: {e}");
+        }
+    }
+
     let status = if outcome.accepted {
         StatusCode::OK
     } else {
@@ -1006,6 +1032,171 @@ mod federation_transport_tests {
         assert_eq!(
             provider.distinct_signers_for_test(order.id, "bridge.release_bth"),
             0
+        );
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+
+    // -- Equivocation detection (#859) --------------------------------------
+
+    /// Build an Ethereum-mint `AttestationKind` for `order` at `safe_nonce`
+    /// (the private `mint_kind` is not exposed; the fields are fully
+    /// determined by the order so we construct it directly).
+    fn eth_mint_kind(order: &BridgeOrder, safe_nonce: u64) -> bth_bridge_core::AttestationKind {
+        bth_bridge_core::AttestationKind::MintWbth {
+            dest_chain: order.dest_chain,
+            dest_address: order.dest_address.clone(),
+            amount: order.net_amount(),
+            order_id: order.id,
+            source_tx: order.source_tx.clone().unwrap(),
+            safe_nonce: Some(safe_nonce),
+        }
+    }
+
+    #[tokio::test]
+    async fn endpoint_audits_equivocation_exactly_once_per_signer() {
+        // A VERIFIED Safe owner that already counted for an order then submits
+        // a CONFLICTING attestation (a DIFFERENT Safe nonce for the same
+        // order) — the classic equivocation move. It must:
+        //   * raise a distinct `attestation_equivocation` audit event,
+        //   * fire that alarm EXACTLY ONCE per signer (repeated conflicts do not spam
+        //     the log),
+        //   * NEVER inflate the threshold set (funds-safety unchanged), and
+        //   * not fire for benign identical re-sends or for a second honest signer.
+        use crate::attestation::sign_attestation_secp256k1;
+
+        const N7: u64 = 7;
+        let (oa, ob) = (eth_key(11), eth_key(22));
+        let owners = vec![oa.address(), ob.address()];
+        let safe = Address::repeat_byte(0x5a);
+        let wbth = Address::repeat_byte(0xeb);
+        let chain_id = 1u64;
+        let order = eth_mint_order();
+
+        let provider = Arc::new(FederationAttestationProvider::new_eth_for_test(
+            &owners,
+            2,
+            chain_id,
+            safe,
+            wbth,
+            Arc::new(FixedNonce(N7)),
+            oa.clone(),
+        ));
+
+        // Hold a clone of the DB the endpoint audits into so we can count rows.
+        let db = db_with_order(&order);
+        let audit_db = db.clone();
+        let (url, sd, srv) = spawn_endpoint(provider.clone(), db).await;
+
+        let now = chrono::Utc::now().timestamp().max(0) as u64;
+        let sign = |safe_nonce: u64, replay_nonce: &str| {
+            let kind = eth_mint_kind(&order, safe_nonce);
+            sign_attestation_secp256k1(
+                &kind,
+                &oa,
+                chain_id,
+                safe,
+                wbth,
+                replay_nonce,
+                now,
+                now + 120,
+            )
+            .unwrap()
+        };
+
+        // 1) Owner A attests at Safe nonce 7 — accepted, counts once.
+        let e_ok = sign(N7, "eq-ok");
+        let (status, body) =
+            post_attest(&url, Some(AUTH), &serde_json::to_string(&e_ok).unwrap()).await;
+        assert_eq!(status, 200, "{body}");
+        assert_eq!(
+            provider.distinct_signers_for_test(order.id, "bridge.mint_wbth"),
+            1
+        );
+        assert_eq!(
+            audit_db
+                .count_audit_action("attestation_equivocation")
+                .unwrap(),
+            0
+        );
+
+        // 2) Owner A EQUIVOCATES: same order, CONFLICTING Safe nonce 8. The set refuses
+        //    to combine it (invalid_payload) AND flags it as an equivocation — one
+        //    audit row.
+        let e_conflict = sign(8, "eq-conflict-1");
+        let (status, body) = post_attest(
+            &url,
+            Some(AUTH),
+            &serde_json::to_string(&e_conflict).unwrap(),
+        )
+        .await;
+        assert_eq!(status, 409, "{body}");
+        assert!(body.contains("invalid_payload"), "{body}");
+        // Still exactly one counted signer — the conflict never counts.
+        assert_eq!(
+            provider.distinct_signers_for_test(order.id, "bridge.mint_wbth"),
+            1
+        );
+        assert_eq!(
+            audit_db
+                .count_audit_action("attestation_equivocation")
+                .unwrap(),
+            1
+        );
+
+        // 3) Owner A keeps equivocating (Safe nonce 9): still refused, but the alarm
+        //    fires EXACTLY ONCE per signer — no second audit row.
+        let e_conflict2 = sign(9, "eq-conflict-2");
+        let (status, _body) = post_attest(
+            &url,
+            Some(AUTH),
+            &serde_json::to_string(&e_conflict2).unwrap(),
+        )
+        .await;
+        assert_eq!(status, 409);
+        assert_eq!(
+            audit_db
+                .count_audit_action("attestation_equivocation")
+                .unwrap(),
+            1,
+            "equivocation must be audited exactly once per signer"
+        );
+
+        // 4) Owner A benignly re-sends its ORIGINAL nonce-7 attestation bytes (fresh
+        //    anti-replay nonce): a benign duplicate, NOT an alarm.
+        let e_benign = sign(N7, "eq-benign");
+        let (status, body) =
+            post_attest(&url, Some(AUTH), &serde_json::to_string(&e_benign).unwrap()).await;
+        assert_eq!(status, 200, "{body}");
+        assert_eq!(
+            audit_db
+                .count_audit_action("attestation_equivocation")
+                .unwrap(),
+            1,
+            "a benign identical re-send must not raise the equivocation alarm"
+        );
+
+        // 5) A DIFFERENT honest owner (B) attests at Safe nonce 7 — accepted, reaches
+        //    threshold, and raises NO equivocation alarm.
+        let e_b = {
+            let kind = eth_mint_kind(&order, N7);
+            sign_attestation_secp256k1(&kind, &ob, chain_id, safe, wbth, "eq-b", now, now + 120)
+                .unwrap()
+        };
+        let (status, body) =
+            post_attest(&url, Some(AUTH), &serde_json::to_string(&e_b).unwrap()).await;
+        assert_eq!(status, 200, "{body}");
+        assert_eq!(
+            provider.distinct_signers_for_test(order.id, "bridge.mint_wbth"),
+            2
+        );
+        assert_eq!(
+            audit_db
+                .count_audit_action("attestation_equivocation")
+                .unwrap(),
+            1,
+            "two distinct honest signers must not trigger the equivocation alarm"
         );
 
         let _ = sd.send(());

--- a/docs/security/bridge-threat-model.md
+++ b/docs/security/bridge-threat-model.md
@@ -122,15 +122,24 @@ of the operator-action tag — and by forged-signature tests.
 | --- | --- | --- |
 | Same signer, two submissions → counts once (no threshold inflation) | `adversarial_tests::equivocating_signer_cannot_inflate_the_distinct_signer_count`, `attestation::pipeline_same_signer_with_fresh_nonces_counts_once_toward_threshold` | new / #847 |
 | Conflicting amount/recipient cannot pass order binding | `adversarial_tests::conflicting_payload_for_the_same_order_cannot_cross_order_binding`, `attestation::test_order_binding_rejects_field_mismatches` | new / #847 |
+| Conflicting bytes classified distinctly from a benign re-send | `adversarial_tests::equivocating_signer_is_classified_distinctly_from_a_benign_resend` | new (#859) |
+| Verified conflicting attestation raises an `attestation_equivocation` audit event, exactly once per signer, funds unchanged | `federation::federation_transport_tests::endpoint_audits_equivocation_exactly_once_per_signer` | new (#859) |
 
-**Residual / follow-up.** Equivocation is *neutralized* (order binding pins
-every field to the on-record order, and the aggregation set deduplicates by
-signer identity, so a single equivocating signer can neither move conflicting
-funds nor inflate the threshold), but it is **not actively detected**: the
-service does not raise an auditable "equivocation" alarm when a signer presents
-conflicting bytes for the same order id — it silently keeps the first valid
-submission and rejects the rest via the normal replay/binding paths. Active
-detection + alerting is filed as a hardening follow-up (see "Follow-ups").
+**Status: neutralized AND detected.** Equivocation is *neutralized* (order
+binding pins every field to the on-record order, and the aggregation set
+deduplicates by signer identity, so a single equivocating signer can neither
+move conflicting funds nor inflate the threshold). As of #859 it is also
+*actively detected*: when a VERIFIED envelope from a counted signer conflicts
+with what that signer already attested for one order (a different payload
+signature, or — for Ethereum mints — a different Safe nonce), the service emits
+a dedicated `attestation_equivocation` audit event carrying the signer key id +
+order id, distinct from `replayed_nonce` / `wrong_order` / `invalid_payload`.
+Detection is observation-only: the threshold decision is unchanged (an
+equivocating signer still counts exactly once), and the alarm fires at most once
+per signer. Auto-tripping the circuit breaker on equivocation was deliberately
+deferred (a single compromised key equivocating is exactly when the *other*
+honest signers may need to keep making progress) and is left as a policy
+follow-up.
 
 ### 8. Reorg double-count (add / orphan / re-add on the source chain)
 
@@ -184,6 +193,9 @@ detection + alerting is filed as a hardening follow-up (see "Follow-ups").
 
 ## Follow-ups filed
 
-- **Active equivocation detection & alerting** (#859) — raise an auditable
-  alarm when a federation member submits conflicting attestations for the same
-  order id (today: neutralized but silent). See threat #7.
+- **Active equivocation detection & alerting** (#859) — LANDED: a verified
+  conflicting attestation now emits a distinct `attestation_equivocation` audit
+  event (exactly once per signer), funds behavior unchanged. See threat #7.
+  Remaining policy follow-up: whether to auto-trip the circuit breaker on
+  equivocation (deferred — halting the whole bridge on one equivocation report
+  can strand the honest signers).


### PR DESCRIPTION
## Summary

Equivocation by a federation signer (submitting CONFLICTING bytes for the same order) was *neutralized* but *silent*: `AttestationSet::insert` returned `Ok(false)` for an already-counted signer without comparing the stored signature/digest, so a Byzantine or compromised-key validator equivocating produced no distinct audit signal. This PR adds **detection-only** classification that emits a dedicated `attestation_equivocation` audit event — funds-safety behavior is unchanged.

## Changes

- **`bridge/core/src/attestation.rs`**
  - New `InsertOutcome` enum (`NewSigner` / `DuplicateBenign` / `Equivocation`).
  - `AttestationSet::insert_classified` compares the newly-presented payload signature against the stored entry for an already-counted signer: identical bytes = benign re-send, differing bytes = equivocation. `insert` is now a thin wrapper preserving its `Result<bool, String>` contract (both already-counted cases still map to `Ok(false)`).
  - `flag_equivocation(signer)` records flagged signers so the alarm fires at most once per signer; `AttestationOutcome.equivocation` flag + `with_equivocation()` builder.
- **`bridge/service/src/attestation.rs`** — `verify_and_aggregate` Step 7 classifies both conflict shapes onto the outcome without changing threshold counting: (1) conflicting payload signature bytes via `insert_classified`; (2) an already-counted signer presenting a different Safe nonce (which `matches` rejects as `Err`) is flagged as equivocation rather than generic `invalid_payload`.
- **`bridge/service/src/federation.rs`** — the db-bearing `attest` handler emits `db.log_audit(Some(order.id), "attestation_equivocation", details)` (signer key id + order id) when the outcome flags equivocation; a failed audit insert never changes the funds-safe HTTP verdict.
- **`bridge/core/src/lib.rs`** — export `InsertOutcome`.
- **`docs/security/bridge-threat-model.md`** — threat #7 updated to "neutralized AND detected"; follow-up entry marked landed (breaker-trip deferred as policy).

### Scope note (breaker / alerting)

Per the curator's guidance this PR is **audit-only**. Auto-tripping the circuit breaker on equivocation was deliberately deferred: a single compromised key equivocating is exactly when the *other* honest signers may need to keep making progress. Left as a policy follow-up (documented in the threat model).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Verified signer with conflicting attestations for one order produces an `attestation_equivocation` audit event | ✅ | `endpoint_audits_equivocation_exactly_once_per_signer` asserts `count_audit_action("attestation_equivocation") == 1` after a conflicting Safe nonce from a counted owner |
| Audit event is DISTINCT from `replayed_nonce` / `wrong_order` / `invalid_payload` | ✅ | New audit action string `attestation_equivocation`; the refusal still carries its own `invalid_payload` tag |
| Fires EXACTLY ONCE per equivocating signer | ✅ | Third conflicting submission (Safe nonce 9) keeps the count at 1; `flag_equivocation` dedups per signer |
| Benign identical re-send does NOT log | ✅ | Step 4 of the service test: re-sending nonce-7 bytes stays 200 with no new audit row |
| Two DIFFERENT honest signers do NOT trigger the alarm | ✅ | Step 5: owner B reaches 2/2, audit count stays 1 |
| Funds-safety unchanged (still neutralized, counts once) | ✅ | `distinct_signers` stays correct throughout; core test asserts `is_threshold_met(2)` false and `insert` still `Ok(false)` |
| Existing equivocation regression tests pass unchanged | ✅ | `equivocating_signer_cannot_inflate_the_distinct_signer_count` and `conflicting_payload_for_the_same_order_cannot_cross_order_binding` pass verbatim |

## Test Plan

- `cargo test -p bth-bridge-core -p bth-bridge-service` → 67 + 201 pass, 0 fail.
- `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets` → clean.
- New tests: `equivocating_signer_is_classified_distinctly_from_a_benign_resend` (core), `endpoint_audits_equivocation_exactly_once_per_signer` (service, drives the real `POST /api/attest` handler + counts `audit_log` rows).

Closes #859

🤖 Generated with [Claude Code](https://claude.com/claude-code)