### PR TITLE
feat(bridge): deploy wBTH NTT bridge Sepolia↔HyperEVM + prove round trip (#1026)

### DIFF
--- a/contracts/ethereum/contracts/WbthPeerToken.sol
+++ b/contracts/ethereum/contracts/WbthPeerToken.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title WbthPeerToken — the HyperEVM-side wBTH for the Wormhole NTT bridge.
+/// @notice A burn-and-mint NTT spoke token: the NttManager is the sole `minter`
+///         and mints/burns on cross-chain transfers, backed 1:1 by wBTH locked
+///         on the Ethereum Sepolia hub. Mirrors Wormhole's `PeerTokenLite` but
+///         pins `decimals()` to 12 so a base unit equals one picocredit (parity
+///         with the Sepolia wBTH, 0x49b985ec…). NTT trims cross-chain amounts to
+///         8 decimals, so transfers are quantized to 1e-8 wBTH (10,000 pc).
+contract WbthPeerToken is ERC20, ERC20Burnable, Ownable {
+    error CallerNotMinter(address caller);
+    error InvalidMinterZeroAddress();
+
+    event NewMinter(address newMinter);
+
+    address public minter;
+
+    modifier onlyMinter() {
+        if (msg.sender != minter) revert CallerNotMinter(msg.sender);
+        _;
+    }
+
+    constructor(string memory _name, string memory _symbol, address _minter, address _owner)
+        ERC20(_name, _symbol)
+        Ownable(_owner)
+    {
+        minter = _minter;
+    }
+
+    /// @notice 12 decimals — 1 base unit == 1 picocredit (1:1 with Sepolia wBTH).
+    function decimals() public pure override returns (uint8) {
+        return 12;
+    }
+
+    function mint(address _account, uint256 _amount) external onlyMinter {
+        _mint(_account, _amount);
+    }
+
+    /// @notice Rotate the minter (e.g. to the NttManager after it is deployed).
+    function setMinter(address newMinter) external onlyOwner {
+        if (newMinter == address(0)) revert InvalidMinterZeroAddress();
+        minter = newMinter;
+        emit NewMinter(newMinter);
+    }
+}

--- a/contracts/ethereum/scripts/hl-1-bridge-eth-to-arbitrum.ts
+++ b/contracts/ethereum/scripts/hl-1-bridge-eth-to-arbitrum.ts
@@ -1,0 +1,57 @@
+// HL official-route step 1/3: bridge ETH from Ethereum mainnet -> Arbitrum via
+// the CANONICAL Arbitrum Delayed Inbox (depositEth). Real mainnet value.
+// Threads the 0.08 Chainstack gate: moves only 0.004 ETH so 0x8E90 stays >=0.08.
+//
+// Run: npx ts-node --compiler-options '{"module":"commonjs","target":"ES2020",
+//   "esModuleInterop":true,"skipLibCheck":true}' scripts/hl-1-bridge-eth-to-arbitrum.ts
+
+import { ethers } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+
+const ETH_RPC = "https://ethereum-rpc.publicnode.com";
+const INBOX = "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f"; // Arbitrum One Delayed Inbox (verified: has code)
+const BRIDGE_ETH = ethers.parseEther("0.004"); // ~$7.5 — enough for a 6 USDC deposit + Arbitrum gas
+const GATE = ethers.parseEther("0.08"); // Chainstack faucet balance gate — must stay >= this
+const KEYFILE = path.resolve(__dirname, "../../../.secrets/bridge-mainnet/eth-botho.key");
+
+const INBOX_ABI = ["function depositEth() payable returns (uint256)"];
+
+async function main() {
+  const provider = new ethers.JsonRpcProvider(ETH_RPC);
+  const net = await provider.getNetwork();
+  if (net.chainId !== 1n) throw new Error(`expected Ethereum mainnet (1), got ${net.chainId}`);
+  const wallet = new ethers.Wallet(fs.readFileSync(KEYFILE, "utf8").trim(), provider);
+  console.log("from:", wallet.address);
+  if (wallet.address.toLowerCase() !== "0x8e9043051a39bc87d969c060d5a2fa5f577844f3")
+    throw new Error("unexpected signer address");
+
+  const bal0 = await provider.getBalance(wallet.address);
+  console.log(`balance: ${ethers.formatEther(bal0)} ETH`);
+
+  const inbox = new ethers.Contract(INBOX, INBOX_ABI, wallet);
+  const data = inbox.interface.encodeFunctionData("depositEth", []);
+  console.log("Inbox:", INBOX, "| calldata:", data, "(expect 0x439370b1)");
+  if (data !== "0x439370b1") throw new Error(`unexpected depositEth selector ${data}`);
+
+  // Gas + safety: after this tx, balance MUST remain >= 0.08 (Chainstack gate).
+  const feeData = await provider.getFeeData();
+  const gasEst = await provider.estimateGas({ to: INBOX, value: BRIDGE_ETH, data, from: wallet.address });
+  const maxGasCost = gasEst * (feeData.maxFeePerGas ?? feeData.gasPrice ?? 0n);
+  const after = bal0 - BRIDGE_ETH - maxGasCost;
+  console.log(`bridging ${ethers.formatEther(BRIDGE_ETH)} ETH; gasEst ${gasEst}, maxGasCost ~${ethers.formatEther(maxGasCost)} ETH`);
+  console.log(`projected balance after: ~${ethers.formatEther(after)} ETH (gate ${ethers.formatEther(GATE)})`);
+  if (after < GATE) throw new Error(`ABORT: would drop below the 0.08 Chainstack gate (${ethers.formatEther(after)} < 0.08)`);
+
+  const tx = await inbox.depositEth({ value: BRIDGE_ETH });
+  console.log("bridge tx:", tx.hash, `\n  https://etherscan.io/tx/${tx.hash}`);
+  const rc = await tx.wait();
+  if (!rc || rc.status !== 1) throw new Error("bridge tx reverted");
+  console.log("mined in block", rc.blockNumber);
+
+  const bal1 = await provider.getBalance(wallet.address);
+  console.log(`balance now: ${ethers.formatEther(bal1)} ETH (gate ${ethers.formatEther(GATE)}: ${bal1 >= GATE ? "SAFE" : "BELOW!"})`);
+  console.log("\nBridged ETH credits on Arbitrum in ~10-15 min. Next: poll Arbitrum balance, then swap ETH->USDC.");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-2-swap-eth-usdc-arbitrum.ts
+++ b/contracts/ethereum/scripts/hl-2-swap-eth-usdc-arbitrum.ts
@@ -1,0 +1,64 @@
+// HL official-route step 2/3: swap ETH -> native USDC on Arbitrum via Uniswap v3
+// SwapRouter02 (0.05% tier). Pays with native ETH (msg.value) — SwapRouter02
+// wraps to WETH internally. Quotes first, sets a 1% min-out.
+//
+// Run: npx ts-node --compiler-options '{"module":"commonjs","target":"ES2020",
+//   "esModuleInterop":true,"skipLibCheck":true}' scripts/hl-2-swap-eth-usdc-arbitrum.ts
+
+import { ethers } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+
+const ARB_RPC = "https://arb1.arbitrum.io/rpc";
+const ROUTER = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"; // SwapRouter02 (verified)
+const QUOTER = "0x61fFE014bA17989E743c5F6cB21bF9697530B21e"; // QuoterV2
+const WETH = "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1";
+const USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"; // native USDC (verified: 6 dec)
+const FEE = 500; // 0.05%
+const AMOUNT_IN = ethers.parseEther("0.0038"); // leave ~0.0002 ETH for gas on this + the deposit tx
+const KEYFILE = path.resolve(__dirname, "../../../.secrets/bridge-mainnet/eth-botho.key");
+
+const QUOTER_ABI = ["function quoteExactInputSingle((address tokenIn,address tokenOut,uint256 amountIn,uint24 fee,uint160 sqrtPriceLimitX96)) returns (uint256 amountOut,uint160,uint32,uint256)"];
+const ROUTER_ABI = ["function exactInputSingle((address tokenIn,address tokenOut,uint24 fee,address recipient,uint256 amountIn,uint256 amountOutMinimum,uint160 sqrtPriceLimitX96)) payable returns (uint256 amountOut)"];
+const USDC_ABI = ["function balanceOf(address) view returns (uint256)"];
+
+async function main() {
+  const provider = new ethers.JsonRpcProvider(ARB_RPC);
+  const net = await provider.getNetwork();
+  if (net.chainId !== 42161n) throw new Error(`expected Arbitrum One (42161), got ${net.chainId}`);
+  const wallet = new ethers.Wallet(fs.readFileSync(KEYFILE, "utf8").trim(), provider);
+  console.log("from:", wallet.address);
+
+  const ethBal = await provider.getBalance(wallet.address);
+  console.log(`Arbitrum ETH: ${ethers.formatEther(ethBal)}`);
+  if (ethBal < AMOUNT_IN) throw new Error("insufficient Arbitrum ETH for the swap");
+
+  const usdc = new ethers.Contract(USDC, USDC_ABI, provider);
+  const usdc0 = await usdc.balanceOf(wallet.address);
+
+  // Quote (staticCall — QuoterV2 is non-view but returns via revert-decode).
+  const quoter = new ethers.Contract(QUOTER, QUOTER_ABI, provider);
+  const q = await quoter.quoteExactInputSingle.staticCall({
+    tokenIn: WETH, tokenOut: USDC, amountIn: AMOUNT_IN, fee: FEE, sqrtPriceLimitX96: 0n,
+  });
+  const quotedOut = q[0] as bigint;
+  const minOut = (quotedOut * 99n) / 100n; // 1% slippage
+  console.log(`quote: ${ethers.formatUnits(quotedOut, 6)} USDC for ${ethers.formatEther(AMOUNT_IN)} ETH; minOut ${ethers.formatUnits(minOut, 6)}`);
+  if (quotedOut < 6_000_000n) throw new Error(`ABORT: quote ${ethers.formatUnits(quotedOut,6)} USDC < 6 (need >=6 to deposit)`);
+
+  const router = new ethers.Contract(ROUTER, ROUTER_ABI, wallet);
+  const tx = await router.exactInputSingle(
+    { tokenIn: WETH, tokenOut: USDC, fee: FEE, recipient: wallet.address, amountIn: AMOUNT_IN, amountOutMinimum: minOut, sqrtPriceLimitX96: 0n },
+    { value: AMOUNT_IN },
+  );
+  console.log("swap tx:", tx.hash, `\n  https://arbiscan.io/tx/${tx.hash}`);
+  const rc = await tx.wait();
+  if (!rc || rc.status !== 1) throw new Error("swap reverted");
+
+  const usdc1 = await usdc.balanceOf(wallet.address);
+  console.log(`USDC: ${ethers.formatUnits(usdc0,6)} -> ${ethers.formatUnits(usdc1,6)} (+${ethers.formatUnits(usdc1-usdc0,6)})`);
+  console.log(`Arbitrum ETH left: ${ethers.formatEther(await provider.getBalance(wallet.address))}`);
+  console.log("\nNext: deposit 6 USDC to Hyperliquid Bridge2.");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-3-deposit-hyperliquid.ts
+++ b/contracts/ethereum/scripts/hl-3-deposit-hyperliquid.ts
@@ -1,0 +1,58 @@
+// HL official-route step 3/3: deposit USDC to Hyperliquid mainnet by transferring
+// native USDC to the Bridge2 contract on Arbitrum. This establishes the
+// "deposited on mainnet with the same address" fact that unlocks the TESTNET
+// faucet for 0x8E90. Min deposit 5 USDC (below = lost forever); we send 6.
+//
+// Run: npx ts-node --compiler-options '{"module":"commonjs","target":"ES2020",
+//   "esModuleInterop":true,"skipLibCheck":true}' scripts/hl-3-deposit-hyperliquid.ts
+
+import { ethers } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+
+const ARB_RPC = "https://arb1.arbitrum.io/rpc";
+const USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"; // native USDC (verified)
+const BRIDGE2 = "0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7"; // Hyperliquid Bridge2 (verified: 38.8KB code, official docs + Arbiscan)
+const DEPOSIT = 6_000_000n; // 6 USDC (6 decimals) — above the 5 USDC minimum
+const KEYFILE = path.resolve(__dirname, "../../../.secrets/bridge-mainnet/eth-botho.key");
+
+const USDC_ABI = [
+  "function balanceOf(address) view returns (uint256)",
+  "function transfer(address to, uint256 amount) returns (bool)",
+  "function decimals() view returns (uint8)",
+  "function symbol() view returns (string)",
+];
+
+async function main() {
+  const provider = new ethers.JsonRpcProvider(ARB_RPC);
+  if ((await provider.getNetwork()).chainId !== 42161n) throw new Error("not Arbitrum One");
+  const wallet = new ethers.Wallet(fs.readFileSync(KEYFILE, "utf8").trim(), provider);
+  console.log("from:", wallet.address);
+
+  const usdc = new ethers.Contract(USDC, USDC_ABI, wallet);
+  // Re-verify the token before sending real value.
+  if ((await usdc.symbol()) !== "USDC" || Number(await usdc.decimals()) !== 6)
+    throw new Error("USDC token sanity check failed");
+  const bal = await usdc.balanceOf(wallet.address);
+  console.log(`USDC balance: ${ethers.formatUnits(bal, 6)}`);
+  if (bal < DEPOSIT) throw new Error(`insufficient USDC: have ${ethers.formatUnits(bal,6)}, need ${ethers.formatUnits(DEPOSIT,6)}`);
+  if (DEPOSIT < 5_000_000n) throw new Error("ABORT: below Hyperliquid 5 USDC minimum");
+
+  // Confirm the bridge contract exists (guard against a typo'd address = lost funds).
+  if ((await provider.getCode(BRIDGE2)) === "0x") throw new Error("ABORT: Bridge2 has no code");
+
+  console.log(`depositing ${ethers.formatUnits(DEPOSIT, 6)} USDC -> Hyperliquid Bridge2 ${BRIDGE2}`);
+  const tx = await usdc.transfer(BRIDGE2, DEPOSIT);
+  console.log("deposit tx:", tx.hash, `\n  https://arbiscan.io/tx/${tx.hash}`);
+  const rc = await tx.wait();
+  if (!rc || rc.status !== 1) throw new Error("deposit transfer reverted");
+  console.log("mined in block", rc.blockNumber);
+
+  console.log(`USDC left on Arbitrum: ${ethers.formatUnits(await usdc.balanceOf(wallet.address), 6)}`);
+  console.log("\n=== DEPOSITED ON HYPERLIQUID MAINNET ===");
+  console.log("Credits to the HL account for", wallet.address, "in a few min (Arbitrum finality).");
+  console.log("This unlocks the TESTNET faucet for this address. Next: claim testnet USDC,");
+  console.log("sell for HYPE, bridge HYPE HyperCore->HyperEVM, forward to 0x111018 (ntt deployer).");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-4-forward-hype.ts
+++ b/contracts/ethereum/scripts/hl-4-forward-hype.ts
@@ -1,0 +1,31 @@
+// HL official-route step 4/4: forward native HYPE on HyperEVM from 0x8E90 to the
+// NTT deployer 0x111018 (which holds the Sepolia ETH), making it the single
+// deployer for both EVM chains. Keeps 0.1 HYPE on 0x8E90 for future use.
+import { ethers } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+
+const RPC = "https://rpc.hyperliquid-testnet.xyz/evm";
+const TO = "0x111018cfe4523097B7f651f3A06fA9a2956CF155";
+const KEY = path.resolve(__dirname, "../../../.secrets/bridge-mainnet/eth-botho.key");
+
+async function main() {
+  const p = new ethers.JsonRpcProvider(RPC);
+  const net = await p.getNetwork();
+  if (net.chainId !== 998n) throw new Error(`expected HyperEVM 998, got ${net.chainId}`);
+  const w = new ethers.Wallet(fs.readFileSync(KEY, "utf8").trim(), p);
+  const bal = await p.getBalance(w.address);
+  console.log("from", w.address, "HYPE:", ethers.formatEther(bal));
+  const gp = (await p.getFeeData()).gasPrice ?? 1_000_000_000n;
+  const gasReserve = 21000n * gp * 3n;
+  const send = bal - gasReserve - ethers.parseEther("0.1");
+  if (send <= 0n) throw new Error("nothing to forward");
+  console.log(`forwarding ${ethers.formatEther(send)} HYPE -> ${TO}`);
+  const tx = await w.sendTransaction({ to: TO, value: send });
+  console.log("tx:", tx.hash);
+  const rc = await tx.wait();
+  if (!rc || rc.status !== 1) throw new Error("forward reverted");
+  console.log("0x111018 HYPE now:", ethers.formatEther(await p.getBalance(TO)));
+  console.log("0x8E90 HYPE left:", ethers.formatEther(await p.getBalance(w.address)));
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-5-deploy-peertoken.ts
+++ b/contracts/ethereum/scripts/hl-5-deploy-peertoken.ts
@@ -1,0 +1,32 @@
+// #1026: deploy the WbthPeerToken (HyperEVM-side wBTH, 12 decimals) to HyperEVM
+// testnet. minter/owner = deployer initially; minter is rotated to the NttManager
+// after `ntt add-chain HyperEVM --mode burning --token <this>` deploys it.
+import { ethers } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+
+const RPC = "https://rpc.hyperliquid-testnet.xyz/evm";
+const KEY = path.resolve(__dirname, "../../../.secrets/bridge-testnet/eth-deployer.key");
+const ART = path.resolve(__dirname, "../artifacts/contracts/WbthPeerToken.sol/WbthPeerToken.json");
+
+async function main() {
+  const p = new ethers.JsonRpcProvider(RPC);
+  if ((await p.getNetwork()).chainId !== 998n) throw new Error("not HyperEVM 998");
+  const w = new ethers.Wallet(fs.readFileSync(KEY, "utf8").trim(), p);
+  console.log("deployer:", w.address, "HYPE:", ethers.formatEther(await p.getBalance(w.address)));
+
+  const art = JSON.parse(fs.readFileSync(ART, "utf8"));
+  const factory = new ethers.ContractFactory(art.abi, art.bytecode, w);
+  console.log("deploying WbthPeerToken(Wrapped BTH, wBTH, minter=deployer, owner=deployer)...");
+  const c = await factory.deploy("Wrapped BTH", "wBTH", w.address, w.address);
+  console.log("deploy tx:", c.deploymentTransaction()?.hash);
+  await c.waitForDeployment();
+  const addr = await c.getAddress();
+  console.log("WbthPeerToken:", addr);
+
+  const tok = new ethers.Contract(addr, art.abi, p);
+  console.log("  name:", await tok.name(), "symbol:", await tok.symbol(), "decimals:", await tok.decimals());
+  console.log("  minter:", await tok.minter(), "owner:", await tok.owner());
+  console.log("\nNext: ntt add-chain HyperEVM --mode burning --token", addr);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-6-set-peertoken-minter.ts
+++ b/contracts/ethereum/scripts/hl-6-set-peertoken-minter.ts
@@ -1,0 +1,32 @@
+// #1026: rotate the WbthPeerToken minter from the deployer to the HyperEVM
+// NttManager, so the manager can mint/burn the PeerToken on cross-chain
+// transfers (burn-and-mint mode). Owner (deployer) calls setMinter.
+import { ethers } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+
+const RPC = "https://rpc.hyperliquid-testnet.xyz/evm";
+const PEER_TOKEN = "0x230f154Ae33A53dcFFEDedB2d92cc1F32BcE7610";
+const HYPEREVM_MANAGER = "0x07F159042E9F89484dfdA37D09057c871dbCB475";
+const KEY = path.resolve(__dirname, "../../../.secrets/bridge-testnet/eth-deployer.key");
+const ABI = [
+  "function minter() view returns (address)",
+  "function owner() view returns (address)",
+  "function setMinter(address newMinter)",
+];
+
+async function main() {
+  const p = new ethers.JsonRpcProvider(RPC);
+  const w = new ethers.Wallet(fs.readFileSync(KEY, "utf8").trim(), p);
+  const tok = new ethers.Contract(PEER_TOKEN, ABI, w);
+  console.log("minter before:", await tok.minter());
+  const tx = await tok.setMinter(HYPEREVM_MANAGER);
+  console.log("setMinter tx:", tx.hash);
+  const rc = await tx.wait();
+  if (!rc || rc.status !== 1) throw new Error("setMinter reverted");
+  const after = await tok.minter();
+  console.log("minter after:", after);
+  if (after.toLowerCase() !== HYPEREVM_MANAGER.toLowerCase()) throw new Error("minter mismatch");
+  console.log("OK — NttManager is now the PeerToken minter.");
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-7-mint-wbth-for-ntt.ts
+++ b/contracts/ethereum/scripts/hl-7-mint-wbth-for-ntt.ts
@@ -1,0 +1,46 @@
+// #1026: mint a small amount of wBTH to the deployer via the real 2-of-3 Safe
+// (ADR-0002 custody path), to fund the NTT demo transfer Sepolia -> HyperEVM.
+import { ethers } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+
+const WBTH = "0x49b985ec427ee771a601f11b18f7d4402fa2dd7b";
+const SAFE = "0x61274F558f9027e2D402d3340dE89152FA3F3947";
+const MINT_TO = "0x111018cfe4523097B7f651f3A06fA9a2956CF155"; // deployer
+const AMOUNT = 100_000_000_000_000n; // 100 wBTH (10^14 pico)
+const ORDER_ID = ethers.id("wbth-ntt-demo-2026-07-16");
+const SECRETS = path.resolve(__dirname, "../../../.secrets/bridge-testnet");
+const key = (n: string) => fs.readFileSync(path.join(SECRETS, `${n}.key`), "utf8").trim();
+
+const WBTH_ABI = ["function bridgeMint(address to, uint256 amount, bytes32 orderId)", "function balanceOf(address) view returns (uint256)", "function processedOrders(bytes32) view returns (bool)"];
+const SAFE_ABI = [
+  "function nonce() view returns (uint256)",
+  "function getThreshold() view returns (uint256)",
+  "function getTransactionHash(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 _nonce) view returns (bytes32)",
+  "function execTransaction(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address payable refundReceiver,bytes signatures) payable returns (bool)",
+];
+
+async function main() {
+  const provider = new ethers.JsonRpcProvider(process.env.SEPOLIA_RPC_URL || "https://ethereum-sepolia-rpc.publicnode.com");
+  const deployer = new ethers.Wallet(key("eth-deployer"), provider);
+  const owners = [1, 2, 3].map((i) => new ethers.Wallet(key(`eth-safe-owner-${i}`), provider));
+  const wbth = new ethers.Contract(WBTH, WBTH_ABI, provider);
+  const safe = new ethers.Contract(SAFE, SAFE_ABI, provider);
+
+  if (await wbth.processedOrders(ORDER_ID)) { console.log("order already minted; balance:", ethers.formatUnits(await wbth.balanceOf(MINT_TO), 12)); return; }
+  const data = wbth.interface.encodeFunctionData("bridgeMint", [MINT_TO, AMOUNT, ORDER_ID]);
+  const nonce = await safe.nonce();
+  const Z = ethers.ZeroAddress;
+  const digest: string = await safe.getTransactionHash(WBTH, 0n, data, 0, 0n, 0n, 0n, Z, Z, nonce);
+  const threshold = Number(await safe.getThreshold());
+  const parts = owners.slice(0, threshold).map((w) => ({ addr: w.address.toLowerCase(), sig: ethers.Signature.from(w.signingKey.sign(digest)).serialized }))
+    .sort((a, b) => (a.addr < b.addr ? -1 : 1));
+  const blob = "0x" + parts.map((p) => p.sig.slice(2)).join("");
+  console.log(`minting ${ethers.formatUnits(AMOUNT, 12)} wBTH -> ${MINT_TO} via 2-of-3 Safe (nonce ${nonce})`);
+  const tx = await (safe.connect(deployer) as ethers.Contract).execTransaction(WBTH, 0n, data, 0, 0n, 0n, 0n, Z, Z, blob);
+  console.log("execTransaction:", tx.hash);
+  const rc = await tx.wait();
+  if (!rc || rc.status !== 1) throw new Error("mint reverted");
+  console.log("deployer wBTH balance:", ethers.formatUnits(await wbth.balanceOf(MINT_TO), 12));
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-8-redeem-vaa-hyperevm.ts
+++ b/contracts/ethereum/scripts/hl-8-redeem-vaa-hyperevm.ts
@@ -1,0 +1,45 @@
+// #1026: manually redeem the NTT transfer on HyperEVM (no Wormhole executor on
+// testnet). Fetch the guardian-signed VAA from Wormholescan and submit it to the
+// HyperEVM WormholeTransceiver.receiveMessage, which delivers to the NttManager
+// (threshold 1) → mints the wBTH PeerToken to the recipient.
+import { ethers } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+
+const RPC = "https://rpc.hyperliquid-testnet.xyz/evm";
+const TRANSCEIVER = "0xC5652d52fBE4c41c91a65Ecd18304B20e58Df491"; // HyperEVM WormholeTransceiver
+const PEER_TOKEN = "0x230f154Ae33A53dcFFEDedB2d92cc1F32BcE7610";
+const RECIPIENT = "0x111018cfe4523097B7f651f3A06fA9a2956CF155";
+const VAA_URL = "https://api.testnet.wormholescan.io/api/v1/vaas/10002/000000000000000000000000bee886bcc887e96487c2103e46fda7ada6b89195/2";
+const KEY = path.resolve(__dirname, "../../../.secrets/bridge-testnet/eth-deployer.key");
+
+const XCVR_ABI = ["function receiveMessage(bytes encodedMessage)"];
+const ERC20_ABI = ["function balanceOf(address) view returns (uint256)"];
+
+async function main() {
+  // 1. fetch VAA
+  const res = await fetch(VAA_URL);
+  const j: any = await res.json();
+  const b64 = j?.data?.vaa ?? j?.vaa;
+  if (!b64) throw new Error("no VAA in response");
+  const vaa = "0x" + Buffer.from(b64, "base64").toString("hex");
+  console.log("VAA bytes:", vaa.length / 2 - 1);
+
+  const p = new ethers.JsonRpcProvider(RPC);
+  const w = new ethers.Wallet(fs.readFileSync(KEY, "utf8").trim(), p);
+  const token = new ethers.Contract(PEER_TOKEN, ERC20_ABI, p);
+  const before = await token.balanceOf(RECIPIENT);
+  console.log("recipient wBTH before:", ethers.formatUnits(before, 12));
+
+  const xcvr = new ethers.Contract(TRANSCEIVER, XCVR_ABI, w);
+  console.log("submitting receiveMessage on HyperEVM transceiver...");
+  const tx = await xcvr.receiveMessage(vaa);
+  console.log("redeem tx:", tx.hash);
+  const rc = await tx.wait();
+  if (!rc || rc.status !== 1) throw new Error("receiveMessage reverted");
+
+  const after = await token.balanceOf(RECIPIENT);
+  console.log("recipient wBTH after:", ethers.formatUnits(after, 12), `(+${ethers.formatUnits(after - before, 12)})`);
+  console.log("\n=== NTT ROUND TRIP COMPLETE: wBTH minted on HyperEVM ===");
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/wbth-ntt/deployment.json
+++ b/contracts/wbth-ntt/deployment.json
@@ -1,0 +1,51 @@
+{
+  "network": "Testnet",
+  "chains": {
+    "Sepolia": {
+      "version": "2.0.0",
+      "mode": "locking",
+      "paused": false,
+      "owner": "0x111018cfe4523097B7f651f3A06fA9a2956CF155",
+      "manager": "0xC5652d52fBE4c41c91a65Ecd18304B20e58Df491",
+      "token": "0x49b985eC427EE771A601F11b18f7d4402fA2DD7B",
+      "transceivers": {
+        "threshold": 1,
+        "wormhole": {
+          "address": "0xbEe886BcC887e96487C2103e46fDa7aDA6b89195",
+          "pauser": "0x111018cfe4523097B7f651f3A06fA9a2956CF155"
+        }
+      },
+      "limits": {
+        "outbound": "184467440737.095516150000",
+        "inbound": {
+          "HyperEVM": "184467440737.095516150000"
+        }
+      },
+      "pauser": "0x111018cfe4523097B7f651f3A06fA9a2956CF155",
+      "managerVariant": "standard"
+    },
+    "HyperEVM": {
+      "version": "2.0.0",
+      "mode": "burning",
+      "paused": false,
+      "owner": "0x111018cfe4523097B7f651f3A06fA9a2956CF155",
+      "manager": "0x07F159042E9F89484dfdA37D09057c871dbCB475",
+      "token": "0x230f154Ae33A53dcFFEDedB2d92cc1F32BcE7610",
+      "transceivers": {
+        "threshold": 1,
+        "wormhole": {
+          "address": "0xC5652d52fBE4c41c91a65Ecd18304B20e58Df491",
+          "pauser": "0x111018cfe4523097B7f651f3A06fA9a2956CF155"
+        }
+      },
+      "limits": {
+        "outbound": "184467440737.095516150000",
+        "inbound": {
+          "Sepolia": "184467440737.095516150000"
+        }
+      },
+      "pauser": "0x111018cfe4523097B7f651f3A06fA9a2956CF155",
+      "managerVariant": "standard"
+    }
+  }
+}

--- a/docs/bridge/hyperliquid-ntt-runbook.md
+++ b/docs/bridge/hyperliquid-ntt-runbook.md
@@ -5,11 +5,43 @@ The testnet path that puts **wBTH** on Hyperliquid, covering issue **#876**
 swap demo). This is mostly ops + third-party (Wormhole / Hyperliquid) tooling,
 not core-bridge Rust.
 
-> Status: **planned** — architecture chosen, commands drafted from the current
-> (2026-07) Wormhole NTT + Hyperliquid docs. Not yet executed on testnet;
-> on-chain steps are gated on HyperEVM gas (HYPE) and, for #877, HyperCore
-> testnet USDC. Verify the flagged items live (CLI chain-name string, decimal
-> knobs) before running.
+> Status: **DEPLOYED on testnet (2026-07-16, #1026)** — the NTT bridge is live
+> and a Sepolia→HyperEVM round trip is proven. Addresses below. #877 (HIP-1
+> spot) is next.
+
+## Deployed (testnet, 2026-07-16, #1026)
+
+Single deployer `0x111018cfe4523097B7f651f3A06fA9a2956CF155` (Sepolia ETH +
+HyperEVM HYPE). Full config in [`contracts/wbth-ntt/deployment.json`](../../contracts/wbth-ntt/deployment.json).
+
+| | Sepolia (hub, LOCKING) | HyperEVM 998 (spoke, BURNING) |
+|---|---|---|
+| NttManager | `0xC5652d52fBE4c41c91a65Ecd18304B20e58Df491` | `0x07F159042E9F89484dfdA37D09057c871dbCB475` |
+| WormholeTransceiver | `0xbEe886BcC887e96487C2103e46fDa7aDA6b89195` | `0xC5652d52fBE4c41c91a65Ecd18304B20e58Df491` |
+| Token | wBTH `0x49b985ec…` (existing, **untouched**) | PeerToken `0x230f154Ae33A53dcFFEDedB2d92cc1F32BcE7610` (`WbthPeerToken.sol`, 12 dec, minter = NttManager) |
+
+Round trip proven: 10 wBTH locked on Sepolia (`NttManager.transfer`, deployer
+100→90) → VAA seq 2 → **manually redeemed** on HyperEVM (no Wormhole executor on
+testnet: `WormholeTransceiver.receiveMessage`, script `hl-8`) → 10 wBTH PeerToken
+minted, 1:1. The Sepolia 2-of-3 Safe was **never touched** (locking uses
+`approve` + `transferFrom`, not the mint path). Peered both directions,
+inbound+outbound rate limits set.
+
+**Ops scripts** (`contracts/ethereum/scripts/hl-1..8`, keys read from gitignored
+`.secrets/`): 1-3 = HYPE funding via the official HL route (bridge ETH→Arbitrum,
+swap→USDC, deposit to HL mainnet), 4 = forward HYPE to deployer, 5 = deploy
+PeerToken, 6 = set minter, 7 = mint demo wBTH via Safe, 8 = redeem VAA.
+
+**Deploy caveats hit** (for a re-run): Sepolia `add-chain` needs `--skip-verify`
+(no etherscan verifier configured); HyperEVM burning mode does **not** auto-deploy
+the PeerToken (deploy `WbthPeerToken` first, pass `--token`); the deployer must
+be HL-testnet-activated *and* opted into big blocks before HyperEVM deploys; no
+Wormhole executor on HyperEVM testnet ⇒ redeem manually.
+
+---
+
+> Original plan (retained for reference). Verify the flagged items on any re-run
+> (CLI chain-name string, decimal knobs).
 
 ## Design decision — hub/locking, keep the Safe untouched
 


### PR DESCRIPTION
Live execution of #876 (issue #1026). **wBTH is now on Hyperliquid HyperEVM** via Wormhole NTT — alongside Ethereum Sepolia (Uniswap) and Solana devnet (Orca).

## Deployed (testnet)
Single deployer `0x111018…` on both chains. Config: `contracts/wbth-ntt/deployment.json` (`ntt status` clean).

| | Sepolia (hub, LOCKING) | HyperEVM (spoke, BURNING) |
|---|---|---|
| NttManager | `0xC5652d52fBE4c41c91a65Ecd18304B20e58Df491` | `0x07F159042E9F89484dfdA37D09057c871dbCB475` |
| Transceiver | `0xbEe886BcC887e96487C2103e46fDa7aDA6b89195` | `0xC5652d52fBE4c41c91a65Ecd18304B20e58Df491` |
| Token | wBTH `0x49b985ec…` (existing, **untouched**) | PeerToken `0x230f154…` (12 dec, minter = manager) |

## Custody preserved
Sepolia is the hub in **locking** mode: `NttManager.transfer` pulls wBTH via `approve`+`transferFrom` and never mints — so the 2-of-3 Gnosis Safe minter and the Sepolia token are untouched, no redeploy. HyperEVM gets a fresh burn/mint PeerToken (minter = the HyperEVM NttManager), backed 1:1 by locked Sepolia wBTH.

## Round trip proven
10 wBTH locked on Sepolia (`NttManager.transfer`, deployer 100→90, manager holds 10) → Wormhole VAA seq 2 → **manually redeemed** on HyperEVM (no Wormhole executor on testnet: `WormholeTransceiver.receiveMessage`) → 10 wBTH PeerToken minted, decimals **1:1**.

## Contents
- `contracts/ethereum/contracts/WbthPeerToken.sol` — the HyperEVM-side wBTH (mintable/burnable ERC20, 12 decimals, settable minter; OZ 5 / solc 0.8.20, Permit dropped to stay on 0.8.20).
- `contracts/ethereum/scripts/hl-1..8` — full ops path: HYPE funding via the official Hyperliquid route (bridge ETH→Arbitrum, swap→USDC, deposit to HL mainnet → testnet faucet → buy HYPE → HyperCore→HyperEVM), PeerToken deploy, minter set, demo mint via Safe, VAA redeem. **No secrets committed** — keys read only from gitignored `.secrets/`.
- `contracts/wbth-ntt/deployment.json` — the deployed NTT config.
- `docs/bridge/hyperliquid-ntt-runbook.md` — deployed addresses + the deploy caveats hit (skip-verify, manual PeerToken, big-blocks + HL activation, manual redeem).

## Notes
- Decimals: NTT trims to 8 → move only 8-decimal-aligned amounts (bridge quantum = 10,000 picocredits).
- Trust surface: NTT adds the Wormhole guardian set (13/19) as a mint authority on the HyperEVM side; Sepolia adds no new mint trust (locking).
- Unblocks #877 (HIP-1 spot listing — wBTH now present on HyperEVM; testnet USDC on hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)