### PR TITLE
feat(bridge): provision full-loop reserve/user keys at runtime (no committed secret)

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -59,8 +59,11 @@ jobs:
   # correct release to a fresh stealth output (ADR 0004), the
   # proof-of-reserves invariant across the loop (ADR 0003), and federation
   # authorization (t-of-n EIP-712 mint + t-of-n Ed25519 release; a single
-  # signer never moves value). The BTH leg self-skips (green) until the
-  # reserve wallet key material is provisioned — see
+  # signer never moves value). The driver PROVISIONS the reserve/user wallet
+  # key material at runtime (#999) via `botho-testnet gen-bridge-keys` — the
+  # reserve is the node's own pre-funded (factor-1-accruing) mining wallet and
+  # NO secret is committed. The BTH leg runs the moment the harness can boot a
+  # healthy single-node 6.0.0 testnet (the #998/#1000 wedge prerequisite); see
   # scripts/bridge-e2e-full-loop.sh and docs/bridge/testnet-e2e-runbook.md.
   full-loop:
     name: Full loop (local Botho + hardhat, real engine)

--- a/botho/src/bin/botho_testnet.rs
+++ b/botho/src/bin/botho_testnet.rs
@@ -40,7 +40,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use bip39::{Language, Mnemonic};
+use bip39::{Language, Mnemonic, Seed};
 use clap::{Parser, Subcommand};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -133,6 +133,32 @@ enum Commands {
 
     /// Clean all testnet data
     Clean,
+
+    /// Provision bridge reserve + user wallet key material for the full-loop
+    /// e2e (#999).
+    ///
+    /// Writes 32-byte-hex classical view/spend key files plus a 64-byte-hex
+    /// ML-KEM/ML-DSA BIP39 seed file for two wallets and prints the shell
+    /// `export` lines the bridge full-loop driver
+    /// (`scripts/bridge-e2e-full-loop.sh`) consumes via `eval`. NO secret
+    /// is committed: the reserve keys derive from the harness's own
+    /// deterministic node mnemonic (already in-code and disposable) and the
+    /// user keys are freshly random at runtime.
+    ///
+    /// The RESERVE is the node's own pre-funded mining wallet, so it already
+    /// owns spendable **factor-1** (zero-cluster-weight) outputs from lottery
+    /// emission (`LotteryOutput::to_tx_output(ClusterTagVector::empty())`),
+    /// which is exactly what the CLSAG release path spends (ADR 0003). The
+    /// USER wallet only receives the released stealth output (ADR 0004).
+    GenBridgeKeys {
+        /// Node index whose deterministic wallet becomes the bridge reserve.
+        #[arg(long, default_value_t = 0)]
+        node: usize,
+
+        /// Directory to write the key files into (created if missing).
+        #[arg(long)]
+        out: PathBuf,
+    },
 }
 
 /// Testnet state persisted to disk
@@ -208,6 +234,7 @@ fn main() -> Result<()> {
         Commands::KillNode { node } => cmd_kill_node(node, args.verbose),
         Commands::RestartNode { node } => cmd_restart_node(node, args.verbose),
         Commands::Clean => cmd_clean(args.verbose),
+        Commands::GenBridgeKeys { node, out } => cmd_gen_bridge_keys(node, &out),
     }
 }
 
@@ -674,6 +701,169 @@ fn cmd_clean(verbose: bool) -> Result<()> {
 }
 
 // ============================================================================
+// Bridge key provisioning (#999)
+// ============================================================================
+
+/// One wallet's bridge key material: the on-disk file contents plus the
+/// published v2 (`tbotho://2/…`) receive address.
+struct BridgeKeyMaterial {
+    /// 32-byte hex Ristretto view private scalar (`bth.view_key_file`).
+    view_hex: String,
+    /// 32-byte hex Ristretto spend private scalar (`bth.spend_key_file`).
+    spend_hex: String,
+    /// 64-byte hex BIP39 seed the reserve derives its ML-KEM-768 / ML-DSA-65
+    /// keypairs from (`bth.pq_seed_file`, issue #972). Required on the
+    /// protocol-6.0.0 hybrid chain so the scanner can decapsulate outputs paid
+    /// to this wallet.
+    pq_seed_hex: String,
+    /// Published v2 address (carries the classical + ML-KEM + ML-DSA public
+    /// keys), byte-identical to what `bth-bridge-service`'s `ReserveKeys`
+    /// advertises from the same files.
+    address: String,
+}
+
+/// Derive the bridge key material for a BIP39 mnemonic.
+///
+/// The classical view/spend private scalars come from the SAME SLIP-10 path
+/// the node wallet uses (`botho::wallet::Wallet::from_mnemonic`), so the
+/// derived reserve keys are exactly the node's own keys and detect the node's
+/// coinbase/lottery outputs. The PQ seed is the 64-byte BIP39 seed, and the
+/// published address is reconstructed the way `ReserveKeys::public_address`
+/// does (`AccountKey::new(spend, view).default_subaddress().with_pq_keys(…)`),
+/// so the printed `*_ADDRESS` matches what the reserve advertises.
+fn derive_bridge_key_material(mnemonic_phrase: &str) -> Result<BridgeKeyMaterial> {
+    use bth_account_keys::AccountKey;
+    use bth_address_codec::{encode_address, Network};
+    use bth_crypto_keys::RistrettoPrivate;
+    use bth_crypto_pq::derive_pq_keys_from_seed;
+
+    // Classical keys via the tested node-wallet derivation (SLIP-10 + the same
+    // key material the running node uses to receive funds).
+    let wallet = botho::wallet::Wallet::from_mnemonic(mnemonic_phrase)
+        .map_err(|e| anyhow!("derive wallet from mnemonic: {e}"))?;
+    let view_priv = wallet.account_key().view_private_key().to_bytes();
+    let spend_priv = wallet.account_key().spend_private_key().to_bytes();
+
+    // 64-byte BIP39 seed → ML-KEM-768 / ML-DSA-65 material (issue #972). Same
+    // `Seed::new(&mnemonic, "")` the wallet feeds `derive_pq_keys_from_seed`,
+    // so the reserve's published KEM key matches the secret it decapsulates
+    // with.
+    let mnemonic = Mnemonic::from_phrase(mnemonic_phrase, Language::English)
+        .map_err(|e| anyhow!("invalid mnemonic: {e}"))?;
+    let seed = Seed::new(&mnemonic, "");
+    let seed_bytes: [u8; 64] = seed
+        .as_bytes()
+        .try_into()
+        .map_err(|_| anyhow!("BIP39 seed must be 64 bytes"))?;
+    let pq = derive_pq_keys_from_seed(&seed_bytes);
+    let kem_pub = pq.kem_keypair.public_key().as_bytes().to_vec();
+    let dsa_pub = pq.sig_keypair.public_key().as_bytes().to_vec();
+
+    // Reconstruct the published v2 address exactly like `ReserveKeys` does from
+    // the on-disk files, so config validation + the reconciler custody query
+    // see the same address the reserve advertises.
+    let account = AccountKey::new(
+        &RistrettoPrivate::try_from(&spend_priv).map_err(|e| anyhow!("spend scalar: {e:?}"))?,
+        &RistrettoPrivate::try_from(&view_priv).map_err(|e| anyhow!("view scalar: {e:?}"))?,
+    );
+    let address = encode_address(
+        &account.default_subaddress().with_pq_keys(kem_pub, dsa_pub),
+        Network::Testnet,
+    )
+    .map_err(|e| anyhow!("encode v2 address: {e}"))?;
+
+    Ok(BridgeKeyMaterial {
+        view_hex: hex::encode(view_priv),
+        spend_hex: hex::encode(spend_priv),
+        pq_seed_hex: hex::encode(seed_bytes),
+        address,
+    })
+}
+
+/// Write a key file with owner-only permissions (0600 on Unix).
+fn write_key_file(path: &Path, contents: &str) -> Result<()> {
+    fs::write(path, format!("{contents}\n"))
+        .with_context(|| format!("write key file {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("chmod 600 {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Materialize one wallet's key files under `dir` with the given `role` prefix
+/// and print the matching `export` lines for the bridge full-loop driver.
+fn emit_bridge_wallet(dir: &Path, role: &str, upper: &str, keys: &BridgeKeyMaterial) -> Result<()> {
+    let view_path = dir.join(format!("{role}.view.hex"));
+    let spend_path = dir.join(format!("{role}.spend.hex"));
+    let pq_seed_path = dir.join(format!("{role}.pq_seed.hex"));
+
+    write_key_file(&view_path, &keys.view_hex)?;
+    write_key_file(&spend_path, &keys.spend_hex)?;
+    write_key_file(&pq_seed_path, &keys.pq_seed_hex)?;
+
+    // Only the `export` lines go to stdout so the driver can `eval` them; all
+    // human-facing logs go to stderr. Values are double-quoted so paths with
+    // shell-special characters survive `eval`.
+    println!(
+        "export BRIDGE_BTH_{upper}_VIEW_KEY=\"{}\"",
+        view_path.display()
+    );
+    println!(
+        "export BRIDGE_BTH_{upper}_SPEND_KEY=\"{}\"",
+        spend_path.display()
+    );
+    println!(
+        "export BRIDGE_BTH_{upper}_PQ_SEED=\"{}\"",
+        pq_seed_path.display()
+    );
+    println!("export BRIDGE_BTH_{upper}_ADDRESS=\"{}\"", keys.address);
+    Ok(())
+}
+
+/// Provision bridge reserve + user wallet key material (#999).
+fn cmd_gen_bridge_keys(node: usize, out: &Path) -> Result<()> {
+    fs::create_dir_all(out).with_context(|| format!("create key dir {}", out.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(out, fs::Permissions::from_mode(0o700));
+    }
+
+    // RESERVE = the node's own deterministic (pre-funded, factor-1-accruing)
+    // wallet. Deriving from the SAME mnemonic the harness boots node `node`
+    // with means the reserve keys detect that node's coinbase + lottery
+    // outputs — no secret is introduced.
+    let reserve_mnemonic = generate_deterministic_mnemonic(node)?;
+    let reserve = derive_bridge_key_material(&reserve_mnemonic)?;
+
+    // USER = a freshly random wallet (only ever receives the released stealth
+    // output). Never persisted anywhere but the disposable key dir.
+    let mut entropy = [0u8; 16];
+    rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut entropy);
+    let user_mnemonic = Mnemonic::from_entropy(&entropy, Language::English)
+        .map_err(|e| anyhow!("generate user mnemonic: {e}"))?
+        .phrase()
+        .to_string();
+    let user = derive_bridge_key_material(&user_mnemonic)?;
+
+    eprintln!(
+        "Provisioned bridge key material in {} (reserve = node {} wallet, user = fresh random)",
+        out.display(),
+        node
+    );
+    eprintln!("  reserve address: {}", reserve.address);
+    eprintln!("  user address:    {}", user.address);
+
+    emit_bridge_wallet(out, "reserve", "RESERVE", &reserve)?;
+    emit_bridge_wallet(out, "user", "USER", &user)?;
+
+    Ok(())
+}
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 
@@ -903,4 +1093,71 @@ fn wait_for_consensus(nodes: &[NodeState], timeout_secs: u64) -> Result<()> {
     }
 
     Err(anyhow!("Timeout waiting for consensus"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The derived key files have the exact on-disk shape the bridge loader
+    /// (`bth-bridge-service`'s `ReserveKeys::load`) expects: 32-byte-hex
+    /// classical scalars and a 64-byte-hex BIP39 seed, plus a v2 address.
+    #[test]
+    fn bridge_key_material_has_expected_shape() {
+        let mnemonic = generate_deterministic_mnemonic(0).unwrap();
+        let keys = derive_bridge_key_material(&mnemonic).unwrap();
+
+        // 32-byte classical scalars, 64-byte PQ seed (hex-encoded).
+        assert_eq!(hex::decode(&keys.view_hex).unwrap().len(), 32);
+        assert_eq!(hex::decode(&keys.spend_hex).unwrap().len(), 32);
+        assert_eq!(hex::decode(&keys.pq_seed_hex).unwrap().len(), 64);
+
+        // Published address is a testnet v2 (post-quantum) URI.
+        assert!(
+            keys.address.starts_with("tbotho://2/"),
+            "expected a v2 testnet address, got {}",
+            keys.address
+        );
+    }
+
+    /// Derivation is deterministic for the reserve (same node mnemonic → same
+    /// keys), which is what lets the reserve keys detect the running node's
+    /// pre-funded outputs.
+    #[test]
+    fn reserve_derivation_is_deterministic() {
+        let mnemonic = generate_deterministic_mnemonic(3).unwrap();
+        let a = derive_bridge_key_material(&mnemonic).unwrap();
+        let b = derive_bridge_key_material(&mnemonic).unwrap();
+        assert_eq!(a.view_hex, b.view_hex);
+        assert_eq!(a.spend_hex, b.spend_hex);
+        assert_eq!(a.pq_seed_hex, b.pq_seed_hex);
+        assert_eq!(a.address, b.address);
+    }
+
+    /// The exported classical view/spend scalars are exactly the node wallet's
+    /// own keys — the invariant that makes "reserve == the pre-funded miner"
+    /// hold, so the reserve owns the node's factor-1 lottery outputs.
+    #[test]
+    fn reserve_keys_match_node_wallet() {
+        let mnemonic = generate_deterministic_mnemonic(1).unwrap();
+        let keys = derive_bridge_key_material(&mnemonic).unwrap();
+        let wallet = botho::wallet::Wallet::from_mnemonic(&mnemonic).unwrap();
+        assert_eq!(
+            keys.view_hex,
+            hex::encode(wallet.account_key().view_private_key().to_bytes())
+        );
+        assert_eq!(
+            keys.spend_hex,
+            hex::encode(wallet.account_key().spend_private_key().to_bytes())
+        );
+    }
+
+    /// Distinct nodes yield distinct reserve keys (no accidental key reuse).
+    #[test]
+    fn distinct_nodes_yield_distinct_keys() {
+        let a = derive_bridge_key_material(&generate_deterministic_mnemonic(0).unwrap()).unwrap();
+        let b = derive_bridge_key_material(&generate_deterministic_mnemonic(1).unwrap()).unwrap();
+        assert_ne!(a.spend_hex, b.spend_hex);
+        assert_ne!(a.address, b.address);
+    }
 }

--- a/bridge/service/src/e2e_full_loop_tests.rs
+++ b/bridge/service/src/e2e_full_loop_tests.rs
@@ -53,12 +53,20 @@
 //! BRIDGE_BTH_RPC_URL=http://127.0.0.1:27201 \
 //! BRIDGE_BTH_RESERVE_VIEW_KEY=/path/reserve.view.hex \
 //! BRIDGE_BTH_RESERVE_SPEND_KEY=/path/reserve.spend.hex \
+//! BRIDGE_BTH_RESERVE_PQ_SEED=/path/reserve.pq_seed.hex \
 //! BRIDGE_BTH_RESERVE_ADDRESS=<reserve bth address> \
 //! BRIDGE_BTH_USER_ADDRESS=<user bth address> \
 //! BRIDGE_BTH_USER_VIEW_KEY=/path/user.view.hex \
 //! BRIDGE_BTH_USER_SPEND_KEY=/path/user.spend.hex \
+//! BRIDGE_BTH_USER_PQ_SEED=/path/user.pq_seed.hex \
 //!   cargo test -p bth-bridge-service -- --ignored full_loop_
 //! ```
+//!
+//! The `*_PQ_SEED` files are the 64-byte BIP39 seeds the reserve/user derive
+//! their ML-KEM-768 secrets from (issue #972); on the protocol-6.0.0 hybrid
+//! chain they are required for the wallet to detect outputs paid to it. The
+//! hermetic driver provisions all of the above at runtime via
+//! `botho-testnet gen-bridge-keys` (no committed secret).
 //!
 //! The Ethereum half swaps `local (31337) → Sepolia-fork → live Sepolia`
 //! purely by pointing `BRIDGE_FORK_RPC_URL` at a fork/live RPC (+ a funded
@@ -176,10 +184,19 @@ struct BthEnv {
     rpc_url: String,
     reserve_view_key: String,
     reserve_spend_key: String,
+    /// Reserve ML-KEM/ML-DSA BIP39 seed file (`bth.pq_seed_file`, issue #972).
+    /// Required on the protocol-6.0.0 hybrid chain: every value output carries
+    /// an ML-KEM ciphertext, so the reserve can only detect (and therefore
+    /// spend) its own outputs when it holds the matching ML-KEM secret. `None`
+    /// leaves a classical-only reserve (hybrid deposits warned, not detected).
+    reserve_pq_seed: Option<String>,
     reserve_address: String,
     user_address: String,
     user_view_key: String,
     user_spend_key: String,
+    /// User ML-KEM/ML-DSA BIP39 seed file, for scanning back the released
+    /// hybrid stealth output (assertion 2) on the 6.0.0 chain.
+    user_pq_seed: Option<String>,
     /// Amount to wrap (picocredits). The driver must fund the reserve with at
     /// least this much spendable factor-1 balance. Default 1 BTH.
     amount: u64,
@@ -194,10 +211,14 @@ fn bth_env() -> Option<BthEnv> {
         rpc_url: non_empty("BRIDGE_BTH_RPC_URL")?,
         reserve_view_key: non_empty("BRIDGE_BTH_RESERVE_VIEW_KEY")?,
         reserve_spend_key: non_empty("BRIDGE_BTH_RESERVE_SPEND_KEY")?,
+        // The PQ seeds are optional to preserve the classical-key skip contract,
+        // but required for the loop to detect hybrid outputs on the 6.0.0 chain.
+        reserve_pq_seed: non_empty("BRIDGE_BTH_RESERVE_PQ_SEED"),
         reserve_address: non_empty("BRIDGE_BTH_RESERVE_ADDRESS")?,
         user_address: non_empty("BRIDGE_BTH_USER_ADDRESS")?,
         user_view_key: non_empty("BRIDGE_BTH_USER_VIEW_KEY")?,
         user_spend_key: non_empty("BRIDGE_BTH_USER_SPEND_KEY")?,
+        user_pq_seed: non_empty("BRIDGE_BTH_USER_PQ_SEED"),
         amount: non_empty("BRIDGE_BTH_AMOUNT")
             .and_then(|s| s.parse().ok())
             .unwrap_or(1_000_000_000_000),
@@ -319,7 +340,10 @@ async fn full_loop_wrap_mint_burn_release() {
         ws_url: String::new(),
         view_key_file: Some(bth.reserve_view_key.clone()),
         spend_key_file: Some(bth.reserve_spend_key.clone()),
-        pq_seed_file: None,
+        // On protocol 6.0.0 every value output is hybrid, so the reserve needs
+        // its ML-KEM secret to detect (and spend) its own factor-1 outputs
+        // (issue #972). The driver provisions this from the node's own seed.
+        pq_seed_file: bth.reserve_pq_seed.clone(),
         confirmations_required: 0,
         reserve_address: Some(bth.reserve_address.clone()),
         release_signers: vec![
@@ -566,7 +590,9 @@ async fn full_loop_wrap_mint_burn_release() {
         ws_url: String::new(),
         view_key_file: Some(bth.user_view_key.clone()),
         spend_key_file: Some(bth.user_spend_key.clone()),
-        pq_seed_file: None,
+        // The user scans back a hybrid stealth output (ADR 0004) on the 6.0.0
+        // chain, so it likewise needs its ML-KEM secret to see the release.
+        pq_seed_file: bth.user_pq_seed.clone(),
         confirmations_required: 0,
         reserve_address: Some(bth.user_address.clone()),
         release_signers: Vec::new(),

--- a/docs/bridge/testnet-e2e-runbook.md
+++ b/docs/bridge/testnet-e2e-runbook.md
@@ -243,12 +243,32 @@ four properties as hard failures:
    Ed25519 signature does NOT release (left `BurnConfirmed`); both cross the
    configured 2-of-2 threshold before any value moves.
 
-Provision the BTH reserve/user wallet key material (32-byte hex files) via
-the environment variables documented in the script header. Without them the
-test **self-skips** (green — never a false pass, the same discipline as
-Layer 1.5). The Ethereum half swaps `local → Sepolia-fork → live Sepolia`
-purely by pointing `BRIDGE_FORK_RPC_URL` at a fork/live RPC (+ a funded
-relayer key for live) with no test-logic change (companion #992/#866).
+The BTH reserve/user wallet key material is **provisioned at runtime** by the
+driver (#999): after the node is up it runs `botho-testnet gen-bridge-keys`,
+which exports the node's own deterministic **pre-funded mining wallet** as the
+reserve and mints a fresh random user wallet. Because the reserve *is* the
+miner, it already owns spendable **factor-1** (zero-cluster-weight) outputs
+from lottery emission (`LotteryOutput::to_tx_output(ClusterTagVector::empty())`,
+ADR 0003) — exactly what the CLSAG release spends. Each wallet emits a
+32-byte-hex classical view/spend pair plus a 64-byte-hex ML-KEM/ML-DSA BIP39
+seed (`*_PQ_SEED`, issue #972), which the protocol-6.0.0 hybrid chain requires
+for the wallet to detect outputs paid to it. **No private key is committed**:
+the reserve derives from the harness's in-code disposable node mnemonic and the
+user keys are random at runtime. Bring-your-own-reserve still works — set the
+`BRIDGE_BTH_RESERVE_*` env vars and auto-provisioning is skipped; leave them
+unset and provisioning disabled and the test **self-skips** (green — never a
+false pass, the same discipline as Layer 1.5).
+
+> **Gating prerequisite.** The driver boots a single-node `botho-testnet`
+> (`start --nodes 1`). Until the harness can bring up a *healthy* single-node
+> 6.0.0 testnet that externalizes blocks (the #998/#1000 wedge work — today the
+> harness rejects `--nodes 1` outright), the job cannot reach the provisioning
+> or test steps. The key-provisioning wiring above lands independently and runs
+> the moment that prerequisite is met.
+
+The Ethereum half swaps `local → Sepolia-fork → live Sepolia` purely by
+pointing `BRIDGE_FORK_RPC_URL` at a fork/live RPC (+ a funded relayer key for
+live) with no test-logic change (companion #992/#866).
 
 ## Phase B — account provisioning (#1008)
 

--- a/scripts/bridge-e2e-full-loop.sh
+++ b/scripts/bridge-e2e-full-loop.sh
@@ -27,16 +27,27 @@
 #   BRIDGE_BTH_RPC_URL            node JSON-RPC (default http://127.0.0.1:27200)
 #   BRIDGE_BTH_RESERVE_VIEW_KEY   reserve wallet view key (32-byte hex file)
 #   BRIDGE_BTH_RESERVE_SPEND_KEY  reserve wallet spend key (32-byte hex file)
+#   BRIDGE_BTH_RESERVE_PQ_SEED    reserve ML-KEM/ML-DSA BIP39 seed (64-byte hex
+#                                 file; required on the 6.0.0 hybrid chain to
+#                                 detect + spend the reserve's own outputs)
 #   BRIDGE_BTH_RESERVE_ADDRESS    reserve public BTH address (change target)
 #   BRIDGE_BTH_USER_ADDRESS       user BTH address (release destination)
 #   BRIDGE_BTH_USER_VIEW_KEY      user wallet view key (scan-back)
 #   BRIDGE_BTH_USER_SPEND_KEY     user wallet spend key (scan-back)
+#   BRIDGE_BTH_USER_PQ_SEED       user ML-KEM/ML-DSA BIP39 seed (64-byte hex)
 #   BRIDGE_BTH_AMOUNT             picocredits to wrap (default 1 BTH)
 #
-# When the BTH reserve key material is not provided the test SELF-SKIPS
-# (green), exactly like bridge/service/src/bth_fork_tests.rs — it never claims
-# a live path it could not exercise. Provision the reserve wallet keys (an
-# operator or a key-export step) to run the loop unattended.
+# The reserve key material is PROVISIONED AT RUNTIME (#999): after the node is
+# up this script runs `botho-testnet gen-bridge-keys`, which exports the
+# node's own deterministic (pre-funded) mining wallet as the reserve — so it
+# already owns spendable factor-1 (zero-demurrage, ADR 0003) outputs from
+# lottery emission — and mints a fresh random user wallet. NO private key is
+# committed to the repo. If you would rather bring your own reserve, set the
+# BRIDGE_BTH_RESERVE_* vars yourself and the auto-provisioning is skipped.
+#
+# When no reserve key material is provided AND provisioning is disabled the
+# test SELF-SKIPS (green), exactly like bridge/service/src/bth_fork_tests.rs —
+# it never claims a live path it could not exercise.
 #
 # The live-Sepolia variant of this same loop stays a manual drill (funded
 # Safes + Sepolia ETH): docs/bridge/testnet-e2e-runbook.md.
@@ -105,6 +116,20 @@ echo "==> Mining a reserve warmup (spendable factor-1 outputs + decoy ring)"
 # the recent window (DEFAULT_RING_SIZE-1 per input). The harness pre-funds a
 # deterministic wallet; give the chain time to produce a spendable window.
 sleep 15
+
+# Provision the reserve + user wallet key material at runtime (#999) unless the
+# caller supplied their own reserve. The reserve is the node's own pre-funded
+# mining wallet (it owns spendable factor-1 lottery-emission outputs), so no
+# secret is committed. `eval` imports the `export BRIDGE_BTH_*` lines the tool
+# prints on stdout (its human logs go to stderr).
+if [[ -z "${BRIDGE_BTH_RESERVE_VIEW_KEY:-}" ]]; then
+    echo "==> Provisioning bridge reserve + user keys (runtime keygen; no secret committed)"
+    BRIDGE_KEYS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bridge-full-loop-keys.XXXXXX")"
+    eval "$(cargo run --release --bin botho-testnet -- \
+        gen-bridge-keys --node 0 --out "$BRIDGE_KEYS_DIR")"
+else
+    echo "==> Using caller-provided BTH reserve key material"
+fi
 
 echo "==> Running the full-loop e2e against ETH=$BRIDGE_FORK_RPC_URL BTH=$BRIDGE_BTH_RPC_URL"
 if [[ -z "${BRIDGE_BTH_RESERVE_VIEW_KEY:-}" || -z "${BRIDGE_BTH_RESERVE_SPEND_KEY:-}" ]]; then


### PR DESCRIPTION
## Summary

The full-loop `wrap → mint-wBTH → burn → release-BTH` e2e's BTH leg self-skips
(green) until a funded **factor-1 reserve wallet's** key files are provisioned.
This wires that provisioning **at harness runtime** — no private key is
committed to the repo — and closes the protocol-6.0.0 gap that would otherwise
stop the reserve from detecting its own outputs.

### Key design decision: no committed secret, reserve == the pre-funded miner

A committed reserve spend key is a smell, and a *freshly random* reserve owns no
on-chain outputs (so the CLSAG release has nothing to spend). Instead the driver
exports the **node's own deterministic mining wallet** as the bridge reserve:

- The reserve keys derive from the harness's in-code disposable node mnemonic
  (`generate_deterministic_mnemonic`), so they detect that node's coinbase +
  lottery outputs. Nothing new is committed.
- The reserve already owns spendable **factor-1** (zero-cluster-weight) outputs:
  lottery emission pays `LotteryOutput::to_tx_output(ClusterTagVector::empty())`
  (ADR 0003), which is exactly what `BthReleaser::prepare_release` filters for
  (`bth.rs:352`, `scanned.owned.factor_one`). Coinbase is cluster-tagged (not
  factor-1); the lottery-emission payouts are the factor-1 source.
- The **user** wallet is freshly random at runtime (it only ever receives the
  released stealth output, ADR 0004).

## Changes

- **`botho/src/bin/botho_testnet.rs`** — new `gen-bridge-keys --node N --out DIR`
  subcommand. Writes 32-byte-hex classical view/spend key files + a 64-byte-hex
  ML-KEM/ML-DSA BIP39 seed file for the reserve (node-N wallet) and a fresh user
  wallet, each 0600, and prints the `export BRIDGE_BTH_*` lines (quoted) the
  driver `eval`s. The published v2 address is derived the same way
  `bth-bridge-service`'s `ReserveKeys::public_address` does, so it matches what
  the reserve advertises. + 4 unit tests.
- **`bridge/service/src/e2e_full_loop_tests.rs`** — thread the reserve/user PQ
  seeds (`BRIDGE_BTH_{RESERVE,USER}_PQ_SEED`) into `BthConfig.pq_seed_file`.
  On protocol 6.0.0 every value output is a hybrid ML-KEM output; without the
  seed the scanner returns `None` (warns) and the reserve cannot detect or spend
  its own factor-1 outputs (`bth_scan.rs:126-141`). Seeds are optional, so the
  classical-key self-skip contract is preserved.
- **`scripts/bridge-e2e-full-loop.sh`** — after node warmup, run
  `gen-bridge-keys` and `eval` its exports (skipped when the caller supplies
  `BRIDGE_BTH_RESERVE_*`). Header env docs updated with the two `*_PQ_SEED` vars.
- **`docs/bridge/testnet-e2e-runbook.md`**, **`.github/workflows/bridge-e2e.yml`**
  — document the runtime provisioning and the gating prerequisite.

## Acceptance Criteria Verification

| Criterion (issue #999) | Status | Verification |
|---|---|---|
| Provision reserve view/spend key files in the format the harness expects | ✅ | `gen-bridge-keys` writes 32-byte-hex view/spend + 64-byte-hex PQ seed; unit test `bridge_key_material_has_expected_shape` |
| Reserve is a funded factor-1 wallet | ✅ (design) | Reserve = node's own miner, which accrues factor-1 lottery-emission outputs (`ClusterTagVector::empty()`); the release filters to `factor_one` outputs. Live funding is gated (see below). |
| Wire key files into the `full-loop` job | ✅ | Driver auto-provisions + exports all `BRIDGE_BTH_*`; the job runs the driver |
| Do NOT commit any real/secret private key | ✅ | Reserve derives from in-code disposable mnemonic; user keys random at runtime; files land only in a temp dir. `git status` shows no key files. |
| Make the deposit factor-1 (ADR 0003) | ✅ | Reserve spends factor-1 lottery outputs; PQ seed lets it detect them on 6.0.0 |

## Test Plan

Verified locally (no live node required):

- `cargo check --bin botho-testnet` — compiles.
- `cargo test --bin botho-testnet tests::` — **4/4 pass** (key shape; reserve
  derivation deterministic; exported classical keys == node wallet's own keys;
  distinct nodes → distinct keys).
- `cargo check -p bth-bridge-service --tests` — the PQ-seed threading compiles.
- Ran `gen-bridge-keys` end to end: emits the 8 `export` lines, writes six 0600
  files (64-hex scalars, 128-hex seeds), both `tbotho://2/…` v2 addresses.
- `bash -n scripts/bridge-e2e-full-loop.sh` — shell syntax OK.
- `cargo clippy --bin botho-testnet` — no new warnings.

### What remains CI-gated (could not run the full loop locally)

The driver boots a single-node `botho-testnet` (`start --nodes 1`). The harness
currently **rejects `--nodes 1`** outright (`cmd_start` guard `(2..=10)`;
confirmed: `botho-testnet start --nodes 1` exits 1). So the job cannot yet reach
the provisioning/test steps — this is the `#998/#1000` "healthy 6.0.0 testnet"
prerequisite the issue flags. I did **not** touch that guard (out of scope,
consensus-adjacent, unverifiable here). The provisioning wiring lands
independently and runs the moment a healthy single-node 6.0.0 testnet boots and
mines enough lottery-emission factor-1 outputs to cover the wrap amount + fee.

Closes #999