### PR TITLE
docs(bridge): Hyperliquid wBTH runbook + NTT config scaffold (#876)

### DIFF
--- a/contracts/wbth-ntt/README.md
+++ b/contracts/wbth-ntt/README.md
@@ -1,0 +1,53 @@
+# wbth-ntt — Wormhole NTT deployment config (Sepolia ↔ HyperEVM)
+
+Deployment tooling for bridging **wBTH** from Ethereum Sepolia to Hyperliquid's
+HyperEVM testnet via **Wormhole NTT** (issue #876). The full step-by-step,
+decimal reconciliation, trust surface, and operator gates live in
+[`docs/bridge/hyperliquid-ntt-runbook.md`](../../docs/bridge/hyperliquid-ntt-runbook.md).
+
+## What's tracked here vs. regenerated
+
+The NTT CLI works out of a standalone workspace (`ntt new` clones a Foundry
+project with its own git + submodules — too heavy to nest in this repo). That
+workspace is **regenerated on demand**; only the small, meaningful artifacts are
+tracked here:
+
+- `overrides.example.json` — the RPC overrides (Sepolia + HyperEVM testnet).
+  Copy to `overrides.json` in the workspace. The public HyperEVM RPC is
+  rate-limited (~100 req/min); swap in an Alchemy/Chainstack key for the deploy.
+- `deployment.json` — **committed after the deploy** (records the on-chain
+  NttManager/Transceiver/PeerToken addresses for reproducibility). Not present
+  until the transport hop runs.
+
+## Toolchain (recorded for reproducibility)
+
+- `ntt` CLI **v1.7.0** (installs from `main`: `curl -fsSL https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/cli/install.sh | bash`)
+- Foundry (forge) 1.7.x · Bun ≥1.2.23 · Node ≥18
+
+## Deploy sequence (gated on HyperEVM HYPE gas)
+
+```bash
+ntt new wbth-ntt && cd wbth-ntt
+ntt init Testnet
+cp <repo>/contracts/wbth-ntt/overrides.example.json overrides.json   # edit RPCs
+
+# HUB: Sepolia in LOCKING mode against the EXISTING wBTH — NttManager only locks,
+# never mints, so the 2-of-3 Safe minter and the Sepolia token stay untouched.
+ntt add-chain Sepolia --latest --mode locking \
+    --token 0x49b985ec427ee771a601f11b18f7d4402fa2dd7b
+
+# SPOKE: HyperEVM in BURNING mode (fresh PeerToken; minter = HyperEVM NttManager).
+ntt add-chain HyperEVM --latest --mode burning
+
+ntt push          # deploys + wires peers
+ntt status        # reconcile
+```
+
+> `ntt add-chain` **deploys on-chain** — it is not a local-only config step.
+> Sepolia needs the deployer's ETH (have it); HyperEVM needs **HYPE gas** and the
+> deployer opted into **big blocks** first (see the runbook's operator gates).
+> Both sides are deployed together so peering is coherent.
+
+Decimals: PeerToken 12 · HyperCore weiDecimals 8 · `--evm-extra-wei-decimals 4`;
+move only 8-decimal-aligned amounts (bridge quantum = 10,000 picocredits). See
+the runbook for the full three-layer explanation.

--- a/contracts/wbth-ntt/overrides.example.json
+++ b/contracts/wbth-ntt/overrides.example.json
@@ -1,0 +1,10 @@
+{
+  "chains": {
+    "Sepolia": {
+      "rpc": "https://ethereum-sepolia-rpc.publicnode.com"
+    },
+    "HyperEVM": {
+      "rpc": "https://rpc.hyperliquid-testnet.xyz/evm"
+    }
+  }
+}

--- a/docs/bridge/hyperliquid-ntt-runbook.md
+++ b/docs/bridge/hyperliquid-ntt-runbook.md
@@ -1,0 +1,146 @@
+# Hyperliquid wBTH Runbook — Sepolia → HyperEVM (NTT) → HIP-1 spot
+
+The testnet path that puts **wBTH** on Hyperliquid, covering issue **#876**
+(transport hop: Sepolia wBTH → HyperEVM) and **#877** (HIP-1 spot listing +
+swap demo). This is mostly ops + third-party (Wormhole / Hyperliquid) tooling,
+not core-bridge Rust.
+
+> Status: **planned** — architecture chosen, commands drafted from the current
+> (2026-07) Wormhole NTT + Hyperliquid docs. Not yet executed on testnet;
+> on-chain steps are gated on HyperEVM gas (HYPE) and, for #877, HyperCore
+> testnet USDC. Verify the flagged items live (CLI chain-name string, decimal
+> knobs) before running.
+
+## Design decision — hub/locking, keep the Safe untouched
+
+**Sepolia is the NTT hub in LOCKING mode; HyperEVM is a spoke in BURNING mode.**
+
+Why this and not burn-and-mint everywhere: locking mode requires only a
+standard ERC-20 on the hub — the NttManager **locks** wBTH via
+`transferFrom` (the user approves it) and **never needs the mint role**. So the
+2-of-3 Gnosis Safe that is wBTH's sole minter (ADR-0002) is **not modified, not
+granted to Wormhole, and the Sepolia token is not redeployed**. Burn-and-mint
+would force adding `mint`/`burn` to the Sepolia wBTH and handing the NttManager
+minter rights there — a custody regression we explicitly avoid.
+
+On HyperEVM, NTT deploys a fresh **PeerToken** (the HyperEVM-side wBTH) whose
+minter is the HyperEVM NttManager. Minting there is a bridge-internal op backed
+1:1 by the wBTH locked on Sepolia — unrelated to the Safe.
+
+```
+  Sepolia (hub, LOCKING)                         HyperEVM testnet (spoke, BURNING)
+  ┌──────────────────────┐   Wormhole VAA        ┌─────────────────────────────┐
+  │ wBTH 0x49b985ec…dd7b │  (13/19 guardians)    │ PeerToken (HyperEVM wBTH)   │
+  │ minter = 2/3 Safe    │ ───────────────────▶  │ minter = HyperEVM NttManager│
+  │ NttManager LOCKS it  │                       │ mints/burns on transfer     │
+  └──────────────────────┘                       └─────────────────────────────┘
+        Safe untouched                              ─ ntt hype link ─▶ HyperCore HIP-1 spot
+```
+
+## Chain facts (HyperEVM testnet)
+
+| Fact | Value |
+|---|---|
+| Chain id | **998** |
+| RPC | `https://rpc.hyperliquid-testnet.xyz/evm` (~100 req/min; use an Alchemy/Chainstack key for the deploy) |
+| Explorer | `https://testnet.purrsec.com/` |
+| Gas token | **HYPE** (18 decimals) |
+| Deploy Spot UI | `https://app.hyperliquid-testnet.xyz/deploySpot` |
+
+**Big blocks required to deploy.** HyperEVM small blocks cap at 2M gas — too
+small for contract deploys. Opt the deployer address into big blocks (30M) with
+the L1 action `{"type":"evmUserModify","usingBigBlocks":true}` (Hyperliquid API/
+SDK) **before** `ntt push`, or deploys silently underprovision.
+
+## Decimals — three stacked layers (highest-risk surface)
+
+wBTH is **12 decimals** (1 unit = 1 picocredit). Three precisions stack:
+1. **NTT wire trim = 8 decimals.** Cross-chain amounts are normalized to ≤8
+   decimals ⇒ bridge quantum is **1e-8 wBTH = 10,000 picocredits**. Sub-quantum
+   remainder isn't sent (in locking mode it simply stays unlocked on Sepolia —
+   not burned).
+2. **HyperEVM PeerToken `decimals()`** — a deploy-time choice. Set it
+   **explicitly to 12** to keep balances 1:1 with picocredits (document that
+   transfers quantize to 1e-8 wBTH), OR to 8 to match the bridge trim exactly.
+3. **HyperCore `weiDecimals`** via `evmExtraWeiDecimals = EVM_decimals −
+   weiDecimals` (must be in [-2, 18]; `ntt hype link` default 10 is HYPE's
+   18−8). For PeerToken=12 + weiDecimals=8 → pass `--evm-extra-wei-decimals 4`.
+   **Rounding gotcha:** HyperCore↔HyperEVM transfers **burn** any non-round
+   remainder below `evmExtraWeiDecimals` zeros. Keep all demo amounts aligned to
+   the coarsest precision (8 decimals) end to end.
+
+Recommended for the demo: PeerToken **12 decimals**, HyperCore `weiDecimals`
+**8**, `--evm-extra-wei-decimals 4`, and only ever move 8-decimal-aligned
+amounts.
+
+## #876 — command sequence (transport hop)
+
+Prereqs: Foundry (`forge`), Bun ≥1.2.23, Node/npm. Deployer key in
+`ETH_PRIVATE_KEY` (use the gitignored `.secrets/bridge-testnet/eth-deployer.key`
+account — it needs Sepolia ETH **and** HyperEVM HYPE).
+
+```bash
+# Install the NTT CLI (tracks main — record `ntt --version` in the drill log).
+curl -fsSL https://raw.githubusercontent.com/wormhole-foundation/native-token-transfers/main/cli/install.sh | bash
+ntt --version
+
+ntt new wbth-ntt && cd wbth-ntt
+ntt init Testnet
+
+# HUB = Sepolia, LOCKING, existing wBTH (no --token deploy):
+ntt add-chain Sepolia --latest --mode locking \
+    --token 0x49b985ec427ee771a601f11b18f7d4402fa2dd7b
+
+# SPOKE = HyperEVM testnet, BURNING (verify the exact chain-name string via
+# `ntt add-chain --help`; omit --token to auto-deploy a PeerToken, or deploy the
+# PeerToken with Forge first and pass --token <addr> + grant minter to manager):
+ntt add-chain <HyperEVM-testnet-name> --latest --mode burning
+
+ntt push        # deploy NttManager + WormholeTransceiver (+ PeerToken) on-chain
+ntt status      # reconcile; ntt pull to sync deployment.json
+```
+
+Permissions to verify after `push`:
+- Sepolia: NttManager needs **no token role**; users `approve` it to lock wBTH.
+- HyperEVM: PeerToken **minter == HyperEVM NttManager** (`setMinter`).
+
+Then a demo transfer (Sepolia wBTH → HyperEVM wBTH), amounts 8-decimal-aligned,
+recorded with tx links. Consider putting the Sepolia NttManager **owner** behind
+a Safe (`ntt transfer-ownership`).
+
+## #877 — HIP-1 spot listing + swap (chains off #876)
+
+1. **Deploy Spot on HyperCore** via the testnet UI (`/deploySpot`) — irreversible,
+   consumes HyperCore testnet USDC: set `szDecimals`/`weiDecimals` with
+   `szDecimals + 5 <= weiDecimals`; save the **Token Index**; genesis-mint supply
+   to the asset-bridge address `0x2000…0{tokenIndex:4-hex}`; RegisterSpot; deploy
+   Hyperliquidity; trigger genesis.
+2. **Link** HyperCore spot ↔ HyperEVM PeerToken:
+   `ntt hype link --token-index <IDX> --evm-extra-wei-decimals <N>`.
+3. **Bridge + trade:** `ntt hype bridge-in/out`, then a spot order-book swap vs
+   spot USDC (API/SDK), capturing order/fill ids + balances.
+
+## Trust surface (added by NTT)
+
+- **Wormhole Guardians (13/19 quorum):** ≥13 malicious guardians could mint
+  unbacked HyperEVM wBTH; ≥7 could censor. This is the core added trust vs. our
+  own Safe federation.
+- **NttManager owner keys** (per chain) can reconfigure peers/thresholds/rate
+  limits and pause — put them behind a Safe.
+- **HyperEVM PeerToken minter = NttManager** — on HyperEVM, bridge security *is*
+  the token's mint authority. Sepolia adds **no** new mint trust (locking).
+- Set inbound/outbound **rate limits** in `deployment.json` so a demo doesn't
+  silently queue.
+
+## Operator gates (need a human)
+
+- [ ] HyperEVM **HYPE** gas for the deployer (third-party faucet — Chainstack/
+      QuickNode; the official faucet gates on a prior mainnet deposit).
+- [ ] Opt the deployer into **big blocks** before deploying.
+- [ ] (#877) HyperCore testnet **USDC** for Deploy Spot (official faucet, same
+      mainnet-deposit gate) + the irreversible UI flow.
+
+## Sources
+Wormhole NTT: deploy-to-hyperliquid, deploy-to-evm, cli-commands, get-started,
+overview, faqs. Hyperliquid: hyperevm, dual-block-architecture,
+hypercore↔hyperevm transfers, HIP-1. (Full URLs in the #876 research thread.)


### PR DESCRIPTION
Part 1 of #876 — the architecture, runbook, and NTT deployment config for bridging wBTH from Sepolia to Hyperliquid's HyperEVM testnet. Docs + config only; the on-chain deploy is a HYPE-gated follow-up.

## Design decision (custody-safe)
**Sepolia = NTT hub in LOCKING mode; HyperEVM = spoke in BURNING mode.** Locking means the NttManager only *locks* wBTH (users approve it) and never needs the mint role — so the **2-of-3 Gnosis Safe minter and the Sepolia token are untouched**, and the token is not redeployed. HyperEVM gets a fresh PeerToken (minter = HyperEVM NttManager), backed 1:1 by locked Sepolia wBTH. Burn-and-mint would force adding mint/burn to the Sepolia wBTH and handing the manager minter rights — a custody regression we avoid.

## Contents
- `docs/bridge/hyperliquid-ntt-runbook.md` — full command flow (#876 + downstream #877), the **three-layer decimal reconciliation** (NTT's 8-dec trim → PeerToken `decimals()` → HyperCore `weiDecimals`, with burn-on-non-round), the **Wormhole guardian trust surface** (13/19 quorum), and the **operator gates** (HYPE gas, big-blocks opt-in, HyperCore USDC for Deploy Spot).
- `contracts/wbth-ntt/` — `overrides.example.json` (Sepolia + HyperEVM RPCs) + README recording the toolchain (ntt v1.7.0, Foundry, Bun) and the deploy sequence.

## Not included (follow-up)
The on-chain deploy — `ntt add-chain Sepolia --mode locking --token 0x49b985…` + `ntt add-chain HyperEVM --mode burning` + `ntt push` — is gated on HyperEVM **HYPE** gas for the deployer + big-blocks opt-in. `deployment.json` (with the deployed addresses) gets committed after that runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)