### PR TITLE
docs(security): document bridge liveness/griefing posture and breaker-trip cost

### DIFF
--- a/docs/security/bridge-threat-model.md
+++ b/docs/security/bridge-threat-model.md
@@ -190,6 +190,35 @@ follow-up.
   fail-safe stubs: an unverified chain is reported `verified: false` and
   excluded from drift math — never silently counted as healthy
   (`reserve::test_unverified_chain_is_flagged_not_alerted`).
+- **Liveness is deliberately traded for safety (griefing / DoS-of-honest-orders).**
+  The bridge is fail-closed everywhere — peg drift, backlog/global caps, the
+  on-chain auto-pause, and the operator kill-switch all *halt* rather than
+  degrade. An adversary who wants to freeze the bridge therefore can, but only
+  by paying real value; there is no free griefing vector. Every breaker trips on
+  **real** activity, not on spoofable signals:
+  - The on-chain auto-pause fires on **cumulative daily mint volume**
+    (`WrappedBTH.sol` `autoPauseThreshold = 10_000_000 * 10 ** 12`, i.e. 10M BTH,
+    contract line ~104; the halt is armed after each mint at lines ~220–222).
+    Minting requires a `t`-of-`n` federation attestation over the attacker's own
+    confirmed BTH deposits, so reaching the threshold means the attacker first
+    locked ~10M BTH of *real* reserve.
+  - The service backlog and global-cap breakers
+    (`max_pending_orders = 1000`, `global_daily_limit = 10M BTH` in
+    `bridge/core/src/config.rs`) trip only on real orders: burns require owning
+    wBTH, deposits require BTH, each order is bounded by
+    `max_order_amount = 1M BTH`, and every order pays `fee_bps = 10` (0.10%,
+    floored at `min_fee = 0.0001 BTH`). Filling the 1000-order backlog with
+    minimum-fee orders costs the attacker at least `1000 × 0.0001 BTH = 0.1 BTH`
+    in fees alone (far more if the orders carry non-trivial value, since the
+    0.10% fee scales with amount), and every order still ties up real BTH or
+    wBTH.
+  DoS-of-honest-orders therefore resolves to "bridge halts, funds safe, operator
+  recovers": the invariants (exactly-once, threshold auth, peg solvency) hold
+  through the halt, and the operator restores service by the documented procedure
+  in [`bridge-order-engine-recovery.md`](../operations/runbooks/bridge-order-engine-recovery.md).
+  The fail-closed cap/breaker behavior is exercised by
+  `engine::test_breaker_auto_trips_on_backlog` and
+  `engine::test_global_cap_trips_breaker` (both #854).
 
 ## Follow-ups filed
 


### PR DESCRIPTION
## Summary

The bridge threat model enumerated its **safety** invariants thoroughly but never stated its **liveness** posture: a griefing adversary cannot steal funds, but could they cheaply freeze the bridge? This adds a "Boundary of the model" bullet that answers the question — the bridge deliberately fails closed everywhere, and every breaker trips only on *real* value, so there is no free griefing vector.

Docs-only change to `docs/security/bridge-threat-model.md`. No renumbering of the ten existing threats (#891/#859 already rewrote threat #7); the new content is an accepted-assumption bullet, per curator placement.

## Changes

- New bullet under `## Boundary of the model` covering:
  - **Fail-closed stance**: drift, backlog/global caps, on-chain auto-pause, and kill-switch all *halt* rather than degrade.
  - **Breaker-trip cost analysis** with verified parameters:
    - On-chain auto-pause fires on cumulative daily mint volume (`WrappedBTH.sol` `autoPauseThreshold = 10_000_000 * 10 ** 12`, i.e. 10M BTH, line ~104; halt armed at ~220–222). Reaching it requires the attacker's own ~10M BTH of locked reserve.
    - Service backlog/global-cap breakers (`max_pending_orders = 1000`, `global_daily_limit = 10M BTH`, `max_order_amount = 1M BTH`, `fee_bps = 10` = 0.10%, `min_fee = 0.0001 BTH` from `bridge/core/src/config.rs`) trip only on real orders — filling the 1000-order backlog costs ≥ 0.1 BTH in fees alone and ties up real BTH/wBTH per order.
  - **Resolution**: DoS-of-honest-orders resolves to "bridge halts, funds safe, operator recovers", cross-referencing the [`bridge-order-engine-recovery.md`](docs/operations/runbooks/bridge-order-engine-recovery.md) runbook by path.
  - Cites the existing `engine::test_breaker_auto_trips_on_backlog` and `engine::test_global_cap_trips_breaker` tests (#854).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New bullet under existing `## Boundary of the model`; no threat renumbering | ✅ | Diff is a single 29-line addition; the ten-threat map and #891/#859 content are untouched |
| Breaker-trip cost analysis with verified params | ✅ | Params confirmed in `bridge/core/src/config.rs` (`fee_bps=10`, `min_fee=100_000_000` picos = 0.0001 BTH, `max_pending_orders=1000`, `max_order_amount=1M`, `global_daily_limit`) and `WrappedBTH.sol` line 104 (`10_000_000 * 10 ** 12`), auto-pause at lines 220–222 |
| Explicit fail-closed / liveness-traded-for-safety stance | ✅ | Bullet states all four breakers halt rather than degrade and DoS resolves to "halts, funds safe, operator recovers" |
| Runbook cross-referenced by path (not "854") | ✅ | Links `../operations/runbooks/bridge-order-engine-recovery.md`; link verified to resolve |
| Cites `test_breaker_auto_trips_on_backlog` and `test_global_cap_trips_breaker` | ✅ | Both present in `bridge/service/src/engine.rs` (lines 2014 / 2088 in this branch) |
| Formal register matches surrounding threats | ✅ | Bold lead-in + backticked symbols, consistent with existing boundary bullets |

## Test Plan

Docs-only; no code paths changed. Verified:
- All relative Markdown links in the file resolve (runbook, ADRs, companion docs).
- Every cited symbol exists at the stated location: config params, `WrappedBTH.sol` `autoPauseThreshold` (line 104) and auto-pause logic (lines 220–222), and both engine tests.
- `git diff --stat` shows only `docs/security/bridge-threat-model.md` (+29, pure addition); main worktree confirmed clean.

Closes #862