### PR TITLE
feat(crypto)!: fold ML-KEM-768 + ML-DSA-65 keys into canonical PublicAddress (address v2)

### DIFF
--- a/account-keys/Cargo.toml
+++ b/account-keys/Cargo.toml
@@ -39,7 +39,12 @@ zeroize = { workspace = true }
 # Botho dependencies
 bth-account-keys-types = { workspace = true }
 bth-core = { workspace = true }
-bth-crypto-digestible = { workspace = true }
+# `alloc` + `derive` are required unconditionally: `PublicAddress` derives
+# `Digestible` over `Vec<u8>` PQ-key fields, and the `Vec<u8>: Digestible` impl
+# is gated behind the digestible `alloc` feature. This crate is always-alloc
+# (`extern crate alloc`), so enabling these here keeps `--no-default-features`
+# builds green.
+bth-crypto-digestible = { workspace = true, features = ["alloc", "derive"] }
 bth-crypto-hashes = { workspace = true }
 bth-crypto-keys = { workspace = true }
 bth-crypto-pq = { workspace = true, optional = true }

--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -12,6 +12,7 @@
 
 #![allow(non_snake_case)]
 
+use alloc::vec::Vec;
 use bth_core::{
     keys::{
         RootSpendPrivate, RootSpendPublic, RootViewPrivate, SubaddressSpendPublic,
@@ -44,7 +45,31 @@ pub use bth_core::{
     },
 };
 
+/// Length in bytes of a raw ML-KEM-768 public key (published in a v2 address).
+///
+/// Kept as a local constant so the base `account-keys` type carries no hard
+/// dependency on `bth-crypto-pq` (D1: raw fixed bytes, validate-on-parse).
+pub const ML_KEM_768_PUBLIC_KEY_LEN: usize = 1184;
+
+/// Length in bytes of a raw ML-DSA-65 public key (published in a v2 address).
+pub const ML_DSA_65_PUBLIC_KEY_LEN: usize = 1952;
+
 /// A Botho user's public subaddress.
+///
+/// # Address format v2 (universal post-quantum)
+///
+/// In addition to the two 32-byte Ristretto keys, an address carries two raw
+/// post-quantum public keys as fixed-length byte payloads (ADR 0008):
+///
+/// - `kem_public_key` — ML-KEM-768 (`ML_KEM_768_PUBLIC_KEY_LEN` = 1184 bytes)
+/// - `dsa_public_key` — ML-DSA-65 (`ML_DSA_65_PUBLIC_KEY_LEN` = 1952 bytes)
+///
+/// Both PQ keys are stored as raw bytes (D1: keep the base type free of a hard
+/// `bth-crypto-pq` dependency; validate the exact length on parse). Both PQ
+/// keys are part of the address's `Digestible` / `ShortAddressHash` identity
+/// (D3: an address's PQ keys must not be swappable). A classical-only ("v1")
+/// address leaves both PQ fields empty and hashes/serializes exactly as before
+/// aside from the two extra (empty) fields.
 #[derive(Clone, Digestible, Eq, Hash, Ord, PartialEq, PartialOrd, Zeroize)]
 #[cfg_attr(feature = "prost", derive(Message))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -56,16 +81,35 @@ pub struct PublicAddress {
     /// The user's public subaddress spend key `D`.
     #[cfg_attr(feature = "prost", prost(message, required, tag = "2"))]
     spend_public_key: RistrettoPublic,
+
+    /// Raw ML-KEM-768 public key (1184 bytes) published in the address.
+    ///
+    /// Empty for classical-only (v1) addresses. For v2 addresses this MUST be
+    /// exactly `ML_KEM_768_PUBLIC_KEY_LEN` bytes (validated on parse).
+    #[cfg_attr(feature = "prost", prost(bytes, tag = "3"))]
+    kem_public_key: Vec<u8>,
+
+    /// Raw ML-DSA-65 public key (1952 bytes) published in the address.
+    ///
+    /// Empty for classical-only (v1) addresses. For v2 addresses this MUST be
+    /// exactly `ML_DSA_65_PUBLIC_KEY_LEN` bytes (validated on parse).
+    #[cfg_attr(feature = "prost", prost(bytes, tag = "4"))]
+    dsa_public_key: Vec<u8>,
 }
 
 impl fmt::Display for PublicAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "BTH")?;
+        // Classical keys first (spend||view), preserving the historical v1
+        // rendering. The PQ keys are appended only when present, so a
+        // classical-only address renders identically to before.
         for byte in self
             .spend_public_key
             .to_bytes()
             .iter()
             .chain(self.view_public_key().to_bytes().iter())
+            .chain(self.kem_public_key.iter())
+            .chain(self.dsa_public_key.iter())
         {
             write!(f, "{byte:02X}")?;
         }
@@ -84,7 +128,48 @@ impl PublicAddress {
         Self {
             view_public_key: *view_public_key,
             spend_public_key: *spend_public_key,
+            kem_public_key: Vec::new(),
+            dsa_public_key: Vec::new(),
         }
+    }
+
+    /// Create a new v2 (universal post-quantum) public address.
+    ///
+    /// # Arguments
+    /// * `spend_public_key` - The user's public subaddress spend key `D`.
+    /// * `view_public_key` - The user's public subaddress view key `C`.
+    /// * `kem_public_key` - Raw ML-KEM-768 public key bytes (expected length
+    ///   `ML_KEM_768_PUBLIC_KEY_LEN`).
+    /// * `dsa_public_key` - Raw ML-DSA-65 public key bytes (expected length
+    ///   `ML_DSA_65_PUBLIC_KEY_LEN`).
+    ///
+    /// The PQ keys are stored verbatim; length validation is performed on
+    /// parse (D1). Callers deriving from real keypairs always supply
+    /// correctly-sized bytes.
+    #[inline]
+    pub fn new_with_pq(
+        spend_public_key: &RistrettoPublic,
+        view_public_key: &RistrettoPublic,
+        kem_public_key: Vec<u8>,
+        dsa_public_key: Vec<u8>,
+    ) -> Self {
+        Self {
+            view_public_key: *view_public_key,
+            spend_public_key: *spend_public_key,
+            kem_public_key,
+            dsa_public_key,
+        }
+    }
+
+    /// Attach post-quantum public keys to an existing (classical) address.
+    ///
+    /// Consumes `self` and returns a v2 address carrying the supplied raw
+    /// ML-KEM-768 and ML-DSA-65 public keys.
+    #[inline]
+    pub fn with_pq_keys(mut self, kem_public_key: Vec<u8>, dsa_public_key: Vec<u8>) -> Self {
+        self.kem_public_key = kem_public_key;
+        self.dsa_public_key = dsa_public_key;
+        self
     }
 
     /// Get the public subaddress view key.
@@ -95,6 +180,30 @@ impl PublicAddress {
     /// Get the public subaddress spend key.
     pub fn spend_public_key(&self) -> &RistrettoPublic {
         &self.spend_public_key
+    }
+
+    /// Get the raw ML-KEM-768 public key bytes.
+    ///
+    /// Empty for classical-only (v1) addresses.
+    pub fn kem_public_key(&self) -> &[u8] {
+        &self.kem_public_key
+    }
+
+    /// Get the raw ML-DSA-65 public key bytes.
+    ///
+    /// Empty for classical-only (v1) addresses.
+    pub fn dsa_public_key(&self) -> &[u8] {
+        &self.dsa_public_key
+    }
+
+    /// Whether this address publishes well-formed post-quantum keys.
+    ///
+    /// Returns true only when both PQ keys are present and have exactly the
+    /// expected raw lengths (`ML_KEM_768_PUBLIC_KEY_LEN` and
+    /// `ML_DSA_65_PUBLIC_KEY_LEN`).
+    pub fn has_pq_keys(&self) -> bool {
+        self.kem_public_key.len() == ML_KEM_768_PUBLIC_KEY_LEN
+            && self.dsa_public_key.len() == ML_DSA_65_PUBLIC_KEY_LEN
     }
 }
 
@@ -262,10 +371,9 @@ impl AccountKey {
             RistrettoPublic::from(&subaddress_spend_private)
         };
 
-        PublicAddress {
-            view_public_key,
-            spend_public_key,
-        }
+        // Classical-only (v1) subaddress. PQ keys are attached by the
+        // quantum-safe derivation path (see `quantum_safe.rs`).
+        PublicAddress::new(&spend_public_key, &view_public_key)
     }
 
     /// The private spend key for the default subaddress.
@@ -430,10 +538,9 @@ impl ViewAccountKey {
         )
             .subaddress(index);
 
-        PublicAddress {
-            view_public_key: view_public.inner(),
-            spend_public_key: spend_public.inner(),
-        }
+        // Classical-only (v1) subaddress. PQ keys are attached by the
+        // quantum-safe derivation path (see `quantum_safe.rs`).
+        PublicAddress::new(&spend_public.inner(), &view_public.inner())
     }
 
     /// The public spend key for the default subaddress.
@@ -501,6 +608,107 @@ mod account_key_tests {
             let result: PublicAddress = bth_util_serial::decode(&ser).unwrap();
             assert_eq!(acct.default_subaddress(), result);
         });
+    }
+
+    // Build a v2 address with deterministic (index-seeded) PQ payloads of the
+    // correct raw lengths. The bytes are not required to be valid PQ keys for
+    // these struct/serde/digest tests (validation happens on address-string
+    // parse, sub-issue 3).
+    fn sample_pq_address(rng: &mut StdRng) -> PublicAddress {
+        let spend = RistrettoPublic::from_random(rng);
+        let view = RistrettoPublic::from_random(rng);
+        let mut kem = alloc::vec![0u8; ML_KEM_768_PUBLIC_KEY_LEN];
+        rng.fill_bytes(&mut kem);
+        let mut dsa = alloc::vec![0u8; ML_DSA_65_PUBLIC_KEY_LEN];
+        rng.fill_bytes(&mut dsa);
+        PublicAddress::new_with_pq(&spend, &view, kem, dsa)
+    }
+
+    #[test]
+    // A v2 address (with both PQ keys) round-trips through prost/bth_util_serial.
+    fn bth_util_serial_prost_roundtrip_public_address_v2() {
+        let mut rng: StdRng = SeedableRng::from_seed([7u8; 32]);
+        let addr = sample_pq_address(&mut rng);
+
+        // Byte-length invariants for a well-formed v2 address.
+        assert_eq!(addr.kem_public_key().len(), ML_KEM_768_PUBLIC_KEY_LEN);
+        assert_eq!(addr.dsa_public_key().len(), ML_DSA_65_PUBLIC_KEY_LEN);
+        assert!(addr.has_pq_keys());
+
+        let ser = bth_util_serial::encode(&addr);
+        let result: PublicAddress = bth_util_serial::decode(&ser).unwrap();
+        assert_eq!(addr, result);
+        assert_eq!(result.kem_public_key(), addr.kem_public_key());
+        assert_eq!(result.dsa_public_key(), addr.dsa_public_key());
+    }
+
+    #[test]
+    // A classical-only (v1) address has empty PQ fields and is not `has_pq_keys`.
+    fn classical_address_has_no_pq_keys() {
+        let mut rng: StdRng = SeedableRng::from_seed([9u8; 32]);
+        let addr = PublicAddress::new(
+            &RistrettoPublic::from_random(&mut rng),
+            &RistrettoPublic::from_random(&mut rng),
+        );
+        assert!(addr.kem_public_key().is_empty());
+        assert!(addr.dsa_public_key().is_empty());
+        assert!(!addr.has_pq_keys());
+    }
+
+    #[test]
+    // Both PQ keys are part of the address identity (Digestible /
+    // ShortAddressHash). Swapping either PQ key MUST change the
+    // ShortAddressHash (D3).
+    fn pq_keys_are_part_of_short_address_hash() {
+        let mut rng: StdRng = SeedableRng::from_seed([11u8; 32]);
+        let spend = RistrettoPublic::from_random(&mut rng);
+        let view = RistrettoPublic::from_random(&mut rng);
+        let mut kem = alloc::vec![0u8; ML_KEM_768_PUBLIC_KEY_LEN];
+        rng.fill_bytes(&mut kem);
+        let mut dsa = alloc::vec![0u8; ML_DSA_65_PUBLIC_KEY_LEN];
+        rng.fill_bytes(&mut dsa);
+
+        let base = PublicAddress::new_with_pq(&spend, &view, kem.clone(), dsa.clone());
+
+        // Classical-only address with the SAME Ristretto keys must hash differently.
+        let classical = PublicAddress::new(&spend, &view);
+        assert_ne!(
+            ShortAddressHash::from(&base),
+            ShortAddressHash::from(&classical),
+            "PQ keys must contribute to the address hash"
+        );
+
+        // Flip one byte of the KEM key -> different hash.
+        let mut kem2 = kem.clone();
+        kem2[0] ^= 0xff;
+        let kem_swapped = PublicAddress::new_with_pq(&spend, &view, kem2, dsa.clone());
+        assert_ne!(
+            ShortAddressHash::from(&base),
+            ShortAddressHash::from(&kem_swapped),
+            "swapping the KEM key must change the address hash"
+        );
+
+        // Flip one byte of the DSA key -> different hash.
+        let mut dsa2 = dsa.clone();
+        dsa2[0] ^= 0xff;
+        let dsa_swapped = PublicAddress::new_with_pq(&spend, &view, kem, dsa2);
+        assert_ne!(
+            ShortAddressHash::from(&base),
+            ShortAddressHash::from(&dsa_swapped),
+            "swapping the DSA key must change the address hash"
+        );
+
+        // Determinism: identical inputs -> identical hash.
+        let base_again = PublicAddress::new_with_pq(
+            &spend,
+            &view,
+            base.kem_public_key().to_vec(),
+            base.dsa_public_key().to_vec(),
+        );
+        assert_eq!(
+            ShortAddressHash::from(&base),
+            ShortAddressHash::from(&base_again)
+        );
     }
 
     #[test]

--- a/account-keys/src/lib.rs
+++ b/account-keys/src/lib.rs
@@ -8,12 +8,12 @@
 //!
 //! # Quantum-Safe Keys (Optional)
 //!
-//! When the `pq` feature is enabled, this crate also provides quantum-safe
-//! account key types that combine classical (Ristretto/Schnorr) keys with
-//! post-quantum (ML-KEM/ML-DSA) keys for protection against future quantum
-//! computers.
-//!
-//! See [`QuantumSafeAccountKey`] and [`QuantumSafePublicAddress`] for details.
+//! When the `pq` feature is enabled, this crate also provides a quantum-safe
+//! account key type ([`QuantumSafeAccountKey`]) that combines classical
+//! (Ristretto/Schnorr) keys with post-quantum (ML-KEM/ML-DSA) keys for
+//! protection against future quantum computers. The post-quantum public keys
+//! are folded directly into the canonical [`PublicAddress`] (address format
+//! v2, ADR 0008) rather than a separate address type.
 
 extern crate alloc;
 
@@ -30,6 +30,7 @@ pub use crate::{
     account_keys::{
         AccountKey, PublicAddress, ShortAddressHash, ViewAccountKey, CHANGE_SUBADDRESS_INDEX,
         DEFAULT_SUBADDRESS_INDEX, GIFT_CODE_SUBADDRESS_INDEX, INVALID_SUBADDRESS_INDEX,
+        ML_DSA_65_PUBLIC_KEY_LEN, ML_KEM_768_PUBLIC_KEY_LEN,
     },
     burn_address::{burn_address, burn_address_view_private, BURN_ADDRESS_VIEW_PRIVATE_BYTES},
     error::{Error, Result},
@@ -37,4 +38,4 @@ pub use crate::{
 };
 
 #[cfg(feature = "pq")]
-pub use crate::quantum_safe::{AddressParseError, QuantumSafeAccountKey, QuantumSafePublicAddress};
+pub use crate::quantum_safe::QuantumSafeAccountKey;

--- a/account-keys/src/quantum_safe.rs
+++ b/account-keys/src/quantum_safe.rs
@@ -1,16 +1,27 @@
 //! Quantum-Safe Account Keys
 //!
-//! This module provides post-quantum cryptographic extensions to the standard
-//! account key types. It combines classical (Ristretto/Schnorr) keys with
-//! NIST-standardized post-quantum algorithms:
+//! This module provides the post-quantum *secret-key holder* used to derive an
+//! account's post-quantum public keys. It combines classical (Ristretto/
+//! Schnorr) keys with NIST-standardized post-quantum algorithms:
 //!
 //! - **ML-KEM-768** (Kyber): Key Encapsulation for stealth address key exchange
 //! - **ML-DSA-65** (Dilithium): Digital signatures for transaction signing
 //!
+//! # Unified address type
+//!
+//! As of address format v2 (ADR 0008), the post-quantum public keys are folded
+//! directly into the canonical [`PublicAddress`]. There is no longer a separate
+//! `QuantumSafePublicAddress` type or a `botho-pq://` address string; a
+//! quantum-safe subaddress is simply a [`PublicAddress`] whose
+//! [`PublicAddress::kem_public_key`] and [`PublicAddress::dsa_public_key`]
+//! fields are populated. [`QuantumSafeAccountKey`] remains as the secret-side
+//! keypair holder that derives those keys from the mnemonic (its unification
+//! into `AccountKey` is tracked by the key-hierarchy sub-issue).
+//!
 //! # Hybrid Security Model
 //!
-//! Quantum-safe transactions require BOTH classical and post-quantum signatures
-//! to verify. This provides:
+//! Quantum-safe transactions require BOTH classical and post-quantum secrets to
+//! spend. This provides:
 //!
 //! 1. Immediate protection against "harvest now, decrypt later" attacks
 //! 2. Fallback security if either cryptosystem is broken
@@ -19,73 +30,32 @@
 //! # Usage
 //!
 //! ```ignore
-//! use bth_account_keys::{QuantumSafeAccountKey, QuantumSafePublicAddress};
+//! use bth_account_keys::QuantumSafeAccountKey;
 //!
 //! // Create from mnemonic (PQ keys derived deterministically)
 //! let account = QuantumSafeAccountKey::from_mnemonic("word1 word2 ... word24");
 //!
-//! // Get quantum-safe public address for receiving
+//! // Get the unified public address for receiving (carries both PQ keys)
 //! let address = account.default_subaddress();
 //!
 //! // Address includes both classical and PQ public keys
 //! println!("Classical view key: {:?}", address.view_public_key());
-//! println!("PQ KEM key: {:?}", address.pq_view_public_key());
+//! println!("PQ KEM key bytes:  {}", address.kem_public_key().len());
 //! ```
 
-use alloc::{string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::fmt;
 
 use bip39::{Language, Mnemonic, Seed};
 use bth_crypto_pq::{
-    derive_pq_keys_from_seed, MlDsa65KeyPair, MlDsa65PublicKey, MlKem768KeyPair, MlKem768PublicKey,
-    PqKeyMaterial, BIP39_SEED_SIZE, ML_DSA_65_PUBLIC_KEY_BYTES, ML_KEM_768_PUBLIC_KEY_BYTES,
+    derive_pq_keys_from_seed, MlDsa65KeyPair, MlKem768KeyPair, PqKeyMaterial, BIP39_SEED_SIZE,
 };
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{AccountKey, PublicAddress};
 
-/// Errors that can occur when parsing a quantum-safe address
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AddressParseError {
-    /// Invalid address prefix (expected "botho-pq://1/")
-    InvalidPrefix,
-    /// Invalid base58 encoding
-    InvalidBase58,
-    /// Invalid address length
-    InvalidLength {
-        /// Expected byte length
-        expected: usize,
-        /// Actual byte length
-        got: usize,
-    },
-    /// Invalid classical Ristretto key
-    InvalidClassicalKey,
-    /// Invalid post-quantum key
-    InvalidPqKey,
-}
-
-impl fmt::Display for AddressParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidPrefix => write!(f, "invalid address prefix, expected 'botho-pq://1/'"),
-            Self::InvalidBase58 => write!(f, "invalid base58 encoding"),
-            Self::InvalidLength { expected, got } => {
-                write!(
-                    f,
-                    "invalid length: expected {} bytes, got {}",
-                    expected, got
-                )
-            }
-            Self::InvalidClassicalKey => write!(f, "invalid classical Ristretto public key"),
-            Self::InvalidPqKey => write!(f, "invalid post-quantum public key"),
-        }
-    }
-}
-
-// Note: Error trait requires std; pq feature enables std
+// Note: pq feature enables std; kept for parity with the rest of the crate.
 extern crate std;
-
-impl std::error::Error for AddressParseError {}
 
 /// Quantum-safe account key combining classical and post-quantum keys
 ///
@@ -211,35 +181,40 @@ impl QuantumSafeAccountKey {
         &self.pq_sig_keypair
     }
 
-    /// Get the default quantum-safe subaddress
-    pub fn default_subaddress(&self) -> QuantumSafePublicAddress {
-        QuantumSafePublicAddress::from_parts(
-            self.classical.default_subaddress(),
-            self.pq_kem_keypair.public_key().clone(),
-            self.pq_sig_keypair.public_key().clone(),
-        )
+    /// Raw ML-KEM-768 public key bytes for this account (account-wide).
+    fn kem_public_bytes(&self) -> Vec<u8> {
+        self.pq_kem_keypair.public_key().as_bytes().to_vec()
     }
 
-    /// Get the change quantum-safe subaddress
-    pub fn change_subaddress(&self) -> QuantumSafePublicAddress {
-        QuantumSafePublicAddress::from_parts(
-            self.classical.change_subaddress(),
-            self.pq_kem_keypair.public_key().clone(),
-            self.pq_sig_keypair.public_key().clone(),
-        )
+    /// Raw ML-DSA-65 public key bytes for this account (account-wide).
+    fn dsa_public_bytes(&self) -> Vec<u8> {
+        self.pq_sig_keypair.public_key().as_bytes().to_vec()
     }
 
-    /// Get the i^th quantum-safe subaddress
+    /// Get the default quantum-safe subaddress (as a unified
+    /// [`PublicAddress`]).
+    pub fn default_subaddress(&self) -> PublicAddress {
+        self.classical
+            .default_subaddress()
+            .with_pq_keys(self.kem_public_bytes(), self.dsa_public_bytes())
+    }
+
+    /// Get the change quantum-safe subaddress (as a unified [`PublicAddress`]).
+    pub fn change_subaddress(&self) -> PublicAddress {
+        self.classical
+            .change_subaddress()
+            .with_pq_keys(self.kem_public_bytes(), self.dsa_public_bytes())
+    }
+
+    /// Get the i^th quantum-safe subaddress (as a unified [`PublicAddress`]).
     ///
     /// Note: The PQ public keys are the same across all subaddresses.
     /// Subaddress derivation only affects the classical keys.
     /// One-time PQ keys are derived per-output using the encapsulated secret.
-    pub fn subaddress(&self, index: u64) -> QuantumSafePublicAddress {
-        QuantumSafePublicAddress::from_parts(
-            self.classical.subaddress(index),
-            self.pq_kem_keypair.public_key().clone(),
-            self.pq_sig_keypair.public_key().clone(),
-        )
+    pub fn subaddress(&self, index: u64) -> PublicAddress {
+        self.classical
+            .subaddress(index)
+            .with_pq_keys(self.kem_public_bytes(), self.dsa_public_bytes())
     }
 
     /// Derive classical AccountKey from mnemonic
@@ -274,216 +249,10 @@ impl fmt::Debug for QuantumSafeAccountKey {
     }
 }
 
-/// Quantum-safe public address for receiving funds
-///
-/// This extended address format includes both classical and post-quantum
-/// public keys, enabling senders to create outputs that are protected
-/// against quantum adversaries.
-///
-/// # Size
-///
-/// - Classical keys: 64 bytes (view + spend)
-/// - PQ KEM key: 1184 bytes (ML-KEM-768)
-/// - PQ Signature key: 1952 bytes (ML-DSA-65)
-/// - Total: ~3200 bytes
-///
-/// # Encoding
-///
-/// Quantum-safe addresses use a distinct prefix for identification:
-/// - Standard: `botho://1/<base58(view||spend)>`
-/// - Quantum-safe: `botho-pq://1/<base58(view||spend||pq_kem||pq_sig)>`
-#[derive(Clone)]
-pub struct QuantumSafePublicAddress {
-    /// Classical public address (view + spend public keys)
-    classical: PublicAddress,
-
-    /// ML-KEM-768 public key for quantum-safe key encapsulation
-    pq_kem_public_key: MlKem768PublicKey,
-
-    /// ML-DSA-65 public key for quantum-safe signature verification
-    pq_sig_public_key: MlDsa65PublicKey,
-}
-
-impl QuantumSafePublicAddress {
-    /// Create a quantum-safe address from its component parts
-    pub fn from_parts(
-        classical: PublicAddress,
-        pq_kem_public_key: MlKem768PublicKey,
-        pq_sig_public_key: MlDsa65PublicKey,
-    ) -> Self {
-        Self {
-            classical,
-            pq_kem_public_key,
-            pq_sig_public_key,
-        }
-    }
-
-    /// Get the classical public address
-    pub fn classical(&self) -> &PublicAddress {
-        &self.classical
-    }
-
-    /// Get the classical view public key
-    pub fn view_public_key(&self) -> &bth_crypto_keys::RistrettoPublic {
-        self.classical.view_public_key()
-    }
-
-    /// Get the classical spend public key
-    pub fn spend_public_key(&self) -> &bth_crypto_keys::RistrettoPublic {
-        self.classical.spend_public_key()
-    }
-
-    /// Get the ML-KEM-768 public key for quantum-safe key encapsulation
-    pub fn pq_kem_public_key(&self) -> &MlKem768PublicKey {
-        &self.pq_kem_public_key
-    }
-
-    /// Get the ML-DSA-65 public key for quantum-safe signature verification
-    pub fn pq_sig_public_key(&self) -> &MlDsa65PublicKey {
-        &self.pq_sig_public_key
-    }
-
-    /// Serialize to bytes
-    ///
-    /// Format: classical_view || classical_spend || pq_kem || pq_sig
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes =
-            Vec::with_capacity(32 + 32 + ML_KEM_768_PUBLIC_KEY_BYTES + ML_DSA_65_PUBLIC_KEY_BYTES);
-
-        bytes.extend_from_slice(&self.classical.view_public_key().to_bytes());
-        bytes.extend_from_slice(&self.classical.spend_public_key().to_bytes());
-        bytes.extend_from_slice(self.pq_kem_public_key.as_bytes());
-        bytes.extend_from_slice(self.pq_sig_public_key.as_bytes());
-
-        bytes
-    }
-
-    /// Total serialized size in bytes
-    pub const SERIALIZED_SIZE: usize =
-        32 + 32 + ML_KEM_768_PUBLIC_KEY_BYTES + ML_DSA_65_PUBLIC_KEY_BYTES;
-
-    /// Encode as a quantum-safe address string
-    ///
-    /// Format: `botho-pq://1/<base58>`
-    pub fn to_address_string(&self) -> String {
-        use alloc::format;
-
-        let bytes = self.to_bytes();
-        let encoded = bs58::encode(&bytes).into_string();
-        format!("botho-pq://1/{}", encoded)
-    }
-
-    /// Decode a quantum-safe address from its string representation
-    ///
-    /// Format: `botho-pq://1/<base58>`
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - The prefix is not `botho-pq://1/`
-    /// - The base58 decoding fails
-    /// - The decoded length doesn't match `SERIALIZED_SIZE`
-    /// - The classical keys are not valid Ristretto points
-    pub fn from_address_string(s: &str) -> Result<Self, AddressParseError> {
-        const PREFIX: &str = "botho-pq://1/";
-
-        let encoded = s
-            .strip_prefix(PREFIX)
-            .ok_or(AddressParseError::InvalidPrefix)?;
-
-        let bytes = bs58::decode(encoded)
-            .into_vec()
-            .map_err(|_| AddressParseError::InvalidBase58)?;
-
-        if bytes.len() != Self::SERIALIZED_SIZE {
-            return Err(AddressParseError::InvalidLength {
-                expected: Self::SERIALIZED_SIZE,
-                got: bytes.len(),
-            });
-        }
-
-        Self::from_bytes(&bytes)
-    }
-
-    /// Deserialize from bytes
-    ///
-    /// Format: classical_view || classical_spend || pq_kem || pq_sig
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, AddressParseError> {
-        if bytes.len() != Self::SERIALIZED_SIZE {
-            return Err(AddressParseError::InvalidLength {
-                expected: Self::SERIALIZED_SIZE,
-                got: bytes.len(),
-            });
-        }
-
-        let mut offset = 0;
-
-        // Classical view key (32 bytes)
-        let view_bytes: [u8; 32] = bytes[offset..offset + 32]
-            .try_into()
-            .expect("slice is 32 bytes");
-        let view_public_key = bth_crypto_keys::RistrettoPublic::try_from(&view_bytes)
-            .map_err(|_| AddressParseError::InvalidClassicalKey)?;
-        offset += 32;
-
-        // Classical spend key (32 bytes)
-        let spend_bytes: [u8; 32] = bytes[offset..offset + 32]
-            .try_into()
-            .expect("slice is 32 bytes");
-        let spend_public_key = bth_crypto_keys::RistrettoPublic::try_from(&spend_bytes)
-            .map_err(|_| AddressParseError::InvalidClassicalKey)?;
-        offset += 32;
-
-        let classical = PublicAddress::new(&spend_public_key, &view_public_key);
-
-        // PQ KEM key (1184 bytes)
-        let kem_bytes = &bytes[offset..offset + ML_KEM_768_PUBLIC_KEY_BYTES];
-        let pq_kem_public_key = MlKem768PublicKey::from_bytes(kem_bytes)
-            .map_err(|_| AddressParseError::InvalidPqKey)?;
-        offset += ML_KEM_768_PUBLIC_KEY_BYTES;
-
-        // PQ Sig key (1952 bytes)
-        let sig_bytes = &bytes[offset..offset + ML_DSA_65_PUBLIC_KEY_BYTES];
-        let pq_sig_public_key =
-            MlDsa65PublicKey::from_bytes(sig_bytes).map_err(|_| AddressParseError::InvalidPqKey)?;
-
-        Ok(Self {
-            classical,
-            pq_kem_public_key,
-            pq_sig_public_key,
-        })
-    }
-}
-
-impl fmt::Debug for QuantumSafePublicAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("QuantumSafePublicAddress")
-            .field("classical", &self.classical)
-            .field("pq_kem", &format_args!("MlKem768PublicKey(...)"))
-            .field("pq_sig", &format_args!("MlDsa65PublicKey(...)"))
-            .finish()
-    }
-}
-
-impl fmt::Display for QuantumSafePublicAddress {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_address_string())
-    }
-}
-
-impl PartialEq for QuantumSafePublicAddress {
-    fn eq(&self, other: &Self) -> bool {
-        self.classical == other.classical
-            && self.pq_kem_public_key.as_bytes() == other.pq_kem_public_key.as_bytes()
-            && self.pq_sig_public_key.as_bytes() == other.pq_sig_public_key.as_bytes()
-    }
-}
-
-impl Eq for QuantumSafePublicAddress {}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bth_crypto_pq::{ML_DSA_65_PUBLIC_KEY_BYTES, ML_KEM_768_PUBLIC_KEY_BYTES};
 
     const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
@@ -496,37 +265,24 @@ mod tests {
     }
 
     #[test]
-    fn test_quantum_safe_public_address() {
+    fn test_unified_public_address_carries_pq_keys() {
         let account = QuantumSafeAccountKey::from_mnemonic(TEST_MNEMONIC);
         let address = account.default_subaddress();
 
-        // Check size constants
+        // The unified PublicAddress carries both PQ keys at their raw lengths.
+        assert_eq!(address.kem_public_key().len(), ML_KEM_768_PUBLIC_KEY_BYTES);
+        assert_eq!(address.dsa_public_key().len(), ML_DSA_65_PUBLIC_KEY_BYTES);
+        assert!(address.has_pq_keys());
+
+        // The published PQ keys match the account's keypairs.
         assert_eq!(
-            address.pq_kem_public_key().as_bytes().len(),
-            ML_KEM_768_PUBLIC_KEY_BYTES
+            address.kem_public_key(),
+            account.pq_kem_keypair().public_key().as_bytes()
         );
         assert_eq!(
-            address.pq_sig_public_key().as_bytes().len(),
-            ML_DSA_65_PUBLIC_KEY_BYTES
+            address.dsa_public_key(),
+            account.pq_sig_keypair().public_key().as_bytes()
         );
-    }
-
-    #[test]
-    fn test_address_serialization() {
-        let account = QuantumSafeAccountKey::from_mnemonic(TEST_MNEMONIC);
-        let address = account.default_subaddress();
-
-        let bytes = address.to_bytes();
-        assert_eq!(bytes.len(), QuantumSafePublicAddress::SERIALIZED_SIZE);
-    }
-
-    #[test]
-    fn test_address_string_format() {
-        let account = QuantumSafeAccountKey::from_mnemonic(TEST_MNEMONIC);
-        let address = account.default_subaddress();
-
-        let addr_string = address.to_address_string();
-        assert!(addr_string.starts_with("botho-pq://1/"));
     }
 
     #[test]
@@ -538,14 +294,8 @@ mod tests {
         let addr_change = account.change_subaddress();
 
         // PQ keys should be the same across subaddresses
-        assert_eq!(
-            addr0.pq_kem_public_key().as_bytes(),
-            addr1.pq_kem_public_key().as_bytes()
-        );
-        assert_eq!(
-            addr0.pq_sig_public_key().as_bytes(),
-            addr_change.pq_sig_public_key().as_bytes()
-        );
+        assert_eq!(addr0.kem_public_key(), addr1.kem_public_key());
+        assert_eq!(addr0.dsa_public_key(), addr_change.dsa_public_key());
 
         // Classical keys should differ between subaddresses
         assert_ne!(
@@ -555,70 +305,15 @@ mod tests {
     }
 
     #[test]
-    fn test_address_roundtrip() {
-        let account = QuantumSafeAccountKey::from_mnemonic(TEST_MNEMONIC);
-        let address = account.default_subaddress();
-
-        // Encode to string
-        let addr_string = address.to_address_string();
-
-        // Decode back
-        let parsed = QuantumSafePublicAddress::from_address_string(&addr_string)
-            .expect("should parse valid address");
-
-        // Should be equal
-        assert_eq!(address, parsed);
-    }
-
-    #[test]
-    fn test_address_bytes_roundtrip() {
-        let account = QuantumSafeAccountKey::from_mnemonic(TEST_MNEMONIC);
-        let address = account.default_subaddress();
-
-        // Serialize to bytes
-        let bytes = address.to_bytes();
-
-        // Deserialize back
-        let parsed =
-            QuantumSafePublicAddress::from_bytes(&bytes).expect("should parse valid bytes");
-
-        // Should be equal
-        assert_eq!(address, parsed);
-    }
-
-    #[test]
-    fn test_address_parse_invalid_prefix() {
-        let result = QuantumSafePublicAddress::from_address_string("botho://1/abc");
-        assert_eq!(result, Err(AddressParseError::InvalidPrefix));
-    }
-
-    #[test]
-    fn test_address_parse_invalid_base58() {
-        let result = QuantumSafePublicAddress::from_address_string("botho-pq://1/invalid!base58");
-        assert_eq!(result, Err(AddressParseError::InvalidBase58));
-    }
-
-    #[test]
-    fn test_address_parse_invalid_length() {
-        // Valid base58 but wrong length
-        let result = QuantumSafePublicAddress::from_address_string("botho-pq://1/abc123");
-        assert!(matches!(
-            result,
-            Err(AddressParseError::InvalidLength { .. })
-        ));
-    }
-
-    #[test]
     fn test_deterministic_key_derivation() {
         // Same mnemonic should produce identical keys every time
         let account1 = QuantumSafeAccountKey::from_mnemonic(TEST_MNEMONIC);
         let account2 = QuantumSafeAccountKey::from_mnemonic(TEST_MNEMONIC);
 
-        // Get addresses to compare classical keys
         let addr1 = account1.default_subaddress();
         let addr2 = account2.default_subaddress();
 
-        // Classical keys should be identical (via address comparison)
+        // Classical keys should be identical
         assert_eq!(
             addr1.view_public_key().to_bytes(),
             addr2.view_public_key().to_bytes()
@@ -640,9 +335,8 @@ mod tests {
             account2.pq_sig_keypair().public_key().as_bytes()
         );
 
-        // Full address should be identical
+        // Full unified address should be identical (classical + PQ).
         assert_eq!(addr1, addr2);
-        assert_eq!(addr1.to_address_string(), addr2.to_address_string());
     }
 
     #[test]
@@ -652,7 +346,6 @@ mod tests {
             "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
         );
 
-        // Get addresses to compare
         let addr1 = account1.default_subaddress();
         let addr2 = account2.default_subaddress();
 

--- a/botho-wallet/src/commands/address.rs
+++ b/botho-wallet/src/commands/address.rs
@@ -36,12 +36,21 @@ pub async fn run(wallet_path: &Path, show_pq: bool) -> Result<()> {
         println!();
         println!("Quantum-safe address (ML-KEM-768 + ML-DSA-65):");
         println!();
-        let pq_addr = keys.pq_address_string();
-        // The address is long, so we'll show it wrapped
-        println!("  {}", pq_addr);
+        let pq_addr = keys.pq_public_address();
+        println!(
+            "  ML-KEM-768 public key ({} bytes):",
+            pq_addr.kem_public_key().len()
+        );
+        println!("    {}", hex::encode(pq_addr.kem_public_key()));
+        println!(
+            "  ML-DSA-65 public key ({} bytes):",
+            pq_addr.dsa_public_key().len()
+        );
+        println!("    {}", hex::encode(pq_addr.dsa_public_key()));
         println!();
-        println!("  Note: This address is ~4.3KB and includes post-quantum public keys");
-        println!("  for protection against future quantum computer attacks.");
+        println!("  Note: post-quantum public keys are now part of the unified");
+        println!("  address (format v2). The compact base58 v2 address string is");
+        println!("  introduced in a later rollout step.");
     }
 
     #[cfg(not(feature = "pq"))]

--- a/botho-wallet/src/keys.rs
+++ b/botho-wallet/src/keys.rs
@@ -22,7 +22,7 @@ use zeroize::Zeroizing;
 use crate::secmem::{lock_string, LockedRegion};
 
 #[cfg(feature = "pq")]
-use bth_account_keys::{QuantumSafeAccountKey, QuantumSafePublicAddress};
+use bth_account_keys::QuantumSafeAccountKey;
 
 /// Number of words in the mnemonic phrase
 const MNEMONIC_WORDS: usize = 24;
@@ -225,23 +225,17 @@ impl WalletKeys {
 
     /// Get the quantum-safe public address for receiving funds
     ///
-    /// This address includes both classical and post-quantum public keys,
-    /// allowing senders to create quantum-resistant outputs.
+    /// Returns the unified [`PublicAddress`] (address format v2, ADR 0008),
+    /// which carries both classical Ristretto keys and the post-quantum
+    /// ML-KEM-768 / ML-DSA-65 public keys, allowing senders to create
+    /// quantum-resistant outputs.
+    ///
+    /// Note: the v2 base58 address-*string* encoding is introduced in a later
+    /// rollout sub-issue; the legacy `botho-pq://` string was retired together
+    /// with the parallel `QuantumSafePublicAddress` type.
     #[cfg(feature = "pq")]
-    pub fn pq_public_address(&self) -> QuantumSafePublicAddress {
+    pub fn pq_public_address(&self) -> PublicAddress {
         self.pq_account_key().default_subaddress()
-    }
-
-    /// Get the quantum-safe address as a string
-    ///
-    /// Format: `botho-pq://1/<base58(view||spend||pq_kem||pq_sig)>`
-    ///
-    /// Note: This address is ~4.3KB when base58-encoded due to the size
-    /// of post-quantum public keys (ML-KEM-768: 1184 bytes, ML-DSA-65: 1952
-    /// bytes).
-    #[cfg(feature = "pq")]
-    pub fn pq_address_string(&self) -> String {
-        self.pq_public_address().to_address_string()
     }
 }
 
@@ -461,29 +455,16 @@ mod tests {
         }
 
         #[test]
-        fn test_pq_address_string_format() {
-            let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
-            let pq_addr = keys.pq_address_string();
-
-            // Should have the correct prefix
-            assert!(pq_addr.starts_with("botho-pq://1/"));
-
-            // Should be a valid base58-encoded address
-            assert!(pq_addr.len() > 100); // PQ addresses are large
-        }
-
-        #[test]
-        fn test_pq_address_roundtrip() {
-            use bth_account_keys::QuantumSafePublicAddress;
+        fn test_pq_public_address_carries_pq_keys() {
+            use bth_account_keys::{ML_DSA_65_PUBLIC_KEY_LEN, ML_KEM_768_PUBLIC_KEY_LEN};
 
             let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
-            let pq_addr = keys.pq_address_string();
+            let addr = keys.pq_public_address();
 
-            // Should be able to parse the address back
-            let parsed =
-                QuantumSafePublicAddress::from_address_string(&pq_addr).expect("should parse");
-            let reparsed = parsed.to_address_string();
-            assert_eq!(pq_addr, reparsed);
+            // The unified v2 address carries both PQ keys at their raw lengths.
+            assert_eq!(addr.kem_public_key().len(), ML_KEM_768_PUBLIC_KEY_LEN);
+            assert_eq!(addr.dsa_public_key().len(), ML_DSA_65_PUBLIC_KEY_LEN);
+            assert!(addr.has_pq_keys());
         }
     }
 }

--- a/botho/src/wallet.rs
+++ b/botho/src/wallet.rs
@@ -13,7 +13,7 @@ use tracing::{debug, warn};
 use zeroize::Zeroizing;
 
 #[cfg(feature = "pq")]
-use bth_account_keys::{QuantumSafeAccountKey, QuantumSafePublicAddress};
+use bth_account_keys::QuantumSafeAccountKey;
 #[cfg(feature = "pq")]
 use bth_crypto_pq::{derive_pq_keys_from_seed, BIP39_SEED_SIZE};
 
@@ -331,15 +331,13 @@ impl Wallet {
     }
 
     /// Get the quantum-safe public address for receiving funds
+    ///
+    /// Returns the unified [`PublicAddress`] (address format v2, ADR 0008),
+    /// carrying both classical Ristretto keys and the post-quantum ML-KEM-768
+    /// / ML-DSA-65 public keys.
     #[cfg(feature = "pq")]
-    pub fn quantum_safe_address(&self) -> QuantumSafePublicAddress {
+    pub fn quantum_safe_address(&self) -> PublicAddress {
         self.pq_account_key.default_subaddress()
-    }
-
-    /// Format the quantum-safe public address as a string for display
-    #[cfg(feature = "pq")]
-    pub fn quantum_safe_address_string(&self) -> String {
-        self.quantum_safe_address().to_address_string()
     }
 
     /// Get the quantum-safe account key

--- a/docs/decisions/0006-pq-architecture-ratification.md
+++ b/docs/decisions/0006-pq-architecture-ratification.md
@@ -101,3 +101,6 @@ ML-DSA-65 the designated future signature family.
   CLSAG sender privacy)
 - #899 — whitepaper §4 ↔ code divergence report
 - Whitepaper §4 "Minting Attribution", §Post-Quantum Stealth Addresses
+- [ADR 0008](0008-universal-pq-address-format-and-hybrid-stealth.md) — the
+  concrete universal-PQ address format (v2), hybrid stealth preimage, and
+  KEM/DSA bundling that implement this direction

--- a/docs/decisions/0008-universal-pq-address-format-and-hybrid-stealth.md
+++ b/docs/decisions/0008-universal-pq-address-format-and-hybrid-stealth.md
@@ -1,0 +1,194 @@
+# ADR 0008: Universal PQ Address Format (v2) + Hybrid Stealth Preimage
+
+**Status**: Accepted
+**Date**: 2026-07-15
+**Decision Makers**: Core Team
+
+## Context
+
+[ADR 0006](0006-pq-architecture-ratification.md) ratified the post-quantum &
+privacy direction: universal ML-KEM on every output, an ML-DSA-65 key published
+per account, retirement of the unreachable `QuantumPrivateTransaction` (QP)
+class, and the whitepaper §4/§4.2 seed-derived ML-KEM construction as the
+normative spec. That ADR set *direction*; it did not fix the concrete on-chain
+**address format** or the exact **stealth-output key-derivation preimage**.
+
+Two facts on `main` forced those format commitments:
+
+1. **A parallel address type.** The canonical `PublicAddress`
+   (`account-keys/src/account_keys.rs`) carried only two 32-byte Ristretto keys
+   and had no PQ dependency. A separate `QuantumSafePublicAddress`
+   (`account-keys/src/quantum_safe.rs`) bundled the ML-KEM-768 and ML-DSA-65
+   public keys and serialized itself under a distinct `botho-pq://1/` address
+   string. The universal-PQ path does not use the parallel type — so the PQ
+   keys had to move into the canonical address, and the two types had to be
+   unified to avoid a permanent fork in the address spine.
+
+2. **Hybrid, not replacement, stealth.** The #957 foundation
+   (`crypto/ring-signature/src/pq_onetime_keys.rs`, `transaction/clsag`) derives
+   each one-time output key from BOTH the classical Diffie-Hellman shared secret
+   AND the ML-KEM shared secret, so an attacker must break classical *and*
+   post-quantum cryptography. This is a departure from the "replace ECDH with
+   ML-KEM" phrasing in the whitepaper §4.2 prose and needed to be recorded as a
+   deliberate format commitment.
+
+Because the entire chain resets to protocol **6.0.0** (fresh genesis, riding
+the demurrage/settlement reset batch #925/#831), there is no in-place UTXO or
+address migration to straddle. One format break can cover all post-quantum keys.
+
+## Problem Statement
+
+Fix, as durable format commitments for the 6.0.0 reset:
+
+- what the canonical address carries (which keys, in what representation);
+- whether the PQ keys are part of address *identity* (digest / hash);
+- how addresses are versioned;
+- the disposition of the parallel `QuantumSafePublicAddress` type;
+- the stealth-output key-derivation preimage (hybrid vs. replacement).
+
+## Decisions
+
+### D1 — PQ keys stored as raw fixed-length bytes (validate-on-parse)
+
+`PublicAddress` gains two fields stored as **raw byte payloads**, not typed
+crypto objects:
+
+- `kem_public_key`: ML-KEM-768 public key, `ML_KEM_768_PUBLIC_KEY_LEN` = **1184
+  bytes**
+- `dsa_public_key`: ML-DSA-65 public key, `ML_DSA_65_PUBLIC_KEY_LEN` = **1952
+  bytes**
+
+Rationale: keeping the base `account-keys` type free of a hard `bth-crypto-pq`
+dependency preserves the crate's `no_std`/`--no-default-features` builds and
+avoids pulling the full lattice stack into every consumer of an address. The
+exact byte length is enforced when an address is **parsed** (from its string /
+wire form), not by the storage type. A classical-only ("v1") address leaves
+both fields empty.
+
+### D2 — Address versioning: bump to `botho://2/` (deferred to the string sub-issue)
+
+The v2 address is `view(32) ‖ spend(32) ‖ ML-KEM-768(1184) ‖ ML-DSA-65(1952)`
+≈ **3.2 KB**. The compact base58 address *string* moves from `botho://1/` to
+a new **`botho://2/`** prefix so that old 64-byte addresses fail loudly rather
+than silently truncating. The retired `botho-pq://1/` prefix is rejected.
+
+Scope note: this ADR records the versioning decision; the base58 string
+encoder/decoder change (and the shared codec of D5) land in a later rollout
+sub-issue. This sub-issue changes only the struct + prost/serde/digest
+representation.
+
+### D3 — Both PQ keys are part of address identity (digest / `ShortAddressHash`)
+
+The ML-KEM and ML-DSA public keys enter the `PublicAddress` `Digestible`
+transcript and therefore its `ShortAddressHash`. An address's PQ keys must not
+be swappable: two addresses that share Ristretto keys but differ in either PQ
+key are distinct identities and hash differently. (Implemented by deriving
+`Digestible` over the new fields; covered by a swap-detection test.)
+
+### D4 — Bundle BOTH PQ keys now; unify/retire `QuantumSafePublicAddress`
+
+Address v2 publishes the ML-KEM **and** the ML-DSA key together. One format
+break covers all post-quantum keys — there is no third break later when
+lattice signature verification consumers arrive. ML-KEM is wired into stealth
+outputs by the universal rollout; the ML-DSA key is published and
+hierarchy-derived and available for signature-verification consumers as they
+arise (post-quantum *spend authorization* via lattice ring signatures is
+explicitly out of scope for now).
+
+`QuantumSafePublicAddress` and its `botho-pq://` string path are **retired**:
+the KEM+DSA keys are folded into the canonical `PublicAddress`. The secret-side
+`QuantumSafeAccountKey` (the mnemonic-seeded keypair holder) is **kept** as a
+thin shim that now yields the unified `PublicAddress`; its own unification into
+`AccountKey` is tracked by the key-hierarchy sub-issue.
+
+### D5 — Single shared base58 address codec (deferred to the string sub-issue)
+
+At ~3.2 KB, the four independent base58 encoders (node / wasm / mobile /
+wallet) risk byte-level drift. A single shared address codec is to be extracted
+so they cannot diverge. Recorded here; implemented in the string sub-issue.
+
+### Hybrid stealth preimage (normative)
+
+Each output's one-time key is derived from a hybrid preimage combining the
+classical DH shared secret and the ML-KEM shared secret (per #957 /
+`pq_onetime_keys`), i.e. `s = Hs(dh ‖ K ‖ index)`-style domain-separated
+hashing over BOTH secrets — **hybrid**, not a replacement of ECDH by ML-KEM.
+Breaking either cryptosystem alone is insufficient to recover or link an
+output. The whitepaper §4.2 prose is updated from "replace ECDH" to this
+hybrid construction in the enforcement sub-issue.
+
+## Consequences
+
+### Positive
+
+1. One canonical address type on the spine; no parallel PQ address to keep in
+   sync.
+2. Defense-in-depth stealth: classical *and* post-quantum security must both
+   fall for an output to be compromised.
+3. A single format break (6.0.0) absorbs all PQ keys — no future forced break
+   for ML-DSA.
+4. The base `account-keys` type stays PQ-dependency-free and `no_std`-friendly.
+
+### Negative
+
+1. Addresses grow from 64 bytes to ~3.2 KB; QR/URI capacity grows ~50×
+   (addressed by the v2 string + shared codec sub-issue).
+2. Changing the address digest changes `ShortAddressHash` for every address —
+   acceptable only because 6.0.0 is a fresh-genesis reset with no migration.
+3. Storing PQ keys as raw bytes defers structural validity to parse time; a
+   malformed in-memory address is possible until validated.
+
+### Neutral
+
+1. Old 64-byte `botho://1/` addresses cannot receive on the reset chain;
+   faucet, web wallet, mobile, and any published testnet addresses must
+   regenerate after the format bump.
+
+## Alternatives Considered
+
+### 1. Typed `MlKem768PublicKey` / `MlDsa65PublicKey` fields in `PublicAddress`
+
+- Pro: validity enforced by construction.
+- Con: forces a hard `bth-crypto-pq` dependency into the base address type and
+  every crate that touches an address; breaks `--no-default-features`. Rejected
+  in favor of raw bytes + validate-on-parse (D1).
+
+### 2. KEM-only address now, ML-DSA in a later break
+
+- Pro: smaller address initially.
+- Con: a second consensus-breaking format change later. Rejected — one break
+  covers both (D4).
+
+### 3. Keep `QuantumSafePublicAddress` as a separate type
+
+- Pro: no downstream churn.
+- Con: a permanent parallel address spine the universal path never uses.
+  Rejected — unify into the canonical address (D4).
+
+### 4. Replace ECDH with ML-KEM (drop classical DH from the stealth key)
+
+- Pro: simpler preimage.
+- Con: single point of cryptographic failure; loses classical security during
+  the PQ transition. Rejected in favor of the hybrid preimage.
+
+## Implementation
+
+Rolls out across the #958 sub-issues (rides the 6.0.0 reset batch; protocol
+version is **not** bumped further):
+
+1. **This sub-issue (#959):** `PublicAddress` carries both PQ keys as raw
+   bytes; prost tags 3/4; `Digestible`/`ShortAddressHash` include them (D3);
+   `new_with_pq`/`with_pq_keys` constructors; classical callers unchanged;
+   `QuantumSafePublicAddress` retired (D4); ADR 0008.
+2. Key hierarchy publishes the derived KEM/DSA keys (§4.2 seed-derived).
+3. v2 base58 address string (`botho://2/`) + shared codec (D2, D5).
+4-6. Send path attaches ciphertexts; minting/lottery outputs; scanner
+   decapsulates on the hybrid path.
+7. Consensus enforcement + whitepaper §4.2 prose update to the hybrid preimage.
+
+## References
+
+- [ADR 0006: Post-Quantum & Privacy Architecture Ratification](0006-pq-architecture-ratification.md)
+- Whitepaper §4 / §4.2 (seed-derived ML-KEM; normative spec)
+- Issue #958 (universal-PQ rollout plan + ratified decisions D1–D5)
+- Issue #959 (this sub-issue), #954, #957 (hybrid-stealth foundation)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -24,6 +24,7 @@ ADRs are immutable once accepted. If a decision changes, a new ADR supersedes th
 | [0005](0005-bridge-v1-chain-scope-ethereum-and-solana.md) | Bridge v1 Chain Scope — Ethereum and Solana | Accepted | 2026-07-13 |
 | [0006](0006-pq-architecture-ratification.md) | Post-Quantum & Privacy Architecture Ratification | Accepted | 2026-07-14 |
 | [0007](0007-bridge-import-cluster-tagging.md) | Bridge-Import Cluster Tagging via Block-Epoch Keys | Accepted | 2026-07-14 |
+| [0008](0008-universal-pq-address-format-and-hybrid-stealth.md) | Universal PQ Address Format (v2) + Hybrid Stealth Preimage | Accepted | 2026-07-15 |
 
 ## ADR Statuses
 


### PR DESCRIPTION
## Summary

Spine-root change for the universal-PQ rollout (#958, sub-issue 1). The canonical `PublicAddress` (`account-keys/src/account_keys.rs`) now carries both post-quantum public keys, and the parallel `QuantumSafePublicAddress` type is retired. Rides the **6.0.0** reset batch; protocol version is **not** bumped.

## Changes

- **PublicAddress v2** carries two raw fixed-length PQ key byte payloads:
  - `kem_public_key` — **ML-KEM-768, 1184 bytes** (`ML_KEM_768_PUBLIC_KEY_LEN`), prost tag 3
  - `dsa_public_key` — **ML-DSA-65, 1952 bytes** (`ML_DSA_65_PUBLIC_KEY_LEN`), prost tag 4
  - Stored as `Vec<u8>` (D1: no hard `bth-crypto-pq` dep in the base type; validate-on-parse).
- **Both PQ keys are in the digest** (D3): the derived `Digestible` includes the new fields, so `ShortAddressHash` binds them. New test asserts swapping either PQ key (or dropping to classical) changes the address hash, and that identical inputs hash identically.
- **Constructors**: `new` unchanged (classical-only, empty PQ vecs); added `new_with_pq` and `with_pq_keys`; accessors `kem_public_key()`, `dsa_public_key()`, `has_pq_keys()`. `Display` appends PQ hex only when present (classical addresses render identically).
- **Construction sites**: the ~44 `PublicAddress` sites use `PublicAddress::new(...)` and keep compiling untouched. Only the two internal `PublicAddress { .. }` struct literals (in `AccountKey::subaddress` / `ViewAccountKey::subaddress`) were updated to `PublicAddress::new`. No other struct literals exist in the workspace.
- **QuantumSafePublicAddress disposition (D4): fully retired.** Its KEM+DSA keys are folded into `PublicAddress`; the type, `AddressParseError`, and the `botho-pq://` string path are removed. `QuantumSafeAccountKey` is **kept as a thin secret-side keypair holder** whose `default/change/subaddress` methods now return the unified `PublicAddress` (its own unification into `AccountKey` is sub-issue 2). Downstream `pq_public_address()` / `quantum_safe_address()` now return `PublicAddress`; the legacy `pq_address_string()` / `quantum_safe_address_string()` (botho-pq://) methods are removed — the v2 base58 string encoding is a later sub-issue. The `address` CLI command now prints the PQ key sizes + hex.
- **Cargo**: `account-keys` enables `bth-crypto-digestible` `alloc`+`derive` unconditionally so the `Vec<u8>` Digestible fields build under `--no-default-features` (verified both modes).
- **ADR 0008** (`docs/decisions/0008-universal-pq-address-format-and-hybrid-stealth.md`): records format-v2, hybrid stealth preimage, KEM/DSA bundling, versioning, and D1–D5; index row added to `README.md`; cross-linked from ADR 0006.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `PublicAddress` carries both PQ keys; prost + `bth_util_serial` + `Digestible` round-trip; byte-length + determinism asserts | ✅ | `bth_util_serial_prost_roundtrip_public_address_v2` (roundtrip + 1184/1952 length asserts); determinism in `pq_keys_are_part_of_short_address_hash` |
| Both PQ keys in `ShortAddressHash`/digest | ✅ | `pq_keys_are_part_of_short_address_hash`: flipping KEM byte, DSA byte, or dropping to classical each changes the hash |
| `QuantumSafePublicAddress` unified/retired; no dead parallel type | ✅ | Type + `botho-pq://` removed; unified return type across botho/botho-wallet; `git grep QuantumSafePublicAddress` clean |
| ADR 0008 committed | ✅ | New file + README index row + ADR 0006 cross-link |
| Whole workspace compiles including tests via `cargo test --workspace --no-run` | ✅ | **Green** (Finished, no errors); also `cargo build --workspace --all-targets` exit 0 |

## Test Plan

- `cargo test -p bth-account-keys --features pq` — 17 passed (incl. new v2 roundtrip, digest-swap, classical-empty tests).
- `cargo test --workspace --no-run` — **green**.
- `cargo build --workspace --all-targets` — exit 0 (only pre-existing warnings).
- `cargo check -p bth-account-keys --no-default-features` and default — both green.
- `cargo +nightly-2025-12-03 fmt --all`; `cargo clippy -p bth-account-keys --features pq` — clean on changed files.

Closes #959