### PR TITLE
docs: add missing ADR 0006 row to decisions index

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -22,6 +22,7 @@ ADRs are immutable once accepted. If a decision changes, a new ADR supersedes th
 | [0003](0003-wbth-peg-factor-1-wrapping-and-demurrage-settlement.md) | wBTH Peg — Factor-1 Wrapping + Demurrage-Settlement On-ramp | Accepted | 2026-07-13 |
 | [0004](0004-bridge-privacy-semantics.md) | Bridge Privacy Semantics | Accepted | 2026-07-13 |
 | [0005](0005-bridge-v1-chain-scope-ethereum-and-solana.md) | Bridge v1 Chain Scope — Ethereum and Solana | Accepted | 2026-07-13 |
+| [0006](0006-pq-architecture-ratification.md) | Post-Quantum & Privacy Architecture Ratification | Accepted | 2026-07-14 |
 | [0007](0007-bridge-import-cluster-tagging.md) | Bridge-Import Cluster Tagging via Block-Epoch Keys | Accepted | 2026-07-14 |
 
 ## ADR Statuses


### PR DESCRIPTION
## Summary

The ADR index table in `docs/decisions/README.md` jumped from **0005** directly to **0007**, omitting the row for `0006-pq-architecture-ratification.md` (the ADR file exists in `docs/decisions/`).

This adds the single missing index row between 0005 and 0007. Title, status, and date were pulled directly from the ADR file's header (not guessed):

- **Title**: Post-Quantum & Privacy Architecture Ratification
- **Status**: Accepted
- **Date**: 2026-07-14

## Change

```
| [0006](0006-pq-architecture-ratification.md) | Post-Quantum & Privacy Architecture Ratification | Accepted | 2026-07-14 |
```

The index now reads 0005 → 0006 → 0007 with no other rows disturbed. `git diff` shows exactly one added line.

Pre-existing gap (not introduced by #946, which correctly added only the 0007 row). Docs-only, low priority.

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)