### PR TITLE
fix(web-wallet): derive SafeQR fit cap from the rendered EC level

### DIFF
--- a/web/packages/web-wallet/src/components/SafeQR.test.tsx
+++ b/web/packages/web-wallet/src/components/SafeQR.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for SafeQR's capacity-aware fit guard (#965, #979).
+ *
+ * The core invariant (#979): the fit-check cap MUST correspond to the EC level
+ * the symbol is actually rendered at. The component defaults to level 'M'
+ * (version-40 byte capacity 2331), so a payload in the 2332..2953 band — which
+ * the old level-L cap (2953) wrongly accepted — must fall back to the copy
+ * panel instead of being handed to `qrcode.react` (where it throws at level M).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import {
+  SafeQR,
+  singleQrByteCap,
+  QR_V40_BYTE_CAP,
+  SINGLE_QR_BYTE_CAP,
+} from './SafeQR'
+
+afterEach(() => cleanup())
+
+/** The rendered QR lives inside an <svg>; the fallback is a role="note" panel. */
+function hasQr(container: HTMLElement): boolean {
+  return container.querySelector('svg') !== null
+}
+function hasCopyPanel(): boolean {
+  return screen.queryByRole('note') !== null
+}
+
+describe('singleQrByteCap — cap matches the rendered EC level', () => {
+  it('returns the version-40 byte capacity for each EC level', () => {
+    expect(singleQrByteCap('L')).toBe(2953)
+    expect(singleQrByteCap('M')).toBe(2331)
+    expect(singleQrByteCap('Q')).toBe(1663)
+    expect(singleQrByteCap('H')).toBe(1273)
+  })
+
+  it('is the single source of truth for the level table', () => {
+    for (const level of ['L', 'M', 'Q', 'H'] as const) {
+      expect(singleQrByteCap(level)).toBe(QR_V40_BYTE_CAP[level])
+    }
+  })
+
+  it('keeps the deprecated flat constant pinned to the level-L ceiling only', () => {
+    // Back-compat: SINGLE_QR_BYTE_CAP is the L ceiling and must NOT be used as
+    // the default-level (M) cap — that mismatch is the #979 drift.
+    expect(SINGLE_QR_BYTE_CAP).toBe(QR_V40_BYTE_CAP.L)
+    expect(SINGLE_QR_BYTE_CAP).not.toBe(QR_V40_BYTE_CAP.M)
+  })
+})
+
+describe('SafeQR fit guard — default level M', () => {
+  const capM = singleQrByteCap('M') // 2331
+
+  it('renders a QR for a payload exactly at the level-M cap', () => {
+    const { container } = render(<SafeQR value={'a'.repeat(capM)} />)
+    expect(hasQr(container)).toBe(true)
+    expect(hasCopyPanel()).toBe(false)
+  })
+
+  it('falls back to the copy panel one byte over the level-M cap', () => {
+    // This byte lands in the old 2332..2953 danger band: the level-L cap (2953)
+    // would have (wrongly) rendered a QR that throws at level M.
+    render(<SafeQR value={'a'.repeat(capM + 1)} />)
+    expect(hasCopyPanel()).toBe(true)
+  })
+
+  it('rejects a payload sitting in the L-vs-M drift band (e.g. 2600 bytes)', () => {
+    render(<SafeQR value={'a'.repeat(2600)} />)
+    expect(hasCopyPanel()).toBe(true)
+  })
+})
+
+describe('SafeQR fit guard — explicit level L widens the cap consistently', () => {
+  it('renders a QR at 2600 bytes when level="L" (cap 2953)', () => {
+    const { container } = render(<SafeQR value={'a'.repeat(2600)} level="L" />)
+    expect(hasQr(container)).toBe(true)
+    expect(hasCopyPanel()).toBe(false)
+  })
+
+  it('still falls back one byte over the level-L cap', () => {
+    render(<SafeQR value={'a'.repeat(singleQrByteCap('L') + 1)} level="L" />)
+    expect(hasCopyPanel()).toBe(true)
+  })
+})
+
+describe('SafeQR edge cases', () => {
+  it('shows the copy panel for an empty payload', () => {
+    render(<SafeQR value="" />)
+    expect(hasCopyPanel()).toBe(true)
+  })
+
+  it('renders a QR for a short address-like payload', () => {
+    const { container } = render(<SafeQR value="botho://1/abcDEF123" />)
+    expect(hasQr(container)).toBe(true)
+    expect(hasCopyPanel()).toBe(false)
+  })
+})

--- a/web/packages/web-wallet/src/components/SafeQR.tsx
+++ b/web/packages/web-wallet/src/components/SafeQR.tsx
@@ -22,12 +22,41 @@ import { QrCode } from 'lucide-react'
  */
 
 /**
- * Maximum payload (characters ≈ bytes for our base58/ASCII payloads) that fits a
- * single QR symbol. Uses the EC-level-L byte-mode ceiling; we intentionally pick
- * the largest so short payloads always QR, and only genuinely oversized ones
- * (full v2 addresses / links) fall back.
+ * Version-40 byte-mode capacity of a single QR symbol, per error-correction
+ * level. The fit decision MUST use the ceiling for the *same* EC level the
+ * symbol is rendered at — a higher-EC level packs fewer data bytes, so using
+ * the level-L ceiling (2953) while rendering at the default level M (2331)
+ * would judge a ~2331..2953-byte payload as "fits" and then hand it to
+ * `qrcode.react`, which throws during render (#979). Keying the cap off the
+ * rendered `level` makes the two impossible to drift apart.
+ *
+ * Sources: ISO/IEC 18004 version-40 byte-mode data capacities.
  */
-export const SINGLE_QR_BYTE_CAP = 2953
+export const QR_V40_BYTE_CAP: Record<'L' | 'M' | 'Q' | 'H', number> = {
+  L: 2953,
+  M: 2331,
+  Q: 1663,
+  H: 1273,
+}
+
+/**
+ * Maximum payload (characters ≈ bytes for our base58/ASCII payloads) that fits a
+ * single QR symbol at the given EC `level`. This is the single source of truth
+ * for the fit decision, so the cap can never diverge from the level the symbol
+ * is actually rendered at.
+ */
+export function singleQrByteCap(level: 'L' | 'M' | 'Q' | 'H'): number {
+  return QR_V40_BYTE_CAP[level]
+}
+
+/**
+ * Level-L ceiling, retained for reference/back-compat. Prefer
+ * `singleQrByteCap(level)` — this constant is only correct when rendering at
+ * EC level L, and using it directly is exactly the drift that #979 fixed.
+ *
+ * @deprecated Use {@link singleQrByteCap} keyed on the rendered `level`.
+ */
+export const SINGLE_QR_BYTE_CAP = QR_V40_BYTE_CAP.L
 
 export function SafeQR({
   value,
@@ -42,7 +71,10 @@ export function SafeQR({
   ariaLabel?: string
   className?: string
 }) {
-  const fits = value.length > 0 && value.length <= SINGLE_QR_BYTE_CAP
+  // Cap is derived from the SAME level the symbol renders at, so a payload that
+  // passes this guard is always encodable at that level (#979).
+  const cap = singleQrByteCap(level)
+  const fits = value.length > 0 && value.length <= cap
 
   if (fits) {
     return (


### PR DESCRIPTION
## Summary
`SafeQR` (added in #965) decided whether a payload fits one QR symbol using a
fixed `SINGLE_QR_BYTE_CAP = 2953` — the version-40 **EC-level-L** byte-mode
ceiling — but the component renders at its default `level='M'`, whose version-40
byte capacity is only **2331**. A payload in the 2332..2953 band passed the
`fits` guard and was then handed to `qrcode.react`, which throws during render at
level M/Q/H. No current caller lands in that band (v2 addresses are ~4.4 KB and
always fall back; short aliases are well under 2331), so this is a latent
correctness fix, not a fund-safety issue — filed to close the gap before any
mid-size payload is handed to `SafeQR`.

## Fix (option 3 — drift-proof)
Derive the cap from the actual `level` prop so the two can never diverge:

- `QR_V40_BYTE_CAP` — version-40 byte capacities per EC level (L/M/Q/H =
  2953/2331/1663/1273).
- `singleQrByteCap(level)` — single source of truth for the fit decision; the
  component computes `cap = singleQrByteCap(level)` and gates on it.
- `SINGLE_QR_BYTE_CAP` retained (marked `@deprecated`) as the L ceiling for
  back-compat; a test pins it to L and asserts it is **not** the default-level
  (M) cap, guarding against a re-introduction of the drift.

**Invariant restored:** the fit-check cap always corresponds to the EC level the
QR is actually rendered at, so no scannable-but-wrong QR can be produced.

## Changes
- `web/packages/web-wallet/src/components/SafeQR.tsx`: level-keyed cap lookup;
  guard uses `singleQrByteCap(level)`; deprecate flat constant; updated docs.
- `web/packages/web-wallet/src/components/SafeQR.test.tsx`: new test file (10 tests).

## Acceptance Criteria Verification
| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fit-check cap corresponds to the rendered EC level | ✅ | `singleQrByteCap(level)` drives both the guard and the render; test asserts caps per level |
| Payload just above corrected cap → copy panel | ✅ | 2332 B (M cap + 1) and mid-band 2600 B render the `role="note"` copy panel |
| Payload just below → QR | ✅ | 2331 B (exactly M cap) renders an `<svg>` QR |
| Cap matches rendered level | ✅ | `level="L"` renders 2600 B as a QR; default M rejects it |
| Existing SafeQR behavior preserved | ✅ | empty/short-address cases still behave; full web suite green |

## Test Plan
- `pnpm test:run SafeQR` — 10/10 pass.
- `pnpm -r typecheck` — clean across all 8 web packages.
- `pnpm test:run` (full web suite, matches web CI) — 926 passed, 10 skipped.

Closes #979