### PR TITLE
test(bridge): orchestrate the full wBTH DeFi round-trip e2e (Sepolia fork)

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -150,6 +150,79 @@ jobs:
           SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
         run: ./scripts/bridge-e2e-fork.sh
 
+  # The full wBTH DeFi ROUND TRIP (#1005) — the mainnet liquidity-launch
+  # rehearsal. Joins the full-loop wrap/repatriate legs (real engine) with the
+  # Uniswap-v3 fork harness into ONE continuous journey of a coin, driven end to
+  # end against a node forking REAL Sepolia state (chain id 11155111) plus a
+  # local Botho node:
+  #   mint BTH -> wrap->wBTH (t-of-n EIP-712 Safe bridgeMint) -> fund gas +
+  #   WETH -> seed the wBTH/WETH Uniswap v3 pool + add liquidity -> swap
+  #   WETH->wBTH (the market buys) -> bridgeBurn the swap proceeds -> t-of-n
+  #   Ed25519 release to a fresh stealth output the user scans back.
+  # It asserts the peg on wrap (ADR 0003), pool + swap moved balances, the burn
+  # amount == the swap output and the released BTH == that amount to a fresh
+  # ADR-0004 output, and proof-of-reserves drift == 0 across the whole loop.
+  #
+  # workflow_dispatch ONLY and skips cleanly when SEPOLIA_RPC_URL is absent —
+  # the Uniswap periphery only exists on a Sepolia fork, and a public-RPC fork
+  # in nightly CI risks rate-limit flakiness (same discipline as
+  # ethereum-leg-sepolia-fork). The BTH leg self-skips (green) until the reserve
+  # wallet key material is provisioned (#999), same as the full-loop job. The
+  # live-Sepolia variant flips by swapping RPC + a funded key (#866/#869) — see
+  # scripts/bridge-e2e-defi-fork.sh and docs/bridge/testnet-e2e-runbook.md.
+  defi-round-trip:
+    name: DeFi round trip (Sepolia fork + local Botho, real engine + Uniswap)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for SEPOLIA_RPC_URL
+        id: rpc
+        env:
+          SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+        run: |
+          if [[ -z "$SEPOLIA_RPC_URL" ]]; then
+            echo "::notice::SEPOLIA_RPC_URL secret is not set — skipping the DeFi"
+            echo "::notice::round-trip e2e (the Uniswap v3 periphery only exists on a"
+            echo "::notice::Sepolia fork). Provision a public/Alchemy/Infura Sepolia"
+            echo "::notice::RPC as the SEPOLIA_RPC_URL repo secret to run it."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Node
+        if: steps.rpc.outputs.present == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: contracts/ethereum/package-lock.json
+
+      - name: Install Rust
+        if: steps.rpc.outputs.present == 'true'
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-12-03
+
+      - name: Install Foundry (anvil)
+        if: steps.rpc.outputs.present == 'true'
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Cache cargo
+        if: steps.rpc.outputs.present == 'true'
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: bridge-e2e-defi-round-trip
+
+      - name: Run DeFi round-trip e2e
+        if: steps.rpc.outputs.present == 'true'
+        env:
+          SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+        run: ./scripts/bridge-e2e-defi-fork.sh
+
   # The live-testnet BTH -> wBTH -> burn -> BTH round trip is a MANUAL
   # drill for now: it needs funded Gnosis Safes + Sepolia ETH (#866/#868),
   # and the BTH live transports (#856). The local variant of this same loop

--- a/bridge/service/src/defi_round_trip_tests.rs
+++ b/bridge/service/src/defi_round_trip_tests.rs
@@ -1,0 +1,743 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Full wBTH DeFi round-trip e2e (#1005) — the headline
+//! **mint → wrap → fund → pool → swap → repatriate** loop, driven end to end
+//! against a node **forking real Sepolia state** plus a local Botho node.
+//!
+//! This is **Phase A of the mainnet-liquidity-bootstrap DeFi round trip
+//! (#865)**: the single orchestrated demonstration AND the rehearsal script for
+//! the mainnet liquidity launch. It wires two already-landed pieces into one
+//! continuous journey of a coin:
+//!
+//! - The full-loop wrap/repatriate legs ([`crate::e2e_full_loop_tests`], #993)
+//!   drive the REAL bridge engine ([`OrderProcessor::process_pending_orders`]):
+//!   a confirmed BTH deposit → t-of-n EIP-712 federation attestation →
+//!   `Safe.execTransaction(bridgeMint)` (steps 1–2), and a `bridgeBurn` →
+//!   t-of-n Ed25519 attestation → [`BthReleaser`] reserve spend to a fresh
+//!   stealth output (step 6).
+//! - The Uniswap-v3 fork harness ([`crate::uniswap_fork_tests`], #1004) seeds a
+//!   real wBTH/WETH pool and swaps against it (steps 3–5), factored into the
+//!   reusable [`crate::uniswap_fork_tests::create_pool_and_add_liquidity`] /
+//!   [`crate::uniswap_fork_tests::swap_weth_for_wbth`] helpers this test
+//!   shares.
+//!
+//! ## The journey of one coin
+//!
+//! 1. **Mint BTH** on a local `botho-testnet` node (a funded factor-1 reserve).
+//! 2. **Wrap → wBTH**: the engine drives the mint order to `Completed`, minting
+//!    wBTH to the user through the Safe. **Every wBTH in this test is a wrapped
+//!    coin** — the token's only `MINTER` is the federation Safe, so there is no
+//!    other mint path.
+//! 3. **Fund gas** for the fork's dev accounts via `*_setBalance` and wrap ETH
+//!    into WETH (the faucet + WETH stand-ins).
+//! 4. **Seed the pool**: create the wBTH/WETH Uniswap v3 pool and add two-sided
+//!    liquidity — the wBTH side is the coin that was just wrapped.
+//! 5. **Purchase**: swap WETH → wBTH against the seeded pool (the market buys
+//!    wBTH; the bought wBTH comes straight out of the pool).
+//! 6. **Repatriate**: `bridgeBurn` exactly the swap proceeds and let the engine
+//!    drive the burn order to `Released`, paying native BTH to a fresh stealth
+//!    output the user scans back off the live node.
+//!
+//! So a coin genuinely travels **Botho BTH → wBTH → into a DEX pool → bought
+//! via a swap → back to native BTH**.
+//!
+//! ## The round-trip assertions (the demonstration's proof)
+//!
+//! - **Peg on wrap** — `wbth.balanceOf(user) == wbth.totalSupply() == BTH
+//!   locked` (ADR 0003 factor-1, exact); the reserve reconciler reports `drift
+//!   == 0` after the mint.
+//! - **Pool + swap** — `factory.getPool(...)` is non-zero, the position has
+//!   `liquidity > 0`, and the swap moved WETH → wBTH in the right direction.
+//! - **Provenance of the repatriated coin** — the burn amount **equals the swap
+//!   output**, and the released BTH equals the burn amount (net of fees, zero
+//!   here), delivered to a fresh stealth output the user's view key scans back
+//!   (ADR 0004), on a tx unlinkable to the EVM burn.
+//! - **Proof-of-reserves across the whole loop** — the reconciler reports
+//!   `drift == 0` at the start (`0/0`), after the mint (`WRAP/WRAP`), and after
+//!   the partial repatriation (`WRAP-swapOut / WRAP-swapOut`): only the backing
+//!   for the burned coins is unlocked, the rest stays locked behind the wBTH
+//!   still circulating in the pool.
+//!
+//! ## Running (the mainnet liquidity-launch rehearsal)
+//!
+//! `#[ignore]`d AND **self-skips** unless a Sepolia-fork RPC AND the BTH
+//! reserve key material are both present — it never claims a live path it could
+//! not exercise (the #992/#993 discipline). The hermetic driver boots both
+//! nodes, funds via `*_setBalance` (zero external creds):
+//!
+//! ```text
+//! ./scripts/bridge-e2e-defi-fork.sh https://ethereum-sepolia-rpc.publicnode.com
+//! ```
+//!
+//! or manually, against an `anvil --fork-url <sepolia>` node + a local Botho
+//! node with a funded factor-1 reserve:
+//!
+//! ```text
+//! BRIDGE_FORK_RPC_URL=http://127.0.0.1:8545 \
+//! BRIDGE_FORK_EXPECTED_CHAIN_ID=11155111 \
+//! BRIDGE_FORK_FUND_ACCOUNTS=1 \
+//! BRIDGE_BTH_RPC_URL=http://127.0.0.1:27200 \
+//! BRIDGE_BTH_RESERVE_VIEW_KEY=/path/reserve.view.hex \
+//! BRIDGE_BTH_RESERVE_SPEND_KEY=/path/reserve.spend.hex \
+//! BRIDGE_BTH_RESERVE_ADDRESS=<reserve bth address> \
+//! BRIDGE_BTH_USER_ADDRESS=<user bth address> \
+//! BRIDGE_BTH_USER_VIEW_KEY=/path/user.view.hex \
+//! BRIDGE_BTH_USER_SPEND_KEY=/path/user.spend.hex \
+//!   cargo test -p bth-bridge-service -- --ignored defi_round_trip_ --nocapture
+//! ```
+//!
+//! ## Fork → testnet → mainnet flip
+//!
+//! The SAME test seeds a live pool by swapping endpoints only (no test-logic
+//! change): point `BRIDGE_FORK_RPC_URL` at a live Sepolia/mainnet RPC, set the
+//! `BRIDGE_UNISWAP_*` / `BRIDGE_WETH_ADDRESS` for that chain, set
+//! `BRIDGE_WBTH_ADDRESS` to the #866-deployed token instead of a throwaway
+//! deploy, leave `BRIDGE_FORK_FUND_ACCOUNTS` **unset** (there is no
+//! `setBalance` on a real chain), and supply genuinely funded relayer/LP keys.
+//! That live-Sepolia execution is Phase B (#866/#868/#869) — this issue is the
+//! fork rehearsal + the harness those reuse verbatim.
+
+use alloy::{
+    network::{EthereumWallet, TransactionBuilder},
+    primitives::{Address, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::TransactionRequest,
+    sol,
+    sol_types::{SolCall, SolValue},
+};
+use bth_bridge_core::{
+    attestation::{sign_attestation_ed25519, AttestationKind},
+    BridgeConfig, BridgeOrder, BthConfig, Chain, GasPriceStrategy, OrderStatus,
+};
+use chrono::Utc;
+use ed25519_dalek::SigningKey;
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use uuid::Uuid;
+
+use crate::{
+    attestation::{sign_attestation_secp256k1, AttestationProvider, FederationAttestationProvider},
+    db::Database,
+    engine::OrderProcessor,
+    fork_tests::{
+        artifact_bytecode, call_u256, deploy, dev_signer, expected_chain_id,
+        fund_dev_accounts_if_requested, rpc_url,
+    },
+    mint::{ethereum::EthMinter, Minter},
+    release::{bth::BthReleaser, Releaser},
+    reserve::Reconciler,
+    uniswap_fork_tests::{
+        create_pool_and_add_liquidity, swap_weth_for_wbth, uniswap_periphery_present,
+        uniswap_v3_env, wrap_weth,
+    },
+    watchers::{
+        bth::{BthChainClient, NodeBthClient},
+        ethereum::{with_tx_ordinals, AlloyEthClient, EthChainClient},
+    },
+};
+
+sol! {
+    #[allow(missing_docs)]
+    interface IWrappedBTHRoundTrip {
+        function balanceOf(address account) external view returns (uint256);
+        function totalSupply() external view returns (uint256);
+        function bridgeBurn(uint256 amount, string calldata bthAddress) external;
+    }
+}
+
+/// Well-known dev accounts of `anvil` / `npx hardhat node` (mnemonic
+/// "test test test test test test test test test test test junk"). Test ETH
+/// only — not secrets. Mirrors `fork_tests.rs` / `e2e_full_loop_tests.rs`.
+const DEV_KEYS: [&str; 4] = [
+    // 0: contract deployer + relayer EOA (pays gas, holds no authority)
+    "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    // 1: Safe owner 1 (local mint attestation signer)
+    "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+    // 2: Safe owner 2 (peer federation member, envelope injected)
+    "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a",
+    // 3: the bridging user — LP + swapping "market" + repatriating burner
+    "7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
+];
+
+/// The live BTH-node environment for the round trip. `None` when any piece is
+/// absent — the test then self-skips (never a false green). Mirrors the
+/// full-loop `BthEnv`, but defaults `amount` to a pool-viable 200,000 BTH so
+/// the wrapped wBTH can seed real Uniswap liquidity.
+struct BthEnv {
+    rpc_url: String,
+    reserve_view_key: String,
+    reserve_spend_key: String,
+    reserve_address: String,
+    user_address: String,
+    user_view_key: String,
+    user_spend_key: String,
+    /// Amount to wrap (picocredits). The driver must fund the reserve with at
+    /// least this much spendable factor-1 balance. Default 200,000 BTH — under
+    /// the wBTH `maxMintPerTx` (1M BTH) and ample to seed the pool.
+    amount: u64,
+}
+
+fn non_empty(var: &str) -> Option<String> {
+    std::env::var(var).ok().filter(|s| !s.is_empty())
+}
+
+fn bth_env() -> Option<BthEnv> {
+    Some(BthEnv {
+        rpc_url: non_empty("BRIDGE_BTH_RPC_URL")?,
+        reserve_view_key: non_empty("BRIDGE_BTH_RESERVE_VIEW_KEY")?,
+        reserve_spend_key: non_empty("BRIDGE_BTH_RESERVE_SPEND_KEY")?,
+        reserve_address: non_empty("BRIDGE_BTH_RESERVE_ADDRESS")?,
+        user_address: non_empty("BRIDGE_BTH_USER_ADDRESS")?,
+        user_view_key: non_empty("BRIDGE_BTH_USER_VIEW_KEY")?,
+        user_spend_key: non_empty("BRIDGE_BTH_USER_SPEND_KEY")?,
+        amount: non_empty("BRIDGE_BTH_AMOUNT")
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(200_000_000_000_000_000),
+    })
+}
+
+/// Drive `process_pending_orders` up to `ticks` times, stopping as soon as the
+/// order reaches `target`. Returns the final observed status. (Same shape as
+/// the full-loop driver — duplicated to keep this module additive.)
+async fn drive_until(
+    processor: &OrderProcessor,
+    db: &Database,
+    order_id: &Uuid,
+    target: OrderStatus,
+    ticks: usize,
+) -> OrderStatus {
+    let mut last = OrderStatus::AwaitingDeposit;
+    for _ in 0..ticks {
+        processor
+            .process_pending_orders()
+            .await
+            .expect("processor tick");
+        last = db
+            .get_order(order_id)
+            .expect("get_order")
+            .expect("order present")
+            .status;
+        if last == target {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    last
+}
+
+/// The full six-step DeFi round trip through the real engine + real Uniswap.
+#[tokio::test]
+#[ignore = "requires a Sepolia-fork node (anvil --fork-url) + a local Botho node with a funded reserve; run scripts/bridge-e2e-defi-fork.sh"]
+async fn defi_round_trip_mint_wrap_pool_swap_repatriate() {
+    // ---- Gate 1: BTH reserve key material (self-skip until #999) ----------
+    let Some(bth) = bth_env() else {
+        eprintln!(
+            "SKIP defi_round_trip: set BRIDGE_BTH_RPC_URL, \
+             BRIDGE_BTH_RESERVE_VIEW_KEY, BRIDGE_BTH_RESERVE_SPEND_KEY, \
+             BRIDGE_BTH_RESERVE_ADDRESS, BRIDGE_BTH_USER_ADDRESS, \
+             BRIDGE_BTH_USER_VIEW_KEY, BRIDGE_BTH_USER_SPEND_KEY to run the \
+             round trip (a funded factor-1 reserve on a live Botho node is \
+             required)"
+        );
+        return;
+    };
+
+    // Liquidity sizing: seed the pool with 10^17 pico wBTH (100,000 BTH) — the
+    // proven #1004 scale — matched by 10^17 wei WETH (0.1 WETH), and swap in
+    // 10^16 wei WETH (0.01 WETH). The wBTH side is drawn from the wrap, so the
+    // wrapped amount must cover it.
+    let wbth_liq = U256::from(100_000_000_000_000_000u64); // 10^17 pico wBTH
+    let weth_liq = U256::from(100_000_000_000_000_000u64); // 10^17 wei WETH
+    let swap_in = U256::from(10_000_000_000_000_000u64); //  10^16 wei WETH
+    let fee: u32 = 3000; // 0.30% tier
+    assert!(
+        U256::from(bth.amount) >= wbth_liq,
+        "BRIDGE_BTH_AMOUNT ({}) must be >= the wBTH liquidity side ({wbth_liq}); \
+         raise it or lower the liquidity target",
+        bth.amount
+    );
+
+    let url: alloy::transports::http::reqwest::Url = rpc_url().parse().expect("valid RPC url");
+    let deployer = dev_signer(0);
+    let owner1 = dev_signer(1);
+    let owner2 = dev_signer(2);
+    let user = dev_signer(3); // wraps, LPs, swaps, and repatriates
+    let user_addr = user.address();
+
+    let deploy_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(deployer.clone()))
+        .connect_http(url.clone())
+        .erased();
+
+    // ---- Gate 2: an Ethereum node is reachable ----------------------------
+    let chain_id = match deploy_provider.get_chain_id().await {
+        Ok(id) => id,
+        Err(e) => {
+            eprintln!(
+                "SKIP defi_round_trip: no Ethereum node reachable at {} ({e}). \
+                 Start one with `anvil --fork-url <sepolia-rpc>` — see module docs.",
+                rpc_url()
+            );
+            return;
+        }
+    };
+    if let Some(expected) = expected_chain_id() {
+        assert_eq!(
+            chain_id, expected,
+            "node reports chain id {chain_id}, expected {expected}"
+        );
+    }
+
+    // ---- Gate 3: the real Uniswap v3 periphery is present -----------------
+    // On a plain local dev chain the canonical Sepolia periphery has no code;
+    // this test needs a fork (or a live chain). Self-skip cleanly otherwise.
+    let uni = uniswap_v3_env();
+    if !uniswap_periphery_present(&deploy_provider, &uni).await {
+        eprintln!(
+            "SKIP defi_round_trip: no Uniswap v3 periphery code at the configured \
+             addresses on chain {chain_id}. Point BRIDGE_FORK_RPC_URL at an \
+             `anvil --fork-url <sepolia>` node (or set BRIDGE_UNISWAP_* for the \
+             target chain)."
+        );
+        return;
+    }
+
+    // Fund the dev accounts on the fork (test ETH via *_setBalance; no real
+    // funded account). No-op on local 31337.
+    fund_dev_accounts_if_requested(&deploy_provider).await;
+
+    // ---- Deploy the 2-of-2 validator Safe and the wBTH token -------------
+    // The Safe is the token's ONLY MINTER — so every wBTH is a wrapped coin.
+    let mut owners = vec![owner1.address(), owner2.address()];
+    owners.sort();
+    let safe_addr = deploy(
+        &deploy_provider,
+        artifact_bytecode("contracts/test/SafeStub.sol/SafeStub.json"),
+        (owners.clone(), U256::from(2u8)).abi_encode_params(),
+    )
+    .await;
+    let wbth_addr = deploy(
+        &deploy_provider,
+        artifact_bytecode("contracts/WrappedBTH.sol/WrappedBTH.json"),
+        // admin / MINTER (the Safe!) / pauser
+        (deployer.address(), safe_addr, deployer.address()).abi_encode_params(),
+    )
+    .await;
+
+    // ---- Federation keys: secp256k1 (mint) + Ed25519 (release) -----------
+    let ed_local = SigningKey::from_bytes(&[0x11u8; 32]); // this node
+    let ed_peer = SigningKey::from_bytes(&[0x22u8; 32]); // peer validator
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let relayer_key_path = dir.path().join("relayer.hex");
+    std::fs::write(&relayer_key_path, DEV_KEYS[0]).unwrap();
+    let owner1_key_path = dir.path().join("owner1.hex");
+    std::fs::write(&owner1_key_path, DEV_KEYS[1]).unwrap();
+    let ed_local_key_path = dir.path().join("ed_local.hex");
+    std::fs::write(&ed_local_key_path, hex::encode(ed_local.to_bytes())).unwrap();
+
+    // ---- One BridgeConfig wiring BOTH chains -----------------------------
+    let mut config = BridgeConfig::default();
+    config.ethereum.rpc_url = rpc_url();
+    config.ethereum.chain_id = chain_id;
+    config.ethereum.wbth_contract = format!("{:#x}", wbth_addr);
+    config.ethereum.safe_address = Some(format!("{:#x}", safe_addr));
+    config.ethereum.private_key_file = Some(relayer_key_path.to_string_lossy().into_owned());
+    config.ethereum.confirmations_required = 1;
+    config.ethereum.gas_price_strategy = GasPriceStrategy::Fixed(3);
+    config.ethereum.mint_signers = vec![
+        format!("{:#x}", owner1.address()),
+        format!("{:#x}", owner2.address()),
+    ];
+    config.ethereum.mint_threshold = 2;
+
+    config.bth = BthConfig {
+        rpc_url: bth.rpc_url.clone(),
+        ws_url: String::new(),
+        view_key_file: Some(bth.reserve_view_key.clone()),
+        spend_key_file: Some(bth.reserve_spend_key.clone()),
+        pq_seed_file: None,
+        confirmations_required: 0,
+        reserve_address: Some(bth.reserve_address.clone()),
+        release_signers: vec![
+            hex::encode(ed_local.verifying_key().to_bytes()),
+            hex::encode(ed_peer.verifying_key().to_bytes()),
+        ],
+        release_threshold: 2,
+        release_confirmations_required: 0,
+    };
+
+    config.bridge.db_path = dir.path().join("bridge.db").to_string_lossy().into_owned();
+    config.bridge.attestation_secp256k1_key_file =
+        Some(owner1_key_path.to_string_lossy().into_owned());
+    config.bridge.attestation_ed25519_key_file =
+        Some(ed_local_key_path.to_string_lossy().into_owned());
+    config.reserve.api_listen = String::new();
+
+    // ---- Real engine wiring: minter, releaser, attestation, reconciler ---
+    let db = Database::open_in_memory().expect("db");
+    db.migrate().expect("migrate");
+
+    let eth_minter = EthMinter::new(config.ethereum.clone()).expect("eth minter builds");
+    let mut minters: HashMap<Chain, Arc<dyn Minter>> = HashMap::new();
+    minters.insert(Chain::Ethereum, Arc::new(eth_minter));
+
+    let releaser = BthReleaser::new(config.bth.clone()).expect("bth releaser builds");
+
+    let provider = Arc::new(
+        FederationAttestationProvider::from_config(&config)
+            .expect("valid federation config")
+            .expect("federation configured (both eth mint + bth release)"),
+    );
+
+    let processor = OrderProcessor::new(
+        config.clone(),
+        db.clone(),
+        minters,
+        Some(Arc::new(releaser) as Arc<dyn Releaser>),
+        provider.clone() as Arc<dyn AttestationProvider>,
+    );
+
+    let reconciler = Reconciler::from_config(&config, db.clone());
+
+    // Assertion 0 — proof-of-reserves starts pristine: nothing wrapped, nothing
+    // locked, zero drift.
+    let proof_start = reconciler
+        .reconcile_once()
+        .await
+        .expect("reconcile (start)");
+    assert_eq!(proof_start.eth_supply, Some(0), "no wBTH before the wrap");
+    assert_eq!(proof_start.locked_reserve, 0, "no reserve locked yet");
+    assert_eq!(proof_start.drift, 0, "peg starts flat");
+
+    // =====================================================================
+    // STEP 1+2 — MINT BTH (reserve) then WRAP → wBTH through the real engine.
+    // =====================================================================
+    let mut mint_order = BridgeOrder::new_mint(
+        Chain::Ethereum,
+        bth.amount,
+        0, // keep the peg exact (fee accounting is covered by unit tests)
+        bth.reserve_address.clone(),
+        format!("{:#x}", user_addr),
+    );
+    mint_order.source_tx = Some("bth_deposit_confirmed_by_watcher".to_string());
+    mint_order.set_status(OrderStatus::DepositConfirmed);
+    db.insert_order(&mint_order).expect("insert mint order");
+
+    // Fail-safe: a single Safe-owner signature must NOT authorize a mint.
+    processor
+        .process_pending_orders()
+        .await
+        .expect("tick (below-threshold mint)");
+    assert_eq!(
+        db.get_order(&mint_order.id).unwrap().unwrap().status,
+        OrderStatus::DepositConfirmed,
+        "single signer must not authorize a mint (fail-safe)"
+    );
+    let pre_mint_supply = call_u256(
+        &deploy_provider,
+        wbth_addr,
+        IWrappedBTHRoundTrip::totalSupplyCall {}.abi_encode(),
+    )
+    .await;
+    assert_eq!(pre_mint_supply, U256::ZERO, "no wBTH before the threshold");
+
+    // Peer (owner 2) submits its EIP-712 envelope, bound to the fresh Safe
+    // nonce (0).
+    let now = Utc::now().timestamp().max(0) as u64;
+    let mint_kind = AttestationKind::MintWbth {
+        dest_chain: Chain::Ethereum,
+        dest_address: mint_order.dest_address.clone(),
+        amount: mint_order.net_amount(),
+        order_id: mint_order.id,
+        source_tx: mint_order.source_tx.clone().unwrap(),
+        safe_nonce: Some(0),
+    };
+    let mint_envelope = sign_attestation_secp256k1(
+        &mint_kind,
+        &owner2,
+        chain_id,
+        safe_addr,
+        wbth_addr,
+        &Uuid::new_v4().simple().to_string(),
+        now,
+        now + 300,
+    )
+    .expect("peer mint envelope signs");
+    assert!(
+        provider
+            .submit_attestation(&mint_envelope, &mint_order)
+            .accepted,
+        "peer mint attestation must be accepted"
+    );
+
+    // At threshold (2/2) the engine mints through the Safe.
+    let final_mint = drive_until(&processor, &db, &mint_order.id, OrderStatus::Completed, 40).await;
+    assert_eq!(
+        final_mint,
+        OrderStatus::Completed,
+        "engine must drive the mint to Completed"
+    );
+
+    // Assertion (peg on wrap) — wBTH minted == BTH locked (factor-1, ADR 0003).
+    let wrap_amount = mint_order.net_amount();
+    let minted_balance = call_u256(
+        &deploy_provider,
+        wbth_addr,
+        IWrappedBTHRoundTrip::balanceOfCall { account: user_addr }.abi_encode(),
+    )
+    .await;
+    assert_eq!(
+        minted_balance,
+        U256::from(wrap_amount),
+        "wBTH balance == locked BTH (factor-1)"
+    );
+    let supply_after_mint = call_u256(
+        &deploy_provider,
+        wbth_addr,
+        IWrappedBTHRoundTrip::totalSupplyCall {}.abi_encode(),
+    )
+    .await;
+    assert_eq!(
+        supply_after_mint,
+        U256::from(wrap_amount),
+        "supply == locked"
+    );
+
+    // Proof-of-reserves after mint: Σ(wBTH) == locked, zero drift, custody
+    // leg actually consulted.
+    let proof_after_mint = reconciler.reconcile_once().await.expect("reconcile (mint)");
+    assert_eq!(proof_after_mint.eth_supply, Some(wrap_amount));
+    assert_eq!(proof_after_mint.locked_reserve, wrap_amount);
+    assert_eq!(proof_after_mint.drift, 0, "Σ wBTH == locked reserve");
+    assert!(proof_after_mint.in_tolerance, "peg within tolerance");
+    assert!(
+        proof_after_mint.reserve_balance_checked,
+        "the live BTH reserve balance must be checked (custody leg)"
+    );
+
+    // =====================================================================
+    // STEP 3 — FUND gas + WETH (the faucet + WETH stand-ins).
+    // =====================================================================
+    let user_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(user.clone()))
+        .connect_http(url.clone())
+        .erased();
+    // Wrap 1 ETH into WETH: ample for the 0.1 WETH liquidity + 0.01 WETH swap.
+    wrap_weth(
+        &user_provider,
+        uni.weth,
+        U256::from(1_000_000_000_000_000_000u64),
+    )
+    .await;
+
+    // =====================================================================
+    // STEP 4 — SEED the pool: create wBTH/WETH pool + add liquidity. The wBTH
+    // side is the coin just wrapped.
+    // =====================================================================
+    let liq = create_pool_and_add_liquidity(
+        &user_provider,
+        &uni,
+        wbth_addr,
+        user_addr,
+        wbth_liq,
+        weth_liq,
+        fee,
+    )
+    .await;
+    assert_ne!(liq.pool, Address::ZERO, "pool created");
+    assert!(liq.liquidity > 0, "position has liquidity > 0");
+    assert!(liq.amount0 > U256::ZERO, "token0 side funded");
+    assert!(liq.amount1 > U256::ZERO, "token1 side funded");
+
+    // Supply is unchanged by seeding + (soon) swapping — no mint/burn — so the
+    // peg still reconciles flat while the wBTH sits in the pool.
+    let proof_after_seed = reconciler.reconcile_once().await.expect("reconcile (seed)");
+    assert_eq!(proof_after_seed.eth_supply, Some(wrap_amount));
+    assert_eq!(
+        proof_after_seed.drift, 0,
+        "peg flat while liquidity is live"
+    );
+
+    // =====================================================================
+    // STEP 5 — PURCHASE: swap WETH → wBTH against the seeded pool.
+    // =====================================================================
+    let swap = swap_weth_for_wbth(&user_provider, &uni, wbth_addr, user_addr, swap_in, fee).await;
+    assert!(swap.wbth_out > U256::ZERO, "swap increased wBTH");
+    assert_eq!(
+        swap.weth_spent, swap_in,
+        "exactInputSingle spent exactly amountIn WETH"
+    );
+    let swapped_wbth = swap.wbth_out;
+    let swapped_pc = u64::try_from(swapped_wbth).expect("swap output fits u64 picocredits");
+    eprintln!(
+        "defi round trip: pool {:#x}, liquidity {}, bought {swapped_pc} pico wBTH \
+         with {swap_in} wei WETH",
+        liq.pool, liq.liquidity
+    );
+
+    // =====================================================================
+    // STEP 6 — REPATRIATE: bridgeBurn exactly the swap proceeds → engine drives
+    // the reserve release to a fresh stealth output.
+    // =====================================================================
+    let burn_receipt = user_provider
+        .send_transaction(
+            TransactionRequest::default().with_to(wbth_addr).with_input(
+                IWrappedBTHRoundTrip::bridgeBurnCall {
+                    amount: swapped_wbth,
+                    bthAddress: bth.user_address.clone(),
+                }
+                .abi_encode(),
+            ),
+        )
+        .await
+        .expect("burn tx accepted")
+        .get_receipt()
+        .await
+        .expect("burn tx mined");
+    assert!(burn_receipt.status(), "bridgeBurn reverted");
+
+    // Detect the burn with the SAME transport the Ethereum watcher runs.
+    let eth_client = AlloyEthClient::new(&config.ethereum).expect("watcher client");
+    let tip = eth_client.latest_block().await.expect("eth tip");
+    let events = eth_client.burn_events(0, tip).await.expect("burn scan");
+    let ordered = with_tx_ordinals(events);
+    let (event, _ordinal) = ordered
+        .iter()
+        .find(|(e, _)| e.tx_hash == format!("{:#x}", burn_receipt.transaction_hash))
+        .expect("watcher sees the burn");
+
+    // Provenance: the burn amount EQUALS the swap output.
+    assert_eq!(
+        event.amount, swapped_pc,
+        "burn amount == swap output (the repatriated coin is exactly what the market bought)"
+    );
+    assert_eq!(event.bth_address, bth.user_address);
+
+    let mut burn_order = BridgeOrder::new_burn(
+        Chain::Ethereum,
+        event.amount,
+        0,
+        event.from.clone(),
+        event.bth_address.clone(),
+        event.tx_hash.clone(),
+    );
+    burn_order.set_status(OrderStatus::BurnConfirmed);
+    db.insert_order(&burn_order).expect("insert burn order");
+
+    // Fail-safe: a single Ed25519 signature must NOT authorize a release.
+    processor
+        .process_pending_orders()
+        .await
+        .expect("tick (below-threshold release)");
+    assert_eq!(
+        db.get_order(&burn_order.id).unwrap().unwrap().status,
+        OrderStatus::BurnConfirmed,
+        "single signer must not authorize a release (fail-safe)"
+    );
+
+    // Peer validator submits its Ed25519 release envelope.
+    let release_kind = FederationAttestationProvider::release_kind_for_test(&burn_order);
+    let release_envelope = sign_attestation_ed25519(
+        &release_kind,
+        &ed_peer,
+        &Uuid::new_v4().simple().to_string(),
+        now,
+        now + 300,
+    )
+    .expect("peer release envelope signs");
+    assert!(
+        provider
+            .submit_attestation(&release_envelope, &burn_order)
+            .accepted,
+        "peer release attestation must be accepted"
+    );
+
+    // At threshold (2/2) the engine releases through the live BthReleaser.
+    let final_release =
+        drive_until(&processor, &db, &burn_order.id, OrderStatus::Released, 60).await;
+    assert_eq!(
+        final_release,
+        OrderStatus::Released,
+        "engine must drive the release to Released (requires a funded factor-1 reserve)"
+    );
+
+    // Assertion (provenance + ADR 0004) — the released BTH equals the burned
+    // (== swapped) amount, delivered to a FRESH stealth output the USER's own
+    // view key scans back, distinct from the EVM burn tx.
+    let user_client = NodeBthClient::new(BthConfig {
+        rpc_url: bth.rpc_url.clone(),
+        ws_url: String::new(),
+        view_key_file: Some(bth.user_view_key.clone()),
+        spend_key_file: Some(bth.user_spend_key.clone()),
+        pq_seed_file: None,
+        confirmations_required: 0,
+        reserve_address: Some(bth.user_address.clone()),
+        release_signers: Vec::new(),
+        release_threshold: 0,
+        release_confirmations_required: 0,
+    })
+    .expect("user scan client");
+    let user_tip = user_client.tip_height().await.expect("bth tip");
+    let scan_start = user_tip.saturating_sub(200);
+    let mut released_output = None;
+    for height in scan_start..=user_tip {
+        if let Some(block) = user_client.block_at(height).await.expect("scan block") {
+            if let Some(dep) = block.deposits.iter().find(|d| d.amount == swapped_pc) {
+                released_output = Some(dep.clone());
+                break;
+            }
+        }
+    }
+    let released_output =
+        released_output.expect("user must scan back the fresh released stealth output");
+    assert_eq!(
+        released_output.amount, swapped_pc,
+        "released BTH == burned == swap output (net of fees)"
+    );
+    assert_ne!(
+        released_output.tx_hash,
+        burn_order.source_tx.clone().unwrap(),
+        "the BTH release output is a fresh on-chain tx, unlinkable to the EVM burn"
+    );
+
+    // Assertion (proof-of-reserves across the loop) — only the backing for the
+    // repatriated coins is unlocked; the rest stays locked behind the wBTH
+    // still circulating in the pool. Supply and locked both drop by exactly the
+    // swap output, drift stays zero.
+    let expected_supply = wrap_amount - swapped_pc;
+    let final_supply = call_u256(
+        &deploy_provider,
+        wbth_addr,
+        IWrappedBTHRoundTrip::totalSupplyCall {}.abi_encode(),
+    )
+    .await;
+    assert_eq!(
+        final_supply,
+        U256::from(expected_supply),
+        "supply dropped by exactly the burned swap output"
+    );
+
+    let proof_after_release = reconciler
+        .reconcile_once()
+        .await
+        .expect("reconcile (release)");
+    assert_eq!(
+        proof_after_release.eth_supply,
+        Some(expected_supply),
+        "wBTH supply == wrapped − repatriated"
+    );
+    assert_eq!(
+        proof_after_release.drift, 0,
+        "peg exact after the partial repatriation (Σ wBTH == locked reserve)"
+    );
+    assert!(
+        proof_after_release.in_tolerance,
+        "peg within tolerance after the round trip"
+    );
+
+    eprintln!(
+        "defi round trip OK: wrapped {wrap_amount} pc → seeded wBTH/WETH pool → \
+         market bought {swapped_pc} pc wBTH → repatriated to a fresh stealth \
+         output; peg exact (supply {expected_supply}, drift 0)"
+    );
+}

--- a/bridge/service/src/lib.rs
+++ b/bridge/service/src/lib.rs
@@ -34,6 +34,8 @@ mod bth_scan;
 mod chaos_tests;
 mod db;
 #[cfg(test)]
+mod defi_round_trip_tests;
+#[cfg(test)]
 mod e2e_full_loop_tests;
 mod engine;
 mod federation;

--- a/bridge/service/src/uniswap_fork_tests.rs
+++ b/bridge/service/src/uniswap_fork_tests.rs
@@ -244,6 +244,267 @@ fn full_range_ticks(fee: u32) -> (i32, i32) {
     (lower, upper)
 }
 
+// ---------------------------------------------------------------------------
+// Reusable harness helpers (#1005): the Uniswap v3 pool-seed + swap primitive,
+// factored out of the inline test below so the DeFi round-trip e2e
+// (`defi_round_trip_tests.rs`) drives the SAME real-periphery path. Kept
+// `pub(crate)` — internal to the bridge service test tree.
+// ---------------------------------------------------------------------------
+
+/// The real (forked) Uniswap v3 periphery + WETH, resolved from env with the
+/// canonical Sepolia values as defaults (the fork -> live flip point).
+pub(crate) struct UniswapV3Env {
+    pub factory: Address,
+    pub position_manager: Address,
+    pub swap_router: Address,
+    pub weth: Address,
+}
+
+/// Resolve the Uniswap v3 periphery + WETH addresses from env (canonical
+/// Sepolia defaults). The same struct flips to a live pool by swapping env.
+pub(crate) fn uniswap_v3_env() -> UniswapV3Env {
+    UniswapV3Env {
+        factory: env_addr("BRIDGE_UNISWAP_FACTORY", DEFAULT_FACTORY),
+        position_manager: env_addr("BRIDGE_UNISWAP_POSITION_MANAGER", DEFAULT_POSITION_MANAGER),
+        swap_router: env_addr("BRIDGE_UNISWAP_SWAP_ROUTER", DEFAULT_SWAP_ROUTER),
+        weth: env_addr("BRIDGE_WETH_ADDRESS", DEFAULT_WETH),
+    }
+}
+
+/// Result of seeding the pool + adding two-sided liquidity.
+pub(crate) struct LiquidityResult {
+    pub pool: Address,
+    pub liquidity: u128,
+    pub amount0: U256,
+    pub amount1: U256,
+}
+
+/// Outcome of a WETH -> wBTH swap (deltas on the swapper's balances).
+pub(crate) struct SwapResult {
+    pub wbth_out: U256,
+    pub weth_spent: U256,
+}
+
+/// Wrap `amount` wei of native ETH into WETH on the signer behind `provider`
+/// (`WETH9.deposit`). The account must already hold `amount` + gas.
+pub(crate) async fn wrap_weth(provider: &DynProvider, weth: Address, amount: U256) {
+    send_tx_value(provider, weth, IWETH9::depositCall {}.abi_encode(), amount).await;
+}
+
+/// Create the wBTH/WETH pool at a 1:1 raw price if it does not exist, then add
+/// a full-range two-sided position of `wbth_amount` wBTH + `weth_amount` WETH
+/// from the signer behind `provider` (which must hold both balances). Returns
+/// the pool address and the minted liquidity. The exact price is not
+/// load-bearing for a full-range position — a 1:1 interior guarantees both
+/// sides are consumed.
+pub(crate) async fn create_pool_and_add_liquidity(
+    provider: &DynProvider,
+    uni: &UniswapV3Env,
+    wbth: Address,
+    lp_addr: Address,
+    wbth_amount: U256,
+    weth_amount: U256,
+    fee: u32,
+) -> LiquidityResult {
+    let weth = uni.weth;
+    // Sort into token0/token1 and map the desired amounts to the sorted slots.
+    let (token0, token1, amount0, amount1) = if wbth < weth {
+        (wbth, weth, wbth_amount, weth_amount)
+    } else {
+        (weth, wbth, weth_amount, wbth_amount)
+    };
+    let (tick_lower, tick_upper) = full_range_ticks(fee);
+    let sqrt_price_x96: U160 = U160::from(1u8) << 96;
+
+    send_tx(
+        provider,
+        uni.position_manager,
+        INonfungiblePositionManager::createAndInitializePoolIfNecessaryCall {
+            token0,
+            token1,
+            fee: U24::from(fee),
+            sqrtPriceX96: sqrt_price_x96,
+        }
+        .abi_encode(),
+    )
+    .await;
+
+    // Confirm the pool now exists in the factory.
+    let pool_ret = provider
+        .call(
+            TransactionRequest::default()
+                .with_to(uni.factory)
+                .with_input(
+                    IUniswapV3Factory::getPoolCall {
+                        tokenA: token0,
+                        tokenB: token1,
+                        fee: U24::from(fee),
+                    }
+                    .abi_encode(),
+                ),
+        )
+        .await
+        .expect("getPool call");
+    let pool = IUniswapV3Factory::getPoolCall::abi_decode_returns(&pool_ret).expect("pool address");
+    assert_ne!(
+        pool,
+        Address::ZERO,
+        "factory.getPool returned the zero address"
+    );
+
+    // Approve both tokens to the position manager.
+    send_tx(
+        provider,
+        token0,
+        IERC20::approveCall {
+            spender: uni.position_manager,
+            amount: U256::MAX,
+        }
+        .abi_encode(),
+    )
+    .await;
+    send_tx(
+        provider,
+        token1,
+        IERC20::approveCall {
+            spender: uni.position_manager,
+            amount: U256::MAX,
+        }
+        .abi_encode(),
+    )
+    .await;
+
+    let mint_params = INonfungiblePositionManager::MintParams {
+        token0,
+        token1,
+        fee: U24::from(fee),
+        tickLower: I24::try_from(tick_lower).expect("tickLower fits i24"),
+        tickUpper: I24::try_from(tick_upper).expect("tickUpper fits i24"),
+        amount0Desired: amount0,
+        amount1Desired: amount1,
+        amount0Min: U256::ZERO,
+        amount1Min: U256::ZERO,
+        recipient: lp_addr,
+        deadline: U256::from(u64::MAX),
+    };
+    let mint_input = INonfungiblePositionManager::mintCall {
+        params: mint_params,
+    }
+    .abi_encode();
+
+    // Simulate the mint to read the minted liquidity (a state-changing call
+    // returns nothing usable from the receipt), then apply it on-chain.
+    let mint_ret = provider
+        .call(
+            TransactionRequest::default()
+                .with_from(lp_addr)
+                .with_to(uni.position_manager)
+                .with_input(mint_input.clone()),
+        )
+        .await
+        .expect("mint simulates");
+    let minted =
+        INonfungiblePositionManager::mintCall::abi_decode_returns(&mint_ret).expect("mint return");
+    send_tx(provider, uni.position_manager, mint_input).await;
+
+    LiquidityResult {
+        pool,
+        liquidity: minted.liquidity,
+        amount0: minted.amount0,
+        amount1: minted.amount1,
+    }
+}
+
+/// Swap `amount_in` WETH -> wBTH through the real `SwapRouter02` from the
+/// signer behind `provider`, returning the balance deltas. Approves WETH to
+/// the router first.
+pub(crate) async fn swap_weth_for_wbth(
+    provider: &DynProvider,
+    uni: &UniswapV3Env,
+    wbth: Address,
+    recipient: Address,
+    amount_in: U256,
+    fee: u32,
+) -> SwapResult {
+    send_tx(
+        provider,
+        uni.weth,
+        IWETH9::approveCall {
+            spender: uni.swap_router,
+            amount: U256::MAX,
+        }
+        .abi_encode(),
+    )
+    .await;
+
+    let wbth_before = call_u256(
+        provider,
+        wbth,
+        IERC20::balanceOfCall { account: recipient }.abi_encode(),
+    )
+    .await;
+    let weth_before = call_u256(
+        provider,
+        uni.weth,
+        IWETH9::balanceOfCall { account: recipient }.abi_encode(),
+    )
+    .await;
+
+    send_tx(
+        provider,
+        uni.swap_router,
+        ISwapRouter02::exactInputSingleCall {
+            params: ISwapRouter02::ExactInputSingleParams {
+                tokenIn: uni.weth,
+                tokenOut: wbth,
+                fee: U24::from(fee),
+                recipient,
+                amountIn: amount_in,
+                amountOutMinimum: U256::ZERO,
+                sqrtPriceLimitX96: U160::ZERO,
+            },
+        }
+        .abi_encode(),
+    )
+    .await;
+
+    let wbth_after = call_u256(
+        provider,
+        wbth,
+        IERC20::balanceOfCall { account: recipient }.abi_encode(),
+    )
+    .await;
+    let weth_after = call_u256(
+        provider,
+        uni.weth,
+        IWETH9::balanceOfCall { account: recipient }.abi_encode(),
+    )
+    .await;
+
+    SwapResult {
+        wbth_out: wbth_after - wbth_before,
+        weth_spent: weth_before - weth_after,
+    }
+}
+
+/// Whether the resolved Uniswap factory address actually has deployed code at
+/// the connected node — false on a plain local dev chain (31337) where the
+/// canonical Sepolia periphery does not exist. The round-trip e2e uses this to
+/// self-skip cleanly when pointed at a non-fork node (#1005).
+pub(crate) async fn uniswap_periphery_present(provider: &DynProvider, uni: &UniswapV3Env) -> bool {
+    let has_code = |addr: Address| async move {
+        provider
+            .get_code_at(addr)
+            .await
+            .map(|code| !code.is_empty())
+            .unwrap_or(false)
+    };
+    has_code(uni.factory).await
+        && has_code(uni.position_manager).await
+        && has_code(uni.swap_router).await
+        && has_code(uni.weth).await
+}
+
 /// The Uniswap-v3 fork harness: pool create + two-sided liquidity + swap
 /// against the real forked Sepolia periphery. Requires a fork node — see the
 /// module docs. Self-skips cleanly when no node is reachable.
@@ -286,10 +547,8 @@ async fn uniswap_fork_pool_create_add_liquidity_and_swap() {
     fund_dev_accounts_if_requested(&deploy_provider).await;
 
     // ---- Resolve the real (forked) Uniswap periphery + WETH -------------
-    let factory = env_addr("BRIDGE_UNISWAP_FACTORY", DEFAULT_FACTORY);
-    let position_manager = env_addr("BRIDGE_UNISWAP_POSITION_MANAGER", DEFAULT_POSITION_MANAGER);
-    let swap_router = env_addr("BRIDGE_UNISWAP_SWAP_ROUTER", DEFAULT_SWAP_ROUTER);
-    let weth = env_addr("BRIDGE_WETH_ADDRESS", DEFAULT_WETH);
+    let uni = uniswap_v3_env();
+    let weth = uni.weth;
 
     // ---- Deploy a throwaway wBTH; deployer holds MINTER_ROLE ------------
     // (admin / minter / pauser) — deployer as minter so it can mint directly.
@@ -323,204 +582,56 @@ async fn uniswap_fork_pool_create_add_liquidity_and_swap() {
 
     // Wrap 1 ETH -> WETH (the LP was funded above / already funded locally).
     let one_eth = U256::from(1_000_000_000_000_000_000u64);
-    send_tx_value(
-        &lp_provider,
-        weth,
-        IWETH9::depositCall {}.abi_encode(),
-        one_eth,
-    )
-    .await;
+    wrap_weth(&lp_provider, weth, one_eth).await;
 
-    // ---- Sort into token0/token1 and pick a fee tier --------------------
-    let (token0, token1) = if wbth < weth {
-        (wbth, weth)
-    } else {
-        (weth, wbth)
-    };
     let fee: u32 = 3000; // 0.30% tier, tick spacing 60
-    let (tick_lower, tick_upper) = full_range_ticks(fee);
 
-    // Initialize at a 1:1 raw price: sqrtPriceX96 = sqrt(1) * 2^96 = 2^96.
-    // Full-range liquidity means the exact price is not load-bearing; a 1:1
-    // interior price simply guarantees both sides are consumed two-sided.
-    let sqrt_price_x96: U160 = U160::from(1u8) << 96;
-    send_tx(
-        &lp_provider,
-        position_manager,
-        INonfungiblePositionManager::createAndInitializePoolIfNecessaryCall {
-            token0,
-            token1,
-            fee: U24::from(fee),
-            sqrtPriceX96: sqrt_price_x96,
-        }
-        .abi_encode(),
-    )
-    .await;
-
-    // Pool must now exist in the factory.
-    let pool_ret = lp_provider
-        .call(
-            TransactionRequest::default().with_to(factory).with_input(
-                IUniswapV3Factory::getPoolCall {
-                    tokenA: token0,
-                    tokenB: token1,
-                    fee: U24::from(fee),
-                }
-                .abi_encode(),
-            ),
-        )
-        .await
-        .expect("getPool call");
-    let pool = IUniswapV3Factory::getPoolCall::abi_decode_returns(&pool_ret).expect("pool address");
-    assert_ne!(
-        pool,
-        Address::ZERO,
-        "factory.getPool returned the zero address"
-    );
-
-    // ---- Approve both tokens to the position manager, then mint ---------
-    send_tx(
-        &lp_provider,
-        token0,
-        IERC20::approveCall {
-            spender: position_manager,
-            amount: U256::MAX,
-        }
-        .abi_encode(),
-    )
-    .await;
-    send_tx(
-        &lp_provider,
-        token1,
-        IERC20::approveCall {
-            spender: position_manager,
-            amount: U256::MAX,
-        }
-        .abi_encode(),
-    )
-    .await;
-
+    // ---- Create the pool + add two-sided liquidity via the shared helper --
     // Provide an equal raw amount of each token (1:1 price -> both consumed).
     // 10^17 base units: 10^17 pico wBTH (of the 2*10^17 minted) and 0.1 WETH
     // (of the 1 wrapped) — both sides funded, so the position is two-sided.
     let liq_amount = U256::from(100_000_000_000_000_000u64);
-    let mint_params = INonfungiblePositionManager::MintParams {
-        token0,
-        token1,
-        fee: U24::from(fee),
-        tickLower: I24::try_from(tick_lower).expect("tickLower fits i24"),
-        tickUpper: I24::try_from(tick_upper).expect("tickUpper fits i24"),
-        amount0Desired: liq_amount,
-        amount1Desired: liq_amount,
-        amount0Min: U256::ZERO,
-        amount1Min: U256::ZERO,
-        recipient: lp_addr,
-        deadline: U256::from(u64::MAX),
-    };
-    let mint_input = INonfungiblePositionManager::mintCall {
-        params: mint_params,
-    }
-    .abi_encode();
-
-    // Simulate the mint to read the minted liquidity (a state-changing call
-    // returns nothing usable from the receipt), then apply it on-chain.
-    let mint_ret = lp_provider
-        .call(
-            TransactionRequest::default()
-                .with_from(lp_addr)
-                .with_to(position_manager)
-                .with_input(mint_input.clone()),
-        )
-        .await
-        .expect("mint simulates");
-    let minted =
-        INonfungiblePositionManager::mintCall::abi_decode_returns(&mint_ret).expect("mint return");
-    assert!(minted.liquidity > 0, "minted position has zero liquidity");
-    assert!(minted.amount0 > U256::ZERO, "token0 side not funded");
-    assert!(minted.amount1 > U256::ZERO, "token1 side not funded");
-    send_tx(&lp_provider, position_manager, mint_input).await;
-
-    // ---- Swap WETH -> wBTH through the real router ----------------------
-    send_tx(
+    let liq = create_pool_and_add_liquidity(
         &lp_provider,
-        weth,
-        IWETH9::approveCall {
-            spender: swap_router,
-            amount: U256::MAX,
-        }
-        .abi_encode(),
+        &uni,
+        wbth,
+        lp_addr,
+        liq_amount,
+        liq_amount,
+        fee,
     )
     .await;
+    assert!(liq.liquidity > 0, "minted position has zero liquidity");
+    assert!(liq.amount0 > U256::ZERO, "token0 side not funded");
+    assert!(liq.amount1 > U256::ZERO, "token1 side not funded");
 
+    // ---- Swap WETH -> wBTH through the real router (shared helper) --------
+    // 0.01 WETH in (leaves plenty after the 0.1 WETH provided as liquidity).
+    let amount_in = U256::from(10_000_000_000_000_000u64);
     let wbth_before = call_u256(
         &lp_provider,
         wbth,
         IERC20::balanceOfCall { account: lp_addr }.abi_encode(),
     )
     .await;
-    let weth_before = call_u256(
-        &lp_provider,
-        weth,
-        IWETH9::balanceOfCall { account: lp_addr }.abi_encode(),
-    )
-    .await;
-
-    // 0.01 WETH in (leaves plenty after the 0.1 WETH provided as liquidity).
-    let amount_in = U256::from(10_000_000_000_000_000u64);
-    send_tx(
-        &lp_provider,
-        swap_router,
-        ISwapRouter02::exactInputSingleCall {
-            params: ISwapRouter02::ExactInputSingleParams {
-                tokenIn: weth,
-                tokenOut: wbth,
-                fee: U24::from(fee),
-                recipient: lp_addr,
-                amountIn: amount_in,
-                amountOutMinimum: U256::ZERO,
-                sqrtPriceLimitX96: U160::ZERO,
-            },
-        }
-        .abi_encode(),
-    )
-    .await;
-
-    let wbth_after = call_u256(
-        &lp_provider,
-        wbth,
-        IERC20::balanceOfCall { account: lp_addr }.abi_encode(),
-    )
-    .await;
-    let weth_after = call_u256(
-        &lp_provider,
-        weth,
-        IWETH9::balanceOfCall { account: lp_addr }.abi_encode(),
-    )
-    .await;
-
-    assert!(
-        wbth_after > wbth_before,
-        "swap did not increase wBTH ({wbth_before} -> {wbth_after})"
-    );
-    assert!(
-        weth_after < weth_before,
-        "swap did not decrease WETH ({weth_before} -> {weth_after})"
-    );
+    let swap = swap_weth_for_wbth(&lp_provider, &uni, wbth, lp_addr, amount_in, fee).await;
+    assert!(swap.wbth_out > U256::ZERO, "swap did not increase wBTH");
     assert_eq!(
-        weth_before - weth_after,
-        amount_in,
+        swap.weth_spent, amount_in,
         "exactInputSingle spent exactly amountIn WETH"
     );
-    let swapped_wbth = wbth_after - wbth_before;
+    let swapped_wbth = swap.wbth_out;
     eprintln!(
-        "uniswap fork: pool {pool:#x}, minted liquidity {}, swapped in {amount_in} WETH -> {swapped_wbth} wBTH",
-        minted.liquidity
+        "uniswap fork: pool {:#x}, minted liquidity {}, swapped in {amount_in} WETH -> {swapped_wbth} wBTH",
+        liq.pool, liq.liquidity
     );
 
     // ---- The swapped wBTH is a normal ERC-20 balance the user can redeem -
-    // Prove it: bridgeBurn the swap proceeds (the repatriation hook #1005 will
-    // wire) and confirm the balance drops — closing the DeFi round trip's
-    // "purchase wBTH, then send it home" half.
+    // Prove it: bridgeBurn the swap proceeds (the repatriation hook the
+    // round-trip e2e #1005 wires through the real engine) and confirm the
+    // balance drops — closing the DeFi round trip's "purchase wBTH, then send
+    // it home" half.
+    let wbth_after = wbth_before + swapped_wbth;
     send_tx(
         &lp_provider,
         wbth,

--- a/docs/bridge/testnet-e2e-runbook.md
+++ b/docs/bridge/testnet-e2e-runbook.md
@@ -26,6 +26,7 @@ funded Safes + Sepolia ETH land (#866/#868) — the
 |---|---|---|---|
 | 0 | Ethereum leg, real Rust pipeline, local chain | `scripts/bridge-e2e-local.sh` | nightly CI + on demand |
 | 0.5 | Ethereum leg, real Rust pipeline, **Sepolia fork** (no secrets/funds) | `scripts/bridge-e2e-fork.sh` | on-demand CI (`workflow_dispatch`) |
+| 0.75 | **Full DeFi round trip** (mint→wrap→fund→pool→swap→repatriate) through the real engine + real Uniswap v3, **Sepolia fork** + local Botho node (no secrets/funds) | `scripts/bridge-e2e-defi-fork.sh` | on-demand CI (`workflow_dispatch`) |
 | 1.75 | Orchestrated full loop through the real engine, local Botho + Hardhat nodes | `scripts/bridge-e2e-full-loop.sh` | nightly CI + on demand |
 | 1 | wBTH contract on Sepolia (mint through the real Safe) | this runbook, steps 1–5 | before any bridge deploy |
 | 2 | Full BTH testnet round trip (live Sepolia) | this runbook, all steps | blocked on #866/#868 |
@@ -84,6 +85,95 @@ set `BRIDGE_FORK_EXPECTED_CHAIN_ID=11155111`, leave `BRIDGE_FORK_FUND_ACCOUNTS`
 **unset** (there is no `setBalance` on a real chain), and supply a genuinely
 funded relayer/owner key in place of the dev keys. No test code changes —
 #866 is a config swap, not a rewrite.
+
+## Layer 0.75: full DeFi round trip (Sepolia fork, #1005)
+
+**The mainnet liquidity-launch rehearsal.** This is the headline
+demonstration AND the exact sequence the team runs at mainnet to bootstrap
+wBTH liquidity on a DEX — first against a Sepolia fork (here, zero creds),
+then live testnet, then mainnet, by swapping the RPC endpoint and a funded
+key (see the [flip table](#fork--testnet--mainnet-flip-the-launch-runbook)).
+
+It joins two already-landed pieces into ONE continuous journey of a coin,
+driven end to end through the REAL bridge engine
+(`OrderProcessor::process_pending_orders`) and the REAL Uniswap v3 periphery
+inherited from forked Sepolia state:
+
+```bash
+./scripts/bridge-e2e-defi-fork.sh https://ethereum-sepolia-rpc.publicnode.com
+# or:  SEPOLIA_RPC_URL=... ./scripts/bridge-e2e-defi-fork.sh
+```
+
+The driver compiles the contracts, starts `anvil --fork-url <rpc>` (chain id
+11155111) and a `botho-testnet` node, mines a reserve warmup, then runs the
+`#[ignore]`d test `bridge/service/src/defi_round_trip_tests.rs`, which walks
+the six steps:
+
+1. **Mint BTH** on the local Botho node (a funded factor-1 reserve).
+2. **Wrap → wBTH** — the engine drives the mint order to `Completed` via
+   t-of-n EIP-712 federation attestation → `Safe.execTransaction(bridgeMint)`
+   (reusing the Layer 1.75 wrap leg). The token's ONLY `MINTER` is the Safe,
+   so **every wBTH in the demo is a wrapped coin**.
+3. **Fund gas** on the fork via `*_setBalance` and wrap ETH into WETH (the
+   faucet + WETH stand-ins — no real funds).
+4. **Seed the pool** — create the wBTH/WETH Uniswap v3 pool and add two-sided
+   liquidity, the wBTH side drawn from the wrap (reusing the #1004 harness
+   helpers `create_pool_and_add_liquidity`).
+5. **Purchase** — swap WETH → wBTH against the seeded pool (the market buys
+   wBTH; `swap_weth_for_wbth`).
+6. **Repatriate** — `bridgeBurn` exactly the swap proceeds and let the engine
+   drive the burn order to `Released` via t-of-n Ed25519 attestation →
+   `BthReleaser` reserve spend to a fresh stealth output the user scans back
+   (reusing the Layer 1.75 unwrap leg).
+
+So a coin genuinely travels **Botho BTH → wBTH → into a DEX pool → bought via
+a swap → back to native BTH.** The test enforces as hard failures:
+
+1. **Peg on wrap** — `wbth.balanceOf(user) == totalSupply() == BTH locked`
+   (ADR 0003 factor-1, exact); the reconciler reports `drift == 0` after the
+   mint.
+2. **Pool + swap** — `factory.getPool(...)` is non-zero, the position has
+   `liquidity > 0`, and the swap moved WETH → wBTH in the right direction.
+3. **Provenance of the repatriated coin** — the burn amount **equals the swap
+   output**, and the released BTH equals that amount (net of fees, zero here),
+   paid to a fresh one-time stealth output (ADR 0004) the user's OWN view key
+   scans back, on a tx unlinkable to the EVM burn.
+4. **Proof-of-reserves across the whole loop** — `drift == 0` at the start
+   (`0/0`), after the mint (`WRAP/WRAP`), and after the partial repatriation
+   (`WRAP−swapOut / WRAP−swapOut`): only the backing for the repatriated coins
+   is unlocked; the rest stays locked behind the wBTH still circulating in the
+   pool.
+
+The test **self-skips** (green — never a false pass) unless BOTH a Sepolia
+fork is reachable (the Uniswap periphery only exists on a fork/live chain)
+AND the BTH reserve/user wallet key material is provided (32-byte hex files
+via the env vars in the script header). Without the reserve keys the BTH legs
+skip, exactly like Layers 1.5/1.75 — pending the reserve key provisioning
+(#999).
+
+CI wiring: the `defi-round-trip` job in `.github/workflows/bridge-e2e.yml`
+runs this on `workflow_dispatch` only (kept off the nightly schedule for the
+same public-RPC rate-limit reason as Layer 0.5), reads the `SEPOLIA_RPC_URL`
+repo secret, and skips cleanly when it is absent.
+
+### Fork → testnet → mainnet flip (the launch runbook)
+
+The SAME test + driver seed a live pool by swapping endpoints only — no
+test-logic change. This is the literal mainnet liquidity-bootstrap procedure:
+
+| Setting | Fork (Layer 0.75, now) | Live testnet (Phase B) | Mainnet launch |
+|---|---|---|---|
+| `BRIDGE_FORK_RPC_URL` | local `anvil --fork-url <sepolia>` | live Sepolia RPC | mainnet RPC |
+| `BRIDGE_FORK_EXPECTED_CHAIN_ID` | `11155111` | `11155111` | `1` |
+| `BRIDGE_UNISWAP_*` / `BRIDGE_WETH_ADDRESS` | Sepolia defaults | Sepolia defaults | mainnet addresses |
+| `BRIDGE_WBTH_ADDRESS` | throwaway deploy | #866-deployed token | mainnet token |
+| `BRIDGE_FORK_FUND_ACCOUNTS` | `1` (`*_setBalance`) | **unset** (real gas) | **unset** (real gas) |
+| LP / relayer key | dev key | funded testnet key | funded mainnet key |
+| BTH reserve | local `botho-testnet` reserve | live testnet reserve | mainnet reserve |
+
+Phase B (#866/#868/#869) supplies the live deploy, funded keys, and a
+persistent pool; the Solana venue is #867/#870. This layer is the fork
+rehearsal + the harness those reuse verbatim.
 
 ## Layer 1.5: BTH node leg (live)
 

--- a/scripts/bridge-e2e-defi-fork.sh
+++ b/scripts/bridge-e2e-defi-fork.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Bridge DeFi ROUND-TRIP end-to-end driver against a SEPOLIA FORK (#1005).
+#
+# THE MAINNET LIQUIDITY-LAUNCH REHEARSAL. This is the exact sequence the team
+# runs to bootstrap wBTH liquidity on a DEX — first against a Sepolia fork (this
+# script, zero creds), then live testnet, then mainnet, by swapping the RPC
+# endpoint and a funded key (see docs/bridge/testnet-e2e-runbook.md, layer 0.75
+# and the fork -> testnet -> mainnet flip table).
+#
+# It joins the two already-landed pieces into ONE continuous journey of a coin,
+# driven through the REAL bridge engine (OrderProcessor::process_pending_orders)
+# and the REAL Uniswap v3 periphery inherited from forked Sepolia state:
+#
+#   1. MINT BTH on a local Botho node (a funded factor-1 reserve),
+#   2. WRAP -> wBTH: t-of-n EIP-712 federation attestation -> Safe bridgeMint,
+#   3. FUND gas via *_setBalance + wrap ETH into WETH,
+#   4. SEED the pool: create the wBTH/WETH Uniswap v3 pool + add liquidity,
+#   5. PURCHASE: swap WETH -> wBTH against the seeded pool (the market buys),
+#   6. REPATRIATE: bridgeBurn the swap proceeds -> t-of-n Ed25519 attestation ->
+#      BthReleaser pays native BTH to a fresh stealth output the user scans back.
+#
+# So a coin travels: Botho BTH -> wBTH -> into a DEX pool -> bought via a swap ->
+# back to native BTH, with the peg verified at both ends and proof-of-reserves
+# drift == 0 across the whole loop.
+#
+# The Uniswap v3 periphery + WETH already exist on Sepolia, so an
+# `anvil --fork-url <sepolia>` node inherits them; only a throwaway WrappedBTH +
+# SafeStub is freshly deployed onto the fork. NO funded account, NO deployed
+# contract, NO secret — the dev accounts are funded on the fork via *_setBalance.
+#
+# Usage:
+#   ./scripts/bridge-e2e-defi-fork.sh <SEPOLIA_RPC_URL>
+#   SEPOLIA_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com \
+#     ./scripts/bridge-e2e-defi-fork.sh
+#
+# Env (Ethereum fork leg):
+#   SEPOLIA_RPC_URL      upstream archive/public RPC to fork from (required,
+#                        unless passed as the first argument).
+#   BRIDGE_FORK_RPC_URL  override the LOCAL fork endpoint the test talks to
+#                        (default http://127.0.0.1:8545). Point this at an
+#                        already-running fork to skip starting one here.
+#
+# Env (BTH leg — a funded factor-1 reserve on a local Botho node):
+#   BRIDGE_BTH_RPC_URL            node JSON-RPC (default http://127.0.0.1:27200)
+#   BRIDGE_BTH_RESERVE_VIEW_KEY   reserve wallet view key (32-byte hex file)
+#   BRIDGE_BTH_RESERVE_SPEND_KEY  reserve wallet spend key (32-byte hex file)
+#   BRIDGE_BTH_RESERVE_ADDRESS    reserve public BTH address (change target)
+#   BRIDGE_BTH_USER_ADDRESS       user BTH address (release destination)
+#   BRIDGE_BTH_USER_VIEW_KEY      user wallet view key (scan-back)
+#   BRIDGE_BTH_USER_SPEND_KEY     user wallet spend key (scan-back)
+#   BRIDGE_BTH_AMOUNT             picocredits to wrap (default 200,000 BTH;
+#                                 must cover the pool's wBTH liquidity side)
+#
+# When the BTH reserve key material is not provided the test SELF-SKIPS (green),
+# exactly like scripts/bridge-e2e-full-loop.sh — it never claims a live path it
+# could not exercise. Provision the reserve wallet keys (#999) to run the whole
+# round trip unattended.
+#
+# Fork -> testnet -> mainnet flip (same test, config-only — the launch runbook):
+#   point BRIDGE_FORK_RPC_URL at a live RPC, set BRIDGE_UNISWAP_* /
+#   BRIDGE_WETH_ADDRESS for that chain, set BRIDGE_WBTH_ADDRESS to the
+#   #866-deployed token instead of a throwaway deploy, leave
+#   BRIDGE_FORK_FUND_ACCOUNTS unset (no setBalance on a real chain), and supply
+#   genuinely funded relayer/LP keys.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTRACTS_DIR="$REPO_ROOT/contracts/ethereum"
+NODE_PID=""
+BOTHO_STARTED=""
+
+SEPOLIA_RPC_URL="${1:-${SEPOLIA_RPC_URL:-}}"
+if [[ -z "$SEPOLIA_RPC_URL" && -z "${BRIDGE_FORK_RPC_URL:-}" ]]; then
+    echo "error: SEPOLIA_RPC_URL is required (pass as \$1 or export it), unless" >&2
+    echo "       BRIDGE_FORK_RPC_URL points at an already-running fork node." >&2
+    echo "       e.g. ./scripts/bridge-e2e-defi-fork.sh https://ethereum-sepolia-rpc.publicnode.com" >&2
+    exit 2
+fi
+
+cleanup() {
+    if [[ -n "$BOTHO_STARTED" ]]; then
+        echo "Stopping botho-testnet"
+        (cd "$REPO_ROOT" && cargo run --release --bin botho-testnet -- stop) 2>/dev/null || true
+    fi
+    if [[ -n "$NODE_PID" ]] && kill -0 "$NODE_PID" 2>/dev/null; then
+        echo "Stopping fork node (pid $NODE_PID)"
+        kill "$NODE_PID" 2>/dev/null || true
+        wait "$NODE_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+echo "==> Compiling Ethereum contracts (throwaway WrappedBTH + SafeStub)"
+cd "$CONTRACTS_DIR"
+if [[ ! -d node_modules ]]; then
+    npm ci
+fi
+npx hardhat compile
+
+if [[ -z "${BRIDGE_FORK_RPC_URL:-}" ]]; then
+    if command -v anvil >/dev/null 2>&1; then
+        echo "==> Starting anvil forking Sepolia"
+        anvil --fork-url "$SEPOLIA_RPC_URL" --port 8545 \
+            >/tmp/bridge-e2e-defi-fork-node.log 2>&1 &
+    else
+        echo "==> anvil not found; starting hardhat node forking Sepolia"
+        cd "$CONTRACTS_DIR"
+        npx hardhat node --fork "$SEPOLIA_RPC_URL" --port 8545 \
+            >/tmp/bridge-e2e-defi-fork-node.log 2>&1 &
+    fi
+    NODE_PID=$!
+
+    echo "==> Waiting for the fork RPC to come up"
+    for _ in $(seq 1 60); do
+        if curl -sf -X POST -H 'Content-Type: application/json' \
+            --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+            http://127.0.0.1:8545 >/dev/null 2>&1; then
+            break
+        fi
+        if ! kill -0 "$NODE_PID" 2>/dev/null; then
+            echo "fork node died; log follows:" >&2
+            cat /tmp/bridge-e2e-defi-fork-node.log >&2
+            exit 1
+        fi
+        sleep 1
+    done
+    export BRIDGE_FORK_RPC_URL="http://127.0.0.1:8545"
+else
+    echo "==> Using existing fork node at $BRIDGE_FORK_RPC_URL"
+fi
+
+# Pin the expected chain id to Sepolia and fund the dev accounts on the fork.
+export BRIDGE_FORK_EXPECTED_CHAIN_ID="${BRIDGE_FORK_EXPECTED_CHAIN_ID:-11155111}"
+export BRIDGE_FORK_FUND_ACCOUNTS=1
+export BRIDGE_BTH_RPC_URL="${BRIDGE_BTH_RPC_URL:-http://127.0.0.1:27200}"
+
+echo "==> Starting local Botho node (botho-testnet)"
+cd "$REPO_ROOT"
+# A single node externalizes blocks under SCP with an n=1 quorum. --clean
+# guarantees a fresh chain each run.
+cargo run --release --bin botho-testnet -- start --nodes 1 --clean --wait-consensus
+BOTHO_STARTED=1
+
+echo "==> Mining a reserve warmup (spendable factor-1 outputs + decoy ring)"
+# The CLSAG release needs reserve-owned factor-1 outputs AND enough decoys in
+# the recent window. Give the chain time to produce a spendable window large
+# enough to also cover the ~200,000 BTH wrap.
+sleep 15
+
+if [[ -z "${BRIDGE_BTH_RESERVE_VIEW_KEY:-}" || -z "${BRIDGE_BTH_RESERVE_SPEND_KEY:-}" ]]; then
+    echo "::notice::BTH reserve key material not provided; the round-trip test will"
+    echo "::notice::self-skip its BTH legs (see script header + testnet-e2e-runbook.md)."
+fi
+
+echo "==> Running the DeFi round-trip e2e against ETH(fork)=$BRIDGE_FORK_RPC_URL BTH=$BRIDGE_BTH_RPC_URL"
+echo "    mint -> wrap -> fund -> pool -> swap -> repatriate (mainnet liquidity-launch rehearsal)"
+cargo test -p bth-bridge-service -- --ignored defi_round_trip_ --nocapture
+
+echo "==> Bridge DeFi round-trip Sepolia-fork e2e finished"


### PR DESCRIPTION
## Summary

Wires the two already-landed bridge pieces into **one orchestrated end-to-end DeFi round trip** — the headline **mint → wrap → fund → pool → swap → repatriate** loop, Phase A of the mainnet-liquidity-bootstrap round trip (#865). A coin genuinely travels **Botho BTH → wBTH → into a DEX pool → bought via a swap → back to native BTH**, driven through the REAL bridge engine (`OrderProcessor::process_pending_orders`) and the REAL Uniswap v3 periphery inherited from forked Sepolia state.

Framed as the **mainnet liquidity-launch rehearsal**: this exact sequence is what the team runs at mainnet to bootstrap wBTH liquidity, flipping fork → testnet → mainnet by swapping the RPC endpoint + a funded key.

## The 6-step orchestration (which existing piece each step reuses)

| Step | What runs | Reused from |
|---|---|---|
| 1. Mint BTH | funded factor-1 reserve on a local `botho-testnet` node | full-loop (#993) |
| 2. Wrap → wBTH | mint order → t-of-n EIP-712 federation attestation → `Safe.execTransaction(bridgeMint)` via the real `EthMinter`; engine walks it to `Completed` | full-loop wrap leg (`e2e_full_loop_tests.rs`) |
| 3. Fund gas + WETH | `*_setBalance` (faucet stand-in) + `WETH9.deposit` | `fork_tests::fund_dev_accounts_if_requested` + new `wrap_weth` helper |
| 4. Seed the pool | create wBTH/WETH Uniswap v3 pool + add two-sided liquidity (wBTH side drawn from the wrap) | #1004 harness → factored into `create_pool_and_add_liquidity` |
| 5. Purchase | swap WETH → wBTH against the seeded pool (the market buys) | #1004 harness → factored into `swap_weth_for_wbth` |
| 6. Repatriate | `bridgeBurn` the swap proceeds → t-of-n Ed25519 attestation → `BthReleaser` reserve spend to a fresh stealth output the user scans back | full-loop unwrap leg |

The wBTH token's ONLY `MINTER` is the federation Safe, so **every wBTH in the demo is a wrapped coin** — there is no other mint path.

## Round-trip assertions (a coin round-trips Botho→wBTH→pool→swap→Botho)

- **Peg on wrap** — `wbth.balanceOf(user) == totalSupply() == BTH locked` (ADR 0003 factor-1, exact); reconciler `drift == 0` after the mint.
- **Pool + swap** — `factory.getPool(...)` non-zero, position `liquidity > 0`, swap moved WETH → wBTH in the right direction (spent exactly `amountIn`).
- **Provenance** — the burn amount **equals the swap output**, and the released BTH equals that amount (net of fees, zero here), paid to a **fresh one-time stealth output (ADR 0004)** the user's OWN view key scans back, on a tx unlinkable to the EVM burn.
- **Proof-of-reserves across the whole loop** — `drift == 0` at the start (`0/0`), after the mint (`WRAP/WRAP`), and after the **partial** repatriation (`WRAP−swapOut / WRAP−swapOut`): only the backing for the repatriated coins is unlocked; the rest stays locked behind the wBTH still circulating in the pool.
- **Fail-safe** — a single Safe-owner signature does NOT mint and a single Ed25519 signature does NOT release; both cross the 2-of-2 threshold before any value moves.

## Changes

- **`bridge/service/src/defi_round_trip_tests.rs`** (new) — the six-step orchestrated e2e; `#[ignore]`d and self-skips unless BOTH a Sepolia fork is reachable (Uniswap periphery only exists on a fork/live chain) AND the BTH reserve/user keys are provided. The existing full-loop test is left untouched.
- **`bridge/service/src/uniswap_fork_tests.rs`** — factored the inline #1004 harness into reusable `pub(crate)` helpers (`uniswap_v3_env`, `wrap_weth`, `create_pool_and_add_liquidity`, `swap_weth_for_wbth`, `uniswap_periphery_present`); the existing test now drives them, preserving every assertion.
- **`bridge/service/src/lib.rs`** — register the new `#[cfg(test)]` module.
- **`scripts/bridge-e2e-defi-fork.sh`** (new) — the driver/runbook; boots `anvil --fork-url` + a local Botho node, funds via `setBalance`, runs the test. Documents the fork → testnet → mainnet flip.
- **`.github/workflows/bridge-e2e.yml`** — new `defi-round-trip` job (`workflow_dispatch` only, gated on `SEPOLIA_RPC_URL`, no external creds); additive alongside `full-loop` / `ethereum-leg-sepolia-fork`.
- **`docs/bridge/testnet-e2e-runbook.md`** — Layer 0.75 + the fork → testnet → mainnet flip table (the launch runbook).

## Acceptance Criteria Verification

| Criterion (issue) | Status | Verification |
|---|---|---|
| New `#[ignore]`d e2e composing wrap→mint + Uniswap + burn→release | ✅ | `defi_round_trip_tests.rs`, distinct from the untouched full-loop test |
| Assert peg, pool+liquidity, swap moved balances, release-to-fresh-stealth, drift==0 both ends | ✅ | See assertions above; drift asserted at 3 checkpoints |
| `scripts/bridge-e2e-defi-fork.sh` driver mirroring `bridge-e2e-fork.sh` | ✅ | `bash -n` clean; boots both nodes, funds via setBalance |
| `defi-round-trip` job, `workflow_dispatch`, gated on `SEPOLIA_RPC_URL` | ✅ | YAML validated; skips cleanly when the secret is absent |
| Parameterized for fork→live flip (`BRIDGE_WBTH_ADDRESS`, funding toggle, funded key) | ✅ | All env-gated; flip table in the runbook |
| Runbook layer 0.75 + flip table | ✅ | Added to `testnet-e2e-runbook.md` |
| Additive — don't break existing jobs | ✅ | Existing jobs unchanged; 213 non-ignored bridge tests still pass |

## Test Plan

- `cargo build --workspace --all-targets` — clean.
- `cargo test -p bth-bridge-service --no-run` — clean.
- Non-ignored bridge suite: **213 passed, 0 failed, 10 ignored**.
- `cargo clippy -p bth-bridge-service --all-targets -- -D warnings` — clean.
- `cargo +nightly-2025-12-03 fmt --all --check` — clean.
- Hardhat: `npx hardhat compile` — 14 contracts compiled successfully.
- Round-trip test **self-skips green** with no env (verified: `cargo test -p bth-bridge-service -- --ignored defi_round_trip_` → `ok`).

**Did it run end-to-end?** No — this environment has no `anvil`, no outbound RPC (the public Sepolia endpoint returns 403 from the sandbox), and no provisioned BTH reserve, so the test self-skipped (as designed). To run it end-to-end:

```bash
./scripts/bridge-e2e-defi-fork.sh https://ethereum-sepolia-rpc.publicnode.com
```

The two composed halves each have their own `workflow_dispatch` jobs that exercise the real periphery (`ethereum-leg-sepolia-fork`, `full-loop`). Live-Sepolia execution is Phase B (#866/#868/#869), gated on the reserve keys (#999).

Closes #1005