### PR TITLE
feat(bridge): wire reserve ML-KEM key so hybrid deposits are detected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,6 +2064,7 @@ dependencies = [
  "bincode",
  "bs58 0.4.0",
  "bth-account-keys",
+ "bth-address-codec",
  "bth-bridge-core",
  "bth-cluster-tax",
  "bth-crypto-keys",

--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -174,6 +174,16 @@ pub struct BthConfig {
     /// Path to encrypted spend key file (for withdrawals)
     pub spend_key_file: Option<String>,
 
+    /// Path to the reserve's post-quantum seed file: a single hex-encoded
+    /// 64-byte BIP39 seed. When present, the reserve derives its ML-KEM-768 +
+    /// ML-DSA-65 keypairs from this seed exactly as a normal wallet does
+    /// (`derive_pq_keys_from_seed`), publishes a v2 (`botho://2/…`) address so
+    /// senders can encapsulate to it, and can DETECT + spend hybrid (ML-KEM)
+    /// deposits under protocol 6.0.0. Absent = classical-only (v1) reserve:
+    /// hybrid deposits are warned about, not detected (issue #972).
+    #[serde(default)]
+    pub pq_seed_file: Option<String>,
+
     /// Number of confirmations required (0 for SCP finality)
     #[serde(default)]
     pub confirmations_required: u32,
@@ -482,6 +492,7 @@ impl Default for BridgeConfig {
                 ws_url: "ws://localhost:7101/ws".to_string(),
                 view_key_file: None,
                 spend_key_file: None,
+                pq_seed_file: None,
                 confirmations_required: 0,
                 reserve_address: None,
                 release_signers: Vec::new(),

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -68,8 +68,13 @@ bth-transaction-types = { workspace = true }
 bth-account-keys = { workspace = true }
 bth-crypto-keys = { workspace = true }
 bth-crypto-ring-signature = { workspace = true }
-# ML-KEM-768 encapsulation/decapsulation for hybrid deposit detection (#970).
+# ML-KEM-768 encapsulation/decapsulation for hybrid deposit detection (#970),
+# plus `derive_pq_keys_from_seed` to derive the reserve's PQ keypairs from its
+# seed exactly as a normal wallet does (issue #972).
 bth-crypto-pq = { path = "../../crypto/pq" }
+# Canonical v2 (`botho://2/…`) address encoder/decoder: publishes the reserve's
+# post-quantum receive address so senders can encapsulate to it (issue #972).
+bth-address-codec = { workspace = true }
 
 # JSON-RPC over HTTP to the BTH node (getChainInfo / getBlockByHeight /
 # chain_getOutputs / tx_submit / getTransaction / chain_areKeyImagesSpent).

--- a/bridge/service/src/bth_fork_tests.rs
+++ b/bridge/service/src/bth_fork_tests.rs
@@ -56,6 +56,7 @@ fn live_config() -> Option<BthConfig> {
         ws_url: String::new(),
         view_key_file: Some(view_key_file),
         spend_key_file: Some(spend_key_file),
+        pq_seed_file: None,
         confirmations_required: 0,
         reserve_address: Some("bth_reserve_addr".to_string()),
         release_signers: Vec::new(),

--- a/bridge/service/src/bth_keys.rs
+++ b/bridge/service/src/bth_keys.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2024 The Botho Foundation
 
-//! Reserve wallet key material for the live BTH transports (#856).
+//! Reserve wallet key material for the live BTH transports (#856, #972).
 //!
 //! Both the deposit watcher (view-key scanning outputs paid to the bridge
 //! deposit/reserve address) and the release path (spending reserve-owned
@@ -11,34 +11,82 @@
 //! node-identical [`AccountKey`] so ownership detection and one-time-key
 //! recovery cannot drift from the chain.
 //!
+//! # Post-quantum reserve key (issue #972)
+//!
+//! On the universal-ML-KEM chain (protocol 6.0.0, #958) every output carries an
+//! ML-KEM ciphertext, and a hybrid deposit paid to the reserve can only be
+//! detected by ML-KEM decapsulation with the reserve's secret. When
+//! `BthConfig::pq_seed_file` is configured (a single hex-encoded 64-byte BIP39
+//! seed), the reserve derives its ML-KEM-768 + ML-DSA-65 keypairs from that
+//! seed using the SAME `derive_pq_keys_from_seed` a normal wallet uses, so its
+//! published v2 (`botho://2/…`) address is self-consistent: the ML-KEM public
+//! key it advertises matches the secret the scanner decapsulates with. The
+//! ML-DSA public key is bundled into the address (v2 carries both) even though
+//! reserve spends remain CLSAG (the ML-DSA secret is unused for spending).
+//!
 //! Absent key files disable the relevant transport (watch-only): the deposit
 //! watcher stays idle and release submission is disabled, exactly the
-//! fail-safe posture the stubs had.
+//! fail-safe posture the stubs had. An absent `pq_seed_file` leaves a
+//! classical-only (v1) reserve: hybrid deposits are warned about, not detected.
 
 use bth_account_keys::AccountKey;
+use bth_address_codec::{encode_address, Network};
 use bth_crypto_keys::RistrettoPrivate;
+use bth_crypto_pq::{derive_pq_keys_from_seed, MlKem768KeyPair, BIP39_SEED_SIZE};
 
 /// Reserve wallet keys reconstructed from the configured key files.
 #[derive(Clone)]
 pub struct ReserveKeys {
     account: AccountKey,
+    /// Present when a reserve PQ seed file is configured: the ML-KEM-768
+    /// keypair the scanner decapsulates hybrid deposits with, alongside the
+    /// account-wide ML-KEM + ML-DSA public keys bundled into the reserve's
+    /// published v2 address. `None` == classical-only (v1) reserve.
+    pq: Option<ReservePqKeys>,
+}
+
+/// Post-quantum reserve material derived from the reserve PQ seed.
+#[derive(Clone)]
+struct ReservePqKeys {
+    /// The ML-KEM-768 keypair used to decapsulate hybrid deposits (the scanner
+    /// needs the secret; the public key is what senders encapsulate to).
+    kem_keypair: MlKem768KeyPair,
+    /// Raw ML-KEM-768 public key bytes (published in the v2 address).
+    kem_public_key: Vec<u8>,
+    /// Raw ML-DSA-65 public key bytes (published in the v2 address). The DSA
+    /// secret is not retained: reserve spends are CLSAG, so it is never used.
+    dsa_public_key: Vec<u8>,
 }
 
 impl ReserveKeys {
-    /// Load from the hex spend/view private-key files. Returns `Ok(None)`
-    /// (transport disabled, not an error) when either path is absent —
-    /// watch-only deployments run without reserve keys.
+    /// Load from the hex spend/view private-key files and an optional PQ seed
+    /// file. Returns `Ok(None)` (transport disabled, not an error) when either
+    /// classical key path is absent — watch-only deployments run without
+    /// reserve keys.
+    ///
+    /// When `pq_seed_file` is present the reserve additionally derives its
+    /// ML-KEM-768 + ML-DSA-65 keypairs from the seed (issue #972), enabling
+    /// hybrid-deposit detection and a v2 published address. When absent the
+    /// reserve stays classical-only (hybrid deposits warned, not detected).
     pub fn load(
         view_key_file: Option<&str>,
         spend_key_file: Option<&str>,
+        pq_seed_file: Option<&str>,
     ) -> Result<Option<Self>, String> {
         let (Some(view_path), Some(spend_path)) = (view_key_file, spend_key_file) else {
             return Ok(None);
         };
         let view_private = read_hex_scalar(view_path, "bth.view_key_file")?;
         let spend_private = read_hex_scalar(spend_path, "bth.spend_key_file")?;
+
+        let pq = match pq_seed_file {
+            Some(seed_path) => Some(load_pq_keys(seed_path)?),
+            None => None,
+        };
+
         Ok(Some(Self {
             account: AccountKey::new(&spend_private, &view_private),
+            pq,
         }))
     }
 
@@ -46,6 +94,64 @@ impl ReserveKeys {
     pub fn account(&self) -> &AccountKey {
         &self.account
     }
+
+    /// The reserve's ML-KEM-768 keypair, when a PQ seed file is configured.
+    ///
+    /// This is the secret the deposit scanner / release path pass into
+    /// [`crate::bth_scan::scan_deposit_output`] /
+    /// [`crate::bth_scan::build_release_tx`] to detect and spend hybrid
+    /// deposits. `None` for a classical-only reserve (hybrid deposits are
+    /// then warned about, not detected).
+    pub fn kem_keypair(&self) -> Option<&MlKem768KeyPair> {
+        self.pq.as_ref().map(|pq| &pq.kem_keypair)
+    }
+
+    /// Whether this reserve holds a post-quantum key (can detect hybrid
+    /// deposits and publish a v2 address).
+    pub fn has_pq_keys(&self) -> bool {
+        self.pq.is_some()
+    }
+
+    /// The reserve's published receive address: a v2 [`PublicAddress`] carrying
+    /// the reserve's ML-KEM + ML-DSA public keys when a PQ seed is configured,
+    /// else the classical (v1) default subaddress. Senders encapsulate to the
+    /// ML-KEM key in this address; the scanner decapsulates with the matching
+    /// secret, so the pair is self-consistent by construction.
+    pub fn public_address(&self) -> bth_account_keys::PublicAddress {
+        let base = self.account.default_subaddress();
+        match &self.pq {
+            Some(pq) => base.with_pq_keys(pq.kem_public_key.clone(), pq.dsa_public_key.clone()),
+            None => base,
+        }
+    }
+
+    /// The reserve's published address as a `botho://2/…` (or `tbotho://2/…`)
+    /// URI. Errors for a classical-only reserve (v2 requires both PQ keys).
+    pub fn public_address_uri(&self, network: Network) -> Result<String, String> {
+        encode_address(&self.public_address(), network)
+            .map_err(|e| format!("reserve address is not v2-encodable: {e}"))
+    }
+}
+
+/// Load the reserve PQ keypairs from a hex-encoded 64-byte BIP39 seed file,
+/// deriving them with the same `derive_pq_keys_from_seed` a normal wallet uses
+/// so the published v2 address is self-consistent (issue #972).
+fn load_pq_keys(path: &str) -> Result<ReservePqKeys, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| format!("bth.pq_seed_file: cannot read {path}: {e}"))?;
+    let bytes = hex::decode(raw.trim())
+        .map_err(|e| format!("bth.pq_seed_file: invalid hex in {path}: {e}"))?;
+    let seed: [u8; BIP39_SEED_SIZE] = bytes.try_into().map_err(|_| {
+        format!("bth.pq_seed_file: {path} must decode to exactly {BIP39_SEED_SIZE} bytes")
+    })?;
+    let material = derive_pq_keys_from_seed(&seed);
+    let kem_public_key = material.kem_keypair.public_key().as_bytes().to_vec();
+    let dsa_public_key = material.sig_keypair.public_key().as_bytes().to_vec();
+    Ok(ReservePqKeys {
+        kem_keypair: material.kem_keypair,
+        kem_public_key,
+        dsa_public_key,
+    })
 }
 
 /// Read a file containing a single hex-encoded 32-byte scalar into a
@@ -67,11 +173,22 @@ mod tests {
     use super::*;
     use std::io::Write;
 
+    /// Write a hex-encoded classical scalar key file (with a trailing newline
+    /// an editor/`echo` would leave, which loading must tolerate).
+    fn write_key(path: &std::path::Path, bytes: &[u8]) {
+        writeln!(
+            std::fs::File::create(path).unwrap(),
+            "{}",
+            hex::encode(bytes)
+        )
+        .unwrap();
+    }
+
     #[test]
     fn load_none_when_key_files_absent() {
-        assert!(ReserveKeys::load(None, None).unwrap().is_none());
-        assert!(ReserveKeys::load(Some("v"), None).unwrap().is_none());
-        assert!(ReserveKeys::load(None, Some("s")).unwrap().is_none());
+        assert!(ReserveKeys::load(None, None, None).unwrap().is_none());
+        assert!(ReserveKeys::load(Some("v"), None, None).unwrap().is_none());
+        assert!(ReserveKeys::load(None, Some("s"), None).unwrap().is_none());
     }
 
     #[test]
@@ -81,23 +198,13 @@ mod tests {
 
         let view_path = dir.path().join("view.hex");
         let spend_path = dir.path().join("spend.hex");
-        // A trailing newline (as an editor/`echo` would leave) must be tolerated.
-        writeln!(
-            std::fs::File::create(&view_path).unwrap(),
-            "{}",
-            hex::encode(account.view_private_key().to_bytes())
-        )
-        .unwrap();
-        writeln!(
-            std::fs::File::create(&spend_path).unwrap(),
-            "{}",
-            hex::encode(account.spend_private_key().to_bytes())
-        )
-        .unwrap();
+        write_key(&view_path, &account.view_private_key().to_bytes());
+        write_key(&spend_path, &account.spend_private_key().to_bytes());
 
         let loaded = ReserveKeys::load(
             Some(view_path.to_str().unwrap()),
             Some(spend_path.to_str().unwrap()),
+            None,
         )
         .unwrap()
         .expect("both key files present");
@@ -111,6 +218,12 @@ mod tests {
                 .to_bytes(),
             account.default_subaddress().spend_public_key().to_bytes()
         );
+        // No PQ seed => classical-only reserve (hybrid deposits warned, not
+        // detected): no ML-KEM secret and no v2 address.
+        assert!(!loaded.has_pq_keys());
+        assert!(loaded.kem_keypair().is_none());
+        assert!(!loaded.public_address().has_pq_keys());
+        assert!(loaded.public_address_uri(Network::Testnet).is_err());
     }
 
     #[test]
@@ -129,8 +242,183 @@ mod tests {
         )
         .unwrap();
 
+        assert!(ReserveKeys::load(
+            Some(bad.to_str().unwrap()),
+            Some(ok.to_str().unwrap()),
+            None
+        )
+        .is_err());
+    }
+
+    /// With a PQ seed file the reserve derives ML-KEM + ML-DSA keys and
+    /// publishes a v2 address whose ML-KEM public key matches the secret the
+    /// scanner decapsulates with — self-consistent by construction (#972).
+    #[test]
+    fn load_derives_pq_keys_and_publishes_v2_address() {
+        let dir = tempfile::tempdir().unwrap();
+        let account = AccountKey::random(&mut rand::rngs::OsRng);
+        let view_path = dir.path().join("view.hex");
+        let spend_path = dir.path().join("spend.hex");
+        write_key(&view_path, &account.view_private_key().to_bytes());
+        write_key(&spend_path, &account.spend_private_key().to_bytes());
+
+        // A 64-byte BIP39 seed, exactly what a normal wallet feeds
+        // `derive_pq_keys_from_seed`.
+        let seed_path = dir.path().join("pq_seed.hex");
+        write_key(&seed_path, &[0x42u8; BIP39_SEED_SIZE]);
+
+        let loaded = ReserveKeys::load(
+            Some(view_path.to_str().unwrap()),
+            Some(spend_path.to_str().unwrap()),
+            Some(seed_path.to_str().unwrap()),
+        )
+        .unwrap()
+        .expect("classical + PQ material present");
+
+        // The reserve now holds an ML-KEM secret.
+        assert!(loaded.has_pq_keys());
+        let kem = loaded.kem_keypair().expect("reserve has an ML-KEM keypair");
+
+        // The published address is v2, and its ML-KEM public key is the one
+        // senders will encapsulate to — the exact key whose secret the scanner
+        // decapsulates with.
+        let addr = loaded.public_address();
+        assert!(addr.has_pq_keys(), "reserve address is v2");
+        assert_eq!(
+            addr.kem_public_key(),
+            kem.public_key().as_bytes(),
+            "published ML-KEM key matches the reserve's decapsulation secret",
+        );
+
+        // The v2 URI round-trips: decoding it recovers the same PQ keys.
+        let uri = loaded.public_address_uri(Network::Testnet).unwrap();
+        assert!(uri.starts_with("tbotho://2/"), "got: {uri}");
+        let (decoded, network) = bth_address_codec::decode_address(&uri).unwrap();
+        assert_eq!(network, Network::Testnet);
+        assert!(decoded.has_pq_keys());
+        assert_eq!(decoded.kem_public_key(), addr.kem_public_key());
+        assert_eq!(decoded.dsa_public_key(), addr.dsa_public_key());
+        assert_eq!(
+            decoded.spend_public_key().to_bytes(),
+            addr.spend_public_key().to_bytes()
+        );
+
+        // Deterministic: the same seed derives the same published PQ keys.
+        let loaded2 = ReserveKeys::load(
+            Some(view_path.to_str().unwrap()),
+            Some(spend_path.to_str().unwrap()),
+            Some(seed_path.to_str().unwrap()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            loaded2.public_address().kem_public_key(),
+            addr.kem_public_key()
+        );
+    }
+
+    #[test]
+    fn load_rejects_malformed_pq_seed_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let account = AccountKey::random(&mut rand::rngs::OsRng);
+        let view_path = dir.path().join("view.hex");
+        let spend_path = dir.path().join("spend.hex");
+        write_key(&view_path, &account.view_private_key().to_bytes());
+        write_key(&spend_path, &account.spend_private_key().to_bytes());
+
+        // Wrong length (32 bytes, not the 64-byte BIP39 seed) is rejected.
+        let short = dir.path().join("short.hex");
+        std::fs::write(&short, hex::encode([0x11u8; 32])).unwrap();
+        assert!(ReserveKeys::load(
+            Some(view_path.to_str().unwrap()),
+            Some(spend_path.to_str().unwrap()),
+            Some(short.to_str().unwrap()),
+        )
+        .is_err());
+
+        // Non-hex is rejected.
+        let bad = dir.path().join("bad.hex");
+        std::fs::write(&bad, "not-hex").unwrap();
+        assert!(ReserveKeys::load(
+            Some(view_path.to_str().unwrap()),
+            Some(spend_path.to_str().unwrap()),
+            Some(bad.to_str().unwrap()),
+        )
+        .is_err());
+    }
+
+    /// End-to-end: a hybrid deposit encapsulated to the reserve's PUBLISHED v2
+    /// address is DETECTED by the reserve scanner. This is the #970 warn-path
+    /// becoming a detect-path once the reserve holds its ML-KEM secret (#972):
+    /// the sender encapsulates to the exact address the reserve advertises, and
+    /// the scanner decapsulates with the matching secret.
+    #[test]
+    fn hybrid_deposit_to_published_v2_address_is_detected() {
+        use crate::{bth_rpc::RpcOutput, bth_scan::scan_deposit_output};
+        use bth_transaction_clsag::TxOutput;
+        use bth_transaction_types::ClusterTagVector;
+
+        let dir = tempfile::tempdir().unwrap();
+        let account = AccountKey::random(&mut rand::rngs::OsRng);
+        let view_path = dir.path().join("view.hex");
+        let spend_path = dir.path().join("spend.hex");
+        write_key(&view_path, &account.view_private_key().to_bytes());
+        write_key(&spend_path, &account.spend_private_key().to_bytes());
+        let seed_path = dir.path().join("pq_seed.hex");
+        write_key(&seed_path, &[0x24u8; BIP39_SEED_SIZE]);
+
+        let reserve = ReserveKeys::load(
+            Some(view_path.to_str().unwrap()),
+            Some(spend_path.to_str().unwrap()),
+            Some(seed_path.to_str().unwrap()),
+        )
+        .unwrap()
+        .unwrap();
+
+        // A sender encapsulates a hybrid deposit to the reserve's published v2
+        // address (exactly what `decode_address` would hand a sender).
+        let published = reserve.public_address();
+        let output_index = 0u32;
+        let out = TxOutput::new_hybrid_to_address(
+            7_000_000_000_000,
+            &published,
+            output_index,
+            None,
+            ClusterTagVector::empty(),
+        )
+        .expect("published address is v2 (carries an ML-KEM key)");
         assert!(
-            ReserveKeys::load(Some(bad.to_str().unwrap()), Some(ok.to_str().unwrap())).is_err()
+            out.kem_ciphertext.is_some(),
+            "a hybrid deposit carries a KEM ciphertext"
+        );
+
+        let rpc = RpcOutput {
+            tx_hash: "0xpublished".to_string(),
+            output_index,
+            target_key: hex::encode(out.target_key),
+            public_key: hex::encode(out.public_key),
+            amount: out.amount,
+            cluster_tags: vec![],
+            e_memo: None,
+            kem_ciphertext: out.kem_ciphertext.as_ref().map(hex::encode),
+        };
+
+        // Without the ML-KEM secret the reserve cannot see it (the #970 warn
+        // path)...
+        assert!(
+            scan_deposit_output(&rpc, reserve.account(), None)
+                .unwrap()
+                .is_none(),
+            "classical-only reserve cannot detect a hybrid deposit",
+        );
+        // ...but wired with the reserve's real secret, it is DETECTED (#972).
+        let scanned = scan_deposit_output(&rpc, reserve.account(), reserve.kem_keypair())
+            .unwrap()
+            .expect("reserve detects a hybrid deposit to its published v2 address");
+        assert_eq!(scanned.owned.amount, 7_000_000_000_000);
+        assert!(
+            scanned.owned.kem_ciphertext.is_some(),
+            "detected output retains its KEM ciphertext for the release path",
         );
     }
 }

--- a/bridge/service/src/release/bth.rs
+++ b/bridge/service/src/release/bth.rs
@@ -285,6 +285,7 @@ impl BthReleaser {
         let reserve = match ReserveKeys::load(
             config.view_key_file.as_deref(),
             config.spend_key_file.as_deref(),
+            config.pq_seed_file.as_deref(),
         ) {
             Ok(keys) => keys,
             Err(e) => {
@@ -292,6 +293,17 @@ impl BthReleaser {
                 None
             }
         };
+        // Publish the reserve's v2 (`botho://2/…`) receive address at startup
+        // when a PQ seed is configured, so operators/senders can encapsulate
+        // hybrid deposits to it (issue #972).
+        if let Some(keys) = reserve.as_ref() {
+            if keys.has_pq_keys() {
+                match keys.public_address_uri(bth_address_codec::Network::Mainnet) {
+                    Ok(uri) => info!("BTH reserve published v2 address: {uri}"),
+                    Err(e) => warn!("BTH reserve v2 address unavailable: {e}"),
+                }
+            }
+        }
 
         Ok(Self {
             config,
@@ -330,9 +342,12 @@ impl BthReleaser {
 
         for block in &blocks {
             for out in &block.outputs {
-                // Reserve holds no ML-KEM secret today; hybrid outputs are
-                // warned about, not silently missed (issue #970).
-                match scan_deposit_output(out, account, None).map_err(ReleaseError::Config)? {
+                // Pass the reserve's ML-KEM secret (when configured) so hybrid
+                // reserve outputs are DETECTED as spendable inputs, not warned
+                // about (issue #972). A classical-only reserve passes `None`.
+                match scan_deposit_output(out, account, reserve.kem_keypair())
+                    .map_err(ReleaseError::Config)?
+                {
                     // A reserve-owned, factor-1 output is a candidate input.
                     Some(scanned) if scanned.owned.factor_one => owned.push(scanned.owned),
                     // A reserve-owned but NON-factor-1 output must never be
@@ -350,10 +365,12 @@ impl BthReleaser {
         }
 
         // Drop already-spent / pending inputs so we never double-spend the
-        // reserve across releases.
+        // reserve across releases. A hybrid reserve output's key image must be
+        // derived from its hybrid one-time key (issue #972), so the reserve's
+        // ML-KEM secret is threaded through.
         let key_images: Vec<String> = owned
             .iter()
-            .map(|o| release_input_key_image(account, o))
+            .map(|o| release_input_key_image(account, o, reserve.kem_keypair()))
             .collect::<Result<_, _>>()?;
         let statuses = rpc.are_key_images_spent(&key_images).await?;
         let spendable: Vec<OwnedOutput> = owned
@@ -373,6 +390,7 @@ impl BthReleaser {
 fn release_input_key_image(
     account: &bth_account_keys::AccountKey,
     owned: &OwnedOutput,
+    kem_keypair: Option<&bth_crypto_pq::MlKem768KeyPair>,
 ) -> Result<String, ReleaseError> {
     let target_key: [u8; 32] = hex::decode(&owned.target_key)
         .ok()
@@ -388,11 +406,23 @@ fn release_input_key_image(
         public_key,
         e_memo: None,
         cluster_tags: Default::default(),
-        kem_ciphertext: None,
+        kem_ciphertext: owned.kem_ciphertext.clone(),
     };
-    let onetime = tx_out
-        .recover_spend_key(account, owned.subaddress_index)
-        .ok_or_else(|| ReleaseError::Config("cannot recover reserve one-time key".into()))?;
+    // A hybrid reserve output's one-time key (and hence its key image) can only
+    // be reconstructed via ML-KEM decapsulation; a classical output uses the
+    // pure view-key path (issue #972). Both dispatch through the same unified
+    // recovery the release signer uses, so the spent-status key image matches.
+    let onetime = if tx_out.kem_ciphertext.is_some() {
+        let kp = kem_keypair.ok_or_else(|| {
+            ReleaseError::Config(
+                "hybrid reserve output requires an ML-KEM secret to derive its key image".into(),
+            )
+        })?;
+        tx_out.recover_spend_key_for(account, kp, owned.subaddress_index, owned.output_index)
+    } else {
+        tx_out.recover_spend_key(account, owned.subaddress_index)
+    }
+    .ok_or_else(|| ReleaseError::Config("cannot recover reserve one-time key".into()))?;
     Ok(hex::encode(KeyImage::from(&onetime).as_bytes()))
 }
 
@@ -480,10 +510,10 @@ impl Releaser for BthReleaser {
         // 4-5, 7. Build + CLSAG-sign: fresh stealth recipient output, change
         // back to the reserve, self-verified against the node's verifier.
         let created_at_height = rpc.chain_tip().await?;
-        // The reserve holds no ML-KEM secret today (classical key files), so
-        // pass `None`. A hybrid reserve input would fail loudly here rather than
-        // produce an invalid tx (issue #970); wiring a reserve KEM key is a
-        // follow-up.
+        // Pass the reserve's ML-KEM secret (when a PQ seed is configured) so a
+        // hybrid reserve input can be spent via hybrid one-time-key recovery
+        // (issue #972). A classical-only reserve passes `None`, and a hybrid
+        // input then fails loudly rather than producing an invalid tx (#970).
         let tx = build_release_tx(
             reserve.account(),
             &recipient,
@@ -491,7 +521,7 @@ impl Releaser for BthReleaser {
             RELEASE_FEE,
             &inputs,
             created_at_height,
-            None,
+            reserve.kem_keypair(),
             &mut rand_core::OsRng,
         )
         .map_err(|e| ReleaseError::Config(format!("release tx construction failed: {e}")))?;
@@ -612,6 +642,7 @@ mod tests {
             ws_url: "ws://localhost:7101/ws".to_string(),
             view_key_file: None,
             spend_key_file: None,
+            pq_seed_file: None,
             confirmations_required: 0,
             reserve_address: Some("bth_reserve_addr".to_string()),
             release_signers: signers

--- a/bridge/service/src/reserve.rs
+++ b/bridge/service/src/reserve.rs
@@ -323,6 +323,7 @@ impl NodeReserveBalanceSource {
         let reserve = match ReserveKeys::load(
             config.view_key_file.as_deref(),
             config.spend_key_file.as_deref(),
+            config.pq_seed_file.as_deref(),
         ) {
             Ok(keys) => keys,
             Err(e) => {
@@ -384,11 +385,13 @@ impl ReserveBalanceSource for NodeReserveBalanceSource {
         let mut owned: Vec<OwnedOutput> = Vec::new();
         for block in &blocks {
             for out in &block.outputs {
-                // The reserve is loaded from classical view/spend key files and
-                // holds no ML-KEM secret today, so pass `None`: hybrid deposits
-                // are warned about (never silently missed, issue #970) rather
-                // than detected. Wiring a reserve KEM key file is a follow-up.
-                match scan_deposit_output(out, account, None).map_err(ReserveError::Config)? {
+                // Pass the reserve's ML-KEM secret (when a PQ seed is
+                // configured) so hybrid deposits to the reserve are DETECTED,
+                // not just warned about (issue #972). A classical-only reserve
+                // still passes `None` and warns on hybrid outputs (#970).
+                match scan_deposit_output(out, account, reserve.kem_keypair())
+                    .map_err(ReserveError::Config)?
+                {
                     Some(scanned) if scanned.owned.factor_one => owned.push(scanned.owned),
                     _ => {}
                 }

--- a/bridge/service/src/watchers/bth.rs
+++ b/bridge/service/src/watchers/bth.rs
@@ -146,6 +146,7 @@ impl NodeBthClient {
         let reserve = ReserveKeys::load(
             config.view_key_file.as_deref(),
             config.spend_key_file.as_deref(),
+            config.pq_seed_file.as_deref(),
         )
         .map_err(WatchError::Config)?;
         Ok(Self { rpc, reserve })
@@ -190,9 +191,11 @@ impl BthChainClient for NodeBthClient {
 
         let mut deposits = Vec::new();
         for out in &block.outputs {
-            // Reserve holds no ML-KEM secret today; hybrid outputs are warned
-            // about, not silently missed (issue #970).
-            let scanned = scan_deposit_output(out, account, None).map_err(WatchError::Rpc)?;
+            // Pass the reserve's ML-KEM secret (when a PQ seed is configured)
+            // so hybrid deposits to the reserve are DETECTED, not just warned
+            // about (issue #972). A classical-only reserve passes `None`.
+            let scanned = scan_deposit_output(out, account, reserve.kem_keypair())
+                .map_err(WatchError::Rpc)?;
             let Some(scanned) = scanned else {
                 continue; // not ours
             };
@@ -555,6 +558,7 @@ mod tests {
             ws_url: "ws://localhost:7101/ws".to_string(),
             view_key_file: None,
             spend_key_file: None,
+            pq_seed_file: None,
             confirmations_required,
             reserve_address: None,
             release_signers: Vec::new(),
@@ -732,6 +736,7 @@ mod tests {
                 ws_url: String::new(),
                 view_key_file: None,
                 spend_key_file: None,
+                pq_seed_file: None,
                 confirmations_required: 0,
                 reserve_address: None,
                 release_signers: Vec::new(),


### PR DESCRIPTION
## Summary

On the 6.0.0 universal-ML-KEM chain (#958) every output carries an ML-KEM ciphertext, so a hybrid deposit paid to the bridge reserve can only be detected by ML-KEM decapsulation. The live reserve (from #970) loaded only classical v1 view/spend key files and passed `None` for its ML-KEM secret, so hybrid deposits to the reserve were **WARNED about rather than detected** (detection capability was proven by unit test but never wired to production call sites).

This wires a reserve ML-KEM key so the reserve actually **detects + spends** hybrid deposits, and publishes the reserve's v2 (`botho://2/…`) address so senders can encapsulate to it. Protocol stays **6.0.0** (no version change).

## Reserve PQ key provisioning (derived from a seed)

`BthConfig` gains an optional `pq_seed_file`: a single hex-encoded **64-byte BIP39 seed**. When present, `ReserveKeys` derives its ML-KEM-768 + ML-DSA-65 keypairs from that seed via the **same `derive_pq_keys_from_seed` a normal wallet uses** (`QuantumSafeAccountKey` path), so the reserve's published v2 address is self-consistent: the advertised ML-KEM public key is exactly the key whose secret the scanner decapsulates with. The ML-DSA public key is bundled into the address (v2 carries both) even though reserve spends remain CLSAG — the ML-DSA secret is not retained.

Absent `pq_seed_file` ⇒ classical-only (v1) reserve: hybrid deposits warned, not detected (the pre-6.0.0 back-compat path is preserved).

## Changes

- `bridge/core/src/config.rs`: `BthConfig` gains `pq_seed_file: Option<String>` (`#[serde(default)]`).
- `bridge/service/src/bth_keys.rs`: `ReserveKeys::load` takes the PQ seed path; derives + holds the ML-KEM keypair and the ML-KEM/ML-DSA public keys. New `kem_keypair()`, `has_pq_keys()`, `public_address()` (v2 `PublicAddress`), `public_address_uri(network)`.
- `bridge/service/src/reserve.rs`, `watchers/bth.rs`, `release/bth.rs`: pass `reserve.kem_keypair()` into `scan_deposit_output` / `build_release_tx` (was `None`).
- `release/bth.rs`: `release_input_key_image` is hybrid-aware (a hybrid reserve output's spent-status key image is derived via `recover_spend_key_for`, matching the release signer's one-time key); releaser publishes the reserve v2 address at startup.
- `bridge/service/Cargo.toml`: add `bth-address-codec` (v2 address encode/decode).

## Reserve v2 address

`ReserveKeys::public_address()` returns a v2 `PublicAddress` carrying the reserve's ML-KEM-768 + ML-DSA-65 public keys; `public_address_uri(Network::Mainnet)` encodes it as `botho://2/<base58>`. Test `load_derives_pq_keys_and_publishes_v2_address` round-trips it through `bth_address_codec::decode_address` and asserts the decoded PQ keys equal the reserve's.

## Detect-not-warn proof

`hybrid_deposit_to_published_v2_address_is_detected` (new, `bth_keys.rs`): loads a reserve from key files + a PQ seed, has a sender encapsulate a hybrid deposit to the reserve's **published** v2 address (`TxOutput::new_hybrid_to_address`), then:
- `scan_deposit_output(.., None)` ⇒ `None` (the #970 warn path — not detected), and
- `scan_deposit_output(.., reserve.kem_keypair())` ⇒ **detected** (correct amount, ciphertext retained).

Plus `bth_scan.rs::hybrid_deposit_is_detected_and_released_with_kem_secret` proves the detected hybrid UTXO is spendable in `build_release_tx`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Reserve gets an ML-KEM-768 (+ ML-DSA-65) keypair alongside classical keys, derived like a normal wallet | ✅ | `load_pq_keys` uses `derive_pq_keys_from_seed`; `load_derives_pq_keys_and_publishes_v2_address` |
| Reserve's published address is v2 carrying ML-KEM + ML-DSA pubkeys | ✅ | `public_address()`/`public_address_uri()`; round-trip test asserts `has_pq_keys()` + matching keys |
| Scanner passes the real ML-KEM secret; hybrid deposits DETECTED (not warned) | ✅ | `reserve.kem_keypair()` threaded into all call sites; `hybrid_deposit_to_published_v2_address_is_detected` |
| `build_release_tx` recovers/spends a hybrid reserve UTXO | ✅ | `hybrid_deposit_is_detected_and_released_with_kem_secret` |
| Classical (pre-6.0.0) path still supported | ✅ | `None` `pq_seed_file` ⇒ classical-only; `load_reconstructs_account_from_hex_files` |
| Protocol stays 6.0.0 | ✅ | No version constant changed |

## Build Gates

- `cargo test --workspace --no-run` ✅
- `cargo build --workspace --all-targets` ✅
- `cargo build --workspace --no-default-features` ✅
- `cd fuzz && cargo check` ✅
- `cargo +nightly-2025-12-03 fmt --all` ✅
- `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets -- -D warnings` ✅
- `bth-bridge-service` lib suite: **213 passed** (up from 210).

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)