### PR TITLE
test(cluster-tax): demonstrate + document demurrage background-reset leak (closes #834)

### DIFF
--- a/cluster-tax/src/demurrage.rs
+++ b/cluster-tax/src/demurrage.rs
@@ -31,6 +31,28 @@
 //! invariant to churn frequency; churning just adds transaction fees on
 //! top (which also feed the lottery pool).
 //!
+//! ### Scope of the churn-invariance claim: it holds WITHIN a wealth class
+//!
+//! Churn-invariance is invariance of *accrued* demurrage under re-spending at
+//! the *same* cluster factor. It does NOT price a **class transition**. The
+//! charge is proportional to `elapsed` (age-since-creation), so a coin spent
+//! while young (`elapsed ≈ 0`) pays ≈0 *regardless of factor* — the
+//! ring-centroid factor floor ([`ring_centroid_implied_factor`]) raises the
+//! factor a background-tagged output claims, but multiplies a near-zero
+//! elapsed. A holder can therefore spend a freshly-created wealthy coin to a
+//! fully background-tagged output (legal deflation under
+//! `check_cluster_tag_inheritance`, which only rejects inflation), pay ≈0, and
+//! land a genuinely-background coin whose future ring floor is 1× — escaping
+//! all FUTURE stock-level demurrage. This is a real, unpriced future-demurrage
+//! leak, demonstrated by [`tests::demurrage_background_reset_leak_is_real`] and
+//! written up in `docs/research/demurrage-background-reset-leak.md`. It mirrors
+//! exactly the escape #831's settlement op closes for the wrapping on-ramp: the
+//! settlement op prices the same class transition by charging *capitalized
+//! future* demurrage (ADR 0003), whereas an ordinary spend charges only
+//! *accrued-to-date* demurrage. The proposed on-chain fix (price the class
+//! transition = charge capitalized future demurrage on deflation) is tracked as
+//! a mainnet blocker in issue #925.
+//!
 //! ## Determinism
 //!
 //! CONSENSUS-CRITICAL: pure integer arithmetic throughout.
@@ -589,5 +611,126 @@ mod tests {
         let one_year = demurrage_charge(1_000_000, 6_000, BLOCKS_PER_YEAR, 200, BLOCKS_PER_YEAR);
         let half = demurrage_charge(1_000_000, 6_000, BLOCKS_PER_YEAR / 2, 200, BLOCKS_PER_YEAR);
         assert_eq!(one_year, half * 2);
+    }
+
+    /// REGRESSION / EVIDENCE (issue #834): a wealthy holder can reset a coin's
+    /// demurrage class to background via an ordinary spend, paying ≈0 and
+    /// escaping ALL future stock-level demurrage.
+    ///
+    /// This test walks the exact suspect sequence and ASSERTS the observed
+    /// charges at each step. It is the executable answer to issue #834:
+    /// **the leak is real.** The full write-up is in
+    /// `docs/research/demurrage-background-reset-leak.md`.
+    ///
+    /// The mechanism reproduced here is the consensus fee-floor demurrage term
+    /// (`Ledger::consensus_fee_floor` in `botho/src/ledger/store.rs`):
+    /// `demurrage_charge(output_sum, max(claimed_factor, ring_implied),
+    /// elapsed@max, rate, bpy)`. This test drives the two pure pieces that
+    /// path composes — [`ring_centroid_implied_factor`] (the factor floor
+    /// the spender cannot rewrite) and [`demurrage_charge`] (the
+    /// accrued-time charge) — so the numbers are the real consensus
+    /// numbers, not a re-derivation.
+    ///
+    /// If a future fix prices the class transition (e.g. charging capitalized
+    /// future demurrage on deflation, mirroring #831's settlement charge), the
+    /// `spend#1` assertion below will start failing — which is the intended
+    /// signal that the leak is closed. Update this test at that point to assert
+    /// the new priced-transition charge.
+    #[test]
+    fn demurrage_background_reset_leak_is_real() {
+        use crate::ClusterFactorCurve;
+        const PICO_PER_BTH: u128 = 1_000_000_000_000;
+        let curve = ClusterFactorCurve::default_params();
+        let rate_bps = 200u32; // 2%/yr at max factor
+
+        // A wealthy cluster: 10M BTH of tagged wealth.
+        let wealthy_cluster_wealth: u128 = 10_000_000 * PICO_PER_BTH;
+        // The coin being manipulated: 1000 BTH (in picocredits, fits u64).
+        let output_sum: u64 = 1_000 * PICO_PER_BTH as u64;
+
+        // --- Baseline: what an HONEST wealthy holder pays if they simply hold
+        //     the coin for a year and then spend it (no class reset). The ring
+        //     is composed of members carrying the wealthy cluster's public,
+        //     inherited tags, so the implied factor floor is high; the coin is
+        //     one year old, so elapsed = BLOCKS_PER_YEAR.
+        let wealthy_ring = [(output_sum, wealthy_cluster_wealth)];
+        let wealthy_factor = ring_centroid_implied_factor(&wealthy_ring, &curve);
+        assert_eq!(
+            wealthy_factor, 5745,
+            "10M-BTH cluster maps to factor 5.745x (observed floor)"
+        );
+        let honest_annual_charge = demurrage_charge(
+            output_sum,
+            wealthy_factor,
+            BLOCKS_PER_YEAR,
+            rate_bps,
+            BLOCKS_PER_YEAR,
+        );
+        assert_eq!(
+            honest_annual_charge, 18_980_000_000_000,
+            "honest wealthy holder pays ~18.98 BTH/yr on a 1000-BTH coin (in pico)"
+        );
+
+        // --- Step 1 of the attack: the whale first re-spends the wealthy coin
+        //     wealthy->wealthy to RESET its creation height (standard UTXO
+        //     behavior: a new output's created_at = the current block). This
+        //     pays the accrued charge for however long it had sat — but the
+        //     whale times it so the coin is spent again immediately, so the
+        //     age it must pay for at Step 2 is ~0. We model the post-reset coin
+        //     as elapsed = 0.
+
+        // --- Step 2 (the leak): spend the now-YOUNG wealthy coin to a fully
+        //     background-tagged output. `check_cluster_tag_inheritance` permits
+        //     this (deflation is legal; only inflation is rejected). The ring
+        //     floor still raises the factor to the wealthy 5745 — but demurrage
+        //     is proportional to elapsed, and elapsed ≈ 0, so the charge is 0.
+        let young_elapsed = 0u64;
+        let reset_spend_charge = demurrage_charge(
+            output_sum,
+            wealthy_factor, // ring floor IS applied — factor is high...
+            young_elapsed,  // ...but elapsed is ~0, so it does nothing.
+            rate_bps,
+            BLOCKS_PER_YEAR,
+        );
+        assert_eq!(
+            reset_spend_charge, 0,
+            "THE LEAK: spending a young wealthy coin to background pays ZERO \
+             demurrage despite the ring floor raising the factor to {wealthy_factor}"
+        );
+
+        // --- After the reset: the output genuinely carries background tags, so
+        //     future rings composed of background members imply factor 1x.
+        let background_ring = [(output_sum, 0u128)];
+        let background_factor = ring_centroid_implied_factor(&background_ring, &curve);
+        assert_eq!(
+            background_factor, FACTOR_SCALE,
+            "the reset coin's ring floor is now 1x (background)"
+        );
+
+        // --- Future demurrage on the reset coin: ZERO, forever, no matter how
+        //     long it is held. The stock-level charge the mechanism is designed
+        //     to extract has been fully escaped.
+        let future_charge_one_year = demurrage_charge(
+            output_sum,
+            background_factor,
+            BLOCKS_PER_YEAR,
+            rate_bps,
+            BLOCKS_PER_YEAR,
+        );
+        assert_eq!(
+            future_charge_one_year, 0,
+            "escaped: the reset background coin pays zero demurrage even held a full year, \
+             vs the honest {honest_annual_charge} it would owe as a wealthy coin"
+        );
+
+        // --- The bottom line: total demurrage paid to shed the wealthy class is
+        //     0, while the priced exit (#831's settlement op) would charge the
+        //     capitalized future demurrage. The gap between these is the leak.
+        let total_paid_to_escape = reset_spend_charge + future_charge_one_year;
+        assert_eq!(total_paid_to_escape, 0);
+        assert!(
+            honest_annual_charge > total_paid_to_escape,
+            "an unpriced class transition strictly undercuts holding: {honest_annual_charge} > {total_paid_to_escape}"
+        );
     }
 }

--- a/docs/research/demurrage-background-reset-leak.md
+++ b/docs/research/demurrage-background-reset-leak.md
@@ -1,0 +1,156 @@
+# Demurrage Background-Reset Leak — Verdict
+
+**Issue**: [#834](https://github.com/botho-project/botho/issues/834)
+**Status**: **VERDICT — leak is REAL (option (a))**. An unpriced class transition.
+**Date**: 2026-07-14
+**Related**: ADR 0003 (demurrage-settlement on-ramp), #831 (settlement charge), #713/#581 (cluster-tag inheritance bound)
+**Evidence**: `cluster-tax/src/demurrage.rs::tests::demurrage_background_reset_leak_is_real` (permanent regression test)
+
+## The question
+
+Can a wealthy holder cheaply reset a coin's demurrage class to background via an
+**ordinary spend**, escaping the future stock-level demurrage the cluster-tilted
+mechanism is designed to extract?
+
+## Verdict
+
+**Yes.** The escape is real and currently **unpriced**. Nothing on the ordinary
+spend path charges the coin for shedding its wealthy cluster provenance. This is
+in tension with the intent of the churn-invariance property, and it is the same
+escape #831's settlement op deliberately *prices* for the wrapping on-ramp — so
+leaving it open on the pure on-chain path would make #831 pointless. **Marked a
+mainnet blocker.**
+
+## Why the existing anti-gaming floors do NOT price it
+
+The consensus demurrage term (`Ledger::consensus_fee_floor`,
+`botho/src/ledger/store.rs:1784`) is:
+
+```
+demurrage = demurrage_charge(
+    output_sum,
+    max(claimed_factor, ring_centroid_implied_factor),  // the factor floor (B2)
+    ring_elapsed_quantile@max,                            // the age clock (B1)
+    rate_bps(height),
+    blocks_per_year,
+)
+```
+
+and (`cluster-tax/src/demurrage.rs`):
+
+```
+charge = value × rate × (factor − 1)/(max_factor − 1) × elapsed / blocks_per_year
+```
+
+Two floors already defend this charge, and the leak slips **between** them:
+
+1. **The factor floor** (`ring_centroid_implied_factor`, item B2) stops a spender
+   from *claiming* a background factor while spending a wealthy coin: the ring
+   members carry public, inherited tags the spender cannot rewrite, so the factor
+   is floored at what the ring composition implies. This works — but it only
+   controls the **factor** term.
+
+2. **The age clock** (`ring_elapsed_quantile@max`, item B1) stops a spender from
+   diluting the **elapsed** term to zero with *fresh decoys* when the real input
+   is *old*. It surfaces a lone old real input as the ring maximum.
+
+Neither floor helps when **the real input is genuinely young**. The charge is
+*proportional to elapsed*. A freshly-created wealthy coin has `elapsed ≈ 0`, so
+even with the factor floored to its true wealthy value (5.745× in the test), the
+product is `≈ 0`. The factor floor multiplies a near-zero quantity and does
+nothing.
+
+## The exact leak sequence (with observed numbers)
+
+Numbers below are the assertions in the regression test, for a **1,000 BTH** coin
+tagged into a **10M BTH** cluster, at the default factor curve and 2%/yr rate.
+All values are in picocredits.
+
+| Step | Factor applied | `elapsed` | Demurrage charged |
+|------|---------------|-----------|-------------------|
+| Honest baseline: hold 1 yr, then spend as wealthy | 5745 (ring floor) | 1 year | **18,980,000,000,000** (≈18.98 BTH) |
+| Step 1: re-spend wealthy→wealthy to reset `created_at` | — | pays accrued only (≈0 if timed) | ≈0 |
+| Step 2 (**the leak**): spend young wealthy → background | 5745 (ring floor *still applies*) | ≈0 | **0** |
+| Future: spend the reset background coin, held 1 yr | 1000 (1×, background ring) | 1 year | **0** |
+| **Total paid to escape the wealthy class** | | | **0** |
+
+- **Step 1** is standard UTXO mechanics: a new output's `created_at` is the
+  current block height (`store.rs:1054/1088/1142`), so re-spending resets the
+  clock. The attacker times Step 2 to follow immediately, so the age they must
+  pay for is ≈0.
+- **Step 2** is legal deflation. `check_cluster_tag_inheritance`
+  (`store.rs:116`, `CONSENSUS_TAG_DECAY_RATE = 0`) rejects only *inflation*
+  (`actual > expected = input_mass`). Dropping cluster mass to background is
+  permitted by design.
+- **Future**: the reset coin genuinely carries background tags, so any future
+  ring composed of background members implies factor **1×** — the coin is now a
+  clean commerce coin and owes zero demurrage forever.
+
+Net: a whale that periodically (a) re-spends to reset age and (b) immediately
+spends young→background pays **0** to leave the demurrage regime, versus the
+**~1.9%/yr** an honest wealthy holder pays. The stock-level charge is fully
+escaped.
+
+## Resolution of the churn-invariance tension
+
+The issue framed this as: either (a) churn-invariance holds only *within* a
+wealth class and the class transition is the leak, or (b) something already
+prevents/prices the transition. The answer is **(a)**.
+
+Churn-invariance (`demurrage.rs` header) is invariance of *accrued* demurrage
+under re-spending at the **same factor**: `charge(T) = charge(T/2) + charge(T/2)`
+(`test_churn_invariance`). It says nothing about a **change of factor**. The
+demurrage charged at any spend is *accrued-to-date* (`∝ elapsed`), never
+*capitalized future*. So a coin can walk down from a wealthy class to background
+paying only the accrued cost of the tiny age it happens to carry at the moment of
+the walk — which the attacker drives to ≈0 by resetting age first. The header has
+been amended to record this scope limit next to the churn-invariance claim.
+
+## The symmetry with #831 / ADR 0003
+
+ADR 0003 established that the **only sanctioned way to shed cluster provenance is
+to pay for it**: the demurrage-settlement op reclassifies a wealthy coin to
+factor-1 and charges a settlement fee routed to the lottery pool, and #831
+resolves that fee to be **churn-invariant capitalized** demurrage (full
+prospective, not accrued-to-date). That op exists precisely because an *unpriced*
+downgrade would be "a straight redistribution leak, not a paid transition"
+(ADR 0003, Alternative 4).
+
+This issue shows the **same unpriced downgrade already exists purely on-chain**,
+via an ordinary spend, with no bridge involved. If it stays open, a wealthy
+holder never needs the settlement op at all — they can shed provenance for free
+on the base layer, and #831's paid on-ramp becomes decorative. The fix must
+mirror #831: **price the class transition on any deflating spend.**
+
+## Proposed fix (tracked as a mainnet blocker)
+
+**Candidate mechanism**: when a transfer's output cluster mass drops below the
+ring-implied input cluster mass (a demurrage *class downgrade*), charge the
+**capitalized future demurrage** for the mass being shed, in addition to the
+accrued-to-date charge — exactly the settlement-charge formula #831 uses, applied
+automatically to the deflation. This makes an ordinary spend-to-background
+economically identical to using the settlement op, so there is no cheaper path
+out of the regime. The charge is a pure function of public ring/output data and
+per-cluster wealth (the same inputs the existing floors already read), so it stays
+consensus-deterministic and liveness-safe (it only ever *raises* the fee floor,
+never false-rejects a valid spend).
+
+Design tensions to weigh in the fix issue (carried from the issue's scope list):
+capitalization horizon vs. churn-invariance, ring-signature privacy (the charge
+must not leak which member is real), and not over-charging honest background-to-
+background spends (the charge must key off an actual downgrade relative to the
+ring floor, which for a genuine background spend is already 1× → no charge).
+
+**Fix issue**: [#925](https://github.com/botho-project/botho/issues/925) —
+*price the demurrage class transition on deflating spends*, filed as the fix for
+this leak and marked mainnet-blocking (`priority:high` + `loom:urgent`).
+
+## Reproduction
+
+```
+cargo test -p bth-cluster-tax --lib demurrage_background_reset_leak_is_real
+```
+
+The test asserts every number in the table above and will begin failing the
+moment the class transition is priced — the intended signal that the leak is
+closed.


### PR DESCRIPTION
## VERDICT: the leak is REAL (issue #834)

A wealthy holder **can** reset a coin's demurrage class to background via an **ordinary spend**, paying **~0 demurrage** and escaping **all future** stock-level demurrage. This is option (a) from the issue: churn-invariance holds only *within* a wealth class, and the **class transition is the unpriced leak**.

### The mechanism

The consensus demurrage charge (`Ledger::consensus_fee_floor`, `botho/src/ledger/store.rs`) is:
```
demurrage_charge(output_sum, max(claimed_factor, ring_centroid_implied_factor), ring_elapsed_quantile@max, rate, bpy)
```
and `charge = value × rate × (factor−1)/(max−1) × elapsed / blocks_per_year`.

The charge is **proportional to `elapsed`**. Two floors defend it — `ring_centroid_implied_factor` (B2, floors the FACTOR) and `ring_elapsed_quantile@max` (B1, defends ELAPSED against fresh-decoy dilution of an OLD real input). The leak slips **between** them: when the real input is genuinely **young**, `elapsed ≈ 0`, so the factor floor multiplies a near-zero quantity and does nothing. Spending a young wealthy coin to a background output is **legal deflation** (`check_cluster_tag_inheritance` only rejects inflation), pays 0, and yields a genuinely-background coin whose future ring floor is 1×.

### Observed charges (from the regression test)

1000-BTH coin in a 10M-BTH cluster, 2%/yr, default curve, picocredits:

| Step | factor | elapsed | charge |
|------|--------|---------|--------|
| Honest: hold 1yr, spend as wealthy | 5745 (floor) | 1yr | **18,980,000,000,000** (~18.98 BTH) |
| Spend young wealthy → background (**the leak**) | 5745 (floored, useless) | ~0 | **0** |
| Future spend of reset background coin, 1yr | 1000 (1×) | 1yr | **0** |
| **Total paid to escape the wealthy class** | | | **0** |

### Symmetry with #831 / ADR 0003

This is the exact escape #831's settlement op **prices** for the wrapping on-ramp (capitalized future demurrage routed to the lottery pool). ADR 0003 established that the only sanctioned way to shed cluster provenance is to *pay* for it. Leaving the same downgrade **free** on the pure on-chain path would make #831 decorative — which is why this question is load-bearing.

## Deliverables

- **Executable evidence**: `cluster-tax/src/demurrage.rs::tests::demurrage_background_reset_leak_is_real` — permanent regression test that walks the exact sequence and asserts every number above. It will begin failing the moment the transition is priced (the intended close signal).
- **Verdict doc**: `docs/research/demurrage-background-reset-leak.md`.
- **Header updated**: the churn-invariance scope limit is now recorded next to the claim in `demurrage.rs`, referencing the fix.

## Fix issue (MAINNET BLOCKER)

**#925** — *price the demurrage class transition on deflating spends* (`loom:triage`, `priority:high`, `loom:urgent`). Proposed mechanism: charge capitalized future demurrage when output cluster mass drops below the ring-implied input floor, mirroring #831's settlement charge.

## Testing

`cargo test -p bth-cluster-tax` → 432 + 5 passed, 0 failed (incl. the new test).

Closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)