### PR TITLE
feat(consensus)!: price the demurrage class transition on deflating spends (#925)

### DIFF
--- a/botho/src/decoy_selection.rs
+++ b/botho/src/decoy_selection.rs
@@ -284,6 +284,66 @@ pub fn age_similarity_band(real_input_age: u64) -> (u64, u64) {
     (min_age, max_age)
 }
 
+/// Fixed-point scale for cluster factors (1000 = 1.0×, 6000 = 6.0×). Matches
+/// `bth_cluster_tax::ClusterFactorCurve::FACTOR_SCALE` and the demurrage
+/// kernel.
+pub const FACTOR_SCALE: u64 = 1_000;
+
+/// Maximum cluster factor in FACTOR_SCALE units (6.0×).
+pub const MAX_FACTOR_SCALED: u64 = 6 * FACTOR_SCALE;
+
+/// Factor-similarity policy: maximum relative spread, in basis points, of a
+/// selected decoy's cluster factor around the real input's factor
+/// (1000 bps = ±10%).
+///
+/// # Why this exists (issue #925, consensus-economic dependency of the #834 fix)
+///
+/// #925 prices a demurrage class DOWNGRADE: the consensus fee floor charges the
+/// capitalized future demurrage whenever a spend's declared output factor drops
+/// **below** the value-weighted ring-implied input floor
+/// (`bth_cluster_tax::spend_demurrage_charge`). For a genuine background (1×)
+/// spend the floor is exactly 1× ⇒ no downgrade ⇒ zero charge — but ONLY if the
+/// ring floor is exact. A single high-value **wealthy decoy** in a background
+/// spender's ring inflates the value-weighted floor above 1× and spuriously
+/// trips the downgrade charge (the honest-overcharge channel quantified in
+/// `docs/research/demurrage-downgrade-overcharge.md` §4.5: 8.3% false positives
+/// at just 1% contamination).
+///
+/// This band closes that channel at the wallet layer, exactly as
+/// [`AGE_SIMILARITY_SPREAD_BPS`] closes the age-dilution channel for the
+/// elapsed term: a spender draws only decoys whose cluster factor is within
+/// ±10% of its real input's factor, so a background spender draws only near-1×
+/// decoys and the ring floor stays exact.
+///
+/// # Why ±10% (docs/research/demurrage-downgrade-overcharge.md §4.6)
+///
+/// The band-width sweep (`downgrade_overcharge_sweep::factor_band_sweep`) shows
+/// the honest false-positive rate stays at **exactly 0%** for every band up to
+/// ±90% (the nearest wealthy class, 1.939×, only enters the band at ±100%),
+/// while the same-class background pool is retained at 100% at every width
+/// (factor is class-quantized, unlike continuous age). ±10% is adopted to match
+/// the established [`AGE_SIMILARITY_SPREAD_BPS`] convention with a ~9× safety
+/// margin to the first contaminating class, and it caps any in-band decoy's
+/// factor at 1.100× — so a worst-case admitted decoy can lift the floor by at
+/// most 10% of the 1× minimum. The gamma/OSPEAD age distribution and the
+/// [`AGE_SIMILARITY_SPREAD_BPS`] age band still apply WITHIN the factor band.
+pub const FACTOR_SIMILARITY_SPREAD: u64 = 1_000;
+
+/// Compute the inclusive `[min_factor, max_factor]` decoy-factor band around a
+/// real input's cluster factor under the [`FACTOR_SIMILARITY_SPREAD`] policy.
+///
+/// Mirrors [`age_similarity_band`]. Both bounds are clamped into the valid
+/// factor range `[FACTOR_SCALE, MAX_FACTOR_SCALED]`, so a background (1×) real
+/// input yields `[1000, 1100]` — admitting the whole background class while
+/// excluding every wealthy class.
+pub fn factor_similarity_band(real_input_factor: u64) -> (u64, u64) {
+    let f = real_input_factor.clamp(FACTOR_SCALE, MAX_FACTOR_SCALED);
+    let delta = (f as u128 * FACTOR_SIMILARITY_SPREAD as u128 / 10_000) as u64;
+    let min_factor = f.saturating_sub(delta).max(FACTOR_SCALE);
+    let max_factor = f.saturating_add(delta).min(MAX_FACTOR_SCALED);
+    (min_factor, max_factor)
+}
+
 /// An output candidate for decoy selection with age and cluster information.
 #[derive(Debug, Clone)]
 pub struct OutputCandidate {
@@ -295,6 +355,12 @@ pub struct OutputCandidate {
     pub age_blocks: u64,
     /// Cluster tags for this output (for cluster-aware selection)
     pub cluster_tags: ClusterTags,
+    /// The candidate's effective cluster factor in FACTOR_SCALE units
+    /// (1000 = 1×, 6000 = 6×), resolved by the wallet from the output's tags
+    /// against global per-cluster wealth. Drives the [`factor_similarity_band`]
+    /// filter (#925). Defaults to `FACTOR_SCALE` (1× / background) when
+    /// unknown.
+    pub effective_factor: u64,
 }
 
 impl OutputCandidate {
@@ -309,6 +375,7 @@ impl OutputCandidate {
             created_at: utxo.created_at,
             age_blocks,
             cluster_tags: ClusterTags::empty(),
+            effective_factor: FACTOR_SCALE,
         }
     }
 
@@ -324,12 +391,22 @@ impl OutputCandidate {
             created_at: utxo.created_at,
             age_blocks,
             cluster_tags,
+            effective_factor: FACTOR_SCALE,
         }
     }
 
     /// Add cluster tags to an existing candidate.
     pub fn with_cluster_tags(mut self, cluster_tags: ClusterTags) -> Self {
         self.cluster_tags = cluster_tags;
+        self
+    }
+
+    /// Set the candidate's effective cluster factor (FACTOR_SCALE units), used
+    /// by the [`factor_similarity_band`] decoy filter (#925). The wallet
+    /// resolves this from the output's cluster tags against global per-cluster
+    /// wealth via `bth_cluster_tax::ClusterFactorCurve`.
+    pub fn with_effective_factor(mut self, effective_factor: u64) -> Self {
+        self.effective_factor = effective_factor.clamp(FACTOR_SCALE, MAX_FACTOR_SCALED);
         self
     }
 
@@ -835,26 +912,64 @@ impl GammaDecoySelector {
         exclude_keys: &[[u8; 32]],
         rng: &mut R,
     ) -> Result<Vec<TxOutput>, DecoySelectionError> {
+        // #925 factor-similarity band: only draw decoys whose cluster factor is
+        // within ±FACTOR_SIMILARITY_SPREAD of the real input's factor, so a
+        // background (1×) spender draws only near-1× decoys and the consensus
+        // ring floor stays exact — a wealthy decoy would inflate the
+        // value-weighted floor and spuriously trip the #925 downgrade charge
+        // (docs/research/demurrage-downgrade-overcharge.md §4.5/§4.6). The band
+        // is applied ON TOP of the age + cluster-similarity filters; the gamma
+        // age distribution still applies within it.
+        let (min_factor, max_factor) = factor_similarity_band(real_input.effective_factor);
+        let in_factor_band = |c: &OutputCandidate| {
+            c.effective_factor >= min_factor && c.effective_factor <= max_factor
+        };
+
         // Filter candidates by:
         // 1. Minimum age
         // 2. Not excluded
-        // 3. Cluster similarity above threshold
+        // 3. Factor-similarity band (#925)
+        // 4. Cluster similarity above threshold
         let cluster_compatible: Vec<&OutputCandidate> = candidates
             .iter()
             .filter(|c| {
                 c.age_blocks >= MIN_DECOY_AGE_BLOCKS
                     && !exclude_keys.contains(&c.output.target_key)
+                    && in_factor_band(c)
                     && real_input.cluster_similarity(c) >= MIN_CLUSTER_SIMILARITY
             })
             .collect();
 
-        // If we have enough cluster-compatible candidates, use those
+        // If we have enough cluster-compatible, factor-banded candidates, use them
         if cluster_compatible.len() >= count {
             return self.select_from_pool(&cluster_compatible, count, exclude_keys, rng);
         }
 
-        // Fallback: relax cluster requirements but prefer similar ones
-        // This happens early in network life or with unusual cluster profiles
+        // Fallback 1: keep the factor band (it is consensus-economically
+        // load-bearing) but relax the cluster-similarity requirement.
+        let factor_banded: Vec<&OutputCandidate> = candidates
+            .iter()
+            .filter(|c| {
+                c.age_blocks >= MIN_DECOY_AGE_BLOCKS
+                    && !exclude_keys.contains(&c.output.target_key)
+                    && in_factor_band(c)
+            })
+            .collect();
+        if factor_banded.len() >= count {
+            return self.select_with_cluster_scoring(
+                &factor_banded,
+                count,
+                real_input,
+                exclude_keys,
+                rng,
+            );
+        }
+
+        // Fallback 2 (liveness): a sparse chain cannot supply `count` in-band
+        // decoys. Rather than fail the spend, relax the factor band and select
+        // from the full eligible pool. The #925 charge is liveness-safe (it only
+        // ever raises the fee floor), so a rare over-charge here is preferable to
+        // a stuck transaction — and the wallet can surface the higher fee.
         let eligible: Vec<&OutputCandidate> = candidates
             .iter()
             .filter(|c| {
@@ -1184,6 +1299,7 @@ mod tests {
             created_at: current_height.saturating_sub(age_blocks),
             age_blocks,
             cluster_tags: ClusterTags::empty(),
+            effective_factor: FACTOR_SCALE,
         }
     }
 
@@ -1204,6 +1320,7 @@ mod tests {
             created_at: current_height.saturating_sub(age_blocks),
             age_blocks,
             cluster_tags,
+            effective_factor: FACTOR_SCALE,
         }
     }
 
@@ -1842,5 +1959,107 @@ mod tests {
             high_sim > low_sim,
             "Matching cluster should have higher similarity"
         );
+    }
+
+    // =========================================================================
+    // Factor-similarity band tests (#925)
+    // =========================================================================
+
+    #[test]
+    fn test_factor_similarity_band_background() {
+        // A background (1×) real input admits [1000, 1100] — the whole
+        // background class, excluding every wealthy class.
+        let (lo, hi) = factor_similarity_band(FACTOR_SCALE);
+        assert_eq!(lo, 1_000);
+        assert_eq!(hi, 1_100);
+        // The nearest wealthy class (1.939× = 1939) is well outside the band.
+        assert!(1_939 > hi);
+    }
+
+    #[test]
+    fn test_factor_similarity_band_clamps() {
+        // Below-1× and above-6× inputs clamp into the valid factor range.
+        let (lo, _) = factor_similarity_band(0);
+        assert_eq!(lo, FACTOR_SCALE);
+        let (_, hi) = factor_similarity_band(u64::MAX);
+        assert_eq!(hi, MAX_FACTOR_SCALED);
+        // A mid-tier factor gets a symmetric ±10% band.
+        let (lo, hi) = factor_similarity_band(3_000);
+        assert_eq!(lo, 2_700);
+        assert_eq!(hi, 3_300);
+    }
+
+    #[test]
+    fn test_factor_band_excludes_wealthy_decoys_for_background_spender() {
+        // A background spender's ring must exclude a high-value wealthy decoy —
+        // exactly the §4.5 contamination the #925 charge would otherwise trip.
+        let selector = GammaDecoySelector::new();
+        let current_height = 100_000;
+        let mut real_key = [0u8; 32];
+        real_key[0] = 200;
+        // Background real input (factor 1×).
+        let real_input = make_candidate(real_key, 5_000, current_height);
+        assert_eq!(real_input.effective_factor, FACTOR_SCALE);
+
+        // Candidate pool: plenty of background (1×) decoys + a few wealthy ones.
+        let mut candidates = Vec::new();
+        for i in 0..15u8 {
+            let mut key = [0u8; 32];
+            key[0] = i;
+            candidates.push(make_candidate(key, 4_800 + i as u64 * 10, current_height));
+        }
+        for i in 0..5u8 {
+            let mut key = [0u8; 32];
+            key[0] = 100 + i;
+            // Wealthy decoy: factor 5.745× — the §4.5 contaminant.
+            candidates.push(
+                make_candidate(key, 4_800 + i as u64 * 10, current_height)
+                    .with_effective_factor(5_745),
+            );
+        }
+
+        let mut rng = rand::thread_rng();
+        let exclude = vec![real_key];
+        let decoys = selector
+            .select_decoys_cluster_aware(&candidates, 6, &real_input, &exclude, &mut rng)
+            .expect("selection succeeds with ample in-band background decoys");
+        assert_eq!(decoys.len(), 6);
+
+        // None of the selected decoys may be one of the wealthy keys (100..105):
+        // the factor band filtered them out, so the ring floor stays 1×.
+        for d in &decoys {
+            assert!(
+                d.target_key[0] < 100,
+                "a wealthy decoy leaked past the factor band"
+            );
+        }
+    }
+
+    #[test]
+    fn test_factor_band_liveness_fallback_when_pool_sparse() {
+        // If the in-band pool cannot supply `count`, selection still succeeds
+        // (liveness fallback), rather than failing the spend.
+        let selector = GammaDecoySelector::new();
+        let current_height = 100_000;
+        let mut real_key = [0u8; 32];
+        real_key[0] = 200;
+        let real_input = make_candidate(real_key, 5_000, current_height);
+
+        // Only wealthy candidates available (no in-band background decoys).
+        let candidates: Vec<OutputCandidate> = (0..8u8)
+            .map(|i| {
+                let mut key = [0u8; 32];
+                key[0] = i;
+                make_candidate(key, 4_800 + i as u64 * 10, current_height)
+                    .with_effective_factor(5_745)
+            })
+            .collect();
+
+        let mut rng = rand::thread_rng();
+        let exclude = vec![real_key];
+        let decoys = selector
+            .select_decoys_cluster_aware(&candidates, 6, &real_input, &exclude, &mut rng)
+            .expect("liveness fallback selects out-of-band decoys rather than failing");
+        assert_eq!(decoys.len(), 6);
     }
 }

--- a/botho/src/ledger/store.rs
+++ b/botho/src/ledger/store.rs
@@ -1759,11 +1759,21 @@ impl Ledger {
     /// consensus_floor(tx) = base_minimum_fee(tx_size, num_outputs, num_memos,
     ///                                        cluster_wealth,  // NO congestion
     ///                                        CONSENSUS_FEE_BASE)
-    ///                     + demurrage_charge(output_sum, floored_factor,
+    ///                     + spend_demurrage_charge(output_sum,
+    ///                                        floored_factor,  // composed input floor
+    ///                                        claimed_factor,  // declared output
     ///                                        ring_elapsed_quantile@max,
     ///                                        rate_bps(height), blocks_per_year)
     /// require: tx.fee >= consensus_floor(tx)
     /// ```
+    ///
+    /// where `spend_demurrage_charge = max(accrued_to_date, capitalized_reset)`
+    /// (issue #925): the capitalized term prices a genuine class downgrade
+    /// (`claimed_factor < floored_factor`) at capitalized future demurrage over
+    /// the shared `SETTLEMENT_HORIZON_BLOCKS`, closing the #834
+    /// background-reset leak. It is zero for in-class and
+    /// background→background spends, so it only ever raises the floor on an
+    /// actual downgrade.
     ///
     /// # Why this is a pure function of block + chain state (design #574 Q5)
     ///
@@ -1918,9 +1928,23 @@ impl Ledger {
         let import_floor = self.import_floor_factor_from_outputs(&tx.outputs)?;
         let demurrage_factor = demurrage_factor.max(import_floor);
 
-        let demurrage = bth_cluster_tax::demurrage_charge(
+        // #925 (background-reset leak, #834): total demurrage is
+        // `max(accrued_to_date, capitalized_reset_charge)`. The capitalized term
+        // prices a genuine class DOWNGRADE — the spender-declared output factor
+        // `claimed_factor` dropping below the composed input-class floor
+        // `demurrage_factor` (ring-centroid B2 + ADR-0007 import floor) — at
+        // capitalized future demurrage over the shared
+        // `SETTLEMENT_HORIZON_BLOCKS`, mirroring #831's settlement charge. It
+        // fires ONLY on a downgrade (`claimed_factor < demurrage_factor`); an
+        // in-class or background→background spend has `claimed_factor ==
+        // demurrage_factor` ⇒ zero capitalized, so honest holds pay only their
+        // accrued-to-date demurrage exactly as before. The young-coin exploit
+        // (elapsed ≈ 0 ⇒ accrued ≈ 0) is now caught by the capitalized term.
+        // Pure integer math; only ever RAISES the floor (liveness-safe).
+        let demurrage = bth_cluster_tax::spend_demurrage_charge(
             output_sum,
             demurrage_factor,
+            claimed_factor,
             elapsed,
             policy.demurrage_rate_bps(block_height),
             blocks_per_year,
@@ -5250,6 +5274,180 @@ mod tests {
             floor > base_only,
             "the wealthy ring's implied factor must floor the background claim and \
              charge demurrage (floor={floor}, base={base_only})"
+        );
+    }
+
+    /// Recompute the pure base minimum fee (no demurrage) for a tx, so a test
+    /// can isolate the demurrage contribution of the consensus floor.
+    #[cfg(test)]
+    fn base_only_fee(ledger: &Ledger, tx: &BothoTransaction) -> u64 {
+        use bth_cluster_tax::{FeeConfig, TransactionType};
+        let fc = FeeConfig::default();
+        let cw = ledger
+            .effective_cluster_wealth_from_outputs(&tx.outputs)
+            .unwrap();
+        fc.minimum_fee_dynamic_with_outputs(
+            TransactionType::Hidden,
+            tx.estimate_size(),
+            cw,
+            tx.outputs.len(),
+            tx.outputs.iter().filter(|o| o.has_memo()).count(),
+            CONSENSUS_FEE_BASE,
+        )
+    }
+
+    /// #925: spending a YOUNG wealthy coin to a background output — the #834
+    /// background-reset exploit — is now PRICED at the capitalized reset even
+    /// though the accrued-to-date demurrage is ≈0 (elapsed ≈ 0). This is the
+    /// consensus analog of `demurrage_background_reset_leak_is_real`.
+    #[test]
+    fn consensus_fee_floor_prices_young_wealthy_to_background_downgrade() {
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        // Wealthy cluster 7 (10M BTH in picocredits).
+        ledger
+            .set_cluster_wealth_for_test(7, 10_000_000_000_000_000_000)
+            .unwrap();
+
+        // Demurrage active (past the halving interval).
+        let block_height = 8_000_000u64;
+        // The real input is YOUNG: created at the current height (age 0), and
+        // wealthy (tagged to cluster 7). Fresh wealthy decoys too — the whole
+        // ring is young.
+        let mut specs = vec![(100_000_000u64, block_height, 7u64, 70u8)];
+        for i in 0..10u8 {
+            specs.push((100_000_000, block_height, 7, 71 + i));
+        }
+        let ring = seed_ring_utxos(&ledger, &specs);
+        // Output: fully background (the deflating downgrade).
+        let output_sum = 90_000_000u64;
+        let outputs = vec![mk_tagged_output(output_sum, 140, ClusterTagVector::empty())];
+        let tx = mk_transfer_tx(ring, outputs, 0);
+
+        let floor = ledger.consensus_fee_floor(&tx, block_height).unwrap();
+        let base_only = base_only_fee(&ledger, &tx);
+        let demurrage = floor - base_only;
+
+        assert!(
+            demurrage > 0,
+            "the young-wealthy→background downgrade must be priced (leak closed): \
+             demurrage={demurrage}"
+        );
+
+        // The charge equals the capitalized reset over SETTLEMENT_HORIZON_BLOCKS,
+        // computed from the same public inputs.
+        let policy = crate::monetary::mainnet_policy();
+        let rate = policy.demurrage_rate_bps(block_height);
+        let bpy = (365 * 24 * 60 * 60) / policy.target_block_time_secs.max(1);
+        let curve = bth_cluster_tax::ClusterFactorCurve::default_params();
+        let floor_factor =
+            bth_cluster_tax::ring_centroid_implied_factor(&[(output_sum, 10u128.pow(19))], &curve);
+        assert_eq!(floor_factor, 5745, "10M-BTH cluster floors at 5.745×");
+        let expected = bth_cluster_tax::capitalized_reset_charge(
+            output_sum,
+            floor_factor,
+            bth_cluster_tax::demurrage::FACTOR_SCALE, // background 1× declared
+            bth_cluster_tax::SETTLEMENT_HORIZON_BLOCKS,
+            rate,
+            bpy,
+        );
+        assert_eq!(
+            demurrage, expected,
+            "downgrade charge must equal the capitalized reset ({expected})"
+        );
+
+        // Determinism: proposer and validators recompute the identical verdict.
+        let again = ledger.consensus_fee_floor(&tx, block_height).unwrap();
+        assert_eq!(floor, again, "consensus floor must be deterministic");
+    }
+
+    /// #925 no-over-charge: an honest background→background spend (declared 1×
+    /// over a background ring) incurs ZERO downgrade charge — the floor is 1×
+    /// on both sides, so there is nothing to price. Honest commerce is
+    /// untouched.
+    #[test]
+    fn consensus_fee_floor_honest_background_spend_has_zero_downgrade_charge() {
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        let block_height = 8_000_000u64;
+        // Background ring (cluster 0 = untagged) + background output.
+        let ring = seed_ring_utxos(
+            &ledger,
+            &[(100_000_000, 0, 0, 50), (100_000_000, 10, 0, 51)],
+        );
+        let outputs = vec![mk_tagged_output(90_000_000, 150, ClusterTagVector::empty())];
+        let tx = mk_transfer_tx(ring, outputs, 0);
+
+        let floor = ledger.consensus_fee_floor(&tx, block_height).unwrap();
+        let base_only = base_only_fee(&ledger, &tx);
+        assert_eq!(
+            floor, base_only,
+            "an honest background spend pays zero demurrage (floor==base): \
+             floor={floor}, base={base_only}"
+        );
+    }
+
+    /// #925 max-form: an honest OLD in-class wealthy spend pays its
+    /// accrued-to-date demurrage, NOT the (larger) capitalized reset — the
+    /// `max(accrued, capitalized)` form never over-charges an in-class hold
+    /// because there is no downgrade (capitalized term is 0).
+    #[test]
+    fn consensus_fee_floor_honest_inclass_wealthy_pays_accrued_not_capitalized() {
+        let dir = tempdir().unwrap();
+        let ledger = Ledger::open(dir.path()).unwrap();
+        ledger
+            .set_cluster_wealth_for_test(8, 10_000_000_000_000_000_000)
+            .unwrap();
+        let block_height = 8_000_000u64;
+        // OLD wealthy ring (created at height 0 → age 8M blocks), spent IN-CLASS
+        // (output tagged to the same wealthy cluster 8).
+        let ring = seed_ring_utxos(&ledger, &[(100_000_000, 0, 8, 60), (100_000_000, 0, 8, 61)]);
+        let output_sum = 90_000_000u64;
+        let outputs = vec![mk_tagged_output(
+            output_sum,
+            160,
+            ClusterTagVector::from_pairs(&[(
+                bth_transaction_types::ClusterId(8),
+                TAG_WEIGHT_SCALE,
+            )]),
+        )];
+        let tx = mk_transfer_tx(ring, outputs, 0);
+
+        let floor = ledger.consensus_fee_floor(&tx, block_height).unwrap();
+        let base_only = base_only_fee(&ledger, &tx);
+        let demurrage = floor - base_only;
+
+        let policy = crate::monetary::mainnet_policy();
+        let rate = policy.demurrage_rate_bps(block_height);
+        let bpy = (365 * 24 * 60 * 60) / policy.target_block_time_secs.max(1);
+        let elapsed = bth_cluster_tax::ring_elapsed_quantile(
+            &[(100_000_000, 0), (100_000_000, 0)],
+            block_height,
+            CONSENSUS_RING_AGE_QUANTILE_BPS,
+        );
+        // In-class: floor factor == declared factor == 5745, so the accrued term
+        // is charged and the capitalized (downgrade) term is exactly 0.
+        let accrued = bth_cluster_tax::demurrage_charge(output_sum, 5745, elapsed, rate, bpy);
+        assert_eq!(
+            demurrage, accrued,
+            "an in-class hold pays only accrued-to-date demurrage: \
+             demurrage={demurrage}, accrued={accrued}"
+        );
+        // And that accrued (8M blocks ≈ 1.27yr) is strictly below the 5yr
+        // capitalized reset a downgrade would have cost — proving `max` picked
+        // the smaller, honest obligation.
+        let capitalized = bth_cluster_tax::capitalized_reset_charge(
+            output_sum,
+            5745,
+            bth_cluster_tax::demurrage::FACTOR_SCALE,
+            bth_cluster_tax::SETTLEMENT_HORIZON_BLOCKS,
+            rate,
+            bpy,
+        );
+        assert!(
+            accrued < capitalized,
+            "the honest accrued charge {accrued} must be below the capitalized reset \
+             {capitalized} it is NOT charged"
         );
     }
 

--- a/botho/src/mempool.rs
+++ b/botho/src/mempool.rs
@@ -812,9 +812,17 @@ impl Mempool {
                 10_000, // quantile_bps = 10000 == max
             );
             let blocks_per_year = (365 * 24 * 60 * 60) / policy.target_block_time_secs.max(1);
-            bth_cluster_tax::demurrage_charge(
+            // #925: mirror the consensus fee floor's downgrade pricing exactly so
+            // relay never admits a tx below what block validation requires (the
+            // relay-only-tightening invariant asserted below). Same
+            // `spend_demurrage_charge = max(accrued, capitalized_reset)` kernel,
+            // same `demurrage_factor` (composed input floor) and `claimed_factor`
+            // (declared output), so the demurrage term is byte-identical to
+            // `Ledger::consensus_fee_floor`.
+            bth_cluster_tax::spend_demurrage_charge(
                 output_sum,
                 demurrage_factor,
+                claimed_factor,
                 elapsed,
                 policy.demurrage_rate_bps(chain_height),
                 blocks_per_year,
@@ -2394,9 +2402,13 @@ mod tests {
         let chain_height = ledger.get_chain_state().map(|s| s.height).unwrap_or(0);
         let elapsed = bth_cluster_tax::ring_elapsed_quantile(&ring_members, chain_height, 10_000);
         let blocks_per_year = (365 * 24 * 60 * 60) / policy.target_block_time_secs.max(1);
-        let demurrage = bth_cluster_tax::demurrage_charge(
+        // Mirror the mempool's real demurrage term (#925): the downgrade-aware
+        // `spend_demurrage_charge`, so this helper stays in lockstep with both
+        // `Mempool::validate_transaction` and `Ledger::consensus_fee_floor`.
+        let demurrage = bth_cluster_tax::spend_demurrage_charge(
             output_sum,
             demurrage_factor,
+            claimed_factor,
             elapsed,
             policy.demurrage_rate_bps(chain_height),
             blocks_per_year,

--- a/botho/src/network/discovery.rs
+++ b/botho/src/network/discovery.rs
@@ -121,7 +121,20 @@ use crate::{
 /// index is built from genesis). Interacts with #925 (the remaining spend-to-
 /// background reset door) only in that both touch the factor-floor area; they
 /// are SEPARATE mechanisms.
-pub const PROTOCOL_VERSION: &str = "5.0.0";
+/// PROTOCOL 6.0.0 (#925, background-reset leak): the consensus fee floor now
+/// prices a demurrage class DOWNGRADE — a spend whose declared output factor
+/// drops below the composed ring-implied input floor — at capitalized future
+/// demurrage over `SETTLEMENT_HORIZON_BLOCKS` (`max(accrued,
+/// capitalized_reset)` via `bth_cluster_tax::spend_demurrage_charge`), routed
+/// to the lottery pool. This closes the last domestic reset door (spend
+/// young-wealthy → background paid ≈0). It is CONSENSUS-BREAKING: a 5.x peer
+/// charges only accrued-to-date demurrage and would accept/produce blocks whose
+/// deflating spends the 6.0.0 chain now requires to pay the higher downgrade
+/// floor, so the two fork. MAJOR bump (`is_consensus_compatible` is major-only)
+/// with `MIN_SUPPORTED_PROTOCOL_VERSION` rising to 6.0.0 in lockstep
+/// (pre-mainnet testnet reset). Shares the single `SETTLEMENT_HORIZON_BLOCKS`
+/// dial with #831.
+pub const PROTOCOL_VERSION: &str = "6.0.0";
 
 /// Minimum supported protocol version.
 /// Peers below this version are consensus-incompatible and are disconnected.
@@ -140,7 +153,12 @@ pub const PROTOCOL_VERSION: &str = "5.0.0";
 /// floor (#938): 4.x peers apply no import floor and would fork the
 /// import-tagged/floored chain, so they must be disconnected (major-only
 /// check).
-pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "5.0.0";
+///
+/// Raised to 6.0.0 for the #925 downgrade-charge consensus rule: 5.x peers
+/// price only accrued-to-date demurrage and would fork the chain that now
+/// charges the capitalized reset on deflating spends, so they must be
+/// disconnected.
+pub const MIN_SUPPORTED_PROTOCOL_VERSION: &str = "6.0.0";
 
 /// Topic for block announcements
 const BLOCKS_TOPIC: &str = "botho/blocks/1.0.0";
@@ -2221,11 +2239,31 @@ mod tests {
         // the >=F import floor (#938): a consensus-breaking fee-floor rule.
         // MAJOR (not minor) because `is_consensus_compatible` is major-only, so
         // a minor bump would leave 4.x peers connected and silently forking.
-        assert_eq!(PROTOCOL_VERSION, "5.0.0");
+        //
+        // Bumped to 6.0.0 (MAJOR) for the #925 downgrade charge: the consensus
+        // fee floor now prices a demurrage class downgrade at capitalized future
+        // demurrage, another consensus-breaking fee-floor rule. MAJOR so 5.x
+        // peers (accrued-only) are disconnected rather than left forking.
+        assert_eq!(PROTOCOL_VERSION, "6.0.0");
         let parsed = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
-        assert_eq!(parsed.major, 5);
+        assert_eq!(parsed.major, 6);
         assert_eq!(parsed.minor, 0);
         assert_eq!(parsed.patch, 0);
+    }
+
+    /// #925 is a consensus-breaking MAJOR bump (5.x → 6.0.0): 5.x peers price
+    /// only accrued-to-date demurrage and would silently fork the chain that
+    /// now charges the capitalized downgrade reset, so they must be
+    /// DISCONNECTED.
+    #[test]
+    fn test_v5_peers_are_consensus_incompatible_after_issue_925() {
+        let local = ProtocolVersion::parse(PROTOCOL_VERSION).unwrap();
+        let v5_peer = ProtocolVersion::parse("5.0.0").unwrap();
+        assert!(!v5_peer.is_consensus_compatible(&local));
+        assert_eq!(
+            ProtocolVersion::consensus_incompatibility(&Some(v5_peer.clone()), &local),
+            Some(v5_peer)
+        );
     }
 
     /// ADR 0007 (#938) is a consensus-breaking MAJOR bump (4.x → 5.0.0), so 4.x
@@ -2244,9 +2282,9 @@ mod tests {
 
     #[test]
     fn test_min_supported_protocol_version_constant() {
-        assert_eq!(MIN_SUPPORTED_PROTOCOL_VERSION, "5.0.0");
+        assert_eq!(MIN_SUPPORTED_PROTOCOL_VERSION, "6.0.0");
         let parsed = ProtocolVersion::parse(MIN_SUPPORTED_PROTOCOL_VERSION).unwrap();
-        assert_eq!(parsed.major, 5);
+        assert_eq!(parsed.major, 6);
         assert_eq!(parsed.minor, 0);
     }
 

--- a/cluster-tax/src/demurrage.rs
+++ b/cluster-tax/src/demurrage.rs
@@ -43,15 +43,25 @@
 //! fully background-tagged output (legal deflation under
 //! `check_cluster_tag_inheritance`, which only rejects inflation), pay ≈0, and
 //! land a genuinely-background coin whose future ring floor is 1× — escaping
-//! all FUTURE stock-level demurrage. This is a real, unpriced future-demurrage
-//! leak, demonstrated by [`tests::demurrage_background_reset_leak_is_real`] and
-//! written up in `docs/research/demurrage-background-reset-leak.md`. It mirrors
-//! exactly the escape #831's settlement op closes for the wrapping on-ramp: the
-//! settlement op prices the same class transition by charging *capitalized
-//! future* demurrage (ADR 0003), whereas an ordinary spend charges only
-//! *accrued-to-date* demurrage. The proposed on-chain fix (price the class
-//! transition = charge capitalized future demurrage on deflation) is tracked as
-//! a mainnet blocker in issue #925.
+//! all FUTURE stock-level demurrage. This was a real, unpriced future-demurrage
+//! leak (issue #834, write-up in
+//! `docs/research/demurrage-background-reset-leak.md`).
+//!
+//! ### The fix (#925): price the class transition
+//!
+//! [`spend_demurrage_charge`] closes the leak by charging
+//! `max(accrued_to_date, capitalized_reset_charge)` on every spend. The
+//! capitalized term ([`capitalized_reset_charge`]) prices the permanent exit
+//! from a wealth class at *capitalized future* demurrage over the shared
+//! [`SETTLEMENT_HORIZON_BLOCKS`], mirroring exactly the escape #831's
+//! settlement op closes for the wrapping on-ramp (ADR 0003). Because it keys
+//! strictly off an actual downgrade relative to the ring floor, an honest hold
+//! spent at its true class pays only its accrued demurrage, and a genuine
+//! background→ background spend (floor 1× on both sides) pays zero — but the
+//! young-coin exploit, whose `elapsed ≈ 0` zeroed the accrued term, now pays
+//! the full capitalized reset.
+//! [`tests::demurrage_background_reset_leak_is_real`] asserts the priced
+//! transition.
 //!
 //! ## Determinism
 //!
@@ -115,6 +125,141 @@ pub fn demurrage_charge(
     let charge = charge.saturating_mul(time_fraction) / TIME_SCALE;
 
     u64::try_from(charge).unwrap_or(u64::MAX)
+}
+
+/// Blocks per year at the 5s reference block time (`31_536_000 s / 5 s`).
+/// Matches `mainnet_policy().target_block_time_secs = 5` and the simulation
+/// sweeps (`settlement_horizon_sweep`, `downgrade_overcharge_sweep`).
+pub const BLOCKS_PER_YEAR_5S: u64 = 6_307_200;
+
+/// Shared capitalization horizon for a **permanent exit from the demurrage
+/// regime** (ADR 0003 / issue #833).
+///
+/// Both escape doors read this ONE constant so neither is a cheaper route than
+/// the other:
+///
+/// - #831's opt-in **settlement op** (wrap wealthy → factor-1, then bridge
+///   out).
+/// - #925's automatic **downgrade charge** (spend wealthy → background output),
+///   priced by [`spend_demurrage_charge`] / [`capitalized_reset_charge`].
+///
+/// = **5 years** at the 5s reference block time (`5 × BLOCKS_PER_YEAR_5S` =
+/// `31_536_000`). Calibrated in
+/// `docs/research/settlement-horizon-calibration.md`: 5yr is the only swept
+/// horizon that keeps the residual redistribution gain above the 0.05 design
+/// floor even if the entire top decile exits at once, while keeping the
+/// wrap/downgrade cost a 1.9%–9.5% friction rather than a wall. A single shared
+/// horizon prevents the cheaper door from dominating (calibration doc §6); if a
+/// future need to diverge the two arises it must be its own ADR.
+pub const SETTLEMENT_HORIZON_BLOCKS: u64 = 5 * BLOCKS_PER_YEAR_5S; // 31_536_000
+
+/// Capitalized future-demurrage charge for a demurrage-class **downgrade** —
+/// the base-layer analog of #831's settlement charge (issue #925).
+///
+/// Prices the permanent exit from a wealth class on a deflating spend: the
+/// **net** capitalized future demurrage escaped by declaring an output at
+/// `output_factor` when the input's true class floor — the ring-implied /
+/// import-composed factor the spender cannot rewrite — is `input_floor_factor`:
+///
+/// ```text
+/// if output_factor < input_floor_factor {
+///     demurrage_charge(value, input_floor_factor, horizon)
+///         - demurrage_charge(value, output_factor, horizon)
+/// } else { 0 }   // in-class or inflation ⇒ nothing to price
+/// ```
+///
+/// Reuses [`demurrage_charge`] verbatim (no second charge model). A genuine
+/// background→background spend floors at 1× on both sides ⇒ `1000 < 1000` is
+/// false ⇒ zero charge, so honest commerce is never touched. Keyed strictly off
+/// an actual downgrade relative to the ring floor, so it fires only on the
+/// young-coin exploit the accrued-to-date term misses.
+///
+/// # Determinism
+/// CONSENSUS-CRITICAL: pure integer arithmetic (two [`demurrage_charge`] calls
+/// and a saturating subtraction). Liveness-safe: only ever raises the fee
+/// floor.
+pub fn capitalized_reset_charge(
+    transfer_value: u64,
+    input_floor_factor: u64,
+    output_factor: u64,
+    horizon_blocks: u64,
+    rate_bps: u32,
+    blocks_per_year: u64,
+) -> u64 {
+    if output_factor >= input_floor_factor {
+        return 0;
+    }
+    let at_floor = demurrage_charge(
+        transfer_value,
+        input_floor_factor,
+        horizon_blocks,
+        rate_bps,
+        blocks_per_year,
+    );
+    let at_output = demurrage_charge(
+        transfer_value,
+        output_factor,
+        horizon_blocks,
+        rate_bps,
+        blocks_per_year,
+    );
+    at_floor.saturating_sub(at_output)
+}
+
+/// Total demurrage owed on a spend under #925: the greater of accrued-to-date
+/// demurrage and the capitalized charge for a class downgrade.
+///
+/// ```text
+/// charge = max(
+///     demurrage_charge(value, input_floor_factor, elapsed, ...),        // accrued-to-date
+///     capitalized_reset_charge(value, input_floor_factor, output_factor,
+///                              SETTLEMENT_HORIZON_BLOCKS, ...),          // priced class exit
+/// )
+/// ```
+///
+/// This is the **load-bearing formula** from the #925 verdict
+/// (`docs/research/demurrage-background-reset-leak.md`): an honest hold spent
+/// at its true class pays its real accrued demurrage (the capitalized term is 0
+/// because there is no downgrade), while the young-coin exploit — which drives
+/// `elapsed ≈ 0` so accrued ≈ 0 — is caught by the capitalized term. The `max`
+/// (not a sum) guarantees the charge never exceeds the larger of the two
+/// obligations, so it never over-charges an honest spend and stays symmetric
+/// with #831's opt-in settlement price (capitalized future demurrage over the
+/// same [`SETTLEMENT_HORIZON_BLOCKS`]).
+///
+/// `input_floor_factor` is the composed ring floor the spender cannot rewrite
+/// (`max(claimed, ring_centroid_implied_factor, import_floor)`),
+/// `output_factor` is the spender-declared output factor. A downgrade is
+/// exactly `output_factor < input_floor_factor`; a background→background spend
+/// floors at 1× on both sides and pays zero.
+///
+/// # Determinism
+/// CONSENSUS-CRITICAL: pure integer arithmetic. Liveness-safe: only ever raises
+/// the fee floor, never false-rejects a valid spend.
+pub fn spend_demurrage_charge(
+    transfer_value: u64,
+    input_floor_factor: u64,
+    output_factor: u64,
+    elapsed_blocks: u64,
+    rate_bps: u32,
+    blocks_per_year: u64,
+) -> u64 {
+    let accrued = demurrage_charge(
+        transfer_value,
+        input_floor_factor,
+        elapsed_blocks,
+        rate_bps,
+        blocks_per_year,
+    );
+    let capitalized = capitalized_reset_charge(
+        transfer_value,
+        input_floor_factor,
+        output_factor,
+        SETTLEMENT_HORIZON_BLOCKS,
+        rate_bps,
+        blocks_per_year,
+    );
+    accrued.max(capitalized)
 }
 
 /// Compute the value-weighted elapsed-blocks centroid for a set of ring
@@ -613,29 +758,26 @@ mod tests {
         assert_eq!(one_year, half * 2);
     }
 
-    /// REGRESSION / EVIDENCE (issue #834): a wealthy holder can reset a coin's
-    /// demurrage class to background via an ordinary spend, paying ≈0 and
-    /// escaping ALL future stock-level demurrage.
+    /// REGRESSION (issue #834 → fix #925): the wealthy-holder class-reset
+    /// escape is now **priced**. A holder who spends a young wealthy coin
+    /// to a background output no longer pays ≈0 —
+    /// [`spend_demurrage_charge`] charges the capitalized reset (the same
+    /// capitalized future demurrage #831's settlement op charges), so the
+    /// class transition costs the full price.
     ///
-    /// This test walks the exact suspect sequence and ASSERTS the observed
-    /// charges at each step. It is the executable answer to issue #834:
-    /// **the leak is real.** The full write-up is in
+    /// This test walks the exact former-leak sequence and ASSERTS the new
+    /// priced charge at the deflating step. It is the executable proof that
+    /// the fix closes the #834 leak. The full write-up is in
     /// `docs/research/demurrage-background-reset-leak.md`.
     ///
     /// The mechanism reproduced here is the consensus fee-floor demurrage term
     /// (`Ledger::consensus_fee_floor` in `botho/src/ledger/store.rs`):
-    /// `demurrage_charge(output_sum, max(claimed_factor, ring_implied),
-    /// elapsed@max, rate, bpy)`. This test drives the two pure pieces that
-    /// path composes — [`ring_centroid_implied_factor`] (the factor floor
-    /// the spender cannot rewrite) and [`demurrage_charge`] (the
-    /// accrued-time charge) — so the numbers are the real consensus
-    /// numbers, not a re-derivation.
-    ///
-    /// If a future fix prices the class transition (e.g. charging capitalized
-    /// future demurrage on deflation, mirroring #831's settlement charge), the
-    /// `spend#1` assertion below will start failing — which is the intended
-    /// signal that the leak is closed. Update this test at that point to assert
-    /// the new priced-transition charge.
+    /// `spend_demurrage_charge(output_sum, floor_factor, output_factor,
+    /// elapsed@max, rate, bpy)`, which composes
+    /// [`ring_centroid_implied_factor`] (the factor floor the spender
+    /// cannot rewrite), [`demurrage_charge`] (the accrued-time charge) and
+    /// [`capitalized_reset_charge`] (the priced class exit) — so the
+    /// numbers are the real consensus numbers, not a re-derivation.
     #[test]
     fn demurrage_background_reset_leak_is_real() {
         use crate::ClusterFactorCurve;
@@ -649,88 +791,113 @@ mod tests {
         let output_sum: u64 = 1_000 * PICO_PER_BTH as u64;
 
         // --- Baseline: what an HONEST wealthy holder pays if they simply hold
-        //     the coin for a year and then spend it (no class reset). The ring
-        //     is composed of members carrying the wealthy cluster's public,
-        //     inherited tags, so the implied factor floor is high; the coin is
-        //     one year old, so elapsed = BLOCKS_PER_YEAR.
+        //     the coin for a year and then spend it IN-CLASS (no downgrade). The
+        //     ring members carry the wealthy cluster's public tags, so the
+        //     implied factor floor is high; the coin is one year old, so
+        //     elapsed = BLOCKS_PER_YEAR. Spent in-class, the capitalized term is
+        //     0 and the holder pays only the accrued-to-date demurrage.
         let wealthy_ring = [(output_sum, wealthy_cluster_wealth)];
         let wealthy_factor = ring_centroid_implied_factor(&wealthy_ring, &curve);
         assert_eq!(
             wealthy_factor, 5745,
             "10M-BTH cluster maps to factor 5.745x (observed floor)"
         );
-        let honest_annual_charge = demurrage_charge(
+        let honest_annual_charge = spend_demurrage_charge(
             output_sum,
-            wealthy_factor,
+            wealthy_factor, // input floor
+            wealthy_factor, // output declared in-class => no downgrade
             BLOCKS_PER_YEAR,
             rate_bps,
             BLOCKS_PER_YEAR,
         );
         assert_eq!(
             honest_annual_charge, 18_980_000_000_000,
-            "honest wealthy holder pays ~18.98 BTH/yr on a 1000-BTH coin (in pico)"
+            "honest in-class wealthy holder pays ~18.98 BTH/yr on a 1000-BTH coin (accrued only)"
         );
 
-        // --- Step 1 of the attack: the whale first re-spends the wealthy coin
+        // --- Step 1 of the former attack: the whale re-spends the wealthy coin
         //     wealthy->wealthy to RESET its creation height (standard UTXO
-        //     behavior: a new output's created_at = the current block). This
-        //     pays the accrued charge for however long it had sat — but the
-        //     whale times it so the coin is spent again immediately, so the
-        //     age it must pay for at Step 2 is ~0. We model the post-reset coin
-        //     as elapsed = 0.
+        //     behavior). It times Step 2 to follow immediately, so the age it
+        //     must pay for at Step 2 is ~0. We model the post-reset coin as
+        //     elapsed = 0.
 
-        // --- Step 2 (the leak): spend the now-YOUNG wealthy coin to a fully
-        //     background-tagged output. `check_cluster_tag_inheritance` permits
-        //     this (deflation is legal; only inflation is rejected). The ring
-        //     floor still raises the factor to the wealthy 5745 — but demurrage
-        //     is proportional to elapsed, and elapsed ≈ 0, so the charge is 0.
+        // --- Step 2 (formerly THE LEAK, now PRICED): spend the now-YOUNG wealthy
+        //     coin to a fully background-tagged output. The ring floor raises the
+        //     input factor to the wealthy 5745 while the declared output factor
+        //     is 1x — a genuine class DOWNGRADE. `spend_demurrage_charge` now
+        //     charges the capitalized reset for the shed mass even though the
+        //     accrued-to-date term is ~0 (elapsed ≈ 0).
         let young_elapsed = 0u64;
-        let reset_spend_charge = demurrage_charge(
+        let output_declared_factor = FACTOR_SCALE; // background 1x claim
+        let reset_spend_charge = spend_demurrage_charge(
             output_sum,
-            wealthy_factor, // ring floor IS applied — factor is high...
-            young_elapsed,  // ...but elapsed is ~0, so it does nothing.
+            wealthy_factor,         // input floor (ring-implied, unrewritable)
+            output_declared_factor, // declared background => downgrade
+            young_elapsed,          // accrued term ≈ 0 ...
+            rate_bps,
+            BLOCKS_PER_YEAR,
+        );
+        // The charge equals the capitalized reset over the 5-year settlement
+        // horizon: by linearity that is exactly 5 × one honest year at the floor.
+        let expected_capitalized = capitalized_reset_charge(
+            output_sum,
+            wealthy_factor,
+            output_declared_factor,
+            SETTLEMENT_HORIZON_BLOCKS,
             rate_bps,
             BLOCKS_PER_YEAR,
         );
         assert_eq!(
-            reset_spend_charge, 0,
-            "THE LEAK: spending a young wealthy coin to background pays ZERO \
-             demurrage despite the ring floor raising the factor to {wealthy_factor}"
+            reset_spend_charge, expected_capitalized,
+            "the priced downgrade charge must equal the capitalized reset"
+        );
+        assert_eq!(
+            reset_spend_charge, 94_900_000_000_000,
+            "THE FIX: spending a young wealthy coin to background now costs the capitalized \
+             reset = 5 × the honest annual ({honest_annual_charge}), i.e. ~94.9 BTH"
+        );
+        assert_eq!(
+            reset_spend_charge,
+            honest_annual_charge * 5,
+            "capitalized over the 5yr horizon = 5 years of accrued demurrage, up front"
+        );
+        assert!(
+            reset_spend_charge > 0,
+            "the class transition is no longer free (leak closed)"
         );
 
         // --- After the reset: the output genuinely carries background tags, so
-        //     future rings composed of background members imply factor 1x.
+        //     future rings composed of background members imply factor 1x. A
+        //     genuine background→background spend floors at 1x on BOTH sides,
+        //     so there is no downgrade to price and the charge is zero — honest
+        //     commerce is never touched.
         let background_ring = [(output_sum, 0u128)];
         let background_factor = ring_centroid_implied_factor(&background_ring, &curve);
         assert_eq!(
             background_factor, FACTOR_SCALE,
             "the reset coin's ring floor is now 1x (background)"
         );
-
-        // --- Future demurrage on the reset coin: ZERO, forever, no matter how
-        //     long it is held. The stock-level charge the mechanism is designed
-        //     to extract has been fully escaped.
-        let future_charge_one_year = demurrage_charge(
+        let future_charge_one_year = spend_demurrage_charge(
             output_sum,
-            background_factor,
+            background_factor, // input floor 1x
+            background_factor, // output 1x => no downgrade
             BLOCKS_PER_YEAR,
             rate_bps,
             BLOCKS_PER_YEAR,
         );
         assert_eq!(
             future_charge_one_year, 0,
-            "escaped: the reset background coin pays zero demurrage even held a full year, \
-             vs the honest {honest_annual_charge} it would owe as a wealthy coin"
+            "an honest background->background spend pays zero: floor 1x on both sides"
         );
 
-        // --- The bottom line: total demurrage paid to shed the wealthy class is
-        //     0, while the priced exit (#831's settlement op) would charge the
-        //     capitalized future demurrage. The gap between these is the leak.
-        let total_paid_to_escape = reset_spend_charge + future_charge_one_year;
-        assert_eq!(total_paid_to_escape, 0);
+        // --- The bottom line: shedding the wealthy class now costs the full
+        //     capitalized reset up front (symmetric with #831's settlement op),
+        //     which strictly exceeds the honest single-year accrued charge. The
+        //     free exit is closed.
         assert!(
-            honest_annual_charge > total_paid_to_escape,
-            "an unpriced class transition strictly undercuts holding: {honest_annual_charge} > {total_paid_to_escape}"
+            reset_spend_charge > honest_annual_charge,
+            "the priced class transition now costs MORE than one honest year: \
+             {reset_spend_charge} > {honest_annual_charge}"
         );
     }
 }

--- a/cluster-tax/src/lib.rs
+++ b/cluster-tax/src/lib.rs
@@ -101,7 +101,9 @@ pub use crypto::{
     MIN_ENTROPY_THRESHOLD_SCALED,
 };
 pub use demurrage::{
-    demurrage_charge, ring_centroid_implied_factor, ring_elapsed_centroid, ring_elapsed_quantile,
+    capitalized_reset_charge, demurrage_charge, ring_centroid_implied_factor,
+    ring_elapsed_centroid, ring_elapsed_quantile, spend_demurrage_charge, BLOCKS_PER_YEAR_5S,
+    SETTLEMENT_HORIZON_BLOCKS,
 };
 pub use dynamic_fee::{DynamicFeeBase, DynamicFeeState, FeeSuggestion};
 pub use entropy_decay::{

--- a/cluster-tax/src/simulation/downgrade_overcharge_sweep.rs
+++ b/cluster-tax/src/simulation/downgrade_overcharge_sweep.rs
@@ -97,7 +97,9 @@ use crate::{
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
-use super::settlement_horizon_sweep::{candidate_horizons, Horizon, BLOCKS_PER_YEAR, RATE_BPS};
+use super::settlement_horizon_sweep::{
+    candidate_horizons, factor_classes, FactorClass, Horizon, BLOCKS_PER_YEAR, RATE_BPS,
+};
 
 /// Deterministic seed for this sweep (distinct from the settlement sweep's
 /// `0xB07A_0833`).
@@ -324,24 +326,16 @@ pub fn downgrade_charge(
     output_declared_factor: u64,
     horizon_blocks: u64,
 ) -> u64 {
-    if output_declared_factor >= input_floor_factor {
-        return 0;
-    }
-    let at_floor = demurrage_charge(
+    // Reuse the shipped consensus kernel verbatim so the sim and the node price
+    // the identical downgrade (issue #925 Part 2).
+    crate::capitalized_reset_charge(
         value_pico,
         input_floor_factor,
-        horizon_blocks,
-        RATE_BPS,
-        BLOCKS_PER_YEAR,
-    );
-    let at_output = demurrage_charge(
-        value_pico,
         output_declared_factor,
         horizon_blocks,
         RATE_BPS,
         BLOCKS_PER_YEAR,
-    );
-    at_floor.saturating_sub(at_output)
+    )
 }
 
 /// A generated honest spend, with its horizon-independent downgrade
@@ -640,6 +634,217 @@ fn evaluate_exploit(
     }
 }
 
+// ===========================================================================
+// Factor-similarity decoy band (§4.6, issue #925 Part 1)
+// ===========================================================================
+//
+// §4.5 showed the ONLY honest over-charge channel is a wealthy decoy
+// contaminating a background spender's value-weighted ring floor (8.3% FP at 1%
+// contamination). The wallet-layer fix mirrors the shipped
+// `AGE_SIMILARITY_SPREAD_BPS = 1000` (±10%) age band in
+// `botho/src/decoy_selection.rs`: draw only decoys whose cluster factor is
+// within a band around the real input's factor, so a background (1×) spender
+// draws only near-1× decoys and the floor stays exact.
+//
+// This sweep finds the widest band that keeps the honest false-positive rate at
+// ~0% while retaining the same-class decoy pool (anonymity). Because factor is
+// class-quantized (the curve is flat at exactly 1× for background wealth), the
+// same-class background pool is retained at ANY band width; the binding
+// constraint is the band's UPPER edge staying below the nearest wealthy class.
+
+/// The pathological raw decoy contamination the factor band is stress-tested
+/// against: 5% wealthy decoys (the §4.5 level that produced a 34% FP rate with
+/// NO band filter). A good band must drive that back to ~0.
+pub const FACTOR_BAND_CONTAMINATION_BPS: u32 = 500;
+
+/// Candidate factor-similarity band widths (basis points of multiplicative
+/// spread around the real input's factor). ±5% … ±500%: the lower values match
+/// the age band convention; the wide values expose the knee where wealthy
+/// classes bleed into a background spender's band.
+pub fn factor_band_widths() -> Vec<u32> {
+    vec![
+        500, 1_000, 2_000, 3_500, 5_000, 9_000, 10_000, 25_000, 50_000,
+    ]
+}
+
+/// Inclusive upper edge of the factor band around `real_factor` at `band_bps`
+/// spread, clamped to the curve maximum (6×). Mirrors `age_similarity_band`.
+fn factor_band_hi(real_factor: u64, band_bps: u32) -> u64 {
+    let delta = (real_factor as u128 * band_bps as u128 / 10_000) as u64;
+    real_factor
+        .saturating_add(delta)
+        .min(6 * ClusterFactorCurve::FACTOR_SCALE)
+}
+
+/// Inclusive lower edge of the factor band, floored at the 1× minimum.
+fn factor_band_lo(real_factor: u64, band_bps: u32) -> u64 {
+    let delta = (real_factor as u128 * band_bps as u128 / 10_000) as u64;
+    real_factor
+        .saturating_sub(delta)
+        .max(ClusterFactorCurve::FACTOR_SCALE)
+}
+
+/// Draw one wealthy decoy's `(value_pico, cluster_wealth_pico)` from a random
+/// factor class (spread across the top decile), so the band knee surfaces as
+/// each class progressively enters a widening band.
+fn draw_wealthy_decoy(
+    classes: &[FactorClass],
+    params: &HonestSweepParams,
+    rng: &mut ChaCha8Rng,
+) -> (u64, u128) {
+    let class = &classes[rng.gen_range(0..classes.len())];
+    let dv = rng.gen_range(params.wealthy_decoy_value_bth.0..=params.wealthy_decoy_value_bth.1);
+    (
+        bth_to_pico_u64(dv),
+        class.cluster_wealth_bth as u128 * PICO_PER_BTH,
+    )
+}
+
+/// One row of the factor-band sweep: a candidate band width and its measured
+/// effect on the honest FP rate and the eligible decoy pool.
+#[derive(Clone, Debug)]
+pub struct FactorBandRow {
+    /// Band width in basis points of multiplicative spread (1000 = ±10%).
+    pub band_bps: u32,
+    /// Inclusive upper factor edge for a background (1×) spender at this band.
+    pub band_hi_factor: u64,
+    /// Number of wealthy factor classes that leak into a 1× spender's band.
+    pub wealthy_classes_admitted: usize,
+    /// Fraction of a realistic mixed candidate pool
+    /// ((1−c) background + c wealthy) admitted by the band — the eligible pool.
+    pub eligible_pool_frac: f64,
+    /// Fraction of the same-class (background) sub-pool retained (anonymity).
+    /// 1.0 at every band: factor is class-quantized, so a background spender
+    /// never loses same-class candidates.
+    pub same_class_retained: f64,
+    /// Honest false-positive rate for background spends WITH the band filter,
+    /// at the pathological [`FACTOR_BAND_CONTAMINATION_BPS`] raw
+    /// contamination.
+    pub false_positive_rate: f64,
+    /// Mean over-charge (% of value) on the tripped spends at the 5yr horizon.
+    pub mean_overcharge_5yr: f64,
+}
+
+impl FactorBandRow {
+    /// True when the band drives the honest false-positive rate to zero — the
+    /// selection criterion for `FACTOR_SIMILARITY_SPREAD`.
+    pub fn fp_safe(&self) -> bool {
+        self.false_positive_rate == 0.0
+    }
+}
+
+/// Evaluate one factor-band width: apply the band filter to a background
+/// spender's decoy selection at the pathological contamination level and
+/// measure the residual FP rate + eligible pool.
+fn evaluate_factor_band(
+    params: &HonestSweepParams,
+    classes: &[FactorClass],
+    curve: &ClusterFactorCurve,
+    band_bps: u32,
+) -> FactorBandRow {
+    // A background spender's real input is fully diffused → factor 1×.
+    let real_factor = curve.factor(0);
+    let lo = factor_band_lo(real_factor, band_bps);
+    let hi = factor_band_hi(real_factor, band_bps);
+
+    // Which wealthy classes leak into the band (analytic).
+    let wealthy_classes_admitted = classes
+        .iter()
+        .filter(|c| {
+            let f = curve.factor(c.cluster_wealth_bth as u128 * PICO_PER_BTH);
+            f > real_factor && f >= lo && f <= hi
+        })
+        .count();
+
+    // Eligible pool of a mixed candidate set: (1−c) background (always in-band)
+    // + c wealthy spread uniformly across the classes (in-band iff its factor
+    // fits the band). Background retention is 1.0 by construction.
+    let c = FACTOR_BAND_CONTAMINATION_BPS as f64 / 10_000.0;
+    let eligible_pool_frac =
+        (1.0 - c) + c * (wealthy_classes_admitted as f64 / classes.len() as f64);
+
+    // Monte-Carlo FP: build banded background rings and count floors > 1×.
+    let value_pico = bth_to_pico_u64(params.exploit_coin_value_bth.max(1));
+    let mut rng = ChaCha8Rng::seed_from_u64(params.seed ^ 0xBA0D_0000 ^ band_bps as u64);
+    let output_declared = real_factor; // background spender declares 1×
+    let mut tripped = 0usize;
+    let mut sum_overcharge = 0.0f64;
+    for _ in 0..params.n_spends {
+        // Real background input.
+        let mut ring: Vec<(u64, u128)> = Vec::with_capacity(params.ring_size);
+        let bg_real_value =
+            rng.gen_range(params.bg_decoy_value_bth.0..=params.bg_decoy_value_bth.1);
+        ring.push((bth_to_pico_u64(bg_real_value), 0));
+        for _ in 1..params.ring_size {
+            let wealthy = rng.gen_range(0..10_000u32) < FACTOR_BAND_CONTAMINATION_BPS;
+            let (dv, dw) = if wealthy {
+                draw_wealthy_decoy(classes, params, &mut rng)
+            } else {
+                let dv = rng.gen_range(params.bg_decoy_value_bth.0..=params.bg_decoy_value_bth.1);
+                (bth_to_pico_u64(dv), 0u128)
+            };
+            let f = curve.factor(dw);
+            if f >= lo && f <= hi {
+                // Passes the band filter → admitted.
+                ring.push((dv, dw));
+            } else {
+                // Rejected by the band filter → the wallet substitutes an
+                // in-band (background) decoy, exactly as Part 3 does.
+                let sub = rng.gen_range(params.bg_decoy_value_bth.0..=params.bg_decoy_value_bth.1);
+                ring.push((bth_to_pico_u64(sub), 0));
+            }
+        }
+        let input_floor = ring_centroid_implied_factor(&ring, curve);
+        if output_declared < input_floor {
+            tripped += 1;
+            let charge = downgrade_charge(
+                value_pico,
+                input_floor,
+                output_declared,
+                5 * BLOCKS_PER_YEAR,
+            );
+            sum_overcharge += charge as f64 / value_pico as f64 * 100.0;
+        }
+    }
+
+    FactorBandRow {
+        band_bps,
+        band_hi_factor: hi,
+        wealthy_classes_admitted,
+        eligible_pool_frac,
+        same_class_retained: 1.0,
+        false_positive_rate: tripped as f64 / params.n_spends as f64,
+        mean_overcharge_5yr: if tripped > 0 {
+            sum_overcharge / tripped as f64
+        } else {
+            0.0
+        },
+    }
+}
+
+/// Run the factor-band sweep across all candidate band widths.
+pub fn factor_band_sweep(
+    params: &HonestSweepParams,
+    classes: &[FactorClass],
+    curve: &ClusterFactorCurve,
+) -> Vec<FactorBandRow> {
+    factor_band_widths()
+        .into_iter()
+        .map(|bw| evaluate_factor_band(params, classes, curve, bw))
+        .collect()
+}
+
+/// The widest FP-safe band width in a completed sweep — the recommended
+/// `FACTOR_SIMILARITY_SPREAD`. Falls back to the tightest band if none is safe
+/// (never happens for the shipped population).
+pub fn recommended_factor_band(rows: &[FactorBandRow]) -> u32 {
+    rows.iter()
+        .filter(|r| r.fp_safe())
+        .map(|r| r.band_bps)
+        .max()
+        .unwrap_or(0)
+}
+
 /// The full honest-overcharge report.
 #[derive(Clone, Debug)]
 pub struct HonestOverchargeReport {
@@ -655,6 +860,11 @@ pub struct HonestOverchargeReport {
     pub sensitivity: Vec<PopulationResult>,
     /// The exploit spend, confirming the leak is still priced at every horizon.
     pub exploit: ExploitResult,
+    /// Factor-similarity decoy band sweep (§4.6, #925 Part 1): picks
+    /// `FACTOR_SIMILARITY_SPREAD` for the wallet-layer decoy filter.
+    pub factor_band: Vec<FactorBandRow>,
+    /// The recommended (widest FP-safe) band width, in basis points.
+    pub recommended_factor_band_bps: u32,
 }
 
 /// Run the complete honest-overcharge sweep with the default configuration.
@@ -671,6 +881,9 @@ pub fn run_honest_overcharge_sweep() -> HonestOverchargeReport {
         .map(|c| evaluate_population(&archetypes, &params, &horizons, c, &curve))
         .collect();
     let exploit = evaluate_exploit(&params, &horizons, &curve);
+    let classes = factor_classes();
+    let factor_band = factor_band_sweep(&params, &classes, &curve);
+    let recommended_factor_band_bps = recommended_factor_band(&factor_band);
 
     HonestOverchargeReport {
         horizons,
@@ -680,6 +893,8 @@ pub fn run_honest_overcharge_sweep() -> HonestOverchargeReport {
         clean,
         sensitivity,
         exploit,
+        factor_band,
+        recommended_factor_band_bps,
     }
 }
 
@@ -845,6 +1060,58 @@ pub fn to_markdown(report: &HonestOverchargeReport) -> String {
     }
     s.push('\n');
 
+    // 6. Factor-similarity decoy band (§4.6, #925 Part 1).
+    s.push_str("### Factor-similarity decoy band (picks `FACTOR_SIMILARITY_SPREAD`)\n\n");
+    s.push_str(&format!(
+        "The §4.5 contamination channel is closed at the wallet layer by a factor band \
+         mirroring the shipped `AGE_SIMILARITY_SPREAD_BPS` (±10%) age band: a background (1×) \
+         spender draws only decoys whose cluster factor sits within the band around its real \
+         input's factor. This sweep applies that filter at the pathological {:.1}% raw \
+         contamination (the §4.5 level that gave a {:.1}% FP rate UNFILTERED) and finds the \
+         widest band that keeps the honest FP rate at 0%. Band edge = `1000 × (1 + spread)` \
+         clamped to 6×; same-class (background) pool retention is 1.00 at every band because \
+         factor is class-quantized.\n\n",
+        FACTOR_BAND_CONTAMINATION_BPS as f64 / 100.0,
+        report
+            .sensitivity
+            .iter()
+            .find(|r| r.contamination_bps == FACTOR_BAND_CONTAMINATION_BPS)
+            .map(|r| r.false_positive_rate * 100.0)
+            .unwrap_or(0.0),
+    ));
+    s.push_str(
+        "| factor band | band edge (×) | wealthy classes admitted | eligible pool | \
+         same-class pool | honest FP rate | mean over-charge @5yr | FP-safe |\n",
+    );
+    s.push_str(
+        "|------------:|--------------:|-------------------------:|--------------:|\
+         ----------------:|---------------:|----------------------:|:-------:|\n",
+    );
+    for r in &report.factor_band {
+        s.push_str(&format!(
+            "| ±{:.0}% | {:.3}× | {} / {} | {:.2}% | {:.2}% | {:.4}% | {:.4}% | {} |\n",
+            r.band_bps as f64 / 100.0,
+            r.band_hi_factor as f64 / ClusterFactorCurve::FACTOR_SCALE as f64,
+            r.wealthy_classes_admitted,
+            factor_classes().len(),
+            r.eligible_pool_frac * 100.0,
+            r.same_class_retained * 100.0,
+            r.false_positive_rate * 100.0,
+            r.mean_overcharge_5yr,
+            if r.fp_safe() { "yes" } else { "NO" },
+        ));
+    }
+    s.push('\n');
+    s.push_str(&format!(
+        "**Recommended `FACTOR_SIMILARITY_SPREAD` = ±{:.0}% ({} bps)** — the age-band \
+         convention, comfortably inside the widest FP-safe band (±{:.0}%). Every band that \
+         excludes the nearest wealthy class drives the honest FP rate to exactly 0% while \
+         retaining the full same-class background pool.\n\n",
+        1_000_f64 / 100.0,
+        1_000,
+        recommended_factor_band(&report.factor_band) as f64 / 100.0,
+    ));
+
     s
 }
 
@@ -957,6 +1224,61 @@ mod tests {
             *rates.last().unwrap() > 0.0,
             "heavy contamination must produce some false positives"
         );
+    }
+
+    #[test]
+    fn factor_band_recommendation_is_the_age_band_and_is_fp_safe() {
+        // The recommended band (±10%, matching AGE_SIMILARITY_SPREAD_BPS) must
+        // drive the honest FP rate to exactly 0 at the pathological
+        // contamination, and the widest FP-safe band must be at least ±10%.
+        let report = run_honest_overcharge_sweep();
+        let ten_pct = report
+            .factor_band
+            .iter()
+            .find(|r| r.band_bps == 1_000)
+            .expect("±10% band swept");
+        assert_eq!(
+            ten_pct.false_positive_rate, 0.0,
+            "±10% band must be FP-safe at {}bps contamination",
+            FACTOR_BAND_CONTAMINATION_BPS
+        );
+        assert_eq!(ten_pct.same_class_retained, 1.0, "same-class pool retained");
+        assert!(
+            report.recommended_factor_band_bps >= 1_000,
+            "widest FP-safe band {} must be at least the ±10% convention",
+            report.recommended_factor_band_bps
+        );
+    }
+
+    #[test]
+    fn factor_band_knee_admits_wealthy_classes_and_raises_fp() {
+        // A pathologically wide band eventually bleeds a wealthy class into a
+        // background spender's ring, lifting FP above zero — the knee that
+        // bounds the safe band from above.
+        let report = run_honest_overcharge_sweep();
+        let widest = report.factor_band.last().unwrap();
+        assert!(
+            widest.wealthy_classes_admitted > 0,
+            "the widest swept band must admit at least one wealthy class"
+        );
+        assert!(
+            widest.false_positive_rate > 0.0,
+            "admitting wealthy classes must produce honest false positives (FP={})",
+            widest.false_positive_rate
+        );
+        // FP rate is monotonically non-decreasing in band width (wider admits
+        // more contamination, never less).
+        let rates: Vec<f64> = report
+            .factor_band
+            .iter()
+            .map(|r| r.false_positive_rate)
+            .collect();
+        for w in rates.windows(2) {
+            assert!(
+                w[1] >= w[0] - 1e-12,
+                "FP rate must be non-decreasing in band width: {rates:?}"
+            );
+        }
     }
 
     #[test]

--- a/docs/research/demurrage-downgrade-overcharge.md
+++ b/docs/research/demurrage-downgrade-overcharge.md
@@ -169,6 +169,47 @@ mean over-charge is ~9.39% of the small coin's value at 5yr, essentially the ful
 capitalized demurrage applied to an innocent commerce coin. This is the reverse of the H2
 age-dilution attack — here value-weighting *inflates* the floor instead of a spender diluting it.
 
+### 4.6 Factor-similarity decoy band — closing the §4.5 channel (issue #925 Part 1)
+
+§4.5 leaves exactly one wallet-layer lever: a background spender must not draw a high-value
+wealthy coin as a decoy. This is the direct analog of the age-dilution concern PR #595 closed
+for the elapsed term with the **`AGE_SIMILARITY_SPREAD_BPS = 1000` (±10%)** age band. We
+close the factor channel the same way: a background (1×) spender draws only decoys whose
+cluster factor sits within a band around its real input's factor. The sweep below applies that
+filter at the **pathological 5% raw contamination** (the §4.5 level that produced a 34.1% FP
+rate *unfiltered*) and finds the widest band that still keeps the honest false-positive rate at
+0%, while retaining the same-class decoy pool. Reproduce with `honest-overcharge-sweep`; every
+number is regenerated, nothing hand-computed.
+
+| factor band | band edge (×) | wealthy classes admitted | eligible pool | same-class pool | honest FP rate | mean over-charge @5yr | FP-safe |
+|------------:|--------------:|-------------------------:|--------------:|----------------:|---------------:|----------------------:|:-------:|
+| ±5% | 1.050× | 0 / 6 | 95.00% | 100.00% | 0.0000% | 0.0000% | yes |
+| ±10% | 1.100× | 0 / 6 | 95.00% | 100.00% | 0.0000% | 0.0000% | yes |
+| ±20% | 1.200× | 0 / 6 | 95.00% | 100.00% | 0.0000% | 0.0000% | yes |
+| ±35% | 1.350× | 0 / 6 | 95.00% | 100.00% | 0.0000% | 0.0000% | yes |
+| ±50% | 1.500× | 0 / 6 | 95.00% | 100.00% | 0.0000% | 0.0000% | yes |
+| ±90% | 1.900× | 0 / 6 | 95.00% | 100.00% | 0.0000% | 0.0000% | yes |
+| ±100% | 2.000× | 1 / 6 | 95.83% | 100.00% | 8.0300% | 1.5649% | NO |
+| ±250% | 3.500× | 3 / 6 | 97.50% | 100.00% | 22.3000% | 3.3979% | NO |
+| ±500% | 6.000× | 6 / 6 | 100.00% | 100.00% | 41.6500% | 6.1196% | NO |
+
+**Reading it:** because the factor curve is flat at *exactly* 1× for background wealth, the
+same-class (background) decoy pool is retained at **100% at every band width** — unlike the
+continuous age band, tightening the factor band never costs a background spender any same-class
+candidate. The band's only job is to keep its **upper** edge below the nearest wealthy class.
+The nearest wealthy class is 1.939× (a 10k-BTH cluster), which enters the band only at ±100%
+(edge 2.000×). Every band up to **±90%** therefore drives the honest FP rate to **exactly 0%**;
+at ±100% the first wealthy class bleeds in and FP jumps to 8.03%, then rises monotonically as
+wider bands admit more classes.
+
+**Recommended `FACTOR_SIMILARITY_SPREAD` = ±10% (1000 bps)** — the established
+`AGE_SIMILARITY_SPREAD_BPS` convention, sitting ~9× inside the widest FP-safe band (±90%). It
+gives a background spender the full same-class background pool (maximal within-class anonymity)
+with a large margin against cross-class contamination, and by construction caps any admitted
+decoy's factor at 1.100× — so even a worst-case in-band decoy could lift the floor by at most
+10% of the 1× minimum, exactly mirroring the ≤1.10 over-charge bound the age band guarantees.
+Part 3 wires this constant into `botho/src/decoy_selection.rs`.
+
 ## 5. Read-out: is the keying tight enough?
 
 **Yes, at the consensus layer — conditional on decoy-selection hygiene at the wallet layer.**


### PR DESCRIPTION
**MAINNET BLOCKER (#834).** Closes the zero-cost demurrage-escape leak: a wealthy holder could reset a coin to background via an ordinary spend, paying **0** and escaping **all future** stock-level demurrage. Ratified this session (5yr horizon; honest-overcharge ruled out by simulation).

## What it does
When a spend deflates a coin's output cluster mass below the ring-implied input floor (a genuine class **downgrade**), it charges **`max(accrued_to_date, capitalized_reset_charge)`** — routed to the lottery pool. This makes an ordinary spend-to-background economically identical to the sanctioned #831 settlement op.

## Parts
1. **`demurrage.rs`** — `spend_demurrage_charge` + `capitalized_reset_charge` over the shared **`SETTLEMENT_HORIZON_BLOCKS = 31_536_000` (5 yr)**. Pure integer, liveness-safe (only raises the fee floor, never false-rejects), ring-privacy preserving. The horizon constant is the shared primitive #831 will reuse.
2. **`store.rs`** — consensus wiring of the charge into ledger validation.
3. **`decoy_selection.rs`** — **`FACTOR_SIMILARITY_SPREAD = ±10%`** factor-similarity decoy band, mirroring the existing `AGE_SIMILARITY_SPREAD_BPS`. Background coins now draw only near-1× decoys, eliminating the wallet-layer ring-contamination false-positive (the *only* honest-overcharge channel found by the #950 sim).
4. **`downgrade_overcharge_sweep.rs`** — factor-band calibration (recommends the ±10% age band; regenerated tables in `docs/research/demurrage-downgrade-overcharge.md`).
5. **`discovery.rs`** — `PROTOCOL_VERSION` **5.0.0 → 6.0.0** (consensus-breaking; rides the 6.0.0 testnet-reset batch with #831).

## Tests
- `demurrage_background_reset_leak_is_real` now asserts the **priced** transition (was asserting the 0-cost leak).
- `exploit_is_charged_at_every_horizon`, `honest_background_and_inclass_are_never_charged_on_clean_rings`, `factor_band_recommendation_is_the_age_band_and_is_fp_safe`, `exploit_floor_matches_the_leak_test`, `report_is_reproducible` — all green.
- Full `cargo test -p bth-cluster-tax`: 462 passed, 0 failed.

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)