### PR TITLE
fix(build): make BUILD_TIME honor SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,13 @@ junit*
 **/cargo/
 **/cmake-build-debug/
 
+# Reproducible release build scratch dirs (scripts/build-release.sh).
+# These live at the repo root and would otherwise show as untracked, marking
+# the working tree "dirty" and mislabeling tagged release binaries as
+# "<hash>-dirty" (see botho/build.rs and #996).
+/target-release/
+/.cargo-home/
+
 # Coverage reports
 coverage-report/
 

--- a/botho/build.rs
+++ b/botho/build.rs
@@ -37,8 +37,24 @@ fn main() {
         git_hash_short.to_string()
     };
 
-    // Get build timestamp
-    let build_time = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    // Get build timestamp.
+    //
+    // For reproducible release builds we must NOT embed the wall-clock time:
+    // two builds of the same commit happen at different instants, so a
+    // `chrono::Utc::now()` timestamp bakes a different string into the binary
+    // and breaks byte-for-byte reproducibility (the Reproducibility Check job
+    // in release.yml compares the original build against a rebuild — see #996).
+    //
+    // Honor SOURCE_DATE_EPOCH (a Unix timestamp) when set, which the reproducible
+    // build script exports from the git commit time. This makes BUILD_TIME a pure
+    // function of the source commit. Fall back to the current time for ordinary
+    // developer builds where SOURCE_DATE_EPOCH is unset.
+    let build_time = std::env::var("SOURCE_DATE_EPOCH")
+        .ok()
+        .and_then(|epoch| epoch.trim().parse::<i64>().ok())
+        .and_then(|secs| chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0))
+        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+        .unwrap_or_else(|| chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string());
 
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
     println!("cargo:rustc-env=GIT_HASH_SHORT={}", git_hash_display);
@@ -47,4 +63,6 @@ fn main() {
     // Rerun if git HEAD changes
     println!("cargo:rerun-if-changed=../.git/HEAD");
     println!("cargo:rerun-if-changed=../.git/index");
+    // Rebuild when the reproducibility pin changes so BUILD_TIME stays in sync.
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
 }


### PR DESCRIPTION
## Summary

The `release.yml` **Reproducibility Check** job failed on the v0.6.0 tag (and prior tags) even though every platform artifact published correctly. Root cause: `botho/build.rs` embedded `chrono::Utc::now()` as the `BUILD_TIME` compile-time env. The two builds the check compares (the matrix `build` job vs. the `reproducibility-check` rebuild) run at different wall-clock instants, so each baked a *different* timestamp string into the `botho` binary — different bytes, different SHA256, `MISMATCH`.

This was a genuine build-determinism defect, not an over-strict check. The other two shipped binaries (`botho-wallet`, `botho-exchange-scanner`) have no `build.rs` timestamp and were already reproducible; only `botho` mismatched.

## Changes

- **`botho/build.rs`**: `BUILD_TIME` now honors `SOURCE_DATE_EPOCH` when set — `scripts/build-release.sh` already exports it from the git commit time (`git log -1 --format=%ct`). This makes `BUILD_TIME` a pure function of the source commit. Wall-clock `Utc::now()` is retained as the fallback for ordinary developer builds. Added `cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH` so the pin is respected on change.
- **`.gitignore`**: ignore the reproducible-build scratch dirs `/target-release/` and `/.cargo-home/`. `build-release.sh` creates these at the repo root; `**/target/` does not match `target-release`, so they showed as untracked, marking the tree dirty and mislabeling tagged release binaries as `<hash>-dirty` via the `git status --porcelain` check in `build.rs`.

## Root Cause

`chrono::Utc::now()` in `build.rs` is evaluated at compile time. `SOURCE_DATE_EPOCH` is the standard reproducible-builds mechanism for pinning build timestamps; the release script set it but nothing consumed it. Now `build.rs` consumes it.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Identify what differs between the two reproducibility builds | ✅ | `BUILD_TIME` embedded via `chrono::Utc::now()` differs per build instant |
| Fix build determinism OR relax the check | ✅ | Fixed determinism (correct fix): `build.rs` now honors `SOURCE_DATE_EPOCH` |
| Build still compiles | ✅ | `cargo check -p botho` → `Finished dev profile` (34.5s) |
| BUILD_TIME deterministic under the release script | ✅ | See Test Plan below |

## Test Plan

Forced `build.rs` to rerun and inspected the emitted `BUILD_TIME` (via `cargo check -vv`):

- Run 1 — `SOURCE_DATE_EPOCH=<commit epoch>` → `BUILD_TIME=2026-07-16T16:54:41Z`
- Run 2 — same `SOURCE_DATE_EPOCH`, wall clock ~2s later → `BUILD_TIME=2026-07-16T16:54:41Z` (identical)
- Run 3 — no `SOURCE_DATE_EPOCH` (dev fallback) → `BUILD_TIME=2026-07-16T17:54:32Z` (wall clock, the pre-fix behavior)

Runs 1 and 2 prove `BUILD_TIME` is now independent of wall-clock time and equal to the git commit time under the release script, which is exactly what makes the two CI builds byte-identical.

## What remains CI-gated

I verified the determinism of the `BUILD_TIME` env at the `build.rs` level, not a full byte-for-byte SHA256 match of two complete release binaries (that requires the RandomX C++/cmake release build twice, impractical to fully reproduce in this environment). Final confirmation that the **Reproducibility Check** job goes green requires a tagged run (or a `workflow_dispatch` run of `release.yml`) on a commit containing this fix. Based on the root-cause analysis, `BUILD_TIME` was the sole non-deterministic input to the `botho` binary, so this is expected to resolve the mismatch — but it should be confirmed on the next release tag.

Closes #996