### PR TITLE
fix(bridge): correct global_daily_limit comment — 10k BTH federation cap is intentional

### DIFF
--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -336,13 +336,12 @@ pub struct BridgeSettings {
     ///
     /// This is one half of a deliberate two-layer defense:
     /// 1. This service-side cap trips the circuit breaker first
-    ///    (`engine::test_global_cap_trips_breaker`), pausing mints and
-    ///    releases while confirmations settle.
+    ///    (`engine::test_global_cap_trips_breaker`), pausing mints and releases
+    ///    while confirmations settle.
     /// 2. The contract-side `autoPauseThreshold`
-    ///    (`contracts/ethereum/contracts/WrappedBTH.sol:104`,
-    ///    `10_000_000 * 10 ** 12` = 10M BTH/day) is the last-resort
-    ///    on-chain breaker that halts minting even if the federation
-    ///    layer is compromised or misconfigured.
+    ///    (`contracts/ethereum/contracts/WrappedBTH.sol:104`, `10_000_000 * 10
+    ///    ** 12` = 10M BTH/day) is the last-resort on-chain breaker that halts
+    ///    minting even if the federation layer is compromised or misconfigured.
     ///
     /// The two knobs are intentionally 1000× apart: the tight cap bounds
     /// normal-operations blast radius, the loose breaker only backstops

--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -331,7 +331,23 @@ pub struct BridgeSettings {
     #[serde(default = "default_daily_limit")]
     pub daily_limit_per_address: u64,
 
-    /// Global daily limit in picocredits
+    /// Global daily mint-volume limit in picocredits — the
+    /// FEDERATION-SIDE tight cap (default 10,000 BTH/day).
+    ///
+    /// This is one half of a deliberate two-layer defense:
+    /// 1. This service-side cap trips the circuit breaker first
+    ///    (`engine::test_global_cap_trips_breaker`), pausing mints and
+    ///    releases while confirmations settle.
+    /// 2. The contract-side `autoPauseThreshold`
+    ///    (`contracts/ethereum/contracts/WrappedBTH.sol:104`,
+    ///    `10_000_000 * 10 ** 12` = 10M BTH/day) is the last-resort
+    ///    on-chain breaker that halts minting even if the federation
+    ///    layer is compromised or misconfigured.
+    ///
+    /// The two knobs are intentionally 1000× apart: the tight cap bounds
+    /// normal-operations blast radius, the loose breaker only backstops
+    /// catastrophe. Raising this cap is an operator/economics decision,
+    /// not a code cleanup — see issue #895.
     #[serde(default = "default_global_daily_limit")]
     pub global_daily_limit: u64,
 
@@ -389,15 +405,19 @@ fn default_min_fee() -> u64 {
 }
 
 fn default_max_order() -> u64 {
-    1_000_000_000_000_000 // 1M BTH
+    1_000_000_000_000_000 // 1,000 BTH per order (picocredits)
 }
 
 fn default_daily_limit() -> u64 {
-    100_000_000_000_000 // 100k BTH per address
+    100_000_000_000_000 // 100 BTH per address per day (picocredits)
 }
 
 fn default_global_daily_limit() -> u64 {
-    10_000_000_000_000_000 // 10M BTH global
+    // 10,000 BTH/day global — federation-side tight cap. The contract's
+    // autoPauseThreshold (WrappedBTH.sol:104) is 10M BTH, the last-resort
+    // on-chain breaker; the 1000× gap is intentional (see #895 and the
+    // doc-comment on `BridgeSettings::global_daily_limit`).
+    10_000_000_000_000_000
 }
 
 fn default_order_expiry() -> i64 {
@@ -535,6 +555,25 @@ mod tests {
         assert!(!config.bridge.testnet);
         assert!(!config.bridge.paused);
         assert_eq!(config.bridge.max_pending_orders, 1_000);
+    }
+
+    #[test]
+    fn test_global_daily_limit_pinned_to_10k_bth() {
+        // Pin the federation-side global daily cap to 10,000 BTH
+        // (× 10^12 picocredits/BTH). This value is DELIBERATELY 1000×
+        // below the contract-side autoPauseThreshold (WrappedBTH.sol:104,
+        // 10M BTH last-resort breaker) — two-layer defense in depth.
+        //
+        // If this assertion fails, someone changed a security cap.
+        // Raising it is an operator/economics decision requiring explicit
+        // sign-off (see issue #895), plus updates to the field
+        // doc-comment and docs/security/bridge-threat-model.md.
+        const PICOCREDITS_PER_BTH: u64 = 1_000_000_000_000;
+        assert_eq!(default_global_daily_limit(), 10_000 * PICOCREDITS_PER_BTH);
+        assert_eq!(
+            BridgeConfig::default().bridge.global_daily_limit,
+            10_000 * PICOCREDITS_PER_BTH
+        );
     }
 
     #[test]

--- a/docs/bridge/architecture.md
+++ b/docs/bridge/architecture.md
@@ -148,9 +148,12 @@ fee_bps = 10              # 0.1% fee
 min_fee = 100000000       # 0.0001 BTH minimum
 
 # Rate limits (in picocredits, 12 decimals)
-max_order_amount = 1000000000000000      # 1M BTH per order
-daily_limit_per_address = 100000000000000  # 100k BTH/day per address
-global_daily_limit = 10000000000000000    # 10M BTH/day global
+max_order_amount = 1000000000000000      # 1,000 BTH per order
+daily_limit_per_address = 100000000000000  # 100 BTH/day per address
+global_daily_limit = 10000000000000000    # 10,000 BTH/day global (federation
+                                          # tight cap; contract-side
+                                          # autoPauseThreshold = 10M BTH is the
+                                          # last-resort breaker — see #895)
 
 # Timing
 order_expiry_minutes = 60  # 1 hour timeout

--- a/docs/bridge/security.md
+++ b/docs/bridge/security.md
@@ -77,10 +77,16 @@ Rate limits protect against:
 
 ```toml
 [bridge]
-max_order_amount = 1000000000000000      # 1M BTH max per order
-daily_limit_per_address = 100000000000000  # 100k BTH/day per address
-global_daily_limit = 10000000000000000    # 10M BTH/day total
+max_order_amount = 1000000000000000      # 1,000 BTH max per order
+daily_limit_per_address = 100000000000000  # 100 BTH/day per address
+global_daily_limit = 10000000000000000    # 10,000 BTH/day total
 ```
+
+The service-side `global_daily_limit` (10,000 BTH/day) is intentionally
+1000× below the wBTH contract's `autoPauseThreshold` (`WrappedBTH.sol:104`,
+10M BTH/day): the federation cap is the tight first-line breaker, the
+contract threshold is the last-resort on-chain halt if the federation layer
+is compromised. Raising the federation cap is an operator decision (#895).
 
 ### Limit Tuning
 

--- a/docs/security/bridge-threat-model.md
+++ b/docs/security/bridge-threat-model.md
@@ -203,10 +203,10 @@ follow-up.
     confirmed BTH deposits, so reaching the threshold means the attacker first
     locked ~10M BTH of *real* reserve.
   - The service backlog and global-cap breakers
-    (`max_pending_orders = 1000`, `global_daily_limit = 10M BTH` in
+    (`max_pending_orders = 1000`, `global_daily_limit = 10,000 BTH` in
     `bridge/core/src/config.rs`) trip only on real orders: burns require owning
     wBTH, deposits require BTH, each order is bounded by
-    `max_order_amount = 1M BTH`, and every order pays `fee_bps = 10` (0.10%,
+    `max_order_amount = 1,000 BTH`, and every order pays `fee_bps = 10` (0.10%,
     floored at `min_fee = 0.0001 BTH`). Filling the 1000-order backlog with
     minimum-fee orders costs the attacker at least `1000 × 0.0001 BTH = 0.1 BTH`
     in fees alone (far more if the orders carry non-trivial value, since the
@@ -219,6 +219,17 @@ follow-up.
   The fail-closed cap/breaker behavior is exercised by
   `engine::test_breaker_auto_trips_on_backlog` and
   `engine::test_global_cap_trips_breaker` (both #854).
+
+  The 1000× gap between the federation cap and the contract breaker is
+  deliberate two-layer defense, not drift (#895): the service-side
+  `global_daily_limit` (10,000 BTH/day) is the *tight* cap that trips first
+  and bounds normal-operations blast radius, while the contract-side
+  `autoPauseThreshold` (`WrappedBTH.sol:104`, `10_000_000 * 10 ** 12` =
+  10M BTH/day) is the *loose*, last-resort on-chain breaker that still halts
+  minting even if the federation layer itself is compromised or
+  misconfigured. The federation default is pinned by
+  `config::tests::test_global_daily_limit_pinned_to_10k_bth`; raising it is
+  an operator/economics decision requiring explicit sign-off, not a refactor.
 
 ## Follow-ups filed
 


### PR DESCRIPTION
Closes #895

## Summary

Resolves the `global_daily_limit` literal-vs-comment 1000× mismatch per the curator's binding resolution direction: **the comment is fixed, the literal is unchanged**. The 1e16 picocredits = 10,000 BTH federation-side tight cap sitting 1000× below the contract's `autoPauseThreshold` (`WrappedBTH.sol:104`, `10_000_000 * 10 ** 12` = 10M BTH) is deliberate two-layer defense-in-depth; raising a security cap 1000× would be an operator/economics decision, out of scope here.

## Changes

- **bridge/core/src/config.rs**
  - Doc-comment on the `global_daily_limit` field explaining the two-layer semantics (federation tight cap trips first; contract `autoPauseThreshold` is the last-resort breaker, intentionally 1000× apart; cites WrappedBTH.sol:104).
  - Corrected all three nanoBTH-era default-fn comments (see sweep below).
  - New pin-assertion test `test_global_daily_limit_pinned_to_10k_bth` asserting the default equals 10,000 BTH × 10^12 picocredits (both the default fn and `BridgeConfig::default()`), with a comment stating that changing it requires an operator decision (#895).
- **docs/security/bridge-threat-model.md**: corrected `global_daily_limit = 10M BTH` → 10,000 BTH and `max_order_amount = 1M BTH` → 1,000 BTH in the griefing analysis (the on-chain 10M BTH figure there was already correct — it refers to the contract breaker), and added a paragraph documenting the deliberate 1000× layering.
- **docs/bridge/architecture.md**, **docs/bridge/security.md**: same nanoBTH-era comment fixes in the example TOML blocks, plus a short layering note in security.md.

## Magnitude sweep findings (task item 4)

Swept `bridge/` and `contracts/` for BTH comments near numeric literals. The root cause is a family of nanoBTH-era comments (1 BTH = 1e9 nano) left over the now-canonical picocredit literals (1 BTH = 1e12 pico) — all exactly 1000× off, all fixed in this PR:

| Location | Literal (pico) | Old comment | Actual |
|---|---|---|---|
| config.rs `default_max_order` | 1e15 | 1M BTH | **1,000 BTH** |
| config.rs `default_daily_limit` | 1e14 | 100k BTH | **100 BTH** |
| config.rs `default_global_daily_limit` | 1e16 | 10M BTH | **10,000 BTH** (the issue) |
| docs/bridge/architecture.md:151–153 | same three | same | fixed |
| docs/bridge/security.md:80–82 | same three | same | fixed |
| docs/security/bridge-threat-model.md:206,209 | prose | 10M / 1M BTH | fixed |

Everything else verifies clean: `min_fee` (1e8 = 0.0001 BTH) is correct, all test-fixture comments (order.rs, chaos_tests.rs, fork_tests.rs, solana_devnet_tests.rs, bth_rpc.rs) are correct, and `WrappedBTH.sol` is internally consistent (12-decimal wBTH: `maxMintPerTx` 1M BTH, `dailyMintLimit`/`autoPauseThreshold` 10M BTH). No new live mismatch found, so no new issues filed.

Note: the corrected values reveal that `daily_limit_per_address` (100 BTH) < `max_order_amount` (1,000 BTH), i.e. a single max-size order exceeds the per-address daily allowance. That is a knob-tuning observation, not a code defect (fail-closed either way), and changing either literal is the same class of operator decision this PR deliberately avoids — flagging it here rather than filing an issue.

## Test plan

- [x] `cargo build -p bth-bridge-core` clean
- [x] `cargo test -p bth-bridge-core` — 68 passed, 0 failed (includes new pin test)
- [x] `cargo test -p bth-bridge-service` — 209 passed, 0 failed, 7 ignored (incl. `test_global_cap_trips_breaker`)
- [x] Sweep confirms no remaining magnitude-comment contradictions in bridge/ or contracts/

🤖 Generated with [Claude Code](https://claude.com/claude-code)