### PR TITLE
fix(web): stop RemoteNodeAdapter fabricating tx fields + hashRate

### DIFF
--- a/web/packages/adapters/src/__tests__/remote.test.ts
+++ b/web/packages/adapters/src/__tests__/remote.test.ts
@@ -292,6 +292,108 @@ describe('RemoteNodeAdapter.getBlock enriched fields (#700)', () => {
   })
 })
 
+describe('RemoteNodeAdapter.getNetworkStats', () => {
+  function rpc(result: Record<string, unknown>) {
+    return { jsonrpc: '2.0', result, id: 1 }
+  }
+
+  it('reports hashRate as null (not a fabricated "0") — the read RPC has no hash rate (#913)', async () => {
+    const adapter = await connectedAdapter({
+      getChainInfo: rpc({ difficulty: 12345 }),
+    })
+    const stats = await adapter.getNetworkStats()
+    expect(stats.hashRate).toBeNull()
+    // The public fields the RPC does expose are still populated.
+    expect(typeof stats.blockHeight).toBe('number')
+    expect(stats.difficulty).toBe(12345n)
+  })
+})
+
+describe('RemoteNodeAdapter.getTransaction', () => {
+  function rpc(result: Record<string, unknown>) {
+    return { jsonrpc: '2.0', result, id: 1 }
+  }
+
+  const txHash = 'ab'.repeat(32)
+
+  it('does not fabricate amount or type — the node exposes neither (#913, D1)', async () => {
+    const adapter = await connectedAdapter({
+      getTransaction: rpc({
+        txHash,
+        status: 'confirmed',
+        blockHeight: null,
+        confirmations: 3,
+        inMempool: false,
+        fee: 250,
+      }),
+    })
+    const tx = await adapter.getTransaction(txHash)
+    expect(tx).not.toBeNull()
+    // Neither amount nor direction is asserted.
+    expect(tx!.amount).toBeUndefined()
+    expect(tx!.type).toBeUndefined()
+    // The public fee is preserved as a bigint.
+    expect(tx!.fee).toBe(250n)
+  })
+
+  it('leaves timestamp undefined (not Date.now()) when the tx is not in a block (#913)', async () => {
+    const adapter = await connectedAdapter({
+      getTransaction: rpc({
+        txHash,
+        status: 'pending',
+        blockHeight: null,
+        confirmations: 0,
+        inMempool: true,
+        fee: 100,
+      }),
+    })
+    const tx = await adapter.getTransaction(txHash)
+    expect(tx!.timestamp).toBeUndefined()
+  })
+
+  it('resolves the real block timestamp when the tx is in a block (#913)', async () => {
+    const adapter = await connectedAdapter({
+      getTransaction: rpc({
+        txHash,
+        status: 'confirmed',
+        blockHeight: 42,
+        confirmations: 5,
+        inMempool: false,
+        fee: 250,
+      }),
+      getBlockByHeight: rpc({
+        height: 42,
+        hash: 'f'.repeat(64),
+        prevHash: 'e'.repeat(64),
+        timestamp: 1751840000,
+        difficulty: 1,
+        txCount: 1,
+        mintingReward: 0,
+      }),
+    })
+    const tx = await adapter.getTransaction(txHash)
+    expect(tx!.timestamp).toBe(1751840000)
+    expect(tx!.blockHeight).toBe(42)
+  })
+
+  it('leaves timestamp undefined when the block lookup fails (no fabrication)', async () => {
+    const adapter = await connectedAdapter({
+      getTransaction: rpc({
+        txHash,
+        status: 'confirmed',
+        blockHeight: 42,
+        confirmations: 5,
+        inMempool: false,
+        fee: 250,
+      }),
+      // getBlockByHeight is intentionally unrouted -> RPC error -> getBlock returns null.
+    })
+    const tx = await adapter.getTransaction(txHash)
+    expect(tx!.timestamp).toBeUndefined()
+    expect(tx!.blockHeight).toBe(42)
+  })
+})
+
 describe('u128 / u64 wire-format round-trips', () => {
   it('round-trips BigInt("99999999999999999999") (> u64 max) exactly', () => {
     const big = '99999999999999999999'

--- a/web/packages/adapters/src/remote.ts
+++ b/web/packages/adapters/src/remote.ts
@@ -266,7 +266,10 @@ export class RemoteNodeAdapter implements NodeAdapter {
     return {
       blockHeight: status.chainHeight,
       difficulty: BigInt(chain.difficulty || 0),
-      hashRate: '0', // Not provided by RPC
+      // The seed-node read RPC does not expose hash rate. Report null so the
+      // consumer renders "n/a"/"—" rather than a fabricated "0 H/s" that would
+      // read as a real reading (#913, #541-class fabrication).
+      hashRate: null,
       connectedPeers: status.peerCount,
       mempoolSize: status.mempoolSize,
     }
@@ -483,15 +486,29 @@ export class RemoteNodeAdapter implements NodeAdapter {
 
       const status: Transaction['status'] = result.status === 'confirmed' ? 'confirmed' : 'pending'
 
+      // Resolve the real block timestamp when the tx is in a block. The RPC
+      // does not carry a per-tx timestamp, so rather than fabricate `Date.now()`
+      // (#913), look up the containing block. If the lookup fails, leave the
+      // timestamp undefined and let the consumer render "—".
+      let timestamp: number | undefined
+      if (result.blockHeight != null) {
+        const block = await this.getBlock(result.blockHeight)
+        if (block) {
+          timestamp = block.timestamp
+        }
+      }
+
       return {
         id: result.txHash,
-        type: 'receive' as const,
-        amount: BigInt(0), // Private (ring signatures) - amount not visible
+        // Direction, amount, and (when unresolved) timestamp are deliberately
+        // omitted: the node exposes no per-tx direction, and per-tx amounts are
+        // never public (deprecation D1, docs/design/post-ct-analytics.md). Only
+        // publicly-verifiable fields are asserted (#913).
         fee: BigInt(result.fee || 0),
         privacyLevel: 'private' as const,
         cryptoType,
         status,
-        timestamp: Date.now(), // RPC does not expose tx timestamp; block timestamp would require an extra lookup
+        timestamp,
         blockHeight: result.blockHeight ?? undefined,
         confirmations: result.confirmations || 0,
       }
@@ -839,13 +856,14 @@ export class RemoteNodeAdapter implements NodeAdapter {
 
     return {
       id: data.hash as string,
-      type: 'receive' as const,
-      amount: BigInt(0), // Private - not visible
+      // Direction and amount are not exposed by the node (and amounts never will
+      // be under CT); omit them rather than fabricate (#913). The WS event
+      // carries no wall-clock timestamp either — leave it undefined so consumers
+      // render "—" instead of "now".
       fee: BigInt((data.fee as number) || 0),
       privacyLevel: 'private' as const,
       cryptoType,
       status: data.in_block ? 'confirmed' as const : 'pending' as const,
-      timestamp: Date.now(),
       blockHeight: data.in_block as number | undefined,
       confirmations: data.in_block ? 1 : 0,
     }

--- a/web/packages/core/src/types/index.ts
+++ b/web/packages/core/src/types/index.ts
@@ -33,14 +33,34 @@ export type CryptoType = 'clsag' | 'minting' | 'hybrid'
 
 export interface Transaction {
   id: TxHash
-  type: TransactionType
-  amount: Amount
+  /**
+   * Direction/kind of the transaction. Present for wallet-owned history rows
+   * (the wallet knows whether it sent or received). Omitted by the block
+   * explorer's `getTransaction`, where the node exposes no per-tx direction —
+   * consumers must not assert one (#913).
+   */
+  type?: TransactionType
+  /**
+   * Transaction amount in picocredits. Present only for wallet-owned history
+   * rows, where the amount is recovered from the wallet's own view key. The
+   * node never exposes per-tx amounts to third parties, and under confidential
+   * transactions (ADR 0006 Decision 1) it never will — so the block explorer
+   * leaves this undefined rather than fabricating a `0` (#913, deprecation D1
+   * in docs/design/post-ct-analytics.md).
+   */
+  amount?: Amount
   fee: Amount
   privacyLevel: PrivacyLevel
   /** Attribution type: clsag (ring signatures for private tx), minting (PoW-bound, no signature), or hybrid */
   cryptoType: CryptoType
   status: TransactionStatus
-  timestamp: Timestamp
+  /**
+   * Wall-clock time of the transaction (unix seconds). Present for wallet
+   * history and blocks whose timestamp is known. Omitted by the block
+   * explorer's `getTransaction` when the RPC does not expose a real timestamp —
+   * consumers render "—" rather than fabricating `Date.now()` (#913).
+   */
+  timestamp?: Timestamp
   blockHeight?: BlockHeight
   confirmations: number
   counterparty?: Address
@@ -84,7 +104,13 @@ export interface NodeInfo {
 export interface NetworkStats {
   blockHeight: BlockHeight
   difficulty: bigint
-  hashRate: string
+  /**
+   * Network hash rate as a decimal string. `null` when the data source does
+   * not expose it (e.g. the seed-node read RPC), in which case consumers render
+   * "n/a"/"—" rather than a fabricated "0" (#913, derive-or-n/a rule in
+   * docs/design/block-explorer-network-stats.md).
+   */
+  hashRate: string | null
   connectedPeers: number
   mempoolSize: number
 }

--- a/web/packages/desktop/src/pages/dashboard.tsx
+++ b/web/packages/desktop/src/pages/dashboard.tsx
@@ -17,7 +17,10 @@ function formatNumber(n: number): string {
   return new Intl.NumberFormat().format(n)
 }
 
-function formatHashRate(hashRate: string | number): string {
+function formatHashRate(hashRate: string | number | null): string {
+  // null means the connected data source does not expose hash rate (e.g. the
+  // seed-node read RPC): render "n/a" rather than a fabricated "0 H/s" (#913).
+  if (hashRate === null) return 'n/a'
   const rate = typeof hashRate === 'string' ? parseFloat(hashRate) : hashRate
   if (isNaN(rate)) return hashRate.toString()
   if (rate >= 1e12) return `${(rate / 1e12).toFixed(2)} TH/s`

--- a/web/packages/features/src/explorer/components/transaction-detail.test.tsx
+++ b/web/packages/features/src/explorer/components/transaction-detail.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The transaction-detail view must never fabricate values the node does not
+ * expose (#913):
+ *   - No "Amount" row (deprecation D1): the node exposes no per-tx amount and
+ *     under confidential transactions never will. Only the public fee is shown.
+ *   - An absent `timestamp` renders "—", not a fabricated wall-clock time.
+ *   - An absent `type` renders a neutral label, not an asserted "receive".
+ */
+import { describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach } from 'vitest'
+import type { Transaction } from '@botho/core'
+import { ExplorerProvider } from '../context'
+import type { ExplorerDataSource } from '../types'
+import { TransactionDetail } from './transaction-detail'
+
+afterEach(cleanup)
+
+const dataSource: ExplorerDataSource = {
+  getRecentBlocks: async () => [],
+  getBlock: async () => null,
+  getTransaction: async () => null,
+}
+
+function renderDetail(tx: Transaction) {
+  return render(
+    <ExplorerProvider dataSource={dataSource}>
+      <TransactionDetail transaction={tx} />
+    </ExplorerProvider>,
+  )
+}
+
+/** An explorer-sourced tx: fee is public; direction/amount/timestamp unknown. */
+function explorerTx(over: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'ab'.repeat(32),
+    fee: 1_000_000n,
+    privacyLevel: 'private',
+    cryptoType: 'clsag',
+    status: 'confirmed',
+    confirmations: 12,
+    ...over,
+  }
+}
+
+describe('TransactionDetail', () => {
+  it('does not render an Amount row (deprecation D1)', () => {
+    renderDetail(explorerTx())
+    expect(screen.queryByText('Amount')).toBeNull()
+  })
+
+  it('still renders the public Fee row', () => {
+    renderDetail(explorerTx())
+    expect(screen.getByText('Fee')).toBeTruthy()
+  })
+
+  it('renders "—" for an absent timestamp instead of fabricating a time', () => {
+    renderDetail(explorerTx({ timestamp: undefined }))
+    // The Time row's value should be the em dash placeholder.
+    const timeLabel = screen.getByText('Time')
+    const row = timeLabel.closest('div')?.parentElement ?? timeLabel.parentElement
+    expect(row?.textContent).toContain('—')
+  })
+
+  it('renders a real time when the timestamp is present', () => {
+    renderDetail(explorerTx({ timestamp: 1_751_840_000 }))
+    const timeLabel = screen.getByText('Time')
+    const row = timeLabel.closest('div')?.parentElement ?? timeLabel.parentElement
+    expect(row?.textContent).not.toContain('—')
+  })
+
+  it('uses a neutral label when direction is unknown, not "receive"', () => {
+    renderDetail(explorerTx({ type: undefined }))
+    expect(screen.getByText('Transaction')).toBeTruthy()
+    expect(screen.queryByText('receive')).toBeNull()
+  })
+})

--- a/web/packages/features/src/explorer/components/transaction-detail.tsx
+++ b/web/packages/features/src/explorer/components/transaction-detail.tsx
@@ -1,6 +1,6 @@
 import type { Transaction } from '@botho/core'
 import { Card, CardHeader, CardTitle, CardContent, Button } from '@botho/ui'
-import { ArrowLeft, ArrowUpRight, ArrowDownLeft, Pickaxe } from 'lucide-react'
+import { ArrowLeft, ArrowUpRight, ArrowDownLeft, Pickaxe, FileText } from 'lucide-react'
 import { useExplorer } from '../context'
 import { DetailRow } from './detail-row'
 import { formatTime, formatHash, formatAmount } from '../utils'
@@ -15,24 +15,33 @@ export interface TransactionDetailProps {
 export function TransactionDetail({ transaction, className }: TransactionDetailProps) {
   const { goBack, viewBlock } = useExplorer()
 
+  // The block explorer's node RPC exposes no per-tx direction, so `type` is
+  // often absent (#913). Fall back to a neutral icon/label rather than
+  // asserting "receive" for every transaction.
   const TypeIcon =
     transaction.type === 'send'
       ? ArrowUpRight
       : transaction.type === 'receive'
         ? ArrowDownLeft
-        : Pickaxe
+        : transaction.type === 'minting'
+          ? Pickaxe
+          : FileText
 
   const typeColors = {
     send: 'text-[--color-danger]',
     receive: 'text-[--color-success]',
     minting: 'text-[--color-pulse]',
-  }
+  } as const
 
   const typeBgColors = {
     send: 'bg-[--color-danger]/10',
     receive: 'bg-[--color-success]/10',
     minting: 'bg-[--color-pulse]/10',
-  }
+  } as const
+
+  const typeColor = transaction.type ? typeColors[transaction.type] : 'text-[--color-dim]'
+  const typeBgColor = transaction.type ? typeBgColors[transaction.type] : 'bg-[--color-slate]'
+  const typeLabel = transaction.type ?? 'Transaction'
 
   return (
     <div className={`space-y-4 ${className || ''}`}>
@@ -47,23 +56,23 @@ export function TransactionDetail({ transaction, className }: TransactionDetailP
         <CardHeader>
           <div className="flex items-center gap-3">
             <div
-              className={`flex h-12 w-12 items-center justify-center rounded-lg ${typeBgColors[transaction.type]}`}
+              className={`flex h-12 w-12 items-center justify-center rounded-lg ${typeBgColor}`}
             >
-              <TypeIcon className={`h-6 w-6 ${typeColors[transaction.type]}`} />
+              <TypeIcon className={`h-6 w-6 ${typeColor}`} />
             </div>
             <div>
-              <CardTitle className="capitalize">{transaction.type}</CardTitle>
+              <CardTitle className="capitalize">{typeLabel}</CardTitle>
               <p className="mt-1 font-mono text-xs text-[--color-dim]">{transaction.id}</p>
             </div>
           </div>
         </CardHeader>
         <CardContent>
           <div className="grid gap-4 sm:grid-cols-2">
-            <DetailRow
-              label="Amount"
-              value={`${formatAmount(transaction.amount)} BTH`}
-              valueClass={typeColors[transaction.type]}
-            />
+            {/* No "Amount" row: the node exposes no per-tx amount, and under
+                confidential transactions (ADR 0006) it never will. Rendering a
+                fabricated "0 BTH" here read as a real value (#913, deprecation
+                D1 in docs/design/post-ct-analytics.md). Fees are public and
+                stay. */}
             <DetailRow label="Fee" value={`${formatAmount(transaction.fee)} BTH`} />
             <DetailRow
               label="Status"
@@ -86,7 +95,10 @@ export function TransactionDetail({ transaction, className }: TransactionDetailP
                   : 'text-[--color-ghost]'
               }
             />
-            <DetailRow label="Time" value={formatTime(transaction.timestamp)} />
+            <DetailRow
+              label="Time"
+              value={transaction.timestamp != null ? formatTime(transaction.timestamp) : '—'}
+            />
             {transaction.blockHeight && (
               <DetailRow
                 label="Block"

--- a/web/packages/features/src/wallet/components/transaction-row.tsx
+++ b/web/packages/features/src/wallet/components/transaction-row.tsx
@@ -133,9 +133,9 @@ export function TransactionRow({
               than fabricating a relative time. */}
           <span
             className="text-xs text-[--color-dim]"
-            title={tx.timestamp > 0 ? formatAbsoluteTime(tx.timestamp) : undefined}
+            title={tx.timestamp != null && tx.timestamp > 0 ? formatAbsoluteTime(tx.timestamp) : undefined}
           >
-            {tx.timestamp > 0
+            {tx.timestamp != null && tx.timestamp > 0
               ? formatRelativeTime(tx.timestamp)
               : tx.blockHeight != null
                 ? `Block #${tx.blockHeight}`
@@ -151,8 +151,7 @@ export function TransactionRow({
         <div
           className={`font-mono font-semibold ${isReceive ? 'text-[--color-success]' : 'text-[--color-light]'}`}
         >
-          {isReceive ? '+' : '-'}
-          {formatBTH(tx.amount)} BTH
+          {tx.amount != null ? `${isReceive ? '+' : '-'}${formatBTH(tx.amount)} BTH` : '—'}
         </div>
         <div
           className={`flex items-center justify-end gap-1 text-xs ${statusConfig.color}`}


### PR DESCRIPTION
## Summary

`RemoteNodeAdapter` (`web/packages/adapters/src/remote.ts`) hardcoded several fields that render to users as if they were live readings — the #541–#544 fabrication pattern reproduced in the web adapter. This makes the return types honest (nullable/optional where the node genuinely exposes nothing) and updates consumers to render the absence gracefully rather than papering over it with fake defaults.

Refs: #908, PR #910, `docs/design/post-ct-analytics.md` §5 + D1, `docs/design/block-explorer-network-stats.md` (derive-or-n/a rule).

## Changes

- **hashRate (`getNetworkStats`)**: `NetworkStats.hashRate` is now `string | null`. The adapter returns `null` (the seed read RPC has no hash rate) and the desktop dashboard "Hash Rate" card (`dashboard.tsx`) renders `n/a` via `formatHashRate` instead of a fabricated `0 H/s`.
- **amount / type (`getTransaction`)**: `Transaction.amount` and `Transaction.type` are now optional. The adapter omits both — the node exposes no per-tx direction, and per-tx amounts are never public (deprecation **D1**). The explorer `transaction-detail.tsx` **deletes the "Amount" row** entirely and falls back to a neutral icon/label when direction is unknown.
- **timestamp (`getTransaction`)**: `Transaction.timestamp` is now optional. Instead of `Date.now()`, the adapter resolves the real containing-block timestamp when the tx is in a block, else leaves it undefined; `transaction-detail.tsx` renders `—`.
- **WS path**: `parseTransactionEvent` had the same amount/type/timestamp fabrications — fixed consistently.
- `transaction-row.tsx` (wallet history, which supplies real values) guards the now-optional fields; the wallet UI is unchanged in practice.
- Tests: added adapter tests (`getNetworkStats` null hashRate; `getTransaction` no fabricated amount/type, timestamp resolved-from-block / undefined-otherwise) and a `transaction-detail` test (no Amount row, `—` for absent timestamp, neutral type).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| hashRate no longer a fabricated constant; dashboard shows n/a (not "0 H/s") | ✅ | adapter returns `null`; `formatHashRate(null) => 'n/a'`; adapter test asserts `stats.hashRate` is null |
| tx "Amount: 0 BTH" row removed (D1) | ✅ | Amount `DetailRow` deleted from `transaction-detail.tsx`; test asserts no "Amount" text |
| timestamp not fabricated as now | ✅ | resolves block timestamp or undefined; tests cover in-block, pending, and failed-lookup cases; detail renders `—` |
| type not hardcoded 'receive' | ✅ | `type` omitted by adapter; detail uses neutral label; test asserts no asserted "receive" |
| Types honest (nullable/optional, not defaults) | ✅ | `NetworkStats.hashRate: string \| null`; `Transaction.{type,amount,timestamp}` optional; `pnpm -r typecheck` green |

## Test Plan

- `pnpm -r typecheck` — green (8 packages)
- `pnpm test:run` — 895 passed, 10 skipped, 0 failures (includes 5 new adapter + 5 new transaction-detail tests)

## Follow-up (out of scope, not fixed here)

`parseBlockEvent` (WS block events) sets `reward: BigInt(0)` and `size: 0` because the WS event omits them; these feed the explorer block list via `onNewBlock`, so a live WS block flashes a fabricated `+0` reward. This is a distinct surface from the four fabrications this issue enumerates — filing separately rather than expanding scope.

## Post-merge

botho.io redeploy needed (desktop dashboard + explorer render paths changed).

Closes #913