### PR TITLE
feat(crypto)!: attach ML-KEM ciphertexts to value-transfer send outputs

### DIFF
--- a/botho-wallet/src/transaction.rs
+++ b/botho-wallet/src/transaction.rs
@@ -408,23 +408,34 @@ impl TransactionBuilder {
         // the inputs (matches the node's create_private_transaction).
         let inherited_tags = inherited_cluster_tags(&selected);
 
-        // Recipient output (real stealth address via Ristretto DH).
-        let mut outputs = vec![TxOutput::new_with_cluster_tags(
+        // Recipient output (index 0): a hybrid post-quantum stealth output.
+        // The sender encapsulates a shared secret against the recipient's
+        // published ML-KEM-768 key and attaches the 1,088-byte ciphertext,
+        // folding the secret into the one-time key (issue #958 sub-issue 4,
+        // whitepaper §4.2). Fails loudly if the address is not v2 (post-quantum).
+        let mut outputs = vec![TxOutput::new_hybrid_to_address(
             amount,
             recipient,
+            0,
             None,
             inherited_tags.clone(),
-        )];
+        )
+        .map_err(|e| anyhow!("recipient address is not post-quantum: {}", e))?];
 
         // Change: if above dust, create a change output back to ourselves;
         // otherwise absorb the dust into the fee to avoid an unspendable UTXO.
+        // The change output (index 1) is a self-send whose ciphertext is
+        // encapsulated to our OWN published address so we can later scan and
+        // recover it under the hybrid scheme.
         let (actual_fee, change_output_public_key) = if change >= DUST_THRESHOLD {
-            let change_output = TxOutput::new_with_cluster_tags(
+            let change_output = TxOutput::new_hybrid_to_address(
                 change,
                 &self.keys.public_address(),
+                1,
                 None,
                 inherited_tags.clone(),
-            );
+            )
+            .map_err(|e| anyhow!("wallet address is not post-quantum: {}", e))?;
             let change_key = change_output.public_key;
             outputs.push(change_output);
             (fee, Some(change_key))
@@ -1142,40 +1153,96 @@ mod tests {
             )
             .expect("build should succeed");
 
-        // The first output is the recipient output. The recipient's scanner
-        // must detect ownership via the DH stealth protocol.
-        let recipient_scanner = WalletScanner::new(&recipient_keys);
+        // The first output is the recipient output.
         let out = &result.transaction.outputs[0];
         assert_eq!(out.amount, send_amount);
-        let owned = recipient_scanner.check_ownership(&out.target_key, &out.public_key);
-        assert_eq!(
-            owned,
-            Some(0),
-            "recipient must detect the output on their default subaddress"
-        );
 
-        // And the *sender* must NOT detect the recipient's output as their own.
-        let sender_scanner = WalletScanner::new(&keys);
-        assert_eq!(
-            sender_scanner.check_ownership(&out.target_key, &out.public_key),
-            None,
-            "sender must not own the recipient's output"
-        );
-
-        // The change output (if any) must be detectable by the sender.
-        if let Some(change_key) = result.change_output_public_key {
-            let change_out = result
-                .transaction
-                .outputs
-                .iter()
-                .find(|o| o.public_key == change_key)
-                .expect("change output present");
-            assert!(
-                sender_scanner
-                    .check_ownership(&change_out.target_key, &change_out.public_key)
-                    .is_some(),
-                "sender must detect their own change output"
+        // Protocol 6.0.0: every value-transfer output is a hybrid post-quantum
+        // stealth output, so detection requires BOTH the classical view key and
+        // the ML-KEM secret key (belongs_to_hybrid), scanned at the output's
+        // index within the transaction.
+        #[cfg(feature = "pq")]
+        {
+            let recipient_account = recipient_keys.account_key();
+            let recipient_pq = recipient_keys.pq_account_key();
+            assert_eq!(
+                out.belongs_to_hybrid(recipient_account, recipient_pq.pq_kem_keypair(), 0),
+                Some(bth_account_keys::DEFAULT_SUBADDRESS_INDEX),
+                "recipient must detect the hybrid output on their default subaddress"
             );
+
+            // The recipient output carries a 1,088-byte ML-KEM ciphertext.
+            assert_eq!(
+                out.kem_ciphertext.as_ref().map(|c| c.len()),
+                Some(bth_crypto_pq::ML_KEM_768_CIPHERTEXT_BYTES),
+                "recipient output must carry a 1088-byte ML-KEM ciphertext"
+            );
+
+            // The *sender* must NOT detect the recipient's output as their own.
+            let sender_account = keys.account_key();
+            let sender_pq = keys.pq_account_key();
+            assert_eq!(
+                out.belongs_to_hybrid(sender_account, sender_pq.pq_kem_keypair(), 0),
+                None,
+                "sender must not own the recipient's output"
+            );
+
+            // The change output (if any) must be detectable by the sender at its
+            // own output index and carry a ciphertext of its own.
+            if let Some(change_key) = result.change_output_public_key {
+                let (idx, change_out) = result
+                    .transaction
+                    .outputs
+                    .iter()
+                    .enumerate()
+                    .find(|(_, o)| o.public_key == change_key)
+                    .expect("change output present");
+                assert_eq!(
+                    change_out.kem_ciphertext.as_ref().map(|c| c.len()),
+                    Some(bth_crypto_pq::ML_KEM_768_CIPHERTEXT_BYTES),
+                    "change output must carry a 1088-byte ML-KEM ciphertext"
+                );
+                assert!(
+                    change_out
+                        .belongs_to_hybrid(sender_account, sender_pq.pq_kem_keypair(), idx as u32)
+                        .is_some(),
+                    "sender must detect their own change output under the hybrid scheme"
+                );
+            }
+        }
+
+        // Classical fallback (`--no-default-features`): outputs are classical
+        // stealth outputs and remain detectable via the DH scanner.
+        #[cfg(not(feature = "pq"))]
+        {
+            let recipient_scanner = WalletScanner::new(&recipient_keys);
+            assert_eq!(
+                recipient_scanner.check_ownership(&out.target_key, &out.public_key),
+                Some(0),
+                "recipient must detect the output on their default subaddress"
+            );
+
+            let sender_scanner = WalletScanner::new(&keys);
+            assert_eq!(
+                sender_scanner.check_ownership(&out.target_key, &out.public_key),
+                None,
+                "sender must not own the recipient's output"
+            );
+
+            if let Some(change_key) = result.change_output_public_key {
+                let change_out = result
+                    .transaction
+                    .outputs
+                    .iter()
+                    .find(|o| o.public_key == change_key)
+                    .expect("change output present");
+                assert!(
+                    sender_scanner
+                        .check_ownership(&change_out.target_key, &change_out.public_key)
+                        .is_some(),
+                    "sender must detect their own change output"
+                );
+            }
         }
     }
 

--- a/botho/src/commands/send.rs
+++ b/botho/src/commands/send.rs
@@ -4,6 +4,8 @@ use anyhow::{Context, Result};
 use bth_cluster_tax::{FeeConfig, TransactionType};
 use std::{fs, path::Path};
 
+use bth_transaction_types::ClusterTagVector;
+
 use crate::{
     address::Address,
     config::{ledger_db_path_from_config, Config},
@@ -150,17 +152,42 @@ pub fn run(
         selected_amount += utxo.output.amount;
     }
 
-    // Build outputs
+    // Build outputs.
+    //
+    // Under protocol 6.0.0 every value-transfer output is a hybrid
+    // post-quantum stealth output: the sender encapsulates a shared secret
+    // against the destination's published ML-KEM-768 key and attaches the
+    // 1,088-byte ciphertext (issue #958 sub-issue 4, whitepaper §4.2). The
+    // recipient output is index 0; the change output (a self-send whose
+    // ciphertext is encapsulated to our OWN published address) is index 1.
     let mut outputs = Vec::new();
 
     // Output to recipient (with optional memo)
     let memo_payload = memo.map(MemoPayload::destination);
-    outputs.push(TxOutput::new_with_memo(amount, &recipient, memo_payload));
+    outputs.push(
+        TxOutput::new_hybrid_to_address(
+            amount,
+            &recipient,
+            0,
+            memo_payload,
+            ClusterTagVector::empty(),
+        )
+        .context("recipient address does not publish a valid ML-KEM-768 key")?,
+    );
 
-    // Change output (if any) - no memo on change
+    // Change output (if any) - no memo on change, encapsulated to our address
     let change = selected_amount - amount - fee;
     if change > 0 {
-        outputs.push(TxOutput::new(change, &our_address));
+        outputs.push(
+            TxOutput::new_hybrid_to_address(
+                change,
+                &our_address,
+                1,
+                None,
+                ClusterTagVector::empty(),
+            )
+            .context("wallet address does not publish a valid ML-KEM-768 key")?,
+        );
     }
 
     // Create the transaction (always private with CLSAG ring signatures)

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -3643,14 +3643,47 @@ async fn handle_faucet_request(
         }
     };
 
-    // Build outputs
+    // Build outputs.
+    //
+    // Protocol 6.0.0: every value-transfer output is a hybrid post-quantum
+    // stealth output carrying an ML-KEM-768 ciphertext encapsulated to the
+    // destination's published KEM key (issue #958 sub-issue 4). The recipient
+    // output is index 0; the change output (a self-send encapsulated to our
+    // own address) is index 1.
     let mut outputs = Vec::new();
-    outputs.push(TxOutput::new(amount, &recipient));
+    match TxOutput::new_hybrid_to_address(
+        amount,
+        &recipient,
+        0,
+        None,
+        bth_transaction_types::ClusterTagVector::empty(),
+    ) {
+        Ok(out) => outputs.push(out),
+        Err(e) => {
+            error!(
+                "Faucet: recipient address lacks a valid ML-KEM-768 key: {}",
+                e
+            );
+            return JsonRpcResponse::error(id, -32000, "Recipient address is not post-quantum");
+        }
+    }
 
-    // Change output (if any)
+    // Change output (if any), encapsulated to our own published address.
     let change = selected_amount - amount - fee;
     if change > 0 {
-        outputs.push(TxOutput::new(change, &our_address));
+        match TxOutput::new_hybrid_to_address(
+            change,
+            &our_address,
+            1,
+            None,
+            bth_transaction_types::ClusterTagVector::empty(),
+        ) {
+            Ok(out) => outputs.push(out),
+            Err(e) => {
+                error!("Faucet: wallet address lacks a valid ML-KEM-768 key: {}", e);
+                return JsonRpcResponse::error(id, -32000, "Wallet address is not post-quantum");
+            }
+        }
     }
 
     // Create the transaction

--- a/transaction/clsag/src/lib.rs
+++ b/transaction/clsag/src/lib.rs
@@ -129,6 +129,37 @@ impl std::fmt::Display for TransactionStructureError {
 
 impl std::error::Error for TransactionStructureError {}
 
+/// Error returned when a value-transfer output cannot be built as a hybrid
+/// post-quantum stealth output because the destination address does not
+/// publish a well-formed ML-KEM-768 public key.
+///
+/// Under the protocol 6.0.0 output format every address is v2 and publishes a
+/// 1,184-byte ML-KEM-768 key (issue #958, whitepaper §4.2), so the
+/// value-transfer send path fails loudly rather than emit a KEM-less output
+/// that consensus enforcement (issue #958 sub-issue 7) would reject. There is
+/// no silent classical fallback on a `pq`-enabled node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HybridOutputError {
+    /// The destination address does not carry a valid ML-KEM-768 public key
+    /// (the published key is absent or not exactly
+    /// `bth_account_keys::ML_KEM_768_PUBLIC_KEY_LEN` bytes).
+    MissingKemPublicKey,
+}
+
+impl std::fmt::Display for HybridOutputError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingKemPublicKey => write!(
+                f,
+                "destination address does not publish a valid ML-KEM-768 public key \
+                 (required for the protocol 6.0.0 hybrid stealth output format)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for HybridOutputError {}
+
 /// Picocredits per credit (10^12)
 pub const PICOCREDITS_PER_CREDIT: u64 = 1_000_000_000_000;
 
@@ -750,6 +781,69 @@ impl TxOutput {
             &subaddress_spend_private,
             &kem_secret,
             output_index,
+        ))
+    }
+
+    /// Build a hybrid post-quantum stealth output addressed to `recipient`,
+    /// reading the ML-KEM-768 public key published in the recipient's address.
+    ///
+    /// This is the value-transfer **send-path** constructor: it looks up the
+    /// recipient's published ML-KEM-768 key (address format v2, ADR 0008),
+    /// encapsulates a shared secret against it, attaches the resulting
+    /// 1,088-byte ciphertext, and folds the secret into the one-time
+    /// `target_key` (see [`TxOutput::new_hybrid`]).
+    ///
+    /// `output_index` is the output's position within its transaction and is
+    /// bound into the one-time-key derivation, so the recipient (and, for
+    /// change/self-send, the sender) must scan with the same index.
+    ///
+    /// # Errors
+    /// Returns [`HybridOutputError::MissingKemPublicKey`] if `recipient` does
+    /// not publish a well-formed ML-KEM-768 key. Under protocol 6.0.0 every
+    /// address is v2, so a missing key is a hard error rather than a silent
+    /// classical fallback (which would emit a KEM-less output that consensus
+    /// enforcement rejects).
+    pub fn new_hybrid_to_address(
+        amount: u64,
+        recipient: &PublicAddress,
+        output_index: u32,
+        memo: Option<MemoPayload>,
+        cluster_tags: ClusterTagVector,
+    ) -> Result<Self, HybridOutputError> {
+        let kem_public_key = MlKem768PublicKey::from_bytes(recipient.kem_public_key())
+            .map_err(|_| HybridOutputError::MissingKemPublicKey)?;
+        Ok(Self::new_hybrid(
+            amount,
+            recipient,
+            &kem_public_key,
+            output_index,
+            memo,
+            cluster_tags,
+        ))
+    }
+}
+
+/// Classical fallback for builds without the `pq` feature.
+///
+/// The protocol 6.0.0 node builds with `pq` enabled by default; this branch
+/// exists solely so the `--no-default-features` build keeps compiling. It emits
+/// a classical stealth output with `kem_ciphertext == None`.
+#[cfg(not(feature = "pq"))]
+impl TxOutput {
+    /// Classical fallback: constructs a classical stealth output (no ML-KEM
+    /// ciphertext). `output_index` is unused in the classical derivation.
+    pub fn new_hybrid_to_address(
+        amount: u64,
+        recipient: &PublicAddress,
+        _output_index: u32,
+        memo: Option<MemoPayload>,
+        cluster_tags: ClusterTagVector,
+    ) -> Result<Self, HybridOutputError> {
+        Ok(Self::new_with_cluster_tags(
+            amount,
+            recipient,
+            memo,
+            cluster_tags,
         ))
     }
 }
@@ -2274,5 +2368,65 @@ mod pq_tests {
             id_with_ct, id_without_ct,
             "the ML-KEM ciphertext must be bound into the output id"
         );
+    }
+
+    // The send-path constructor reads the ML-KEM key PUBLISHED in the
+    // recipient's address (rather than taking it as a separate argument),
+    // encapsulates to it, and produces a spendable hybrid output.
+    #[test]
+    fn new_hybrid_to_address_reads_published_kem_key() {
+        let (account, kem) = recipient(20);
+        // A v2 address that publishes the recipient's ML-KEM-768 key.
+        let addr = account
+            .default_subaddress()
+            .with_pq_keys(kem.public_key().as_bytes().to_vec(), Vec::new());
+
+        let output_index = 2u32;
+        let out = TxOutput::new_hybrid_to_address(
+            3_000_000,
+            &addr,
+            output_index,
+            None,
+            ClusterTagVector::empty(),
+        )
+        .expect("address publishes a valid ML-KEM key");
+
+        // Carries a 1,088-byte ML-KEM ciphertext.
+        assert_eq!(
+            out.kem_ciphertext.as_ref().map(|c| c.len()),
+            Some(ML_KEM_768_CIPHERTEXT_BYTES),
+            "send-path output must carry a 1088-byte ciphertext"
+        );
+
+        // Recipient decapsulates, detects ownership, and recovers the one-time
+        // spend key whose public point equals the output target_key.
+        let idx = out
+            .belongs_to_hybrid(&account, &kem, output_index)
+            .expect("recipient detects the send-path output");
+        let spend_key = out
+            .recover_spend_key_hybrid(&account, &kem, idx, output_index)
+            .expect("recipient recovers the one-time spend key");
+        assert_eq!(
+            RistrettoPublic::from(&spend_key).to_bytes(),
+            out.target_key,
+            "recovered one-time key must regenerate the output target_key"
+        );
+    }
+
+    // On the 6.0.0 chain every address is v2. A classical-only (KEM-less)
+    // address must fail loudly rather than silently emit a KEM-less output.
+    #[test]
+    fn new_hybrid_to_address_rejects_kem_less_address() {
+        let (account, _kem) = recipient(21);
+        let addr = account.default_subaddress();
+        assert!(
+            addr.kem_public_key().is_empty(),
+            "fixture address must be classical-only"
+        );
+
+        let err =
+            TxOutput::new_hybrid_to_address(1_000_000, &addr, 0, None, ClusterTagVector::empty())
+                .expect_err("a KEM-less address must be rejected");
+        assert_eq!(err, HybridOutputError::MissingKemPublicKey);
     }
 }


### PR DESCRIPTION
## Summary

Sub-issue 4 of the #958 universal-PQ rollout. Switches the **value-transfer send path** to the #957 hybrid post-quantum stealth envelope: every recipient and change output now encapsulates a shared secret against the destination's published ML-KEM-768 key, attaches the 1,088-byte ciphertext, and folds the ML-KEM secret into the one-time `target_key` (whitepaper §4.2). Minting/lottery (sub-issue 5), the receiving scanner (6), and consensus enforcement (7) remain out of scope.

## Changes

- **`transaction/clsag`**: new `TxOutput::new_hybrid_to_address(amount, recipient, output_index, memo, cluster_tags)` — the send-path constructor. It reads the ML-KEM-768 key **published on the recipient `PublicAddress`** (address v2, ADR 0008), encapsulates, and delegates to `new_hybrid`. Adds `HybridOutputError::MissingKemPublicKey`. A `#[cfg(not(feature = "pq"))]` variant returns a classical output so the `--no-default-features` build keeps compiling.
- **Send sites switched to `new_hybrid_to_address`** (recipient = output index 0, change = index 1):
  - `botho/src/commands/send.rs` (CLI send: recipient + change)
  - `botho/src/rpc/mod.rs` (faucet RPC: recipient + change)
  - `botho-wallet/src/transaction.rs` `build_signed_transaction` (recipient + change)
- **Change / self-send**: the change output is encapsulated to the sender's **own** published address (`our_address` / `self.keys.public_address()`), so the sender can later scan and recover it under the hybrid scheme.
- **KEM-less-address decision**: on the 6.0.0 chain every address is v2, so a recipient (or wallet) address that publishes no valid ML-KEM key is a **hard error** (`MissingKemPublicKey`, surfaced as a `context`/`anyhow`/JSON-RPC error), never a silent classical fallback that enforcement (sub-issue 7) would reject.
- **Tests**: updated `test_output_is_detectable_by_recipient` to the hybrid path (`belongs_to_hybrid`) under `pq` with a classical fallback under `--no-default-features`; added clsag `new_hybrid_to_address_reads_published_kem_key` (1088-byte ciphertext + recipient decapsulate → recover one-time key regenerates `target_key`) and `new_hybrid_to_address_rejects_kem_less_address`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Every transfer output (recipient + change) carries a valid 1088-byte ML-KEM ciphertext from the destination's published KEM key | ✅ | `new_hybrid_to_address` reads `recipient.kem_public_key()`; asserted in clsag + wallet tests |
| One-time key uses the #957 hybrid (DH + ML-KEM) construction | ✅ | Delegates to `new_hybrid` / `create_tx_out_target_key_hybrid` |
| Sender `belongs_to_hybrid`-recovers its own change; recipient can decapsulate/derive the output key | ✅ | wallet `test_output_is_detectable_by_recipient` + clsag `new_hybrid_to_address_reads_published_kem_key` |
| KEM-less address fails loudly (no classical fallback) | ✅ | `HybridOutputError::MissingKemPublicKey`; `new_hybrid_to_address_rejects_kem_less_address` |
| Protocol stays 6.0.0 | ✅ | `PROTOCOL_VERSION` in `network/discovery.rs` unchanged |

## Test Plan

- `cargo test -p bth-transaction-clsag --features pq` → 32 passed (incl. 2 new)
- `cargo test -p botho-wallet` → 113 passed
- `cargo test -p botho --lib` (wallet/send/faucet subsets) → green
- `cargo test --workspace --no-run` → compiles ✅
- `cargo build --workspace --all-targets` → ✅
- `cd fuzz && cargo check` → ✅
- `cargo check --workspace --no-default-features` → ✅ (classical fallback)
- `cargo +nightly-2025-12-03 fmt --all` → clean

Closes #966