### PR TITLE
feat(consensus)!: bridge-import cluster tagging — epoch-keyed factor, F=1.5x floor (ADR 0007)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,6 +2046,7 @@ dependencies = [
  "bs58 0.4.0",
  "bth-account-keys",
  "bth-bridge-core",
+ "bth-cluster-tax",
  "bth-crypto-keys",
  "bth-crypto-ring-signature",
  "bth-transaction-clsag",

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -278,15 +278,16 @@ pub struct Ledger {
     cluster_wealth_db: Database<Bytes, Bytes>,
     /// bridge_import_clusters: cluster_id (8 bytes) -> [] (presence-only set)
     ///
-    /// PROTOCOL 4.2.0 (ADR 0007, #938): the set of cluster ids that are
+    /// PROTOCOL 5.0.0 (ADR 0007, #938): the set of cluster ids that are
     /// bridge-import clusters `c_import(m) = H("bridge-import" ‖ m)`. An id is
     /// recorded when a block whose height falls in epoch `m` creates an output
     /// tagged to `import_cluster_id(m)` — i.e. an unwrap's minted output (the
-    /// bridge tags it; see `bridge/service/src/bth_scan.rs`). Membership is what
-    /// makes the ≥F import floor enforceable at spend time: a coin whose tag
-    /// references a recorded import cluster is priced at `max(curve, F)` on that
-    /// tagged fraction, whether it is a fresh unwrap output or a forwarded
-    /// import tag on a later spend. Recording is a pure function of block height
+    /// bridge tags it; see `bridge/service/src/bth_scan.rs`). Membership is
+    /// what makes the ≥F import floor enforceable at spend time: a coin
+    /// whose tag references a recorded import cluster is priced at
+    /// `max(curve, F)` on that tagged fraction, whether it is a fresh
+    /// unwrap output or a forwarded import tag on a later spend. Recording
+    /// is a pure function of block height
     /// + output tag (the id must equal this-epoch's `import_cluster_id`), so
     /// every node builds the identical set — no fork, and the rebuild path
     /// reconstructs it byte-identically from the block store.
@@ -513,10 +514,7 @@ impl Ledger {
         let bridge_import_clusters_db = env
             .create_database(&mut wtxn, Some("bridge_import_clusters"))
             .map_err(|e| {
-                LedgerError::Database(format!(
-                    "Failed to create bridge_import_clusters db: {}",
-                    e
-                ))
+                LedgerError::Database(format!("Failed to create bridge_import_clusters db: {}", e))
             })?;
 
         wtxn.commit()
@@ -1993,19 +1991,17 @@ impl Ledger {
     ///
     /// This mirrors the calibration sim's value-weighted `effective_factor`
     /// blend (`simulation::bridge_import_sweep`): a coin that is 100% import-
-    /// tagged floors at exactly `F`; a coin whose import weight has blended down
-    /// through domestic spends floors proportionally lower, decaying to `1×` as
-    /// the import weight reaches zero (decay-by-circulation, ADR 0007 §4). A tx
-    /// with no import-tagged value returns `1×` (FACTOR_SCALE), a no-op against
-    /// the `max` at the call site. Membership is the recorded-import-cluster set
+    /// tagged floors at exactly `F`; a coin whose import weight has blended
+    /// down through domestic spends floors proportionally lower, decaying
+    /// to `1×` as the import weight reaches zero (decay-by-circulation, ADR
+    /// 0007 §4). A tx with no import-tagged value returns `1×`
+    /// (FACTOR_SCALE), a no-op against the `max` at the call site.
+    /// Membership is the recorded-import-cluster set
     /// (`is_bridge_import_cluster`), fail-closed on DB error.
     ///
     /// Pure integer u128 accumulation; no float. `TAG_WEIGHT_SCALE` weights and
     /// `FACTOR_SCALE` factors compose exactly.
-    fn import_floor_factor_from_outputs(
-        &self,
-        outputs: &[TxOutput],
-    ) -> Result<u64, LedgerError> {
+    fn import_floor_factor_from_outputs(&self, outputs: &[TxOutput]) -> Result<u64, LedgerError> {
         use bth_cluster_tax::{ClusterFactorCurve, BRIDGE_IMPORT_FACTOR_FLOOR};
 
         let background = ClusterFactorCurve::FACTOR_SCALE as u128; // 1× in FACTOR_SCALE
@@ -2035,7 +2031,8 @@ impl Ledger {
         let background_value = total_value - import_value;
 
         // Value-weighted blend of F (import fraction) and 1× (rest).
-        let blended = (floor.saturating_mul(import_value)
+        let blended = (floor
+            .saturating_mul(import_value)
             .saturating_add(background.saturating_mul(background_value)))
             / total_value;
         Ok(blended as u64)
@@ -2510,15 +2507,16 @@ impl Ledger {
     /// Record any bridge-import cluster tags carried by an output created at
     /// `height` (ADR 0007, #938).
     ///
-    /// An output tag is a genuine bridge-import origin iff its cluster id equals
-    /// `import_cluster_id(⌊height/K⌋)` — the deterministic epoch key for the
-    /// block that creates it. This is the ONLY way a cluster enters the
-    /// import set: the derivation is a pure function of the block height and the
-    /// tag, so every node records the identical set (no fork). A domestic mint
-    /// or ordinary transfer output can only be recorded here if its randomly-
-    /// derived tag id collides with this exact epoch's hash-derived import id
-    /// (cryptographically negligible), and even then the id *is* that epoch's
-    /// import cluster, so treating it as one is consistent.
+    /// An output tag is a genuine bridge-import origin iff its cluster id
+    /// equals `import_cluster_id(⌊height/K⌋)` — the deterministic epoch key
+    /// for the block that creates it. This is the ONLY way a cluster enters
+    /// the import set: the derivation is a pure function of the block
+    /// height and the tag, so every node records the identical set (no
+    /// fork). A domestic mint or ordinary transfer output can only be
+    /// recorded here if its randomly- derived tag id collides with this
+    /// exact epoch's hash-derived import id (cryptographically negligible),
+    /// and even then the id *is* that epoch's import cluster, so treating
+    /// it as one is consistent.
     fn record_bridge_import_clusters_for_output(
         &self,
         wtxn: &mut RwTxn,
@@ -2809,9 +2807,11 @@ impl Ledger {
         self.cluster_wealth_db
             .clear(&mut wtxn)
             .map_err(|e| LedgerError::Database(format!("Failed to clear cluster wealth: {}", e)))?;
-        self.bridge_import_clusters_db.clear(&mut wtxn).map_err(|e| {
-            LedgerError::Database(format!("Failed to clear bridge-import clusters: {}", e))
-        })?;
+        self.bridge_import_clusters_db
+            .clear(&mut wtxn)
+            .map_err(|e| {
+                LedgerError::Database(format!("Failed to clear bridge-import clusters: {}", e))
+            })?;
 
         // Write new values
         for (cluster_id, wealth) in &cluster_wealths {
@@ -5326,9 +5326,9 @@ mod tests {
     // enforcement point. K = 17,280 blocks, F = 1.5x (1500 FACTOR_SCALE).
     // ========================================================================
 
-    /// A small import (below the curve knee) lands at exactly the >=F floor, and
-    /// a flood import lands at the epoch-summed factor (well above F). This is
-    /// the core ADR 0007 pricing at the consensus layer.
+    /// A small import (below the curve knee) lands at exactly the >=F floor,
+    /// and a flood import lands at the epoch-summed factor (well above F).
+    /// This is the core ADR 0007 pricing at the consensus layer.
     #[test]
     fn import_floor_small_lands_at_f_flood_lands_at_curve() {
         use bth_cluster_tax::{
@@ -5343,7 +5343,9 @@ mod tests {
         // An unwrap output created at some height carries this-epoch's import id.
         let height = 3 * bth_cluster_tax::BRIDGE_IMPORT_EPOCH_BLOCKS + 42;
         let import_id = import_cluster_id_for_height(height).0;
-        ledger.record_bridge_import_cluster_for_test(import_id).unwrap();
+        ledger
+            .record_bridge_import_cluster_for_test(import_id)
+            .unwrap();
 
         // SMALL import: a 1,000-BTH epoch. curve(small) < F, so the import floor
         // binds at exactly F = 1.5x. import_floor_factor_from_outputs blends F on
@@ -5353,7 +5355,9 @@ mod tests {
             80,
             ClusterTagVector::from_pairs(&[(ClusterId(import_id), TAG_WEIGHT_SCALE)]),
         )];
-        ledger.set_cluster_wealth_for_test(import_id, 1_000 * PICO_PER_BTH).unwrap();
+        ledger
+            .set_cluster_wealth_for_test(import_id, 1_000 * PICO_PER_BTH)
+            .unwrap();
         let small_floor = ledger.import_floor_factor_from_outputs(&small_out).unwrap();
         assert_eq!(
             small_floor, BRIDGE_IMPORT_FACTOR_FLOOR,
@@ -5378,8 +5382,9 @@ mod tests {
     }
 
     /// Two unwraps in the SAME epoch share one accumulating cluster (the
-    /// Sybil-resistance load-bearing fact). Distinct heights inside `[mK,(m+1)K)`
-    /// resolve to the same import cluster id, so their wealth pools together.
+    /// Sybil-resistance load-bearing fact). Distinct heights inside
+    /// `[mK,(m+1)K)` resolve to the same import cluster id, so their wealth
+    /// pools together.
     #[test]
     fn import_two_unwraps_same_epoch_share_cluster() {
         use bth_cluster_tax::{import_cluster_id_for_height, BRIDGE_IMPORT_EPOCH_BLOCKS};
@@ -5397,7 +5402,9 @@ mod tests {
         let dir = tempdir().unwrap();
         let ledger = Ledger::open(dir.path()).unwrap();
         let shared = import_cluster_id_for_height(h1).0;
-        ledger.record_bridge_import_cluster_for_test(shared).unwrap();
+        ledger
+            .record_bridge_import_cluster_for_test(shared)
+            .unwrap();
         assert!(ledger.is_bridge_import_cluster(shared).unwrap());
     }
 
@@ -5427,8 +5434,11 @@ mod tests {
 
         let dir = tempdir().unwrap();
         let ledger = Ledger::open(dir.path()).unwrap();
-        let import_id = import_cluster_id_for_height(7 * bth_cluster_tax::BRIDGE_IMPORT_EPOCH_BLOCKS).0;
-        ledger.record_bridge_import_cluster_for_test(import_id).unwrap();
+        let import_id =
+            import_cluster_id_for_height(7 * bth_cluster_tax::BRIDGE_IMPORT_EPOCH_BLOCKS).0;
+        ledger
+            .record_bridge_import_cluster_for_test(import_id)
+            .unwrap();
 
         // 100% import-tagged => floor is exactly F.
         let full = vec![mk_tagged_output(
@@ -5464,8 +5474,9 @@ mod tests {
         );
     }
 
-    /// A pure-external hold — an import-tagged coin that never blends in domestic
-    /// value — stays at >=F. Its tag never shifts, so the floor never falls.
+    /// A pure-external hold — an import-tagged coin that never blends in
+    /// domestic value — stays at >=F. Its tag never shifts, so the floor
+    /// never falls.
     #[test]
     fn import_pure_external_hold_stays_at_f() {
         use bth_cluster_tax::import_cluster_id_for_height;
@@ -5473,8 +5484,11 @@ mod tests {
 
         let dir = tempdir().unwrap();
         let ledger = Ledger::open(dir.path()).unwrap();
-        let import_id = import_cluster_id_for_height(9 * bth_cluster_tax::BRIDGE_IMPORT_EPOCH_BLOCKS).0;
-        ledger.record_bridge_import_cluster_for_test(import_id).unwrap();
+        let import_id =
+            import_cluster_id_for_height(9 * bth_cluster_tax::BRIDGE_IMPORT_EPOCH_BLOCKS).0;
+        ledger
+            .record_bridge_import_cluster_for_test(import_id)
+            .unwrap();
 
         // A never-mixing coin keeps its 100% import tag through any number of
         // self-spends; the floor helper still returns exactly F for it.
@@ -5492,8 +5506,8 @@ mod tests {
     /// The >=F import floor and the ring-centroid floor compose without a
     /// double-floor: the consensus fee floor uses `max(claimed, ring_centroid,
     /// import_floor)`, so a wealthy-ring demurrage factor already above F is
-    /// UNCHANGED by the import floor, and a background claim with an import tag is
-    /// raised to F (not stacked on top of the ring floor).
+    /// UNCHANGED by the import floor, and a background claim with an import tag
+    /// is raised to F (not stacked on top of the ring floor).
     #[test]
     fn import_floor_composes_with_ring_centroid_no_double_floor() {
         use bth_cluster_tax::{import_cluster_id_for_height, PICO_PER_BTH};
@@ -5505,7 +5519,9 @@ mod tests {
         // Demurrage active (past halving) so factors actually price.
         let block_height = 8_000_000u64;
         let import_id = import_cluster_id_for_height(block_height).0;
-        ledger.record_bridge_import_cluster_for_test(import_id).unwrap();
+        ledger
+            .record_bridge_import_cluster_for_test(import_id)
+            .unwrap();
 
         // CASE A: background ring + a 100% import-tagged output, small import
         // wealth. The ring implies ~1x (no wealthy cluster), the claimed factor
@@ -5519,9 +5535,13 @@ mod tests {
         )];
         // Keep the import cluster's global wealth tiny so curve(wealth) < F and
         // the floor is what binds (not the curve).
-        ledger.set_cluster_wealth_for_test(import_id, 1_000 * PICO_PER_BTH).unwrap();
+        ledger
+            .set_cluster_wealth_for_test(import_id, 1_000 * PICO_PER_BTH)
+            .unwrap();
         let tx_import = mk_transfer_tx(ring_bg.clone(), import_out, 0);
-        let floor_import = ledger.consensus_fee_floor(&tx_import, block_height).unwrap();
+        let floor_import = ledger
+            .consensus_fee_floor(&tx_import, block_height)
+            .unwrap();
 
         // Same-shape tx whose output is a non-import cluster of equal tiny wealth
         // (so its claimed factor is also ~1x) — no import floor applies.
@@ -5562,21 +5582,27 @@ mod tests {
             ClusterTagVector::from_pairs(&[(ClusterId(import_id), TAG_WEIGHT_SCALE)]),
         )];
         let tx_rich_import = mk_transfer_tx(rich_ring.clone(), out_rich, 0);
-        let floor_rich_import = ledger.consensus_fee_floor(&tx_rich_import, block_height).unwrap();
+        let floor_rich_import = ledger
+            .consensus_fee_floor(&tx_rich_import, block_height)
+            .unwrap();
 
         // Same wealthy ring, same output but tagged to a DISTINCT non-import
         // cluster of equally-tiny wealth: the ring-centroid floor is identical,
         // and since the import floor (1.5x) is below that ring floor, the two
         // fee floors MUST be equal — proving no double-floor stacking.
         let plain2 = 555555u64;
-        ledger.set_cluster_wealth_for_test(plain2, 1_000 * PICO_PER_BTH).unwrap();
+        ledger
+            .set_cluster_wealth_for_test(plain2, 1_000 * PICO_PER_BTH)
+            .unwrap();
         let out_rich_plain = vec![mk_tagged_output(
             90_000_000,
             96,
             ClusterTagVector::from_pairs(&[(ClusterId(plain2), TAG_WEIGHT_SCALE)]),
         )];
         let tx_rich_plain = mk_transfer_tx(rich_ring, out_rich_plain, 0);
-        let floor_rich_plain = ledger.consensus_fee_floor(&tx_rich_plain, block_height).unwrap();
+        let floor_rich_plain = ledger
+            .consensus_fee_floor(&tx_rich_plain, block_height)
+            .unwrap();
         assert_eq!(
             floor_rich_import, floor_rich_plain,
             "when the ring-centroid floor already exceeds F, the import floor must be \

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -276,6 +276,21 @@ pub struct Ledger {
     /// supply range. See [`decode_cluster_wealth`] for the reject-legacy read
     /// contract.
     cluster_wealth_db: Database<Bytes, Bytes>,
+    /// bridge_import_clusters: cluster_id (8 bytes) -> [] (presence-only set)
+    ///
+    /// PROTOCOL 4.2.0 (ADR 0007, #938): the set of cluster ids that are
+    /// bridge-import clusters `c_import(m) = H("bridge-import" ‖ m)`. An id is
+    /// recorded when a block whose height falls in epoch `m` creates an output
+    /// tagged to `import_cluster_id(m)` — i.e. an unwrap's minted output (the
+    /// bridge tags it; see `bridge/service/src/bth_scan.rs`). Membership is what
+    /// makes the ≥F import floor enforceable at spend time: a coin whose tag
+    /// references a recorded import cluster is priced at `max(curve, F)` on that
+    /// tagged fraction, whether it is a fresh unwrap output or a forwarded
+    /// import tag on a later spend. Recording is a pure function of block height
+    /// + output tag (the id must equal this-epoch's `import_cluster_id`), so
+    /// every node builds the identical set — no fork, and the rebuild path
+    /// reconstructs it byte-identically from the block store.
+    bridge_import_clusters_db: Database<Bytes, Bytes>,
 }
 
 /// Serialized width of a `cluster_wealth_db` value: 16-byte little-endian
@@ -399,6 +414,30 @@ impl Ledger {
         Ok(())
     }
 
+    /// Test-only: record a cluster id in the bridge-import set directly (ADR
+    /// 0007, #938), bypassing the block-apply recording path. Used by the
+    /// consensus import-floor tests to seed an import cluster without minting a
+    /// full block at the matching epoch height.
+    #[cfg(test)]
+    pub fn record_bridge_import_cluster_for_test(
+        &self,
+        cluster_id: u64,
+    ) -> Result<(), LedgerError> {
+        let mut wtxn = self
+            .env
+            .write_txn()
+            .map_err(|e| LedgerError::Database(format!("Failed to start write txn: {}", e)))?;
+        self.bridge_import_clusters_db
+            .put(&mut wtxn, cluster_id.to_le_bytes().as_slice(), &[])
+            .map_err(|e| {
+                LedgerError::Database(format!("Failed to record bridge-import cluster: {}", e))
+            })?;
+        wtxn.commit().map_err(|e| {
+            LedgerError::Database(format!("Failed to commit bridge-import cluster: {}", e))
+        })?;
+        Ok(())
+    }
+
     /// Open or create a ledger at the given path for a specific network.
     ///
     /// The ledger will be initialized with the appropriate genesis block
@@ -432,7 +471,7 @@ impl Ledger {
         // its lifetime.
         let env = unsafe {
             let mut opts = EnvOpenOptions::new();
-            opts.max_dbs(7) // Increased for cluster_wealth_db
+            opts.max_dbs(8) // +bridge_import_clusters_db (ADR 0007, #938)
                 .map_size(1024 * 1024 * 1024); // 1GB
             if let Some(readers) = max_readers {
                 opts.max_readers(readers);
@@ -471,6 +510,14 @@ impl Ledger {
             .map_err(|e| {
                 LedgerError::Database(format!("Failed to create cluster_wealth db: {}", e))
             })?;
+        let bridge_import_clusters_db = env
+            .create_database(&mut wtxn, Some("bridge_import_clusters"))
+            .map_err(|e| {
+                LedgerError::Database(format!(
+                    "Failed to create bridge_import_clusters db: {}",
+                    e
+                ))
+            })?;
 
         wtxn.commit()
             .map_err(|e| LedgerError::Database(format!("Failed to commit: {}", e)))?;
@@ -485,6 +532,7 @@ impl Ledger {
             key_images_db,
             tx_index_db,
             cluster_wealth_db,
+            bridge_import_clusters_db,
         };
 
         // Initialize with genesis if empty
@@ -1096,6 +1144,10 @@ impl Ledger {
                 self.add_to_address_index(&mut wtxn, &utxo)?;
                 // Update cluster wealth tracking
                 self.update_cluster_wealth_for_output(&mut wtxn, output)?;
+                // ADR 0007 (#938): if this output carries this-epoch's
+                // bridge-import tag (an unwrap's minted output), record the
+                // import cluster so the ≥F floor is enforceable at spend time.
+                self.record_bridge_import_clusters_for_output(&mut wtxn, output, new_height)?;
             }
         }
 
@@ -1857,6 +1909,17 @@ impl Ledger {
             &fee_config.cluster_curve,
         )?;
 
+        // ADR 0007 (#938): the bridge-import floor. Imported wealth (tagged to a
+        // bridge-import cluster) is priced at ≥ F on its import-tagged fraction,
+        // so an unwrapped coin cannot be spent at background factor-1 until it
+        // circulates the tag off. This is a SEPARATE lower bound from the
+        // ring-centroid floor above: both are `max` against the demurrage
+        // factor, so composing them is a single dominating `max` — no
+        // double-floor. It only ever RAISES the factor, and only for value that
+        // actually traces to a recorded import cluster.
+        let import_floor = self.import_floor_factor_from_outputs(&tx.outputs)?;
+        let demurrage_factor = demurrage_factor.max(import_floor);
+
         let demurrage = bth_cluster_tax::demurrage_charge(
             output_sum,
             demurrage_factor,
@@ -1912,6 +1975,70 @@ impl Ledger {
         }
 
         Ok(total_weighted_wealth / total_value)
+    }
+
+    /// The bridge-import factor floor implied by a transaction's OUTPUT tags
+    /// (ADR 0007, #938).
+    ///
+    /// Returns a value-weighted blend, in FACTOR_SCALE units, of the
+    /// bridge-import floor `F` on the value tagged to recorded import clusters
+    /// and background `1×` on the rest:
+    ///
+    /// ```text
+    /// import_floor = Σ_outputs Σ_import-tags (value·weight/SCALE)·F
+    ///              + (Σ_outputs value − import-tagged value)·1×
+    ///              ────────────────────────────────────────────────
+    ///                              Σ_outputs value
+    /// ```
+    ///
+    /// This mirrors the calibration sim's value-weighted `effective_factor`
+    /// blend (`simulation::bridge_import_sweep`): a coin that is 100% import-
+    /// tagged floors at exactly `F`; a coin whose import weight has blended down
+    /// through domestic spends floors proportionally lower, decaying to `1×` as
+    /// the import weight reaches zero (decay-by-circulation, ADR 0007 §4). A tx
+    /// with no import-tagged value returns `1×` (FACTOR_SCALE), a no-op against
+    /// the `max` at the call site. Membership is the recorded-import-cluster set
+    /// (`is_bridge_import_cluster`), fail-closed on DB error.
+    ///
+    /// Pure integer u128 accumulation; no float. `TAG_WEIGHT_SCALE` weights and
+    /// `FACTOR_SCALE` factors compose exactly.
+    fn import_floor_factor_from_outputs(
+        &self,
+        outputs: &[TxOutput],
+    ) -> Result<u64, LedgerError> {
+        use bth_cluster_tax::{ClusterFactorCurve, BRIDGE_IMPORT_FACTOR_FLOOR};
+
+        let background = ClusterFactorCurve::FACTOR_SCALE as u128; // 1× in FACTOR_SCALE
+        let floor = BRIDGE_IMPORT_FACTOR_FLOOR as u128; // F in FACTOR_SCALE
+
+        let mut total_value: u128 = 0;
+        let mut import_value: u128 = 0;
+
+        for output in outputs {
+            let amount = output.amount as u128;
+            total_value = total_value.saturating_add(amount);
+            for entry in &output.cluster_tags.entries {
+                if self.is_bridge_import_cluster(entry.cluster_id.0)? {
+                    let tagged =
+                        amount.saturating_mul(entry.weight as u128) / (TAG_WEIGHT_SCALE as u128);
+                    import_value = import_value.saturating_add(tagged);
+                }
+            }
+        }
+
+        if total_value == 0 {
+            return Ok(ClusterFactorCurve::FACTOR_SCALE);
+        }
+        // Clamp defensively: a malformed tag set could push import_value past
+        // total_value; the blend must never exceed F.
+        let import_value = import_value.min(total_value);
+        let background_value = total_value - import_value;
+
+        // Value-weighted blend of F (import fraction) and 1× (rest).
+        let blended = (floor.saturating_mul(import_value)
+            .saturating_add(background.saturating_mul(background_value)))
+            / total_value;
+        Ok(blended as u64)
     }
 
     // ========================================================================
@@ -2380,6 +2507,62 @@ impl Ledger {
         Ok(())
     }
 
+    /// Record any bridge-import cluster tags carried by an output created at
+    /// `height` (ADR 0007, #938).
+    ///
+    /// An output tag is a genuine bridge-import origin iff its cluster id equals
+    /// `import_cluster_id(⌊height/K⌋)` — the deterministic epoch key for the
+    /// block that creates it. This is the ONLY way a cluster enters the
+    /// import set: the derivation is a pure function of the block height and the
+    /// tag, so every node records the identical set (no fork). A domestic mint
+    /// or ordinary transfer output can only be recorded here if its randomly-
+    /// derived tag id collides with this exact epoch's hash-derived import id
+    /// (cryptographically negligible), and even then the id *is* that epoch's
+    /// import cluster, so treating it as one is consistent.
+    fn record_bridge_import_clusters_for_output(
+        &self,
+        wtxn: &mut RwTxn,
+        output: &TxOutput,
+        height: u64,
+    ) -> Result<(), LedgerError> {
+        let epoch_import_id = bth_cluster_tax::import_cluster_id_for_height(height).0;
+        for entry in &output.cluster_tags.entries {
+            if entry.cluster_id.0 == epoch_import_id {
+                let key = epoch_import_id.to_le_bytes();
+                self.bridge_import_clusters_db
+                    .put(wtxn, key.as_slice(), &[])
+                    .map_err(|e| {
+                        LedgerError::Database(format!(
+                            "Failed to record bridge-import cluster: {}",
+                            e
+                        ))
+                    })?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether `cluster_id` is a recorded bridge-import cluster (ADR 0007).
+    ///
+    /// Presence-only lookup; fail-closed on DB error (propagates rather than
+    /// defaulting to `false`, which would silently drop the ≥F import floor —
+    /// the M7 fail-closed discipline).
+    pub fn is_bridge_import_cluster(&self, cluster_id: u64) -> Result<bool, LedgerError> {
+        let rtxn = self
+            .env
+            .read_txn()
+            .map_err(|e| LedgerError::Database(format!("Failed to start read txn: {}", e)))?;
+        let key = cluster_id.to_le_bytes();
+        match self.bridge_import_clusters_db.get(&rtxn, key.as_slice()) {
+            Ok(Some(_)) => Ok(true),
+            Ok(None) => Ok(false),
+            Err(e) => Err(LedgerError::Database(format!(
+                "Failed to read bridge-import cluster: {}",
+                e
+            ))),
+        }
+    }
+
     /// Get the total wealth attributed to a specific cluster.
     ///
     /// Returns the sum of (amount × weight / TAG_WEIGHT_SCALE) for all UTXOs
@@ -2575,8 +2758,14 @@ impl Ledger {
             .read_txn()
             .map_err(|e| LedgerError::Database(format!("Failed to start read txn: {}", e)))?;
 
-        // First pass: compute wealth from all UTXOs
+        // First pass: compute wealth from all UTXOs, and reconstruct the
+        // bridge-import cluster set (ADR 0007, #938) from each UTXO's
+        // `created_at` height — an output tag is an import origin iff its id
+        // equals `import_cluster_id(⌊created_at/K⌋)`, exactly the incremental
+        // `record_bridge_import_clusters_for_output` rule, so the rebuilt set is
+        // byte-identical.
         let mut cluster_wealths: HashMap<u64, u128> = HashMap::new();
+        let mut import_clusters: std::collections::HashSet<u64> = std::collections::HashSet::new();
         let iter = self
             .utxo_db
             .iter(&rtxn)
@@ -2585,6 +2774,8 @@ impl Ledger {
         for item in iter {
             if let Ok((_, value)) = item {
                 if let Ok(utxo) = bincode::deserialize::<Utxo>(value) {
+                    let epoch_import_id =
+                        bth_cluster_tax::import_cluster_id_for_height(utxo.created_at).0;
                     for entry in &utxo.output.cluster_tags.entries {
                         // Full u128 contribution (no down-cast), matching the
                         // incremental path exactly at the new width.
@@ -2598,6 +2789,10 @@ impl Ledger {
                         // demurrage inputs read `cluster_wealth_db`. See #604.
                         let e = cluster_wealths.entry(entry.cluster_id.0).or_insert(0u128);
                         *e = e.saturating_add(contribution);
+
+                        if entry.cluster_id.0 == epoch_import_id {
+                            import_clusters.insert(epoch_import_id);
+                        }
                     }
                 }
             }
@@ -2614,6 +2809,9 @@ impl Ledger {
         self.cluster_wealth_db
             .clear(&mut wtxn)
             .map_err(|e| LedgerError::Database(format!("Failed to clear cluster wealth: {}", e)))?;
+        self.bridge_import_clusters_db.clear(&mut wtxn).map_err(|e| {
+            LedgerError::Database(format!("Failed to clear bridge-import clusters: {}", e))
+        })?;
 
         // Write new values
         for (cluster_id, wealth) in &cluster_wealths {
@@ -2621,6 +2819,13 @@ impl Ledger {
                 .put(&mut wtxn, &cluster_id.to_le_bytes(), &wealth.to_le_bytes())
                 .map_err(|e| {
                     LedgerError::Database(format!("Failed to write cluster wealth: {}", e))
+                })?;
+        }
+        for cluster_id in &import_clusters {
+            self.bridge_import_clusters_db
+                .put(&mut wtxn, &cluster_id.to_le_bytes(), &[])
+                .map_err(|e| {
+                    LedgerError::Database(format!("Failed to write bridge-import cluster: {}", e))
                 })?;
         }
 
@@ -5110,6 +5315,273 @@ mod tests {
         assert!(
             rich > poor,
             "raising the cluster's global wealth must raise the floor (poor={poor}, rich={rich})"
+        );
+    }
+
+    // ========================================================================
+    // ADR 0007 bridge-import cluster tagging + >=F import floor (#938)
+    //
+    // Consensus-layer assertions mirroring the #940 calibration sim
+    // (cluster-tax/src/simulation/bridge_import_sweep.rs) at the fee-floor
+    // enforcement point. K = 17,280 blocks, F = 1.5x (1500 FACTOR_SCALE).
+    // ========================================================================
+
+    /// A small import (below the curve knee) lands at exactly the >=F floor, and
+    /// a flood import lands at the epoch-summed factor (well above F). This is
+    /// the core ADR 0007 pricing at the consensus layer.
+    #[test]
+    fn import_floor_small_lands_at_f_flood_lands_at_curve() {
+        use bth_cluster_tax::{
+            import_cluster_id_for_height, ClusterFactorCurve, BRIDGE_IMPORT_FACTOR_FLOOR,
+            PICO_PER_BTH,
+        };
+        use bth_transaction_types::ClusterId;
+
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        // An unwrap output created at some height carries this-epoch's import id.
+        let height = 3 * bth_cluster_tax::BRIDGE_IMPORT_EPOCH_BLOCKS + 42;
+        let import_id = import_cluster_id_for_height(height).0;
+        ledger.record_bridge_import_cluster_for_test(import_id).unwrap();
+
+        // SMALL import: a 1,000-BTH epoch. curve(small) < F, so the import floor
+        // binds at exactly F = 1.5x. import_floor_factor_from_outputs blends F on
+        // the (100%) import-tagged output => exactly F.
+        let small_out = vec![mk_tagged_output(
+            90_000_000,
+            80,
+            ClusterTagVector::from_pairs(&[(ClusterId(import_id), TAG_WEIGHT_SCALE)]),
+        )];
+        ledger.set_cluster_wealth_for_test(import_id, 1_000 * PICO_PER_BTH).unwrap();
+        let small_floor = ledger.import_floor_factor_from_outputs(&small_out).unwrap();
+        assert_eq!(
+            small_floor, BRIDGE_IMPORT_FACTOR_FLOOR,
+            "a small import must land at exactly F=1.5x (got {small_floor})"
+        );
+
+        // FLOOD import: a 10,000,000-BTH epoch saturates the curve. The import
+        // *cluster factor* (curve then floor) is well above F. The floor does
+        // not lower a curve factor that already exceeds it.
+        let curve = ClusterFactorCurve::default_params();
+        let flood_wealth = 10_000_000u128 * PICO_PER_BTH;
+        let flood_factor = bth_cluster_tax::import_cluster_factor(flood_wealth, &curve);
+        assert!(
+            flood_factor > 5_000,
+            "a flood import must price near 6x, got {flood_factor}"
+        );
+        assert_eq!(
+            flood_factor,
+            curve.factor(flood_wealth),
+            "the >=F floor must NOT alter a flood factor already above F (no double-floor)"
+        );
+    }
+
+    /// Two unwraps in the SAME epoch share one accumulating cluster (the
+    /// Sybil-resistance load-bearing fact). Distinct heights inside `[mK,(m+1)K)`
+    /// resolve to the same import cluster id, so their wealth pools together.
+    #[test]
+    fn import_two_unwraps_same_epoch_share_cluster() {
+        use bth_cluster_tax::{import_cluster_id_for_height, BRIDGE_IMPORT_EPOCH_BLOCKS};
+
+        let m = 5u64;
+        let h1 = m * BRIDGE_IMPORT_EPOCH_BLOCKS + 1;
+        let h2 = m * BRIDGE_IMPORT_EPOCH_BLOCKS + (BRIDGE_IMPORT_EPOCH_BLOCKS - 1);
+        assert_eq!(
+            import_cluster_id_for_height(h1),
+            import_cluster_id_for_height(h2),
+            "two unwraps in the same epoch must share one import cluster"
+        );
+
+        // And that shared cluster, once recorded, floors an output tagged to it.
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        let shared = import_cluster_id_for_height(h1).0;
+        ledger.record_bridge_import_cluster_for_test(shared).unwrap();
+        assert!(ledger.is_bridge_import_cluster(shared).unwrap());
+    }
+
+    /// Unwraps in DIFFERENT epochs form distinct clusters (diluting requires
+    /// spreading across epochs — the time-as-cost that defeats the drip-split).
+    #[test]
+    fn import_different_epochs_distinct_clusters() {
+        use bth_cluster_tax::{import_cluster_id_for_height, BRIDGE_IMPORT_EPOCH_BLOCKS};
+        let h1 = 5 * BRIDGE_IMPORT_EPOCH_BLOCKS + 1;
+        let h2 = 6 * BRIDGE_IMPORT_EPOCH_BLOCKS + 1;
+        assert_ne!(
+            import_cluster_id_for_height(h1),
+            import_cluster_id_for_height(h2),
+            "unwraps in different epochs must form distinct clusters"
+        );
+    }
+
+    /// Decay-on-spend: as an imported coin blends its import tag down toward
+    /// background (the existing value-weighted mix), the import floor it faces
+    /// falls proportionally, reaching 1x (background) as the import weight hits
+    /// zero. Proven here via the consensus floor helper on partially-blended
+    /// output tags — no new decay machinery.
+    #[test]
+    fn import_floor_decays_with_tag_blend_toward_background() {
+        use bth_cluster_tax::import_cluster_id_for_height;
+        use bth_transaction_types::{ClusterId, ClusterTagEntry};
+
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        let import_id = import_cluster_id_for_height(7 * bth_cluster_tax::BRIDGE_IMPORT_EPOCH_BLOCKS).0;
+        ledger.record_bridge_import_cluster_for_test(import_id).unwrap();
+
+        // 100% import-tagged => floor is exactly F.
+        let full = vec![mk_tagged_output(
+            100_000_000,
+            81,
+            ClusterTagVector::from_pairs(&[(ClusterId(import_id), TAG_WEIGHT_SCALE)]),
+        )];
+        let full_floor = ledger.import_floor_factor_from_outputs(&full).unwrap();
+        assert_eq!(full_floor, 1_500, "100% import weight floors at F=1.5x");
+
+        // 50% import weight (blended with background) => floor blends halfway
+        // between F (1500) and background (1000) = 1250.
+        let mut half_tags = ClusterTagVector::empty();
+        half_tags.entries.push(ClusterTagEntry {
+            cluster_id: ClusterId(import_id),
+            weight: TAG_WEIGHT_SCALE / 2,
+        });
+        let half = vec![mk_tagged_output(100_000_000, 82, half_tags)];
+        let half_floor = ledger.import_floor_factor_from_outputs(&half).unwrap();
+        assert_eq!(
+            half_floor, 1_250,
+            "50% import weight must blend the floor halfway to background (got {half_floor})"
+        );
+
+        // 0% import weight (fully blended to background) => floor is 1x: the
+        // imported coin is now as cheap as domestically-circulated money.
+        let bg = vec![mk_tagged_output(100_000_000, 83, ClusterTagVector::empty())];
+        let bg_floor = ledger.import_floor_factor_from_outputs(&bg).unwrap();
+        assert_eq!(
+            bg_floor,
+            bth_cluster_tax::ClusterFactorCurve::FACTOR_SCALE,
+            "a fully-circulated coin faces no import floor (1x)"
+        );
+    }
+
+    /// A pure-external hold — an import-tagged coin that never blends in domestic
+    /// value — stays at >=F. Its tag never shifts, so the floor never falls.
+    #[test]
+    fn import_pure_external_hold_stays_at_f() {
+        use bth_cluster_tax::import_cluster_id_for_height;
+        use bth_transaction_types::ClusterId;
+
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        let import_id = import_cluster_id_for_height(9 * bth_cluster_tax::BRIDGE_IMPORT_EPOCH_BLOCKS).0;
+        ledger.record_bridge_import_cluster_for_test(import_id).unwrap();
+
+        // A never-mixing coin keeps its 100% import tag through any number of
+        // self-spends; the floor helper still returns exactly F for it.
+        let held = vec![mk_tagged_output(
+            50_000_000,
+            84,
+            ClusterTagVector::from_pairs(&[(ClusterId(import_id), TAG_WEIGHT_SCALE)]),
+        )];
+        for _ in 0..5 {
+            let f = ledger.import_floor_factor_from_outputs(&held).unwrap();
+            assert_eq!(f, 1_500, "a pure-external hold must stay at >=F=1.5x");
+        }
+    }
+
+    /// The >=F import floor and the ring-centroid floor compose without a
+    /// double-floor: the consensus fee floor uses `max(claimed, ring_centroid,
+    /// import_floor)`, so a wealthy-ring demurrage factor already above F is
+    /// UNCHANGED by the import floor, and a background claim with an import tag is
+    /// raised to F (not stacked on top of the ring floor).
+    #[test]
+    fn import_floor_composes_with_ring_centroid_no_double_floor() {
+        use bth_cluster_tax::{import_cluster_id_for_height, PICO_PER_BTH};
+        use bth_transaction_types::ClusterId;
+
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+
+        // Demurrage active (past halving) so factors actually price.
+        let block_height = 8_000_000u64;
+        let import_id = import_cluster_id_for_height(block_height).0;
+        ledger.record_bridge_import_cluster_for_test(import_id).unwrap();
+
+        // CASE A: background ring + a 100% import-tagged output, small import
+        // wealth. The ring implies ~1x (no wealthy cluster), the claimed factor
+        // is ~1x, but the import floor raises the demurrage factor to F. The
+        // floor must therefore EXCEED the identical tx with a non-import tag.
+        let ring_bg = seed_ring_utxos(&ledger, &[(100_000_000, 0, 0, 90)]);
+        let import_out = vec![mk_tagged_output(
+            90_000_000,
+            91,
+            ClusterTagVector::from_pairs(&[(ClusterId(import_id), TAG_WEIGHT_SCALE)]),
+        )];
+        // Keep the import cluster's global wealth tiny so curve(wealth) < F and
+        // the floor is what binds (not the curve).
+        ledger.set_cluster_wealth_for_test(import_id, 1_000 * PICO_PER_BTH).unwrap();
+        let tx_import = mk_transfer_tx(ring_bg.clone(), import_out, 0);
+        let floor_import = ledger.consensus_fee_floor(&tx_import, block_height).unwrap();
+
+        // Same-shape tx whose output is a non-import cluster of equal tiny wealth
+        // (so its claimed factor is also ~1x) — no import floor applies.
+        let plain_cluster = 424242u64;
+        ledger
+            .set_cluster_wealth_for_test(plain_cluster, 1_000 * PICO_PER_BTH)
+            .unwrap();
+        let plain_out = vec![mk_tagged_output(
+            90_000_000,
+            92,
+            ClusterTagVector::from_pairs(&[(ClusterId(plain_cluster), TAG_WEIGHT_SCALE)]),
+        )];
+        let tx_plain = mk_transfer_tx(ring_bg, plain_out, 0);
+        let floor_plain = ledger.consensus_fee_floor(&tx_plain, block_height).unwrap();
+        assert!(
+            floor_import > floor_plain,
+            "the import floor must raise a background-priced import above an \
+             equivalent non-import tx (import={floor_import}, plain={floor_plain})"
+        );
+
+        // CASE B: a WEALTHY ring already drives the demurrage factor above F.
+        // Adding the import tag must NOT stack another floor on top — the
+        // effective factor is the single dominating max, so the floor equals a
+        // recomputation where import_floor <= ring_centroid and is absorbed.
+        ledger
+            .set_cluster_wealth_for_test(5, 10_000_000_000_000_000_000)
+            .unwrap();
+        let rich_ring =
+            seed_ring_utxos(&ledger, &[(100_000_000, 0, 5, 93), (100_000_000, 0, 5, 94)]);
+        // Output tagged to the (low-wealth) import cluster: its own claimed
+        // factor is ~1x but the rich ring floors far above F. The import floor
+        // (F=1.5x) is BELOW the ring-centroid floor here, so it must be absorbed
+        // by the max — the presence of the import tag cannot raise the floor
+        // beyond what the wealthy ring already implies.
+        let out_rich = vec![mk_tagged_output(
+            90_000_000,
+            95,
+            ClusterTagVector::from_pairs(&[(ClusterId(import_id), TAG_WEIGHT_SCALE)]),
+        )];
+        let tx_rich_import = mk_transfer_tx(rich_ring.clone(), out_rich, 0);
+        let floor_rich_import = ledger.consensus_fee_floor(&tx_rich_import, block_height).unwrap();
+
+        // Same wealthy ring, same output but tagged to a DISTINCT non-import
+        // cluster of equally-tiny wealth: the ring-centroid floor is identical,
+        // and since the import floor (1.5x) is below that ring floor, the two
+        // fee floors MUST be equal — proving no double-floor stacking.
+        let plain2 = 555555u64;
+        ledger.set_cluster_wealth_for_test(plain2, 1_000 * PICO_PER_BTH).unwrap();
+        let out_rich_plain = vec![mk_tagged_output(
+            90_000_000,
+            96,
+            ClusterTagVector::from_pairs(&[(ClusterId(plain2), TAG_WEIGHT_SCALE)]),
+        )];
+        let tx_rich_plain = mk_transfer_tx(rich_ring, out_rich_plain, 0);
+        let floor_rich_plain = ledger.consensus_fee_floor(&tx_rich_plain, block_height).unwrap();
+        assert_eq!(
+            floor_rich_import, floor_rich_plain,
+            "when the ring-centroid floor already exceeds F, the import floor must be \
+             absorbed by the single max (no double-floor): import={floor_rich_import}, \
+             plain={floor_rich_plain}"
         );
     }
 }

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -99,6 +99,49 @@ fn effective_cluster_wealth_from_outputs(
     Ok(total_weighted_wealth / total_value)
 }
 
+/// The bridge-import factor floor implied by a tx's OUTPUT tags (ADR 0007,
+/// #938), mirroring `Ledger::import_floor_factor_from_outputs`.
+///
+/// Value-weighted blend, in FACTOR_SCALE units, of `F` on the value tagged to
+/// recorded bridge-import clusters and `1×` on the rest. Relay policy mirrors
+/// the consensus floor so a tx admitted by the mempool can never fall below what
+/// consensus requires (the relay-only-tightening invariant). Fail-closed on DB
+/// error.
+fn import_floor_factor_from_outputs(outputs: &[TxOutput], ledger: &Ledger) -> Result<u64, String> {
+    use bth_cluster_tax::{ClusterFactorCurve, BRIDGE_IMPORT_FACTOR_FLOOR};
+
+    let background = ClusterFactorCurve::FACTOR_SCALE as u128;
+    let floor = BRIDGE_IMPORT_FACTOR_FLOOR as u128;
+
+    let mut total_value: u128 = 0;
+    let mut import_value: u128 = 0;
+
+    for output in outputs {
+        let amount = output.amount as u128;
+        total_value = total_value.saturating_add(amount);
+        for entry in &output.cluster_tags.entries {
+            let is_import = ledger
+                .is_bridge_import_cluster(entry.cluster_id.0)
+                .map_err(|e| format!("is_bridge_import_cluster({}): {}", entry.cluster_id.0, e))?;
+            if is_import {
+                let tagged =
+                    amount.saturating_mul(entry.weight as u128) / (TAG_WEIGHT_SCALE as u128);
+                import_value = import_value.saturating_add(tagged);
+            }
+        }
+    }
+
+    if total_value == 0 {
+        return Ok(ClusterFactorCurve::FACTOR_SCALE);
+    }
+    let import_value = import_value.min(total_value);
+    let background_value = total_value - import_value;
+    let blended = (floor.saturating_mul(import_value)
+        .saturating_add(background.saturating_mul(background_value)))
+        / total_value;
+    Ok(blended as u64)
+}
+
 // ============================================================================
 // Ring Tag Plausibility Validation
 // ============================================================================
@@ -738,6 +781,15 @@ impl Mempool {
         let claimed_factor = self.fee_config.cluster_factor(cluster_wealth);
         let demurrage_factor =
             self.ring_centroid_floored_factor(&ring_tags, claimed_factor, ledger)?;
+
+        // ADR 0007 (#938): the bridge-import floor. Mirror the consensus fee
+        // floor's ≥F clamp on imported-wealth outputs so relay never admits a
+        // tx below what consensus requires (the relay-only-tightening invariant
+        // asserted below depends on this). Separate `max` from the ring-centroid
+        // floor above — no double-floor.
+        let import_floor = import_floor_factor_from_outputs(&tx.outputs, ledger)
+            .map_err(MempoolError::LedgerError)?;
+        let demurrage_factor = demurrage_factor.max(import_floor);
 
         // Current chain tip height. Used both for the demurrage clock below and
         // for the relay-only-tightening invariant check (M1-B5), so the mempool

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -104,9 +104,9 @@ fn effective_cluster_wealth_from_outputs(
 ///
 /// Value-weighted blend, in FACTOR_SCALE units, of `F` on the value tagged to
 /// recorded bridge-import clusters and `1×` on the rest. Relay policy mirrors
-/// the consensus floor so a tx admitted by the mempool can never fall below what
-/// consensus requires (the relay-only-tightening invariant). Fail-closed on DB
-/// error.
+/// the consensus floor so a tx admitted by the mempool can never fall below
+/// what consensus requires (the relay-only-tightening invariant). Fail-closed
+/// on DB error.
 fn import_floor_factor_from_outputs(outputs: &[TxOutput], ledger: &Ledger) -> Result<u64, String> {
     use bth_cluster_tax::{ClusterFactorCurve, BRIDGE_IMPORT_FACTOR_FLOOR};
 
@@ -136,7 +136,8 @@ fn import_floor_factor_from_outputs(outputs: &[TxOutput], ledger: &Ledger) -> Re
     }
     let import_value = import_value.min(total_value);
     let background_value = total_value - import_value;
-    let blended = (floor.saturating_mul(import_value)
+    let blended = (floor
+        .saturating_mul(import_value)
         .saturating_add(background.saturating_mul(background_value)))
         / total_value;
     Ok(blended as u64)

--- a/botho/src/network/discovery.rs
+++ b/botho/src/network/discovery.rs
@@ -106,7 +106,22 @@ use crate::{
 /// since the 4.0.0 reset (#626) — every migrated value is identical in BTH
 /// terms, so 4.0.0 peers accept exactly the same blocks. Per the #608 lesson:
 /// major = consensus-breaking disconnect, minor = warn (soft, RPC-shape-only).
-pub const PROTOCOL_VERSION: &str = "4.1.0";
+/// PROTOCOL 5.0.0 (ADR 0007, #938): bridge-import cluster tagging. Unwrapping
+/// wBTH → BTH now tags the minted output 100% to a block-epoch import cluster
+/// `c_import(⌊height/K⌋)` (K = 17,280 blocks) instead of returning it at
+/// factor-1 (background), and the consensus fee floor prices any import-tagged
+/// value at ≥ F = 1.5× on that fraction until it circulates the tag off. This is
+/// a CONSENSUS-BREAKING change: a 4.x peer applies no import floor and would
+/// accept/produce blocks whose release outputs the 5.0.0 chain now expects to be
+/// import-tagged and floored, so the two fork. The bump is therefore MAJOR
+/// (`is_consensus_compatible` compares majors only — a minor bump would merely
+/// warn, leaving 4.x peers connected and silently forking) and
+/// `MIN_SUPPORTED_PROTOCOL_VERSION` rises to 5.0.0 in lockstep (pre-mainnet
+/// testnet reset — no in-place migration; the new `bridge_import_clusters` index
+/// is built from genesis). Interacts with #925 (the remaining spend-to-
+/// background reset door) only in that both touch the factor-floor area; they
+/// are SEPARATE mechanisms.
+pub const PROTOCOL_VERSION: &str = "5.0.0";
 
 /// Minimum supported protocol version.
 /// Peers below this version are consensus-incompatible and are disconnected.
@@ -119,8 +134,12 @@ pub const PROTOCOL_VERSION: &str = "4.1.0";
 ///
 /// Deliberately NOT raised for the 4.1.0 minor bump (#694 unit migration):
 /// 4.0.0 peers remain consensus-compatible (no block-acceptance rule changed),
-/// so they must keep connecting rather than be disconnected.
-pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "4.0.0";
+/// so they kept connecting rather than being disconnected.
+///
+/// Raised to 5.0.0 for the ADR 0007 bridge-import cluster tagging + ≥F import
+/// floor (#938): 4.x peers apply no import floor and would fork the
+/// import-tagged/floored chain, so they must be disconnected (major-only check).
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "5.0.0";
 
 /// Topic for block announcements
 const BLOCKS_TOPIC: &str = "botho/blocks/1.0.0";
@@ -2196,31 +2215,37 @@ mod tests {
         // Bumped to 4.1.0 (MINOR) for the #694 nanoBTH -> picocredits
         // migration: the RPC contract's declared units change but no
         // consensus rule does, so 4.0.x peers stay connected (warn-only).
-        assert_eq!(PROTOCOL_VERSION, "4.1.0");
+        //
+        // Bumped to 5.0.0 (MAJOR) for ADR 0007 bridge-import cluster tagging +
+        // the >=F import floor (#938): a consensus-breaking fee-floor rule.
+        // MAJOR (not minor) because `is_consensus_compatible` is major-only, so
+        // a minor bump would leave 4.x peers connected and silently forking.
+        assert_eq!(PROTOCOL_VERSION, "5.0.0");
         let parsed = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
-        assert_eq!(parsed.major, 4);
-        assert_eq!(parsed.minor, 1);
+        assert_eq!(parsed.major, 5);
+        assert_eq!(parsed.minor, 0);
         assert_eq!(parsed.patch, 0);
     }
 
-    /// The #694 unit migration must NOT disconnect 4.0.0 peers: it is a
-    /// minor (RPC-shape-only) bump and 4.0.0 is consensus-compatible.
+    /// ADR 0007 (#938) is a consensus-breaking MAJOR bump (4.x → 5.0.0), so 4.x
+    /// peers must now be DISCONNECTED as consensus-incompatible — they apply no
+    /// import floor and would silently fork the import-tagged/floored chain.
     #[test]
-    fn test_v4_peers_remain_consensus_compatible_with_current() {
+    fn test_v4_peers_are_consensus_incompatible_after_adr0007() {
         let local = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
-        let v4_peer = ProtocolVersion::parse("4.0.0").unwrap();
-        assert!(v4_peer.is_consensus_compatible(&local));
+        let v4_peer = ProtocolVersion::parse("4.1.0").unwrap();
+        assert!(!v4_peer.is_consensus_compatible(&local));
         assert_eq!(
-            ProtocolVersion::consensus_incompatibility(&Some(v4_peer), &local),
-            None
+            ProtocolVersion::consensus_incompatibility(&Some(v4_peer.clone()), &local),
+            Some(v4_peer)
         );
     }
 
     #[test]
     fn test_min_supported_protocol_version_constant() {
-        assert_eq!(MIN_SUPPORTED_PROTOCOL_VERSION, "4.0.0");
+        assert_eq!(MIN_SUPPORTED_PROTOCOL_VERSION, "5.0.0");
         let parsed = ProtocolVersion::parse(MIN_SUPPORTED_PROTOCOL_VERSION).unwrap();
-        assert_eq!(parsed.major, 4);
+        assert_eq!(parsed.major, 5);
         assert_eq!(parsed.minor, 0);
     }
 

--- a/botho/src/network/discovery.rs
+++ b/botho/src/network/discovery.rs
@@ -110,15 +110,15 @@ use crate::{
 /// wBTH → BTH now tags the minted output 100% to a block-epoch import cluster
 /// `c_import(⌊height/K⌋)` (K = 17,280 blocks) instead of returning it at
 /// factor-1 (background), and the consensus fee floor prices any import-tagged
-/// value at ≥ F = 1.5× on that fraction until it circulates the tag off. This is
-/// a CONSENSUS-BREAKING change: a 4.x peer applies no import floor and would
-/// accept/produce blocks whose release outputs the 5.0.0 chain now expects to be
-/// import-tagged and floored, so the two fork. The bump is therefore MAJOR
+/// value at ≥ F = 1.5× on that fraction until it circulates the tag off. This
+/// is a CONSENSUS-BREAKING change: a 4.x peer applies no import floor and would
+/// accept/produce blocks whose release outputs the 5.0.0 chain now expects to
+/// be import-tagged and floored, so the two fork. The bump is therefore MAJOR
 /// (`is_consensus_compatible` compares majors only — a minor bump would merely
 /// warn, leaving 4.x peers connected and silently forking) and
 /// `MIN_SUPPORTED_PROTOCOL_VERSION` rises to 5.0.0 in lockstep (pre-mainnet
-/// testnet reset — no in-place migration; the new `bridge_import_clusters` index
-/// is built from genesis). Interacts with #925 (the remaining spend-to-
+/// testnet reset — no in-place migration; the new `bridge_import_clusters`
+/// index is built from genesis). Interacts with #925 (the remaining spend-to-
 /// background reset door) only in that both touch the factor-floor area; they
 /// are SEPARATE mechanisms.
 pub const PROTOCOL_VERSION: &str = "5.0.0";
@@ -138,7 +138,8 @@ pub const PROTOCOL_VERSION: &str = "5.0.0";
 ///
 /// Raised to 5.0.0 for the ADR 0007 bridge-import cluster tagging + ≥F import
 /// floor (#938): 4.x peers apply no import floor and would fork the
-/// import-tagged/floored chain, so they must be disconnected (major-only check).
+/// import-tagged/floored chain, so they must be disconnected (major-only
+/// check).
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "5.0.0";
 
 /// Topic for block announcements

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -57,6 +57,11 @@ ed25519-dalek = { workspace = true, features = ["std"] }
 #   - bth-crypto-ring-signature: node-identical key-image derivation for the
 #     provably-dead (dropped) release check.
 bth-transaction-clsag = { path = "../../transaction/clsag", default-features = false }
+# Single source of truth for the bridge-import cluster key + floor (ADR 0007):
+# the release tag derivation MUST be byte-identical to the ledger's consensus
+# check, so both consume `bth_cluster_tax::import_cluster_id_for_height`.
+bth-cluster-tax = { workspace = true }
+bth-transaction-types = { workspace = true }
 bth-account-keys = { workspace = true }
 bth-crypto-keys = { workspace = true }
 bth-crypto-ring-signature = { workspace = true }
@@ -106,6 +111,6 @@ proptest = { workspace = true, features = ["default-code-coverage"] }
 tempfile = { workspace = true }
 # Deterministic RNG for reproducible tx-construction test vectors (#856).
 rand = { workspace = true, features = ["std_rng"] }
-# Test-only stealth outputs paid to the reserve (deposit-scan + release
-# input construction unit tests) reuse the node-identical output builder.
-bth-transaction-types = { workspace = true }
+# (bth-transaction-types is a normal dependency — see [dependencies] — since
+# the release path now constructs the ADR 0007 import cluster tag in production
+# code, not just tests.)

--- a/bridge/service/src/bth_scan.rs
+++ b/bridge/service/src/bth_scan.rs
@@ -25,6 +25,7 @@ use bth_transaction_clsag::{
     ClsagRingInput, EncryptedMemo, MemoPayload, RingMember, Transaction, TxOutput,
     DEFAULT_RING_SIZE, DUST_THRESHOLD, MIN_TX_FEE,
 };
+use bth_transaction_types::{ClusterId, ClusterTagVector};
 use rand_core::{CryptoRng, RngCore};
 
 use crate::bth_rpc::RpcOutput;
@@ -212,10 +213,21 @@ pub fn build_release_tx<R: RngCore + CryptoRng>(
         .checked_sub(spent)
         .ok_or("insufficient reserve inputs: do not cover amount + fee")?;
 
-    // Recipient output: a FRESH one-time stealth output (ADR 0004). Assert it
-    // carries no cluster tags — the release must not launder provenance.
-    let recipient_output = TxOutput::new(amount, recipient);
-    debug_assert!(recipient_output.cluster_tags.is_empty());
+    // Recipient output: a FRESH one-time stealth output (ADR 0004), tagged
+    // 100% to the block-epoch bridge-import cluster (ADR 0007). Before ADR 0007
+    // this output carried NO cluster tag, so unwrapped BTH returned at factor-1
+    // (background) — the entry leak / round-trip-laundromat the ADR closes. Now
+    // it joins `c_import(⌊height/K⌋)`, an accumulating shared origin whose
+    // factor is `max(F=1.5x, curve(Σ epoch unwrap volume))`; it normalizes to
+    // background only by circulating (the existing value-weighted tag blend on
+    // spends), never by sitting idle. The derivation is the single
+    // consensus-canonical helper the ledger also uses, so the tag can never
+    // drift from the node's enforcement.
+    let import_cluster_id = bth_cluster_tax::import_cluster_id_for_height(created_at_height);
+    let import_tags =
+        ClusterTagVector::single(ClusterId(import_cluster_id.0));
+    let recipient_output =
+        TxOutput::new_with_cluster_tags(amount, recipient, None, import_tags);
     let mut outputs = vec![recipient_output];
 
     // Change back to the reserve's default subaddress (ADR 0003). Sub-dust
@@ -490,9 +502,22 @@ mod tests {
         let recipient_out = &tx.outputs[0];
         assert_eq!(recipient_out.amount, amount);
         assert!(recipient_out.belongs_to(&recipient_account).is_some());
-        assert!(
-            recipient_out.cluster_tags.is_empty(),
-            "recipient output must carry no cluster tags (no laundering)"
+        // ...and it is tagged 100% to the block-epoch bridge-import cluster
+        // (ADR 0007, #938): height 5,000 is in epoch 0 (< K = 17,280).
+        let expected_import = bth_cluster_tax::import_cluster_id_for_height(5_000).0;
+        assert_eq!(
+            recipient_out.cluster_tags.entries.len(),
+            1,
+            "recipient output must carry exactly the import cluster tag"
+        );
+        assert_eq!(
+            recipient_out.cluster_tags.entries[0].cluster_id.0, expected_import,
+            "recipient output must be tagged to c_import(epoch 0)"
+        );
+        assert_eq!(
+            recipient_out.cluster_tags.entries[0].weight,
+            bth_transaction_types::TAG_WEIGHT_SCALE,
+            "the import tag must be 100% weight"
         );
         // ...and it must NOT be detectable by the reserve (fresh one-time key).
         assert!(recipient_out.belongs_to(&reserve).is_none());

--- a/bridge/service/src/bth_scan.rs
+++ b/bridge/service/src/bth_scan.rs
@@ -224,10 +224,8 @@ pub fn build_release_tx<R: RngCore + CryptoRng>(
     // consensus-canonical helper the ledger also uses, so the tag can never
     // drift from the node's enforcement.
     let import_cluster_id = bth_cluster_tax::import_cluster_id_for_height(created_at_height);
-    let import_tags =
-        ClusterTagVector::single(ClusterId(import_cluster_id.0));
-    let recipient_output =
-        TxOutput::new_with_cluster_tags(amount, recipient, None, import_tags);
+    let import_tags = ClusterTagVector::single(ClusterId(import_cluster_id.0));
+    let recipient_output = TxOutput::new_with_cluster_tags(amount, recipient, None, import_tags);
     let mut outputs = vec![recipient_output];
 
     // Change back to the reserve's default subaddress (ADR 0003). Sub-dust

--- a/cluster-tax/src/bridge_import.rs
+++ b/cluster-tax/src/bridge_import.rs
@@ -1,0 +1,210 @@
+//! Bridge-import cluster tagging (ADR 0007).
+//!
+//! Unwrapping wBTH → BTH mints BTH into a **block-epoch import cluster** instead
+//! of returning it at factor-1 (background). Every unwrap whose output lands in
+//! block-height range `[mK, (m+1)K)` joins one shared cluster origin
+//!
+//! ```text
+//! c_import(m) = H("bridge-import" ‖ m),   m = ⌊height / K⌋
+//! ```
+//!
+//! The import cluster accumulates wealth (the sum of the unwrap amounts tagged
+//! to it) exactly like any domestic cluster, and the production
+//! [`crate::ClusterFactorCurve`] maps that wealth to a factor. The effective
+//! factor of an import cluster is then clamped to a floor `F`:
+//!
+//! ```text
+//! import_factor(m) = max(F, ClusterFactorCurve(Σ unwrap amounts in epoch m))
+//! ```
+//!
+//! This module is the single, consensus-critical source of the two ratified
+//! constants (`K`, `F`), the epoch key, the deterministic import-cluster-id
+//! derivation, and the floor clamp. Both the ledger (consensus enforcement) and
+//! the bridge service (tag assignment on release) depend on it, so the id
+//! derivation and clamp can never drift between the two.
+//!
+//! # Why the floor is a **separate** clamp from the ring-centroid floor
+//!
+//! The consensus fee floor already raises a spender-claimed factor to the
+//! ring-centroid-implied factor via `max(claimed, ring_centroid)` (audit
+//! cycle-6 H2). The import floor is a DIFFERENT `max`: it clamps *the import
+//! cluster's own curve-derived factor* up to `F`. Because both are `max`
+//! operations against independent lower bounds, composing them is just a wider
+//! `max` — there is no double-floor: `max(claimed, ring_centroid, F_import)`
+//! collapses to a single dominating bound. The import floor only ever RAISES a
+//! factor, and only for wealth that actually traces to an import cluster; a
+//! purely-domestic coin never touches it.
+//!
+//! # Determinism
+//!
+//! CONSENSUS-CRITICAL. `import_epoch` is integer division; `import_cluster_id`
+//! is SHA-256 over a fixed-format preimage (mirroring how
+//! `MintingTx::to_tx_output` derives a mint `ClusterId` from a hash — first 8
+//! little-endian bytes); the floor clamp is a `max` on `u64` FACTOR_SCALE units.
+//! No floats, bit-identical on every platform.
+
+use sha2::{Digest, Sha256};
+
+use crate::{ClusterId, ClusterFactorCurve};
+
+/// Epoch length `K`, in blocks (ADR 0007, ratified 2026-07-14 via #937/#940).
+///
+/// `K = 17_280` blocks = 1 day at the 5 s reference block time
+/// (`86_400 s / 5 s`). All unwraps whose output is created in block-height
+/// range `[mK, (m+1)K)` share the single import cluster `c_import(m)`, so
+/// intra-epoch splitting piles into one accumulating pool (Sybil resistance).
+///
+/// A future maintainer preferring minimal co-location collateral over
+/// operational legibility may lower this to `10_080` (~14 h); the calibration
+/// sim (`simulation::bridge_import_sweep`) regenerates the numbers. Changing it
+/// is a consensus change (new import-cluster ids ⇒ protocol bump + reset).
+pub const BRIDGE_IMPORT_EPOCH_BLOCKS: u64 = 17_280;
+
+/// Import-factor floor `F`, in [`ClusterFactorCurve::FACTOR_SCALE`] units
+/// (1000 = 1.0×), ratified 2026-07-14 (#937/#940).
+///
+/// `F = 1_500` = 1.5×. This is the residual anti-hoarding premium a split-gamer
+/// cannot erode (the best factor reachable by diluting across epochs is `F`, not
+/// 1×) and the minimum toll for entering via the bridge rather than earning
+/// domestically. It clears the ~1.27× a genuine ~1000-BTH retail import already
+/// prices on the raw curve (so the floor binds) at a ~0.20 %/yr transient
+/// onboarding toll that blends off in ≈9 domestic spends.
+pub const BRIDGE_IMPORT_FACTOR_FLOOR: u64 = 1_500;
+
+/// Domain-separation tag for the import-cluster-id hash preimage.
+const BRIDGE_IMPORT_DOMAIN: &[u8] = b"bridge-import";
+
+/// The block-height epoch `m = ⌊height / K⌋` an unwrap at `height` belongs to.
+///
+/// Integer division; deterministic. All unwraps in `[mK, (m+1)K)` map to the
+/// same `m` and therefore the same import cluster.
+#[inline]
+pub fn import_epoch(height: u64) -> u64 {
+    height / BRIDGE_IMPORT_EPOCH_BLOCKS
+}
+
+/// The canonical import cluster id for epoch `m`:
+/// `c_import(m) = H("bridge-import" ‖ m)`.
+///
+/// The preimage is `BRIDGE_IMPORT_DOMAIN ‖ m.to_le_bytes()`; the id is the first
+/// 8 little-endian bytes of the SHA-256 digest, folded into the `u64` cluster-id
+/// space — the identical convention `MintingTx::to_tx_output` uses to derive a
+/// mint cluster id from a tx hash. A bridge-import cluster is simply a third way
+/// to create a cluster origin (alongside minting), with no new machinery beyond
+/// the tag.
+pub fn import_cluster_id(epoch: u64) -> ClusterId {
+    let mut hasher = Sha256::new();
+    hasher.update(BRIDGE_IMPORT_DOMAIN);
+    hasher.update(epoch.to_le_bytes());
+    let digest = hasher.finalize();
+    let id = u64::from_le_bytes(digest[0..8].try_into().unwrap());
+    ClusterId::new(id)
+}
+
+/// The import cluster id for an unwrap whose output is created at `height`:
+/// `import_cluster_id(import_epoch(height))`.
+#[inline]
+pub fn import_cluster_id_for_height(height: u64) -> ClusterId {
+    import_cluster_id(import_epoch(height))
+}
+
+/// Apply the import-factor floor to a factor known to belong to an import
+/// cluster.
+///
+/// `curve_factor` is the import cluster's curve-derived factor
+/// (`ClusterFactorCurve::factor(import_cluster_wealth)`), in FACTOR_SCALE units.
+/// Returns `max(curve_factor, F)`. Never lowers a factor; a flood epoch whose
+/// curve factor already exceeds `F` is unchanged.
+#[inline]
+pub fn apply_import_floor(curve_factor: u64) -> u64 {
+    curve_factor.max(BRIDGE_IMPORT_FACTOR_FLOOR)
+}
+
+/// The effective factor of an import cluster with the given accumulated wealth:
+/// `max(F, ClusterFactorCurve(wealth))`.
+///
+/// This is the consensus-canonical import factor — the identical expression the
+/// calibration sim (`simulation::bridge_import_sweep::import_factor`) models,
+/// computed here from the real curve so the ledger and the sim agree.
+pub fn import_cluster_factor(import_cluster_wealth_pico: u128, curve: &ClusterFactorCurve) -> u64 {
+    apply_import_floor(curve.factor(import_cluster_wealth_pico))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PICO_PER_BTH;
+
+    #[test]
+    fn epoch_boundaries_are_k_blocks() {
+        assert_eq!(import_epoch(0), 0);
+        assert_eq!(import_epoch(BRIDGE_IMPORT_EPOCH_BLOCKS - 1), 0);
+        assert_eq!(import_epoch(BRIDGE_IMPORT_EPOCH_BLOCKS), 1);
+        assert_eq!(import_epoch(2 * BRIDGE_IMPORT_EPOCH_BLOCKS + 5), 2);
+    }
+
+    #[test]
+    fn constants_match_ratified_values() {
+        // ADR 0007: K = 17,280 blocks (1 day @ 5s), F = 1.5x.
+        assert_eq!(BRIDGE_IMPORT_EPOCH_BLOCKS, 17_280);
+        assert_eq!(BRIDGE_IMPORT_FACTOR_FLOOR, 1_500);
+        assert_eq!(
+            BRIDGE_IMPORT_FACTOR_FLOOR,
+            ClusterFactorCurve::FACTOR_SCALE * 3 / 2
+        );
+    }
+
+    #[test]
+    fn import_cluster_id_is_deterministic_and_epoch_distinct() {
+        // Deterministic: the same epoch always yields the same id.
+        assert_eq!(import_cluster_id(7), import_cluster_id(7));
+        // Distinct across epochs (defeats the drip-split: each epoch is its own
+        // pool, but two unwraps in the SAME epoch share one).
+        assert_ne!(import_cluster_id(7), import_cluster_id(8));
+        assert_ne!(import_cluster_id(0), import_cluster_id(1));
+    }
+
+    #[test]
+    fn two_unwraps_same_epoch_share_one_cluster() {
+        // Heights inside the same epoch window map to the same cluster id.
+        let h1 = 3 * BRIDGE_IMPORT_EPOCH_BLOCKS + 1;
+        let h2 = 3 * BRIDGE_IMPORT_EPOCH_BLOCKS + BRIDGE_IMPORT_EPOCH_BLOCKS - 1;
+        assert_eq!(
+            import_cluster_id_for_height(h1),
+            import_cluster_id_for_height(h2)
+        );
+    }
+
+    #[test]
+    fn unwraps_in_different_epochs_form_distinct_clusters() {
+        let h1 = 3 * BRIDGE_IMPORT_EPOCH_BLOCKS + 1;
+        let h2 = 4 * BRIDGE_IMPORT_EPOCH_BLOCKS + 1;
+        assert_ne!(
+            import_cluster_id_for_height(h1),
+            import_cluster_id_for_height(h2)
+        );
+    }
+
+    #[test]
+    fn floor_binds_small_import_and_yields_to_flood() {
+        let curve = ClusterFactorCurve::default_params();
+
+        // A small import sits below the curve knee → floored to exactly F.
+        let small = 1_000u128 * PICO_PER_BTH;
+        assert_eq!(import_cluster_factor(small, &curve), BRIDGE_IMPORT_FACTOR_FLOOR);
+
+        // A flood import saturates the curve well above F → floor does not bind.
+        let flood = 10_000_000u128 * PICO_PER_BTH;
+        let flood_factor = import_cluster_factor(flood, &curve);
+        assert!(flood_factor > 5_000, "flood import must price near 6x, got {flood_factor}");
+        assert_eq!(flood_factor, curve.factor(flood), "floor must not alter a flood factor");
+    }
+
+    #[test]
+    fn apply_import_floor_never_lowers() {
+        assert_eq!(apply_import_floor(0), BRIDGE_IMPORT_FACTOR_FLOOR);
+        assert_eq!(apply_import_floor(1_000), BRIDGE_IMPORT_FACTOR_FLOOR);
+        assert_eq!(apply_import_floor(BRIDGE_IMPORT_FACTOR_FLOOR), BRIDGE_IMPORT_FACTOR_FLOOR);
+        assert_eq!(apply_import_floor(6_000), 6_000);
+    }
+}

--- a/cluster-tax/src/bridge_import.rs
+++ b/cluster-tax/src/bridge_import.rs
@@ -1,8 +1,8 @@
 //! Bridge-import cluster tagging (ADR 0007).
 //!
-//! Unwrapping wBTH → BTH mints BTH into a **block-epoch import cluster** instead
-//! of returning it at factor-1 (background). Every unwrap whose output lands in
-//! block-height range `[mK, (m+1)K)` joins one shared cluster origin
+//! Unwrapping wBTH → BTH mints BTH into a **block-epoch import cluster**
+//! instead of returning it at factor-1 (background). Every unwrap whose output
+//! lands in block-height range `[mK, (m+1)K)` joins one shared cluster origin
 //!
 //! ```text
 //! c_import(m) = H("bridge-import" ‖ m),   m = ⌊height / K⌋
@@ -40,12 +40,12 @@
 //! CONSENSUS-CRITICAL. `import_epoch` is integer division; `import_cluster_id`
 //! is SHA-256 over a fixed-format preimage (mirroring how
 //! `MintingTx::to_tx_output` derives a mint `ClusterId` from a hash — first 8
-//! little-endian bytes); the floor clamp is a `max` on `u64` FACTOR_SCALE units.
-//! No floats, bit-identical on every platform.
+//! little-endian bytes); the floor clamp is a `max` on `u64` FACTOR_SCALE
+//! units. No floats, bit-identical on every platform.
 
 use sha2::{Digest, Sha256};
 
-use crate::{ClusterId, ClusterFactorCurve};
+use crate::{ClusterFactorCurve, ClusterId};
 
 /// Epoch length `K`, in blocks (ADR 0007, ratified 2026-07-14 via #937/#940).
 ///
@@ -64,8 +64,8 @@ pub const BRIDGE_IMPORT_EPOCH_BLOCKS: u64 = 17_280;
 /// (1000 = 1.0×), ratified 2026-07-14 (#937/#940).
 ///
 /// `F = 1_500` = 1.5×. This is the residual anti-hoarding premium a split-gamer
-/// cannot erode (the best factor reachable by diluting across epochs is `F`, not
-/// 1×) and the minimum toll for entering via the bridge rather than earning
+/// cannot erode (the best factor reachable by diluting across epochs is `F`,
+/// not 1×) and the minimum toll for entering via the bridge rather than earning
 /// domestically. It clears the ~1.27× a genuine ~1000-BTH retail import already
 /// prices on the raw curve (so the floor binds) at a ~0.20 %/yr transient
 /// onboarding toll that blends off in ≈9 domestic spends.
@@ -86,12 +86,12 @@ pub fn import_epoch(height: u64) -> u64 {
 /// The canonical import cluster id for epoch `m`:
 /// `c_import(m) = H("bridge-import" ‖ m)`.
 ///
-/// The preimage is `BRIDGE_IMPORT_DOMAIN ‖ m.to_le_bytes()`; the id is the first
-/// 8 little-endian bytes of the SHA-256 digest, folded into the `u64` cluster-id
-/// space — the identical convention `MintingTx::to_tx_output` uses to derive a
-/// mint cluster id from a tx hash. A bridge-import cluster is simply a third way
-/// to create a cluster origin (alongside minting), with no new machinery beyond
-/// the tag.
+/// The preimage is `BRIDGE_IMPORT_DOMAIN ‖ m.to_le_bytes()`; the id is the
+/// first 8 little-endian bytes of the SHA-256 digest, folded into the `u64`
+/// cluster-id space — the identical convention `MintingTx::to_tx_output` uses
+/// to derive a mint cluster id from a tx hash. A bridge-import cluster is
+/// simply a third way to create a cluster origin (alongside minting), with no
+/// new machinery beyond the tag.
 pub fn import_cluster_id(epoch: u64) -> ClusterId {
     let mut hasher = Sha256::new();
     hasher.update(BRIDGE_IMPORT_DOMAIN);
@@ -112,9 +112,9 @@ pub fn import_cluster_id_for_height(height: u64) -> ClusterId {
 /// cluster.
 ///
 /// `curve_factor` is the import cluster's curve-derived factor
-/// (`ClusterFactorCurve::factor(import_cluster_wealth)`), in FACTOR_SCALE units.
-/// Returns `max(curve_factor, F)`. Never lowers a factor; a flood epoch whose
-/// curve factor already exceeds `F` is unchanged.
+/// (`ClusterFactorCurve::factor(import_cluster_wealth)`), in FACTOR_SCALE
+/// units. Returns `max(curve_factor, F)`. Never lowers a factor; a flood epoch
+/// whose curve factor already exceeds `F` is unchanged.
 #[inline]
 pub fn apply_import_floor(curve_factor: u64) -> u64 {
     curve_factor.max(BRIDGE_IMPORT_FACTOR_FLOOR)
@@ -191,20 +191,33 @@ mod tests {
 
         // A small import sits below the curve knee → floored to exactly F.
         let small = 1_000u128 * PICO_PER_BTH;
-        assert_eq!(import_cluster_factor(small, &curve), BRIDGE_IMPORT_FACTOR_FLOOR);
+        assert_eq!(
+            import_cluster_factor(small, &curve),
+            BRIDGE_IMPORT_FACTOR_FLOOR
+        );
 
         // A flood import saturates the curve well above F → floor does not bind.
         let flood = 10_000_000u128 * PICO_PER_BTH;
         let flood_factor = import_cluster_factor(flood, &curve);
-        assert!(flood_factor > 5_000, "flood import must price near 6x, got {flood_factor}");
-        assert_eq!(flood_factor, curve.factor(flood), "floor must not alter a flood factor");
+        assert!(
+            flood_factor > 5_000,
+            "flood import must price near 6x, got {flood_factor}"
+        );
+        assert_eq!(
+            flood_factor,
+            curve.factor(flood),
+            "floor must not alter a flood factor"
+        );
     }
 
     #[test]
     fn apply_import_floor_never_lowers() {
         assert_eq!(apply_import_floor(0), BRIDGE_IMPORT_FACTOR_FLOOR);
         assert_eq!(apply_import_floor(1_000), BRIDGE_IMPORT_FACTOR_FLOOR);
-        assert_eq!(apply_import_floor(BRIDGE_IMPORT_FACTOR_FLOOR), BRIDGE_IMPORT_FACTOR_FLOOR);
+        assert_eq!(
+            apply_import_floor(BRIDGE_IMPORT_FACTOR_FLOOR),
+            BRIDGE_IMPORT_FACTOR_FLOOR
+        );
         assert_eq!(apply_import_floor(6_000), 6_000);
     }
 }

--- a/cluster-tax/src/crypto/committed_tags.rs
+++ b/cluster-tax/src/crypto/committed_tags.rs
@@ -751,10 +751,10 @@ impl CommittedFeeProver {
         let mut challenges = vec![Scalar::ZERO; ZkFeeCurve::NUM_SEGMENTS];
         let mut simulated_challenges_sum = Scalar::ZERO;
 
-        for i in 0..ZkFeeCurve::NUM_SEGMENTS {
+        for (i, challenge) in challenges.iter_mut().enumerate() {
             if i != real_segment {
-                challenges[i] = Scalar::random(rng);
-                simulated_challenges_sum += challenges[i];
+                *challenge = Scalar::random(rng);
+                simulated_challenges_sum += *challenge;
             }
         }
 

--- a/cluster-tax/src/crypto/entropy_proof.rs
+++ b/cluster-tax/src/crypto/entropy_proof.rs
@@ -192,7 +192,7 @@ impl EntropyProofBuilder {
         // p_k = m_k / total_mass
         // p_k^2 = m_k^2 / total_mass^2
         let mut sum_p_squared = 0u128;
-        for (_, mass) in &cluster_masses {
+        for mass in cluster_masses.values() {
             let p_squared = (*mass as u128 * *mass as u128) / (total_mass as u128);
             sum_p_squared += p_squared;
         }
@@ -212,9 +212,8 @@ impl EntropyProofBuilder {
         let p_sum = normalized as f64 / ENTROPY_SCALE as f64;
         let h2 = if p_sum > 0.0 && p_sum < 1.0 {
             -p_sum.log2()
-        } else if p_sum >= 1.0 {
-            0.0
         } else {
+            // p_sum >= 1.0 (max concentration) or p_sum <= 0.0 → zero entropy
             0.0
         };
 

--- a/cluster-tax/src/crypto/entropy_validation.rs
+++ b/cluster-tax/src/crypto/entropy_validation.rs
@@ -30,7 +30,7 @@ use crate::TagWeight;
 // ============================================================================
 
 /// Transaction version indicating supported features.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum TransactionVersion {
     /// V1: Original transaction format
     /// - Basic stealth addresses
@@ -41,6 +41,7 @@ pub enum TransactionVersion {
     /// - Committed cluster tags
     /// - Tag conservation proofs
     /// - ExtendedTxSignature without entropy proof
+    #[default]
     V2 = 2,
 
     /// V3: Phase 2 entropy proofs
@@ -74,12 +75,6 @@ impl TransactionVersion {
     /// Convert to byte.
     pub fn to_byte(self) -> u8 {
         self as u8
-    }
-}
-
-impl Default for TransactionVersion {
-    fn default() -> Self {
-        Self::V2
     }
 }
 

--- a/cluster-tax/src/crypto/serialization.rs
+++ b/cluster-tax/src/crypto/serialization.rs
@@ -402,7 +402,7 @@ impl ExtendedTxSignature {
 
         // Version byte
         let version = r.read_bytes(1)?[0];
-        if version < EXTENDED_SIG_VERSION_V2 || version > EXTENDED_SIG_VERSION_V3 {
+        if !(EXTENDED_SIG_VERSION_V2..=EXTENDED_SIG_VERSION_V3).contains(&version) {
             return Err(DeserializeError::InvalidVersion);
         }
 

--- a/cluster-tax/src/fee_curve.rs
+++ b/cluster-tax/src/fee_curve.rs
@@ -957,7 +957,10 @@ impl ZkFeeCurve {
     /// | b3 = W_MID<<3 | 8e17 | 800,000 | 4928 |
     /// | b4 = W_MID<<8 | 2.56e19 | 25,600,000 | 5909 |
     /// | b5 | u128::MAX | — | 6000 |
-    pub fn default() -> Self {
+    ///
+    /// The canonical constructor lives in the [`Default`] impl; call
+    /// `ZkFeeCurve::default()`.
+    fn default_curve() -> Self {
         let w = ClusterFactorCurve::W_MID_PICO;
         Self {
             boundaries: [0, w >> 8, w >> 3, w << 3, w << 8, u128::MAX],
@@ -1122,7 +1125,7 @@ impl ZkFeeCurve {
 
 impl Default for ZkFeeCurve {
     fn default() -> Self {
-        Self::default()
+        Self::default_curve()
     }
 }
 

--- a/cluster-tax/src/lib.rs
+++ b/cluster-tax/src/lib.rs
@@ -118,10 +118,10 @@ pub use fee_curve::{
     FeeRateBps,
     SegmentParams,
     TransactionType,
-    // Picocredits per BTH (ledger scale) — consumed by the bridge-import floor.
-    PICO_PER_BTH,
     // Phase 2/3: ZK-compatible fee curve
     ZkFeeCurve,
+    // Picocredits per BTH (ledger scale) — consumed by the bridge-import floor.
+    PICO_PER_BTH,
 };
 pub use signing::{
     create_tag_signature, verify_tag_signature, TagSigningConfig, TagSigningError, TagSigningInput,

--- a/cluster-tax/src/lib.rs
+++ b/cluster-tax/src/lib.rs
@@ -35,6 +35,7 @@
 //!   clusters.
 
 pub mod analysis;
+pub mod bridge_import;
 pub mod crypto;
 pub mod demurrage;
 pub mod dynamic_fee;
@@ -53,6 +54,10 @@ mod lottery;
 mod tag;
 mod transfer;
 
+pub use bridge_import::{
+    apply_import_floor, import_cluster_factor, import_cluster_id, import_cluster_id_for_height,
+    import_epoch, BRIDGE_IMPORT_EPOCH_BLOCKS, BRIDGE_IMPORT_FACTOR_FLOOR,
+};
 pub use cluster::{ClusterId, ClusterWealth};
 
 // ============================================================================
@@ -113,6 +118,8 @@ pub use fee_curve::{
     FeeRateBps,
     SegmentParams,
     TransactionType,
+    // Picocredits per BTH (ledger scale) — consumed by the bridge-import floor.
+    PICO_PER_BTH,
     // Phase 2/3: ZK-compatible fee curve
     ZkFeeCurve,
 };

--- a/cluster-tax/src/lottery.rs
+++ b/cluster-tax/src/lottery.rs
@@ -65,7 +65,7 @@ impl Default for LotteryDrawConfig {
 ///
 /// Different modes provide different trade-offs between progressivity
 /// (favoring small holders) and Sybil resistance (preventing gaming).
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub enum SelectionMode {
     /// Uniform: each UTXO has equal chance.
     /// - Progressive: Yes (many small UTXOs beat few large ones)
@@ -87,17 +87,12 @@ pub enum SelectionMode {
 
     /// Cluster-factor weighted: lower factor = more weight.
     /// Progressive via fee system (commerce coins worth more).
+    #[default]
     ClusterWeighted,
 
     /// Entropy-weighted: higher tag entropy = more weight.
     /// Sybil-resistant (splits preserve entropy).
     EntropyWeighted { entropy_bonus: f64 },
-}
-
-impl Default for SelectionMode {
-    fn default() -> Self {
-        Self::ClusterWeighted
-    }
 }
 
 /// Fixed-point scale for cluster factors (1000 = 1.0x, 6000 = 6.0x).


### PR DESCRIPTION
Closes #938. Implements the now-Accepted **ADR 0007** (ratified K = 17,280 blocks / 1 day, F = 1.5×; #937/#940 calibration, #941 flipped the ADR to Accepted).

## Problem
Under ADR 0003 as written, unwrapping wBTH → BTH returned the minted BTH at **factor-1 (background)** — the cheapest, least-taxed class. That is the *entry leak* (external wealth enters clean) and the *bridge round-trip laundromat* (a domestic high-factor holder round-trips to reset to background). ADR 0007 closes the round-trip door and materially narrows the entry leak: **only money that has circulated within Botho is cheap to spend.**

## Mechanism
- **Epoch key.** `m = ⌊height / K⌋`, `c_import(m) = H("bridge-import" ‖ m)` (first 8 LE bytes of the SHA-256 digest folded into the `ClusterId` space — the identical convention `MintingTx::to_tx_output` uses to derive a mint cluster id from a hash). Every unwrap in `[mK,(m+1)K)` shares one accumulating cluster → intra-epoch splitting piles into the same pool; diluting costs wall-clock time across epochs (time-as-cost replaces provenance-as-cost).
- **Factor.** The import cluster accumulates wealth like any cluster; the production `ClusterFactorCurve` maps it to a factor; the effective factor is clamped `max(F, curve(epoch wealth))`.
- **Decay.** None added — the existing value-weighted `TagVector::mix` on spends blends the import tag toward background. The import floor is a value-weighted blend of `F` (import-tagged fraction) and `1×` (rest), so it falls to `1×` as the tag decays. A pure-external holder that never receives domestic value stays `≥ F`.

## Unwrap → mint code path (before vs now)
The unwrap→BTH-mint seam is `build_release_tx` in `bridge/service/src/bth_scan.rs` (called from `release/bth.rs`, where `created_at_height = rpc.chain_tip()` is available). The recipient output was `TxOutput::new(amount, recipient)` with an **empty** `cluster_tags` (factor-1 — the leak). It is now `TxOutput::new_with_cluster_tags(..., ClusterTagVector::single(c_import(⌊height/K⌋)))`. The reserve change output stays untagged (ADR 0003 zero-demurrage reserve).

## ≥F clamp composition (no double-floor)
The consensus fee floor already raised the spender-claimed factor to the ring-centroid-implied factor via `max(claimed, ring_centroid)` (audit cycle-6 H2). The import floor is a **separate `max`** against an independent lower bound, so the demurrage factor is now `max(claimed, ring_centroid, import_floor)` — a single dominating `max`. A wealthy-ring factor already above F is unchanged (test asserts the two fee floors are *equal* when the ring floor dominates); a background-claimed import is raised to F. No stacking.

## How the import floor is enforceable (consensus, collision-free)
A new `bridge_import_clusters` LMDB set records a cluster id **only** when a block whose height falls in epoch `m` creates an output tagged to `import_cluster_id(m)` — a pure function of block height + tag, so every node builds the identical set (rebuilt byte-identically from each UTXO's `created_at` in `rebuild_cluster_wealth_index`). `is_bridge_import_cluster` is then a clean lookup at fee-floor time (fail-closed on DB error). This avoids inverting the hash id.

## Consensus tests (mirror the #940 sim at the consensus layer)
`botho/src/ledger/store.rs`:
- small import lands at exactly F; flood lands at the epoch-summed curve factor (floor does not alter it)
- two unwraps same epoch share one cluster; different epochs form distinct clusters
- decay-on-spend blends the floor 1500 → 1250 (50%) → 1000 (fully circulated)
- pure-external hold stays at ≥F across self-spends
- the ≥F clamp composes with the ring-centroid floor without double-flooring (equal fee floors when the ring floor dominates)

`cluster-tax/src/bridge_import.rs` unit tests cover the epoch key, id determinism/distinctness, and the floor clamp.

## Protocol bump + reset
`PROTOCOL_VERSION` 4.1.0 → **5.0.0** (MAJOR; `MIN_SUPPORTED` → 5.0.0). MAJOR because `is_consensus_compatible` is major-only — a minor bump would leave 4.x peers connected and silently forking the import-tagged/floored chain. **Pre-mainnet testnet reset required** (no in-place migration; the new index builds from genesis). Version-compat tests updated (4.x peers are now consensus-incompatible).

## #925 interaction
#925 (the remaining spend-to-background reset door) and this change both touch the factor-floor area but are **separate mechanisms** — reviewer should confirm no interference. This ADR only removes the *bridge* reset door.

## Test results
- `bth-cluster-tax`: 454 passed, 0 failed (+ the calibration sim tests)
- `botho` lib: 1227 passed, 0 failed (incl. 6 new import-floor tests + updated version tests)
- `bth-bridge-service`: 209 + 5 passed, 0 failed (incl. updated release-tx tag test)
- `cargo build --workspace` clean; clippy clean on changed crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)