### PR TITLE
fix(bridge): unblock the full-loop BTH release leg so it runs green

### DIFF
--- a/botho/src/bin/botho_testnet.rs
+++ b/botho/src/bin/botho_testnet.rs
@@ -1086,6 +1086,12 @@ fn start_node_process(node: &NodeState, config_path: &Path, verbose: bool) -> Re
             "run",
             "--mint",
         ])
+        // These are throwaway local harness nodes: opt in to the dev/test RPC
+        // surface (`dev_settleToBackground` for reserve funding + the lifted
+        // anonymous rate limit for the heavy e2e drive loops, #1025). A live
+        // public testnet node does NOT set this, so it keeps its 100/min
+        // anonymous limit and never exposes the mutating dev RPC (M1/L1).
+        .env("BOTHO_ENABLE_DEV_RPC", "1")
         .stdout(Stdio::from(log_file.try_clone()?))
         .stderr(Stdio::from(log_file))
         .spawn()

--- a/botho/src/bin/botho_testnet.rs
+++ b/botho/src/bin/botho_testnet.rs
@@ -145,11 +145,14 @@ enum Commands {
     /// deterministic node mnemonic (already in-code and disposable) and the
     /// user keys are freshly random at runtime.
     ///
-    /// The RESERVE is the node's own pre-funded mining wallet, so it already
-    /// owns spendable **factor-1** (zero-cluster-weight) outputs from lottery
-    /// emission (`LotteryOutput::to_tx_output(ClusterTagVector::empty())`),
-    /// which is exactly what the CLSAG release path spends (ADR 0003). The
-    /// USER wallet only receives the released stealth output (ADR 0004).
+    /// The RESERVE is the node's own pre-funded mining wallet. NOTE (#1025): a
+    /// freshly-mined node accrues ONLY 100%-cluster-tagged coinbases
+    /// (`MintingTx::to_tx_output` tags each with a new cluster) and lottery
+    /// EMISSION is zero in the bootstrap epoch — so the reserve does NOT
+    /// naturally own the **factor-1** (zero-cluster-weight) outputs the CLSAG
+    /// release path spends (ADR 0003). Run `fund-reserve` after this to settle
+    /// a coinbase into a spendable factor-1 output. The USER wallet only
+    /// receives the released stealth output (ADR 0004).
     GenBridgeKeys {
         /// Node index whose deterministic wallet becomes the bridge reserve.
         #[arg(long, default_value_t = 0)]
@@ -158,6 +161,35 @@ enum Commands {
         /// Directory to write the key files into (created if missing).
         #[arg(long)]
         out: PathBuf,
+    },
+
+    /// Fund the bridge reserve with a spendable **factor-1** (background)
+    /// output by settling the node wallet's own coins (#1025).
+    ///
+    /// A freshly-mined node accrues ONLY 100%-cluster-tagged coinbases, never
+    /// factor-1, so the bridge releaser (which spends only factor-1 reserve
+    /// outputs, ADR 0003) would find nothing. This calls the node's
+    /// `dev_settleToBackground` RPC (testnet-only) to emit an explicit
+    /// demurrage-settlement that reclassifies a coinbase to factor-1, then
+    /// waits for it to be mined — retrying while the chain is still warming up
+    /// (insufficient ring decoys / no mature coinbase yet).
+    FundReserve {
+        /// Node index whose wallet is the reserve (matches `gen-bridge-keys`).
+        #[arg(long, default_value_t = 0)]
+        node: usize,
+
+        /// Picocredits to settle to factor-1 (must cover the wrap amount +
+        /// release fee). Default 1 BTH.
+        #[arg(long, default_value_t = 1_000_000_000_000)]
+        amount: u64,
+
+        /// Base gossip port (RPC = base + 100 + node); locates the node RPC.
+        #[arg(long, default_value_t = DEFAULT_BASE_PORT)]
+        base_port: u16,
+
+        /// Max seconds to wait for the settlement to succeed and be mined.
+        #[arg(long, default_value_t = 900)]
+        timeout_secs: u64,
     },
 }
 
@@ -235,6 +267,12 @@ fn main() -> Result<()> {
         Commands::RestartNode { node } => cmd_restart_node(node, args.verbose),
         Commands::Clean => cmd_clean(args.verbose),
         Commands::GenBridgeKeys { node, out } => cmd_gen_bridge_keys(node, &out),
+        Commands::FundReserve {
+            node,
+            amount,
+            base_port,
+            timeout_secs,
+        } => cmd_fund_reserve(node, amount, base_port, timeout_secs),
     }
 }
 
@@ -832,8 +870,9 @@ fn cmd_gen_bridge_keys(node: usize, out: &Path) -> Result<()> {
         let _ = fs::set_permissions(out, fs::Permissions::from_mode(0o700));
     }
 
-    // RESERVE = the node's own deterministic (pre-funded, factor-1-accruing)
-    // wallet. Deriving from the SAME mnemonic the harness boots node `node`
+    // RESERVE = the node's own deterministic (pre-funded) wallet. It accrues
+    // cluster-tagged coinbases; `fund-reserve` settles one into factor-1.
+    // Deriving from the SAME mnemonic the harness boots node `node`
     // with means the reserve keys detect that node's coinbase + lottery
     // outputs — no secret is introduced.
     let reserve_mnemonic = generate_deterministic_mnemonic(node)?;
@@ -861,6 +900,102 @@ fn cmd_gen_bridge_keys(node: usize, out: &Path) -> Result<()> {
     emit_bridge_wallet(out, "user", "USER", &user)?;
 
     Ok(())
+}
+
+/// Fund the bridge reserve with a spendable factor-1 output (#1025).
+///
+/// Calls the node's testnet-only `dev_settleToBackground` RPC, which emits an
+/// explicit demurrage-settlement reclassifying one of the node wallet's own
+/// (cluster-tagged) coinbases to a factor-1/background output back to itself.
+/// Retries while the chain is still warming up (no mature coinbase yet, or too
+/// few decoys to form the ring), then waits for the settlement to be mined.
+fn cmd_fund_reserve(node: usize, amount: u64, base_port: u16, timeout_secs: u64) -> Result<()> {
+    let rpc_port = base_port + RPC_PORT_OFFSET + node as u16;
+    let rpc_url = format!("http://127.0.0.1:{}", rpc_port);
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(RPC_TIMEOUT_SECS))
+        .build()?;
+
+    eprintln!(
+        "Funding reserve (node {}) with a factor-1 settlement of {} pc via {}",
+        node, amount, rpc_url
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+
+    // 1) Retry the settlement until the chain has matured enough to build it (a
+    //    mature coinbase to spend + DEFAULT_RING_SIZE-1 decoys for the ring).
+    let tx_hash = loop {
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "timed out waiting to submit the reserve settlement (chain never \
+                 warmed up enough: need a mature coinbase + a full decoy ring)"
+            ));
+        }
+
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "dev_settleToBackground",
+            "params": { "amount": amount },
+        });
+        match client.post(&rpc_url).json(&request).send() {
+            Ok(resp) => {
+                let body: serde_json::Value = resp.json().unwrap_or_else(|_| json!({}));
+                if let Some(hash) = body
+                    .get("result")
+                    .and_then(|r| r.get("txHash"))
+                    .and_then(|h| h.as_str())
+                {
+                    eprintln!("Reserve settlement submitted: tx {hash}");
+                    break hash.to_string();
+                }
+                let msg = body
+                    .get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("unknown error");
+                eprintln!("  settlement not ready yet ({msg}); retrying in 10s");
+            }
+            Err(e) => eprintln!("  RPC call failed ({e}); retrying in 10s"),
+        }
+        thread::sleep(Duration::from_secs(10));
+    };
+
+    // 2) Wait for the settlement to be mined (confirmed), so the reserve owns a
+    //    spendable factor-1 output before the release leg runs.
+    loop {
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "reserve settlement {tx_hash} submitted but not mined before timeout"
+            ));
+        }
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tx_get",
+            "params": { "tx_hash": tx_hash },
+        });
+        if let Ok(resp) = client.post(&rpc_url).json(&request).send() {
+            let body: serde_json::Value = resp.json().unwrap_or_else(|_| json!({}));
+            if body
+                .get("result")
+                .and_then(|r| r.get("status"))
+                .and_then(|s| s.as_str())
+                == Some("confirmed")
+            {
+                let h = body
+                    .get("result")
+                    .and_then(|r| r.get("blockHeight"))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                eprintln!("Reserve settlement {tx_hash} confirmed at block {h}");
+                eprintln!("Reserve now owns a spendable factor-1 output.");
+                return Ok(());
+            }
+        }
+        thread::sleep(Duration::from_secs(5));
+    }
 }
 
 // ============================================================================
@@ -1136,7 +1271,8 @@ mod tests {
 
     /// The exported classical view/spend scalars are exactly the node wallet's
     /// own keys — the invariant that makes "reserve == the pre-funded miner"
-    /// hold, so the reserve owns the node's factor-1 lottery outputs.
+    /// hold, so the reserve detects (and, after `fund-reserve` settles one into
+    /// factor-1, can spend) the node's own coinbase outputs.
     #[test]
     fn reserve_keys_match_node_wallet() {
         let mnemonic = generate_deterministic_mnemonic(1).unwrap();

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -36,8 +36,8 @@ use crate::{
     node::{MintedMintingTx, Node, SharedLedger},
     rpc::{
         calculate_dir_size, init_metrics, start_metrics_server, start_rpc_server, FaucetState,
-        MetricsUpdater, NodeIdentity, PeerInfoSnapshot, RpcState, WsBroadcaster,
-        DATA_DIR_USAGE_BYTES,
+        KeyTier, MetricsUpdater, NodeIdentity, PeerInfoSnapshot, RateLimiter, RpcState,
+        WsBroadcaster, DATA_DIR_USAGE_BYTES,
     },
     transaction::Transaction,
     wallet::Wallet,
@@ -619,6 +619,17 @@ async fn run_async(mut config: Config, config_path: &Path, mint: bool) -> Result
         }
     } else {
         debug!("No wallet configured (running in relay mode)");
+    }
+
+    // Local testnet harness / e2e drivers poll the RPC very heavily: the bridge
+    // full-loop reconciler + release drive loop + the user's 200-block stealth
+    // scan-back easily blow past the 100 req/min "anonymous" tier and start
+    // getting 429s mid-loop (#1025). Rate limiting is pointless for a
+    // localhost dev/testnet node, so lift the default tier on any non-production
+    // network. Mainnet keeps the standard 100/min anonymous limit unchanged.
+    if !config.network_type.is_production() {
+        rpc_state.rate_limiter =
+            Arc::new(RateLimiter::with_default_tier(KeyTier::Custom(1_000_000)));
     }
 
     let rpc_state = Arc::new(rpc_state);

--- a/botho/src/commands/run.rs
+++ b/botho/src/commands/run.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 
 use crate::{
     block::MintingTx,
-    config::{Config, QuorumConfig, QuorumMode},
+    config::{is_dev_rpc_enabled, Config, QuorumConfig, QuorumMode},
     consensus::{
         BlockBuilder, ConsensusConfig, ConsensusEvent, ConsensusService, LotteryFeeConfig,
         QuorumGateSnapshot, ScpSlotSnapshot, TransactionValidator,
@@ -624,10 +624,18 @@ async fn run_async(mut config: Config, config_path: &Path, mint: bool) -> Result
     // Local testnet harness / e2e drivers poll the RPC very heavily: the bridge
     // full-loop reconciler + release drive loop + the user's 200-block stealth
     // scan-back easily blow past the 100 req/min "anonymous" tier and start
-    // getting 429s mid-loop (#1025). Rate limiting is pointless for a
-    // localhost dev/testnet node, so lift the default tier on any non-production
-    // network. Mainnet keeps the standard 100/min anonymous limit unchanged.
-    if !config.network_type.is_production() {
+    // getting 429s mid-loop (#1025). Lifting the limit is fine for a throwaway
+    // localhost harness node, but a *live public* testnet node is
+    // internet-facing, so an unlimited anonymous tier is a DoS-amplification
+    // vector (M1). Gate the lift on Testnet AND the explicit dev-RPC opt-in
+    // (`BOTHO_ENABLE_DEV_RPC`, which the `botho-testnet` harness sets on the
+    // nodes it spawns) — off by default. A normal public testnet node keeps the
+    // standard 100/min anonymous limit; mainnet is unchanged.
+    if !config.network_type.is_production() && is_dev_rpc_enabled() {
+        info!(
+            "Dev RPC enabled (BOTHO_ENABLE_DEV_RPC): lifting the anonymous RPC rate limit \
+             for local e2e drivers"
+        );
         rpc_state.rate_limiter =
             Arc::new(RateLimiter::with_default_tier(KeyTier::Custom(1_000_000)));
     }

--- a/botho/src/config.rs
+++ b/botho/src/config.rs
@@ -935,8 +935,8 @@ pub fn is_mainnet_enabled() -> bool {
 /// Some testnet conveniences are unsafe to expose on an *internet-facing*
 /// public testnet node even though they are firewalled off mainnet:
 ///
-///   * `dev_settleToBackground` — an unauthenticated, CPU-heavy (full UTXO
-///     scan + CLSAG ring build), *mutating* self-send RPC, and
+///   * `dev_settleToBackground` — an unauthenticated, CPU-heavy (full UTXO scan
+///     + CLSAG ring build), *mutating* self-send RPC, and
 ///   * lifting the anonymous RPC rate limit to effectively unlimited.
 ///
 /// Both are DoS-amplification vectors if reachable on a live public node, so

--- a/botho/src/config.rs
+++ b/botho/src/config.rs
@@ -930,6 +930,29 @@ pub fn is_mainnet_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// Whether the local dev/test RPC surface is enabled.
+///
+/// Some testnet conveniences are unsafe to expose on an *internet-facing*
+/// public testnet node even though they are firewalled off mainnet:
+///
+///   * `dev_settleToBackground` — an unauthenticated, CPU-heavy (full UTXO
+///     scan + CLSAG ring build), *mutating* self-send RPC, and
+///   * lifting the anonymous RPC rate limit to effectively unlimited.
+///
+/// Both are DoS-amplification vectors if reachable on a live public node, so
+/// they are gated on Testnet AND this explicit opt-in flag (off by default).
+/// The local full-loop e2e harness (`botho-testnet`) sets it for the throwaway
+/// nodes it spawns; a normal `botho --testnet run` does not, so a public
+/// testnet node keeps its 100/min anonymous limit and never exposes the dev
+/// RPC. Mainnet is unaffected (already firewalled by network type).
+///
+/// Set `BOTHO_ENABLE_DEV_RPC=1` (or `true`) to enable.
+pub fn is_dev_rpc_enabled() -> bool {
+    std::env::var("BOTHO_ENABLE_DEV_RPC")
+        .map(|v| v == "1" || v.to_lowercase() == "true")
+        .unwrap_or(false)
+}
+
 /// Validate that the requested network can be used.
 /// Returns an error if mainnet is requested but not enabled.
 pub fn validate_network(network: Network) -> Result<()> {

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -3812,13 +3812,18 @@ async fn handle_dev_settle_to_background(
     params: &Value,
     state: &RpcState,
 ) -> JsonRpcResponse {
-    // Testnet-only footgun guard: settlement is a legitimate operation for any
-    // holder, but this self-send helper exists purely for the local harness.
-    if state.network_type != Network::Testnet {
+    // Footgun guard: settlement is a legitimate operation for any holder, but
+    // this unauthenticated, CPU-heavy (full UTXO scan + CLSAG ring build),
+    // *mutating* self-send helper exists purely for the local harness. It is
+    // firewalled off mainnet by network type AND gated behind the explicit
+    // dev-RPC opt-in (`BOTHO_ENABLE_DEV_RPC`, set by the `botho-testnet`
+    // harness) so that a *live public* internet-facing testnet node does not
+    // expose it by default — only a throwaway local harness node does (M1/L1).
+    if state.network_type != Network::Testnet || !crate::config::is_dev_rpc_enabled() {
         return JsonRpcResponse::error(
             id,
             -32000,
-            "dev_settleToBackground is only available on testnet",
+            "dev_settleToBackground is not enabled (testnet + BOTHO_ENABLE_DEV_RPC only)",
         );
     }
 

--- a/botho/src/rpc/mod.rs
+++ b/botho/src/rpc/mod.rs
@@ -1042,6 +1042,13 @@ async fn handle_rpc_method(request: &JsonRpcRequest, state: &RpcState) -> JsonRp
         "faucet_request" => handle_faucet_request(id, &request.params, state, None).await,
         "faucet_getStatus" => handle_faucet_status(id, state).await,
 
+        // Dev/testnet-only: settle the node wallet's own coins to factor-1
+        // (background) so a bridge reserve can accrue spendable factor-1 outputs
+        // (#1025 full-loop reserve funding).
+        "dev_settleToBackground" => {
+            handle_dev_settle_to_background(id, &request.params, state).await
+        }
+
         _ => JsonRpcResponse::error(id, -32601, &format!("Method not found: {}", request.method)),
     }
 }
@@ -3782,6 +3789,220 @@ async fn handle_faucet_request(
             JsonRpcResponse::error(id, -32000, &format!("Failed to serialize response: {}", e))
         }
     }
+}
+
+/// `dev_settleToBackground` (testnet-only): build an explicit
+/// demurrage-settlement (#831) that spends the node wallet's own (cluster-
+/// tagged) coins to a **factor-1/background** output back to its own address,
+/// and submit it to the mempool.
+///
+/// This is the local full-loop bridge e2e's reserve-funding primitive (#1025).
+/// The bridge releaser (`release/bth.rs`) only ever spends **factor-1**
+/// reserve outputs (ADR 0003), but a freshly-mined node accrues ONLY
+/// 100%-cluster-tagged coinbases (`block.rs::to_tx_output`) — it never
+/// naturally holds factor-1. A settlement is the consensus-sanctioned
+/// reclassification to background (the same on-ramp a real wrap deposit
+/// uses); in the bootstrap epoch the capitalized settlement charge is zero
+/// (`demurrage_rate_bps == 0`), so it costs only the base fee.
+///
+/// Params: `{ "amount": <picocredits, optional, default 1 BTH> }`.
+/// Gated to testnet — never exposed on mainnet.
+async fn handle_dev_settle_to_background(
+    id: Value,
+    params: &Value,
+    state: &RpcState,
+) -> JsonRpcResponse {
+    // Testnet-only footgun guard: settlement is a legitimate operation for any
+    // holder, but this self-send helper exists purely for the local harness.
+    if state.network_type != Network::Testnet {
+        return JsonRpcResponse::error(
+            id,
+            -32000,
+            "dev_settleToBackground is only available on testnet",
+        );
+    }
+
+    let wallet = match &state.wallet {
+        Some(w) => w,
+        None => return JsonRpcResponse::error(id, -32000, "Node wallet not configured"),
+    };
+
+    // Amount to settle to background (default 1 BTH). The remainder of the
+    // selected input(s) becomes background change back to us.
+    const DEFAULT_SETTLE_AMOUNT: u64 = 1_000_000_000_000; // 1 BTH
+    let amount = params
+        .get("amount")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(DEFAULT_SETTLE_AMOUNT);
+
+    let fee = MIN_TX_FEE;
+    let required = match amount.checked_add(fee) {
+        Some(r) => r,
+        None => return JsonRpcResponse::error(id, -32602, "amount + fee overflow"),
+    };
+
+    let our_address = wallet.default_address();
+
+    let ledger = read_lock!(state.ledger, id);
+
+    // Scan our own spendable UTXOs (stealth ownership via the account key).
+    let all_utxos = match ledger.scan_utxos_for_account(wallet.account_key()) {
+        Ok(u) => u,
+        Err(e) => {
+            error!("dev_settleToBackground: failed to scan UTXOs: {}", e);
+            return JsonRpcResponse::error(id, -32000, "Failed to scan wallet UTXOs");
+        }
+    };
+
+    // Drop spent / pending inputs (chain + mempool), mirroring the faucet.
+    let mempool = read_lock!(state.mempool, id);
+    let mut utxos = Vec::new();
+    for utxo in &all_utxos {
+        if let Some(subaddress_index) = wallet.scan_output(&utxo.output, utxo.id.output_index) {
+            if let Some(onetime_private) = wallet.recover_output_spend_key(
+                &utxo.output,
+                subaddress_index,
+                utxo.id.output_index,
+            ) {
+                let key_image = bth_crypto_ring_signature::KeyImage::from(&onetime_private);
+                let key_image_bytes = key_image.as_bytes();
+                if mempool.is_key_image_pending(&key_image_bytes) {
+                    continue;
+                }
+                match ledger.is_key_image_spent(&key_image_bytes) {
+                    Ok(None) => utxos.push(utxo.clone()),
+                    Ok(Some(_)) => continue,
+                    Err(e) => {
+                        error!("dev_settleToBackground: key image check failed: {}", e);
+                        return JsonRpcResponse::error(id, -32000, "Key image check failed");
+                    }
+                }
+            }
+        }
+    }
+    drop(mempool);
+
+    // Select enough inputs to cover amount + fee.
+    let mut selected_utxos = Vec::new();
+    let mut selected_amount = 0u64;
+    for utxo in &utxos {
+        if selected_amount >= required {
+            break;
+        }
+        selected_utxos.push(utxo.clone());
+        selected_amount = selected_amount.saturating_add(utxo.output.amount);
+    }
+    if selected_amount < required {
+        return JsonRpcResponse::error(
+            id,
+            -32000,
+            &format!(
+                "insufficient spendable balance: have {} pc, need {} pc (mine more blocks)",
+                selected_amount, required
+            ),
+        );
+    }
+
+    let current_height = match ledger.get_chain_state() {
+        Ok(s) => s.height,
+        Err(e) => {
+            error!("dev_settleToBackground: failed to get chain state: {}", e);
+            return JsonRpcResponse::error(id, -32000, "Failed to get chain state");
+        }
+    };
+
+    // Build the (background) outputs: the settled amount + any change, both back
+    // to our own address. `create_settlement_transaction` forces empty cluster
+    // tags and stamps the settlement flag / settled_value.
+    let mut outputs = Vec::new();
+    match TxOutput::new_hybrid_to_address(
+        amount,
+        &our_address,
+        0,
+        None,
+        bth_transaction_types::ClusterTagVector::empty(),
+    ) {
+        Ok(out) => outputs.push(out),
+        Err(e) => {
+            error!(
+                "dev_settleToBackground: wallet address lacks ML-KEM key: {}",
+                e
+            );
+            return JsonRpcResponse::error(id, -32000, "Wallet address is not post-quantum");
+        }
+    }
+    let change = selected_amount - amount - fee;
+    if change > 0 {
+        match TxOutput::new_hybrid_to_address(
+            change,
+            &our_address,
+            1,
+            None,
+            bth_transaction_types::ClusterTagVector::empty(),
+        ) {
+            Ok(out) => outputs.push(out),
+            Err(e) => {
+                error!(
+                    "dev_settleToBackground: wallet address lacks ML-KEM key: {}",
+                    e
+                );
+                return JsonRpcResponse::error(id, -32000, "Wallet address is not post-quantum");
+            }
+        }
+    }
+
+    let tx = match wallet.create_settlement_transaction(
+        &selected_utxos,
+        outputs,
+        fee,
+        current_height,
+        &ledger,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            error!("dev_settleToBackground: failed to build settlement: {}", e);
+            return JsonRpcResponse::error(
+                id,
+                -32000,
+                &format!("Failed to build settlement transaction: {}", e),
+            );
+        }
+    };
+
+    let tx_hash = tx.hash();
+    let tx_hash_hex = hex::encode(tx_hash);
+    drop(ledger);
+
+    // Submit to mempool.
+    {
+        let mut mempool = write_lock!(state.mempool, id);
+        let ledger = read_lock!(state.ledger, id);
+        if let Err(e) = mempool.add_tx(tx.clone(), &ledger) {
+            error!("dev_settleToBackground: mempool rejected settlement: {}", e);
+            return JsonRpcResponse::error(
+                id,
+                -32000,
+                &format!("Failed to submit settlement transaction: {}", e),
+            );
+        }
+    }
+
+    state.ws_broadcaster.new_transaction(&tx_hash, fee, None);
+
+    info!(
+        "dev_settleToBackground: settled {} pc to factor-1 (tx: {})",
+        amount,
+        &tx_hash_hex[..16.min(tx_hash_hex.len())]
+    );
+
+    JsonRpcResponse::success(
+        id,
+        json!({
+            "txHash": tx_hash_hex,
+            "settledAmount": amount.to_string(),
+            "changeAmount": change.to_string(),
+        }),
+    )
 }
 
 /// Faucet dispense statistics calculated from blockchain.

--- a/botho/src/wallet.rs
+++ b/botho/src/wallet.rs
@@ -457,7 +457,74 @@ impl Wallet {
         current_height: u64,
         ledger: &Ledger,
     ) -> Result<Transaction> {
-        self.create_private_transaction_impl(utxos_to_spend, outputs, fee, current_height, ledger)
+        self.create_private_transaction_impl(
+            utxos_to_spend,
+            outputs,
+            fee,
+            current_height,
+            ledger,
+            None,
+        )
+    }
+
+    /// Create an explicit demurrage-settlement transaction (#831): the
+    /// consensus-recognized reclassification of spent (cluster-tagged) value to
+    /// **factor-1/background** for wrap eligibility (ADR 0003).
+    ///
+    /// Unlike [`Self::create_private_transaction`] — which forces every output
+    /// to inherit the inputs' decayed cluster tags (coin-lineage tracking) — a
+    /// settlement emits **all-background** outputs (empty [`ClusterTagVector`])
+    /// and stamps the transaction with a [`SettlementInfo`] whose
+    /// `settled_value` equals the summed output amounts. Consensus prices the
+    /// capitalized future demurrage of the downgrade into the fee floor (C7,
+    /// issue #925); in the bootstrap epoch that charge is zero, so a settlement
+    /// there costs only the base fee.
+    ///
+    /// This is what lets a bridge reserve accrue **spendable factor-1** outputs
+    /// (the releaser's `factor_one` filter, `release/bth.rs`) from otherwise
+    /// cluster-tagged coinbase inputs — the local full-loop e2e's reserve
+    /// funding path (#1025).
+    ///
+    /// The caller supplies the recipient outputs; their `cluster_tags` are
+    /// overwritten to empty here (a settlement MUST reclassify all value to
+    /// background, enforced by `Ledger::verify_settlement`). `settled_value` is
+    /// derived from the output amounts.
+    ///
+    /// # Arguments
+    /// * `utxos_to_spend` - The wallet's UTXOs to settle (spend as inputs)
+    /// * `outputs` - Recipient outputs (their cluster tags are forced empty)
+    /// * `fee` - Transaction fee (must clear the consensus fee floor)
+    /// * `current_height` - Current blockchain height
+    /// * `ledger` - Ledger for fetching decoy outputs
+    pub fn create_settlement_transaction(
+        &self,
+        utxos_to_spend: &[Utxo],
+        outputs: Vec<TxOutput>,
+        fee: u64,
+        current_height: u64,
+        ledger: &Ledger,
+    ) -> Result<Transaction> {
+        // A settlement reclassifies ALL value to background: force every output
+        // to carry an empty cluster-tag vector (verify_settlement rejects any
+        // non-background output).
+        let outputs: Vec<TxOutput> = outputs
+            .into_iter()
+            .map(|mut o| {
+                o.cluster_tags = ClusterTagVector::empty();
+                o
+            })
+            .collect();
+        let settled_value = outputs
+            .iter()
+            .fold(0u64, |acc, o| acc.saturating_add(o.amount));
+        self.create_private_transaction_impl(
+            utxos_to_spend,
+            outputs,
+            fee,
+            current_height,
+            ledger,
+            Some(settled_value),
+        )
     }
 
     /// Alias for `create_clsag_transaction` for backwards compatibility.
@@ -486,10 +553,25 @@ impl Wallet {
         current_height: u64,
         ledger: &Ledger,
     ) -> Result<Transaction> {
-        self.create_private_transaction_impl(utxos_to_spend, outputs, fee, current_height, ledger)
+        self.create_private_transaction_impl(
+            utxos_to_spend,
+            outputs,
+            fee,
+            current_height,
+            ledger,
+            None,
+        )
     }
 
     /// Internal implementation for CLSAG private transactions.
+    ///
+    /// `settlement_value` selects the transaction flavor:
+    /// - `None` — an ordinary transfer: every output inherits the inputs'
+    ///   merged+decayed cluster tags (coin-lineage tracking).
+    /// - `Some(v)` — an explicit demurrage-settlement (#831): outputs keep the
+    ///   (empty/background) tags the caller set and the tx is stamped
+    ///   `new_settlement(.., v)`. The settlement flag is bound into the signing
+    ///   hash, so the preliminary tx used for signing must carry it too.
     fn create_private_transaction_impl(
         &self,
         utxos_to_spend: &[Utxo],
@@ -497,29 +579,39 @@ impl Wallet {
         fee: u64,
         current_height: u64,
         ledger: &Ledger,
+        settlement_value: Option<u64>,
     ) -> Result<Transaction> {
         if utxos_to_spend.is_empty() {
             return Err(anyhow::anyhow!("No UTXOs to spend"));
         }
 
-        // Compute inherited cluster tags from inputs with default decay
-        // All outputs inherit the same merged+decayed tag vector from inputs
-        let inherited_tags =
-            Self::compute_inherited_tags(utxos_to_spend, DEFAULT_CLUSTER_DECAY_RATE);
+        // Ordinary transfers force every output to inherit the inputs'
+        // merged+decayed cluster tags. A settlement instead reclassifies all
+        // value to background, so it keeps the caller's (empty) tags untouched.
+        let outputs: Vec<TxOutput> = if settlement_value.is_some() {
+            outputs
+        } else {
+            let inherited_tags =
+                Self::compute_inherited_tags(utxos_to_spend, DEFAULT_CLUSTER_DECAY_RATE);
+            outputs
+                .into_iter()
+                .map(|mut o| {
+                    o.cluster_tags = inherited_tags.clone();
+                    o
+                })
+                .collect()
+        };
 
-        // Apply inherited tags to all outputs
-        let outputs: Vec<TxOutput> = outputs
-            .into_iter()
-            .map(|mut o| {
-                o.cluster_tags = inherited_tags.clone();
-                o
-            })
-            .collect();
-
-        // Build a preliminary transaction to get the signing hash
-        // We'll replace the inputs with real ring inputs after signing
-        let preliminary_tx =
-            Transaction::new_clsag(Vec::new(), outputs.clone(), fee, current_height);
+        // Build a preliminary transaction to get the signing hash. The
+        // settlement flag is covered by the signing hash, so it must be present
+        // here for a settlement (else the signature would not bind it).
+        // We'll replace the inputs with real ring inputs after signing.
+        let preliminary_tx = match settlement_value {
+            Some(v) => {
+                Transaction::new_settlement(Vec::new(), outputs.clone(), fee, current_height, v)
+            }
+            None => Transaction::new_clsag(Vec::new(), outputs.clone(), fee, current_height),
+        };
         let signing_hash = preliminary_tx.signing_hash();
 
         // Number of decoys per ring (MIN_RING_SIZE - 1 since real input is included)
@@ -651,8 +743,12 @@ impl Wallet {
             ring_inputs.push(ring_input);
         }
 
-        // Create the final transaction with CLSAG ring inputs
-        let tx = Transaction::new_clsag(ring_inputs, outputs, fee, current_height);
+        // Create the final transaction with CLSAG ring inputs, preserving the
+        // settlement flag so the on-chain tx matches what was signed.
+        let tx = match settlement_value {
+            Some(v) => Transaction::new_settlement(ring_inputs, outputs, fee, current_height, v),
+            None => Transaction::new_clsag(ring_inputs, outputs, fee, current_height),
+        };
 
         Ok(tx)
     }
@@ -732,6 +828,7 @@ impl Wallet {
             fee,
             current_height,
             ledger,
+            None,
         )?;
 
         Ok((tx, entropy_result))

--- a/bridge/service/src/bth_scan.rs
+++ b/bridge/service/src/bth_scan.rs
@@ -174,16 +174,24 @@ pub fn scan_deposit_output(
 /// `tbotho://`) or a bare base58 body, matching the node's
 /// `parse_classical_address` layout (64 bytes: view || spend).
 pub fn decode_recipient_address(address: &str) -> Result<PublicAddress, String> {
-    // Strip any scheme prefix up to the last '/'; a bare base58 string is
-    // used as-is. The bridge is network-agnostic here (it validates the byte
-    // layout, not the human-readable prefix).
+    // Prefer the canonical address codec: it parses both v1 (classical) and v2
+    // (hybrid ML-KEM/ML-DSA) addresses and returns a `PublicAddress` carrying
+    // the recipient's post-quantum public keys. On the protocol-6.0.0 chain the
+    // release recipient is the user's published v2 address (`tbotho://2/…`,
+    // ~3.2 KB), which the legacy 64-byte path below cannot represent (#972/#1025).
+    if let Ok((addr, _network)) = bth_address_codec::decode_address(address) {
+        return Ok(addr);
+    }
+
+    // Legacy fallback: a bare base58 `view || spend` (64 bytes), no PQ keys.
+    // Kept so classical callers/tests that pass a raw address still work.
     let body = address.rsplit('/').next().unwrap_or(address);
     let bytes = bs58::decode(body)
         .into_vec()
         .map_err(|e| format!("recipient address: invalid base58: {e}"))?;
     if bytes.len() != 64 {
         return Err(format!(
-            "recipient address: expected 64 bytes, got {}",
+            "recipient address: not a v1/v2 address and not a 64-byte view||spend (got {} bytes)",
             bytes.len()
         ));
     }
@@ -265,13 +273,47 @@ pub fn build_release_tx<R: RngCore + CryptoRng>(
     // drift from the node's enforcement.
     let import_cluster_id = bth_cluster_tax::import_cluster_id_for_height(created_at_height);
     let import_tags = ClusterTagVector::single(ClusterId(import_cluster_id.0));
-    let recipient_output = TxOutput::new_with_cluster_tags(amount, recipient, None, import_tags);
+    // On the protocol-6.0.0 chain the recipient publishes an ML-KEM key, so the
+    // release pays a HYBRID stealth output (ADR 0004): the ciphertext is
+    // encapsulated to the recipient's KEM key and folded into the one-time key,
+    // and the recipient scans it back with its ML-KEM secret (the test's
+    // assertion 2). A classical (v1) recipient falls back to a pure-DH stealth
+    // output. The recipient is output index 0, bound into the hybrid derivation.
+    let recipient_output = if recipient.has_pq_keys() {
+        TxOutput::new_hybrid_to_address(amount, recipient, 0, None, import_tags)
+            .map_err(|e| format!("recipient hybrid output: {e:?}"))?
+    } else {
+        TxOutput::new_with_cluster_tags(amount, recipient, None, import_tags)
+    };
     let mut outputs = vec![recipient_output];
 
     // Change back to the reserve's default subaddress (ADR 0003). Sub-dust
     // change is folded into the fee (never an unspendable output).
+    //
+    // On the protocol-6.0.0 chain EVERY value output must carry an ML-KEM
+    // ciphertext (`KEM_CIPHERTEXT_ENFORCED`, #973) or the node rejects the tx
+    // at intrinsic validation — so the change is a HYBRID self-send encapsulated
+    // to the reserve's OWN ML-KEM key (the reserve's `AccountKey` does not carry
+    // its PQ public key inline, so we pass the keypair's public key directly to
+    // `new_hybrid`). The reserve scans this change back with its ML-KEM secret
+    // for a later release. Change is output index 1, bound into the derivation.
+    // A classical-only reserve (pre-6.0.0 / no PQ seed) falls back to a pure-DH
+    // output (#972/#1025).
+    let change_output = |amount: u64| -> TxOutput {
+        match kem_keypair {
+            Some(kp) => TxOutput::new_hybrid(
+                amount,
+                &account.default_subaddress(),
+                kp.public_key(),
+                1,
+                None,
+                ClusterTagVector::default(),
+            ),
+            None => TxOutput::new(amount, &account.default_subaddress()),
+        }
+    };
     let actual_fee = if change >= DUST_THRESHOLD {
-        outputs.push(TxOutput::new(change, &account.default_subaddress()));
+        outputs.push(change_output(change));
         fee
     } else {
         fee + change

--- a/bridge/service/src/e2e_full_loop_tests.rs
+++ b/bridge/service/src/e2e_full_loop_tests.rs
@@ -573,8 +573,16 @@ async fn full_loop_wrap_mint_burn_release() {
 
     // Assertion 4d — now at threshold (2/2), the engine releases through the
     // live BthReleaser: BurnConfirmed → ReleasePending → Released.
+    //
+    // Unlike the mint leg (Ethereum/Hardhat auto-mines each tx instantly), the
+    // release is confirmed only once its tx is MINED into a real BTH block
+    // (`check_confirmation` requires confirmations >= 1). On a live SCP testnet
+    // that is a full consensus round, so the budget must span at least one
+    // block time — far longer than the mint leg's. `drive_until` returns as
+    // soon as the order is Released, so this large cap only bounds a failure,
+    // never the happy path.
     let final_release =
-        drive_until(&processor, &db, &burn_order.id, OrderStatus::Released, 60).await;
+        drive_until(&processor, &db, &burn_order.id, OrderStatus::Released, 600).await;
     assert_eq!(
         final_release,
         OrderStatus::Released,

--- a/bridge/service/src/release/bth.rs
+++ b/bridge/service/src/release/bth.rs
@@ -354,8 +354,16 @@ impl BthReleaser {
                     // spent (it would launder cluster provenance, ADR 0003);
                     // it is neither an input nor a decoy.
                     Some(_) => {}
-                    // Everyone else's outputs are decoy candidates.
-                    None => decoy_pool.push(out.clone()),
+                    // Everyone else's outputs are decoy candidates — but only if
+                    // they are plausible spendable UTXOs. `chain_getOutputs`
+                    // replays every historical output, including the genesis
+                    // placeholder (height 0, amount 0, all-zero target key) that
+                    // is NOT in the UTXO set; using it as a ring member makes the
+                    // node reject the release block ("ring member target_key not
+                    // in UTXO set", C3). Skip zero-amount / all-zero-key outputs
+                    // so every decoy resolves to a real UTXO (#1025).
+                    None if is_spendable_decoy(out) => decoy_pool.push(out.clone()),
+                    None => {}
                 }
             }
         }
@@ -382,6 +390,16 @@ impl BthReleaser {
 
         Ok((spendable, decoy_pool))
     }
+}
+
+/// Whether an output is a plausible spendable UTXO to use as a CLSAG ring
+/// decoy. `chain_getOutputs` replays every historical output, including the
+/// genesis coinbase placeholder (height 0, amount 0, all-zero target key),
+/// which is not minted into the UTXO set. A ring member whose target key is not
+/// in the UTXO set makes the node reject the whole release block (C3 ring
+/// resolution), so such outputs must never be chosen as decoys (#1025).
+fn is_spendable_decoy(out: &crate::bth_rpc::RpcOutput) -> bool {
+    out.amount > 0 && out.target_key.trim_matches('0').len() != 0
 }
 
 /// Derive the key image of a reserve-owned output (node-identical), for the

--- a/bridge/service/src/release/bth.rs
+++ b/bridge/service/src/release/bth.rs
@@ -399,7 +399,7 @@ impl BthReleaser {
 /// in the UTXO set makes the node reject the whole release block (C3 ring
 /// resolution), so such outputs must never be chosen as decoys (#1025).
 fn is_spendable_decoy(out: &crate::bth_rpc::RpcOutput) -> bool {
-    out.amount > 0 && out.target_key.trim_matches('0').len() != 0
+    out.amount > 0 && !out.target_key.trim_matches('0').is_empty()
 }
 
 /// Derive the key image of a reserve-owned output (node-identical), for the

--- a/scripts/bridge-e2e-full-loop.sh
+++ b/scripts/bridge-e2e-full-loop.sh
@@ -118,7 +118,14 @@ cd "$REPO_ROOT"
 # minting/externalizing — independent of the #1000 SYNC-gate fix. A 2-node
 # cluster satisfies both the participation gate (1 peer each) and the 2-of-2
 # SCP quorum, so it actually produces blocks. --clean guarantees a fresh chain.
-cargo run --release --bin botho-testnet -- start --nodes 2 --clean --wait-consensus
+#
+# NOT --wait-consensus: on a fresh chain the FIRST block takes longer than the
+# harness's 30s consensus-wait timeout (RandomX difficulty calibrates upward
+# over the first few blocks), so --wait-consensus would abort the run before a
+# single block is mined. The height-poll warmup below is the robust wait — it
+# tolerates the slow first block and blocks until the chain is actually deep
+# enough to form decoy rings.
+cargo run --release --bin botho-testnet -- start --nodes 2 --clean
 BOTHO_STARTED=1
 
 # Warm the chain up so the reserve funding + release can each form a CLSAG ring

--- a/scripts/bridge-e2e-full-loop.sh
+++ b/scripts/bridge-e2e-full-loop.sh
@@ -39,11 +39,17 @@
 #
 # The reserve key material is PROVISIONED AT RUNTIME (#999): after the node is
 # up this script runs `botho-testnet gen-bridge-keys`, which exports the
-# node's own deterministic (pre-funded) mining wallet as the reserve — so it
-# already owns spendable factor-1 (zero-demurrage, ADR 0003) outputs from
-# lottery emission — and mints a fresh random user wallet. NO private key is
-# committed to the repo. If you would rather bring your own reserve, set the
-# BRIDGE_BTH_RESERVE_* vars yourself and the auto-provisioning is skipped.
+# node's own deterministic (pre-funded) mining wallet as the reserve, and mints
+# a fresh random user wallet. NO private key is committed to the repo.
+#
+# A freshly-mined node accrues ONLY 100%-cluster-tagged coinbases, never
+# factor-1 (lottery EMISSION is zero in the bootstrap epoch), so the reserve
+# would have nothing the releaser's factor_one filter can spend (#1025). The
+# driver therefore also runs `botho-testnet fund-reserve`, which settles one of
+# node 0's coinbases into a spendable factor-1/background output (ADR 0003) it
+# owns — the zero-cost settlement the bootstrap epoch permits. If you would
+# rather bring your own funded reserve, set the BRIDGE_BTH_RESERVE_* vars
+# yourself and both the keygen and the funding step are skipped.
 #
 # When no reserve key material is provided AND provisioning is disabled the
 # test SELF-SKIPS (green), exactly like bridge/service/src/bth_fork_tests.rs —
@@ -106,27 +112,58 @@ export BRIDGE_BTH_RPC_URL="${BRIDGE_BTH_RPC_URL:-http://127.0.0.1:27200}"
 
 echo "==> Starting local Botho node (botho-testnet)"
 cd "$REPO_ROOT"
-# A single node externalizes blocks under SCP with an n=1 quorum; the harness
-# default is fine too. --clean guarantees a fresh chain each run.
-cargo run --release --bin botho-testnet -- start --nodes 1 --clean --wait-consensus
+# TWO nodes (reserve = node 0). A lone `--nodes 1` node cannot externalize on
+# this harness: the testnet config sets `min_peers = 1`, so the #428
+# participation gate (should_propose_this_round) blocks a peerless node from
+# minting/externalizing — independent of the #1000 SYNC-gate fix. A 2-node
+# cluster satisfies both the participation gate (1 peer each) and the 2-of-2
+# SCP quorum, so it actually produces blocks. --clean guarantees a fresh chain.
+cargo run --release --bin botho-testnet -- start --nodes 2 --clean --wait-consensus
 BOTHO_STARTED=1
 
-echo "==> Mining a reserve warmup (spendable factor-1 outputs + decoy ring)"
-# The CLSAG release needs reserve-owned factor-1 outputs AND enough decoys in
-# the recent window (DEFAULT_RING_SIZE-1 per input). The harness pre-funds a
-# deterministic wallet; give the chain time to produce a spendable window.
-sleep 15
+# Warm the chain up so the reserve funding + release can each form a CLSAG ring
+# (DEFAULT_RING_SIZE = 20, i.e. 19 decoys per input). The release draws its
+# decoys from NON-reserve outputs (node 1's coinbases), so we need enough blocks
+# that ~19 of them exist. Poll the tip until it clears the warmup bar.
+BRIDGE_BTH_WARMUP_HEIGHT="${BRIDGE_BTH_WARMUP_HEIGHT:-50}"
+echo "==> Warming the chain up to height >= $BRIDGE_BTH_WARMUP_HEIGHT (decoy anonymity set)"
+warmup_deadline=$(( $(date +%s) + 2400 ))
+while :; do
+    height="$(curl -sf -X POST -H 'Content-Type: application/json' \
+        --data '{"jsonrpc":"2.0","method":"getChainInfo","params":{},"id":1}' \
+        "$BRIDGE_BTH_RPC_URL" 2>/dev/null | sed -n 's/.*"height":\([0-9]*\).*/\1/p')"
+    height="${height:-0}"
+    echo "    tip height: $height"
+    if [[ "$height" -ge "$BRIDGE_BTH_WARMUP_HEIGHT" ]]; then
+        break
+    fi
+    if [[ "$(date +%s)" -ge "$warmup_deadline" ]]; then
+        echo "::warning::chain did not reach height $BRIDGE_BTH_WARMUP_HEIGHT within the" \
+             "warmup budget (at $height); continuing — the release may skip on too few decoys."
+        break
+    fi
+    sleep 10
+done
 
 # Provision the reserve + user wallet key material at runtime (#999) unless the
 # caller supplied their own reserve. The reserve is the node's own pre-funded
-# mining wallet (it owns spendable factor-1 lottery-emission outputs), so no
-# secret is committed. `eval` imports the `export BRIDGE_BTH_*` lines the tool
-# prints on stdout (its human logs go to stderr).
+# mining wallet, and no secret is committed. `eval` imports the
+# `export BRIDGE_BTH_*` lines the tool prints on stdout (human logs -> stderr).
 if [[ -z "${BRIDGE_BTH_RESERVE_VIEW_KEY:-}" ]]; then
     echo "==> Provisioning bridge reserve + user keys (runtime keygen; no secret committed)"
     BRIDGE_KEYS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bridge-full-loop-keys.XXXXXX")"
     eval "$(cargo run --release --bin botho-testnet -- \
         gen-bridge-keys --node 0 --out "$BRIDGE_KEYS_DIR")"
+
+    # A freshly-mined node accrues ONLY 100%-cluster-tagged coinbases — never
+    # factor-1 — so the releaser's factor_one filter (release/bth.rs) would find
+    # nothing to spend (#1025 gap M2). Settle one of node 0's coinbases to a
+    # factor-1/background output it owns, giving the reserve a spendable
+    # factor-1 UTXO. In the bootstrap epoch the capitalized settlement charge is
+    # zero, so this costs only the base fee. Skipped when the caller BYO reserve.
+    echo "==> Funding the reserve with a factor-1 settlement output (#1025)"
+    cargo run --release --bin botho-testnet -- \
+        fund-reserve --node 0 --amount "${BRIDGE_BTH_AMOUNT:-1000000000000}"
 else
     echo "==> Using caller-provided BTH reserve key material"
 fi


### PR DESCRIPTION
## Summary

Makes the `full-loop` bridge e2e (`scripts/bridge-e2e-full-loop.sh` /
`.github/workflows/bridge-e2e.yml`) run the **BTH release leg for real** —
deposit → mint-wBTH → burn → release-BTH, peg invariant asserted — instead of
self-skipping. Completes what #999/#1024 set up (#1025).

Verified end-to-end locally against the actual driver (real Botho 2-node testnet
+ local Hardhat node), not just a green CI file:

```
==> Warming the chain up to height >= 50 (decoy anonymity set)
    tip height: 50
==> Provisioning bridge reserve + user keys (runtime keygen; no secret committed)
==> Funding the reserve with a factor-1 settlement output (#1025)
Reserve settlement <tx> confirmed at block 52
==> Running the full-loop e2e against ETH=http://127.0.0.1:8545 BTH=http://127.0.0.1:27200
full loop OK: wrapped 1000000000000 pc → wBTH minted (2/2 EIP-712) → burned →
  released to a fresh stealth output (2/2 Ed25519); peg returned to 0
test result: ok. 1 passed; 0 failed; ...
==> Bridge full-loop e2e finished
```

## L1 decision — `--nodes 2` (reserve = node 0), NOT relaxing the guard

The driver called `botho-testnet start --nodes 1`, which `cmd_start` rejects
(`2..=10`). But relaxing that guard would **not** help: the testnet config
hardcodes `min_peers = 1`, so a lone node is blocked from minting/externalizing
by the #428 participation gate (`should_propose_this_round`: a peer-expecting
node must have `connected_peers >= min_peers`) — independent of the #1000
SYNC-gate fix. A single node with this config never produces a block.

So the driver now uses `--nodes 2` (reserve = node 0), which satisfies both the
participation gate (1 peer each) and the 2-of-2 SCP quorum. **Runtime-verified**:
a 2-node cluster externalizes (height 0→1→2→…); a lone node stays at 0. No
consensus safety guard was weakened. (Also dropped `--wait-consensus` from the
driver: a fresh chain's first block exceeds the harness's 30 s consensus-wait
timeout while RandomX difficulty calibrates, so the height-poll warmup is the
robust wait.)

## M2 finding — the reserve does NOT naturally accrue factor-1 (fixed)

#1024's "reserve == node-0 miner accrues factor-1" premise is **false**, and
this is only knowable at runtime. `chain_getOutputs` on a fresh chain shows every
coinbase carries `clusterTags: [[<id>, 1000000]]` — 100 % cluster weight, so
`explicit_cluster_weight() == 1_000_000` and `factor_one == false`. The miner
accrues **only** cluster-tagged coinbases; lottery *emission* is zero in the
bootstrap epoch (`lottery_emission_bps(h<halving)=0`). The releaser's `factor_one`
filter (`release/bth.rs`) would therefore find nothing to spend.

**How the reserve is now sourced:** an explicit demurrage-settlement (#831) — the
consensus-sanctioned reclassification to factor-1/background, the same on-ramp a
real wrap deposit uses. In the bootstrap epoch the capitalized settlement charge
is zero (`demurrage_rate_bps=0`), so it costs only the base fee.

- `wallet::create_settlement_transaction` — reuses the CLSAG ring builder but
  keeps outputs background and stamps `SettlementInfo` (ordinary transfers are
  unchanged).
- testnet-only RPC `dev_settleToBackground` — settles the node wallet's own
  coinbase to a factor-1 output back to itself.
- `botho-testnet fund-reserve` — calls that RPC, retrying through chain warmup,
  and waits for it to mine. The driver runs it after `gen-bridge-keys`.

**Runtime-verified**: after `fund-reserve`, `chain_getOutputs` shows 2 empty-tag
(factor-1) reserve-owned outputs, and the releaser spends them
("Prepared BTH release … spending 1 reserve input(s)").

## Additional gaps found by running the release for real (all fixed)

Once M2/L1 let the release reach `prepare_release`, four more pre-existing gaps
in the release *output* path surfaced (unreachable before, because the leg
always self-skipped):

1. **v2 recipient decode** — `decode_recipient_address` only accepted a bare
   64-byte classical address; the user's address is a v2 (ML-KEM/ML-DSA) address
   (~3.2 KB). Now uses `bth_address_codec::decode_address` (v1+v2), 64-byte path
   kept as legacy fallback.
2. **Hybrid recipient output** — pay an ADR-0004 hybrid stealth output when the
   recipient publishes an ML-KEM key (the user scans it back with its ML-KEM
   secret), classical fallback for v1.
3. **Hybrid change output** — on 6.0.0 every value output must carry an ML-KEM
   ciphertext (`KEM_CIPHERTEXT_ENFORCED`, #973) or the node rejects the tx at
   intrinsic validation. The change was classical (`TxOutput::new`) and silently
   stranded the release tx in the mempool; now a hybrid self-send encapsulated to
   the reserve's own ML-KEM key.
4. **Decoy pool filter** — `chain_getOutputs` replays every historical output,
   incl. the genesis placeholder (h0, amount 0, all-zero target key) not in the
   UTXO set; using it as a ring member made the node reject the release block
   ("ring member target_key not in UTXO set", C3). Zero-amount/all-zero-key
   outputs are now skipped as decoys.

Plus two harness-timing fixes: the release confirms only once its tx is **mined**
(a full SCP round, unlike the Hardhat-auto-mined mint), so the release
`drive_until` budget went 60→600 ticks (returns early on success — only bounds a
failure); and the node's **anonymous RPC rate limit** (100/min) is lifted on
non-production networks — the reconciler + release drive + the user's 200-block
scan-back otherwise 429 mid-loop (mainnet unchanged).

## Acceptance Criteria Verification

| Criterion (issue #1025) | Status | Verification |
|---|---|---|
| L1: driver requests a valid node count that actually externalizes | ✅ | `--nodes 2`; runtime-verified blocks externalize, lone node cannot (min_peers=1 gate) |
| M2: factor-1 accrual verified at runtime; reserve funded from a real factor-1 output | ✅ | Proven coinbases are 100 % cluster-tagged; reserve funded via settlement → 2 factor-1 outputs, spent by the releaser |
| Full-loop BTH release leg runs for real (no self-skip), peg asserted | ✅ | `full loop OK … peg returned to 0`; `test result: ok. 1 passed` via `./scripts/bridge-e2e-full-loop.sh` |
| No committed secrets | ✅ | All keys generated at runtime (`gen-bridge-keys` / `fund-reserve`); nothing written to the repo |

## Test Plan

- Ran the real driver `./scripts/bridge-e2e-full-loop.sh` on a clean chain: 2-node
  testnet → warmup to h50 → `gen-bridge-keys` → `fund-reserve` (settlement mined
  at block 52) → full-loop e2e test **passed** (all four assertions: peg intake,
  release to a fresh ADR-0004 stealth output the user scans back, proof-of-reserves
  drift == 0, t-of-n federation authorization).
- `cargo build --release` (node + harness) and `cargo test -p bth-bridge-service --no-run` clean.
- `cargo test -p botho --lib wallet::` — 18 passed (ordinary-transfer path unchanged).

Closes #1025