### PR TITLE
docs(whitepaper): add intuition passages to the three novel mechanisms

### DIFF
--- a/whitepaper/sections/04-cryptography.tex
+++ b/whitepaper/sections/04-cryptography.tex
@@ -76,6 +76,32 @@ exchange~\cite{cryptonote,courtois-stealth}, building on the dual-key
 stealth-address construction (DKSAP). \Botho replaces the ECDH step with
 ML-KEM-768 to achieve post-quantum recipient privacy.
 
+\paragraph{Intuition.}
+Recipient privacy in a classical CryptoNote coin rests entirely on the
+hardness of the ECDH problem: the link between an output and its owner is an
+elliptic-curve Diffie--Hellman shared secret. That secret is not disclosed on
+chain, but everything needed to \emph{recompute} it under a quantum attacker
+is---the sender's ephemeral public key sits in the transaction permanently.
+An adversary who records the chain today and later runs Shor's algorithm
+recovers the shared secret and deanonymizes every historical recipient. This
+is the \emph{harvest-now, decrypt-later} exposure, and because recipient
+identity is permanent on-chain data (Table~\ref{tab:hybrid}) it cannot be
+mitigated by waiting or rotating keys after the fact.
+
+Replacing the ECDH step with an ML-KEM-768 encapsulation closes this exposure
+at its source. The sender encapsulates a fresh shared secret against the
+recipient's KEM public key; recovering it requires breaking a lattice problem
+believed hard even for quantum adversaries, so the recipient-unlinkability
+reduction of the Security Analysis below survives quantumly. Crucially,
+the KEM hardens only the \emph{key-exchange} step---the part whose secrecy
+must last forever---while sender anonymity continues to rely on the compact
+classical ring signature of Section~\ref{sec:clsag}. Making the entire spend
+authorization post-quantum would instead demand lattice ring signatures, whose
+$\sim$50$\times$ size overhead we quantify in
+Section~\ref{sec:hybrid-rationale} under ``Why not full post-quantum?''; the
+hybrid split buys quantum-durable recipient privacy for the cost of a single
+1{,}088-byte ciphertext per output rather than that blowup.
+
 \subsubsection{Protocol Description}
 
 Let the recipient have address $(A, B)$ where $A$ is interpreted as an
@@ -324,6 +350,7 @@ The minter's ML-DSA public key is derived from the same seed as their
 Ristretto keys, enabling unified key management.
 
 \subsection{Hybrid Architecture Rationale}
+\label{sec:hybrid-rationale}
 
 \begin{table}[h]
 \centering

--- a/whitepaper/sections/06-consensus.tex
+++ b/whitepaper/sections/06-consensus.tex
@@ -52,6 +52,32 @@ Byzantine fault tolerance & --- & \checkmark \\
 \end{tabular}
 \end{center}
 
+\paragraph{Intuition: two jobs, two mechanisms.}
+The table above is not a menu from which \Botho picks the better column; it is
+a division of labor. Consensus has to answer two separate questions, and no
+single mechanism answers both well. The first is \emph{who gets to issue new
+coins and propose the next block}---an open-entry question, where the right
+answer is a permissionless, Sybil-resistant lottery, which is exactly what
+proof-of-work provides. The second is \emph{which proposed block is final}---an
+agreement question, where the right answer is a Byzantine-agreement protocol
+that externalizes one block irreversibly, which is exactly what SCP provides.
+\Botho assigns each question to the mechanism suited to it and keeps the two
+deliberately decoupled: a miner's hashpower buys the right to \emph{propose}
+and to earn issuance, but carries no weight in the SCP \emph{vote} that
+finalizes the block. Mining weight and consensus voting weight are orthogonal.
+
+This decoupling is what distinguishes \Botho from both of its neighbors.
+MobileCoin adopts the same SCP finality but has no mining at all---its supply
+is premined and fixed, so it never needs a permissionless issuance
+lottery~(Section~\ref{sec:related}). Proof-of-work coins such as Bitcoin have
+the issuance lottery but no SCP layer, so they inherit only probabilistic
+finality and remain reorg-vulnerable. By running both, \Botho obtains
+permissionless, fairly distributed issuance \emph{and} fast deterministic
+finality simultaneously---the combination quantified in the comparison of
+Table~\ref{tab:consensus-comparison}. The cost is operating two subsystems
+rather than one; the benefit is that neither has to be compromised to
+approximate the other's guarantee.
+
 \input{figures/consensus-flow}
 
 \subsection{Stellar Consensus Protocol}

--- a/whitepaper/sections/10-economics.tex
+++ b/whitepaper/sections/10-economics.tex
@@ -139,6 +139,33 @@ Holding-side pressure cannot be escaped structurally: splitting does not
 change cluster attribution, and shedding attribution through artificial
 transfers is rate-bounded by tag decay (Section~\ref{sec:security}).
 
+\paragraph{Intuition: why a holding cost, and why a targeted one.}
+A fixed-supply currency in the Bitcoin mold makes hoarding costless, indeed
+rewarding: a coin left untouched keeps its full claim on a supply that will
+never grow, so the rational move for the largest holders is to sit still and
+let scarcity appreciate their stake. That is good for a store of value but
+poor for a medium of exchange, and it concentrates wealth over time because
+those best able to wait accrue the appreciation. A pure tail-emission design
+(perpetual issuance, no offsetting drag) softens the deflation but does not
+change the incentive: new coins accrue to whoever mines, and idle wealth is
+diluted only uniformly, which large holders can hedge simply by holding a
+proportional share of hashpower. In neither design does sitting on wealth cost
+the holder anything relative to their peers.
+
+\Botho's anti-hoarding pressure comes from making idle wealth carry a small,
+\emph{cluster-scaled} holding cost while leaving circulating money alone. The
+$\text{holding\_cost}$ term above is negative---a net drag---precisely for the
+high-factor clusters that dominate the supply and positive-leaning for
+ordinary factor-1 balances, which recover much of their dilution through
+lottery income. The effect is a continuous incentive to \emph{spend} rather
+than accumulate, without penalizing the everyday user the way classical
+uniform demurrage does. Historical demurrage currencies (Freigeld, the
+Chiemgauer) taxed every balance equally and were rejected as user-hostile for
+exactly this reason (Section~\ref{sec:related}); \Botho's contribution is to
+aim the same circulation incentive only where concentration actually occurs,
+using the cluster factor as the targeting signal
+(Section~\ref{sec:economic-modeling}).
+
 \subsection{Game-Theoretic Analysis}
 
 \subsubsection{Miner Strategy}


### PR DESCRIPTION
## Summary

Adds short, formal-register **intuition passages** to only the three whitepaper sections that describe mechanisms genuinely novel to Botho (no external literature to defer to). This is additive prose in the paper's existing voice, not a rewrite, and not a newcomer tutorial (that is the separate #881 companion). Standard primitives stay citation-only.

## Changes

- **`04-cryptography.tex`** — Post-Quantum Stealth Addresses (`sec:pq-stealth`): new "Intuition" paragraph explaining the *harvest-now, decrypt-later* exposure of classical ECDH recipient privacy and how an ML-KEM-768 encapsulation closes it, while sender anonymity stays on the compact classical ring signature. Cross-references the ~50x PQ-ring-signature size argument (does not restate it). Adds a `\label{sec:hybrid-rationale}` to the Hybrid Architecture Rationale subsection so the cross-reference resolves.
- **`06-consensus.tex`** — Hybrid Approach (after the PoW/SCP capability table): "two jobs, two mechanisms" framing — PoW for permissionless issuance, SCP for agreement/finality, deliberately decoupled (mining weight orthogonal to consensus voting weight). Positions against MobileCoin (SCP, no mining) and PoW coins (no SCP finality); points at `tab:consensus-comparison` and Related Work (`sec:related`).
- **`10-economics.tex`** — Anti-Hoarding Dynamics (after the `holding_cost` equation): why a *cluster-scaled* holding cost beats fixed-supply (costless/rewarding hoarding) and tail-emission-only (uniform dilution, hedgeable) designs, and why targeted demurrage beats classical uniform demurrage. Cross-references Related Work Demurrage and the economic-modeling section.

Purely additive: 80 insertions, 0 deletions.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Each of the 3 novel mechanisms gains a concise intuition passage | ✅ | One `\paragraph{Intuition...}` per mechanism in the 3 target files |
| Standard-primitive sections remain citation-only | ✅ | No edits to `03-preliminaries.tex` (ML-KEM/ML-DSA) or the Pedersen/Bulletproofs/plain-ring-sig subsections |
| Additions complement, don't duplicate, existing "Why not…" / Related Work | ✅ | New crypto passage cross-references the size argument at `sec:hybrid-rationale` rather than restating; consensus + economics passages cite `sec:related` / `tab:consensus-comparison` instead of repeating MobileCoin/demurrage prose |
| No overlap with #881 newcomer companion | ✅ | Expert-audience intuition in the paper's formal register; no ground-up primitive explainers added |
| Paper still compiles, 0 undefined refs/cites | ✅ | `cd whitepaper && make` → `botho-whitepaper.pdf` (133 pages); log has no undefined references/citations; `make check` reports no TODO/FIXME/empty cites |

## Test Plan

- `cd whitepaper && make` (pdflatex → bibtex → pdflatex ×2) built `botho-whitepaper.pdf` (133 pages) locally with a clean toolchain (TeX Live 2026).
- Verified `botho-whitepaper.log` has zero "undefined reference"/"undefined citation" warnings and the new `sec:hybrid-rationale` label resolves (`\newlabel{sec:hybrid-rationale}` present in the aux, referenced as subsection 4.6).
- `make check` passed (no TODO/FIXME/empty citations).
- CI gate: `.github/workflows/whitepaper.yml` rebuilds the PDF on this change.

## Note for reviewer

The whitepaper is owned by the Anvil `pub` skill, but the `whitepaper/anvil/wp/` working-copy directory is not present in this worktree (gitignored), so the passages were authored directly into the canonical `whitepaper/sections/*.tex` files matching the surrounding formal register. **An Anvil `pub` review pass (dim-9 Rhetorical-economy guardrail, ≥35/44 gate) is recommended before merge** to confirm voice/economy consistency, per the issue's workflow guidance.

Closes #884