### PR TITLE
chore: release v0.6.0 (ships protocol 6.0.0, testnet reset)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "botho"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "botho-desktop"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "botho-wallet",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "botho-exchange-scanner"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "botho-metrics-daemon"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "botho-mobile"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bip39",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "botho-wallet"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "bth-bridge-core"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "bth-bridge-service"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "bth-cluster-tax"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "bth-transaction-types",
  "clap",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "bth-crypto-pq"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "hex",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "bth-crypto-secp256k1"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "hex",
  "hmac",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "bth-discover"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bth-common",
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "bth-gossip"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "bitflags 2.13.0",
  "bth-common",

--- a/botho-exchange-scanner/Cargo.toml
+++ b/botho-exchange-scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-exchange-scanner"
-version = "0.4.0"
+version = "0.6.0"
 edition = "2021"
 description = "Exchange deposit scanner for Botho cryptocurrency"
 license = "Apache-2.0"

--- a/botho-wallet/Cargo.toml
+++ b/botho-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-wallet"
-version = "0.4.0"
+version = "0.6.0"
 edition = "2021"
 description = "Standalone thin wallet client for Botho cryptocurrency"
 license = "Apache-2.0"

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho"
-version = "0.4.0"
+version = "0.6.0"
 edition = "2021"
 description = "A privacy-preserving mined cryptocurrency"
 license = "GPL-3.0"

--- a/bridge/core/Cargo.toml
+++ b/bridge/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-bridge-core"
-version = "0.4.0"
+version = "0.6.0"
 authors = ["Botho"]
 edition = "2021"
 description = "Core types and logic for BTH bridge"

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-bridge-service"
-version = "0.4.0"
+version = "0.6.0"
 authors = ["Botho"]
 edition = "2021"
 description = "BTH bridge service for Ethereum and Solana"

--- a/cluster-tax/Cargo.toml
+++ b/cluster-tax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-cluster-tax"
-version = "0.4.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 rust-version = { workspace = true }

--- a/contracts/ethereum/package.json
+++ b/contracts/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wbth-ethereum",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "description": "Wrapped BTH ERC-20 token for Ethereum",
   "scripts": {
     "compile": "hardhat compile",

--- a/crypto/pq/Cargo.toml
+++ b/crypto/pq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-crypto-pq"
-version = "0.4.0"
+version = "0.6.0"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/crypto/secp256k1/Cargo.toml
+++ b/crypto/secp256k1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-crypto-secp256k1"
-version = "0.4.0"
+version = "0.6.0"
 authors = ["Botho"]
 edition = "2021"
 description = "Secp256k1 key support for Ethereum compatibility"

--- a/discover/Cargo.toml
+++ b/discover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-discover"
-version = "0.4.0"
+version = "0.6.0"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bth-gossip"
-version = "0.4.0"
+version = "0.6.0"
 authors = ["Botho Foundation"]
 edition = "2021"
 license = "Apache-2.0"

--- a/infra/faucet/metrics-daemon/Cargo.toml
+++ b/infra/faucet/metrics-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-metrics-daemon"
-version = "0.4.0"
+version = "0.6.0"
 edition = "2021"
 description = "Fleet metrics collection daemon and history API for the Botho testnet"
 license = "MIT"

--- a/mobile/app/package.json
+++ b/mobile/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botho-mobile",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "description": "Botho Mobile Wallet",
   "main": "expo-router/entry",
   "scripts": {

--- a/mobile/rust-bridge/Cargo.toml
+++ b/mobile/rust-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-mobile"
-version = "0.4.0"
+version = "0.6.0"
 edition = "2021"
 description = "Mobile FFI bindings for Botho wallet"
 license = "Apache-2.0"

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "botho-web",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @botho/web-wallet dev",

--- a/web/packages/desktop/src-tauri/Cargo.toml
+++ b/web/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botho-desktop"
-version = "0.4.0"
+version = "0.6.0"
 description = "Botho Desktop Wallet"
 authors = ["Botho"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Version bump 0.4.0 → 0.6.0

Mechanical bump across all botho-native version files (+ Cargo.lock) via \`scripts/version.sh set 0.6.0\`. Upstream MobileCoin-fork crates (7.1.0) excluded per the script's scope.

## What v0.6.0 ships — consensus protocol 6.0.0

A consensus-breaking batch requiring a **coordinated testnet reset** onto fresh genesis:
- **#925** demurrage class-transition leak fix (mainnet blocker)
- **#831** demurrage-settlement operation (wrap on-ramp)
- bridge-import cluster tagging (ADR 0007)
- **universal post-quantum addresses + hybrid ML-KEM stealth outputs** (#954/#958 — 7-PR rollout; `botho://2/` addresses carrying ML-KEM-768 + ML-DSA-65, hybrid DH+ML-KEM one-time keys, consensus enforcement)
- **Path C value-free lottery** (#955)
- Web + mobile wallets fully send/receive/spend on 6.0.0

## Versioning note

Crate/release version (0.6.0) is kept **separate** from the consensus protocol version (6.0.0, in \`discovery.rs\`) by design — they track different things and move at different rates. Their numbers coinciding here is incidental, not a coupling.

## Next

Tagging \`v0.6.0\` after merge triggers \`release.yml\` → reproducible linux-aarch64 artifact → deployed to the testnet fleet as the protocol-6.0.0 reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)