### PR TITLE
feat(wallet): detect 6.0.0 hybrid outputs on the shared wallet scan path

### DIFF
--- a/mobile/rust-bridge/src/lib.rs
+++ b/mobile/rust-bridge/src/lib.rs
@@ -557,6 +557,10 @@ impl MobileWallet {
             spend_private_key: hex::encode(account.spend_private_key().to_bytes()),
             view_private_key: hex::encode(account.view_private_key().to_bytes()),
             sender_kem_public_key: sender_pq.kem_public_key,
+            // The BIP39 seed (hex) so the RECEIVE scan can derive the wallet's
+            // ML-KEM secret and detect hybrid incoming payments + its own change
+            // (issue #988). Same feature-independent seed the send path uses.
+            seed: hex::encode(seed),
         };
         Ok((signer, address))
     }
@@ -861,6 +865,8 @@ mod send_acceptance_tests {
             spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
             view_private_key: hex::encode(sender.view_private_key().to_bytes()),
             sender_kem_public_key: hex::encode(sender_pq.kem_keypair.public_key().as_bytes()),
+            // Send-only test: the seed is only consulted by the RECEIVE scan.
+            seed: String::new(),
         };
 
         // Owned input well above amount + fee so a change output exists.

--- a/mobile/rust-bridge/src/rpc.rs
+++ b/mobile/rust-bridge/src/rpc.rs
@@ -31,6 +31,18 @@ pub struct RpcOutput {
     pub public_key: String,
     #[serde(rename = "amountCommitment")]
     pub amount_commitment: String,
+    /// The output's position within its creating transaction. Under protocol
+    /// 6.0.0 this index is bound into the hybrid one-time key, so the RECEIVE
+    /// scan needs it to detect hybrid outputs (issue #988). Coinbase outputs are
+    /// reported as `u32::MAX` by the node and normalized to `MINTING_OUTPUT_INDEX`
+    /// (0) by the consumer. Defaults to 0 when absent.
+    #[serde(rename = "outputIndex", default)]
+    pub output_index: u32,
+    /// Hex-encoded ML-KEM-768 ciphertext, or `null` for a classical/legacy
+    /// KEM-less output (issue #970). The scan decapsulates it to detect the
+    /// hybrid one-time key.
+    #[serde(rename = "kemCiphertext", default)]
+    pub kem_ciphertext: Option<String>,
 }
 
 /// Spent/pending status of a key image from `chain_areKeyImagesSpent`.

--- a/mobile/rust-bridge/src/rpc.rs
+++ b/mobile/rust-bridge/src/rpc.rs
@@ -33,9 +33,10 @@ pub struct RpcOutput {
     pub amount_commitment: String,
     /// The output's position within its creating transaction. Under protocol
     /// 6.0.0 this index is bound into the hybrid one-time key, so the RECEIVE
-    /// scan needs it to detect hybrid outputs (issue #988). Coinbase outputs are
-    /// reported as `u32::MAX` by the node and normalized to `MINTING_OUTPUT_INDEX`
-    /// (0) by the consumer. Defaults to 0 when absent.
+    /// scan needs it to detect hybrid outputs (issue #988). Coinbase outputs
+    /// are reported as `u32::MAX` by the node and normalized to
+    /// `MINTING_OUTPUT_INDEX` (0) by the consumer. Defaults to 0 when
+    /// absent.
     #[serde(rename = "outputIndex", default)]
     pub output_index: u32,
     /// Hex-encoded ML-KEM-768 ciphertext, or `null` for a classical/legacy

--- a/mobile/rust-bridge/src/wallet_ops.rs
+++ b/mobile/rust-bridge/src/wallet_ops.rs
@@ -25,6 +25,13 @@ pub struct SignerKeys {
     /// ciphertext is encapsulated against this key, so the sender can later
     /// recover its change under the 6.0.0 hybrid scheme (issue #978).
     pub sender_kem_public_key: String,
+    /// Hex-encoded 64-byte BIP39 seed of the wallet (never leaves device). The
+    /// RECEIVE scan derives the wallet's ML-KEM SECRET from this
+    /// (feature-independent `derive_pq_keys_from_seed`, NOT
+    /// `WalletKeys::public_address()` — which needs the `pq` feature the mobile
+    /// `botho-wallet` build disables) to decapsulate and detect 6.0.0 hybrid
+    /// outputs — incoming payments and the wallet's own change (issue #988).
+    pub seed: String,
 }
 
 /// A wallet's spendable view of the chain: owned, unspent outputs + the height
@@ -41,15 +48,36 @@ impl SyncedWallet {
     }
 }
 
-/// Fetch every chain output as a `ChainOutput` (with transparent amount).
+/// The node reports a coinbase output's `outputIndex` as this sentinel to
+/// distinguish it from regular transaction outputs; its hybrid one-time key is
+/// bound to `MINTING_OUTPUT_INDEX` (0), so normalize it before scanning.
+const COINBASE_OUTPUT_INDEX_SENTINEL: u32 = u32::MAX;
+/// The index a coinbase output's hybrid one-time key is actually bound to (the
+/// node's `MINTING_OUTPUT_INDEX`).
+const MINTING_OUTPUT_INDEX: u32 = 0;
+
+/// Fetch every chain output as a `ChainOutput` (with transparent amount, its
+/// position within its tx, and its ML-KEM ciphertext) — everything the RECEIVE
+/// scan needs to detect 6.0.0 hybrid outputs (issue #988).
 async fn fetch_candidates(rpc: &NodeRpc, height: u64) -> Result<Vec<ChainOutput>, String> {
     let raw = rpc.get_outputs(0, height).await?;
     Ok(raw
         .into_iter()
-        .map(|o| ChainOutput {
-            target_key: o.target_key,
-            public_key: o.public_key,
-            amount: amount_from_commitment(&o.amount_commitment),
+        .map(|o| {
+            // Normalize the coinbase sentinel to the index its one-time key is
+            // actually bound to, so a mined coinbase is detectable too.
+            let output_index = if o.output_index == COINBASE_OUTPUT_INDEX_SENTINEL {
+                MINTING_OUTPUT_INDEX
+            } else {
+                o.output_index
+            };
+            ChainOutput {
+                target_key: o.target_key,
+                public_key: o.public_key,
+                amount: amount_from_commitment(&o.amount_commitment),
+                output_index,
+                kem_ciphertext: o.kem_ciphertext,
+            }
         })
         .collect())
 }
@@ -71,6 +99,9 @@ pub async fn sync(rpc: &NodeRpc, keys: &SignerKeys) -> Result<SyncedWallet, Stri
     let owned = scan_owned_outputs_inner(&ScanRequest {
         spend_private_key: keys.spend_private_key.clone(),
         view_private_key: keys.view_private_key.clone(),
+        // Seed-derived ML-KEM secret so the scan decapsulates hybrid outputs
+        // (incoming payments + our own change) under 6.0.0 (issue #988).
+        seed: keys.seed.clone(),
         outputs: candidates,
     })?;
 
@@ -100,6 +131,9 @@ async fn filter_spendable(
     let with_images = compute_owned_output_key_images_inner(&KeyImageRequest {
         spend_private_key: keys.spend_private_key.clone(),
         view_private_key: keys.view_private_key.clone(),
+        // Seed so a hybrid owned output's one-time spend key (hence key image)
+        // recovers via the unified path (issue #988).
+        seed: keys.seed.clone(),
         outputs: owned,
     })?;
 
@@ -119,6 +153,10 @@ async fn filter_spendable(
                 public_key: o.public_key,
                 amount: o.amount,
                 subaddress_index: o.subaddress_index,
+                // Preserve hybrid metadata so a later spend recovers the
+                // one-time key on the unified path (issue #988).
+                output_index: o.output_index,
+                kem_ciphertext: o.kem_ciphertext,
             });
         }
     }

--- a/mobile/rust-bridge/tests/wallet_core_offline.rs
+++ b/mobile/rust-bridge/tests/wallet_core_offline.rs
@@ -37,6 +37,12 @@ struct DerivedKeys {
     /// post-quantum output, so the recipient's key is required to encapsulate
     /// the ciphertext and the sender's own key seeds its change (issue #978).
     kem_public_hex: String,
+    /// Hex-encoded 64-byte BIP39 seed. The RECEIVE scan needs this to derive the
+    /// wallet's ML-KEM SECRET (node-identically, via the feature-independent
+    /// `derive_pq_keys_from_seed`) and decapsulate hybrid outputs — proving the
+    /// mobile crate (which builds `botho-wallet` with `pq` OFF) can detect
+    /// hybrid receives without `WalletKeys::public_address()` (issue #988/#984).
+    seed_hex: String,
 }
 
 /// The 64-byte BIP39 seed for a mnemonic (empty passphrase), matching the seed
@@ -71,7 +77,8 @@ fn derive_from_seed(seed: u8) -> DerivedKeys {
     // v2 (post-quantum) and the hybrid send path attaches ML-KEM ciphertexts —
     // exactly what the bridge does. Derived from the seed here because the
     // mobile crate builds `botho-wallet` without its `pq` feature.
-    let pq = bth_crypto_pq::derive_pq_keys_from_seed(&mnemonic_to_seed(&mnemonic));
+    let seed = mnemonic_to_seed(&mnemonic);
+    let pq = bth_crypto_pq::derive_pq_keys_from_seed(&seed);
     let kem_bytes = pq.kem_keypair.public_key().as_bytes().to_vec();
     let dsa_bytes = pq.sig_keypair.public_key().as_bytes().to_vec();
 
@@ -79,6 +86,7 @@ fn derive_from_seed(seed: u8) -> DerivedKeys {
         spend_private_hex: hex::encode(account.spend_private_key().to_bytes()),
         view_private_hex: hex::encode(account.view_private_key().to_bytes()),
         kem_public_hex: hex::encode(&kem_bytes),
+        seed_hex: hex::encode(seed),
         // Outputs are sent to the default subaddress; `belongs_to` returns
         // subaddress index 0 for these. The address carries the derived PQ keys
         // so it is a valid v2 (post-quantum) recipient.
@@ -97,6 +105,28 @@ fn mint_owned_output(amount: u64, recipient: &PublicAddress) -> ChainOutput {
         target_key: hex::encode(out.target_key),
         public_key: hex::encode(out.public_key),
         amount,
+        output_index: 0,
+        kem_ciphertext: None,
+    }
+}
+
+/// Mint a HYBRID (post-quantum) stealth output of `amount` picocredits owned by
+/// `recipient` at `output_index`, shaped as `chain_getOutputs` reports it: with
+/// its ML-KEM-768 ciphertext preserved. This is what a 6.0.0 producer emits and
+/// what the RECEIVE scan must decapsulate to detect (#988).
+fn mint_hybrid_owned_output(
+    amount: u64,
+    recipient: &PublicAddress,
+    output_index: u32,
+) -> ChainOutput {
+    let out = TxOutput::new_hybrid_to_address(amount, recipient, output_index, None, Default::default())
+        .expect("recipient publishes an ML-KEM key (v2 address)");
+    ChainOutput {
+        target_key: hex::encode(out.target_key),
+        public_key: hex::encode(out.public_key),
+        amount,
+        output_index,
+        kem_ciphertext: out.kem_ciphertext.as_ref().map(hex::encode),
     }
 }
 
@@ -148,6 +178,7 @@ fn scan_recovers_owned_outputs_and_ignores_others() {
     let scanned = scan_owned_outputs_inner(&ScanRequest {
         spend_private_key: wallet.spend_private_hex.clone(),
         view_private_key: wallet.view_private_hex.clone(),
+        seed: wallet.seed_hex.clone(),
         outputs: vec![foreign_a, owned_a.clone(), foreign_b, owned_b.clone()],
     })
     .expect("scan should succeed");
@@ -172,6 +203,7 @@ fn key_image_derivation_is_stable_and_unique_per_output() {
     let scanned = scan_owned_outputs_inner(&ScanRequest {
         spend_private_key: wallet.spend_private_hex.clone(),
         view_private_key: wallet.view_private_hex.clone(),
+        seed: wallet.seed_hex.clone(),
         outputs: vec![
             mint_owned_output(5_000_000_000, &wallet.public_address),
             mint_owned_output(3_000_000_000, &wallet.public_address),
@@ -182,6 +214,7 @@ fn key_image_derivation_is_stable_and_unique_per_output() {
     let req = KeyImageRequest {
         spend_private_key: wallet.spend_private_hex.clone(),
         view_private_key: wallet.view_private_hex.clone(),
+        seed: wallet.seed_hex.clone(),
         outputs: scanned,
     };
 
@@ -209,6 +242,7 @@ fn build_and_sign_produces_node_verifiable_tx() {
     let owned = scan_owned_outputs_inner(&ScanRequest {
         spend_private_key: sender.spend_private_hex.clone(),
         view_private_key: sender.view_private_hex.clone(),
+        seed: sender.seed_hex.clone(),
         outputs: vec![mint_owned_output(input_amount, &sender.public_address)],
     })
     .expect("scan input");
@@ -275,6 +309,7 @@ fn build_and_sign_rejects_insufficient_inputs() {
     let owned = scan_owned_outputs_inner(&ScanRequest {
         spend_private_key: sender.spend_private_hex.clone(),
         view_private_key: sender.view_private_hex.clone(),
+        seed: sender.seed_hex.clone(),
         outputs: vec![mint_owned_output(input_amount, &sender.public_address)],
     })
     .expect("scan");
@@ -314,5 +349,77 @@ fn build_and_sign_rejects_insufficient_inputs() {
     assert!(
         result.is_err(),
         "build+sign must reject inputs that cannot cover amount + fee"
+    );
+}
+
+#[test]
+fn scan_detects_hybrid_receive_and_recovers_key_image() {
+    // #988: prove the mobile crate's RECEIVE scan (the same
+    // `bth_wasm_signer::core::scan_owned_outputs_inner` the bridge's
+    // `wallet_ops::sync` calls) detects a 6.0.0 HYBRID output by decapsulating
+    // its ML-KEM ciphertext with the wallet's seed-derived secret — and then
+    // recovers its key image so it is spendable. This is the exact gap that left
+    // mobile wallets unable to see incoming funds / their own change.
+    let wallet = derive_from_seed(1);
+    let foreign = mint_decoy(9_000_000_000);
+
+    // A hybrid payment to us (output index 0) plus a foreign hybrid output.
+    let received = mint_hybrid_owned_output(5_000_000_000, &wallet.public_address, 0);
+    assert!(
+        received.kem_ciphertext.is_some(),
+        "a 6.0.0 output must carry an ML-KEM ciphertext"
+    );
+
+    let scanned = scan_owned_outputs_inner(&ScanRequest {
+        spend_private_key: wallet.spend_private_hex.clone(),
+        view_private_key: wallet.view_private_hex.clone(),
+        seed: wallet.seed_hex.clone(),
+        outputs: vec![foreign, received.clone()],
+    })
+    .expect("scan should succeed");
+
+    assert_eq!(scanned.len(), 1, "only our hybrid output is detected");
+    assert_eq!(scanned[0].amount, 5_000_000_000);
+    assert_eq!(scanned[0].subaddress_index, 0);
+    assert_eq!(scanned[0].target_key, received.target_key);
+    assert!(
+        scanned[0].kem_ciphertext.is_some(),
+        "the detected output carries its ciphertext for spend recovery"
+    );
+
+    // The hybrid one-time spend key must recover (seed-aware key-image path), so
+    // the received funds are spendable.
+    let images = compute_owned_output_key_images_inner(&KeyImageRequest {
+        spend_private_key: wallet.spend_private_hex.clone(),
+        view_private_key: wallet.view_private_hex.clone(),
+        seed: wallet.seed_hex.clone(),
+        outputs: scanned,
+    })
+    .expect("key-image derivation must succeed for the detected hybrid output");
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0].key_image.len(), 64, "hex 32-byte key image");
+}
+
+#[test]
+fn scan_ignores_hybrid_output_addressed_to_another_wallet() {
+    // #988 negative: a hybrid output to someone else must NOT decapsulate to our
+    // keys — the wrong ML-KEM secret yields a useless shared secret and the
+    // stealth check rejects it.
+    let me = derive_from_seed(1);
+    let other = derive_from_seed(2);
+
+    let theirs = mint_hybrid_owned_output(5_000_000_000, &other.public_address, 0);
+
+    let scanned = scan_owned_outputs_inner(&ScanRequest {
+        spend_private_key: me.spend_private_hex.clone(),
+        view_private_key: me.view_private_hex.clone(),
+        seed: me.seed_hex.clone(),
+        outputs: vec![theirs],
+    })
+    .expect("scan should succeed");
+
+    assert!(
+        scanned.is_empty(),
+        "a hybrid output addressed to another wallet must not be detected"
     );
 }

--- a/mobile/rust-bridge/tests/wallet_core_offline.rs
+++ b/mobile/rust-bridge/tests/wallet_core_offline.rs
@@ -37,11 +37,12 @@ struct DerivedKeys {
     /// post-quantum output, so the recipient's key is required to encapsulate
     /// the ciphertext and the sender's own key seeds its change (issue #978).
     kem_public_hex: String,
-    /// Hex-encoded 64-byte BIP39 seed. The RECEIVE scan needs this to derive the
-    /// wallet's ML-KEM SECRET (node-identically, via the feature-independent
-    /// `derive_pq_keys_from_seed`) and decapsulate hybrid outputs — proving the
-    /// mobile crate (which builds `botho-wallet` with `pq` OFF) can detect
-    /// hybrid receives without `WalletKeys::public_address()` (issue #988/#984).
+    /// Hex-encoded 64-byte BIP39 seed. The RECEIVE scan needs this to derive
+    /// the wallet's ML-KEM SECRET (node-identically, via the
+    /// feature-independent `derive_pq_keys_from_seed`) and decapsulate
+    /// hybrid outputs — proving the mobile crate (which builds
+    /// `botho-wallet` with `pq` OFF) can detect hybrid receives without
+    /// `WalletKeys::public_address()` (issue #988/#984).
     seed_hex: String,
 }
 
@@ -119,8 +120,9 @@ fn mint_hybrid_owned_output(
     recipient: &PublicAddress,
     output_index: u32,
 ) -> ChainOutput {
-    let out = TxOutput::new_hybrid_to_address(amount, recipient, output_index, None, Default::default())
-        .expect("recipient publishes an ML-KEM key (v2 address)");
+    let out =
+        TxOutput::new_hybrid_to_address(amount, recipient, output_index, None, Default::default())
+            .expect("recipient publishes an ML-KEM key (v2 address)");
     ChainOutput {
         target_key: hex::encode(out.target_key),
         public_key: hex::encode(out.public_key),

--- a/web/packages/adapters/src/remote.ts
+++ b/web/packages/adapters/src/remote.ts
@@ -66,6 +66,18 @@ function leHexToBigInt(hex: string): bigint {
 }
 
 /**
+ * The node reports a coinbase output's `outputIndex` as `u32::MAX` to
+ * distinguish it from a regular transaction output. Its hybrid one-time key is
+ * bound to `MINTING_OUTPUT_INDEX` (0), so a thin wallet must normalize the
+ * sentinel back to 0 before scanning, or a mined coinbase would be
+ * undetectable (#988).
+ */
+const COINBASE_OUTPUT_INDEX_SENTINEL = 0xffffffff
+function normalizeOutputIndex(outputIndex: number): number {
+  return outputIndex === COINBASE_OUTPUT_INDEX_SENTINEL ? 0 : outputIndex
+}
+
+/**
  * Wire shape of `getBlockByHeight` / `getBlockByHash` results. The
  * `transactions` / `totalFees` / `lottery` fields are the additive explorer
  * enrichment from #700 — older nodes omit them, so they are all optional and
@@ -366,7 +378,15 @@ export class RemoteNodeAdapter implements NodeAdapter {
   async getRawOutputs(
     startHeight: number,
     endHeight: number,
-  ): Promise<Array<{ targetKey: string; publicKey: string; amount: bigint }>> {
+  ): Promise<
+    Array<{
+      targetKey: string
+      publicKey: string
+      amount: bigint
+      outputIndex: number
+      kemCiphertext: string | null
+    }>
+  > {
     const result = await this.call<Array<{
       height: number
       outputs: Array<{
@@ -375,6 +395,7 @@ export class RemoteNodeAdapter implements NodeAdapter {
         targetKey: string
         publicKey: string
         amountCommitment: string
+        kemCiphertext?: string | null
       }>
     }>>('chain_getOutputs', {
       start_height: startHeight,
@@ -386,6 +407,12 @@ export class RemoteNodeAdapter implements NodeAdapter {
         targetKey: output.targetKey,
         publicKey: output.publicKey,
         amount: leHexToBigInt(output.amountCommitment),
+        // The output's tx position, needed to detect 6.0.0 hybrid outputs
+        // (#988). The node reports a coinbase as u32::MAX; normalize it to the
+        // index its one-time key is actually bound to (MINTING_OUTPUT_INDEX=0).
+        outputIndex: normalizeOutputIndex(output.outputIndex),
+        // ML-KEM ciphertext (hex) or null for a classical/legacy output (#970).
+        kemCiphertext: output.kemCiphertext ?? null,
       })),
     )
   }
@@ -408,6 +435,8 @@ export class RemoteNodeAdapter implements NodeAdapter {
       targetKey: string
       publicKey: string
       amount: bigint
+      outputIndex: number
+      kemCiphertext: string | null
     }>
   > {
     const result = await this.call<Array<{
@@ -418,6 +447,7 @@ export class RemoteNodeAdapter implements NodeAdapter {
         targetKey: string
         publicKey: string
         amountCommitment: string
+        kemCiphertext?: string | null
       }>
     }>>('chain_getOutputs', {
       start_height: startHeight,
@@ -431,6 +461,9 @@ export class RemoteNodeAdapter implements NodeAdapter {
         targetKey: output.targetKey,
         publicKey: output.publicKey,
         amount: leHexToBigInt(output.amountCommitment),
+        // Hybrid-detection metadata (#988), coinbase sentinel normalized.
+        outputIndex: normalizeOutputIndex(output.outputIndex),
+        kemCiphertext: output.kemCiphertext ?? null,
       })),
     )
   }

--- a/web/packages/wasm-signer/src/address.ts
+++ b/web/packages/wasm-signer/src/address.ts
@@ -62,6 +62,19 @@ export async function deriveV2Address(
 }
 
 /**
+ * Derive the wallet's hex-encoded 64-byte BIP39 seed from its mnemonic (empty
+ * passphrase) — the same seed the node/browser derive PQ keys from.
+ *
+ * The RECEIVE scan needs this seed to derive the wallet's ML-KEM SECRET (via the
+ * node-identical `derive_pq_keys_from_seed` in wasm) so it can decapsulate and
+ * detect 6.0.0 hybrid outputs — incoming payments and the wallet's own change
+ * (issue #988). Callers pass it as `SignerKeys.seed`.
+ */
+export function mnemonicToSeedHex(mnemonic: string): string {
+  return toHex(mnemonicToSeedSync(mnemonic, ''))
+}
+
+/**
  * Derive the wallet's raw ML-KEM-768 public key (hex) from its BIP39 mnemonic,
  * via the node-identical `derive_pq_keys_from_seed` in wasm.
  *

--- a/web/packages/wasm-signer/src/core.rs
+++ b/web/packages/wasm-signer/src/core.rs
@@ -553,15 +553,16 @@ pub struct ScanRequest {
     /// Hex-encoded 64-byte BIP39 seed of the wallet. **Stays client-side.**
     ///
     /// Used to derive the wallet's ML-KEM-768 secret keypair
-    /// ([`bth_crypto_pq::derive_pq_keys_from_seed`], node-identical) so the scan
-    /// can decapsulate each hybrid output's ciphertext and detect the 6.0.0
-    /// hybrid one-time key. This is the feature-independent derivation the send
-    /// side already uses (`derivePqPublicKeysFromSeed`) — NOT
-    /// `WalletKeys::public_address()`, which requires the `pq` feature and is
-    /// unavailable in the mobile crate's classical `botho-wallet` build (#984).
-    /// Empty means "classical-only scan" (no ML-KEM secret available): outputs
-    /// are matched with the legacy [`TxOutput::belongs_to`] check, so hybrid
-    /// outputs are not detected. Defaults to empty for back-compat.
+    /// ([`bth_crypto_pq::derive_pq_keys_from_seed`], node-identical) so the
+    /// scan can decapsulate each hybrid output's ciphertext and detect the
+    /// 6.0.0 hybrid one-time key. This is the feature-independent
+    /// derivation the send side already uses (`derivePqPublicKeysFromSeed`)
+    /// — NOT `WalletKeys::public_address()`, which requires the `pq`
+    /// feature and is unavailable in the mobile crate's classical
+    /// `botho-wallet` build (#984). Empty means "classical-only scan" (no
+    /// ML-KEM secret available): outputs are matched with the legacy
+    /// [`TxOutput::belongs_to`] check, so hybrid outputs are not detected.
+    /// Defaults to empty for back-compat.
     #[serde(default)]
     pub seed: String,
     /// Candidate outputs (e.g. every output the node returned for a height
@@ -605,14 +606,14 @@ pub struct OwnedOutput {
 /// published in the wallet's own v2 address. It does NOT route through
 /// `WalletKeys::public_address()` (which needs the `pq` feature and is absent
 /// from the mobile crate's classical build — the trap documented in #984).
-fn derive_kem_keypair(
-    seed_hex: &str,
-) -> Result<Option<bth_crypto_pq::MlKem768KeyPair>, String> {
+fn derive_kem_keypair(seed_hex: &str) -> Result<Option<bth_crypto_pq::MlKem768KeyPair>, String> {
     if seed_hex.trim().is_empty() {
         return Ok(None);
     }
     let seed = parse_bip39_seed(seed_hex)?;
-    Ok(Some(bth_crypto_pq::derive_pq_keys_from_seed(&seed).kem_keypair))
+    Ok(Some(
+        bth_crypto_pq::derive_pq_keys_from_seed(&seed).kem_keypair,
+    ))
 }
 
 /// Parse an optional hex-encoded ML-KEM-768 ciphertext into raw bytes.
@@ -700,9 +701,9 @@ pub struct KeyImageRequest {
     pub spend_private_key: String,
     /// Hex-encoded 32-byte account view private key. **Stays client-side.**
     pub view_private_key: String,
-    /// Hex-encoded 64-byte BIP39 seed. **Stays client-side.** Used to derive the
-    /// wallet's ML-KEM-768 secret so a hybrid owned output's one-time spend key
-    /// (hence its key image) can be recovered via
+    /// Hex-encoded 64-byte BIP39 seed. **Stays client-side.** Used to derive
+    /// the wallet's ML-KEM-768 secret so a hybrid owned output's one-time
+    /// spend key (hence its key image) can be recovered via
     /// [`TxOutput::recover_spend_key_for`]. Empty falls back to classical
     /// recovery; defaults to empty for back-compat (#988).
     #[serde(default)]
@@ -723,9 +724,9 @@ pub struct OwnedOutputKeyImage {
     pub amount: u64,
     /// Subaddress index that received this output (0 = default, 1 = change).
     pub subaddress_index: u64,
-    /// The output's position within its creating transaction, preserved from the
-    /// scan so a subsequent spend recovers the hybrid one-time key on the
-    /// unified path (issue #988). Defaults to 0 for back-compat.
+    /// The output's position within its creating transaction, preserved from
+    /// the scan so a subsequent spend recovers the hybrid one-time key on
+    /// the unified path (issue #988). Defaults to 0 for back-compat.
     #[serde(default)]
     pub output_index: u32,
     /// The owned output's ML-KEM-768 ciphertext (hex), or `None` for a
@@ -772,12 +773,9 @@ pub fn compute_owned_output_key_images_inner(
         // a hybrid (ciphertext-bearing) output needs the ML-KEM secret + its
         // bound `output_index`; a KEM-less output uses classical recovery.
         let onetime_private = match &kem_keypair {
-            Some(kp) => tx_out.recover_spend_key_for(
-                &account,
-                kp,
-                out.subaddress_index,
-                out.output_index,
-            ),
+            Some(kp) => {
+                tx_out.recover_spend_key_for(&account, kp, out.subaddress_index, out.output_index)
+            }
             None => tx_out.recover_spend_key(&account, out.subaddress_index),
         }
         .ok_or("failed to recover one-time private key for owned output")?;
@@ -1472,9 +1470,10 @@ mod tests {
         hex::encode([seed_byte; bth_crypto_pq::BIP39_SEED_SIZE])
     }
 
-    /// Turn a signed transaction output into a `ChainOutput` exactly as the node
-    /// RPC (`chain_getOutputs`) would present it: stealth keys, transparent
-    /// amount, its position within the tx, and its hybrid ML-KEM ciphertext.
+    /// Turn a signed transaction output into a `ChainOutput` exactly as the
+    /// node RPC (`chain_getOutputs`) would present it: stealth keys,
+    /// transparent amount, its position within the tx, and its hybrid
+    /// ML-KEM ciphertext.
     fn chain_output_of(out: &TxOutput, output_index: u32) -> ChainOutput {
         ChainOutput {
             target_key: hex::encode(out.target_key),
@@ -1487,13 +1486,13 @@ mod tests {
 
     /// #988: a hybrid output SENT (via the #978 send path) to the wallet's
     /// address MUST be DETECTED by the shared `scan_owned_outputs_inner` — the
-    /// exact receive path both the browser sync and the mobile `wallet_ops::sync`
-    /// consume — by decapsulating its ML-KEM ciphertext with the wallet's
-    /// seed-derived secret, AND its one-time spend key must recover so the funds
-    /// are spendable (`x·G == target_key`). This is the RECEIVE-side counterpart
-    /// to #978: before this fix the scan built every candidate with
-    /// `kem_ciphertext: None` and used the classical `belongs_to`, so hybrid
-    /// incoming payments were invisible.
+    /// exact receive path both the browser sync and the mobile
+    /// `wallet_ops::sync` consume — by decapsulating its ML-KEM ciphertext
+    /// with the wallet's seed-derived secret, AND its one-time spend key
+    /// must recover so the funds are spendable (`x·G == target_key`). This
+    /// is the RECEIVE-side counterpart to #978: before this fix the scan
+    /// built every candidate with `kem_ciphertext: None` and used the
+    /// classical `belongs_to`, so hybrid incoming payments were invisible.
     #[test]
     fn hybrid_received_output_is_detected_and_spendable_by_scan() {
         let mut rng = StdRng::from_seed([53u8; 32]);

--- a/web/packages/wasm-signer/src/core.rs
+++ b/web/packages/wasm-signer/src/core.rs
@@ -514,8 +514,9 @@ pub fn build_and_sign_with_rng<R: RngCore + CryptoRng>(
 /// A chain output the wallet wants to test for ownership / use as a decoy.
 ///
 /// These are exactly the fields the node returns from `chain_getOutputs`
-/// (`targetKey`, `publicKey`, and the transparent `amount` recovered from
-/// `amountCommitment`).
+/// (`targetKey`, `publicKey`, the transparent `amount` recovered from
+/// `amountCommitment`, the output's `outputIndex` within its transaction, and
+/// its optional ML-KEM `kemCiphertext`).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChainOutput {
@@ -525,6 +526,20 @@ pub struct ChainOutput {
     pub public_key: String,
     /// Amount in picocredits (recovered from the transparent commitment).
     pub amount: u64,
+    /// The output's position within its creating transaction (`outputIndex`
+    /// from `chain_getOutputs`). Under protocol 6.0.0 this index is bound into
+    /// the hybrid one-time key, so it MUST match the value the producer used
+    /// (recipient=0, change=1, coinbase=0). Defaults to 0 so legacy callers
+    /// that only scanned classical (index-independent) outputs still
+    /// deserialize.
+    #[serde(default)]
+    pub output_index: u32,
+    /// Hex-encoded ML-KEM-768 ciphertext (`kemCiphertext` from
+    /// `chain_getOutputs`), or `None` for a classical/legacy KEM-less output.
+    /// When present, the scan decapsulates it with the wallet's seed-derived
+    /// ML-KEM secret to detect the hybrid one-time key (issue #970/#988).
+    #[serde(default)]
+    pub kem_ciphertext: Option<String>,
 }
 
 /// A scan request: the account's private keys plus candidate chain outputs.
@@ -535,6 +550,20 @@ pub struct ScanRequest {
     pub spend_private_key: String,
     /// Hex-encoded 32-byte account view private key. **Stays client-side.**
     pub view_private_key: String,
+    /// Hex-encoded 64-byte BIP39 seed of the wallet. **Stays client-side.**
+    ///
+    /// Used to derive the wallet's ML-KEM-768 secret keypair
+    /// ([`bth_crypto_pq::derive_pq_keys_from_seed`], node-identical) so the scan
+    /// can decapsulate each hybrid output's ciphertext and detect the 6.0.0
+    /// hybrid one-time key. This is the feature-independent derivation the send
+    /// side already uses (`derivePqPublicKeysFromSeed`) — NOT
+    /// `WalletKeys::public_address()`, which requires the `pq` feature and is
+    /// unavailable in the mobile crate's classical `botho-wallet` build (#984).
+    /// Empty means "classical-only scan" (no ML-KEM secret available): outputs
+    /// are matched with the legacy [`TxOutput::belongs_to`] check, so hybrid
+    /// outputs are not detected. Defaults to empty for back-compat.
+    #[serde(default)]
+    pub seed: String,
     /// Candidate outputs (e.g. every output the node returned for a height
     /// range) to test for ownership.
     pub outputs: Vec<ChainOutput>,
@@ -552,37 +581,106 @@ pub struct OwnedOutput {
     pub amount: u64,
     /// Subaddress index that received this output (0 = default, 1 = change).
     pub subaddress_index: u64,
+    /// The output's position within its creating transaction. Carried through
+    /// from the scan so the hybrid one-time-key recovery
+    /// ([`TxOutput::recover_spend_key_for`]) can rebind it when deriving the
+    /// key image / spend key. Defaults to 0 for back-compat.
+    #[serde(default)]
+    pub output_index: u32,
+    /// The owned output's ML-KEM-768 ciphertext (hex), or `None` for a
+    /// classical/legacy output. Preserved from the scan so key-image
+    /// derivation dispatches down the same hybrid-when-present path (#988).
+    #[serde(default)]
+    pub kem_ciphertext: Option<String>,
+}
+
+/// Derive the wallet's ML-KEM-768 secret keypair from its hex BIP39 seed, using
+/// the **node-identical**, feature-independent
+/// [`bth_crypto_pq::derive_pq_keys_from_seed`].
+///
+/// Returns `Ok(None)` when `seed_hex` is empty (a classical-only scan: no
+/// ML-KEM secret available, so hybrid outputs cannot be decapsulated). This is
+/// the same derivation the send side uses for the public half
+/// (`derive_pq_public_keys_from_seed`), so the secret matches the ML-KEM key
+/// published in the wallet's own v2 address. It does NOT route through
+/// `WalletKeys::public_address()` (which needs the `pq` feature and is absent
+/// from the mobile crate's classical build — the trap documented in #984).
+fn derive_kem_keypair(
+    seed_hex: &str,
+) -> Result<Option<bth_crypto_pq::MlKem768KeyPair>, String> {
+    if seed_hex.trim().is_empty() {
+        return Ok(None);
+    }
+    let seed = parse_bip39_seed(seed_hex)?;
+    Ok(Some(bth_crypto_pq::derive_pq_keys_from_seed(&seed).kem_keypair))
+}
+
+/// Parse an optional hex-encoded ML-KEM-768 ciphertext into raw bytes.
+fn parse_kem_ciphertext(field: &str, ct: &Option<String>) -> Result<Option<Vec<u8>>, String> {
+    match ct {
+        None => Ok(None),
+        Some(s) if s.trim().is_empty() => Ok(None),
+        Some(s) => {
+            let bytes = hex::decode(s.trim()).map_err(|e| format!("{field}: invalid hex: {e}"))?;
+            Ok(Some(bytes))
+        }
+    }
 }
 
 /// Identify which of `outputs` belong to the account, using the
-/// **node-identical** stealth-address ownership check
-/// ([`TxOutput::belongs_to`]).
+/// **node-identical** unified hybrid scan ([`TxOutput::belongs_to_account`],
+/// issue #970).
 ///
-/// This runs the same Rust the node runs in `scan_utxos_for_account`, so a
-/// thin client never has to re-implement the subaddress math in JavaScript (a
-/// notorious source of cross-implementation drift). The view/spend keys are
-/// used only to recover the stealth relationship and never leave the client.
+/// This is the single RECEIVE-scan path shared by both wallet frontends (the
+/// browser sync and the mobile `wallet_ops::sync`). Under protocol 6.0.0 every
+/// producer emits **hybrid** outputs whose one-time key folds in an ML-KEM
+/// shared secret, so a purely-classical `belongs_to` check (the pre-#988
+/// behaviour) could not detect incoming payments or the wallet's own change.
+///
+/// For each candidate it reconstructs the on-chain [`TxOutput`] **with its real
+/// `kem_ciphertext`** and dispatches via `belongs_to_account`:
+/// * ciphertext present + seed supplied → decapsulate with the wallet's
+///   seed-derived ML-KEM secret and check the hybrid one-time key at the
+///   output's `output_index`;
+/// * ciphertext absent → classical [`TxOutput::belongs_to`] (back-compat).
+///
+/// When no seed is supplied (`req.seed` empty) the scan stays classical-only
+/// and hybrid outputs are skipped, exactly as before. The keys/seed never leave
+/// the client.
 pub fn scan_owned_outputs_inner(req: &ScanRequest) -> Result<Vec<OwnedOutput>, String> {
     let spend_private = parse_private("spendPrivateKey", &req.spend_private_key)?;
     let view_private = parse_private("viewPrivateKey", &req.view_private_key)?;
     let account = AccountKey::new(&spend_private, &view_private);
+    let kem_keypair = derive_kem_keypair(&req.seed)?;
 
     let mut owned = Vec::new();
     for out in &req.outputs {
+        let kem_ciphertext = parse_kem_ciphertext("output.kem_ciphertext", &out.kem_ciphertext)?;
         let tx_out = TxOutput {
             amount: out.amount,
             target_key: parse_hex_32("output.target_key", &out.target_key)?,
             public_key: parse_hex_32("output.public_key", &out.public_key)?,
             e_memo: None,
             cluster_tags: Default::default(),
-            kem_ciphertext: None,
+            kem_ciphertext,
         };
-        if let Some(subaddress_index) = tx_out.belongs_to(&account) {
+        // Unified dispatch (mirrors the node's `Wallet::scan_output`): with the
+        // ML-KEM secret available, `belongs_to_account` decapsulates a
+        // ciphertext-bearing output and folds the secret into the classical DH
+        // stealth check; a KEM-less output falls through to the classical path.
+        // Without a seed we can only run the classical check.
+        let detected = match &kem_keypair {
+            Some(kp) => tx_out.belongs_to_account(&account, kp, out.output_index),
+            None => tx_out.belongs_to(&account),
+        };
+        if let Some(subaddress_index) = detected {
             owned.push(OwnedOutput {
                 target_key: out.target_key.clone(),
                 public_key: out.public_key.clone(),
                 amount: out.amount,
                 subaddress_index,
+                output_index: out.output_index,
+                kem_ciphertext: out.kem_ciphertext.clone(),
             });
         }
     }
@@ -602,6 +700,13 @@ pub struct KeyImageRequest {
     pub spend_private_key: String,
     /// Hex-encoded 32-byte account view private key. **Stays client-side.**
     pub view_private_key: String,
+    /// Hex-encoded 64-byte BIP39 seed. **Stays client-side.** Used to derive the
+    /// wallet's ML-KEM-768 secret so a hybrid owned output's one-time spend key
+    /// (hence its key image) can be recovered via
+    /// [`TxOutput::recover_spend_key_for`]. Empty falls back to classical
+    /// recovery; defaults to empty for back-compat (#988).
+    #[serde(default)]
+    pub seed: String,
     /// The wallet's owned outputs to derive key images for.
     pub outputs: Vec<OwnedOutput>,
 }
@@ -618,6 +723,15 @@ pub struct OwnedOutputKeyImage {
     pub amount: u64,
     /// Subaddress index that received this output (0 = default, 1 = change).
     pub subaddress_index: u64,
+    /// The output's position within its creating transaction, preserved from the
+    /// scan so a subsequent spend recovers the hybrid one-time key on the
+    /// unified path (issue #988). Defaults to 0 for back-compat.
+    #[serde(default)]
+    pub output_index: u32,
+    /// The owned output's ML-KEM-768 ciphertext (hex), or `None` for a
+    /// classical/legacy output, preserved from the scan (issue #988).
+    #[serde(default)]
+    pub kem_ciphertext: Option<String>,
     /// Hex-encoded 32-byte key image. Querying the node's
     /// `chain_areKeyImagesSpent` RPC with this value reveals whether the output
     /// has already been spent on-chain (or is pending in the mempool).
@@ -641,26 +755,40 @@ pub fn compute_owned_output_key_images_inner(
     let spend_private = parse_private("spendPrivateKey", &req.spend_private_key)?;
     let view_private = parse_private("viewPrivateKey", &req.view_private_key)?;
     let account = AccountKey::new(&spend_private, &view_private);
+    let kem_keypair = derive_kem_keypair(&req.seed)?;
 
     let mut result = Vec::with_capacity(req.outputs.len());
     for out in &req.outputs {
+        let kem_ciphertext = parse_kem_ciphertext("output.kem_ciphertext", &out.kem_ciphertext)?;
         let tx_out = TxOutput {
             amount: out.amount,
             target_key: parse_hex_32("output.target_key", &out.target_key)?,
             public_key: parse_hex_32("output.public_key", &out.public_key)?,
             e_memo: None,
             cluster_tags: Default::default(),
-            kem_ciphertext: None,
+            kem_ciphertext,
         };
-        let onetime_private = tx_out
-            .recover_spend_key(&account, out.subaddress_index)
-            .ok_or("failed to recover one-time private key for owned output")?;
+        // Recover the one-time spend key on the same unified path as the scan:
+        // a hybrid (ciphertext-bearing) output needs the ML-KEM secret + its
+        // bound `output_index`; a KEM-less output uses classical recovery.
+        let onetime_private = match &kem_keypair {
+            Some(kp) => tx_out.recover_spend_key_for(
+                &account,
+                kp,
+                out.subaddress_index,
+                out.output_index,
+            ),
+            None => tx_out.recover_spend_key(&account, out.subaddress_index),
+        }
+        .ok_or("failed to recover one-time private key for owned output")?;
         let key_image = KeyImage::from(&onetime_private);
         result.push(OwnedOutputKeyImage {
             target_key: out.target_key.clone(),
             public_key: out.public_key.clone(),
             amount: out.amount,
             subaddress_index: out.subaddress_index,
+            output_index: out.output_index,
+            kem_ciphertext: out.kem_ciphertext.clone(),
             key_image: hex::encode(key_image.as_bytes()),
         });
     }
@@ -849,11 +977,14 @@ mod tests {
         let ki_req = KeyImageRequest {
             spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
             view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            seed: String::new(),
             outputs: vec![OwnedOutput {
                 target_key: hex::encode(owned.target_key),
                 public_key: hex::encode(owned.public_key),
                 amount: owned_amount,
                 subaddress_index: 0,
+                output_index: 0,
+                kem_ciphertext: None,
             }],
         };
         let computed = compute_owned_output_key_images_inner(&ki_req).unwrap();
@@ -903,16 +1034,21 @@ mod tests {
         let scan = ScanRequest {
             spend_private_key: hex::encode(me.spend_private_key().to_bytes()),
             view_private_key: hex::encode(me.view_private_key().to_bytes()),
+            seed: String::new(),
             outputs: vec![
                 ChainOutput {
                     target_key: hex::encode(mine.target_key),
                     public_key: hex::encode(mine.public_key),
                     amount: 1_000_000_000,
+                    output_index: 0,
+                    kem_ciphertext: None,
                 },
                 ChainOutput {
                     target_key: hex::encode(theirs.target_key),
                     public_key: hex::encode(theirs.public_key),
                     amount: 2_000_000_000,
+                    output_index: 0,
+                    kem_ciphertext: None,
                 },
             ],
         };
@@ -922,6 +1058,7 @@ mod tests {
         let ki_req = KeyImageRequest {
             spend_private_key: scan.spend_private_key.clone(),
             view_private_key: scan.view_private_key.clone(),
+            seed: scan.seed.clone(),
             outputs: owned,
         };
         let kis = compute_owned_output_key_images_inner(&ki_req).unwrap();
@@ -1002,11 +1139,14 @@ mod tests {
             target_key: hex::encode(o.target_key),
             public_key: hex::encode(o.public_key),
             amount: o.amount,
+            output_index: 0,
+            kem_ciphertext: o.kem_ciphertext.as_ref().map(hex::encode),
         };
 
         let req = ScanRequest {
             spend_private_key: hex::encode(me.spend_private_key().to_bytes()),
             view_private_key: hex::encode(me.view_private_key().to_bytes()),
+            seed: String::new(),
             outputs: vec![to_chain(&mine_a), to_chain(&theirs), to_chain(&mine_b)],
         };
 
@@ -1058,11 +1198,14 @@ mod tests {
             target_key: hex::encode(o.target_key),
             public_key: hex::encode(o.public_key),
             amount: o.amount,
+            output_index: 0,
+            kem_ciphertext: o.kem_ciphertext.as_ref().map(hex::encode),
         };
 
         let req = ScanRequest {
             spend_private_key: hex::encode(recipient.spend_private_key().to_bytes()),
             view_private_key: hex::encode(recipient.view_private_key().to_bytes()),
+            seed: String::new(),
             outputs: vec![to_chain(&to_subaddress), to_chain(&to_account_root)],
         };
 
@@ -1319,6 +1462,257 @@ mod tests {
         assert!(
             err.contains("ML-KEM") || err.contains("post-quantum"),
             "error should explain the address is not post-quantum, got: {err}"
+        );
+    }
+
+    /// The hex-encoded 64-byte BIP39 seed whose `derive_pq_keys_from_seed`
+    /// ML-KEM keypair equals `pq_keys(seed_byte)` — so a wallet built from this
+    /// seed can decapsulate outputs encapsulated against `pq_keys(seed_byte)`.
+    fn seed_hex(seed_byte: u8) -> String {
+        hex::encode([seed_byte; bth_crypto_pq::BIP39_SEED_SIZE])
+    }
+
+    /// Turn a signed transaction output into a `ChainOutput` exactly as the node
+    /// RPC (`chain_getOutputs`) would present it: stealth keys, transparent
+    /// amount, its position within the tx, and its hybrid ML-KEM ciphertext.
+    fn chain_output_of(out: &TxOutput, output_index: u32) -> ChainOutput {
+        ChainOutput {
+            target_key: hex::encode(out.target_key),
+            public_key: hex::encode(out.public_key),
+            amount: out.amount,
+            output_index,
+            kem_ciphertext: out.kem_ciphertext.as_ref().map(hex::encode),
+        }
+    }
+
+    /// #988: a hybrid output SENT (via the #978 send path) to the wallet's
+    /// address MUST be DETECTED by the shared `scan_owned_outputs_inner` — the
+    /// exact receive path both the browser sync and the mobile `wallet_ops::sync`
+    /// consume — by decapsulating its ML-KEM ciphertext with the wallet's
+    /// seed-derived secret, AND its one-time spend key must recover so the funds
+    /// are spendable (`x·G == target_key`). This is the RECEIVE-side counterpart
+    /// to #978: before this fix the scan built every candidate with
+    /// `kem_ciphertext: None` and used the classical `belongs_to`, so hybrid
+    /// incoming payments were invisible.
+    #[test]
+    fn hybrid_received_output_is_detected_and_spendable_by_scan() {
+        let mut rng = StdRng::from_seed([53u8; 32]);
+
+        // Sender pays a recipient whose ML-KEM keypair is derived from a known
+        // seed (so the recipient can scan with that seed).
+        let sender = AccountKey::random(&mut rng);
+        let recipient_account = AccountKey::random(&mut rng);
+        let recipient_pq = pq_keys(0x22);
+
+        let owned_amount = 10_000_000_000u64;
+        let send_amount = 4_000_000_000u64;
+        let owned = TxOutput::new(owned_amount, &sender.default_subaddress());
+        let decoys = make_decoys(DEFAULT_RING_SIZE - 1, owned_amount, &mut rng);
+
+        let req = SignRequest {
+            spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            inputs: vec![SpendInput {
+                target_key: hex::encode(owned.target_key),
+                public_key: hex::encode(owned.public_key),
+                amount: owned_amount,
+                subaddress_index: 0,
+                decoys,
+            }],
+            recipient: recipient_of_with_pq(&recipient_account, &recipient_pq),
+            sender_kem_public_key: kem_public_hex(&pq_keys(0x11)),
+            amount: send_amount,
+            fee: MIN_TX_FEE,
+            created_at_height: 1000,
+        };
+        let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
+        assert_eq!(tx.outputs.len(), 2, "recipient (0) + change (1)");
+
+        // The recipient scans the chain outputs through the SHARED path, passing
+        // its seed so the scan derives its ML-KEM secret and decapsulates.
+        let scan = ScanRequest {
+            spend_private_key: hex::encode(recipient_account.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(recipient_account.view_private_key().to_bytes()),
+            seed: seed_hex(0x22),
+            outputs: vec![
+                chain_output_of(&tx.outputs[0], 0),
+                chain_output_of(&tx.outputs[1], 1),
+            ],
+        };
+        let owned = scan_owned_outputs_inner(&scan).expect("scan should succeed");
+        assert_eq!(
+            owned.len(),
+            1,
+            "recipient must detect exactly its own hybrid output"
+        );
+        assert_eq!(owned[0].amount, send_amount);
+        assert_eq!(owned[0].subaddress_index, 0);
+        assert_eq!(owned[0].output_index, 0);
+        assert!(
+            owned[0].kem_ciphertext.is_some(),
+            "detected hybrid output must carry its ciphertext for spend recovery"
+        );
+
+        // The recovered one-time spend key must satisfy x·G == target_key, i.e.
+        // the recipient can actually SPEND what it received. Recovery runs on the
+        // same unified path the key-image derivation uses.
+        let recovered = tx.outputs[0]
+            .recover_spend_key_for(&recipient_account, &recipient_pq.kem_keypair, 0, 0)
+            .expect("hybrid spend key must recover");
+        assert_eq!(
+            RistrettoPublic::from(&recovered).to_bytes(),
+            tx.outputs[0].target_key,
+            "x·G must equal the output's one-time target key (spendable)"
+        );
+
+        // And the shared key-image path (seed-aware) succeeds end-to-end.
+        let ki = compute_owned_output_key_images_inner(&KeyImageRequest {
+            spend_private_key: scan.spend_private_key.clone(),
+            view_private_key: scan.view_private_key.clone(),
+            seed: scan.seed.clone(),
+            outputs: owned,
+        })
+        .expect("key-image derivation must succeed for the detected hybrid output");
+        assert_eq!(ki.len(), 1);
+    }
+
+    /// #988: the wallet's OWN change (a hybrid self-send, output index 1) must be
+    /// detected by its own sync through the shared scan path. Without the fix,
+    /// spending money made your change vanish from your balance until a full
+    /// rescan by a hybrid-aware node.
+    #[test]
+    fn hybrid_self_send_change_is_detected_on_sync() {
+        let mut rng = StdRng::from_seed([59u8; 32]);
+
+        // The sender's change is encapsulated against its OWN ML-KEM key, which
+        // is derived from `seed_hex(0x33)`.
+        let sender = AccountKey::random(&mut rng);
+        let sender_pq = pq_keys(0x33);
+        let recipient_account = AccountKey::random(&mut rng);
+        let recipient_pq = pq_keys(0x44);
+
+        let owned_amount = 10_000_000_000u64;
+        let send_amount = 4_000_000_000u64;
+        let owned = TxOutput::new(owned_amount, &sender.default_subaddress());
+        let decoys = make_decoys(DEFAULT_RING_SIZE - 1, owned_amount, &mut rng);
+
+        let req = SignRequest {
+            spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            inputs: vec![SpendInput {
+                target_key: hex::encode(owned.target_key),
+                public_key: hex::encode(owned.public_key),
+                amount: owned_amount,
+                subaddress_index: 0,
+                decoys,
+            }],
+            recipient: recipient_of_with_pq(&recipient_account, &recipient_pq),
+            sender_kem_public_key: kem_public_hex(&sender_pq),
+            amount: send_amount,
+            fee: MIN_TX_FEE,
+            created_at_height: 1000,
+        };
+        let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
+        assert_eq!(tx.outputs.len(), 2);
+
+        // The sender syncs and must find its own change (output index 1) at the
+        // change subaddress (index 1).
+        let owned = scan_owned_outputs_inner(&ScanRequest {
+            spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            seed: seed_hex(0x33),
+            outputs: vec![
+                chain_output_of(&tx.outputs[0], 0),
+                chain_output_of(&tx.outputs[1], 1),
+            ],
+        })
+        .expect("scan should succeed");
+
+        assert_eq!(owned.len(), 1, "sender must detect its own change");
+        let change = &owned[0];
+        // The change output is at position 1 within the tx, but the browser send
+        // path pays change back to the sender's DEFAULT subaddress (index 0) —
+        // the same key its own address publishes (mirrors #978's node-scanner
+        // test, which detects the change at subaddress 0).
+        assert_eq!(change.output_index, 1);
+        assert_eq!(change.subaddress_index, 0);
+        assert_eq!(change.amount, owned_amount - send_amount - MIN_TX_FEE);
+    }
+
+    /// #988 back-compat: a classical (`kemCiphertext: None`) output must still be
+    /// detected on the same shared scan path, even when a seed IS supplied. The
+    /// unified `belongs_to_account` dispatch falls through to the classical
+    /// `belongs_to` when an output carries no ciphertext.
+    #[test]
+    fn classical_none_ciphertext_output_still_scans_with_seed() {
+        let mut rng = StdRng::from_seed([61u8; 32]);
+        let me = AccountKey::random(&mut rng);
+
+        // A legacy classical output (no ciphertext) paid to my default address.
+        let mine = TxOutput::new(7_000, &me.default_subaddress());
+        assert!(mine.kem_ciphertext.is_none());
+
+        let owned = scan_owned_outputs_inner(&ScanRequest {
+            spend_private_key: hex::encode(me.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(me.view_private_key().to_bytes()),
+            // Seed present, but the output is KEM-less → classical branch.
+            seed: seed_hex(0x77),
+            outputs: vec![chain_output_of(&mine, 0)],
+        })
+        .expect("scan should succeed");
+
+        assert_eq!(owned.len(), 1, "classical output must still be detected");
+        assert_eq!(owned[0].amount, 7_000);
+        assert_eq!(owned[0].subaddress_index, 0);
+        assert!(owned[0].kem_ciphertext.is_none());
+    }
+
+    /// #988 negative: a hybrid output addressed to a DIFFERENT wallet must NOT be
+    /// detected by this wallet's scan — decapsulating the ciphertext with the
+    /// wrong ML-KEM secret yields a useless secret and the stealth check fails.
+    #[test]
+    fn hybrid_output_to_other_wallet_is_not_detected() {
+        let mut rng = StdRng::from_seed([67u8; 32]);
+
+        let sender = AccountKey::random(&mut rng);
+        let recipient_account = AccountKey::random(&mut rng);
+        let recipient_pq = pq_keys(0x22);
+        // A DIFFERENT wallet doing the scanning.
+        let stranger = AccountKey::random(&mut rng);
+
+        let owned_amount = 10_000_000_000u64;
+        let owned = TxOutput::new(owned_amount, &sender.default_subaddress());
+        let decoys = make_decoys(DEFAULT_RING_SIZE - 1, owned_amount, &mut rng);
+
+        let req = SignRequest {
+            spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            inputs: vec![SpendInput {
+                target_key: hex::encode(owned.target_key),
+                public_key: hex::encode(owned.public_key),
+                amount: owned_amount,
+                subaddress_index: 0,
+                decoys,
+            }],
+            recipient: recipient_of_with_pq(&recipient_account, &recipient_pq),
+            sender_kem_public_key: kem_public_hex(&pq_keys(0x11)),
+            amount: 4_000_000_000,
+            fee: MIN_TX_FEE,
+            created_at_height: 1000,
+        };
+        let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
+
+        // The stranger scans the recipient's output with its OWN (wrong) seed.
+        let owned = scan_owned_outputs_inner(&ScanRequest {
+            spend_private_key: hex::encode(stranger.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(stranger.view_private_key().to_bytes()),
+            seed: seed_hex(0x99),
+            outputs: vec![chain_output_of(&tx.outputs[0], 0)],
+        })
+        .expect("scan should succeed");
+        assert!(
+            owned.is_empty(),
+            "an output addressed to another wallet must not be detected"
         );
     }
 }

--- a/web/packages/wasm-signer/src/index.ts
+++ b/web/packages/wasm-signer/src/index.ts
@@ -105,6 +105,21 @@ export interface ChainOutput {
   publicKey: string
   /** Amount in picocredits (recovered from the transparent commitment). */
   amount: bigint | number
+  /**
+   * The output's position within its creating transaction (`outputIndex` from
+   * `chain_getOutputs`). Under protocol 6.0.0 this index is bound into the
+   * hybrid one-time key, so it must be supplied for hybrid detection to work.
+   * Optional (defaults to 0) so legacy callers that only scanned classical
+   * outputs keep compiling (#988).
+   */
+  outputIndex?: number
+  /**
+   * Hex-encoded ML-KEM-768 ciphertext (`kemCiphertext` from
+   * `chain_getOutputs`), or null/undefined for a classical/legacy KEM-less
+   * output. When present (and a `seed` is supplied), the scan decapsulates it
+   * to detect the hybrid one-time key (#970/#988).
+   */
+  kemCiphertext?: string | null
 }
 
 /** A request to scan candidate outputs for ones owned by the account. */
@@ -113,6 +128,13 @@ export interface ScanRequest {
   spendPrivateKey: string
   /** Hex-encoded 32-byte account view private key. Stays client-side. */
   viewPrivateKey: string
+  /**
+   * Hex-encoded 64-byte BIP39 seed. Stays client-side. Used to derive the
+   * wallet's ML-KEM secret (node-identical `derive_pq_keys_from_seed`) so the
+   * scan can decapsulate hybrid outputs and detect 6.0.0 incoming payments and
+   * change. Omit / empty for a classical-only scan (#988).
+   */
+  seed?: string
   /** Candidate outputs to test for ownership. */
   outputs: ChainOutput[]
 }
@@ -127,6 +149,17 @@ export interface OwnedOutput {
   amount: bigint
   /** Subaddress index that received this output (0 = default, 1 = change). */
   subaddressIndex: bigint
+  /**
+   * The output's position within its creating transaction, carried through from
+   * the scan so a later spend recovers the hybrid one-time key. Optional for
+   * back-compat (#988).
+   */
+  outputIndex?: number
+  /**
+   * The owned output's ML-KEM-768 ciphertext (hex), or null for a classical
+   * output — preserved from the scan for hybrid spend-key recovery (#988).
+   */
+  kemCiphertext?: string | null
 }
 
 /**
@@ -138,6 +171,12 @@ export interface KeyImageRequest {
   spendPrivateKey: string
   /** Hex-encoded 32-byte account view private key. Stays client-side. */
   viewPrivateKey: string
+  /**
+   * Hex-encoded 64-byte BIP39 seed. Stays client-side. Used to recover a hybrid
+   * owned output's one-time spend key (hence its key image). Omit / empty for
+   * classical recovery (#988).
+   */
+  seed?: string
   /** The wallet's owned outputs to derive key images for. */
   outputs: OwnedOutput[]
 }
@@ -152,6 +191,10 @@ export interface OwnedOutputKeyImage {
   amount: bigint
   /** Subaddress index that received this output (0 = default, 1 = change). */
   subaddressIndex: bigint
+  /** The output's position within its creating transaction (#988). */
+  outputIndex?: number
+  /** The owned output's ML-KEM-768 ciphertext (hex), or null (#988). */
+  kemCiphertext?: string | null
   /**
    * Hex-encoded 32-byte key image. Querying the node's
    * `chain_areKeyImagesSpent` RPC with this value reveals whether the output
@@ -352,7 +395,7 @@ export function setSigner(signer: WasmSigner): void {
   cached = Promise.resolve(signer)
 }
 
-export { deriveV2Address, decodeV2Address, deriveKemPublicKey } from './address'
+export { deriveV2Address, decodeV2Address, deriveKemPublicKey, mnemonicToSeedHex } from './address'
 
 export {
   buildSendTransaction,

--- a/web/packages/wasm-signer/src/send.ts
+++ b/web/packages/wasm-signer/src/send.ts
@@ -98,7 +98,7 @@ export async function spendableOwnedOutputs(
   const withImages = signer.computeOwnedOutputKeyImages({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
-    seed: keys.seed,
+    seed: keys.seed ?? '',
     outputs: owned,
   })
   const statuses = await rpc.areKeyImagesSpent(withImages.map((o) => o.keyImage))
@@ -137,7 +137,7 @@ export async function spendableBalance(
   const owned = signer.scanOwnedOutputs({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
-    seed: keys.seed,
+    seed: keys.seed ?? '',
     outputs: candidates,
   })
   const spendable = await spendableOwnedOutputs(signer, keys, owned, rpc)
@@ -168,7 +168,7 @@ export async function ownedOutputTargetKeys(
   const owned = signer.scanOwnedOutputs({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
-    seed: keys.seed,
+    seed: keys.seed ?? '',
     outputs: candidates,
   })
   return owned.map((o) => o.targetKey)
@@ -254,7 +254,7 @@ export async function buildOwnedHistory(
   const owned = signer.scanOwnedOutputs({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
-    seed: keys.seed,
+    seed: keys.seed ?? '',
     outputs: candidates.map((c) => ({
       targetKey: c.targetKey,
       publicKey: c.publicKey,
@@ -270,7 +270,7 @@ export async function buildOwnedHistory(
   const withImages = signer.computeOwnedOutputKeyImages({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
-    seed: keys.seed,
+    seed: keys.seed ?? '',
     outputs: owned,
   })
   const statuses = await rpc.areKeyImagesSpent(withImages.map((o) => o.keyImage))
@@ -534,7 +534,7 @@ export async function buildSendTransaction(
   const owned = signer.scanOwnedOutputs({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
-    seed: keys.seed,
+    seed: keys.seed ?? '',
     outputs: candidates,
   })
   if (owned.length === 0) {

--- a/web/packages/wasm-signer/src/send.ts
+++ b/web/packages/wasm-signer/src/send.ts
@@ -30,6 +30,13 @@ export interface SignerKeys {
   spendPrivateKey: string
   /** Hex-encoded 32-byte account view private key. */
   viewPrivateKey: string
+  /**
+   * Hex-encoded 64-byte BIP39 seed (from `mnemonicToSeedSync(mnemonic, '')`).
+   * Threaded into the RECEIVE scan so it can derive the wallet's ML-KEM secret
+   * and detect 6.0.0 hybrid outputs — incoming payments and the wallet's own
+   * change. Optional: omit for a classical-only scan (#988).
+   */
+  seed?: string
 }
 
 /**
@@ -91,6 +98,7 @@ export async function spendableOwnedOutputs(
   const withImages = signer.computeOwnedOutputKeyImages({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
+    seed: keys.seed,
     outputs: owned,
   })
   const statuses = await rpc.areKeyImagesSpent(withImages.map((o) => o.keyImage))
@@ -129,6 +137,7 @@ export async function spendableBalance(
   const owned = signer.scanOwnedOutputs({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
+    seed: keys.seed,
     outputs: candidates,
   })
   const spendable = await spendableOwnedOutputs(signer, keys, owned, rpc)
@@ -159,6 +168,7 @@ export async function ownedOutputTargetKeys(
   const owned = signer.scanOwnedOutputs({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
+    seed: keys.seed,
     outputs: candidates,
   })
   return owned.map((o) => o.targetKey)
@@ -244,10 +254,14 @@ export async function buildOwnedHistory(
   const owned = signer.scanOwnedOutputs({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
+    seed: keys.seed,
     outputs: candidates.map((c) => ({
       targetKey: c.targetKey,
       publicKey: c.publicKey,
       amount: c.amount,
+      // Preserve the hybrid metadata so 6.0.0 outputs are detected (#988).
+      outputIndex: c.outputIndex,
+      kemCiphertext: c.kemCiphertext,
     })),
   })
   if (owned.length === 0) return []
@@ -256,6 +270,7 @@ export async function buildOwnedHistory(
   const withImages = signer.computeOwnedOutputKeyImages({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
+    seed: keys.seed,
     outputs: owned,
   })
   const statuses = await rpc.areKeyImagesSpent(withImages.map((o) => o.keyImage))
@@ -519,6 +534,7 @@ export async function buildSendTransaction(
   const owned = signer.scanOwnedOutputs({
     spendPrivateKey: keys.spendPrivateKey,
     viewPrivateKey: keys.viewPrivateKey,
+    seed: keys.seed,
     outputs: candidates,
   })
   if (owned.length === 0) {

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -11,7 +11,7 @@ import { RemoteNodeAdapter, type FeeEstimate, type WsConnectionStatus } from '@b
 import { AddressBook, EncryptedAddressBook, ClaimLinkStore, EncryptedClaimLinks, saveWallet, loadWallet, loadWalletWithKey, getWalletInfo, deriveKeypairs, parseAddress, isValidMnemonic, clearWallet, createClaimLinkMnemonic, buildClaimLink, assertClaimLinkAmountWithinCap, VaultKey, MIN_PASSWORD_LENGTH } from '@botho/core'
 import { deriveV2Address } from '@botho/wasm-signer'
 import type { Balance, Contact, NodeInfo, Transaction, ClaimLinkRecord, Timestamp } from '@botho/core'
-import { buildSendTransaction, spendableBalance, buildOwnedHistory, netOwnedHistory, ownedOutputTargetKeys, deriveKemPublicKey } from '@botho/wasm-signer'
+import { buildSendTransaction, spendableBalance, buildOwnedHistory, netOwnedHistory, ownedOutputTargetKeys, deriveKemPublicKey, mnemonicToSeedHex } from '@botho/wasm-signer'
 import { buildAndSubmitSend, scanEphemeral, sweepEphemeral, SWEEP_FEE_RESERVE } from '../lib/claim-link-ops'
 import { type NetworkConfig, loadSelectedNetwork, loadSelectedIngress, NETWORKS, DEFAULT_NETWORK_ID, DEFAULT_INGRESS_ID, createCustomNetwork, networkForIngress, getIngressNode } from '../config/networks'
 
@@ -206,6 +206,8 @@ async function fetchBalance(
       {
         spendPrivateKey: toHex(kp.spendPrivate),
         viewPrivateKey: toHex(kp.viewPrivate),
+        // Seed so the scan detects 6.0.0 hybrid incoming payments + change (#988).
+        seed: mnemonicToSeedHex(mnemonic),
       },
       {
         getChainHeight: () => adapter.getBlockHeight(),
@@ -246,6 +248,8 @@ async function fetchHistory(
       {
         spendPrivateKey: toHex(kp.spendPrivate),
         viewPrivateKey: toHex(kp.viewPrivate),
+        // Seed so hybrid receives + change appear in history (#988).
+        seed: mnemonicToSeedHex(mnemonic),
       },
       {
         getChainHeight: () => adapter.getBlockHeight(),
@@ -1037,6 +1041,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         {
           spendPrivateKey: toHex(kp.spendPrivate),
           viewPrivateKey: toHex(kp.viewPrivate),
+          // Seed so hybrid outputs count toward cluster identity (#988).
+          seed: mnemonicToSeedHex(mnemonic),
         },
         {
           getChainHeight: () => adapter.getBlockHeight(),
@@ -1069,6 +1075,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       keys: {
         spendPrivateKey: toHex(kp.spendPrivate),
         viewPrivateKey: toHex(kp.viewPrivate),
+        // Seed so the send's own scan/spent-filter sees hybrid inputs + change (#988).
+        seed: mnemonicToSeedHex(mnemonic),
       },
       recipient: {
         spend_public_key: toHex(recipientKeys.spendPublic),
@@ -1140,6 +1148,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         {
           spendPrivateKey: toHex(kp.spendPrivate),
           viewPrivateKey: toHex(kp.viewPrivate),
+          // Seed so hybrid outputs count toward cluster identity (#988).
+          seed: mnemonicToSeedHex(mnemonic),
         },
         {
           getChainHeight: () => adapter.getBlockHeight(),

--- a/web/packages/web-wallet/src/lib/claim-link-ops.ts
+++ b/web/packages/web-wallet/src/lib/claim-link-ops.ts
@@ -16,7 +16,7 @@
  */
 
 import { deriveKeypairs, parseAddress } from '@botho/core'
-import { buildSendTransaction, spendableBalance, deriveKemPublicKey, type SendRpc } from '@botho/wasm-signer'
+import { buildSendTransaction, spendableBalance, deriveKemPublicKey, mnemonicToSeedHex, type SendRpc } from '@botho/wasm-signer'
 import type { RemoteNodeAdapter } from '@botho/adapters'
 
 /** Signer's MIN_TX_FEE (picocredits) — mirrors wallet.tsx `send()`. */
@@ -83,6 +83,7 @@ export async function buildAndSubmitSend(
     keys: {
       spendPrivateKey: toHex(kp.spendPrivate),
       viewPrivateKey: toHex(kp.viewPrivate),
+      seed: mnemonicToSeedHex(senderMnemonic),
     },
     recipient: {
       spend_public_key: toHex(recipientKeys.spendPublic),
@@ -130,6 +131,7 @@ export async function scanEphemeral(
     {
       spendPrivateKey: toHex(kp.spendPrivate),
       viewPrivateKey: toHex(kp.viewPrivate),
+      seed: mnemonicToSeedHex(ephMnemonic),
     },
     rpcFromAdapter(adapter),
   )
@@ -169,6 +171,7 @@ export async function sweepEphemeral(
     keys: {
       spendPrivateKey: toHex(kp.spendPrivate),
       viewPrivateKey: toHex(kp.viewPrivate),
+      seed: mnemonicToSeedHex(ephMnemonic),
     },
     recipient: {
       spend_public_key: toHex(destKeys.spendPublic),


### PR DESCRIPTION
## Summary

The shared receive-scan `bth_wasm_signer::core::scan_owned_outputs_inner` — consumed by **both** the browser wallet sync and the mobile `wallet_ops::sync` — built every candidate output with `kem_ciphertext: None` and used the classical `TxOutput::belongs_to`. Under protocol 6.0.0 every producer emits **hybrid** outputs whose one-time key folds in an ML-KEM shared secret, so a frontend wallet's own sync could not surface incoming payments **or its own change**: the balance never updated. The SEND side was already correct (#978/#984); this is the RECEIVE-scan counterpart.

This wires the wallet's seed-derived ML-KEM secret through the scan and dispatches on the unified hybrid detector from #970 — one scan path, hybrid-when-ciphertext-present, classical otherwise. Both wallet frontends are fixed through the shared function. Protocol stays 6.0.0 (web/wasm + mobile, no consensus files).

## Unified hybrid-scan approach

- `scan_owned_outputs_inner` reconstructs each candidate `TxOutput` **with its real `kem_ciphertext`** and dispatches via `TxOutput::belongs_to_account(&account, &kem_keypair, output_index)` (#970): a ciphertext-bearing output is decapsulated with the wallet's ML-KEM secret and its hybrid one-time key checked at the output's bound `output_index`; a `None`-ciphertext (classical/legacy) output falls through to the classical `belongs_to` on the same path. This mirrors the node's `Wallet::scan_output` exactly.
- Spend-key recovery (`compute_owned_output_key_images_inner`) uses the matching `recover_spend_key_for`, so the frontend can not only DETECT but SPEND what it received. `ChainOutput`/`OwnedOutput`/`OwnedOutputKeyImage` now carry `output_index` + `kem_ciphertext` so the metadata survives scan → key-image → spend.

## How the KEM secret is threaded (feature-independent)

`ScanRequest`/`KeyImageRequest` gain an optional `seed` (hex BIP39 seed). The scan derives the ML-KEM secret via `bth_crypto_pq::derive_pq_keys_from_seed(&seed).kem_keypair` — the **same feature-independent derivation the send side already uses** for the public half (`derivePqPublicKeysFromSeed`). It does **not** route through `WalletKeys::public_address()`, which requires the `pq` feature the mobile crate's classical `botho-wallet` build disables (the trap #984's Doctor documented). Empty seed = classical-only scan (back-compat).

- **Mobile**: `SignerKeys` gains `seed`; `signer_keys()` already computes the BIP39 seed, so it is threaded straight in. `RpcOutput` now surfaces `outputIndex`/`kemCiphertext`, and `fetch_candidates` normalizes the coinbase `u32::MAX` sentinel to `MINTING_OUTPUT_INDEX` (0).
- **Browser**: `SignerKeys.seed` (via the new `mnemonicToSeedHex` helper); the adapter's `getRawOutputs`/`getRawOutputsWithMeta` surface `outputIndex`/`kemCiphertext` (coinbase sentinel normalized). Balance, history, cluster-wealth, send, and claim-link paths all pass the seed.

## Receive round-trip result

New tests prove the full receive round trip in **both** the unified and isolated mobile-crate builds:
- A hybrid output SENT (via the #978 send path) to the wallet is DETECTED by `scan_owned_outputs_inner` via decapsulation, and its spend key recovers (`x·G == target_key`) — spendable.
- The wallet's own change (self-send) is detected on sync.
- A classical `None`-ciphertext output still scans (back-compat), even with a seed present.
- Negative: a hybrid output to a different wallet is NOT detected.

`cargo test -p bth-wasm-signer` = 20 passed; `cargo test -p botho-mobile` offline suite = 8 passed (incl. `scan_detects_hybrid_receive_and_recovers_key_image`).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Scan computes hybrid one-time key by decapsulating `kem_ciphertext` with seed-derived ML-KEM secret; None-ciphertext still scans | ✅ | `belongs_to_account` dispatch; `hybrid_received_output_is_detected_and_spendable_by_scan` + `classical_none_ciphertext_output_still_scans_with_seed` |
| Spend-key recovery uses `recover_spend_key_for` keyed on correct `output_index` | ✅ | `compute_owned_output_key_images_inner`; round-trip test asserts `x·G == target_key` |
| Both browser sync + mobile `sync` fixed through the shared function | ✅ | shared `scan_owned_outputs_inner`; seed threaded in `wallet.tsx`/`claim-link-ops.ts` and mobile `signer_keys()` |
| KEM secret derived feature-independently (not via `public_address()`) | ✅ | `derive_pq_keys_from_seed`; `cargo test -p botho-mobile` (pq OFF) green |
| Hybrid receive detected + spendable; change detected; classical back-compat; negative | ✅ | 4 new wasm-signer tests + 2 new mobile tests |

## Build gates (all green)

- `cargo build --workspace --all-targets`
- `cargo test --workspace --no-run`
- `cd fuzz && cargo check`
- `cargo build --workspace --no-default-features`
- `cargo test -p bth-wasm-signer` (20 passed)
- `cargo test -p botho-mobile` (offline suite 8 passed)
- `cargo +nightly-2025-12-03 fmt --all`
- `pnpm -r typecheck` (all 8 projects)
- `pnpm test:run` (926 passed)
- `wasm-pack build --target web`

Closes #988