### PR TITLE
test(consensus): fresh-genesis liveness + lottery-winner + federated-minter coverage (#998)

### DIFF
--- a/botho/src/consensus/block_builder.rs
+++ b/botho/src/consensus/block_builder.rs
@@ -483,6 +483,154 @@ mod tests {
         }
     }
 
+    /// REPRODUCTION (issue #998): once the lottery first draws WINNERS (fleet
+    /// runs with a low `min_utxo_age`, so eligible coinbase outputs appear a
+    /// few blocks in), the block the proposer builds via `apply_lottery`
+    /// must pass the validator gates `validate_block_lottery` AND
+    /// `validate_lottery_output_bindings` — otherwise the proposer's own
+    /// `add_block` rejects its block and the chain wedges (the minter re-mints
+    /// the same height forever). No existing test exercised the winner path
+    /// (all use min_utxo_age=720, so nothing is ever eligible).
+    #[test]
+    fn winner_drawing_block_passes_validator_gates() {
+        use crate::{
+            block::BlockLotterySummary,
+            consensus::lottery::{
+                validate_block_lottery, validate_lottery_output_bindings, LotteryFeeConfig,
+            },
+            transaction::{TxOutput, UtxoId},
+        };
+        use bth_cluster_tax::{LotteryCandidate, LotteryDrawConfig, TagVector};
+        use bth_transaction_types::ClusterTagVector;
+
+        // Lottery config with a LOW age gate (the fleet's testnet setting) so the
+        // eligible-output / winner path is actually exercised.
+        let config = LotteryFeeConfig {
+            pool_fraction_permille: 800,
+            draw_config: LotteryDrawConfig {
+                min_utxo_age: 0,
+                min_utxo_value: 1,
+                winners_per_draw: 4,
+                ..Default::default()
+            },
+        };
+
+        let height = 5u64;
+        let prev_hash = [7u8; 32];
+
+        // A single eligible coinbase UTXO carrying a 6.0.0 hybrid ML-KEM
+        // ciphertext, created early so it is in-window and mature at height 5.
+        let winner_utxo_id = UtxoId::new([0xAAu8; 32], 0);
+        let winner_out = TxOutput {
+            amount: 50_000_000_000_000,
+            target_key: [0x11u8; 32],
+            public_key: [0x22u8; 32],
+            e_memo: None,
+            cluster_tags: ClusterTagVector::empty(),
+            kem_ciphertext: Some(vec![0x33u8; 1088]),
+        };
+        let winner_utxo = Utxo {
+            id: winner_utxo_id,
+            output: winner_out.clone(),
+            created_at: 0,
+        };
+        let candidate = LotteryCandidate::new(
+            winner_utxo_id.to_bytes(),
+            winner_out.amount,
+            1000,
+            &TagVector::new(),
+            0,
+        );
+        let candidates = vec![candidate];
+
+        // A carryover pool large enough that the per-block payout is nonzero, so
+        // the draw actually produces winners.
+        let stored_pool: u128 = 10_000_000_000_000;
+
+        // Minting-only block (no transfers/fees) at height 5.
+        let minting_tx = MintingTx {
+            block_height: height,
+            reward: 50_000_000_000_000,
+            minter_view_key: [1u8; 32],
+            minter_spend_key: [2u8; 32],
+            target_key: [3u8; 32],
+            public_key: [4u8; 32],
+            kem_ciphertext: Some(vec![9u8; 1088]),
+            prev_block_hash: prev_hash,
+            difficulty: u64::MAX,
+            nonce: 1,
+            timestamp: 1_000_000,
+        };
+        let block = Block {
+            header: BlockHeader {
+                version: 1,
+                prev_block_hash: prev_hash,
+                tx_root: [0u8; 32],
+                timestamp: 1_000_000,
+                height,
+                difficulty: u64::MAX,
+                nonce: 1,
+                minter_view_key: [1u8; 32],
+                minter_spend_key: [2u8; 32],
+            },
+            minting_tx,
+            transactions: vec![],
+            lottery_outputs: vec![],
+            lottery_summary: BlockLotterySummary::default(),
+        };
+
+        // Proposer path: build the block's lottery outputs/summary.
+        let lookup_utxo = |id: &[u8; 36]| {
+            if *id == winner_utxo_id.to_bytes() {
+                Some(winner_utxo.clone())
+            } else {
+                None
+            }
+        };
+        let built =
+            BlockBuilder::apply_lottery(block, &candidates, stored_pool, lookup_utxo, &config);
+
+        // The draw must have produced at least one winner (otherwise the test is
+        // vacuous and the winner path is not exercised).
+        assert!(
+            !built.lottery_outputs.is_empty(),
+            "test setup did not draw any winners (payout={}, summary={:?})",
+            built.lottery_summary.pool_distributed,
+            built.lottery_summary
+        );
+
+        // Validator path 1: validate_block_lottery must accept the proposer's
+        // own block (this is what add_block runs; a mismatch wedges the chain).
+        let vres = validate_block_lottery(&built, &candidates, stored_pool, &prev_hash, &config);
+        assert!(
+            vres.is_ok(),
+            "validate_block_lottery REJECTED the proposer's own winner block \
+             (chain would wedge): {:?}; summary={:?}, outputs={}",
+            vres.err(),
+            built.lottery_summary,
+            built.lottery_outputs.len()
+        );
+
+        // Validator path 2: the ML-KEM binding gate (#973) must accept it too.
+        let bindings = validate_lottery_output_bindings(&built.lottery_outputs, |id| {
+            if *id == winner_utxo_id.to_bytes() {
+                Some((
+                    winner_out.target_key,
+                    winner_out.public_key,
+                    winner_out.kem_ciphertext.clone(),
+                ))
+            } else {
+                None
+            }
+        });
+        assert!(
+            bindings.is_ok(),
+            "validate_lottery_output_bindings REJECTED the proposer's own \
+             winner block (chain would wedge): {:?}",
+            bindings.err()
+        );
+    }
+
     #[test]
     fn test_build_direct() {
         let minting_tx = mock_minting_tx(1);

--- a/botho/src/consensus/service.rs
+++ b/botho/src/consensus/service.rs
@@ -2505,6 +2505,176 @@ mod tests {
         );
     }
 
+    /// REPRODUCTION (issue #998): a fresh 6.0.0 genesis externalizes a few
+    /// blocks then wedges — the single minter re-proposes its coinbase forever
+    /// but the slot never externalizes. This drives the exact fleet topology
+    /// (a 2-of-2 quorum where only ONE node mints — the faucet) across many
+    /// successive slots and asserts the slot index advances past height 5.
+    #[test]
+    fn single_minter_federated_advances_past_height_5() {
+        let cfg = ConsensusConfig::fixed_timing(0);
+        let qs = recommended_quorum(&[1, 2]);
+
+        // Node A is the sole minter (faucet); node B validates only.
+        let mut a = ConsensusService::new(node(1), qs.clone(), cfg.clone(), genesis_chain_state());
+        let mut b = ConsensusService::new(node(2), qs, cfg, genesis_chain_state());
+        assert!(
+            !a.is_solo_mode() && !b.is_solo_mode(),
+            "must be a 2-node quorum"
+        );
+
+        let mut prev = [0u8; 32];
+        for height in 1..=8u64 {
+            // The faucet mints its coinbase for this height and gossips it to B.
+            let tx = intrinsic_valid_minting_tx(1, prev, height);
+            submit_and_register(&mut a, &mut b, &tx);
+
+            // Faithful pump: sleep so the SCP round/ballot TIMEOUTS actually fire
+            // (default scp_timebase is 1s), matching the live fleet where the
+            // single minter re-proposes for many seconds. Without real elapsed
+            // time, a single-proposer slot can never escalate nomination leaders.
+            let mut a_ext: Option<Vec<ConsensusValue>> = None;
+            let mut b_ext: Option<Vec<ConsensusValue>> = None;
+            let mut to_a: Vec<ScpMessage> = Vec::new();
+            let mut to_b: Vec<ScpMessage> = Vec::new();
+            for _ in 0..120 {
+                for m in to_a.drain(..) {
+                    let _ = a.handle_message(m);
+                }
+                for m in to_b.drain(..) {
+                    let _ = b.handle_message(m);
+                }
+                a.tick();
+                b.tick();
+                while let Some(ev) = a.next_event() {
+                    match ev {
+                        ConsensusEvent::BroadcastMessage(msg) => to_b.push(msg),
+                        ConsensusEvent::SlotExternalized { values, .. } => {
+                            a_ext.get_or_insert(values);
+                        }
+                        _ => {}
+                    }
+                }
+                while let Some(ev) = b.next_event() {
+                    match ev {
+                        ConsensusEvent::BroadcastMessage(msg) => to_a.push(msg),
+                        ConsensusEvent::SlotExternalized { values, .. } => {
+                            b_ext.get_or_insert(values);
+                        }
+                        _ => {}
+                    }
+                }
+                if a_ext.is_some() && b_ext.is_some() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            let a_vals = a_ext.unwrap_or_else(|| panic!("node A never externalized slot {height}"));
+            let b_vals = b_ext.unwrap_or_else(|| panic!("node B never externalized slot {height}"));
+            assert_eq!(a_vals, b_vals, "fork at height {height}");
+            assert_eq!(
+                a_vals.iter().filter(|v| v.is_minting_tx).count(),
+                1,
+                "exactly one coinbase must externalize at height {height}"
+            );
+
+            // Advance both nodes to the next slot, as the run loop does after
+            // applying the externalized block.
+            a.advance_slot();
+            b.advance_slot();
+
+            // Derive the next tip from the externalized coinbase hash so each
+            // height proposes a distinct value (mirrors a real chain tip).
+            prev = a_vals[0].tx_hash;
+        }
+
+        assert!(
+            a.current_slot() > 5,
+            "chain wedged: slot only reached {}",
+            a.current_slot()
+        );
+    }
+
+    /// REPRODUCTION probe (issue #998): the gossip/SCP delivery RACE. A peer
+    /// can receive the minter's SCP `NominatePrepare` (which references the
+    /// coinbase by hash) BEFORE it has registered the gossiped minting-tx
+    /// bytes — the 6.0.0 coinbase is ~1 KB larger (ML-KEM ciphertext),
+    /// widening this window. On the cache miss the validity_fn drops the
+    /// value ("not in cache"). SCP must still recover once the tx is
+    /// registered and the minter re-broadcasts on its nomination timeout;
+    /// if it cannot, the slot wedges silently in `NominatePrepare` —
+    /// exactly the reported symptom.
+    #[test]
+    fn federated_recovers_from_delayed_minting_tx_registration() {
+        let cfg = ConsensusConfig::fixed_timing(0);
+        let qs = recommended_quorum(&[1, 2]);
+        let mut a = ConsensusService::new(node(1), qs.clone(), cfg.clone(), genesis_chain_state());
+        let mut b = ConsensusService::new(node(2), qs, cfg, genesis_chain_state());
+
+        let tx = intrinsic_valid_minting_tx(1, [0u8; 32], 1);
+        let tx_hash = tx.hash();
+        let bytes = bincode::serialize(&tx).expect("serialize");
+
+        // A submits and proposes; B does NOT yet have the tx (registration lost
+        // the race with the SCP message).
+        a.submit_minting_tx(tx_hash, tx.pow_priority(), bytes.clone());
+
+        let mut to_a: Vec<ScpMessage> = Vec::new();
+        let mut to_b: Vec<ScpMessage> = Vec::new();
+        let mut a_ext: Option<Vec<ConsensusValue>> = None;
+        let mut b_ext: Option<Vec<ConsensusValue>> = None;
+        let mut registered_b = false;
+
+        for round in 0..120 {
+            for m in to_a.drain(..) {
+                let _ = a.handle_message(m);
+            }
+            for m in to_b.drain(..) {
+                // B processes A's nominate; on the first few rounds the tx is
+                // NOT in B's cache, so the value is dropped.
+                let _ = b.handle_message(m);
+            }
+            // Register the tx on B only AFTER it has already seen (and dropped)
+            // A's first nominate — the delayed-gossip race.
+            if round == 2 && !registered_b {
+                b.register_minting_tx(tx_hash, bytes.clone());
+                registered_b = true;
+            }
+            a.tick();
+            b.tick();
+            while let Some(ev) = a.next_event() {
+                match ev {
+                    ConsensusEvent::BroadcastMessage(msg) => to_b.push(msg),
+                    ConsensusEvent::SlotExternalized { values, .. } => {
+                        a_ext.get_or_insert(values);
+                    }
+                    _ => {}
+                }
+            }
+            while let Some(ev) = b.next_event() {
+                match ev {
+                    ConsensusEvent::BroadcastMessage(msg) => to_a.push(msg),
+                    ConsensusEvent::SlotExternalized { values, .. } => {
+                        b_ext.get_or_insert(values);
+                    }
+                    _ => {}
+                }
+            }
+            if a_ext.is_some() && b_ext.is_some() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        assert!(
+            a_ext.is_some() && b_ext.is_some(),
+            "WEDGE: slot never externalized after a delayed minting-tx \
+             registration race (a_ext={:?}, b_ext={:?})",
+            a_ext.is_some(),
+            b_ext.is_some()
+        );
+    }
+
     /// Issue #593 regression (pins the #428/#433 gates against #427 Finding 3):
     /// the STAGGERED-start 2-node solo-latch fork must not occur end-to-end.
     ///

--- a/botho/tests/issue_998_fresh_genesis_liveness.rs
+++ b/botho/tests/issue_998_fresh_genesis_liveness.rs
@@ -1,0 +1,136 @@
+// Copyright (c) 2024 Botho Foundation
+//
+//! Issue #998 — fresh 6.0.0 genesis liveness.
+//!
+//! A fresh protocol-6.0.0 genesis was reported to externalize a few blocks and
+//! then wedge permanently (the minter re-submits the next height's coinbase
+//! forever). This test drives the single-node BLOCK-APPLY path — the one the
+//! 6.0.0 batch changed for every block: a hybrid ML-KEM coinbase output
+//! (#968/#969), its fold into `MintingTx::hash()`, the coinbase UTXO write, and
+//! the per-block lottery/cluster-wealth accounting — across MANY successive
+//! blocks on a fresh genesis and asserts the height advances each time.
+//!
+//! No previous test exercised this: the e2e consensus harness uses a stub SCP
+//! validity callback and a classical (ciphertext-less) coinbase, so it never
+//! ran the 6.0.0 coinbase through `add_block` repeatedly on a fresh chain.
+
+use std::time::SystemTime;
+
+use serial_test::serial;
+use tempfile::TempDir;
+
+use botho::{
+    block::{Block, BlockHeader, BlockLotterySummary, MintingTx},
+    ledger::Ledger,
+    transaction::PICOCREDITS_PER_CREDIT,
+};
+use bth_account_keys::PublicAddress;
+use botho_wallet::WalletKeys;
+
+/// Trivial PoW difficulty for instant mining; must equal the chain's pinned
+/// difficulty because block acceptance enforces `header.difficulty ==
+/// chain.difficulty` (audit cycle 6, C1).
+const TRIVIAL_DIFFICULTY: u64 = u64::MAX;
+
+/// Block reward for testing (50 BTH), matching the fresh-genesis emission.
+const TEST_BLOCK_REWARD: u64 = 50 * PICOCREDITS_PER_CREDIT;
+
+fn create_test_ledger() -> (TempDir, Ledger) {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let ledger = Ledger::open(&temp_dir.path().join("ledger")).expect("open ledger");
+    ledger.set_difficulty(TRIVIAL_DIFFICULTY).unwrap();
+    (temp_dir, ledger)
+}
+
+/// A deterministic **post-quantum** (hybrid ML-KEM) address, so the coinbase
+/// carries a real 1,088-byte ML-KEM ciphertext exactly like the live 6.0.0
+/// minter (`coinbase_stealth_fields`), not a classical ciphertext-less output.
+fn pq_minter_address() -> PublicAddress {
+    let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon \
+                    abandon abandon abandon abandon abandon abandon abandon abandon \
+                    abandon abandon abandon abandon abandon abandon abandon art";
+    WalletKeys::from_mnemonic(mnemonic)
+        .expect("wallet")
+        .pq_public_address()
+}
+
+/// Build a valid minting-only block for `height` on top of `prev_hash`, mining a
+/// trivial-difficulty PoW. The coinbase is a hybrid ML-KEM output.
+fn mine_minting_block(height: u64, prev_hash: [u8; 32], minter: &PublicAddress) -> Block {
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let mut minting_tx = MintingTx::new(
+        height,
+        TEST_BLOCK_REWARD,
+        minter,
+        prev_hash,
+        TRIVIAL_DIFFICULTY,
+        timestamp,
+    );
+    // Sanity: the 6.0.0 coinbase must carry the hybrid ML-KEM ciphertext.
+    assert!(
+        minting_tx.kem_ciphertext.is_some(),
+        "pq coinbase must attach an ML-KEM ciphertext (6.0.0)"
+    );
+
+    for nonce in 0..200_000u64 {
+        minting_tx.nonce = nonce;
+        if minting_tx.verify_pow() {
+            break;
+        }
+    }
+    assert!(minting_tx.verify_pow(), "failed to find trivial PoW");
+
+    Block {
+        header: BlockHeader {
+            version: 1,
+            prev_block_hash: prev_hash,
+            tx_root: [0u8; 32],
+            timestamp: minting_tx.timestamp,
+            height: minting_tx.block_height,
+            difficulty: minting_tx.difficulty,
+            nonce: minting_tx.nonce,
+            minter_view_key: minting_tx.minter_view_key,
+            minter_spend_key: minting_tx.minter_spend_key,
+        },
+        minting_tx,
+        transactions: vec![],
+        lottery_outputs: vec![],
+        lottery_summary: BlockLotterySummary::default(),
+    }
+}
+
+/// REGRESSION (issue #998): a fresh 6.0.0 genesis must apply many successive
+/// hybrid-coinbase blocks with the height advancing every block — never wedge.
+#[test]
+#[serial]
+fn fresh_6_0_0_genesis_advances_past_height_6() {
+    let (_tmp, ledger) = create_test_ledger();
+    let minter = pq_minter_address();
+
+    // Mint well past the reported wedge point (height ~5).
+    const N: u64 = 12;
+    for height in 1..=N {
+        let prev_hash = ledger.get_tip().expect("tip").hash();
+        let block = mine_minting_block(height, prev_hash, &minter);
+        ledger
+            .add_block(&block)
+            .unwrap_or_else(|e| panic!("WEDGE at height {height}: add_block failed: {e}"));
+
+        let state = ledger.get_chain_state().expect("chain state");
+        assert_eq!(
+            state.height, height,
+            "chain height must advance to {height} after applying block {height}"
+        );
+    }
+
+    let final_state = ledger.get_chain_state().expect("chain state");
+    assert_eq!(final_state.height, N, "final height must be {N}");
+    assert!(
+        final_state.height > 6,
+        "chain must advance past the reported wedge height"
+    );
+}

--- a/botho/tests/issue_998_fresh_genesis_liveness.rs
+++ b/botho/tests/issue_998_fresh_genesis_liveness.rs
@@ -24,8 +24,8 @@ use botho::{
     ledger::Ledger,
     transaction::PICOCREDITS_PER_CREDIT,
 };
-use bth_account_keys::PublicAddress;
 use botho_wallet::WalletKeys;
+use bth_account_keys::PublicAddress;
 
 /// Trivial PoW difficulty for instant mining; must equal the chain's pinned
 /// difficulty because block acceptance enforces `header.difficulty ==
@@ -54,8 +54,8 @@ fn pq_minter_address() -> PublicAddress {
         .pq_public_address()
 }
 
-/// Build a valid minting-only block for `height` on top of `prev_hash`, mining a
-/// trivial-difficulty PoW. The coinbase is a hybrid ML-KEM output.
+/// Build a valid minting-only block for `height` on top of `prev_hash`, mining
+/// a trivial-difficulty PoW. The coinbase is a hybrid ML-KEM output.
 fn mine_minting_block(height: u64, prev_hash: [u8; 32], minter: &PublicAddress) -> Block {
     let timestamp = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)


### PR DESCRIPTION
Coverage tests from the #998 investigation. The height-5 "wedge" during the 6.0.0 reset was **operational** (stale 4.0.0 zombie nodes holding the minter's propose-gate closed + a degenerate `members=[]` quorum misconfig), NOT a 6.0.0 code bug — see #998. These tests **rule out the code suspects** and fill real gaps; no production code changes.

## Tests added
- `botho/tests/issue_998_fresh_genesis_liveness.rs` — mints **12 successive hybrid-ML-KEM-coinbase blocks** on a fresh 6.0.0 genesis through the real `add_block` path; asserts height advances every block. (The exact scenario the reset exercised — proves the batch doesn't wedge a fresh chain.)
- `botho/src/consensus/block_builder.rs` — `winner_drawing_block_passes_validator_gates`: the lottery **winner** path, **never previously tested** (all prior tests use `min_utxo_age=720` so nothing is ever eligible), now passes `validate_block_lottery` + `validate_lottery_output_bindings`. Real gap closed.
- `botho/src/consensus/service.rs` — `single_minter_federated_advances_past_height_5` (2-of-2, one minter, advances past height 8 once SCP timeouts fire) + `federated_recovers_from_delayed_minting_tx_registration` (SCP recovers from the gossip/validity-cache race).

## Related
- Operational resolution + root cause: #998 (testnet recovered, live on 6.0.0 at height 9+).
- Hardening follow-up: #1000 (incompatible-peer height advertisement must not hold the propose-gate).

Closes #998

🤖 Generated with [Claude Code](https://claude.com/claude-code)