### PR TITLE
docs(web): align wallet docs-content with ADR 0006 — PoW-bound minting, retired 1q/ tier, CT status qualifiers

### DIFF
--- a/web/packages/web-wallet/src/docs-content/en/getting-started.md
+++ b/web/packages/web-wallet/src/docs-content/en/getting-started.md
@@ -31,10 +31,10 @@ Your wallet address looks like this: `botho://1/4nuKn2U5qsRk3vD...` (about 90 ch
 
 This address format includes:
 - **Protocol identifier** (`botho://` on mainnet, `tbotho://` on testnet) - Different prefixes prevent accidental cross-network sends
-- **Address version** (`1/` for classical addresses, `1q/` for quantum-safe addresses)
+- **Address version** (`1/`, the current address version)
 - **Public keys** - Your view key and spend key, encoded together in base58
 
-Quantum-safe addresses (`1q/`) additionally embed ML-KEM and ML-DSA public keys, which makes them much longer (~4,400 characters) — better suited to QR codes and files than manual copying.
+There is no separate quantum-safe address type: the earlier `1q/` quantum-address tier was retired (ADR 0006). Post-quantum recipient privacy is universal by design — ML-KEM keys are derived from your standard address, so every address keeps the same short format.
 
 You can safely share this address with anyone who wants to send you funds. Thanks to stealth addresses, each incoming transaction will be sent to a unique derived address that only you can spend from.
 

--- a/web/packages/web-wallet/src/docs-content/en/privacy-progressivity.md
+++ b/web/packages/web-wallet/src/docs-content/en/privacy-progressivity.md
@@ -88,7 +88,7 @@ This is crucial: **cluster tags reveal provenance, not identity.**
 |-------------|--------|
 | Who owns a UTXO | **Private** (ring signatures) |
 | Who received a payment | **Private** (stealth addresses) |
-| Amount transferred | **Private** (confidential transactions) |
+| Amount transferred | **Private** in the target design (confidential transactions — in development, ADR 0006; public on the current testnet) |
 | Your total balance | **Private** (no account linkage) |
 | Which UTXO you spent | **Private** (ring signatures) |
 | Where coins originated | Public (cluster tags) |
@@ -183,7 +183,7 @@ Botho achieves privacy + progressivity through layered design:
 |-------|-----------------|---------------------|
 | **Sender** | Ring signatures (1-of-20) | Centroid-validated tag propagation |
 | **Recipient** | Stealth addresses | — |
-| **Amount** | Pedersen commitments | — |
+| **Amount** | Pedersen commitments (in development — ADR 0006) | — |
 | **Fee rate** | — | Cluster factor curve (1-6×) |
 | **Holding cost** | — | Demurrage on idle wealthy-cluster coins |
 | **Redistribution** | Verifiable random drawing | Cluster-tilted weights (value ÷ factor) |

--- a/web/packages/web-wallet/src/docs-content/en/privacy.md
+++ b/web/packages/web-wallet/src/docs-content/en/privacy.md
@@ -38,9 +38,11 @@ CLSAG (Concise Linkable Spontaneous Anonymous Group) is an efficient ring signat
 
 This breaks the transaction graph that would otherwise allow tracing funds through the blockchain. An observer sees that *someone* in the ring spent *some* coins, but cannot determine which participant or which specific coins.
 
-> **Note:** All value transfers use ring signatures. Minting transactions (block rewards) use ML-DSA signatures since the minter is public.
+> **Note:** All value transfers use ring signatures. Minting transactions (block rewards) carry no signature — the PoW preimage commits to the minter's public keys, so attribution is hash-based and quantum-resistant (ADR 0006).
 
 ### Confidential Amounts
+
+> **Implementation status:** Confidential amounts are the ratified design (ADR 0006) and are in development. On the current testnet, transaction amounts are public. This section describes the target design.
 
 In all **Private transactions** (which includes all value transfers), amounts are hidden using **Pedersen commitments** with **Bulletproofs** range proofs. These cryptographic constructs allow the network to verify that transactions balance (inputs equal outputs plus fees) without revealing the actual amounts.
 
@@ -64,22 +66,22 @@ Quantum computers pose a future threat to the cryptographic algorithms that secu
 **Algorithms Used:**
 
 - **ML-KEM-768** (FIPS 203) - Post-quantum stealth addresses (recipient privacy is permanent)
-- **ML-DSA-65** (FIPS 204) - Post-quantum signatures for minting transactions
+- **PoW-preimage binding** (RandomX, hash-based) - Minting attribution without signatures (quantum-resistant)
 - **CLSAG** - Classical ring signatures for private transactions (sender privacy is ephemeral)
-- **Pedersen + Bulletproofs** - Information-theoretic amount hiding (quantum-safe)
+- **Pedersen + Bulletproofs** - Information-theoretic amount hiding (quantum-safe; confidential amounts are in development, see above)
 
 **Why This Architecture?**
 
-Recipient identity is recorded on-chain forever—a quantum attacker in 2045 could link recipients from 2025 transactions. ML-KEM protects against this "harvest now, decrypt later" threat. Sender privacy, however, is ephemeral—its value degrades over time as economic context becomes historical. Using classical CLSAG keeps transactions small (~4 KB vs ~65 KB for post-quantum alternatives).
+Recipient identity is recorded on-chain forever—a quantum attacker in 2045 could link recipients from 2025 transactions. ML-KEM protects against this "harvest now, decrypt later" threat. Sender privacy, however, is ephemeral—its value degrades over time as economic context becomes historical. Using classical CLSAG keeps transactions small (~4 KB vs ~65 KB for post-quantum alternatives). ML-DSA-65 (FIPS 204) remains Botho's designated future signature family for quantum theft protection, but it has no live protocol role today.
 
 **Transaction Types:**
 
 | Type | Recipient | Amount | Sender | Use Case |
 |------|-----------|--------|--------|----------|
-| Minting | Hidden (ML-KEM) | Public | Known (ML-DSA) | Block rewards |
-| Private | Hidden (ML-KEM) | Hidden | Hidden (CLSAG ring=20) | All transfers (~4 KB) |
+| Minting | Hidden (ML-KEM) | Public | Known (PoW-bound) | Block rewards |
+| Private | Hidden (ML-KEM) | Hidden (in development) | Hidden (CLSAG ring=20) | All transfers (~4 KB) |
 
-Recipients and amounts are protected against quantum computers. Sender privacy uses efficient classical signatures.
+Recipients are protected against quantum computers; amount hiding is information-theoretically secure once confidential amounts ship. Sender privacy uses efficient classical signatures.
 
 ### Privacy Best Practices
 

--- a/web/packages/web-wallet/src/docs-content/es/getting-started.md
+++ b/web/packages/web-wallet/src/docs-content/es/getting-started.md
@@ -31,10 +31,10 @@ La dirección de tu monedero se parece a esto: `botho://1/4nuKn2U5qsRk3vD...` (u
 
 Este formato de dirección incluye:
 - **Identificador de protocolo** (`botho://` en mainnet, `tbotho://` en testnet): los distintos prefijos evitan envíos accidentales entre redes
-- **Versión de dirección** (`1/` para direcciones clásicas, `1q/` para direcciones a prueba de cuántica)
+- **Versión de dirección** (`1/`, la versión de dirección actual)
 - **Claves públicas**: tu clave de visualización y tu clave de gasto, codificadas juntas en base58
 
-Las direcciones a prueba de cuántica (`1q/`) incorporan además claves públicas ML-KEM y ML-DSA, lo que las hace mucho más largas (~4 400 caracteres); son más adecuadas para códigos QR y archivos que para copiarlas a mano.
+No existe un tipo de dirección a prueba de cuántica separado: el antiguo nivel de direcciones cuánticas `1q/` fue retirado (ADR 0006). La privacidad poscuántica del destinatario es universal por diseño: las claves ML-KEM se derivan de tu dirección estándar, de modo que todas las direcciones mantienen el mismo formato corto.
 
 Puedes compartir esta dirección con total tranquilidad con cualquiera que quiera enviarte fondos. Gracias a las direcciones sigilosas, cada transacción entrante se enviará a una dirección derivada única que solo tú puedes gastar.
 

--- a/web/packages/web-wallet/src/docs-content/es/privacy-progressivity.md
+++ b/web/packages/web-wallet/src/docs-content/es/privacy-progressivity.md
@@ -88,7 +88,7 @@ Esto es crucial: **las etiquetas de clúster revelan procedencia, no identidad.*
 |-------------|--------|
 | Quién posee un UTXO | **Privado** (firmas de anillo) |
 | Quién recibió un pago | **Privado** (direcciones sigilosas) |
-| Importe transferido | **Privado** (transacciones confidenciales) |
+| Importe transferido | **Privado** en el diseño objetivo (transacciones confidenciales: en desarrollo, ADR 0006; públicos en la testnet actual) |
 | Tu saldo total | **Privado** (sin vinculación de cuentas) |
 | Qué UTXO gastaste | **Privado** (firmas de anillo) |
 | De dónde se originaron las monedas | Público (etiquetas de clúster) |
@@ -183,7 +183,7 @@ Botho logra privacidad + progresividad mediante un diseño por capas:
 |-------|-----------------|---------------------|
 | **Remitente** | Firmas de anillo (1 de 20) | Propagación de etiquetas validada por centroide |
 | **Destinatario** | Direcciones sigilosas | — |
-| **Importe** | Compromisos de Pedersen | — |
+| **Importe** | Compromisos de Pedersen (en desarrollo — ADR 0006) | — |
 | **Tarifa de comisión** | — | Curva del factor de clúster (1-6×) |
 | **Coste de retención** | — | Demurrage sobre monedas inactivas de clúster rico |
 | **Redistribución** | Sorteo aleatorio verificable | Pesos inclinados por clúster (valor ÷ factor) |

--- a/web/packages/web-wallet/src/docs-content/es/privacy.md
+++ b/web/packages/web-wallet/src/docs-content/es/privacy.md
@@ -38,9 +38,11 @@ CLSAG (Concise Linkable Spontaneous Anonymous Group) es un esquema eficiente de 
 
 Esto rompe el grafo de transacciones que de otro modo permitiría rastrear fondos a través de la cadena de bloques. Un observador ve que *alguien* del anillo gastó *algunas* monedas, pero no puede determinar qué participante ni qué monedas concretas.
 
-> **Nota:** Todas las transferencias de valor usan firmas de anillo. Las transacciones de acuñación (recompensas de bloque) usan firmas ML-DSA, ya que el acuñador es público.
+> **Nota:** Todas las transferencias de valor usan firmas de anillo. Las transacciones de acuñación (recompensas de bloque) no llevan firma: la preimagen de PoW se compromete con las claves públicas del acuñador, de modo que la atribución se basa en hashes y es resistente a la computación cuántica (ADR 0006).
 
 ### Importes confidenciales
+
+> **Estado de implementación:** Los importes confidenciales son el diseño ratificado (ADR 0006) y están en desarrollo. En la testnet actual, los importes de las transacciones son públicos. Esta sección describe el diseño objetivo.
 
 En todas las **transacciones privadas** (que incluyen todas las transferencias de valor), los importes se ocultan mediante **compromisos de Pedersen** con pruebas de rango **Bulletproofs**. Estas construcciones criptográficas permiten a la red verificar que las transacciones cuadran (las entradas igualan a las salidas más las comisiones) sin revelar los importes reales.
 
@@ -64,22 +66,22 @@ Los ordenadores cuánticos suponen una amenaza futura para los algoritmos cripto
 **Algoritmos utilizados:**
 
 - **ML-KEM-768** (FIPS 203): direcciones sigilosas poscuánticas (la privacidad del destinatario es permanente)
-- **ML-DSA-65** (FIPS 204): firmas poscuánticas para las transacciones de acuñación
+- **Vinculación por preimagen de PoW** (RandomX, basada en hashes): atribución de la acuñación sin firmas (resistente a la computación cuántica)
 - **CLSAG**: firmas de anillo clásicas para las transacciones privadas (la privacidad del remitente es efímera)
-- **Pedersen + Bulletproofs**: ocultación de importes con seguridad de teoría de la información (a prueba de cuántica)
+- **Pedersen + Bulletproofs**: ocultación de importes con seguridad de teoría de la información (a prueba de cuántica; los importes confidenciales están en desarrollo, véase más arriba)
 
 **¿Por qué esta arquitectura?**
 
-La identidad del destinatario queda registrada en la cadena para siempre: un atacante cuántico en 2045 podría vincular destinatarios a partir de transacciones de 2025. ML-KEM protege frente a esta amenaza de "recolectar ahora, descifrar después". La privacidad del remitente, en cambio, es efímera: su valor se degrada con el tiempo a medida que el contexto económico se vuelve histórico. Usar CLSAG clásico mantiene las transacciones pequeñas (~4 KB frente a ~65 KB de las alternativas poscuánticas).
+La identidad del destinatario queda registrada en la cadena para siempre: un atacante cuántico en 2045 podría vincular destinatarios a partir de transacciones de 2025. ML-KEM protege frente a esta amenaza de "recolectar ahora, descifrar después". La privacidad del remitente, en cambio, es efímera: su valor se degrada con el tiempo a medida que el contexto económico se vuelve histórico. Usar CLSAG clásico mantiene las transacciones pequeñas (~4 KB frente a ~65 KB de las alternativas poscuánticas). ML-DSA-65 (FIPS 204) sigue siendo la familia de firmas futura designada de Botho para la protección frente al robo cuántico, pero hoy no desempeña ningún papel activo en el protocolo.
 
 **Tipos de transacción:**
 
 | Tipo | Destinatario | Importe | Remitente | Caso de uso |
 |------|-----------|--------|--------|----------|
-| Acuñación | Oculto (ML-KEM) | Público | Conocido (ML-DSA) | Recompensas de bloque |
-| Privada | Oculto (ML-KEM) | Oculto | Oculto (anillo CLSAG=20) | Todas las transferencias (~4 KB) |
+| Acuñación | Oculto (ML-KEM) | Público | Conocido (vinculado a PoW) | Recompensas de bloque |
+| Privada | Oculto (ML-KEM) | Oculto (en desarrollo) | Oculto (anillo CLSAG=20) | Todas las transferencias (~4 KB) |
 
-Los destinatarios y los importes están protegidos frente a los ordenadores cuánticos. La privacidad del remitente usa firmas clásicas eficientes.
+Los destinatarios están protegidos frente a los ordenadores cuánticos; la ocultación de importes tendrá seguridad de teoría de la información cuando se implementen los importes confidenciales. La privacidad del remitente usa firmas clásicas eficientes.
 
 ### Buenas prácticas de privacidad
 

--- a/web/packages/web-wallet/src/docs-content/es/privacy.md
+++ b/web/packages/web-wallet/src/docs-content/es/privacy.md
@@ -38,7 +38,7 @@ CLSAG (Concise Linkable Spontaneous Anonymous Group) es un esquema eficiente de 
 
 Esto rompe el grafo de transacciones que de otro modo permitiría rastrear fondos a través de la cadena de bloques. Un observador ve que *alguien* del anillo gastó *algunas* monedas, pero no puede determinar qué participante ni qué monedas concretas.
 
-> **Nota:** Todas las transferencias de valor usan firmas de anillo. Las transacciones de acuñación (recompensas de bloque) no llevan firma: la preimagen de PoW se compromete con las claves públicas del acuñador, de modo que la atribución se basa en hashes y es resistente a la computación cuántica (ADR 0006).
+> **Nota:** Todas las transferencias de valor usan firmas de anillo. Las transacciones de acuñación (recompensas de bloque) no llevan firma: la preimagen de PoW queda vinculada a las claves públicas del acuñador, de modo que la atribución se basa en hashes y es resistente a la computación cuántica (ADR 0006).
 
 ### Importes confidenciales
 


### PR DESCRIPTION
Closes #912

## Summary

The web wallet's rendered in-app docs pages (`web/packages/web-wallet/src/docs-content/{en,es}`) fell between the #906 sweep (docs/ tree) and the #907 sweep (web ts/json) and still claimed ML-DSA minting signatures and the retired `1q/` quantum-address tier. This PR aligns them with ADR 0006 (`docs/decisions/0006-pq-architecture-ratification.md`), in both locales.

### privacy.md (en + es)
- **Decision 3** — line-41 note, "Algorithms Used" list, and transaction-types table: ML-DSA minting signatures replaced with PoW-preimage binding (hash-based, signature-free, quantum-resistant). Table cell now reads "Known (PoW-bound)", matching the #909 badge language; phrasing adapted from PR #914's `docs/concepts/privacy.md`.
- **Decision 1** — Confidential Amounts section gains the implementation-status qualifier (ratified design, in development; amounts public on current testnet); Private-row amount cell and the closing quantum-protection sentence qualified accordingly.
- ML-DSA-65 survives only as the designated future signature family for quantum theft protection (one sentence per locale, mirroring #914).

### getting-started.md (en + es)
- **Decision 4** — the `1q/` quantum-safe address bullet and the "~4,400-character quantum address" paragraph replaced: the tier is retired (code deleted in #903/PR #911; parsing `1q/` now errors), and PQ recipient privacy is the universal unified-address ML-KEM story.

### privacy-progressivity.md (en + es) — surrounding-section audit
- Two tables made present-tense CT claims ("Private (confidential transactions)", "Pedersen commitments"); both now carry the ADR 0006 in-development qualifier.

## Acceptance grep

`grep -rni "ml-dsa\|mldsa" web/packages --include="*.md" --include="*.ts" --include="*.tsx" --include="*.json"` — surviving hits, all justified:

| File | Justification |
|------|---------------|
| `docs-content/en/privacy.md:75` | designated-future-family sentence ("no live protocol role today") |
| `docs-content/es/privacy.md:75` | es mirror of the above |

`grep -rni "1q/" web/packages --include="*.md"` survivors are the two retirement notices ("the earlier 1q/ quantum-address tier was retired (ADR 0006)") in en/es getting-started.md.

## Testing

- `pnpm vitest run packages/web-wallet/src/pages/docs.i18n.test.tsx packages/web-wallet/src/pages/docs-deep-link.test.tsx` — 23/23 pass (docs pages render both locales from these markdown files via Vite `?raw`).
- en/es parity maintained: every edit mirrored, es is a real translation (not English copy).

## Judgment calls

- ML-KEM recipient-privacy claims kept present-tense, following the judge-approved precedent in PR #909 (landing.json) and PR #914 (concepts/privacy.md); only CT amount claims got the in-development qualifier per the issue's Decision-1 instruction.
- privacy-progressivity.md was not in the issue's file list but is covered by its "audit the surrounding sections per the #906 rules" instruction; cluster-tags.md's Pedersen mention already says "Planned" and was left alone.
- Reverted a stray `allowBuilds` scaffold pnpm wrote into `web/pnpm-workspace.yaml` during test setup (not part of this change).

## Post-merge

botho.io needs a redeploy for the wallet docs pages to pick this up (single 'botho' Pages project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)