### PR TITLE
chore(bridge): address PR #1014 judge follow-ups (#1015/#1016/#1017)

### DIFF
--- a/.github/workflows/solana-contracts-ci.yml
+++ b/.github/workflows/solana-contracts-ci.yml
@@ -112,12 +112,11 @@ jobs:
         with:
           node-version: 22
 
-      # No JS lockfile is committed under contracts/solana/, so `npm ci` (which
-      # requires one) cannot be used here; `npm install` tolerates its absence.
-      # If a package-lock.json is committed later, switch to `npm ci` + npm
-      # cache for parity with contracts-ci.yml (#861).
+      # `contracts/solana/package-lock.json` is committed (#1014), so use
+      # `npm ci` for a deterministic, lockfile-pinned install that never
+      # rewrites the lock (parity with contracts-ci.yml, #861/#1016).
       - name: Install JS dependencies
-        run: npm install
+        run: npm ci
 
       # `anchor test` uses ~/.config/solana/id.json as the provider wallet
       # (Anchor.toml [provider].wallet) and funds it from the spawned validator.

--- a/contracts/ethereum/scripts/live-defi-roundtrip.ts
+++ b/contracts/ethereum/scripts/live-defi-roundtrip.ts
@@ -40,6 +40,15 @@ const WBTH_LIQ = 100_000_000_000_000_000n; // 10^17 pico = 100,000 wBTH
 const WETH_LIQ = 100_000_000_000_000_000n; // 10^17 wei  = 0.1 WETH
 const SWAP_IN = 10_000_000_000_000_000n; //   10^16 wei  = 0.01 WETH
 const FEE = 3000; // 0.30% tier
+
+// Slippage bounds. Zero is safe HERE only because this script is Sepolia-only
+// (chainId guard below) and seeds a fresh, empty pool where there is no MEV to
+// sandwich. A mainnet port MUST set non-zero bounds (#1017): SLIPPAGE_BPS
+// clamps the liquidity add against amount*Desired, and SWAP_MIN_OUT sets the
+// swap's amountOutMinimum (best derived from a live Quoter quote off-chain).
+const SLIPPAGE_BPS = BigInt(process.env.SLIPPAGE_BPS ?? "0"); // 0 = no bound
+const SWAP_MIN_OUT = BigInt(process.env.SWAP_MIN_OUT ?? "0"); // wBTH base units
+const minBound = (desired: bigint) => (desired * (10_000n - SLIPPAGE_BPS)) / 10_000n;
 const TICK_SPACING = 60; // fee 3000 -> spacing 60
 const LP_ETH_FUND = ethers.parseEther("0.3"); // WETH (0.11) + gas headroom
 const WETH_WRAP = WETH_LIQ + SWAP_IN; // 0.11 WETH total the LP needs
@@ -231,7 +240,7 @@ async function main() {
   const mintParams = {
     token0, token1, fee: FEE, tickLower, tickUpper,
     amount0Desired: amount0, amount1Desired: amount1,
-    amount0Min: 0n, amount1Min: 0n,
+    amount0Min: minBound(amount0), amount1Min: minBound(amount1),
     recipient: lp.address, deadline: BigInt(2n ** 63n),
   };
   const sim = await npm.mint.staticCall(mintParams);
@@ -247,7 +256,7 @@ async function main() {
   const wbthBeforeSwap = await wbth.balanceOf(lp.address);
   const swapParams = {
     tokenIn: UNI.weth, tokenOut: WBTH, fee: FEE, recipient: lp.address,
-    amountIn: SWAP_IN, amountOutMinimum: 0n, sqrtPriceLimitX96: 0n,
+    amountIn: SWAP_IN, amountOutMinimum: SWAP_MIN_OUT, sqrtPriceLimitX96: 0n,
   };
   await waitTx("exactInputSingle", router.exactInputSingle(swapParams));
   const wbthAfterSwap = await wbth.balanceOf(lp.address);

--- a/contracts/solana/Anchor.toml
+++ b/contracts/solana/Anchor.toml
@@ -8,8 +8,10 @@ wbth = "CZDnzeywrqEM5ereWJmtYKUQ9uJXxX2PydqqKTQStxxE"
 [programs.devnet]
 wbth = "CZDnzeywrqEM5ereWJmtYKUQ9uJXxX2PydqqKTQStxxE"
 
-[programs.mainnet]
-wbth = "CZDnzeywrqEM5ereWJmtYKUQ9uJXxX2PydqqKTQStxxE"
+# [programs.mainnet] is intentionally omitted — no mainnet deploy exists yet.
+# Add it back with the REAL mainnet program id at mainnet-deploy time; do not
+# copy the devnet id here (it would misdirect `anchor deploy --provider.cluster
+# mainnet`). localnet keeps the devnet id only so `anchor test` resolves.
 
 [registry]
 url = "https://api.apr.dev"

--- a/contracts/solana/package-lock.json
+++ b/contracts/solana/package-lock.json
@@ -1046,6 +1046,13 @@
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
       "license": "MIT"
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -2125,7 +2132,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/contracts/solana/scripts/devnet-orca-pool.ts
+++ b/contracts/solana/scripts/devnet-orca-pool.ts
@@ -30,6 +30,9 @@ const SOL_DECIMALS = 9;
 // with tens of thousands of wBTH from the 100k we minted.
 const INIT_PRICE = new Decimal("0.000001");
 const SECRETS = path.resolve(__dirname, "../../../.secrets/bridge-testnet");
+// Slippage bound for liquidity add + swap (#1017). Default 1% for devnet; a
+// mainnet run should tune this and derive tight min-outs from the live quote.
+const SLIPPAGE = Percentage.fromFraction(Number(process.env.SLIPPAGE_BPS ?? "100"), 10_000);
 
 function load(name: string): Keypair {
   return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(fs.readFileSync(path.join(SECRETS, `${name}.json`), "utf8"))));
@@ -101,7 +104,7 @@ async function main() {
     sqrtPrice: data.sqrtPrice,
     tickLowerIndex: lower,
     tickUpperIndex: upper,
-    slippageTolerance: Percentage.fromFraction(1, 100),
+    slippageTolerance: SLIPPAGE,
     tokenExtensionCtx: NO_TOKEN_EXTENSION_CONTEXT,
   });
   console.log(`   quote: tokenA max ${quote.tokenMaxA.toString()}, tokenB max ${quote.tokenMaxB.toString()}`);
@@ -114,7 +117,7 @@ async function main() {
   const refreshed = await client.getPool(poolPda.publicKey);
   const swapIn = DecimalUtil.toBN(new Decimal("0.005"), SOL_DECIMALS);
   const swapQuote = await swapQuoteByInputToken(
-    refreshed, NATIVE_MINT, swapIn, Percentage.fromFraction(1, 100),
+    refreshed, NATIVE_MINT, swapIn, SLIPPAGE,
     ORCA_WHIRLPOOL_PROGRAM_ID, ctx.fetcher, undefined,
   );
   console.log(`   estimated out ${swapQuote.estimatedAmountOut.toString()} (of wBTH mint)`);

--- a/contracts/solana/scripts/devnet-orca-swap.ts
+++ b/contracts/solana/scripts/devnet-orca-swap.ts
@@ -42,7 +42,8 @@ async function main() {
 
   const amountIn = DecimalUtil.toBN(SWAP_WBTH, WBTH_DECIMALS);
   const quote = await swapQuoteByInputToken(
-    pool, WBTH_MINT, amountIn, Percentage.fromFraction(1, 100),
+    pool, WBTH_MINT, amountIn,
+    Percentage.fromFraction(Number(process.env.SLIPPAGE_BPS ?? "100"), 10_000), // #1017
     ORCA_WHIRLPOOL_PROGRAM_ID, ctx.fetcher, undefined,
   );
   console.log(`swap ${SWAP_WBTH} wBTH -> est ${quote.estimatedAmountOut.toString()} lamports WSOL`);


### PR DESCRIPTION
Sweeps the three non-blocking follow-ups the judge left on #1014.

- **#1015** — drop `[programs.mainnet]` from `contracts/solana/Anchor.toml`; it held the **devnet** program id (a global sed set all three clusters), which would misdirect a mainnet `anchor deploy`. Re-add with the real id at mainnet time; `[programs.localnet]` keeps the devnet id so `anchor test` resolves.
- **#1016** — switch Solana CI JS install to `npm ci` (deterministic, lockfile-pinned) and refresh the stale "no lockfile" comment. Re-synced `package-lock.json` — the original `--legacy-peer-deps` install left it missing a transitive dep (`fastestsmallesttextencoderdecoder`), which `npm ci` rejects; verified `npm ci` now passes locally.
- **#1017** — parameterize DEX slippage. Ethereum bootstrap applies `SLIPPAGE_BPS` to the Uniswap liquidity add (`amount*Min`) and `SWAP_MIN_OUT` to the swap; Orca scripts read `SLIPPAGE_BPS` (default 1%). Testnet behavior unchanged by default; mainnet must set non-zero bounds.

All operational-tooling changes; no core protocol or on-chain impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)