### PR TITLE
fix(web): stop parseBlockEvent fabricating reward/size on WS block events (closes #924)

### DIFF
--- a/web/packages/adapters/src/__tests__/remote.test.ts
+++ b/web/packages/adapters/src/__tests__/remote.test.ts
@@ -290,6 +290,49 @@ describe('RemoteNodeAdapter.getBlock enriched fields (#700)', () => {
     expect(block!.transactions).toEqual([])
     expect(lastCall('getBlockByHash')?.params.hash).toBe('f'.repeat(64))
   })
+
+  it('omits size — the read RPC does not expose it (not a fabricated 0) (#924)', async () => {
+    const adapter = await connectedAdapter({ getBlockByHeight: rpc(legacyBlock) })
+    const block = await adapter.getBlock(42)
+    expect(block!.size).toBeUndefined()
+  })
+})
+
+describe('RemoteNodeAdapter.parseBlockEvent (WS block event)', () => {
+  // The node's NewBlock WS payload carries only height/hash/timestamp/tx_count/
+  // difficulty (botho/src/rpc/websocket.rs::WsEvent::NewBlock). It has no reward
+  // or size, so the adapter must omit them rather than fabricate 0/+0 (#924).
+  const wsBlock = {
+    height: 100,
+    hash: 'a'.repeat(64),
+    timestamp: 1751900000,
+    tx_count: 3,
+    difficulty: 54321,
+  }
+
+  /** Exercise the private WS parser via bracket access. */
+  function parse(adapter: RemoteNodeAdapter, data: Record<string, unknown>) {
+    return (adapter as unknown as {
+      parseBlockEvent(d: Record<string, unknown>): import('@botho/core').Block
+    }).parseBlockEvent(data)
+  }
+
+  it('omits reward and size — the WS event carries neither (not fabricated 0) (#924)', async () => {
+    const adapter = await connectedAdapter({})
+    const block = parse(adapter, wsBlock)
+    expect(block.reward).toBeUndefined()
+    expect(block.size).toBeUndefined()
+  })
+
+  it('still maps the fields the WS event does carry', async () => {
+    const adapter = await connectedAdapter({})
+    const block = parse(adapter, wsBlock)
+    expect(block.height).toBe(100)
+    expect(block.hash).toBe('a'.repeat(64))
+    expect(block.timestamp).toBe(1751900000)
+    expect(block.transactionCount).toBe(3)
+    expect(block.difficulty).toBe(54321n)
+  })
 })
 
 describe('RemoteNodeAdapter.getNetworkStats', () => {

--- a/web/packages/adapters/src/remote.ts
+++ b/web/packages/adapters/src/remote.ts
@@ -104,7 +104,8 @@ function mapRpcBlock(result: RpcBlockResult): Block {
     timestamp: result.timestamp,
     previousHash: result.prevHash,
     transactionCount: result.txCount,
-    size: 0, // Not provided
+    // The read RPC does not expose serialized block size; omit it rather than
+    // fabricate `0`, which renders as a real "0 B" reading (#924, #541-class).
     reward: BigInt(result.mintingReward || 0),
     difficulty: BigInt(result.difficulty || 0),
   }
@@ -837,8 +838,10 @@ export class RemoteNodeAdapter implements NodeAdapter {
       timestamp: data.timestamp as number,
       previousHash: '', // Not included in WS event
       transactionCount: data.tx_count as number,
-      size: 0, // Not included in WS event
-      reward: BigInt(0), // Not included in WS event
+      // Size and reward are not carried by the WS block event (the node's
+      // NewBlock payload is height/hash/timestamp/tx_count/difficulty only).
+      // Omit them rather than fabricate `0`/`+0`, which would render as real
+      // readings in the explorer block list (#924, #541-class fabrication).
       difficulty: BigInt((data.difficulty as number) || 0),
     }
   }

--- a/web/packages/core/src/types/index.ts
+++ b/web/packages/core/src/types/index.ts
@@ -169,9 +169,21 @@ export interface Block {
   timestamp: Timestamp
   previousHash: BlockHash
   transactionCount: number
-  size: number
+  /**
+   * Serialized block size in bytes. Present for blocks fetched via the enriched
+   * RPC. Omitted for blocks delivered over the live WebSocket event, whose
+   * payload does not carry a size — consumers render "—" rather than a
+   * fabricated `0` (#924, #541-class fabrication).
+   */
+  size?: number
   minter?: Address
-  reward: Amount
+  /**
+   * Block reward in picocredits. Present for blocks fetched via the enriched
+   * RPC. Omitted for blocks delivered over the live WebSocket event, whose
+   * payload does not carry a reward — consumers omit the reward rather than
+   * flash a fabricated "+0" (#924, #541-class fabrication).
+   */
+  reward?: Amount
   difficulty: bigint
   /**
    * Enriched explorer fields (#700). Optional and additive — older nodes

--- a/web/packages/features/src/explorer/components/block-detail.tsx
+++ b/web/packages/features/src/explorer/components/block-detail.tsx
@@ -47,11 +47,16 @@ export function BlockDetail({ block, className }: BlockDetailProps) {
             <DetailRow label="Height" value={block.height.toLocaleString()} />
             <DetailRow label="Timestamp" value={formatTime(block.timestamp)} />
             <DetailRow label="Transactions" value={block.transactionCount.toString()} />
-            <DetailRow label="Size" value={formatSize(block.size)} />
+            <DetailRow
+              label="Size"
+              value={block.size !== undefined ? formatSize(block.size) : '—'}
+            />
             <DetailRow
               label="Reward"
-              value={`${formatAmount(block.reward)} BTH`}
-              valueClass="text-[--color-success]"
+              value={
+                block.reward !== undefined ? `${formatAmount(block.reward)} BTH` : '—'
+              }
+              valueClass={block.reward !== undefined ? 'text-[--color-success]' : undefined}
             />
             <DetailRow label="Difficulty" value={formatDifficulty(block.difficulty)} />
             {block.totalFees !== undefined && (

--- a/web/packages/features/src/explorer/components/block-list.test.tsx
+++ b/web/packages/features/src/explorer/components/block-list.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The recent-blocks list must render honest reward data (#924): a block whose
+ * reward is known shows "+<amount>"; a block delivered over the live WebSocket
+ * event — whose payload carries no reward — shows "—" rather than a fabricated
+ * "+0" (#541-class fabrication).
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { Block } from '@botho/core'
+import { ExplorerProvider } from '../context'
+import { BlockList } from './block-list'
+
+function block(height: number, over: Partial<Block> = {}): Block {
+  return {
+    hash: `hash-${height}`,
+    height,
+    timestamp: Math.floor(Date.now() / 1000) - 60,
+    previousHash: `hash-${height - 1}`,
+    transactionCount: 1,
+    size: 128,
+    reward: 4_800_000_000_000n,
+    difficulty: 0n,
+    ...over,
+  }
+}
+
+function renderList(blocks: Block[]) {
+  const dataSource = {
+    getRecentBlocks: vi.fn(async () => blocks),
+    getBlock: vi.fn(async () => null),
+    getTransaction: vi.fn(async () => null),
+  }
+  return render(
+    <ExplorerProvider dataSource={dataSource}>
+      <BlockList />
+    </ExplorerProvider>,
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('BlockList reward rendering (#924)', () => {
+  it('renders the reward for a block that has one', async () => {
+    renderList([block(10)])
+    expect(await screen.findByText('+4.80')).toBeTruthy()
+  })
+
+  it('renders "—" (not "+0") when a block omits its reward (live WS block)', async () => {
+    // A WS-delivered block: reward/size absent, as parseBlockEvent now leaves them.
+    renderList([block(11, { reward: undefined, size: undefined })])
+    expect(await screen.findByText('—')).toBeTruthy()
+    // Must NOT fabricate a "+0" reward.
+    expect(screen.queryByText('+0.00')).toBeNull()
+    expect(screen.queryByText(/^\+0/)).toBeNull()
+  })
+})

--- a/web/packages/features/src/explorer/components/block-list.tsx
+++ b/web/packages/features/src/explorer/components/block-list.tsx
@@ -91,11 +91,17 @@ export function BlockList({ title = 'Recent Blocks', className }: BlockListProps
                 </div>
               </div>
 
-              {/* Reward */}
+              {/* Reward — omitted for live WebSocket blocks, whose event
+                  payload carries no reward. Render "—" rather than a
+                  fabricated "+0" (#924). */}
               <div className="text-right">
-                <p className="font-mono text-sm text-[--color-success]">
-                  +{formatAmount(block.reward)}
-                </p>
+                {block.reward !== undefined ? (
+                  <p className="font-mono text-sm text-[--color-success]">
+                    +{formatAmount(block.reward)}
+                  </p>
+                ) : (
+                  <p className="font-mono text-sm text-[--color-dim]">—</p>
+                )}
                 <p className="mt-1 text-xs text-[--color-dim]">reward</p>
               </div>
 


### PR DESCRIPTION
Closes #924

## Problem
`parseBlockEvent` in `web/packages/adapters/src/remote.ts` (the WebSocket block-event path) hardcoded `reward: BigInt(0)` and `size: 0`. The node's `NewBlock` WS payload carries **only** `height/hash/timestamp/tx_count/difficulty` (`botho/src/rpc/websocket.rs::WsEvent::NewBlock`) — no reward, no size. These blocks flow into the explorer block list via `onNewBlock`, so a live WebSocket block would flash a fabricated **"+0" reward** and **"0 B" size** to users — the #541-class "fields hardcoded to look live" failure mode.

## WS event shape (checked first)
The WS block event **cannot** carry reward/size — the Rust `WsEvent::NewBlock` variant does not include them. So the honest fix is to omit them, not wire them through (mirrors #913 / PR #923).

## Fix (mirrors #913, PR #923)
- `Block.reward` and `Block.size` are now genuinely **optional** in `@botho/core` (not sentinel defaults). Absence means "not carried by this source", never a real zero.
- `parseBlockEvent` **omits** reward/size instead of fabricating `0`/`+0`.
- `mapRpcBlock` (RPC `getBlock` path) likewise omits `size` — the read RPC does not expose it; it keeps the honest `reward` from `mintingReward`.
- Explorer **block list** renders `—` (not `+0`) when reward is absent.
- Explorer **block detail** renders `—` for absent size/reward.

## Tests
- `remote.test.ts`: new `parseBlockEvent` group asserting reward/size are omitted when the WS payload lacks them, and that the fields the event *does* carry are still mapped; plus a `getBlock` assertion that size is omitted.
- `block-list.test.tsx` (new): a block with a reward renders `+<amount>`; a block that omits its reward (live WS block) renders `—` and never `+0`.
- `pnpm test:run` (adapter + block-list): 28 passed.
- `pnpm -r typecheck`: green across all 8 packages.

## Deploy
botho.io redeploy needed to reach the live web wallet / explorer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)