### PR TITLE
feat(bridge): deploy-safe.ts (2-of-3 Gnosis Safe) + dotenv auto-load + Sepolia-fork deploy test

### DIFF
--- a/contracts/ethereum/hardhat.config.ts
+++ b/contracts/ethereum/hardhat.config.ts
@@ -1,3 +1,8 @@
+// Auto-load contracts/ethereum/.env (git-ignored) so PRIVATE_KEY,
+// SEPOLIA_RPC_URL, ETHERSCAN_API_KEY and the WBTH_*_SAFE / BRIDGE_SAFE_OWNER_*
+// addresses resolve without a manual `source .env` (#1011). Secrets are only
+// read from this git-ignored file — never printed, never committed.
+import "dotenv/config";
 import { HardhatUserConfig } from "hardhat/config";
 import "@nomicfoundation/hardhat-toolbox";
 
@@ -17,6 +22,13 @@ const config: HardhatUserConfig = {
     },
     localhost: {
       url: "http://127.0.0.1:8545",
+    },
+    // Local Sepolia FORK for dry-running deploys with no real testnet ETH
+    // (#1011/#992). Point BRIDGE_FORK_RPC_URL at an `anvil --fork-url <sepolia>`
+    // node; the deployer is any key funded on the fork via anvil_setBalance.
+    fork: {
+      url: process.env.BRIDGE_FORK_RPC_URL || "http://127.0.0.1:8545",
+      accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
     },
     sepolia: {
       url: process.env.SEPOLIA_RPC_URL || "",

--- a/contracts/ethereum/package-lock.json
+++ b/contracts/ethereum/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "wbth-ethereum",
-  "version": "0.3.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wbth-ethereum",
-      "version": "0.3.2",
+      "version": "0.6.0",
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "@openzeppelin/contracts": "^5.0.0",
+        "dotenv": "^17.4.2",
         "hardhat": "^2.19.0",
         "typescript": "^5.3.0"
       }
@@ -3060,6 +3061,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/contracts/ethereum/package.json
+++ b/contracts/ethereum/package.json
@@ -7,11 +7,14 @@
     "test": "hardhat test",
     "deploy:local": "hardhat run scripts/deploy.ts --network localhost",
     "deploy:sepolia": "hardhat run scripts/deploy.ts --network sepolia",
-    "deploy:mainnet": "hardhat run scripts/deploy.ts --network mainnet"
+    "deploy:mainnet": "hardhat run scripts/deploy.ts --network mainnet",
+    "deploy:safe:sepolia": "hardhat run scripts/deploy-safe.ts --network sepolia",
+    "deploy:all:sepolia": "hardhat run scripts/deploy-all.ts --network sepolia"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "@openzeppelin/contracts": "^5.0.0",
+    "dotenv": "^17.4.2",
     "hardhat": "^2.19.0",
     "typescript": "^5.3.0"
   }

--- a/contracts/ethereum/scripts/deploy-all.ts
+++ b/contracts/ethereum/scripts/deploy-all.ts
@@ -1,0 +1,66 @@
+import { ethers } from "hardhat";
+import { deploySafe } from "./deploy-safe";
+
+/**
+ * One-shot bridge custody + token bring-up (#1011, #866).
+ *
+ * Chains, in a single process:
+ *   1. deploy the 2-of-3 Gnosis Safe (scripts/deploy-safe.ts) from the three
+ *      BRIDGE_SAFE_OWNER_{1,2,3} owner EOAs,
+ *   2. wire that ONE Safe as all three WrappedBTH roles (admin/minter/pauser)
+ *      per the maintainer-ratified single-Safe custody model,
+ *   3. deploy WrappedBTH with the Safe holding every role (the deployer gets
+ *      none — ADR 0002),
+ *   4. print the addresses + Etherscan links.
+ *
+ * This does NOT modify scripts/deploy.ts; it reuses the same constructor shape
+ * (adminSafe, minterSafe, pauserSafe). If you prefer discrete steps, run
+ * deploy-safe.ts, copy SAFE_ADDRESS into WBTH_ADMIN_SAFE/MINTER_SAFE/PAUSER_SAFE
+ * in .env, then run deploy.ts — this script is just that sequence automated.
+ */
+async function main() {
+  const safeAddress = await deploySafe();
+
+  // Single-Safe custody: the one 2-of-3 Safe is admin, minter and pauser.
+  const adminSafe = safeAddress;
+  const minterSafe = safeAddress;
+  const pauserSafe = safeAddress;
+
+  const [deployer] = await ethers.getSigners();
+  console.log("");
+  console.log(`Deploying WrappedBTH (deployer ${deployer.address} receives NO roles)`);
+  console.log(`  admin/minter/pauser Safe = ${safeAddress}`);
+
+  const WrappedBTH = await ethers.getContractFactory("WrappedBTH");
+  const wbth = await WrappedBTH.deploy(adminSafe, minterSafe, pauserSafe);
+  await wbth.waitForDeployment();
+  const wbthAddress = ethers.getAddress(await wbth.getAddress());
+
+  const chainId = Number((await ethers.provider.getNetwork()).chainId);
+  const explorer =
+    chainId === 11155111
+      ? "https://sepolia.etherscan.io/address/"
+      : chainId === 1
+        ? "https://etherscan.io/address/"
+        : null;
+
+  console.log("");
+  console.log("=== Bridge custody deployed ===");
+  console.log(`SAFE_ADDRESS=${safeAddress}`);
+  console.log(`WBTH_ADDRESS=${wbthAddress}`);
+  if (explorer) {
+    console.log("");
+    console.log(`Safe:       ${explorer}${safeAddress}`);
+    console.log(`WrappedBTH: ${explorer}${wbthAddress}`);
+  }
+  console.log("");
+  console.log("Record these in contracts/ethereum/README.md, then verify with:");
+  console.log(
+    `  npx hardhat verify --network sepolia ${wbthAddress} ${safeAddress} ${safeAddress} ${safeAddress}`
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contracts/ethereum/scripts/deploy-safe.ts
+++ b/contracts/ethereum/scripts/deploy-safe.ts
@@ -1,0 +1,196 @@
+import { ethers } from "hardhat";
+
+/**
+ * Deploy ONE 2-of-3 Gnosis Safe for the wBTH bridge custody (#1011, #866).
+ *
+ * Per ADR 0002 the WrappedBTH admin/minter/pauser roles must be held by a
+ * Gnosis Safe, not an EOA. The maintainer-ratified custody model for the
+ * testnet bootstrap is a SINGLE 2-of-3 Safe used for all three roles, owned by
+ * the three provisioned owner EOAs (BRIDGE_SAFE_OWNER_1/2/3, see
+ * scripts/bridge-testnet-accounts.sh). The deployer key only pays gas and
+ * receives NO Safe ownership.
+ *
+ * The Safe is created by calling the CANONICAL Safe v1.3.0 SafeProxyFactory
+ * directly (no SDK / no network service dependency): factory
+ * `createProxyWithNonce(singleton, initializer, saltNonce)` where `initializer`
+ * is `Safe.setup(owners, threshold, 0x0, 0x, fallbackHandler, 0x0, 0, 0x0)`.
+ *
+ * Canonical Safe v1.3.0 addresses (identical on Ethereum mainnet and Sepolia;
+ * pinned from https://github.com/safe-global/safe-deployments — v1.3.0
+ * "canonical"). All four were verified live on Sepolia (chainId 11155111) to
+ * have deployed bytecode via `cast code`. Override per-network via env.
+ */
+const SAFE_PROXY_FACTORY =
+  process.env.SAFE_PROXY_FACTORY_ADDRESS ||
+  "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2"; // GnosisSafeProxyFactory v1.3.0
+const SAFE_SINGLETON =
+  process.env.SAFE_SINGLETON_ADDRESS ||
+  "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"; // GnosisSafe (L1) v1.3.0
+const SAFE_FALLBACK_HANDLER =
+  process.env.SAFE_FALLBACK_HANDLER_ADDRESS ||
+  "0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4"; // CompatibilityFallbackHandler v1.3.0
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+// Minimal ABIs — the canonical v1.3.0 contracts. In v1.3.0 the ProxyCreation
+// event args are both NON-indexed (this changed to `indexed proxy` in v1.4.1).
+const FACTORY_ABI = [
+  "function createProxyWithNonce(address _singleton, bytes initializer, uint256 saltNonce) returns (address proxy)",
+  "event ProxyCreation(address proxy, address singleton)",
+];
+const SAFE_ABI = [
+  "function setup(address[] _owners, uint256 _threshold, address to, bytes data, address fallbackHandler, address paymentToken, uint256 payment, address paymentReceiver)",
+  "function getOwners() view returns (address[])",
+  "function getThreshold() view returns (uint256)",
+];
+
+function requireOwner(name: string): string {
+  const v = process.env[name];
+  if (!v || !ethers.isAddress(v)) {
+    throw new Error(
+      `${name} must be a valid EOA address (set the three BRIDGE_SAFE_OWNER_{1,2,3} owner addresses)`
+    );
+  }
+  return ethers.getAddress(v);
+}
+
+async function assertDeployed(label: string, address: string) {
+  const code = await ethers.provider.getCode(address);
+  if (code === "0x" || code.length <= 2) {
+    throw new Error(
+      `${label} has no bytecode at ${address} on this network — wrong chain or ` +
+        `wrong Safe release. Deploy against Sepolia (or a Sepolia fork), or ` +
+        `override SAFE_PROXY_FACTORY_ADDRESS / SAFE_SINGLETON_ADDRESS / ` +
+        `SAFE_FALLBACK_HANDLER_ADDRESS.`
+    );
+  }
+}
+
+/**
+ * Deploy the 2-of-3 Safe and return its address. Idempotent-ish: if a
+ * SAFE_ADDRESS env is already set, returns it without deploying. Exported so
+ * deploy-all.ts can chain Safe → WrappedBTH in one process.
+ */
+export async function deploySafe(): Promise<string> {
+  // Idempotent-ish: if a Safe address is already recorded, do nothing. This
+  // lets deploy-all.ts / a re-run skip a Safe that was already created.
+  if (process.env.SAFE_ADDRESS && ethers.isAddress(process.env.SAFE_ADDRESS)) {
+    const existing = ethers.getAddress(process.env.SAFE_ADDRESS);
+    console.log(`SAFE_ADDRESS already set (${existing}); skipping Safe deploy.`);
+    console.log(`SAFE_ADDRESS=${existing}`);
+    return existing;
+  }
+
+  const owners = [
+    requireOwner("BRIDGE_SAFE_OWNER_1"),
+    requireOwner("BRIDGE_SAFE_OWNER_2"),
+    requireOwner("BRIDGE_SAFE_OWNER_3"),
+  ];
+  const uniqueOwners = new Set(owners.map((o) => o.toLowerCase()));
+  if (uniqueOwners.size !== owners.length) {
+    throw new Error("BRIDGE_SAFE_OWNER_{1,2,3} must be three DISTINCT addresses");
+  }
+
+  const threshold = Number(process.env.SAFE_THRESHOLD || "2");
+  if (!Number.isInteger(threshold) || threshold < 1 || threshold > owners.length) {
+    throw new Error(
+      `SAFE_THRESHOLD must be an integer in [1, ${owners.length}] (default 2)`
+    );
+  }
+
+  const [deployer] = await ethers.getSigners();
+  console.log(`Network:            ${(await ethers.provider.getNetwork()).chainId}`);
+  console.log(`Deployer (gas only): ${deployer.address}`);
+  console.log(`Safe owners:        ${owners.join(", ")}`);
+  console.log(`Safe threshold:     ${threshold}-of-${owners.length}`);
+  console.log(`ProxyFactory:       ${SAFE_PROXY_FACTORY}`);
+  console.log(`Safe singleton:     ${SAFE_SINGLETON}`);
+  console.log(`Fallback handler:   ${SAFE_FALLBACK_HANDLER}`);
+
+  // Fail loudly + early if the canonical contracts are not on this network.
+  await assertDeployed("SafeProxyFactory", SAFE_PROXY_FACTORY);
+  await assertDeployed("Safe singleton", SAFE_SINGLETON);
+  await assertDeployed("Fallback handler", SAFE_FALLBACK_HANDLER);
+
+  const safeInterface = new ethers.Interface(SAFE_ABI);
+  const initializer = safeInterface.encodeFunctionData("setup", [
+    owners,
+    threshold,
+    ZERO_ADDRESS, // to (no module/delegatecall setup)
+    "0x", // data
+    SAFE_FALLBACK_HANDLER,
+    ZERO_ADDRESS, // paymentToken
+    0, // payment
+    ZERO_ADDRESS, // paymentReceiver
+  ]);
+
+  // A fresh salt per run avoids CREATE2 collisions with a previously deployed
+  // Safe that had identical owners/threshold. Override SAFE_SALT_NONCE for a
+  // deterministic address if you need one.
+  const saltNonce = process.env.SAFE_SALT_NONCE || Date.now().toString();
+
+  const factory = new ethers.Contract(SAFE_PROXY_FACTORY, FACTORY_ABI, deployer);
+  console.log(`Deploying Safe (saltNonce=${saltNonce}) ...`);
+  const tx = await factory.createProxyWithNonce(SAFE_SINGLETON, initializer, saltNonce);
+  const receipt = await tx.wait();
+
+  let safeAddress: string | undefined;
+  for (const log of receipt!.logs) {
+    try {
+      const parsed = factory.interface.parseLog({
+        topics: [...log.topics],
+        data: log.data,
+      });
+      if (parsed && parsed.name === "ProxyCreation") {
+        safeAddress = parsed.args.proxy as string;
+        break;
+      }
+    } catch {
+      // not a ProxyCreation log
+    }
+  }
+  if (!safeAddress) {
+    throw new Error("ProxyCreation event not found in receipt — Safe deploy failed");
+  }
+  safeAddress = ethers.getAddress(safeAddress);
+
+  // Verify the deployed Safe really is the 2-of-3 we asked for.
+  const safe = new ethers.Contract(safeAddress, SAFE_ABI, deployer);
+  const deployedOwners: string[] = (await safe.getOwners()).map((o: string) =>
+    ethers.getAddress(o)
+  );
+  const deployedThreshold = Number(await safe.getThreshold());
+
+  const ownersMatch =
+    deployedOwners.length === owners.length &&
+    owners.every((o) => deployedOwners.map((d) => d.toLowerCase()).includes(o.toLowerCase()));
+  if (!ownersMatch) {
+    throw new Error(
+      `Deployed Safe owners ${deployedOwners.join(",")} != requested ${owners.join(",")}`
+    );
+  }
+  if (deployedThreshold !== threshold) {
+    throw new Error(
+      `Deployed Safe threshold ${deployedThreshold} != requested ${threshold}`
+    );
+  }
+
+  console.log("");
+  console.log(`Safe deployed and verified:`);
+  console.log(`  getThreshold() = ${deployedThreshold}`);
+  console.log(`  getOwners()    = ${deployedOwners.join(", ")}`);
+  console.log(`  tx hash        = ${tx.hash}`);
+  console.log("");
+  // Machine-parseable line for deploy-all.ts / the runbook.
+  console.log(`SAFE_ADDRESS=${safeAddress}`);
+  return safeAddress;
+}
+
+// Only run as a standalone script when invoked directly (not when imported by
+// deploy-all.ts). Hardhat runs scripts via `require.main`.
+if (require.main === module) {
+  deploySafe().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/docs/bridge/testnet-e2e-runbook.md
+++ b/docs/bridge/testnet-e2e-runbook.md
@@ -340,6 +340,85 @@ Mapping to `contracts/ethereum/scripts/deploy.ts` +
 - `BRIDGE_SEPOLIA_LP` is the LP / relayer EOA the Layer 0.75 DeFi round trip
   uses (its private key file feeds the harness's LP key env var).
 
+## Phase B.1 — deploy the custody Safe + WrappedBTH (#1011)
+
+The first live-deploy step. Custody is a SINGLE **2-of-3 Gnosis Safe** used for
+all three WrappedBTH roles (admin/minter/pauser), owned by the three
+`BRIDGE_SAFE_OWNER_{1,2,3}` EOAs from the account-provisioning step above
+(maintainer-ratified). The deployer EOA only pays gas and receives NO roles
+(ADR 0002).
+
+`contracts/ethereum/hardhat.config.ts` now auto-loads a **git-ignored**
+`contracts/ethereum/.env` (via `dotenv/config`), so `PRIVATE_KEY`,
+`SEPOLIA_RPC_URL`, `ETHERSCAN_API_KEY`, `BRIDGE_SAFE_OWNER_*` and `WBTH_*_SAFE`
+resolve without a manual `source`. Never print or commit that file.
+
+The Safe is created against the **canonical Safe v1.3.0** deployment (identical
+on mainnet and Sepolia, pinned from `safe-global/safe-deployments`, all verified
+to have live bytecode on Sepolia): SafeProxyFactory
+`0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2`, GnosisSafe singleton
+`0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552`, CompatibilityFallbackHandler
+`0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4`. `deploy-safe.ts` calls
+`createProxyWithNonce(singleton, Safe.setup(owners, 2, 0x0, 0x, handler, 0x0, 0,
+0x0), saltNonce)` and self-asserts `getOwners()`/`getThreshold()`.
+
+### B.1.a — fork-test first (no real ETH, no secret)
+
+Prove the whole bring-up against a Sepolia fork before spending testnet ETH.
+Requires foundry (`anvil` + `cast`):
+
+```bash
+./scripts/deploy-safe-fork-test.sh https://ethereum-sepolia-rpc.publicnode.com
+```
+
+It forks Sepolia (`anvil --fork-url`), `anvil_setBalance`-funds a throwaway
+deployer, deploys the 2-of-3 Safe, asserts owners + threshold, deploys
+WrappedBTH with the Safe as admin/minter/pauser, and asserts the Safe holds all
+three roles while the deployer holds none. Ends with `FORK TEST PASSED`. Uses
+throwaway anvil dev accounts — no `.env`, no real key.
+
+### B.1.b — live Sepolia run
+
+Fill `contracts/ethereum/.env` (git-ignored) with the funded deployer key and
+the three owner addresses, then:
+
+```bash
+cd contracts/ethereum
+cat > .env <<'EOF'          # git-ignored — never commit
+PRIVATE_KEY=0x<funded deployer private key>
+SEPOLIA_RPC_URL=https://<your sepolia rpc>
+ETHERSCAN_API_KEY=<etherscan key, for verify>
+BRIDGE_SAFE_OWNER_1=0x<owner 1>
+BRIDGE_SAFE_OWNER_2=0x<owner 2>
+BRIDGE_SAFE_OWNER_3=0x<owner 3>
+EOF
+
+# 1. Deploy the 2-of-3 Safe (prints SAFE_ADDRESS=0x...):
+npx hardhat run scripts/deploy-safe.ts --network sepolia
+
+# 2. Point all three WrappedBTH roles at that one Safe and deploy the token:
+echo "WBTH_ADMIN_SAFE=0x<safe address>"  >> .env
+echo "WBTH_MINTER_SAFE=0x<safe address>" >> .env
+echo "WBTH_PAUSER_SAFE=0x<safe address>" >> .env
+npx hardhat run scripts/deploy.ts --network sepolia
+
+# 3. Verify on Etherscan (constructor args = the Safe, three times):
+npx hardhat verify --network sepolia 0x<wbth address> \
+  0x<safe address> 0x<safe address> 0x<safe address>
+```
+
+Or run steps 1–2 in one shot (deploy-safe → wire roles → deploy WrappedBTH →
+print addresses + Etherscan links):
+
+```bash
+cd contracts/ethereum
+npx hardhat run scripts/deploy-all.ts --network sepolia
+```
+
+Record the resulting Safe + wBTH addresses and the threshold in the deployment
+table in `contracts/ethereum/README.md`. Then the Layer 1–2 drill below can run
+with `BRIDGE_WBTH_ADDRESS` = the deployed token and the Safe as its minter.
+
 ## Prerequisites (Layers 1–2)
 
 - **BTH testnet**: a synced node with JSON-RPC + websocket exposed; the

--- a/scripts/deploy-safe-fork-test.sh
+++ b/scripts/deploy-safe-fork-test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Fork-test the wBTH bridge custody bring-up (#1011) against a SEPOLIA FORK —
+# proves scripts/deploy-safe.ts + scripts/deploy.ts work end-to-end with NO
+# real testnet ETH and NO secret, before the live Sepolia run.
+#
+# It:
+#   1. starts `anvil --fork-url <sepolia rpc>` (real Sepolia state, chain id
+#      11155111 — so the canonical Safe v1.3.0 factory/singleton/handler the
+#      deploy script pins are really there),
+#   2. funds a throwaway deployer on the fork via `anvil_setBalance` (test ETH
+#      only — never a real chain),
+#   3. runs deploy-safe.ts on `--network fork` and asserts a real 2-of-3 Safe
+#      deployed (the script itself checks getOwners()==owners, getThreshold()==2
+#      and aborts on mismatch),
+#   4. wires that Safe as WrappedBTH admin/minter/pauser and runs deploy.ts on
+#      the fork, then asserts the Safe holds all three roles,
+#   5. tears the fork down.
+#
+# Usage:
+#   ./scripts/deploy-safe-fork-test.sh <SEPOLIA_RPC_URL>
+#   SEPOLIA_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com ./scripts/deploy-safe-fork-test.sh
+#
+# Requires: foundry (anvil, cast) and node/npm. anvil is the only fork backend
+# here (we need anvil_setBalance + cast for the role assertions).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTRACTS_DIR="$REPO_ROOT/contracts/ethereum"
+FORK_PORT="${FORK_PORT:-8545}"
+FORK_URL="http://127.0.0.1:${FORK_PORT}"
+NODE_PID=""
+
+SEPOLIA_RPC_URL="${1:-${SEPOLIA_RPC_URL:-}}"
+if [[ -z "$SEPOLIA_RPC_URL" ]]; then
+    echo "error: SEPOLIA_RPC_URL is required (pass as \$1 or export it)." >&2
+    echo "       e.g. ./scripts/deploy-safe-fork-test.sh https://ethereum-sepolia-rpc.publicnode.com" >&2
+    exit 2
+fi
+
+if ! command -v anvil >/dev/null 2>&1 || ! command -v cast >/dev/null 2>&1; then
+    echo "error: foundry (anvil + cast) required. Install: https://getfoundry.sh" >&2
+    exit 2
+fi
+
+# Deterministic anvil dev accounts (fork-only throwaways — NOT secrets):
+# account[0] is the deployer (gas), accounts[1..3] are the Safe owners.
+DEPLOYER_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+DEPLOYER_ADDR="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+OWNER_1="0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+OWNER_2="0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+OWNER_3="0x90F79bf6EB2c4f870365E785982E1f101E93b906"
+
+cleanup() {
+    if [[ -n "$NODE_PID" ]] && kill -0 "$NODE_PID" 2>/dev/null; then
+        echo "==> Stopping fork node (pid $NODE_PID)"
+        kill "$NODE_PID" 2>/dev/null || true
+        wait "$NODE_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+echo "==> Compiling contracts"
+cd "$CONTRACTS_DIR"
+if [[ ! -d node_modules ]]; then
+    npm ci
+fi
+npx hardhat compile
+
+echo "==> Starting anvil forking Sepolia"
+anvil --fork-url "$SEPOLIA_RPC_URL" --port "$FORK_PORT" \
+    >/tmp/deploy-safe-fork-node.log 2>&1 &
+NODE_PID=$!
+
+echo "==> Waiting for the fork RPC to come up"
+for _ in $(seq 1 60); do
+    if cast chain-id --rpc-url "$FORK_URL" >/dev/null 2>&1; then
+        break
+    fi
+    if ! kill -0 "$NODE_PID" 2>/dev/null; then
+        echo "fork node died; log follows:" >&2
+        cat /tmp/deploy-safe-fork-node.log >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+CHAIN_ID="$(cast chain-id --rpc-url "$FORK_URL")"
+echo "==> Fork chain id: $CHAIN_ID (expect 11155111)"
+
+echo "==> Funding deployer $DEPLOYER_ADDR via anvil_setBalance (test ETH only)"
+cast rpc anvil_setBalance "$DEPLOYER_ADDR" 0x21e19e0c9bab2400000 \
+    --rpc-url "$FORK_URL" >/dev/null
+
+export BRIDGE_FORK_RPC_URL="$FORK_URL"
+export PRIVATE_KEY="$DEPLOYER_KEY"
+export BRIDGE_SAFE_OWNER_1="$OWNER_1"
+export BRIDGE_SAFE_OWNER_2="$OWNER_2"
+export BRIDGE_SAFE_OWNER_3="$OWNER_3"
+unset SAFE_ADDRESS WBTH_ADMIN_SAFE WBTH_MINTER_SAFE WBTH_PAUSER_SAFE
+
+echo "==> Deploying 2-of-3 Safe on the fork"
+SAFE_OUT="$(npx hardhat run scripts/deploy-safe.ts --network fork)"
+echo "$SAFE_OUT"
+SAFE_ADDRESS="$(echo "$SAFE_OUT" | sed -n 's/^SAFE_ADDRESS=//p' | tail -1)"
+if [[ -z "$SAFE_ADDRESS" ]]; then
+    echo "error: deploy-safe.ts did not print SAFE_ADDRESS" >&2
+    exit 1
+fi
+
+echo "==> Asserting Safe owners + threshold via cast"
+GOT_THRESHOLD="$(cast call "$SAFE_ADDRESS" 'getThreshold()(uint256)' --rpc-url "$FORK_URL")"
+GOT_OWNERS="$(cast call "$SAFE_ADDRESS" 'getOwners()(address[])' --rpc-url "$FORK_URL")"
+echo "    getThreshold() = $GOT_THRESHOLD"
+echo "    getOwners()    = $GOT_OWNERS"
+[[ "$GOT_THRESHOLD" == "2" ]] || { echo "FAIL: threshold != 2" >&2; exit 1; }
+for o in "$OWNER_1" "$OWNER_2" "$OWNER_3"; do
+    echo "$GOT_OWNERS" | grep -iq "${o#0x}" || { echo "FAIL: owner $o missing" >&2; exit 1; }
+done
+echo "    OK: 2-of-3 Safe with the three owners"
+
+echo "==> Deploying WrappedBTH with the Safe as admin/minter/pauser"
+export WBTH_ADMIN_SAFE="$SAFE_ADDRESS"
+export WBTH_MINTER_SAFE="$SAFE_ADDRESS"
+export WBTH_PAUSER_SAFE="$SAFE_ADDRESS"
+WBTH_OUT="$(npx hardhat run scripts/deploy.ts --network fork)"
+echo "$WBTH_OUT"
+WBTH_ADDRESS="$(echo "$WBTH_OUT" | sed -n 's/.*WrappedBTH deployed at: //p' | tail -1)"
+if [[ -z "$WBTH_ADDRESS" ]]; then
+    echo "error: deploy.ts did not print the WrappedBTH address" >&2
+    exit 1
+fi
+
+echo "==> Asserting the Safe holds all three WrappedBTH roles via cast"
+DEFAULT_ADMIN_ROLE="0x0000000000000000000000000000000000000000000000000000000000000000"
+MINTER_ROLE="$(cast keccak 'MINTER_ROLE')"
+PAUSER_ROLE="$(cast keccak 'PAUSER_ROLE')"
+for role_pair in "admin=$DEFAULT_ADMIN_ROLE" "minter=$MINTER_ROLE" "pauser=$PAUSER_ROLE"; do
+    label="${role_pair%%=*}"; role="${role_pair##*=}"
+    has="$(cast call "$WBTH_ADDRESS" 'hasRole(bytes32,address)(bool)' "$role" "$SAFE_ADDRESS" --rpc-url "$FORK_URL")"
+    echo "    hasRole($label) = $has"
+    [[ "$has" == "true" ]] || { echo "FAIL: Safe missing $label role" >&2; exit 1; }
+done
+# Deployer must hold NO admin role (ADR 0002).
+DEP_ADMIN="$(cast call "$WBTH_ADDRESS" 'hasRole(bytes32,address)(bool)' "$DEFAULT_ADMIN_ROLE" "$DEPLOYER_ADDR" --rpc-url "$FORK_URL")"
+[[ "$DEP_ADMIN" == "false" ]] || { echo "FAIL: deployer holds admin role" >&2; exit 1; }
+echo "    OK: deployer holds no roles"
+
+echo ""
+echo "==> FORK TEST PASSED"
+echo "    SAFE_ADDRESS=$SAFE_ADDRESS (2-of-3)"
+echo "    WBTH_ADDRESS=$WBTH_ADDRESS (admin=minter=pauser=Safe)"


### PR DESCRIPTION
## Summary

Phase B.1 of the wBTH testnet custody bring-up (#1011, first live-deploy step of #866/#865). Builds and **fork-tests** the tooling to stand up the bridge custody Safe + WrappedBTH; the orchestrator runs it live against a funded Sepolia deployer. Custody is a SINGLE **2-of-3 Gnosis Safe** used for all three WrappedBTH roles (admin/minter/pauser), owned by the three `BRIDGE_SAFE_OWNER_{1,2,3}` EOAs (maintainer-ratified). The deployer only pays gas and receives NO roles (ADR 0002).

## Changes

- **dotenv auto-load** — `contracts/ethereum/hardhat.config.ts` now `import "dotenv/config"`, so the git-ignored `contracts/ethereum/.env` (`PRIVATE_KEY`, `SEPOLIA_RPC_URL`, `ETHERSCAN_API_KEY`, `BRIDGE_SAFE_OWNER_*`, `WBTH_*_SAFE`) auto-resolves without `source`. Added `dotenv` devDependency (+ package-lock) and a `fork` network (`BRIDGE_FORK_RPC_URL`) for dry-runs.
- **`scripts/deploy-safe.ts`** — deploys ONE 2-of-3 Safe by calling the **canonical Safe v1.3.0** `SafeProxyFactory.createProxyWithNonce(singleton, Safe.setup(owners, 2, 0x0, 0x, handler, 0x0, 0, 0x0), saltNonce)` directly (no SDK / no Safe service dependency). Bytecode-verifies the pinned addresses before deploying, self-asserts `getOwners()`/`getThreshold()`, prints `SAFE_ADDRESS=`. Idempotent-ish via `SAFE_ADDRESS`. Exported `deploySafe()` for chaining.
- **`scripts/deploy-all.ts`** — chains deploy-safe → wires the one Safe as admin/minter/pauser → deploys WrappedBTH (reusing the existing `deploy.ts` constructor shape, which is untouched) → prints Etherscan links + a `hardhat verify` command.
- **`scripts/deploy-safe-fork-test.sh`** — drives the whole bring-up against an `anvil --fork-url <sepolia>` fork, `anvil_setBalance`-funded (no real ETH, no secret), asserting Safe owners/threshold and wBTH roles via `cast`.
- **Runbook** — `docs/bridge/testnet-e2e-runbook.md` Phase B.1: fork-test first, then the exact live-Sepolia command sequence.
- Convenience npm scripts `deploy:safe:sepolia` / `deploy:all:sepolia`.

### Safe-deploy approach: direct canonical factory (not the SDK)

Pinned Safe **v1.3.0** addresses (identical mainnet/Sepolia, from `safe-global/safe-deployments`, "canonical"), each **verified live on Sepolia** to have deployed bytecode via `cast code`:

| Contract | Address |
|---|---|
| SafeProxyFactory v1.3.0 | `0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2` |
| GnosisSafe (L1) singleton v1.3.0 | `0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552` |
| CompatibilityFallbackHandler v1.3.0 | `0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4` |

All overridable via env (`SAFE_PROXY_FACTORY_ADDRESS` / `SAFE_SINGLETON_ADDRESS` / `SAFE_FALLBACK_HANDLER_ADDRESS`). Threshold **2**, owners = the three `BRIDGE_SAFE_OWNER_*` EOAs.

## Fork-test result (the proof, no real ETH)

`./scripts/deploy-safe-fork-test.sh https://ethereum-sepolia-rpc.publicnode.com` → **FORK TEST PASSED**:

- Fork chain id `11155111`; deployer funded via `anvil_setBalance`.
- 2-of-3 Safe deployed; `getThreshold() = 2`, `getOwners()` = the three owner EOAs (asserted in-script AND via `cast`).
- WrappedBTH deployed with the Safe as admin/minter/pauser; `hasRole(admin|minter|pauser, safe) = true`, deployer holds no admin role.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| hardhat auto-loads `.env` (dotenv); PRIVATE_KEY/RPC/ETHERSCAN resolve | ✅ | Ran a throwaway-`.env` check script: all vars present, signer address derived correctly, temp files removed |
| `deploy-safe.ts` deploys a 2-of-3 Safe from the owner EOAs, prints Safe address; verified against a Sepolia fork | ✅ | Fork test deployed `0xF425…b906`, owners+threshold asserted via cast |
| Documented flow: safe → `.env` WBTH_*_SAFE → `deploy.ts` → Etherscan verify | ✅ | Runbook Phase B.1.b + `deploy-all.ts` |
| Runbook (Phase B) updated with exact live-run commands | ✅ | `docs/bridge/testnet-e2e-runbook.md` Phase B.1 |
| No secrets printed/committed | ✅ | Deployer key read only from git-ignored `.env`; diff has no `.env`/keys — only the public foundry anvil dev key in the fork script |

## Test Plan

- `npx hardhat compile` — clean.
- `npx hardhat test` — **39 passing** (unchanged).
- `./scripts/deploy-safe-fork-test.sh <public sepolia rpc>` — FORK TEST PASSED.
- dotenv load verified; temp `.env`/check-script removed; `git status` confirms none tracked.

No secrets in the diff (verified: only the well-known public anvil dev key + the zero role hash appear).

Closes #1011