### PR TITLE
feat(account-keys): derive + publish account-wide PQ keys into subaddresses (§4.2 seed-derived)

### DIFF
--- a/account-keys/src/account_keys.rs
+++ b/account-keys/src/account_keys.rs
@@ -37,6 +37,9 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
+#[cfg(feature = "pq")]
+use bth_crypto_pq::{derive_pq_keys_from_seed, BIP39_SEED_SIZE};
+
 pub use bth_core::{
     account::ShortAddressHash,
     consts::{
@@ -257,6 +260,19 @@ impl FromRandom for PublicAddress {
 ///
 /// Containing the pair of secret keys, which can be used
 /// for spending. This should only ever be present in client code.
+///
+/// # Account-wide post-quantum public keys (address format v2)
+///
+/// In addition to the classical Ristretto secret keys, an account carries the
+/// account-wide ML-KEM-768 and ML-DSA-65 *public* keys derived from the same
+/// BIP39/SLIP-0010 root seed (whitepaper §4.2). These are **account-wide** —
+/// identical across every subaddress index, matching the model in
+/// `quantum_safe.rs` — and are attached to each [`PublicAddress`] produced by
+/// [`AccountKey::subaddress`]. They are stored as raw fixed-length byte
+/// payloads (empty for classical/test-only keys that were built without a
+/// seed). Only the *derivation* helper [`AccountKey::attach_pq_from_seed`]
+/// requires the `pq` feature; the raw-bytes builder does not, keeping the base
+/// type free of a hard `bth-crypto-pq` dependency.
 #[derive(Clone, Zeroize)]
 #[cfg_attr(feature = "prost", derive(Message))]
 #[cfg_attr(not(feature = "prost"), derive(Debug))]
@@ -269,6 +285,16 @@ pub struct AccountKey {
     /// Private key `b` used for spending.
     #[cfg_attr(feature = "prost", prost(message, required, tag = "2"))]
     spend_private_key: RistrettoPrivate,
+
+    /// Account-wide raw ML-KEM-768 public key (1184 bytes). Empty for
+    /// classical/test-only account keys derived without a seed.
+    #[cfg_attr(feature = "prost", prost(bytes, tag = "3"))]
+    kem_public_key: Vec<u8>,
+
+    /// Account-wide raw ML-DSA-65 public key (1952 bytes). Empty for
+    /// classical/test-only account keys derived without a seed.
+    #[cfg_attr(feature = "prost", prost(bytes, tag = "4"))]
+    dsa_public_key: Vec<u8>,
 }
 
 // Note: Hash, Ord is implemented in terms of default_subaddress() because
@@ -300,6 +326,13 @@ impl Ord for AccountKey {
 }
 
 /// Create an AccountKey from a SLIP-0010 key
+///
+/// The resulting account key is **classical-only**: a [`Slip10Key`] is the
+/// 32-byte per-account SLIP-0010 node, not the 512-bit BIP39 seed that the
+/// canonical PQ derivation (whitepaper §4.2) requires, so no PQ keys are
+/// attached here. The real wallet paths (`botho-wallet` / `botho`) hold the
+/// full BIP39 seed and attach the account-wide PQ public keys via
+/// [`AccountKey::attach_pq_from_seed`] after this conversion.
 impl From<Slip10Key> for AccountKey {
     fn from(slip10key: Slip10Key) -> Self {
         let spend_private_key = RootSpendPrivate::from(&slip10key);
@@ -320,7 +353,47 @@ impl AccountKey {
         Self {
             spend_private_key: *spend_private_key,
             view_private_key: *view_private_key,
+            // Classical-only: no seed available at this constructor, so the
+            // account publishes no PQ keys. Seed-derived routes attach them via
+            // `attach_pq_from_seed` / `with_pq_public_keys`.
+            kem_public_key: Vec::new(),
+            dsa_public_key: Vec::new(),
         }
+    }
+
+    /// Attach account-wide raw post-quantum public keys to this account key.
+    ///
+    /// Consumes `self` and returns an account key whose [`subaddress`] outputs
+    /// publish the supplied ML-KEM-768 and ML-DSA-65 public keys. The bytes are
+    /// stored verbatim (length validation happens on address-string parse).
+    ///
+    /// [`subaddress`]: AccountKey::subaddress
+    #[inline]
+    pub fn with_pq_public_keys(mut self, kem_public_key: Vec<u8>, dsa_public_key: Vec<u8>) -> Self {
+        self.kem_public_key = kem_public_key;
+        self.dsa_public_key = dsa_public_key;
+        self
+    }
+
+    /// Derive and attach account-wide post-quantum public keys from a BIP39
+    /// seed (§4.2 seed-derived).
+    ///
+    /// Reuses the canonical derivation in `bth-crypto-pq`
+    /// ([`derive_pq_keys_from_seed`]): the 512-bit BIP39 seed is fed through
+    /// HKDF-SHA256 (`"botho-pq-v1"` / `"kem-seed"` and `"sig-seed"`) to
+    /// deterministically produce the ML-KEM-768 and ML-DSA-65 keypairs. Only
+    /// the derived *public* keys are retained here; the secret keys live on
+    /// [`QuantumSafeAccountKey`](crate::QuantumSafeAccountKey). This is the
+    /// same derivation used by `QuantumSafeAccountKey`, so the two agree on
+    /// the same seed.
+    #[cfg(feature = "pq")]
+    #[inline]
+    pub fn attach_pq_from_seed(self, seed: &[u8; BIP39_SEED_SIZE]) -> Self {
+        let pq_keys = derive_pq_keys_from_seed(seed);
+        self.with_pq_public_keys(
+            pq_keys.kem_keypair.public_key().as_bytes().to_vec(),
+            pq_keys.sig_keypair.public_key().as_bytes().to_vec(),
+        )
     }
 
     /// Get the view private key.
@@ -331,6 +404,26 @@ impl AccountKey {
     /// Get the spend private key.
     pub fn spend_private_key(&self) -> &RistrettoPrivate {
         &self.spend_private_key
+    }
+
+    /// Get the account-wide raw ML-KEM-768 public key bytes.
+    ///
+    /// Empty for classical/test-only account keys derived without a seed.
+    pub fn kem_public_key(&self) -> &[u8] {
+        &self.kem_public_key
+    }
+
+    /// Get the account-wide raw ML-DSA-65 public key bytes.
+    ///
+    /// Empty for classical/test-only account keys derived without a seed.
+    pub fn dsa_public_key(&self) -> &[u8] {
+        &self.dsa_public_key
+    }
+
+    /// Whether this account carries well-formed account-wide PQ public keys.
+    pub fn has_pq_keys(&self) -> bool {
+        self.kem_public_key.len() == ML_KEM_768_PUBLIC_KEY_LEN
+            && self.dsa_public_key.len() == ML_DSA_65_PUBLIC_KEY_LEN
     }
 
     /// Create an account key with random secret keys (intended for tests).
@@ -371,9 +464,12 @@ impl AccountKey {
             RistrettoPublic::from(&subaddress_spend_private)
         };
 
-        // Classical-only (v1) subaddress. PQ keys are attached by the
-        // quantum-safe derivation path (see `quantum_safe.rs`).
+        // Attach the account-wide PQ public keys (§4.2). They are identical
+        // across all subaddress indices; only the classical keys vary. When the
+        // account was built without a seed the PQ vecs are empty and the
+        // address is classical-only.
         PublicAddress::new(&spend_public_key, &view_public_key)
+            .with_pq_keys(self.kem_public_key.clone(), self.dsa_public_key.clone())
     }
 
     /// The private spend key for the default subaddress.
@@ -430,6 +526,11 @@ impl AccountKey {
 }
 
 /// View AccountKey, containing the view private key and the spend public key.
+///
+/// Like [`AccountKey`], a view account key carries the account-wide raw
+/// ML-KEM-768 and ML-DSA-65 public keys so the subaddresses it produces publish
+/// the same PQ keys as the full account key it was derived from (empty for
+/// classical/test-only view keys).
 #[derive(Clone, Zeroize)]
 #[cfg_attr(feature = "prost", derive(Message))]
 #[zeroize(drop)]
@@ -441,6 +542,16 @@ pub struct ViewAccountKey {
     /// Public key `B` used for generating Public Addresses.
     #[cfg_attr(feature = "prost", prost(message, required, tag = "2"))]
     spend_public_key: RistrettoPublic,
+
+    /// Account-wide raw ML-KEM-768 public key (1184 bytes). Empty for
+    /// classical/test-only view keys.
+    #[cfg_attr(feature = "prost", prost(bytes, tag = "3"))]
+    kem_public_key: Vec<u8>,
+
+    /// Account-wide raw ML-DSA-65 public key (1952 bytes). Empty for
+    /// classical/test-only view keys.
+    #[cfg_attr(feature = "prost", prost(bytes, tag = "4"))]
+    dsa_public_key: Vec<u8>,
 }
 
 // Note: Hash, Ord is implemented in terms of default_subaddress() because
@@ -476,6 +587,10 @@ impl From<&AccountKey> for ViewAccountKey {
         ViewAccountKey {
             view_private_key: *account_key.view_private_key(),
             spend_public_key: account_key.spend_private_key().into(),
+            // Carry over the account-wide PQ public keys so the view key's
+            // subaddresses publish the same PQ keys as the full account key.
+            kem_public_key: account_key.kem_public_key().to_vec(),
+            dsa_public_key: account_key.dsa_public_key().to_vec(),
         }
     }
 }
@@ -491,7 +606,22 @@ impl ViewAccountKey {
         Self {
             view_private_key,
             spend_public_key,
+            kem_public_key: Vec::new(),
+            dsa_public_key: Vec::new(),
         }
+    }
+
+    /// Attach account-wide raw post-quantum public keys to this view key.
+    ///
+    /// Consumes `self` and returns a view key whose [`subaddress`] outputs
+    /// publish the supplied ML-KEM-768 and ML-DSA-65 public keys.
+    ///
+    /// [`subaddress`]: ViewAccountKey::subaddress
+    #[inline]
+    pub fn with_pq_public_keys(mut self, kem_public_key: Vec<u8>, dsa_public_key: Vec<u8>) -> Self {
+        self.kem_public_key = kem_public_key;
+        self.dsa_public_key = dsa_public_key;
+        self
     }
 
     /// Get the view private key.
@@ -502,6 +632,16 @@ impl ViewAccountKey {
     /// Get the spend public key.
     pub fn spend_public_key(&self) -> &RistrettoPublic {
         &self.spend_public_key
+    }
+
+    /// Get the account-wide raw ML-KEM-768 public key bytes.
+    pub fn kem_public_key(&self) -> &[u8] {
+        &self.kem_public_key
+    }
+
+    /// Get the account-wide raw ML-DSA-65 public key bytes.
+    pub fn dsa_public_key(&self) -> &[u8] {
+        &self.dsa_public_key
     }
 
     /// Create a view account key with random keys
@@ -538,9 +678,10 @@ impl ViewAccountKey {
         )
             .subaddress(index);
 
-        // Classical-only (v1) subaddress. PQ keys are attached by the
-        // quantum-safe derivation path (see `quantum_safe.rs`).
+        // Attach the account-wide PQ public keys (§4.2), identical across all
+        // subaddress indices. Empty vecs yield a classical-only address.
         PublicAddress::new(&spend_public.inner(), &view_public.inner())
+            .with_pq_keys(self.kem_public_key.clone(), self.dsa_public_key.clone())
     }
 
     /// The public spend key for the default subaddress.
@@ -766,6 +907,176 @@ mod account_key_tests {
         assert_eq!(
             account_key.subaddress(500),
             view_account_key.subaddress(500)
+        );
+    }
+
+    // The account key derived from a BIP39 seed publishes the account-wide PQ
+    // public keys on every subaddress, and those keys are the ones the canonical
+    // `derive_pq_keys_from_seed` derivation (§4.2) produces. Round-trip:
+    // encapsulating against the published KEM key decapsulates with the derived
+    // KEM secret, and the published DSA key verifies a signature from the
+    // derived DSA secret.
+    #[test]
+    #[cfg(feature = "pq")]
+    fn account_key_publishes_derived_pq_keys_that_round_trip() {
+        use bth_crypto_pq::{
+            derive_pq_keys_from_seed, MlDsa65PublicKey, MlKem768PublicKey,
+            ML_DSA_65_PUBLIC_KEY_BYTES, ML_KEM_768_PUBLIC_KEY_BYTES,
+        };
+
+        let mut rng: StdRng = SeedableRng::from_seed([5u8; 32]);
+        let seed = [7u8; 64];
+
+        let account_key = AccountKey::new(
+            &RistrettoPrivate::from_random(&mut rng),
+            &RistrettoPrivate::from_random(&mut rng),
+        )
+        .attach_pq_from_seed(&seed);
+
+        // Account-wide keys are present at their raw lengths.
+        assert!(account_key.has_pq_keys());
+        assert_eq!(
+            account_key.kem_public_key().len(),
+            ML_KEM_768_PUBLIC_KEY_BYTES
+        );
+        assert_eq!(
+            account_key.dsa_public_key().len(),
+            ML_DSA_65_PUBLIC_KEY_BYTES
+        );
+
+        // Every subaddress publishes the same account-wide PQ keys.
+        let addr0 = account_key.subaddress(0);
+        let addr7 = account_key.subaddress(7);
+        assert!(addr0.has_pq_keys());
+        assert_eq!(addr0.kem_public_key(), addr7.kem_public_key());
+        assert_eq!(addr0.dsa_public_key(), addr7.dsa_public_key());
+
+        // The published keys equal the canonical seed-derived keypairs.
+        let pq = derive_pq_keys_from_seed(&seed);
+        assert_eq!(
+            addr0.kem_public_key(),
+            pq.kem_keypair.public_key().as_bytes()
+        );
+        assert_eq!(
+            addr0.dsa_public_key(),
+            pq.sig_keypair.public_key().as_bytes()
+        );
+
+        // KEM round-trip: encapsulate to the PUBLISHED key, decapsulate with the
+        // DERIVED secret — shared secrets must match.
+        let published_kem = MlKem768PublicKey::from_bytes(addr0.kem_public_key())
+            .expect("published KEM key is well formed");
+        let (ciphertext, sender_secret) = published_kem.encapsulate();
+        let recipient_secret = pq
+            .kem_keypair
+            .decapsulate(&ciphertext)
+            .expect("decapsulation with derived secret succeeds");
+        assert_eq!(sender_secret.as_bytes(), recipient_secret.as_bytes());
+
+        // DSA round-trip: sign with the DERIVED secret, verify with the
+        // PUBLISHED key.
+        let message = b"botho universal-pq round trip";
+        let signature = pq.sig_keypair.sign(message);
+        let published_dsa = MlDsa65PublicKey::from_bytes(addr0.dsa_public_key())
+            .expect("published DSA key is well formed");
+        assert!(published_dsa.verify(message, &signature).is_ok());
+    }
+
+    // AccountKey and the ViewAccountKey derived from it agree on the published
+    // PQ keys across subaddress indices (extends `test_view_account_keys_
+    // subaddresses` to the post-quantum fields).
+    #[test]
+    #[cfg(feature = "pq")]
+    fn view_account_keys_subaddresses_agree_on_pq_keys() {
+        let mut rng: StdRng = SeedableRng::from_seed([13u8; 32]);
+        let account_key = AccountKey::new(
+            &RistrettoPrivate::from_random(&mut rng),
+            &RistrettoPrivate::from_random(&mut rng),
+        )
+        .attach_pq_from_seed(&[21u8; 64]);
+        let view_account_key = ViewAccountKey::from(&account_key);
+
+        // Full-address equality already covers the PQ fields (they are part of
+        // the address identity), for several indices.
+        for index in [DEFAULT_SUBADDRESS_INDEX, CHANGE_SUBADDRESS_INDEX, 500] {
+            assert_eq!(
+                account_key.subaddress(index),
+                view_account_key.subaddress(index)
+            );
+            assert_eq!(
+                account_key.subaddress(index).kem_public_key(),
+                view_account_key.subaddress(index).kem_public_key()
+            );
+            assert_eq!(
+                account_key.subaddress(index).dsa_public_key(),
+                view_account_key.subaddress(index).dsa_public_key()
+            );
+        }
+        assert!(view_account_key.default_subaddress().has_pq_keys());
+    }
+
+    // Determinism: the same seed yields the same published PQ keys regardless of
+    // the classical keys, and the `AccountKey` derivation agrees with the
+    // `QuantumSafeAccountKey` (from_mnemonic / from_parts) derivation on the
+    // same seed.
+    #[test]
+    #[cfg(feature = "pq")]
+    fn pq_keys_are_deterministic_across_routes() {
+        use crate::QuantumSafeAccountKey;
+        use bth_crypto_pq::derive_pq_keys_from_seed;
+
+        let seed = [42u8; 64];
+        let mut rng: StdRng = SeedableRng::from_seed([1u8; 32]);
+
+        // Same seed, different classical keys -> identical published PQ keys.
+        let ak1 = AccountKey::new(
+            &RistrettoPrivate::from_random(&mut rng),
+            &RistrettoPrivate::from_random(&mut rng),
+        )
+        .attach_pq_from_seed(&seed);
+        let ak2 = AccountKey::new(
+            &RistrettoPrivate::from_random(&mut rng),
+            &RistrettoPrivate::from_random(&mut rng),
+        )
+        .attach_pq_from_seed(&seed);
+        assert_eq!(ak1.kem_public_key(), ak2.kem_public_key());
+        assert_eq!(ak1.dsa_public_key(), ak2.dsa_public_key());
+
+        // Agreement with the canonical keypair derivation.
+        let pq = derive_pq_keys_from_seed(&seed);
+        assert_eq!(ak1.kem_public_key(), pq.kem_keypair.public_key().as_bytes());
+        assert_eq!(ak1.dsa_public_key(), pq.sig_keypair.public_key().as_bytes());
+
+        // Agreement with QuantumSafeAccountKey: from_mnemonic and from_parts must
+        // publish the same PQ keys (both route through
+        // `derive_pq_keys_from_seed`).
+        const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let qsak_from_mnemonic = QuantumSafeAccountKey::from_mnemonic(TEST_MNEMONIC);
+        let mnemonic_seed = {
+            use bth_crypto_pq::BIP39_SEED_SIZE;
+            let mnemonic = bip39::Mnemonic::from_phrase(TEST_MNEMONIC, bip39::Language::English)
+                .expect("valid test mnemonic");
+            let seed = bip39::Seed::new(&mnemonic, "");
+            let bytes: [u8; BIP39_SEED_SIZE] =
+                seed.as_bytes().try_into().expect("BIP39 seed is 64 bytes");
+            bytes
+        };
+        let qsak_from_parts = QuantumSafeAccountKey::from_parts(
+            AccountKey::new(
+                &RistrettoPrivate::from_random(&mut rng),
+                &RistrettoPrivate::from_random(&mut rng),
+            ),
+            derive_pq_keys_from_seed(&mnemonic_seed),
+        );
+        assert_eq!(
+            qsak_from_mnemonic.default_subaddress().kem_public_key(),
+            qsak_from_parts.default_subaddress().kem_public_key(),
+            "from_mnemonic and from_parts must agree on the KEM key"
+        );
+        assert_eq!(
+            qsak_from_mnemonic.default_subaddress().dsa_public_key(),
+            qsak_from_parts.default_subaddress().dsa_public_key(),
+            "from_mnemonic and from_parts must agree on the DSA key"
         );
     }
 }

--- a/account-keys/src/identity.rs
+++ b/account-keys/src/identity.rs
@@ -111,6 +111,12 @@ impl FromRandom for RootIdentity {
 }
 
 /// Derive an AccountKey from RootIdentity
+///
+/// The resulting account key is **classical-only**: `RootIdentity` carries 32
+/// bytes of root entropy, not the 512-bit BIP39 seed that the canonical PQ
+/// derivation (whitepaper §4.2, `derive_pq_keys_from_seed`) requires, so no PQ
+/// public keys are attached. Callers that hold the BIP39 seed attach the
+/// account-wide PQ keys with [`AccountKey::attach_pq_from_seed`].
 impl From<&RootIdentity> for AccountKey {
     fn from(src: &RootIdentity) -> Self {
         let spend_private_key = RistrettoPrivate::from(root_identity_hkdf_helper(

--- a/botho-wallet/src/keys.rs
+++ b/botho-wallet/src/keys.rs
@@ -102,9 +102,27 @@ impl WalletKeys {
         // SAFETY: The phrase we just created is valid for the lifetime of Self
         let lock = unsafe { lock_string(&phrase) };
 
-        // Derive keys using SLIP-0010 (account index 0)
+        // Derive the full BIP39 seed (with PBKDF2 key stretching) BEFORE the
+        // mnemonic is consumed by SLIP-0010 derivation. This is the seed the
+        // canonical PQ derivation (§4.2) requires.
+        #[cfg(feature = "pq")]
+        let bip39_seed = bip39::Seed::new(&mnemonic, "");
+
+        // Derive classical keys using SLIP-0010 (account index 0).
         let slip10_key = mnemonic.derive_slip10_key(0);
         let account_key = AccountKey::from(slip10_key);
+
+        // Attach the account-wide PQ public keys (ML-KEM-768 + ML-DSA-65)
+        // derived from the same BIP39 seed, so the wallet's emitted addresses
+        // publish them (whitepaper §4.2).
+        #[cfg(feature = "pq")]
+        let account_key = {
+            let seed_bytes: &[u8; bth_crypto_pq::BIP39_SEED_SIZE] = bip39_seed
+                .as_bytes()
+                .try_into()
+                .expect("BIP39 seed is always 64 bytes");
+            account_key.attach_pq_from_seed(seed_bytes)
+        };
 
         Ok(Self {
             _mnemonic_lock: Some(lock),
@@ -465,6 +483,25 @@ mod tests {
             assert_eq!(addr.kem_public_key().len(), ML_KEM_768_PUBLIC_KEY_LEN);
             assert_eq!(addr.dsa_public_key().len(), ML_DSA_65_PUBLIC_KEY_LEN);
             assert!(addr.has_pq_keys());
+        }
+
+        #[test]
+        fn test_plain_public_address_carries_derived_pq_keys() {
+            // The wallet's plain account key (not just the quantum-safe view)
+            // now emits addresses carrying the account-wide PQ keys derived from
+            // the same BIP39 seed. The plain and quantum-safe addresses must
+            // agree on the published PQ keys (single unified identity).
+            let keys = WalletKeys::from_mnemonic(TEST_MNEMONIC).unwrap();
+
+            let plain = keys.public_address();
+            assert!(
+                plain.has_pq_keys(),
+                "wallet's default address must publish PQ keys"
+            );
+
+            let pq = keys.pq_public_address();
+            assert_eq!(plain.kem_public_key(), pq.kem_public_key());
+            assert_eq!(plain.dsa_public_key(), pq.dsa_public_key());
         }
     }
 }

--- a/botho/src/wallet.rs
+++ b/botho/src/wallet.rs
@@ -164,16 +164,25 @@ impl Wallet {
         let slip10_key = mnemonic.derive_slip10_key(0);
         let account_key = AccountKey::from(slip10_key);
 
-        // Create unified quantum-safe account from BIP39 seed
-        // IMPORTANT: Uses the SAME classical keys to maintain single identity
+        // Create unified quantum-safe account from BIP39 seed and attach the
+        // account-wide PQ public keys to the classical account key so its
+        // emitted addresses publish them (whitepaper §4.2).
+        // IMPORTANT: Uses the SAME classical keys and the SAME derived PQ keys
+        // to maintain a single unified identity — the account key and the
+        // quantum-safe account key therefore agree on the published PQ keys.
         #[cfg(feature = "pq")]
-        let pq_account_key = {
+        let (account_key, pq_account_key) = {
             let seed_bytes: &[u8; BIP39_SEED_SIZE] = bip39_seed
                 .as_bytes()
                 .try_into()
                 .expect("BIP39 seed is always 64 bytes");
             let pq_keys = derive_pq_keys_from_seed(seed_bytes);
-            QuantumSafeAccountKey::from_parts(account_key.clone(), pq_keys)
+            let account_key = account_key.with_pq_public_keys(
+                pq_keys.kem_keypair.public_key().as_bytes().to_vec(),
+                pq_keys.sig_keypair.public_key().as_bytes().to_vec(),
+            );
+            let pq_account_key = QuantumSafeAccountKey::from_parts(account_key.clone(), pq_keys);
+            (account_key, pq_account_key)
         };
 
         Ok(Self {


### PR DESCRIPTION
## Summary

Sub-issue 2 of the #958 universal-PQ rollout. The canonical `AccountKey` and `ViewAccountKey` now carry the **account-wide** ML-KEM-768 + ML-DSA-65 public keys that sub-issue 1 (#960) added to `PublicAddress`, and **attach them to every `PublicAddress`** their `subaddress()` emits (whitepaper §4.2). Rides the **6.0.0** reset batch; protocol version is **not** bumped.

## Derivation reused (no new derivation)

PQ keys are derived from the **same 512-bit BIP39 seed** as the rest of the key hierarchy via the existing `bth-crypto-pq::derive_pq_keys_from_seed` — HKDF-SHA256 with domain `"botho-pq-v1"` and info labels `"kem-seed"` / `"sig-seed"`, exactly as whitepaper §4.2 specifies and exactly what `QuantumSafeAccountKey` already does. Only the derived **public** keys are retained on the account key; the secret keys continue to live on `QuantumSafeAccountKey`.

## Changes

- **`account-keys/src/account_keys.rs`**
  - `AccountKey` and `ViewAccountKey` gain raw account-wide PQ public-key byte fields (`kem_public_key`, `dsa_public_key`; prost tags 3/4), plus `with_pq_public_keys` builders, `kem_public_key()`/`dsa_public_key()`/`has_pq_keys()` accessors.
  - `AccountKey` gains a pq-gated `attach_pq_from_seed(&[u8; 64])` that reuses `derive_pq_keys_from_seed`.
  - `subaddress()` on both types attaches the account-wide PQ keys (identical across indices; empty vecs yield a classical address).
  - `ViewAccountKey::from(&AccountKey)` copies the account-wide PQ keys, so a view key's subaddresses match the full account key's.
- **`account-keys/src/identity.rs`** — documented that `From<&RootIdentity>` is classical-only (32-byte entropy, not the BIP39 seed the PQ derivation requires).
- **`botho-wallet/src/keys.rs` + `botho/src/wallet.rs`** — `from_mnemonic` composes it: the wallet holds the full BIP39 seed and attaches the derived PQ keys to the account key, so its emitted addresses publish them. The plain account key and the quantum-safe account key agree on the published PQ keys (single unified identity, same seed).

## Routes covered

| Route | PQ keys | Rationale |
|-------|---------|-----------|
| `botho-wallet` / `botho` `from_mnemonic` (real wallet) | derived real | holds the 512-bit BIP39 seed → `attach_pq_from_seed` |
| `QuantumSafeAccountKey::from_mnemonic` / `from_parts` | derived real | pre-existing; both route through `derive_pq_keys_from_seed` and agree |
| `AccountKey::new` / `random` | empty (documented) | test-only; no seed |
| `From<Slip10Key>` | empty (documented) | 32-byte SLIP-0010 node, not the BIP39 seed |
| `From<&RootIdentity>` | empty (documented) | 32-byte entropy, not the BIP39 seed |

Base type keeps **no hard `bth-crypto-pq` dependency** (raw `Vec<u8>`; only `attach_pq_from_seed` is pq-gated); `--no-default-features` builds green.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `AccountKey::subaddress()` / `ViewAccountKey::subaddress()` attach account-wide KEM+DSA keys | ✅ | `subaddress()` calls `.with_pq_keys(...)`; `account_key_publishes_derived_pq_keys_that_round_trip` |
| Derived from same BIP39 seed via existing `derive_pq_keys_from_seed` | ✅ | `attach_pq_from_seed` reuses it; test asserts published keys == `derive_pq_keys_from_seed(seed)` keypairs |
| Every route populates consistently; from_mnemonic == from_parts | ✅ | `pq_keys_are_deterministic_across_routes` (QSAK from_mnemonic vs from_parts agree on KEM+DSA) |
| KEM published key **decapsulates** against derived secret | ✅ | encapsulate to published key → decapsulate with derived secret → shared secrets equal |
| DSA published key **verifies** signature from derived secret | ✅ | sign with derived secret → `published_dsa.verify(...).is_ok()` |
| AccountKey & ViewAccountKey subaddresses agree on PQ keys | ✅ | `view_account_keys_subaddresses_agree_on_pq_keys` across indices |
| Wallet emitted address carries derived PQ keys | ✅ | `test_plain_public_address_carries_derived_pq_keys` (plain addr `has_pq_keys` and matches QSAK) |
| Feature-gated; `--no-default-features` builds | ✅ | `cargo build --workspace --no-default-features` green |
| Protocol stays 6.0.0 | ✅ | no version/consensus files touched |

## Test Plan

- `cargo test -p bth-account-keys --features pq` — **20 passed** (incl. 3 new: round-trip decap/verify, view-key PQ parity, cross-route determinism).
- `cargo test -p botho-wallet keys::` — **16 passed** (incl. new `test_plain_public_address_carries_derived_pq_keys`).
- `cargo test -p botho --lib wallet::` — 17 passed (incl. `test_wallet_from_mnemonic`).
- `cargo test --workspace --no-run` — **green** (exit 0).
- `cargo build --workspace --all-targets` — green.
- `cargo build --workspace --no-default-features` — green.
- `cargo +nightly-2025-12-03 fmt --all --check` — clean; `cargo clippy -p bth-account-keys --features pq` — clean.

Closes #961