### PR TITLE
feat(wasm-signer): attach ML-KEM ciphertexts on browser sends (hybrid outputs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,6 +1757,7 @@ dependencies = [
  "bth-transaction-types",
  "bth-util-from-random",
  "bth-util-serial",
+ "bth-wasm-signer",
  "bytes",
  "chacha20poly1305",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,7 @@ dependencies = [
  "bth-account-keys",
  "bth-address-codec",
  "bth-crypto-keys",
+ "bth-crypto-pq",
  "bth-transaction-clsag",
  "bth-wasm-signer",
  "hex",

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -188,6 +188,11 @@ botho-wallet = { path = "../botho-wallet" }
 # `Transaction::new_stub_with_fee`) for botho's own test/dev builds.
 bth-transaction-clsag = { path = "../transaction/clsag", features = ["test-utils"] }
 bth-transaction-core = { path = "../transaction/core" }
+# The browser (WebAssembly) transaction builder, compiled natively (rlib) so a
+# node-side test can build a transaction exactly as the web wallet does and
+# assert it passes the node's `validate_transfer_tx` universal-ML-KEM gate — the
+# end-to-end acceptance proof for issue #978.
+bth-wasm-signer = { path = "../web/packages/wasm-signer" }
 futures = "0.3"
 criterion = { workspace = true }
 rand_chacha = { workspace = true }

--- a/botho/src/consensus/validation.rs
+++ b/botho/src/consensus/validation.rs
@@ -1014,6 +1014,104 @@ mod tests {
                 other => panic!("unexpected validation result: {other:?}"),
             }
         }
+
+        /// #978 acceptance heart: a transfer built by the BROWSER signer
+        /// (`bth_wasm_signer`, the exact Rust the web wallet compiles to wasm)
+        /// is ACCEPTED by the node's `validate_transfer_tx` universal-ML-KEM
+        /// gate. This closes the loop the issue opened: before this change the
+        /// browser emitted `kem_ciphertext: None` on every output and every
+        /// browser send was rejected. Now the browser encapsulates against the
+        /// recipient's (and its own, for change) published ML-KEM key, so both
+        /// outputs carry a 1088-byte ciphertext and consensus accepts the tx.
+        #[test]
+        fn browser_built_transfer_passes_node_kem_gate() {
+            use bth_account_keys::AccountKey;
+            use bth_transaction_clsag::DEFAULT_RING_SIZE;
+            use bth_wasm_signer::core::{
+                build_and_sign_with_rng, DecoyOutput, RecipientAddress, SignRequest, SpendInput,
+            };
+            use rand_chacha::ChaCha20Rng;
+            use rand_core::{RngCore, SeedableRng};
+
+            let mut rng = ChaCha20Rng::from_seed([73u8; 32]);
+
+            // Sender + recipient classical accounts, each with a published
+            // ML-KEM key (their v2 addresses).
+            let sender = AccountKey::random(&mut rng);
+            let sender_kem = bth_crypto_pq::derive_pq_keys_from_seed(&[0x11; 64]);
+            let recipient = AccountKey::random(&mut rng);
+            let recipient_kem = bth_crypto_pq::derive_pq_keys_from_seed(&[0x22; 64]);
+
+            // The sender's owned output + a full decoy ring.
+            let owned_amount = 10_000_000_000u64;
+            let owned = TxOutput::new(owned_amount, &sender.default_subaddress());
+            let decoys: Vec<DecoyOutput> = (0..DEFAULT_RING_SIZE - 1)
+                .map(|_| {
+                    let acct = AccountKey::random(&mut rng);
+                    let out = TxOutput::new(owned_amount, &acct.default_subaddress());
+                    DecoyOutput {
+                        target_key: hex::encode(out.target_key),
+                        public_key: hex::encode(out.public_key),
+                        amount: owned_amount,
+                    }
+                })
+                .collect();
+
+            let recipient_addr = recipient.default_subaddress();
+            let req = SignRequest {
+                spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+                view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+                inputs: vec![SpendInput {
+                    target_key: hex::encode(owned.target_key),
+                    public_key: hex::encode(owned.public_key),
+                    amount: owned_amount,
+                    subaddress_index: 0,
+                    decoys,
+                }],
+                recipient: RecipientAddress {
+                    spend_public_key: hex::encode(
+                        recipient_addr.spend_public_key().to_bytes(),
+                    ),
+                    view_public_key: hex::encode(recipient_addr.view_public_key().to_bytes()),
+                    kem_public_key: hex::encode(
+                        recipient_kem.kem_keypair.public_key().as_bytes(),
+                    ),
+                },
+                sender_kem_public_key: hex::encode(
+                    sender_kem.kem_keypair.public_key().as_bytes(),
+                ),
+                amount: 4_000_000_000,
+                fee: MIN_TX_FEE,
+                created_at_height: 1000,
+            };
+
+            // Build + CLSAG-sign exactly as the browser does.
+            let mut sign_rng = ChaCha20Rng::from_seed({
+                let mut s = [0u8; 32];
+                rng.fill_bytes(&mut s);
+                s
+            });
+            let tx = build_and_sign_with_rng(&req, &mut sign_rng)
+                .expect("browser signer must build+sign the tx");
+
+            // Every output carries a 1088-byte ML-KEM ciphertext.
+            assert_eq!(tx.outputs.len(), 2, "recipient + change");
+            for out in &tx.outputs {
+                assert_eq!(
+                    out.kem_ciphertext.as_ref().map(|c| c.len()),
+                    Some(ML_KEM_768_CIPHERTEXT_BYTES),
+                    "browser output must carry a 1088-byte ciphertext"
+                );
+            }
+
+            // The node's SCP consensus validity gate ACCEPTS the browser-built
+            // transfer. Enforcement is active in this build (pq + 6.0.0).
+            assert!(KEM_CIPHERTEXT_ENFORCED, "test presumes 6.0.0 + pq build");
+            let validator = TransactionValidator::new(mock_chain_state());
+            validator
+                .validate_transfer_tx(&tx)
+                .expect("node must accept the browser-built transfer under 6.0.0");
+        }
     }
 
     #[test]

--- a/botho/src/consensus/validation.rs
+++ b/botho/src/consensus/validation.rs
@@ -1069,17 +1069,11 @@ mod tests {
                     decoys,
                 }],
                 recipient: RecipientAddress {
-                    spend_public_key: hex::encode(
-                        recipient_addr.spend_public_key().to_bytes(),
-                    ),
+                    spend_public_key: hex::encode(recipient_addr.spend_public_key().to_bytes()),
                     view_public_key: hex::encode(recipient_addr.view_public_key().to_bytes()),
-                    kem_public_key: hex::encode(
-                        recipient_kem.kem_keypair.public_key().as_bytes(),
-                    ),
+                    kem_public_key: hex::encode(recipient_kem.kem_keypair.public_key().as_bytes()),
                 },
-                sender_kem_public_key: hex::encode(
-                    sender_kem.kem_keypair.public_key().as_bytes(),
-                ),
+                sender_kem_public_key: hex::encode(sender_kem.kem_keypair.public_key().as_bytes()),
                 amount: 4_000_000_000,
                 fee: MIN_TX_FEE,
                 created_at_height: 1000,

--- a/mobile/rust-bridge/Cargo.toml
+++ b/mobile/rust-bridge/Cargo.toml
@@ -59,6 +59,10 @@ bip39 = { version = "2", features = ["rand"] }
 [dev-dependencies]
 # Full tokio for the gated live-testnet end-to-end test (multi-thread + macros).
 tokio = { version = "1", features = ["full"] }
+# Node-identical post-quantum key derivation, used only by the send-path
+# acceptance test to derive the sender/recipient ML-KEM keypairs and run the
+# hybrid ownership scan (`belongs_to_hybrid`) over mobile-built outputs (#978).
+bth-crypto-pq = { path = "../../crypto/pq" }
 
 [build-dependencies]
 uniffi = { version = "0.28", features = ["build"] }

--- a/mobile/rust-bridge/src/lib.rs
+++ b/mobile/rust-bridge/src/lib.rs
@@ -357,10 +357,11 @@ impl MobileWallet {
 
     /// Send a transfer of `amount_picocredits` to `to_address`.
     ///
-    /// `to_address` must be a testnet v2 address (`tbotho://2/<base58>`) or the
-    /// legacy `view:<hex>,spend:<hex>` form. Syncs, builds a node-valid CLSAG
-    /// transaction from the wallet's spendable outputs, submits it, and returns
-    /// the transaction hash.
+    /// `to_address` must be a testnet v2 (post-quantum) address
+    /// (`tbotho://2/<base58>`); classical-only forms are rejected because a
+    /// send output on 6.0.0 requires the recipient's published ML-KEM key.
+    /// Syncs, builds a node-valid CLSAG transaction from the wallet's
+    /// spendable outputs, submits it, and returns the transaction hash.
     pub async fn send_transaction(
         &self,
         to_address: String,
@@ -535,9 +536,27 @@ impl MobileWallet {
             .map_err(|_| MobileWalletError::InvalidMnemonic)?;
         let account = keys.account_key();
 
+        // Derive the wallet's OWN ML-KEM-768 public key from its BIP39 seed
+        // using the node-identical derivation (`derive_pq_keys_from_seed`, via
+        // the shared wasm-signer core). The change output is a self-send
+        // encapsulated against this key so the sender can later recover its
+        // change under the 6.0.0 hybrid scheme (issue #978).
+        //
+        // Derived here from the seed (rather than via `WalletKeys`) so it is
+        // present even in the mobile crate's isolated build, where
+        // `botho-wallet`'s `pq` feature is off and `public_address()` carries no
+        // PQ keys. The seed-derived key is byte-identical to the one the node
+        // and browser derive for the same mnemonic.
+        let seed = bip39::Mnemonic::parse_normalized(&mnemonic)
+            .map_err(|_| MobileWalletError::InvalidMnemonic)?
+            .to_seed("");
+        let sender_pq = bth_wasm_signer::core::derive_pq_public_keys_from_seed(&hex::encode(seed))
+            .map_err(|message| MobileWalletError::InternalError { message })?;
+
         let signer = SignerKeys {
             spend_private_key: hex::encode(account.spend_private_key().to_bytes()),
             view_private_key: hex::encode(account.view_private_key().to_bytes()),
+            sender_kem_public_key: sender_pq.kem_public_key,
         };
         Ok((signer, address))
     }
@@ -583,13 +602,20 @@ fn encode_testnet_address(addr: &bth_account_keys::PublicAddress) -> MobileResul
 }
 
 /// Parse a recipient address string into the signer-core recipient form (hex
-/// view/spend keys).
+/// view/spend keys plus the recipient's raw ML-KEM-768 public key).
 ///
-/// Accepts the testnet v2 form (`tbotho://2/<base58(view||spend||kem||dsa)>`,
-/// decoded via the shared [`bth_address_codec`]) and the legacy
-/// `view:<hex>,spend:<hex>` form. (The post-quantum keys carried by a v2
-/// address are validated on decode; wiring them into the outgoing ciphertext is
-/// a later rollout sub-issue.)
+/// Only the v2 post-quantum form
+/// (`(t)botho://2/<base58(view||spend||kem||dsa)>`, decoded via the shared
+/// [`bth_address_codec`]) is accepted. Under protocol 6.0.0 every send output
+/// is a hybrid post-quantum output whose 1,088-byte ML-KEM ciphertext is
+/// encapsulated against the recipient's published ML-KEM-768 key (issue #978),
+/// so that key is required.
+///
+/// The retired v1 form and the legacy `view:<hex>,spend:<hex>` form publish no
+/// ML-KEM key, so a send to them cannot produce a valid output — a KEM-less
+/// output is rejected by consensus enforcement (`validate_transfer_tx`, #974).
+/// Both are hard-errored here rather than silently building an unacceptable
+/// transaction.
 fn parse_recipient(address: &str) -> MobileResult<RecipientAddress> {
     let address = address.trim();
 
@@ -598,31 +624,21 @@ fn parse_recipient(address: &str) -> MobileResult<RecipientAddress> {
     {
         let (addr, _network) = bth_address_codec::decode_address(address)
             .map_err(|_| MobileWalletError::InvalidAddress)?;
+        // A v2 address must publish well-formed post-quantum keys; a
+        // classical-only decode cannot yield the ML-KEM key we must encapsulate
+        // against.
+        if !addr.has_pq_keys() {
+            return Err(MobileWalletError::InvalidAddress);
+        }
         return Ok(RecipientAddress {
             view_public_key: hex::encode(addr.view_public_key().to_bytes()),
             spend_public_key: hex::encode(addr.spend_public_key().to_bytes()),
+            kem_public_key: hex::encode(addr.kem_public_key()),
         });
     }
 
-    // Legacy "view:<hex>,spend:<hex>"
-    if address.starts_with("view:") {
-        let parts: Vec<&str> = address.split(',').collect();
-        if parts.len() == 2 {
-            let view_hex = parts[0].trim().strip_prefix("view:");
-            let spend_hex = parts[1].trim().strip_prefix("spend:");
-            if let (Some(v), Some(s)) = (view_hex, spend_hex) {
-                let view = hex::decode(v.trim()).map_err(|_| MobileWalletError::InvalidAddress)?;
-                let spend = hex::decode(s.trim()).map_err(|_| MobileWalletError::InvalidAddress)?;
-                if view.len() == 32 && spend.len() == 32 {
-                    return Ok(RecipientAddress {
-                        view_public_key: hex::encode(view),
-                        spend_public_key: hex::encode(spend),
-                    });
-                }
-            }
-        }
-    }
-
+    // Any non-v2 form (retired v1, legacy `view:…,spend:…`) publishes no ML-KEM
+    // key and cannot be sent to on 6.0.0.
     Err(MobileWalletError::InvalidAddress)
 }
 
@@ -670,6 +686,9 @@ mod tests {
             parsed.spend_public_key,
             hex::encode(public.spend_public_key().to_bytes())
         );
+        // The parsed recipient must carry the address's published ML-KEM key so
+        // the send path can encapsulate the output's ciphertext (#978).
+        assert_eq!(parsed.kem_public_key, hex::encode(public.kem_public_key()));
     }
 
     // Cross-encoder byte-identical vector (ADR 0008 D5): the SAME address must
@@ -706,6 +725,11 @@ mod tests {
             hex::encode(node_dec.spend_public_key().to_bytes()),
             mobile_dec.spend_public_key
         );
+        // The mobile parse path also recovers the published ML-KEM key.
+        assert_eq!(
+            hex::encode(node_dec.kem_public_key()),
+            mobile_dec.kem_public_key
+        );
         assert_eq!(node_dec.kem_public_key(), wasm_dec.kem_public_key());
         assert_eq!(node_dec.dsa_public_key(), wasm_dec.dsa_public_key());
         assert_eq!(
@@ -724,14 +748,19 @@ mod tests {
         ));
     }
 
+    /// #978: the legacy `view:…,spend:…` form publishes no ML-KEM key, so on
+    /// protocol 6.0.0 it is a hard error — a send to it would produce a
+    /// KEM-less output that consensus enforcement rejects. It must no
+    /// longer parse.
     #[test]
-    fn parse_legacy_address() {
+    fn parse_legacy_address_is_rejected() {
         let view = hex::encode([1u8; 32]);
         let spend = hex::encode([2u8; 32]);
         let legacy = format!("view:{view},spend:{spend}");
-        let parsed = parse_recipient(&legacy).expect("parse legacy");
-        assert_eq!(parsed.view_public_key, view);
-        assert_eq!(parsed.spend_public_key, spend);
+        assert!(matches!(
+            parse_recipient(&legacy),
+            Err(MobileWalletError::InvalidAddress)
+        ));
     }
 
     #[test]
@@ -751,5 +780,150 @@ mod tests {
         assert_eq!(parse_u64_value(&serde_json::json!(42)), 42);
         assert_eq!(parse_u64_value(&serde_json::json!("123")), 123);
         assert_eq!(parse_u64_value(&serde_json::json!(null)), 0);
+    }
+}
+
+/// Send-path acceptance: a transaction built exactly the way the mobile bridge
+/// builds it must produce hybrid post-quantum outputs the node accepts and the
+/// wallets can receive (issue #978). This exercises the two pieces the bridge
+/// wires together — the recipient's ML-KEM key recovered by [`parse_recipient`]
+/// from a real v2 address, and the sender's own ML-KEM key threaded through
+/// [`SignerKeys`] — and proves the resulting outputs carry valid ciphertexts
+/// and are detected by the node-identical hybrid scanner.
+#[cfg(test)]
+mod send_acceptance_tests {
+    use super::{encode_testnet_address, parse_recipient};
+    use crate::wallet_ops::SignerKeys;
+    use bth_account_keys::AccountKey;
+    use bth_crypto_pq::{derive_pq_keys_from_seed, PqKeyMaterial, BIP39_SEED_SIZE};
+    use bth_transaction_clsag::{TxOutput, DEFAULT_RING_SIZE, MIN_TX_FEE};
+    use bth_wasm_signer::core::{build_and_sign_with_rng, DecoyOutput, SignRequest, SpendInput};
+    use rand::{rngs::StdRng, SeedableRng};
+
+    /// Deterministic ML-KEM-768 / ML-DSA-65 keypair from a seed byte, using the
+    /// node-identical derivation.
+    fn pq_from(seed_byte: u8) -> PqKeyMaterial {
+        derive_pq_keys_from_seed(&[seed_byte; BIP39_SEED_SIZE])
+    }
+
+    /// `count` random decoy outputs paid to throwaway recipients.
+    fn make_decoys(count: usize, amount: u64, rng: &mut StdRng) -> Vec<DecoyOutput> {
+        (0..count)
+            .map(|_| {
+                let decoy_account = AccountKey::random(rng);
+                let out = TxOutput::new(amount, &decoy_account.default_subaddress());
+                DecoyOutput {
+                    target_key: hex::encode(out.target_key),
+                    public_key: hex::encode(out.public_key),
+                    amount,
+                }
+            })
+            .collect()
+    }
+
+    /// #978 (mobile): a send built via the bridge's real components — recipient
+    /// parsed from a `tbotho://2/` address (carrying its ML-KEM key) and the
+    /// sender's own KEM key threaded through `SignerKeys` — yields a
+    /// transaction whose recipient (index 0) and change (index 1) outputs
+    /// BOTH carry a valid 1,088-byte ML-KEM ciphertext and are detected by
+    /// the respective node-identical hybrid scanner. Before this fix the
+    /// mobile bridge omitted both KEM keys, so the outputs were KEM-less
+    /// and rejected by 6.0.0 consensus enforcement (`validate_transfer_tx`,
+    /// #974).
+    #[test]
+    fn mobile_built_send_outputs_carry_kem_and_are_receivable() {
+        let mut rng = StdRng::from_seed([57u8; 32]);
+
+        // Sender: classical account + its own ML-KEM keypair.
+        let sender = AccountKey::random(&mut rng);
+        let sender_pq = pq_from(0x31);
+
+        // Recipient: classical account + its own ML-KEM keypair, published in a
+        // real v2 address string the mobile bridge parses.
+        let recipient = AccountKey::random(&mut rng);
+        let recipient_pq = pq_from(0x42);
+        let recipient_address = recipient.default_subaddress().with_pq_keys(
+            recipient_pq.kem_keypair.public_key().as_bytes().to_vec(),
+            recipient_pq.sig_keypair.public_key().as_bytes().to_vec(),
+        );
+        let recipient_addr_str = encode_testnet_address(&recipient_address).expect("encode v2");
+
+        // MOBILE parse path recovers the recipient's published ML-KEM key.
+        let parsed_recipient = parse_recipient(&recipient_addr_str).expect("parse v2 recipient");
+        assert!(
+            !parsed_recipient.kem_public_key.is_empty(),
+            "parsed recipient must carry the published ML-KEM key"
+        );
+
+        // MOBILE signer keys: spend/view + the sender's own derived KEM key
+        // (same shape `signer_keys()` builds).
+        let signer = SignerKeys {
+            spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            sender_kem_public_key: hex::encode(sender_pq.kem_keypair.public_key().as_bytes()),
+        };
+
+        // Owned input well above amount + fee so a change output exists.
+        let owned_amount = 10_000_000_000u64;
+        let send_amount = 4_000_000_000u64;
+        let owned = TxOutput::new(owned_amount, &sender.default_subaddress());
+        let decoys = make_decoys(DEFAULT_RING_SIZE - 1, owned_amount, &mut rng);
+
+        // Build the SignRequest exactly as `wallet_ops::send` does.
+        let request = SignRequest {
+            spend_private_key: signer.spend_private_key.clone(),
+            view_private_key: signer.view_private_key.clone(),
+            inputs: vec![SpendInput {
+                target_key: hex::encode(owned.target_key),
+                public_key: hex::encode(owned.public_key),
+                amount: owned_amount,
+                subaddress_index: 0,
+                decoys,
+            }],
+            recipient: parsed_recipient,
+            sender_kem_public_key: signer.sender_kem_public_key.clone(),
+            amount: send_amount,
+            fee: MIN_TX_FEE,
+            created_at_height: 1000,
+        };
+
+        let tx = build_and_sign_with_rng(&request, &mut rng).expect("mobile build+sign");
+
+        // Recipient (index 0) + change (index 1), each with a 1,088-byte
+        // ML-KEM ciphertext.
+        assert_eq!(tx.outputs.len(), 2, "expected recipient + change outputs");
+        for (i, out) in tx.outputs.iter().enumerate() {
+            let ct = out
+                .kem_ciphertext
+                .as_ref()
+                .unwrap_or_else(|| panic!("output {i} is missing its ML-KEM ciphertext"));
+            assert_eq!(
+                ct.len(),
+                bth_crypto_pq::ML_KEM_768_CIPHERTEXT_BYTES,
+                "output {i} ciphertext must be exactly 1088 bytes"
+            );
+        }
+
+        // The recipient's node-identical hybrid scan detects its output; the
+        // sender's detects its own change. If either KEM key were wrong the
+        // one-time key would not match and the funds would be unspendable.
+        assert_eq!(
+            tx.outputs[0].belongs_to_hybrid(&recipient, &recipient_pq.kem_keypair, 0),
+            Some(0),
+            "recipient must detect the mobile-built output at subaddress 0"
+        );
+        assert_eq!(
+            tx.outputs[1].belongs_to_hybrid(&sender, &sender_pq.kem_keypair, 1),
+            Some(0),
+            "sender must detect its own change at default subaddress"
+        );
+
+        // Cross-check: neither wallet detects the other's output (ciphertexts
+        // are bound to distinct ML-KEM keys).
+        assert_eq!(
+            tx.outputs[1].belongs_to_hybrid(&recipient, &recipient_pq.kem_keypair, 1),
+            None,
+            "recipient must not detect the sender's change"
+        );
     }
 }

--- a/mobile/rust-bridge/src/wallet_ops.rs
+++ b/mobile/rust-bridge/src/wallet_ops.rs
@@ -19,6 +19,12 @@ use crate::rpc::{amount_from_commitment, NodeRpc};
 pub struct SignerKeys {
     pub spend_private_key: String,
     pub view_private_key: String,
+    /// Hex-encoded raw ML-KEM-768 public key (1184 bytes) of the wallet's OWN
+    /// v2 address, derived from its BIP39 seed via the node-identical
+    /// `derive_pq_keys_from_seed`. The change output is a self-send whose
+    /// ciphertext is encapsulated against this key, so the sender can later
+    /// recover its change under the 6.0.0 hybrid scheme (issue #978).
+    pub sender_kem_public_key: String,
 }
 
 /// A wallet's spendable view of the chain: owned, unspent outputs + the height
@@ -231,6 +237,10 @@ pub async fn send(
         view_private_key: keys.view_private_key.clone(),
         inputs: spend_inputs,
         recipient,
+        // The sender's own published ML-KEM-768 key: the change (self-send)
+        // output encapsulates against this so the sender can recover it under
+        // the 6.0.0 hybrid scheme (issue #978).
+        sender_kem_public_key: keys.sender_kem_public_key.clone(),
         amount,
         fee,
         created_at_height: height,

--- a/mobile/rust-bridge/tests/wallet_core_offline.rs
+++ b/mobile/rust-bridge/tests/wallet_core_offline.rs
@@ -32,6 +32,19 @@ struct DerivedKeys {
     spend_private_hex: String,
     view_private_hex: String,
     public_address: PublicAddress,
+    /// Hex raw ML-KEM-768 public key derived from the same mnemonic's BIP39
+    /// seed (node-identical). Under 6.0.0 every send output is a hybrid
+    /// post-quantum output, so the recipient's key is required to encapsulate
+    /// the ciphertext and the sender's own key seeds its change (issue #978).
+    kem_public_hex: String,
+}
+
+/// The 64-byte BIP39 seed for a mnemonic (empty passphrase), matching the seed
+/// the node/browser derive PQ keys from.
+fn mnemonic_to_seed(mnemonic: &str) -> [u8; bth_crypto_pq::BIP39_SEED_SIZE] {
+    bip39::Mnemonic::parse_normalized(mnemonic)
+        .expect("valid mnemonic")
+        .to_seed("")
 }
 
 /// Build a deterministic, checksum-valid 24-word mnemonic from a fixed 32-byte
@@ -52,12 +65,26 @@ fn derive_from_seed(seed: u8) -> DerivedKeys {
     let keys = botho_wallet::keys::WalletKeys::from_mnemonic(&mnemonic)
         .expect("mnemonic should derive wallet keys");
     let account = keys.account_key();
+
+    // Derive the account-wide post-quantum keys from the same BIP39 seed
+    // (node-identical `derive_pq_keys_from_seed`), so the test's addresses are
+    // v2 (post-quantum) and the hybrid send path attaches ML-KEM ciphertexts —
+    // exactly what the bridge does. Derived from the seed here because the
+    // mobile crate builds `botho-wallet` without its `pq` feature.
+    let pq = bth_crypto_pq::derive_pq_keys_from_seed(&mnemonic_to_seed(&mnemonic));
+    let kem_bytes = pq.kem_keypair.public_key().as_bytes().to_vec();
+    let dsa_bytes = pq.sig_keypair.public_key().as_bytes().to_vec();
+
     DerivedKeys {
         spend_private_hex: hex::encode(account.spend_private_key().to_bytes()),
         view_private_hex: hex::encode(account.view_private_key().to_bytes()),
+        kem_public_hex: hex::encode(&kem_bytes),
         // Outputs are sent to the default subaddress; `belongs_to` returns
-        // subaddress index 0 for these.
-        public_address: account.default_subaddress(),
+        // subaddress index 0 for these. The address carries the derived PQ keys
+        // so it is a valid v2 (post-quantum) recipient.
+        public_address: account
+            .default_subaddress()
+            .with_pq_keys(kem_bytes, dsa_bytes),
     }
 }
 
@@ -208,6 +235,7 @@ fn build_and_sign_produces_node_verifiable_tx() {
     let recipient_addr = RecipientAddress {
         view_public_key: hex::encode(recipient.public_address.view_public_key().to_bytes()),
         spend_public_key: hex::encode(recipient.public_address.spend_public_key().to_bytes()),
+        kem_public_key: recipient.kem_public_hex.clone(),
     };
 
     let tx_hex = build_and_sign_inner(&SignRequest {
@@ -221,6 +249,7 @@ fn build_and_sign_produces_node_verifiable_tx() {
             decoys,
         }],
         recipient: recipient_addr,
+        sender_kem_public_key: sender.kem_public_hex.clone(),
         amount,
         fee: MIN_TX_FEE,
         created_at_height: 1,
@@ -274,7 +303,9 @@ fn build_and_sign_rejects_insufficient_inputs() {
         recipient: RecipientAddress {
             view_public_key: hex::encode(recipient.public_address.view_public_key().to_bytes()),
             spend_public_key: hex::encode(recipient.public_address.spend_public_key().to_bytes()),
+            kem_public_key: recipient.kem_public_hex.clone(),
         },
+        sender_kem_public_key: sender.kem_public_hex.clone(),
         amount: 50_000_000_000,
         fee: MIN_TX_FEE,
         created_at_height: 1,

--- a/web/packages/wasm-signer/Cargo.toml
+++ b/web/packages/wasm-signer/Cargo.toml
@@ -17,8 +17,11 @@ path = "src/lib.rs"
 [dependencies]
 # The shared, node-identical CLSAG transaction implementation. Producing a
 # transaction via this crate guarantees byte-for-byte the same bincode wire
-# format the node deserializes in `tx_submit`.
-bth-transaction-clsag = { path = "../../../transaction/clsag" }
+# format the node deserializes in `tx_submit`. The `pq` feature exposes the
+# hybrid post-quantum send-path constructor (`TxOutput::new_hybrid_to_address`),
+# so browser SENDS attach an ML-KEM-768 ciphertext to every output and are
+# accepted under 6.0.0 universal-ML-KEM consensus enforcement (issue #978).
+bth-transaction-clsag = { path = "../../../transaction/clsag", features = ["pq"] }
 bth-account-keys = { path = "../../../account-keys" }
 bth-address-codec = { path = "../../../address-codec" }
 bth-crypto-keys = { path = "../../../crypto/keys" }

--- a/web/packages/wasm-signer/src/address.ts
+++ b/web/packages/wasm-signer/src/address.ts
@@ -62,6 +62,24 @@ export async function deriveV2Address(
 }
 
 /**
+ * Derive the wallet's raw ML-KEM-768 public key (hex) from its BIP39 mnemonic,
+ * via the node-identical `derive_pq_keys_from_seed` in wasm.
+ *
+ * This is the sender's OWN ML-KEM public key — the one published in its
+ * `botho://2/` address. The send path needs it to encapsulate the change output
+ * back to the sender (a hybrid self-send), so the sender can later recover its
+ * change under the post-quantum scheme (issue #978).
+ */
+export async function deriveKemPublicKey(mnemonic: string): Promise<string> {
+  const seed = mnemonicToSeedSync(mnemonic, '')
+  const signer = await loadSigner()
+  if (!signer.derivePqPublicKeysFromSeed) {
+    throw new Error('wasm-signer: derivePqPublicKeysFromSeed unavailable (stale wasm build?)')
+  }
+  return signer.derivePqPublicKeysFromSeed(toHex(seed)).kemPublicKey
+}
+
+/**
  * Decode a v2 address string into its hex components via the shared wasm codec.
  *
  * Use this when a byte-identical-to-the-node decode is required (e.g. to

--- a/web/packages/wasm-signer/src/core.rs
+++ b/web/packages/wasm-signer/src/core.rs
@@ -53,13 +53,15 @@ pub struct SpendInput {
 ///
 /// The browser wallet decodes the recipient's `botho://2/` (v2) address into
 /// these raw components before calling the signer (`parseAddress` in
-/// `@botho/core`, or the wasm `decodeAddress`, both of which expose `kemPublic`).
+/// `@botho/core`, or the wasm `decodeAddress`, both of which expose
+/// `kemPublic`).
 ///
 /// Under protocol 6.0.0 every send output is a hybrid post-quantum stealth
 /// output: the signer encapsulates a shared secret against `kem_public_key` and
 /// attaches the resulting 1,088-byte ML-KEM ciphertext (issue #978). A missing
-/// or malformed key is a hard error — a KEM-less output is rejected by consensus
-/// (`validate_transfer_tx`, #974) — so this field is required, not optional.
+/// or malformed key is a hard error — a KEM-less output is rejected by
+/// consensus (`validate_transfer_tx`, #974) — so this field is required, not
+/// optional.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RecipientAddress {
     /// Hex-encoded 32-byte spend public key (`D`).
@@ -67,8 +69,8 @@ pub struct RecipientAddress {
     /// Hex-encoded 32-byte view public key (`C`).
     pub view_public_key: String,
     /// Hex-encoded raw ML-KEM-768 public key (1184 bytes) published in the
-    /// recipient's v2 address. The sender encapsulates against this to build the
-    /// hybrid one-time key and attach the ciphertext.
+    /// recipient's v2 address. The sender encapsulates against this to build
+    /// the hybrid one-time key and attach the ciphertext.
     pub kem_public_key: String,
 }
 
@@ -415,14 +417,9 @@ pub fn build_and_sign_with_rng<R: RngCore + CryptoRng>(
     // the output's position in the tx (recipient=0, change=1). A recipient (or
     // sender) address that lacks a well-formed ML-KEM key is a hard error, never
     // a silent KEM-less output that 6.0.0 consensus would reject.
-    let recipient_output = TxOutput::new_hybrid_to_address(
-        req.amount,
-        &recipient,
-        0,
-        None,
-        Default::default(),
-    )
-    .map_err(|e| format!("recipient address is not post-quantum (v2): {e}"))?;
+    let recipient_output =
+        TxOutput::new_hybrid_to_address(req.amount, &recipient, 0, None, Default::default())
+            .map_err(|e| format!("recipient address is not post-quantum (v2): {e}"))?;
     let mut outputs = vec![recipient_output];
     let actual_fee = if change >= DUST_THRESHOLD {
         let change_output =
@@ -1258,11 +1255,8 @@ mod tests {
 
         // The recipient's node-identical hybrid scan detects the recipient
         // output (index 0) at its default subaddress.
-        let recipient_index = tx.outputs[0].belongs_to_hybrid(
-            &recipient_account,
-            &recipient_pq.kem_keypair,
-            0,
-        );
+        let recipient_index =
+            tx.outputs[0].belongs_to_hybrid(&recipient_account, &recipient_pq.kem_keypair, 0);
         assert_eq!(
             recipient_index,
             Some(0),
@@ -1270,8 +1264,7 @@ mod tests {
         );
 
         // The sender's own hybrid scan detects the change output (index 1).
-        let change_index =
-            tx.outputs[1].belongs_to_hybrid(&sender, &sender_pq.kem_keypair, 1);
+        let change_index = tx.outputs[1].belongs_to_hybrid(&sender, &sender_pq.kem_keypair, 1);
         assert_eq!(
             change_index,
             Some(0),
@@ -1288,9 +1281,9 @@ mod tests {
     }
 
     /// #978 acceptance #4: a recipient whose address publishes no ML-KEM key
-    /// (empty `kem_public_key`, i.e. a retired v1 / classical-only address) is a
-    /// HARD ERROR on 6.0.0 — the signer must never emit a KEM-less output that
-    /// consensus would reject. Fail loudly instead.
+    /// (empty `kem_public_key`, i.e. a retired v1 / classical-only address) is
+    /// a HARD ERROR on 6.0.0 — the signer must never emit a KEM-less output
+    /// that consensus would reject. Fail loudly instead.
     #[test]
     fn send_to_kemless_address_is_hard_error() {
         let mut rng = StdRng::from_seed([47u8; 32]);

--- a/web/packages/wasm-signer/src/core.rs
+++ b/web/packages/wasm-signer/src/core.rs
@@ -48,16 +48,28 @@ pub struct SpendInput {
     pub decoys: Vec<DecoyOutput>,
 }
 
-/// A recipient address, as the two 32-byte Ristretto public keys.
+/// A recipient address: the two 32-byte Ristretto stealth keys PLUS the
+/// recipient's raw ML-KEM-768 public key.
 ///
-/// The browser wallet decodes whatever address format it uses (e.g. base58)
-/// into these raw keys before calling the signer.
+/// The browser wallet decodes the recipient's `botho://2/` (v2) address into
+/// these raw components before calling the signer (`parseAddress` in
+/// `@botho/core`, or the wasm `decodeAddress`, both of which expose `kemPublic`).
+///
+/// Under protocol 6.0.0 every send output is a hybrid post-quantum stealth
+/// output: the signer encapsulates a shared secret against `kem_public_key` and
+/// attaches the resulting 1,088-byte ML-KEM ciphertext (issue #978). A missing
+/// or malformed key is a hard error — a KEM-less output is rejected by consensus
+/// (`validate_transfer_tx`, #974) — so this field is required, not optional.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RecipientAddress {
     /// Hex-encoded 32-byte spend public key (`D`).
     pub spend_public_key: String,
     /// Hex-encoded 32-byte view public key (`C`).
     pub view_public_key: String,
+    /// Hex-encoded raw ML-KEM-768 public key (1184 bytes) published in the
+    /// recipient's v2 address. The sender encapsulates against this to build the
+    /// hybrid one-time key and attach the ciphertext.
+    pub kem_public_key: String,
 }
 
 /// Encode a [`PublicAddress`] as a `botho://2/<base58>` / `tbotho://2/<base58>`
@@ -246,6 +258,13 @@ pub struct SignRequest {
     pub inputs: Vec<SpendInput>,
     /// Recipient of the transfer.
     pub recipient: RecipientAddress,
+    /// Hex-encoded raw ML-KEM-768 public key (1184 bytes) of the SENDER's own
+    /// v2 address. The change output is a self-send whose ciphertext is
+    /// encapsulated against this key, so the sender can later scan and recover
+    /// its change under the hybrid scheme (issue #978). Derived from the
+    /// wallet's BIP39 seed (`derivePqPublicKeysFromSeed`), it is the same key
+    /// published in the wallet's own `botho://2/` address.
+    pub sender_kem_public_key: String,
     /// Amount to send to the recipient, in picocredits.
     pub amount: u64,
     /// Transaction fee in picocredits.
@@ -272,6 +291,24 @@ fn parse_private(field: &str, s: &str) -> Result<RistrettoPrivate, String> {
 fn parse_public(field: &str, s: &str) -> Result<RistrettoPublic, String> {
     let bytes = parse_hex_32(field, s)?;
     RistrettoPublic::try_from(&bytes).map_err(|e| format!("{field}: invalid public key: {e:?}"))
+}
+
+/// Parse a hex-encoded raw ML-KEM-768 public key, validating its length up
+/// front so the caller gets a clear error before the encapsulation step.
+///
+/// A missing (empty) or wrong-length key means the pasted address is not a v2
+/// post-quantum address; on 6.0.0 that is a hard error, since a KEM-less output
+/// would be rejected by consensus.
+fn parse_kem_public_key(field: &str, s: &str) -> Result<Vec<u8>, String> {
+    let bytes = hex::decode(s.trim()).map_err(|e| format!("{field}: invalid hex: {e}"))?;
+    if bytes.len() != bth_crypto_pq::ML_KEM_768_PUBLIC_KEY_BYTES {
+        return Err(format!(
+            "{field}: expected a {}-byte ML-KEM-768 public key (v2 address), got {} bytes",
+            bth_crypto_pq::ML_KEM_768_PUBLIC_KEY_BYTES,
+            bytes.len()
+        ));
+    }
+    Ok(bytes)
 }
 
 /// Reconstruct a [`RingMember`] from a chain output's keys + amount.
@@ -327,10 +364,27 @@ pub fn build_and_sign_with_rng<R: RngCore + CryptoRng>(
     let view_private = parse_private("viewPrivateKey", &req.view_private_key)?;
     let account = AccountKey::new(&spend_private, &view_private);
 
-    // Reconstruct the recipient address.
-    let recipient = PublicAddress::new(
+    // Reconstruct the recipient's v2 (post-quantum) address: the classical
+    // stealth keys plus the recipient's published ML-KEM-768 key. The DSA key is
+    // not consulted on the send path (only the recipient verifies signatures),
+    // so it is left empty.
+    let recipient = PublicAddress::new_with_pq(
         &parse_public("recipient.spendPublicKey", &req.recipient.spend_public_key)?,
         &parse_public("recipient.viewPublicKey", &req.recipient.view_public_key)?,
+        parse_kem_public_key("recipient.kemPublicKey", &req.recipient.kem_public_key)?,
+        Vec::new(),
+    );
+
+    // Reconstruct the sender's OWN v2 address for change: the account's
+    // default-subaddress stealth keys plus the sender's own published ML-KEM-768
+    // key (derived from the wallet seed). The change output encapsulates against
+    // this so the sender can later recover it under the hybrid scheme.
+    let default_subaddress = account.default_subaddress();
+    let sender_address = PublicAddress::new_with_pq(
+        default_subaddress.spend_public_key(),
+        default_subaddress.view_public_key(),
+        parse_kem_public_key("senderKemPublicKey", &req.sender_kem_public_key)?,
+        Vec::new(),
     );
 
     // Sum inputs and validate the balance equation up front.
@@ -348,12 +402,33 @@ pub fn build_and_sign_with_rng<R: RngCore + CryptoRng>(
         .checked_sub(spent)
         .ok_or("insufficient funds: inputs do not cover amount + fee")?;
 
-    // Build outputs: recipient + (optional) change back to our default
-    // subaddress. Sub-dust change is folded into the fee so we never create an
-    // unspendable output and the balance equation still holds exactly.
-    let mut outputs = vec![TxOutput::new(req.amount, &recipient)];
+    // Build outputs: recipient (index 0) + (optional) change (index 1) back to
+    // our own address. Sub-dust change is folded into the fee so we never create
+    // an unspendable output and the balance equation still holds exactly.
+    //
+    // Every output is a HYBRID post-quantum stealth output (protocol 6.0.0,
+    // issue #978): the signer encapsulates a shared secret against the
+    // recipient's (resp. sender's) published ML-KEM-768 key, attaches the
+    // 1,088-byte ciphertext, and folds the secret into the one-time key —
+    // byte-identical to the node send path (`new_hybrid_to_address`, #966). The
+    // `output_index` is bound into the one-time-key derivation, so it MUST match
+    // the output's position in the tx (recipient=0, change=1). A recipient (or
+    // sender) address that lacks a well-formed ML-KEM key is a hard error, never
+    // a silent KEM-less output that 6.0.0 consensus would reject.
+    let recipient_output = TxOutput::new_hybrid_to_address(
+        req.amount,
+        &recipient,
+        0,
+        None,
+        Default::default(),
+    )
+    .map_err(|e| format!("recipient address is not post-quantum (v2): {e}"))?;
+    let mut outputs = vec![recipient_output];
     let actual_fee = if change >= DUST_THRESHOLD {
-        outputs.push(TxOutput::new(change, &account.default_subaddress()));
+        let change_output =
+            TxOutput::new_hybrid_to_address(change, &sender_address, 1, None, Default::default())
+                .map_err(|e| format!("sender address is not post-quantum (v2): {e}"))?;
+        outputs.push(change_output);
         req.fee
     } else {
         req.fee + change
@@ -630,16 +705,38 @@ fn shuffle<T, R: RngCore>(items: &mut [T], rng: &mut R) {
 mod tests {
     use super::*;
     use bth_account_keys::AccountKey;
+    use bth_crypto_pq::PqKeyMaterial;
     use bth_transaction_clsag::TxOutput;
     use rand::{rngs::StdRng, SeedableRng};
 
-    /// Create a recipient address request fragment from an account.
-    fn recipient_of(account: &AccountKey) -> RecipientAddress {
+    /// Derive a deterministic ML-KEM-768 / ML-DSA-65 keypair for tests from a
+    /// single seed byte (the node-identical `derive_pq_keys_from_seed`).
+    fn pq_keys(seed_byte: u8) -> PqKeyMaterial {
+        let seed = [seed_byte; bth_crypto_pq::BIP39_SEED_SIZE];
+        bth_crypto_pq::derive_pq_keys_from_seed(&seed)
+    }
+
+    /// The hex-encoded raw ML-KEM-768 public key for a test PQ keypair.
+    fn kem_public_hex(pq: &PqKeyMaterial) -> String {
+        hex::encode(pq.kem_keypair.public_key().as_bytes())
+    }
+
+    /// Create a recipient address request fragment from an account, publishing
+    /// the ML-KEM-768 public key of `pq` (so the send path can encapsulate a
+    /// ciphertext against a v2 address).
+    fn recipient_of_with_pq(account: &AccountKey, pq: &PqKeyMaterial) -> RecipientAddress {
         let addr = account.default_subaddress();
         RecipientAddress {
             spend_public_key: hex::encode(addr.spend_public_key().to_bytes()),
             view_public_key: hex::encode(addr.view_public_key().to_bytes()),
+            kem_public_key: kem_public_hex(pq),
         }
+    }
+
+    /// Convenience: a recipient with a throwaway (deterministic) ML-KEM key for
+    /// tests that only care that outputs are well-formed, not receivability.
+    fn recipient_of(account: &AccountKey) -> RecipientAddress {
+        recipient_of_with_pq(account, &pq_keys(0xAB))
     }
 
     /// Make `count` random decoy outputs paid to a throwaway recipient.
@@ -689,6 +786,7 @@ mod tests {
                 decoys,
             }],
             recipient: recipient_of(&recipient_account),
+            sender_kem_public_key: kem_public_hex(&pq_keys(0xCD)),
             amount: send_amount,
             fee,
             created_at_height: 1000,
@@ -779,6 +877,7 @@ mod tests {
                 decoys,
             }],
             recipient: recipient_of(&recipient_account),
+            sender_kem_public_key: kem_public_hex(&pq_keys(0xCD)),
             amount: 5_000_000_000,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
@@ -1078,5 +1177,155 @@ mod tests {
         let mut sorted = items.clone();
         sorted.sort();
         assert_eq!(sorted, original, "shuffle must be a permutation");
+    }
+
+    /// #978: every output a browser SEND builds (recipient + change) MUST carry
+    /// a valid 1,088-byte ML-KEM-768 ciphertext, encapsulated against the
+    /// respective published address. Without this, the output is rejected by
+    /// 6.0.0 consensus enforcement (`validate_transfer_tx`, #974).
+    #[test]
+    fn browser_send_outputs_carry_ml_kem_ciphertexts() {
+        let mut rng = StdRng::from_seed([41u8; 32]);
+        let sender = AccountKey::random(&mut rng);
+
+        // Ensure a change output exists: owned - amount - fee well above dust.
+        let owned_amount = 10_000_000_000u64;
+        let send_amount = 4_000_000_000u64;
+        let req = make_request(&sender, owned_amount, send_amount, MIN_TX_FEE, &mut rng);
+
+        let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
+
+        // Recipient (index 0) + change (index 1).
+        assert_eq!(tx.outputs.len(), 2, "expected recipient + change outputs");
+        for (i, out) in tx.outputs.iter().enumerate() {
+            let ct = out
+                .kem_ciphertext
+                .as_ref()
+                .unwrap_or_else(|| panic!("output {i} is missing its ML-KEM ciphertext"));
+            assert_eq!(
+                ct.len(),
+                bth_crypto_pq::ML_KEM_768_CIPHERTEXT_BYTES,
+                "output {i} ciphertext must be exactly 1088 bytes"
+            );
+        }
+    }
+
+    /// #978: the hybrid one-time key a browser SEND derives must match the node
+    /// construction — proven end-to-end by having a NODE scanner
+    /// (`belongs_to_hybrid`, classical DH ⊕ ML-KEM decapsulation) detect the
+    /// browser-built outputs. The recipient detects its output at index 0; the
+    /// sender detects its own change at index 1. If the browser derived the
+    /// one-time key even slightly differently from the node, neither scan would
+    /// match and the funds would be unspendable.
+    #[test]
+    fn browser_send_outputs_are_receivable_by_node_scanner() {
+        let mut rng = StdRng::from_seed([43u8; 32]);
+
+        // Sender: classical account + its own ML-KEM keypair (published in the
+        // sender's v2 address, used to encapsulate change).
+        let sender = AccountKey::random(&mut rng);
+        let sender_pq = pq_keys(0x11);
+
+        // Recipient: classical account + its own ML-KEM keypair (published in
+        // the recipient's v2 address).
+        let recipient_account = AccountKey::random(&mut rng);
+        let recipient_pq = pq_keys(0x22);
+
+        let owned_amount = 10_000_000_000u64;
+        let send_amount = 4_000_000_000u64;
+        let owned = TxOutput::new(owned_amount, &sender.default_subaddress());
+        let decoys = make_decoys(DEFAULT_RING_SIZE - 1, owned_amount, &mut rng);
+
+        let req = SignRequest {
+            spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            inputs: vec![SpendInput {
+                target_key: hex::encode(owned.target_key),
+                public_key: hex::encode(owned.public_key),
+                amount: owned_amount,
+                subaddress_index: 0,
+                decoys,
+            }],
+            recipient: recipient_of_with_pq(&recipient_account, &recipient_pq),
+            sender_kem_public_key: kem_public_hex(&sender_pq),
+            amount: send_amount,
+            fee: MIN_TX_FEE,
+            created_at_height: 1000,
+        };
+
+        let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
+        assert_eq!(tx.outputs.len(), 2);
+
+        // The recipient's node-identical hybrid scan detects the recipient
+        // output (index 0) at its default subaddress.
+        let recipient_index = tx.outputs[0].belongs_to_hybrid(
+            &recipient_account,
+            &recipient_pq.kem_keypair,
+            0,
+        );
+        assert_eq!(
+            recipient_index,
+            Some(0),
+            "recipient must detect the browser-built output at subaddress 0"
+        );
+
+        // The sender's own hybrid scan detects the change output (index 1).
+        let change_index =
+            tx.outputs[1].belongs_to_hybrid(&sender, &sender_pq.kem_keypair, 1);
+        assert_eq!(
+            change_index,
+            Some(0),
+            "sender must detect its own change at default subaddress"
+        );
+
+        // Cross-check: the recipient must NOT detect the sender's change, and
+        // vice versa (the ciphertexts are bound to distinct ML-KEM keys).
+        assert_eq!(
+            tx.outputs[1].belongs_to_hybrid(&recipient_account, &recipient_pq.kem_keypair, 1),
+            None,
+            "recipient must not detect the sender's change"
+        );
+    }
+
+    /// #978 acceptance #4: a recipient whose address publishes no ML-KEM key
+    /// (empty `kem_public_key`, i.e. a retired v1 / classical-only address) is a
+    /// HARD ERROR on 6.0.0 — the signer must never emit a KEM-less output that
+    /// consensus would reject. Fail loudly instead.
+    #[test]
+    fn send_to_kemless_address_is_hard_error() {
+        let mut rng = StdRng::from_seed([47u8; 32]);
+        let sender = AccountKey::random(&mut rng);
+        let recipient_account = AccountKey::random(&mut rng);
+
+        let owned_amount = 10_000_000_000u64;
+        let owned = TxOutput::new(owned_amount, &sender.default_subaddress());
+        let decoys = make_decoys(DEFAULT_RING_SIZE - 1, owned_amount, &mut rng);
+
+        let mut recipient = recipient_of(&recipient_account);
+        recipient.kem_public_key = String::new(); // v1 / classical-only address
+
+        let req = SignRequest {
+            spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            inputs: vec![SpendInput {
+                target_key: hex::encode(owned.target_key),
+                public_key: hex::encode(owned.public_key),
+                amount: owned_amount,
+                subaddress_index: 0,
+                decoys,
+            }],
+            recipient,
+            sender_kem_public_key: kem_public_hex(&pq_keys(0xCD)),
+            amount: 4_000_000_000,
+            fee: MIN_TX_FEE,
+            created_at_height: 1000,
+        };
+
+        let err = build_and_sign_with_rng(&req, &mut rng)
+            .expect_err("a KEM-less recipient address must be rejected");
+        assert!(
+            err.contains("ML-KEM") || err.contains("post-quantum"),
+            "error should explain the address is not post-quantum, got: {err}"
+        );
     }
 }

--- a/web/packages/wasm-signer/src/index.ts
+++ b/web/packages/wasm-signer/src/index.ts
@@ -49,12 +49,24 @@ export interface SpendInput {
   decoys: DecoyOutput[]
 }
 
-/** A recipient address, as the two 32-byte Ristretto public keys (hex). */
+/**
+ * A recipient address: the two 32-byte Ristretto stealth keys PLUS the
+ * recipient's raw ML-KEM-768 public key (all hex).
+ *
+ * Under protocol 6.0.0 every send output is a hybrid post-quantum stealth
+ * output: the signer encapsulates a shared secret against `kem_public_key` and
+ * attaches the resulting 1,088-byte ML-KEM ciphertext (issue #978). Decode a
+ * `botho://2/` address with `parseAddress` (`@botho/core`) or `decodeAddress`
+ * and pass `kemPublic` here. A missing/malformed key is a hard error — a
+ * KEM-less output is rejected by 6.0.0 consensus.
+ */
 export interface RecipientAddress {
   /** Hex-encoded 32-byte spend public key (`D`). */
   spend_public_key: string
   /** Hex-encoded 32-byte view public key (`C`). */
   view_public_key: string
+  /** Hex-encoded raw ML-KEM-768 public key (1184 bytes) from the v2 address. */
+  kem_public_key: string
 }
 
 /**
@@ -70,6 +82,13 @@ export interface SignRequest {
   inputs: SpendInput[]
   /** Recipient of the transfer. */
   recipient: RecipientAddress
+  /**
+   * Hex-encoded raw ML-KEM-768 public key (1184 bytes) of the SENDER's own v2
+   * address. The change output is a self-send encapsulated against this key so
+   * the sender can later recover its change under the hybrid scheme (#978).
+   * Derive it from the wallet seed via `derivePqPublicKeysFromSeed`.
+   */
+  senderKemPublicKey: string
   /** Amount to send to the recipient, in picocredits. */
   amount: bigint | number
   /** Transaction fee in picocredits. */
@@ -333,7 +352,7 @@ export function setSigner(signer: WasmSigner): void {
   cached = Promise.resolve(signer)
 }
 
-export { deriveV2Address, decodeV2Address } from './address'
+export { deriveV2Address, decodeV2Address, deriveKemPublicKey } from './address'
 
 export {
   buildSendTransaction,

--- a/web/packages/wasm-signer/src/send.ts
+++ b/web/packages/wasm-signer/src/send.ts
@@ -428,8 +428,18 @@ export function netOwnedHistory(entries: HistoryEntry[]): NettedHistoryEntry[] {
 export interface BuildSendParams {
   /** Account keys derived from the wallet mnemonic. */
   keys: SignerKeys
-  /** Recipient address keys (decoded from a `tbotho://` address). */
+  /**
+   * Recipient address keys (decoded from a `botho://2/` address). Must include
+   * the recipient's raw ML-KEM-768 public key (`kem_public_key`) so the send
+   * output can be a hybrid post-quantum output (#978).
+   */
   recipient: RecipientAddress
+  /**
+   * Hex-encoded raw ML-KEM-768 public key (1184 bytes) of the SENDER's own v2
+   * address, used to encapsulate the change output back to the sender (#978).
+   * Derive it from the wallet seed via `derivePqPublicKeysFromSeed`.
+   */
+  senderKemPublicKey: string
   /** Amount to send, in picocredits. */
   amount: bigint
   /** Fee, in picocredits. Must be >= the network minimum. */
@@ -479,9 +489,19 @@ function selectInputs(owned: OwnedOutput[], target: bigint): OwnedOutput[] | nul
 export async function buildSendTransaction(
   params: BuildSendParams,
 ): Promise<BuildSendResult> {
-  const { keys, recipient, amount, fee, rpc } = params
+  const { keys, recipient, senderKemPublicKey, amount, fee, rpc } = params
 
   if (amount <= 0n) throw new Error('Amount must be greater than 0')
+  if (!recipient.kem_public_key) {
+    throw new Error(
+      'Recipient address has no ML-KEM key: it is a retired v1 / classical-only ' +
+        'address that cannot receive on the post-quantum (6.0.0) chain. Ask the ' +
+        'recipient for a current botho://2/ address.',
+    )
+  }
+  if (!senderKemPublicKey) {
+    throw new Error('Missing sender ML-KEM public key for change encapsulation')
+  }
 
   const signer = await loadSigner()
   const ringSize = signer.ringSize()
@@ -570,6 +590,7 @@ export async function buildSendTransaction(
     viewPrivateKey: keys.viewPrivateKey,
     inputs: spendInputs,
     recipient,
+    senderKemPublicKey,
     amount,
     fee,
     createdAtHeight: height,

--- a/web/packages/wasm-signer/test/claim-link-live-node.test.ts
+++ b/web/packages/wasm-signer/test/claim-link-live-node.test.ts
@@ -40,6 +40,7 @@ import {
 import {
   buildSendTransaction,
   deriveV2Address,
+  deriveKemPublicKey,
   spendableBalance,
   setSigner,
   resetSigner,
@@ -117,7 +118,11 @@ const keysOf = (m: string) => {
 }
 const recipientOf = (addr: string) => {
   const k = parseAddress(addr)
-  return { spend_public_key: toHex(k.spendPublic), view_public_key: toHex(k.viewPublic) }
+  return {
+    spend_public_key: toHex(k.spendPublic),
+    view_public_key: toHex(k.viewPublic),
+    kem_public_key: toHex(k.kemPublic),
+  }
 }
 
 maybe('claim-link node-backed: create -> claim -> already-claimed (#460)', () => {
@@ -181,6 +186,7 @@ maybe('claim-link node-backed: create -> claim -> already-claimed (#460)', () =>
     const { txHex } = await buildSendTransaction({
       keys: keysOf(senderM),
       recipient: recipientOf(destAddr),
+      senderKemPublicKey: await deriveKemPublicKey(senderM),
       amount,
       fee,
       rpc: sendRpc,

--- a/web/packages/wasm-signer/test/exchange-live-node.test.ts
+++ b/web/packages/wasm-signer/test/exchange-live-node.test.ts
@@ -54,6 +54,7 @@ import { deriveKeypairs, deriveDefaultSubaddressPublicKeys } from '@botho/core'
 import {
   buildSendTransaction,
   spendableBalance,
+  deriveKemPublicKey,
   setSigner,
   resetSigner,
   type ChainOutput,
@@ -172,12 +173,14 @@ maybe('node-backed: two-user bidirectional payment exchange (#390)', () => {
     }
   }
 
-  // Recipient address keys (default-subaddress, #383) decoded from the address.
-  const recipientOf = (mnemonic: string) => {
+  // Recipient address keys (default-subaddress, #383) plus the recipient's
+  // ML-KEM key (#978), so the send can build a hybrid post-quantum output.
+  const recipientOf = async (mnemonic: string) => {
     const { viewPublic, spendPublic } = deriveDefaultSubaddressPublicKeys(mnemonic, 0)
     return {
       spend_public_key: toHex(spendPublic),
       view_public_key: toHex(viewPublic),
+      kem_public_key: await deriveKemPublicKey(mnemonic),
     }
   }
 
@@ -282,8 +285,10 @@ maybe('node-backed: two-user bidirectional payment exchange (#390)', () => {
 
     const keysA = keysOf(mnemonicA)
     const keysB = keysOf(mnemonicB)
-    const addrB = recipientOf(mnemonicB)
-    const addrA = recipientOf(mnemonicA)
+    const addrB = await recipientOf(mnemonicB)
+    const addrA = await recipientOf(mnemonicA)
+    const kemA = await deriveKemPublicKey(mnemonicA)
+    const kemB = await deriveKemPublicKey(mnemonicB)
 
     // ----------------------------------------------------------------------
     // Step 2: A is funded; B owns nothing yet.
@@ -306,6 +311,7 @@ maybe('node-backed: two-user bidirectional payment exchange (#390)', () => {
     const ab = await buildSendTransaction({
       keys: keysA,
       recipient: addrB,
+      senderKemPublicKey: kemA,
       amount: sendAmount,
       fee,
       rpc: sendRpc(),
@@ -369,6 +375,7 @@ maybe('node-backed: two-user bidirectional payment exchange (#390)', () => {
     const ba = await buildSendTransaction({
       keys: keysB,
       recipient: addrA,
+      senderKemPublicKey: kemB,
       amount: returnAmount,
       fee,
       rpc: sendRpc(),

--- a/web/packages/wasm-signer/test/lottery-live-node.test.ts
+++ b/web/packages/wasm-signer/test/lottery-live-node.test.ts
@@ -54,6 +54,7 @@ import { deriveKeypairs, deriveDefaultSubaddressPublicKeys } from '@botho/core'
 import {
   buildSendTransaction,
   spendableBalance,
+  deriveKemPublicKey,
   setSigner,
   resetSigner,
   type ChainOutput,
@@ -190,11 +191,12 @@ maybe('node-backed: three-user exchange until a lottery payout (#394)', () => {
     }
   }
 
-  const recipientOf = (mnemonic: string) => {
+  const recipientOf = async (mnemonic: string) => {
     const { viewPublic, spendPublic } = deriveDefaultSubaddressPublicKeys(mnemonic, 0)
     return {
       spend_public_key: toHex(spendPublic),
       view_public_key: toHex(viewPublic),
+      kem_public_key: await deriveKemPublicKey(mnemonic),
     }
   }
 
@@ -312,9 +314,12 @@ maybe('node-backed: three-user exchange until a lottery payout (#394)', () => {
     const keysA = keysOf(mnemonicA)
     const keysB = keysOf(mnemonicB)
     const keysC = keysOf(mnemonicC)
-    const addrA = recipientOf(mnemonicA)
-    const addrB = recipientOf(mnemonicB)
-    const addrC = recipientOf(mnemonicC)
+    const addrA = await recipientOf(mnemonicA)
+    const addrB = await recipientOf(mnemonicB)
+    const addrC = await recipientOf(mnemonicC)
+    const kemA = await deriveKemPublicKey(mnemonicA)
+    const kemB = await deriveKemPublicKey(mnemonicB)
+    const kemC = await deriveKemPublicKey(mnemonicC)
 
     // The per-block payout cap (anti-grinding) is one block reward. Read it from
     // a mined block so the cap assertion is grounded in the chain's real reward.
@@ -333,7 +338,7 @@ maybe('node-backed: three-user exchange until a lottery payout (#394)', () => {
     const PER_OUTPUT = 4_000_000_000n // picocredits per distributed output
 
     const distribute = async (
-      recipient: ReturnType<typeof recipientOf>,
+      recipient: Awaited<ReturnType<typeof recipientOf>>,
       label: string,
     ): Promise<void> => {
       for (let i = 0; i < SPLIT; i++) {
@@ -341,6 +346,7 @@ maybe('node-backed: three-user exchange until a lottery payout (#394)', () => {
         const tx = await buildSendTransaction({
           keys: keysA,
           recipient,
+          senderKemPublicKey: kemA,
           amount: PER_OUTPUT,
           fee,
           rpc: sendRpc(),
@@ -368,9 +374,9 @@ maybe('node-backed: three-user exchange until a lottery payout (#394)', () => {
     // a lottery payout to A/B/C after every mined block, until one wins.
     // ----------------------------------------------------------------------
     const wallets = [
-      { name: 'A', keys: keysA, addr: addrA },
-      { name: 'B', keys: keysB, addr: addrB },
-      { name: 'C', keys: keysC, addr: addrC },
+      { name: 'A', keys: keysA, addr: addrA, kem: kemA },
+      { name: 'B', keys: keysB, addr: addrB, kem: kemB },
+      { name: 'C', keys: keysC, addr: addrC, kem: kemC },
     ] as const
 
     // Track which lottery outputs we've already seen, so a "new" payout is one
@@ -419,6 +425,7 @@ maybe('node-backed: three-user exchange until a lottery payout (#394)', () => {
         const tx = await buildSendTransaction({
           keys: from.keys,
           recipient: to.addr,
+          senderKemPublicKey: from.kem,
           amount: sendAmount,
           fee,
           rpc: sendRpc(),

--- a/web/packages/wasm-signer/test/send-live-node.test.ts
+++ b/web/packages/wasm-signer/test/send-live-node.test.ts
@@ -42,6 +42,7 @@ import { deriveKeypairs, parseAddress } from '@botho/core'
 import {
   buildSendTransaction,
   deriveV2Address,
+  deriveKemPublicKey,
   setSigner,
   resetSigner,
   type ChainOutput,
@@ -197,7 +198,10 @@ maybe('node-backed: web-wallet -> tx -> ledger', () => {
     const recipient = {
       spend_public_key: toHex(recipientParsed.spendPublic),
       view_public_key: toHex(recipientParsed.viewPublic),
+      kem_public_key: toHex(recipientParsed.kemPublic),
     }
+    // The sender's own ML-KEM key (for change encapsulation, #978).
+    const senderKemPublicKey = await deriveKemPublicKey(senderMnemonic)
 
     // --- Pre-send ledger snapshot ----------------------------------------
     const heightBefore = (await rpc<{ chainHeight: number }>('node_getStatus', {})).chainHeight
@@ -243,6 +247,7 @@ maybe('node-backed: web-wallet -> tx -> ledger', () => {
     const { txHex, inputTotal } = await buildSendTransaction({
       keys: senderKeys,
       recipient,
+      senderKemPublicKey,
       amount,
       fee,
       rpc: sendRpc,

--- a/web/packages/wasm-signer/test/sign.test.ts
+++ b/web/packages/wasm-signer/test/sign.test.ts
@@ -61,6 +61,10 @@ maybe('wasm signer (requires build:wasm)', () => {
     // structural parsing far enough to hit the balance check; the inputs sum
     // (1) is far below amount + fee, so it must fail with "insufficient funds".
     const zero = '00'.repeat(32)
+    // A structurally valid (length-1184) ML-KEM-768 public key placeholder. The
+    // signer only length-checks it before the balance check this test targets,
+    // so an all-zero key suffices to reach "insufficient funds" (#978).
+    const zeroKem = '00'.repeat(1184)
     const decoys = Array.from({ length: ringSize - 1 }, () => ({
       target_key: zero,
       public_key: zero,
@@ -85,7 +89,8 @@ maybe('wasm signer (requires build:wasm)', () => {
           decoys,
         },
       ],
-      recipient: { spend_public_key: zero, view_public_key: zero },
+      recipient: { spend_public_key: zero, view_public_key: zero, kem_public_key: zeroKem },
+      senderKemPublicKey: zeroKem,
       amount: 5_000_000_000,
       fee: 100_000_000,
       createdAtHeight: 1000,
@@ -97,13 +102,15 @@ maybe('wasm signer (requires build:wasm)', () => {
   it('rejects a fee below the network minimum', async () => {
     const signer = await loadSignerNode()
     const zero = '00'.repeat(32)
+    const zeroKem = '00'.repeat(1184)
     const request: SignRequest = {
       spendPrivateKey: zero,
       viewPrivateKey: zero,
       inputs: [
         { target_key: zero, public_key: zero, amount: 10_000_000_000, subaddress_index: 0, decoys: [] },
       ],
-      recipient: { spend_public_key: zero, view_public_key: zero },
+      recipient: { spend_public_key: zero, view_public_key: zero, kem_public_key: zeroKem },
+      senderKemPublicKey: zeroKem,
       amount: 5_000_000_000,
       fee: 1, // below MIN_TX_FEE
       createdAtHeight: 1000,

--- a/web/packages/web-wallet/src/contexts/wallet-lock.test.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet-lock.test.tsx
@@ -31,6 +31,7 @@ vi.mock('@botho/wasm-signer', () => ({
   spendableBalance: vi.fn().mockResolvedValue(0n),
   buildOwnedHistory: vi.fn().mockResolvedValue([]),
   buildSendTransaction: vi.fn().mockResolvedValue({ txHex: '0xstub' }),
+  deriveKemPublicKey: vi.fn().mockResolvedValue('00'.repeat(1184)),
 }))
 
 // Real-backing localStorage mock so the encrypted stores actually persist blobs

--- a/web/packages/web-wallet/src/contexts/wallet-password.test.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet-password.test.tsx
@@ -31,6 +31,7 @@ vi.mock('@botho/wasm-signer', () => ({
   spendableBalance: vi.fn().mockResolvedValue(0n),
   buildOwnedHistory: vi.fn().mockResolvedValue([]),
   buildSendTransaction: vi.fn().mockResolvedValue({ txHex: '0xstub' }),
+  deriveKemPublicKey: vi.fn().mockResolvedValue('00'.repeat(1184)),
 }))
 
 // Real-backing localStorage mock so the encrypted stores actually persist blobs

--- a/web/packages/web-wallet/src/contexts/wallet.test.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.test.tsx
@@ -35,6 +35,8 @@ vi.mock('@botho/wasm-signer', () => ({
   // No owned outputs => empty client-side history.
   buildOwnedHistory: vi.fn().mockResolvedValue([]),
   buildSendTransaction: vi.fn().mockResolvedValue({ txHex: '0xstub' }),
+  // Sender's own ML-KEM key for change encapsulation (#978); stubbed.
+  deriveKemPublicKey: vi.fn().mockResolvedValue('00'.repeat(1184)),
 }))
 
 // Mock localStorage

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -11,7 +11,7 @@ import { RemoteNodeAdapter, type FeeEstimate, type WsConnectionStatus } from '@b
 import { AddressBook, EncryptedAddressBook, ClaimLinkStore, EncryptedClaimLinks, saveWallet, loadWallet, loadWalletWithKey, getWalletInfo, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet, createClaimLinkMnemonic, buildClaimLink, assertClaimLinkAmountWithinCap, VaultKey, MIN_PASSWORD_LENGTH } from '@botho/core'
 import { deriveV2Address } from '@botho/wasm-signer'
 import type { Balance, Contact, NodeInfo, Transaction, ClaimLinkRecord, Timestamp } from '@botho/core'
-import { buildSendTransaction, spendableBalance, buildOwnedHistory, netOwnedHistory, ownedOutputTargetKeys } from '@botho/wasm-signer'
+import { buildSendTransaction, spendableBalance, buildOwnedHistory, netOwnedHistory, ownedOutputTargetKeys, deriveKemPublicKey } from '@botho/wasm-signer'
 import { buildAndSubmitSend, scanEphemeral, sweepEphemeral, SWEEP_FEE_RESERVE } from '../lib/claim-link-ops'
 import { type NetworkConfig, loadSelectedNetwork, loadSelectedIngress, NETWORKS, DEFAULT_NETWORK_ID, DEFAULT_INGRESS_ID, createCustomNetwork, networkForIngress, getIngressNode } from '../config/networks'
 
@@ -1059,7 +1059,12 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     }
 
     // 4. Build + CLSAG-sign entirely client-side (wasm). The keys never leave
-    //    the browser; only the signed bytes are submitted.
+    //    the browser; only the signed bytes are submitted. Every output is a
+    //    hybrid post-quantum output (6.0.0, #978): the recipient output
+    //    encapsulates against the recipient's published ML-KEM key
+    //    (recipientKeys.kemPublic), and the change output against the wallet's
+    //    OWN ML-KEM key (derived from the mnemonic).
+    const senderKemPublicKey = await deriveKemPublicKey(mnemonic)
     const { txHex } = await buildSendTransaction({
       keys: {
         spendPrivateKey: toHex(kp.spendPrivate),
@@ -1068,7 +1073,9 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       recipient: {
         spend_public_key: toHex(recipientKeys.spendPublic),
         view_public_key: toHex(recipientKeys.viewPublic),
+        kem_public_key: toHex(recipientKeys.kemPublic),
       },
+      senderKemPublicKey,
       amount,
       fee,
       rpc: {

--- a/web/packages/web-wallet/src/lib/claim-link-ops.test.ts
+++ b/web/packages/web-wallet/src/lib/claim-link-ops.test.ts
@@ -32,6 +32,12 @@ function fakeSigner(): WasmSigner {
     buildAndSign: () => 'deadbeef',
     ringSize: () => 3,
     minFee: () => MIN_TX_FEE,
+    // Placeholder v2-length PQ keys so `deriveKemPublicKey` (used by the sweep
+    // path for change encapsulation, #978) resolves without real crypto.
+    derivePqPublicKeysFromSeed: () => ({
+      kemPublicKey: '00'.repeat(1184),
+      dsaPublicKey: '00'.repeat(1952),
+    }),
     scanOwnedOutputs: ({ outputs }) =>
       outputs
         .filter((o) => o.targetKey.startsWith('eph'))

--- a/web/packages/web-wallet/src/lib/claim-link-ops.ts
+++ b/web/packages/web-wallet/src/lib/claim-link-ops.ts
@@ -16,7 +16,7 @@
  */
 
 import { deriveKeypairs, parseAddress } from '@botho/core'
-import { buildSendTransaction, spendableBalance, type SendRpc } from '@botho/wasm-signer'
+import { buildSendTransaction, spendableBalance, deriveKemPublicKey, type SendRpc } from '@botho/wasm-signer'
 import type { RemoteNodeAdapter } from '@botho/adapters'
 
 /** Signer's MIN_TX_FEE (picocredits) — mirrors wallet.tsx `send()`. */
@@ -77,6 +77,7 @@ export async function buildAndSubmitSend(
   const kp = deriveKeypairs(senderMnemonic, 0)
   const recipientKeys = parseAddress(recipientAddress)
   const fee = await resolveFee(adapter)
+  const senderKemPublicKey = await deriveKemPublicKey(senderMnemonic)
 
   const { txHex } = await buildSendTransaction({
     keys: {
@@ -86,7 +87,9 @@ export async function buildAndSubmitSend(
     recipient: {
       spend_public_key: toHex(recipientKeys.spendPublic),
       view_public_key: toHex(recipientKeys.viewPublic),
+      kem_public_key: toHex(recipientKeys.kemPublic),
     },
+    senderKemPublicKey,
     amount,
     fee,
     rpc: rpcFromAdapter(adapter),
@@ -160,6 +163,7 @@ export async function sweepEphemeral(
 
   const kp = deriveKeypairs(ephMnemonic, 0)
   const destKeys = parseAddress(destinationAddress)
+  const senderKemPublicKey = await deriveKemPublicKey(ephMnemonic)
 
   const { txHex } = await buildSendTransaction({
     keys: {
@@ -169,7 +173,9 @@ export async function sweepEphemeral(
     recipient: {
       spend_public_key: toHex(destKeys.spendPublic),
       view_public_key: toHex(destKeys.viewPublic),
+      kem_public_key: toHex(destKeys.kemPublic),
     },
+    senderKemPublicKey,
     amount: net,
     fee,
     rpc: rpcFromAdapter(adapter),


### PR DESCRIPTION
## Summary

Browser-built transfers previously emitted every output with `kem_ciphertext: None`, so under protocol 6.0.0 universal-ML-KEM enforcement (`validate_transfer_tx`, #974) the node **rejected every send the web wallet built**. This wires the browser send path (`bth-wasm-signer`) to the node's hybrid post-quantum construction, so browser sends are accepted on 6.0.0. It is the browser analog of the node send path (#966).

## Changes

### How `RecipientAddress` now carries the KEM key
- `RecipientAddress` (Rust `core.rs` + TS `index.ts`) gains a required `kem_public_key` field — the recipient's raw ML-KEM-768 public key, parsed from the pasted `botho://2/` address (`parseAddress` in `@botho/core` already exposes `kemPublic`; #965 wired the decode).
- `SignRequest` gains `senderKemPublicKey` — the sender's OWN ML-KEM key, used to encapsulate the **change** output back to the sender. A new `deriveKemPublicKey(mnemonic)` helper derives it from the wallet seed via the node-identical `derive_pq_keys_from_seed`.

### The hybrid build path
- `build_and_sign` now builds **every** output via `TxOutput::new_hybrid_to_address` (the clsag `pq` send-path constructor), not `TxOutput::new`:
  - recipient output at **index 0**, change at **index 1** (the `output_index` is bound into the one-time-key derivation, so position matters and matches the node send path #966);
  - each output encapsulates a shared secret against the respective published ML-KEM key, attaches the 1088-byte ciphertext, and folds the secret into the one-time key — byte-identical to the node.
- Enabled the clsag `pq` feature for the wasm-signer crate so the encapsulating constructor is the real one (not the classical fallback).
- A recipient (or sender) address lacking a well-formed ML-KEM key is a **hard error** — never a silent KEM-less output that consensus rejects (acceptance #4).
- TS callers wired: `web-wallet` `wallet.tsx` send + `claim-link-ops.ts` (send + sweep) now pass `recipient.kem_public_key` and `senderKemPublicKey`; `buildSendTransaction` fails loudly on a KEM-less recipient.

### Node-acceptance test (the key evidence)
Added `browser_built_transfer_passes_node_kem_gate` in `botho/src/consensus/validation.rs`: it builds a transfer via the **browser signer** (`bth_wasm_signer::core::build_and_sign_with_rng`, added as a botho dev-dependency) and asserts the node's `validate_transfer_tx` **ACCEPTS** it under 6.0.0 (`KEM_CIPHERTEXT_ENFORCED` is asserted true). This directly proves the gap the issue opened is closed. wasm-signer tests additionally prove both outputs carry 1088-byte ciphertexts and are receivable by a node hybrid scanner (`belongs_to_hybrid`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Browser tx outputs (recipient + change) carry valid 1088-byte ML-KEM ciphertexts | ✅ | `core.rs::browser_send_outputs_carry_ml_kem_ciphertexts` |
| Hybrid one-time key matches the node's construction | ✅ | `core.rs::browser_send_outputs_are_receivable_by_node_scanner` — a node scanner (`belongs_to_hybrid`) detects both recipient (idx 0) and change (idx 1) |
| A browser-built tx is ACCEPTED by 6.0.0 consensus (round-trip vs node enforcement) | ✅ | `validation.rs::browser_built_transfer_passes_node_kem_gate` — `validate_transfer_tx` returns Ok |
| KEM-less / v1 recipient is a hard error | ✅ | `core.rs::send_to_kemless_address_is_hard_error` + `buildSendTransaction` guard |
| Existing web send flows still work; typecheck + vitest green | ✅ | See Test Plan |

## Test Plan

- `cargo test -p bth-wasm-signer` — 16 passed (incl. receivability + hard-error)
- `cargo test -p botho ...::kem_enforcement` — 9 passed (incl. the browser-acceptance test)
- `cargo build --workspace --all-targets` — clean
- `pnpm -r typecheck` — all 8 packages pass
- `pnpm test:run` — 916 passed / 10 skipped
- `wasm-pack build --target web` — compiles with the `pq` feature enabled
- `sign.test.ts` runtime (real wasm) — 4 passed

Protocol stays 6.0.0 (web/wasm change only; no consensus files modified — the botho change is a test + a dev-dependency).

Closes #978