### PR TITLE
docs: align docs tree + README with ADR 0006 (ML-DSA role removal, QP retirement, CT status)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ The world needs a digital currency that works for everyone—not just early adop
 Every transaction is private by default. No surveillance, no tracking, no exceptions.
 
 - **Stealth addresses** ensure recipients can't be linked across transactions
-- **Confidential amounts** hide transaction values from observers
-- **Post-quantum ready** with ML-KEM-768 and ML-DSA-65 hybrid cryptography
+- **Confidential amounts** hide transaction values from observers *(ratified design — in development; see status note below)*
+- **Post-quantum ready** with ML-KEM-768 stealth addresses and hash-based minting attribution
+
+> **Implementation status**: Confidential amounts (Pedersen commitments +
+> Bulletproofs) are the ratified design ([ADR 0006](./docs/decisions/0006-pq-architecture-ratification.md), tracked in
+> [#904](https://github.com/botho-project/botho/issues/904)). On the current
+> testnet, transaction amounts are public; recipient privacy (stealth
+> addresses) and sender privacy (ring signatures) are live.
 
 Unlike "transparent by default" cryptocurrencies, Botho treats financial privacy the way cash does—as the baseline, not a premium feature.
 
@@ -72,7 +78,7 @@ Botho combines proven cryptographic building blocks in a novel architecture:
 | Consensus | Stellar Consensus Protocol (SCP) | 3-5 second finality, Byzantine fault tolerance |
 | Minting | RandomX proof-of-work (issuance only) | CPU-egalitarian rewards, decoupled from consensus |
 | Privacy | CryptoNote stealth addresses | Unlinkable transactions |
-| Quantum safety | ML-KEM-768 + ML-DSA-65 | Future-proof key exchange and signatures |
+| Quantum safety | ML-KEM-768 stealth addresses; PoW-preimage minting attribution | Future-proof recipient privacy and hash-based (quantum-sound) reward binding |
 | Fee system | Cluster-tagged progressive fees | Economic equality without identity |
 | Network privacy | Onion Gossip | Transaction origin hidden from observers |
 
@@ -83,7 +89,7 @@ Botho has two transaction types:
 | Type | Sender | Recipient | Amount | Use Case |
 |:--|:--|:--|:--|:--|
 | **Minting** | Known (minter) | Hidden (ML-KEM) | Public | Block rewards |
-| **Private** | Hidden (CLSAG ring=20) | Hidden (ML-KEM) | Hidden | All transfers |
+| **Private** | Hidden (CLSAG ring=20) | Hidden (ML-KEM) | Hidden (CT — in development, see status note above) | All transfers |
 
 Fees are calculated as: `fee = fee_per_byte × tx_size × cluster_factor × output_penalty`
 
@@ -99,7 +105,7 @@ We use ML-KEM-768 (post-quantum) for stealth addresses and CLSAG (classical) for
 
 3. **Size matters** — Post-quantum ring signatures would be ~50x larger than CLSAG, making blockchain growth unsustainable for desktop nodes. See [ADR-0001](./docs/decisions/0001-deprecate-lion-ring-signatures.md).
 
-4. **Amount hiding is already quantum-safe** — Pedersen commitments have information-theoretic hiding. A quantum computer can't reveal amounts.
+4. **Amount hiding is quantum-safe by design** — Pedersen commitments have information-theoretic hiding. A quantum computer can't reveal amounts. (Confidential amounts are in development — see the status note above.)
 
 ### Fast Finality
 
@@ -217,8 +223,10 @@ Botho is audited internally on a rolling cycle. The most recent cycle (cycle
 6, 2026-06) hardened the gossip/sync block-acceptance path against forged
 difficulty, inflated rewards, counterfeit ring members, and tx-list
 substitution under valid PoW, and migrated to ML-DSA 0.1.1
-(RUSTSEC-2025-0144 timing side-channel in the PQ transaction-authorization
-signature). All audit reports live in [`audits/`](./audits/).
+(RUSTSEC-2025-0144 timing side-channel in the since-retired PQ
+transaction-authorization path; see
+[ADR 0006](./docs/decisions/0006-pq-architecture-ratification.md)). All audit
+reports live in [`audits/`](./audits/).
 
 ### Origins
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -43,6 +43,11 @@ Yes, where it matters most:
 | **Recipient privacy** | ML-KEM-768 stealth addresses | ✓ PQ-safe |
 | **Amount privacy** | Pedersen hiding (info-theoretic) | ✓ PQ-safe |
 | **Sender anonymity** | CLSAG ring signatures | Classical |
+| **Minting attribution** | PoW-preimage binding (hash-based) | ✓ PQ-safe |
+
+> **Status**: Amount privacy (Pedersen commitments + Bulletproofs) is the
+> ratified design ([ADR 0006](decisions/0006-pq-architecture-ratification.md))
+> and is in development (#904). On the current testnet, amounts are public.
 
 **Why is sender anonymity classical?**
 
@@ -103,10 +108,10 @@ All transactions hide the **recipient** (via ML-KEM stealth addresses). Other pr
 | Type | Recipient | Amount | Sender |
 |------|-----------|--------|--------|
 | Minting | Hidden | Public | Known (minter) |
-| Private | Hidden | Hidden | Hidden (20-member ring) |
+| Private | Hidden | Hidden (in development — see status note above) | Hidden (20-member ring) |
 
 **Sender privacy** depends on transaction type:
-- **Minting**: Sender is visible (ML-DSA signature)
+- **Minting**: Minter is known (the PoW preimage commits to the minter's public keys)
 - **Private**: Sender hidden via CLSAG ring signatures (ring size 20)
 
 ### Can I see my transaction on a block explorer?
@@ -114,10 +119,10 @@ All transactions hide the **recipient** (via ML-KEM stealth addresses). Other pr
 You can see that a transaction exists, but:
 
 - **Recipient**: Always hidden (stealth addresses)
-- **Amount**: Hidden except for Minting transactions
+- **Amount**: Hidden by design for Private transactions (confidential amounts are in development — public on the current testnet); always public for Minting
 - **Sender**: Hidden for Private transactions (ring signatures)
 
-For Private transactions, sender, recipient, and amount are all hidden.
+For Private transactions, sender and recipient are hidden today; amounts will be hidden once confidential transactions ship (#904).
 
 ### What information is NOT hidden?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ Botho combines:
 - **Proof-of-Work Minting**: RandomX (CPU-egalitarian) minting with usage-scaled difficulty, decoupled from consensus
 - **Two Transaction Types**: Minting (block rewards) and Private (CLSAG ring signatures)
 - **Hybrid Post-Quantum Security**: ML-KEM stealth addresses, CLSAG ring signatures
-- **Confidential Amounts**: Pedersen commitments with Bulletproofs range proofs
+- **Confidential Amounts**: Pedersen commitments with Bulletproofs range proofs (ratified design — in development, #904; amounts are public on the current testnet)
 - **Byzantine Fault Tolerance**: Stellar Consensus Protocol (SCP) for consensus
 - **Progressive Fees**: Cluster-based taxation that discourages wealth concentration
 - **Network Privacy**: Onion Gossip for transaction origin hiding (phase 1 implemented; see `docs/security/onion-gossip-phase1-audit.md`)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -205,11 +205,11 @@ BIP39 Mnemonic (24 words)
 | Property | Guarantee | Implementation |
 |----------|-----------|----------------|
 | **Double-Spend Prevention** | Key images are unique per output | UTXO model + key image tracking |
-| **Amount Hiding** | Transaction amounts are hidden | Pedersen commitments + Bulletproofs |
+| **Amount Hiding** | Transaction amounts are hidden (ratified design — in development, #904; amounts public on current testnet) | Pedersen commitments + Bulletproofs |
 | **Sender Privacy** | Sender identity is hidden | Ring signatures (CLSAG) with 20 decoys |
 | **Recipient Privacy** | Recipient address not on chain | Stealth addresses (one-time keys) |
 | **Consensus Safety** | No conflicting finalization | SCP with quorum intersection |
-| **Post-Quantum Ready** | PQ stealth addresses and minting | ML-KEM-768, ML-DSA-65 |
+| **Post-Quantum Ready** | PQ stealth addresses; hash-based minting attribution | ML-KEM-768; PoW-preimage binding |
 
 ## Related Documentation
 

--- a/docs/architecture/crypto.md
+++ b/docs/architecture/crypto.md
@@ -252,9 +252,9 @@ Instead of LION, Botho uses a hybrid approach:
 | Component | Algorithm | Quantum Safety |
 |-----------|-----------|----------------|
 | Stealth addresses | ML-KEM-768 | Post-quantum |
-| Minting signatures | ML-DSA-65 | Post-quantum |
+| Minting attribution | PoW-preimage binding (no signature — [ADR 0006](../decisions/0006-pq-architecture-ratification.md)) | Post-quantum (hash-based) |
 | Ring signatures | CLSAG | Classical |
-| Amount hiding | Pedersen | Info-theoretic |
+| Amount hiding | Pedersen (in development — #904) | Info-theoretic |
 
 This provides post-quantum protection for permanent data (recipient identity) while keeping transactions small enough for desktop nodes.
 
@@ -381,5 +381,5 @@ Properties:
 
 ### Post-Quantum
 - [ ] ML-KEM-768 parameters provide 192-bit security
-- [ ] ML-DSA-65 parameters provide 128-bit security
+- [ ] ML-DSA-65 parameters provide 128-bit security (designated future signature family; no live protocol role)
 - [ ] Stealth address key encapsulation verified

--- a/docs/architecture/wallet.md
+++ b/docs/architecture/wallet.md
@@ -44,7 +44,7 @@ Botho wallets derive all keys from a single BIP39 mnemonic and support both clas
 │  │                      │             │                      │            │
 │  │  ┌────────────────┐  │             │  ┌────────────────┐  │            │
 │  │  │ AccountKey     │  │             │  │ ML-DSA-65      │  │            │
-│  │  │ (view+spend)   │  │             │  │ (Signatures)   │  │            │
+│  │  │ (view+spend)   │  │             │  │ (Reserved)     │  │            │
 │  │  └────────────────┘  │             │  └────────────────┘  │            │
 │  │                      │             │                      │            │
 │  └──────────────────────┘             └──────────────────────┘            │
@@ -59,7 +59,7 @@ Botho wallets derive all keys from a single BIP39 mnemonic and support both clas
 | `Wallet` | Struct | Main wallet interface | `botho/src/wallet.rs` |
 | `AccountKey` | Struct | Classical view+spend key pair | `account-keys/src/account_keys.rs` |
 | `MlKem768KeyPair` | Struct | Post-quantum key encapsulation | `crypto/pq/src/kem.rs` |
-| `MlDsa65KeyPair` | Struct | Post-quantum signatures | `crypto/pq/src/sig.rs` |
+| `MlDsa65KeyPair` | Struct | Reserved — designated future signature family, no live protocol role ([ADR 0006](../decisions/0006-pq-architecture-ratification.md)) | `crypto/pq/src/sig.rs` |
 
 **Code Reference:** `botho/src/wallet.rs`
 
@@ -114,7 +114,7 @@ Botho wallets derive all keys from a single BIP39 mnemonic and support both clas
 | Classical View | 32 bytes | 32 bytes | Scanning outputs |
 | Classical Spend | 32 bytes | 32 bytes | Signing transactions |
 | ML-KEM-768 | 1,184 bytes | 2,400 bytes | PQ key exchange |
-| ML-DSA-65 | 1,952 bytes | 4,032 bytes | PQ signatures |
+| ML-DSA-65 | 1,952 bytes | 4,032 bytes | Reserved (designated future signature family; no live protocol role) |
 
 **Code Reference:** `account-keys/src/account_keys.rs`
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -235,10 +235,10 @@ Botho uses battle-tested cryptography with post-quantum enhancements:
 | Component | Implementation |
 |-----------|----------------|
 | Key derivation | BIP39 + SLIP-10 + HKDF |
-| Minting signatures | ML-DSA-65 (post-quantum) |
+| Minting attribution | PoW-preimage binding (hash-based, no signature — see [ADR 0006](../decisions/0006-pq-architecture-ratification.md)) |
 | Transfer signatures | CLSAG ring signatures (ring=20) |
 | Stealth addresses | ML-KEM-768 (post-quantum) |
-| Amount hiding | Pedersen commitments + Bulletproofs |
+| Amount hiding | Pedersen commitments + Bulletproofs (ratified design, in development — #904; public amounts on the current testnet) |
 | Proof-of-work | RandomX (CPU-egalitarian, issuance only) |
 | Hashing | SHA-256, Blake2b (general purpose) |
 

--- a/docs/concepts/comparison.md
+++ b/docs/concepts/comparison.md
@@ -32,7 +32,7 @@ Bitcoin transactions are fully transparent. Anyone can see:
 - Amount transferred
 - Full transaction history
 
-Botho transactions reveal none of this. Every transaction uses stealth addresses (hiding recipients), and ring signature transactions hide senders among 20 decoys.
+Botho transactions hide sender and recipient today: every transaction uses stealth addresses (hiding recipients), and ring signature transactions hide senders among 20 decoys. Amount hiding (confidential transactions) is the ratified design ([ADR 0006](../decisions/0006-pq-architecture-ratification.md)) and is in development (#904) — on the current testnet, amounts are public.
 
 **Finality**
 
@@ -169,14 +169,14 @@ Secret Network focuses on programmable privacy (smart contracts). Botho focuses 
 
 | Component | Botho | Bitcoin | Monero | Zcash |
 |-----------|-------|---------|--------|-------|
-| Signatures | ML-DSA (minting) / CLSAG (transfers) | ECDSA/Schnorr | CLSAG | RedDSA |
+| Signatures | CLSAG (transfers); minting is signature-free (PoW-preimage binding) | ECDSA/Schnorr | CLSAG | RedDSA |
 | Key exchange | ML-KEM-768 | N/A | ECDH | DH |
 | Stealth addresses | Yes (PQ) | No | Yes | Shielded only |
 | Ring signatures | Yes (CLSAG) | No | Yes (CLSAG) | No |
 | Ring size | 20 | N/A | 16 | N/A |
 | Zero-knowledge | Bulletproofs | No | Bulletproofs | Halo2 |
 | Quantum-safe stealth | Yes (ML-KEM) | No | No | No |
-| Quantum-safe amounts | Yes (info-theoretic) | No | No | No |
+| Quantum-safe amounts | Yes by design (info-theoretic; CT in development, #904) | No | No | No |
 
 ### Consensus
 

--- a/docs/concepts/privacy.md
+++ b/docs/concepts/privacy.md
@@ -11,6 +11,12 @@ Botho provides strong transaction privacy through a combination of cryptographic
 | Hide sender | CLSAG ring signatures (ring=20) | Classical | ~10+ effective anonymity |
 | Secure communication | Encrypted memos (AES-256-CTR) | Classical | Perfect |
 
+> **Implementation status**: Amount hiding (confidential transactions) is the
+> ratified design ([ADR 0006](../decisions/0006-pq-architecture-ratification.md))
+> and is in development (#904). On the current testnet, amounts are public;
+> recipient and sender privacy are live. Amount-privacy statements in this
+> document describe the target design.
+
 **Privacy architecture**: Botho prioritizes post-quantum protection for **recipient identity** and **amount privacy** because these are permanent (on-chain forever). Sender anonymity uses classical CLSAG ring signatures, which provides excellent present-day privacy while keeping transactions small and accessible. See [Why This Architecture?](#why-this-architecture) for the detailed rationale.
 
 ## Transaction Types
@@ -152,7 +158,7 @@ Ring signature transactions hide the true sender among a group of possible signe
 |--------|-----------|----------------|----------------|
 | **CLSAG** | 20 | ~700 bytes | Classical |
 
-> **Note**: Ring signatures are used in all private transactions. Minting transactions use ML-DSA signatures (minter is known).
+> **Note**: Ring signatures are used in all private transactions. Minting transactions carry no signature — the PoW preimage commits to the minter's public keys (minter is known; see whitepaper §4, "Minting Attribution").
 
 ### How Ring Signatures Work
 
@@ -275,8 +281,8 @@ Botho supports two transaction types. See [Transaction Types](transactions.md) f
 
 | Type | Amount Privacy | Sender Privacy | Signature | Use Case |
 |------|---------------|----------------|-----------|----------|
-| Minting | Public | Known (minter) | ML-DSA | Block rewards |
-| Private | Hidden | Hidden (CLSAG ring=20) | CLSAG | All transfers |
+| Minting | Public | Known (minter) | None (PoW-preimage binding) | Block rewards |
+| Private | Hidden (CT — in development, see [Confidential Amounts](#confidential-amounts)) | Hidden (CLSAG ring=20) | CLSAG | All transfers |
 
 ### Fee Structure
 
@@ -284,7 +290,7 @@ Botho uses size-based fees: `fee = fee_per_byte × tx_size × cluster_factor`
 
 | Transaction Type | Signature Size | Typical Total Size | Fee (1x cluster) |
 |-----------------|----------------|-------------------|------------------|
-| Minting | ~3.3 KB (ML-DSA) | ~1.5 KB | 0 |
+| Minting | None (PoW-preimage binding) | ~1.5 KB | 0 |
 | Private | ~0.7 KB (CLSAG) | ~4 KB | ~4,000 picocredits |
 
 **Why these sizes?**
@@ -310,6 +316,11 @@ Where:
 See [Tokenomics](tokenomics.md) for details on cluster-based progressive fees.
 
 ## Confidential Amounts
+
+> **Implementation status**: Confidential amounts are the ratified design
+> ([ADR 0006](../decisions/0006-pq-architecture-ratification.md)) and are in
+> development (#904). On the current testnet, transaction amounts are public.
+> This section describes the target design.
 
 All transaction types except Minting hide amounts using Pedersen commitments and Bulletproofs range proofs.
 
@@ -465,9 +476,9 @@ Botho provides post-quantum protection for recipient identity and amount privacy
 | Component | Algorithm | Standard | Quantum Safety |
 |-----------|-----------|----------|----------------|
 | Stealth addresses | ML-KEM-768 | FIPS 203 | ✓ Full |
-| Minting signatures | ML-DSA-65 | FIPS 204 | ✓ Full |
+| Minting attribution | PoW-preimage binding (RandomX) | hash-based | ✓ Full (Grover-only) |
 | Ring signatures | CLSAG | curve25519 | Classical |
-| Amount hiding | Pedersen | info-theoretic | ✓ Full |
+| Amount hiding | Pedersen | info-theoretic | ✓ Full (CT in development, #904) |
 
 ### Ring Size
 
@@ -513,7 +524,7 @@ This ensures all ring members would produce similar output tag patterns, prevent
 All keys derive deterministically from the BIP39 mnemonic:
 
 ```
-mnemonic → SLIP-10 seed → HKDF → {ML-KEM keypair, ML-DSA keypair, classical keypair}
+mnemonic → SLIP-10 seed → HKDF → {ML-KEM keypair, ML-DSA keypair (reserved — designated future signature family, no live protocol role), classical keypair}
 ```
 
 ### Transaction Sizes
@@ -548,10 +559,10 @@ Compact transaction sizes enable desktop-friendly blockchain growth while mainta
 | Ring signatures | All tx (CLSAG) | All tx (CLSAG) | No |
 | Ring size | 20 | 16 | N/A |
 | **Effective anonymity** | **10+ of 20** | ~11 of 16 (estimated) | Perfect (ZK) |
-| Confidential amounts | All types | Yes | Shielded only |
+| Confidential amounts | All transfers by design (in development, #904) | Yes | Shielded only |
 | Encrypted memos | Yes | No | Shielded only |
 | Post-quantum stealth | Yes (ML-KEM-768) | No | No |
-| Post-quantum amounts | Yes (info-theoretic) | No | No |
+| Post-quantum amounts | Yes by design (info-theoretic) | No | No |
 | Privacy by default | Yes | Yes | No (opt-in) |
 | Progressive fees | Yes (cluster tags) | No | No |
 | Desktop node feasible | Yes (~100 GB/yr) | Yes | Yes |
@@ -567,4 +578,4 @@ Compact transaction sizes enable desktop-friendly blockchain growth while mainta
 - [CLSAG Paper](https://eprint.iacr.org/2019/654.pdf) - Concise Linkable Ring Signatures
 - [Bulletproofs Paper](https://eprint.iacr.org/2017/1066.pdf) - Range proof system
 - [ML-KEM (FIPS 203)](https://csrc.nist.gov/pubs/fips/203/final) - Post-quantum key encapsulation
-- [ML-DSA (FIPS 204)](https://csrc.nist.gov/pubs/fips/204/final) - Post-quantum digital signatures
+- [ML-DSA (FIPS 204)](https://csrc.nist.gov/pubs/fips/204/final) - Post-quantum digital signatures (Botho's designated future signature family; no live protocol role)

--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -22,9 +22,9 @@ Security in Botho operates at multiple layers:
 | Threat | Protection |
 |--------|------------|
 | Transaction surveillance | Stealth addresses, ring signatures |
-| Amount analysis | Confidential transactions (Pedersen + Bulletproofs) |
+| Amount analysis | Confidential transactions (Pedersen + Bulletproofs) — ratified design ([ADR 0006](../decisions/0006-pq-architecture-ratification.md)), in development (#904); amounts are public on the current testnet |
 | Quantum computers (recipients) | ML-KEM-768 stealth addresses |
-| Quantum computers (minting) | ML-DSA-65 signatures |
+| Quantum computers (minting) | PoW-preimage binding (hash-based attribution; no signature) |
 | Double-spending | SCP consensus, key images |
 | Replay attacks | Tombstone blocks |
 | Network-level attacks | Peer reputation, rate limiting |

--- a/docs/concepts/transactions.md
+++ b/docs/concepts/transactions.md
@@ -2,6 +2,12 @@
 
 Botho supports two transaction types, each designed for specific use cases.
 
+> **Implementation status**: Amount hiding (Pedersen commitments +
+> Bulletproofs) is the ratified design
+> ([ADR 0006](../decisions/0006-pq-architecture-ratification.md)) and is in
+> development (#904); on the current testnet, amounts are public. Amount
+> privacy descriptions below refer to the target design.
+
 ## Overview
 
 | Property | Minting | Private |
@@ -12,7 +18,7 @@ Botho supports two transaction types, each designed for specific use cases.
 | **Sender Privacy** | Known (minter) | Hidden (CLSAG ring) |
 | **Stealth Address** | ML-KEM-768 | ML-KEM-768 |
 | **Amount Encoding** | Plaintext | Pedersen + Bulletproofs |
-| **Authorization** | ML-DSA-65 | CLSAG (ring size 20) |
+| **Authorization** | None — PoW-preimage binding | CLSAG (ring size 20) |
 | **Ring Size** | — | 20 decoys |
 | **Max Inputs** | 1 | 16 |
 | **Quantum Resistance** | Full | Recipient + Amount: full |
@@ -69,7 +75,7 @@ TxOutput {
 | Stealth addresses | ML-KEM-768 | Recipient unlinkability | 1088 B ciphertext | Post-quantum |
 | Amount commitments | Pedersen | Hide transaction amounts | 32 B | Hiding: unconditional |
 | Range proofs | Bulletproofs | Prove amounts are valid | ~700 B | Classical |
-| Minting auth | ML-DSA-65 | Authorize minting | 3309 B | Post-quantum |
+| Minting attribution | PoW-preimage binding (RandomX) | Bind reward to minter keys | 0 B (no signature) | Post-quantum (hash-based) |
 | Ring signatures | CLSAG (ring=20) | Hide sender | ~700 B/input | Classical |
 | Key images | x * Hp(P) | Prevent double-spending | 32 B | Classical |
 
@@ -83,7 +89,7 @@ Minting transactions create new coins as block rewards. They have no inputs (coi
 
 - **Inputs**: None (coinbase)
 - **Outputs**: Stealth addresses with plaintext amounts
-- **Authorization**: ML-DSA signature from the minter
+- **Authorization**: None — the RandomX PoW preimage commits to the minter's public keys (see whitepaper §4, "Minting Attribution")
 - **Cluster**: Creates a new cluster origin
 
 ### Structure
@@ -91,7 +97,7 @@ Minting transactions create new coins as block rewards. They have no inputs (coi
 ```
 MintingTx {
     block_height: u64,
-    minter_proof: MinterProof,      // PoW solution + ML-DSA signature
+    minter_proof: MinterProof,      // PoW solution (preimage commits to minter keys; no signature)
     outputs: Vec<MintingOutput>,
     cluster_id: ClusterId,          // New cluster created by this mint
 }
@@ -319,7 +325,7 @@ The output penalty is quadratic in output count (capped at 100x) to make UTXO fa
 
 | Type | Ring Size | Signature Size | Typical Total Size | Fee (1x cluster) | Fee (6x cluster) |
 |------|-----------|----------------|-------------------|------------------|------------------|
-| Minting | — | ~3.3 KB (ML-DSA) | ~1.5 KB | 0 | 0 |
+| Minting | — | None (no signature) | ~1.5 KB | 0 | 0 |
 | Private | 20 | ~0.7 KB (CLSAG) | ~4 KB | ~4,000 picocredits | ~24,000 picocredits |
 
 ### Transaction Limits
@@ -367,7 +373,7 @@ Botho provides strong quantum resistance where it matters most:
 |-----------|-------------------|----------------|------------------|
 | Stealth addresses | ECDH | Shor's algorithm | ML-KEM-768 |
 | Amount hiding | Pedersen | Grover (minimal) | Information-theoretic hiding |
-| Minting signatures | Schnorr | Shor's algorithm | ML-DSA-65 |
+| Minting attribution | Hash preimage (RandomX) | Grover (minimal) | PoW-preimage binding (no signature) |
 | Ring signatures | CLSAG | Shor's algorithm | Classical (see rationale) |
 
 **Why is classical CLSAG acceptable?**
@@ -399,7 +405,7 @@ For maximum privacy, follow [privacy best practices](privacy.md#privacy-best-pra
 ## Technical References
 
 - [ML-KEM (FIPS 203)](https://csrc.nist.gov/pubs/fips/203/final) - Post-quantum key encapsulation
-- [ML-DSA (FIPS 204)](https://csrc.nist.gov/pubs/fips/204/final) - Post-quantum signatures
+- [ML-DSA (FIPS 204)](https://csrc.nist.gov/pubs/fips/204/final) - Post-quantum signatures (Botho's designated future signature family; no live protocol role)
 - [CLSAG Paper](https://eprint.iacr.org/2019/654.pdf) - Concise Linkable Ring Signatures
 - [Bulletproofs](https://eprint.iacr.org/2017/1066.pdf) - Range proofs
 - [Pedersen Commitments](https://link.springer.com/content/pdf/10.1007/3-540-46766-1_9.pdf) - Commitment scheme

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -28,7 +28,7 @@ unit, the **picocredit**: 1 BTH = 1,000,000,000,000 picocredits (10^12). BTH is 
 human-facing formatting of picocredit amounts at the UI edge. See [Unit System](tokenomics.md#unit-system) for details.
 
 ### Bulletproofs
-A type of zero-knowledge proof used for range proofs. Ensures transaction amounts are positive without revealing the actual values. Used in Private transactions to hide amounts.
+A type of zero-knowledge proof used for range proofs. Ensures transaction amounts are positive without revealing the actual values. Used in Private transactions to hide amounts (ratified design, in development — #904; amounts are public on the current testnet).
 
 ### Byzantine Fault Tolerance (BFT)
 The ability of a system to continue operating correctly even if some participants are malicious or faulty. SCP provides BFT for Botho consensus.
@@ -63,7 +63,7 @@ In ring signatures, a decoy is a transaction output included to hide the true se
 A measure of how hard it is to find a valid proof-of-work. In Botho, difficulty adjusts every block from the observed inter-block time (5-second target, clamped 0.5x–2x per step); the signal deliberately ignores transaction count so block producers can't skew it.
 
 ### Dilithium
-A lattice-based signature scheme now standardized as ML-DSA. Botho uses ML-DSA-65 for minting transaction signatures.
+A lattice-based signature scheme now standardized as ML-DSA. In Botho, ML-DSA-65 is the designated future signature family if a post-quantum authorization path is ever introduced; it has no live protocol role today (minting attribution uses PoW-preimage binding — see [ADR 0006](decisions/0006-pq-architecture-ratification.md)).
 
 ---
 
@@ -112,7 +112,7 @@ A fixed-size output produced by a hash function. Used for block identification, 
 The speed at which a miner computes hashes, typically measured in H/s (hashes per second).
 
 ### Hybrid Cryptography
-Using both classical and post-quantum algorithms together. Botho uses a strategic hybrid approach: ML-KEM-768 (post-quantum) for all stealth addresses (permanent recipient privacy), ML-DSA-65 (post-quantum) for minting signatures, and CLSAG (classical) for ring signatures (ephemeral sender privacy).
+Using both classical and post-quantum algorithms together. Botho uses a strategic hybrid approach: ML-KEM-768 (post-quantum) for all stealth addresses (permanent recipient privacy), hash-based PoW-preimage binding for minting attribution (quantum-sound), and CLSAG (classical) for ring signatures (ephemeral sender privacy).
 
 ---
 
@@ -151,10 +151,10 @@ The pool of unconfirmed transactions waiting to be included in a block. Transact
 Botho's term for mining — the process of creating new blocks and earning block rewards.
 
 ### Minting Transaction
-A transaction type that creates new coins as block rewards. Minting transactions have no inputs, use ML-DSA signatures, and create new cluster origins. Amounts are public for supply auditability, but recipients are hidden via stealth addresses.
+A transaction type that creates new coins as block rewards. Minting transactions have no inputs, carry no signature (the RandomX PoW preimage commits to the minter's public keys — see whitepaper §4, "Minting Attribution"), and create new cluster origins. Amounts are public for supply auditability, but recipients are hidden via stealth addresses.
 
 ### ML-DSA (Dilithium)
-**Module Lattice Digital Signature Algorithm** — A post-quantum signature scheme standardized by NIST (FIPS 204). Botho uses ML-DSA-65 for Minting transaction authorization.
+**Module Lattice Digital Signature Algorithm** — A post-quantum signature scheme standardized by NIST (FIPS 204). ML-DSA-65 is Botho's designated future signature family if a post-quantum authorization path is ever introduced; it has no live protocol role ([ADR 0006](decisions/0006-pq-architecture-ratification.md)).
 
 ### ML-KEM (Kyber)
 **Module Lattice Key Encapsulation Mechanism** — A post-quantum key exchange scheme standardized by NIST (FIPS 203). Botho uses ML-KEM-768 for post-quantum stealth addresses.
@@ -199,13 +199,13 @@ A cryptographic commitment that hides a value while allowing mathematical operat
 The single base unit of BTH, used for all amounts — transaction values, fees, emission, and monetary policy. 1 BTH = 1,000,000,000,000 picocredits (10^12). Every amount in the protocol is denominated in picocredits (stored as u128 for supply-scale totals); user interfaces format picocredit amounts into BTH for readability.
 
 ### Post-Quantum Cryptography
-Cryptographic algorithms believed to be secure against quantum computer attacks. Botho uses ML-KEM-768 for all stealth addresses (permanent recipient privacy) and ML-DSA-65 for minting transaction signatures. Ring signatures use classical CLSAG for efficiency—sender privacy is ephemeral and degrades over time.
+Cryptographic algorithms believed to be secure against quantum computer attacks. Botho uses ML-KEM-768 for all stealth addresses (permanent recipient privacy); minting attribution is hash-based (PoW-preimage binding), which is quantum-sound. Ring signatures use classical CLSAG for efficiency—sender privacy is ephemeral and degrades over time.
 
 ### Private Key
 A secret value that controls your funds. Never share your private keys or mnemonic.
 
 ### Private Transaction
-The standard transaction type for all value transfers. Uses CLSAG ring signatures (sender hidden among 20 decoys), Pedersen commitments with Bulletproofs (amounts hidden), and ML-KEM stealth addresses (recipient hidden with post-quantum security). Size-based fees (~4 KB typical).
+The standard transaction type for all value transfers. Uses CLSAG ring signatures (sender hidden among 20 decoys), Pedersen commitments with Bulletproofs (amounts hidden — the ratified design per [ADR 0006](decisions/0006-pq-architecture-ratification.md), in development; amounts are public on the current testnet), and ML-KEM stealth addresses (recipient hidden with post-quantum security). Size-based fees (~4 KB typical).
 
 ### Proof-of-Work (PoW)
 A mechanism where miners prove they've done computational work. Botho uses RandomX PoW for coin issuance only — block acceptance is decided by SCP consensus, not hashpower.
@@ -240,7 +240,7 @@ A zero-knowledge proof that a hidden value falls within a valid range (e.g., is 
 A cryptographic signature that proves one member of a group signed a message, without revealing which one. Used to hide transaction senders.
 
 ### RingCT
-**Ring Confidential Transactions** — Combines ring signatures with confidential amounts. Botho implements this via CLSAG ring signatures (for sender privacy) combined with Pedersen commitments and Bulletproofs (for amount privacy).
+**Ring Confidential Transactions** — Combines ring signatures with confidential amounts. Botho's design uses CLSAG ring signatures (for sender privacy) combined with Pedersen commitments and Bulletproofs (for amount privacy); the confidential-amounts half is in development ([ADR 0006](decisions/0006-pq-architecture-ratification.md)) and amounts are public on the current testnet.
 
 ### RPC
 **Remote Procedure Call** — A protocol for making requests to a node. Botho provides a JSON-RPC API on port 7101.

--- a/docs/operations/memory-budget.md
+++ b/docs/operations/memory-budget.md
@@ -62,7 +62,6 @@ Ring signature operations have significant stack requirements:
 | Operation | Memory | Duration |
 |-----------|--------|----------|
 | CLSAG Verification | ~10 KB stack | ~2 ms |
-| ML-DSA Verification | ~50 KB stack | ~5 ms |
 | Batch Verification (10 tx) | ~200 KB stack | ~50 ms |
 
 **Notes:**

--- a/docs/research/botho-vs-zkvm-analysis.md
+++ b/docs/research/botho-vs-zkvm-analysis.md
@@ -1,5 +1,10 @@
 # Ledger Size and Performance: Botho vs zkVM Architectures
 
+> **Historical research note**: This analysis predates [ADR 0006](../decisions/0006-pq-architecture-ratification.md).
+> References to LION and ML-DSA reflect the architecture under study at the
+> time; LION was deprecated (ADR 0001) and ML-DSA has no live protocol role.
+> See the current [whitepaper](../../whitepaper/) for the ratified design.
+
 ## Executive Summary
 
 This analysis compares Botho's ring-signature-based privacy architecture with zkVM-based approaches like Nexus. The fundamental tradeoff is between **verification locality** (ring signatures require all ring members on-chain) and **computational overhead** (zkVMs require expensive proof generation).

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -83,7 +83,7 @@ The following assets require protection in the Botho system:
 |----------|---------|------------------|-------------------|
 | Spend Private Key | Authorizes fund transfers | Encrypted wallet file | Complete fund loss |
 | View Private Key | Scans incoming transactions | Encrypted wallet file | Privacy loss (incoming) |
-| ML-DSA Private Key | Minting transaction signing | Encrypted wallet file | Minting capability loss |
+| ML-DSA Private Key | Reserved (designated future signature family — no live protocol role, [ADR 0006](../decisions/0006-pq-architecture-ratification.md)) | Encrypted wallet file | None today (unused by protocol) |
 | Mnemonic (24 words) | Master seed for all keys | User responsibility | Complete fund loss |
 
 **File references:**
@@ -96,7 +96,7 @@ The following assets require protection in the Botho system:
 |--------------|-----------|----------------|
 | Recipient hiding | ML-KEM-768 stealth addresses | Recipient identity |
 | Sender hiding | CLSAG ring signatures (ring=20) | Sender identity |
-| Amount hiding | Pedersen commitments + Bulletproofs | Transaction values |
+| Amount hiding | Pedersen commitments + Bulletproofs (ratified design, in development — #904; amounts public on current testnet) | Transaction values |
 | Memo privacy | AES-256-CTR encryption | Payment metadata |
 
 **File references:**
@@ -244,7 +244,7 @@ economic state whose integrity is now an asset in its own right. See the
 
 **Cannot:**
 - Break ML-KEM-768 stealth addresses
-- Break ML-DSA minting signatures
+- Break PoW-preimage minting attribution (hash-based)
 - Reverse hash functions
 
 **Note:** CLSAG ring signatures are classical and vulnerable to quantum attacks. However, sender privacy is ephemeral—its value degrades over time as economic context becomes historical. See [ADR-0001](../decisions/0001-deprecate-lion-ring-signatures.md) for the rationale.
@@ -283,7 +283,7 @@ the residuals above are explicitly tracked, not mitigated.
 | Component | Algorithm | Quantum Safety |
 |-----------|-----------|----------------|
 | Stealth addresses | ML-KEM-768 | Full |
-| Minting signatures | ML-DSA-65 | Full |
+| Minting attribution | PoW-preimage binding (RandomX) | Full (hash-based) |
 | Private sender | CLSAG | Classical (ephemeral privacy) |
 | Commitments (hiding) | Pedersen | Information-theoretic |
 | Commitments (binding) | Pedersen | Classical only |
@@ -298,7 +298,7 @@ the residuals above are explicitly tracked, not mitigated.
 |------------|-----------|----------------------|
 | Discrete Log (DLOG) | curve25519 | CLSAG signatures forgeable |
 | Decisional Diffie-Hellman (DDH) | curve25519 | Pedersen binding broken |
-| Learning With Errors (LWE) | ML-KEM, ML-DSA | PQ protections broken |
+| Learning With Errors (LWE) | ML-KEM | PQ recipient privacy broken |
 | Collision Resistance | SHA-256, Blake2b | General hashing compromised |
 | PoW Soundness | RandomX | Minting rewards skewed (consensus safety unaffected — block acceptance is SCP's) |
 
@@ -575,6 +575,8 @@ Pr[adversary correctly determines R1 = R2 | blockchain] ≤ negl(λ)
 
 ### 2. Amount Confidentiality
 
+> **Status**: Target design ([ADR 0006](../decisions/0006-pq-architecture-ratification.md)), in development (#904). Amounts are public on the current testnet.
+
 **Property:** Transaction amounts are hidden from all observers except sender and recipient.
 
 **Formal statement:**
@@ -796,7 +798,7 @@ mempool's dynamic base can only make a node *stricter*.
 | Threat | Mitigation | Implementation |
 |--------|------------|----------------|
 | Key compromise | Argon2id + ChaCha20-Poly1305 | `storage.rs:189-220` |
-| Signature forgery | Ed25519, CLSAG, ML-DSA verification | `transaction.rs:1335-1357` |
+| Signature forgery | Ed25519, CLSAG verification | `transaction.rs:1335-1357` |
 | Quantum harvest-now-decrypt-later | ML-KEM-768 for stealth addresses | `pq_onetime_keys.rs` |
 | Replay attacks | Key images (CLSAG) | `ledger/store.rs:800-845` |
 
@@ -907,7 +909,7 @@ mempool's dynamic base can only make a node *stricter*.
 
 ### External Standards
 - [NIST FIPS 203](https://csrc.nist.gov/pubs/fips/203/final) - ML-KEM specification
-- [NIST FIPS 204](https://csrc.nist.gov/pubs/fips/204/final) - ML-DSA specification
+- [NIST FIPS 204](https://csrc.nist.gov/pubs/fips/204/final) - ML-DSA specification (designated future signature family; no live protocol role)
 - [RFC 9180](https://datatracker.ietf.org/doc/rfc9180/) - HPKE specification
 - [OWASP Top 10](https://owasp.org/www-project-top-ten/) - Web security risks
 - [CryptoNote](https://cryptonote.org/whitepaper.pdf) - Stealth address protocol

--- a/docs/specification/README.md
+++ b/docs/specification/README.md
@@ -46,7 +46,7 @@ The v0.x specification snapshots covered:
 - **Transaction Format**: Minting and Private transaction structures
 - **Consensus (SCP)**: Stellar Consensus Protocol implementation
 - **Network Protocol**: P2P messaging and synchronization
-- **Cryptographic Primitives**: CLSAG, ML-KEM, ML-DSA, Bulletproofs
+- **Cryptographic Primitives**: CLSAG, ML-KEM, ML-DSA, Bulletproofs (ML-DSA as then-specified; it has no live protocol role today — see [ADR 0006](../decisions/0006-pq-architecture-ratification.md))
 - **Block Structure**: Headers, PoW, and minting transactions
 - **Monetary System**: Units, supply schedule, and fee structure
 - **Network Configuration**: Ports, addresses, and parameters

--- a/docs/specification/protocol-v0.1.0.md
+++ b/docs/specification/protocol-v0.1.0.md
@@ -4,7 +4,7 @@
 **Status**: Historical snapshot
 **Last Updated**: 2024-12-31
 
-> **⚠️ HISTORICAL SNAPSHOT (SUPERSEDED)**: This specification was superseded by [v0.2.0](protocol-v0.2.0.md), which is itself a historical snapshot — **neither document describes the current wire protocol** (implemented version 4.1.0). See the [specification index](README.md) for the current protocol version and pointers to authoritative sources. LION (PQ-Private) transactions described here have been **deprecated**; the protocol uses only two transaction types: Minting (ML-DSA signatures) and Private (CLSAG ring signatures). See [ADR-0001](../decisions/0001-deprecate-lion-ring-signatures.md) for the deprecation decision.
+> **⚠️ HISTORICAL SNAPSHOT (SUPERSEDED)**: This specification was superseded by [v0.2.0](protocol-v0.2.0.md), which is itself a historical snapshot — **neither document describes the current wire protocol** (implemented version 4.1.0). See the [specification index](README.md) for the current protocol version and the [whitepaper](../../whitepaper/) for the ratified design. LION (PQ-Private) transactions described here have been **deprecated** ([ADR-0001](../decisions/0001-deprecate-lion-ring-signatures.md)); the protocol uses only two transaction types: Minting and Private (CLSAG ring signatures). The ML-DSA minting signatures described here were also retired — minting attribution binds via the PoW preimage, with no signature ([ADR 0006](../decisions/0006-pq-architecture-ratification.md)).
 
 ## Abstract
 

--- a/docs/specification/protocol-v0.2.0.md
+++ b/docs/specification/protocol-v0.2.0.md
@@ -4,15 +4,20 @@
 **Status**: Historical snapshot
 **Last Updated**: 2025-01-03
 
-> **⚠️ HISTORICAL SNAPSHOT**: This document does **not** describe the current
-> wire protocol (implemented version 4.1.0, defined in
+> **⚠️ HISTORICAL SNAPSHOT (SUPERSEDED)**: This document does **not** describe
+> the current wire protocol (implemented version 4.1.0, defined in
 > [`botho/src/network/discovery.rs`](../../botho/src/network/discovery.rs)).
 > It predates — at minimum — RandomX proof of work, the picocredit single-unit
 > migration, the current emission schedule, time-based difficulty, the 80/20
 > fee split with cluster-weighted lottery, demurrage, and dynamic block
-> timing. Do not implement against it. See the
-> [specification index](README.md) for the current protocol version and
-> pointers to authoritative sources.
+> timing. It is superseded as a design reference by the
+> [whitepaper](../../whitepaper/) and
+> [ADR 0006](../decisions/0006-pq-architecture-ratification.md): in
+> particular, the ML-DSA-65 minting signatures specified below were never
+> the shipped mechanism and were retired by ADR 0006 (minting attribution
+> binds via the RandomX PoW preimage; no signature). Do not implement
+> against this document. See the [specification index](README.md) for the
+> current protocol version and pointers to authoritative sources.
 
 ## Abstract
 


### PR DESCRIPTION
Aligns the `docs/` tree and `README.md` with ADR 0006 (PoW-preimage minting attribution, universal ML-KEM stealth, CT-as-target, QP tier retired). Docs-only change; the corrected whitepaper + `docs/concepts/pq-migration.md` (PR #901) were used as the phrasing reference. Base includes PR #911 (#903), so the QP code surface these docs previously described is already deleted; `docs/api.md` re-read came back clean (zero PQ/quantum/CT hits).

## What changed (18 files)

**Rule 1 — ML-DSA live protocol role → PoW-preimage binding** (cite whitepaper §4 "Minting Attribution"): `docs/glossary.md`, `docs/FAQ.md`, `docs/security/threat-model.md`, `docs/architecture/{crypto,wallet,README}.md`, `docs/concepts/{privacy,architecture,comparison,security,transactions}.md`, `docs/specification/README.md`, `README.md`. ML-DSA survives only as "designated future signature family" (the wallet still derives the keypair — `crypto/pq/src/derive.rs` — so key-inventory rows stay, re-labeled "Reserved").

**Rule 2 — historical/research docs get banners, not rewrites**: `docs/specification/protocol-v0.1.0.md` (existing banner *itself* asserted "Minting (ML-DSA signatures)" as the current protocol — fixed the banner only, body untouched); `docs/research/botho-vs-zkvm-analysis.md` (new historical-context banner; body untouched). `docs/research/zkvm-groth-analysis.md` needed nothing (its one "post-quantum folding" line is generic, no ADR-0006-affected claim).

**Rule 5 — CT status qualifiers**: one coherent status note per doc (README, `docs/README.md`, FAQ, concepts/privacy (top-of-doc + Confidential Amounts section), concepts/transactions (top-of-doc), threat-model §Amount Confidentiality, plus inline qualifiers on isolated table rows in glossary/comparison/architecture docs). Pattern: *ratified design (ADR 0006), in development (#904), amounts public on current testnet*.

**Rule 6 — README line 75**: `ML-KEM-768 + ML-DSA-65` → ML-KEM-768 stealth + PoW-preimage minting attribution.

**Cleanup**: `docs/operations/memory-budget.md` — dropped the "ML-DSA Verification ~50 KB / ~5 ms" row (that verification path was removed in #911; it never ran on the live minting path).

## protocol-v0.2.0.md: supersede vs maintain — **recommend SUPERSEDE**

Upgraded its banner to **HISTORICAL SNAPSHOT (SUPERSEDED)** pointing at the whitepaper + ADR 0006, explicitly noting the ML-DSA-65 minting signatures it specifies were never the shipped mechanism. Rationale: the doc already predates RandomX, picocredits, the current emission schedule, time-based difficulty, the 80/20 fee split, demurrage, and dynamic block timing — maintaining it would mean a whitepaper-scale alignment pass on a document nobody should implement against. Body left untouched. **Human ratifies at review**; if "maintain" is preferred instead, that alignment pass should be its own issue.

## Acceptance grep 1: `grep -rni "ml-dsa\|mldsa" docs/ README.md` — every surviving hit + justification

| Survivor | Justification |
|---|---|
| `docs/decisions/*` (ADRs 0001, 0006) | ADRs — allowed category |
| `docs/specification/protocol-v0.1.0.md` (9 hits) | Deprecation-bannered historical snapshot; banner corrected in this PR |
| `docs/specification/protocol-v0.2.0.md` (13 hits) | Supersede-bannered historical snapshot (banner names the ML-DSA retirement explicitly) |
| `docs/specification/README.md:49` | Describes what the historical snapshots covered; annotated "no live protocol role — ADR 0006" |
| `docs/research/botho-vs-zkvm-analysis.md:4,5,57` | Research analysis under new historical-context banner |
| `docs/glossary.md:66,156,157` (Dilithium / ML-DSA entries) | Rewritten to designated-future-family definitions citing ADR 0006 |
| `docs/security/threat-model.md:86` | Wallet key inventory row re-labeled "Reserved (designated future signature family — no live protocol role)" |
| `docs/security/threat-model.md:912` | FIPS 204 external-standard reference, annotated designated-future-family |
| `docs/architecture/crypto.md:384` | Security-checklist line for the still-present library code, annotated no-live-role |
| `docs/architecture/wallet.md:46,62,117` | Code inventory of `MlDsa65KeyPair` (still derived by the wallet, `crypto/pq/src/derive.rs`); re-labeled "Reserved" |
| `docs/concepts/privacy.md:521,575` | Key-derivation fact (keypair is derived, marked reserved) + FIPS 204 reference annotated |
| `docs/concepts/transactions.md:408` | FIPS 204 reference annotated designated-future-family |
| `docs/concepts/pq-migration.md:18` | The #901-corrected designated-future-family note itself |
| `README.md:225` | Historical audit record (cycle-6 dependency migration), re-worded "since-retired PQ transaction-authorization path" + ADR 0006 link |
| `docs/primer/*` (BRIEF + audit artifacts) | Immutable Anvil primer artifacts / audit findings that *document* the divergence and its resolution — historical records, not live claims |

## Acceptance grep 2: `grep -rni "quantum.private\|quantum address" docs/ README.md`

```
docs/primer/.../botho-from-the-basics.1.audit/findings.md:17   (audit finding describing the retired variant)
docs/primer/.../botho-from-the-basics.1.audit/comments.md:14   (same audit, line comment)
docs/decisions/0001-deprecate-lion-ring-signatures.md:133      (ADR migration checklist)
docs/decisions/0006-pq-architecture-ratification.md:72         (the retirement decision itself)
```

No doc presents quantum-private transactions or quantum addresses as usable.

## Scope notes

- `docs/api.md` carve-out was already completed by #911 — this PR only re-read it (clean).
- **Overlap with #912**: `web/packages/web-wallet/src/docs-content/{en,es}/` mirrors several of these docs (privacy, transactions, FAQ). Not touched here (out of scope), but the en-side fixes are largely copy-paste of this PR's edits; es needs translation.
- Judgment call: `docs/design/archive/*` and `docs/design/entropy-proof-security-analysis.md` retain unqualified amount-hiding language — they are archived/CT-design analyses (not user-facing), and the entropy-proof doc analyzes the CT design itself.

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)
