### PR TITLE
feat(web): add wBTH→BTH Unwrap panel on /trade (release destination + burn guidance + release-order tracking)

### DIFF
--- a/web/packages/features/src/bridge/bridge-client.test.ts
+++ b/web/packages/features/src/bridge/bridge-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { BridgeApiError, createBridgeClient } from './bridge-client'
-import type { MintOrder } from './types'
+import type { MintOrder, ReleaseOrder } from './types'
 
 const ORDER: MintOrder = {
   id: '11111111-1111-1111-1111-111111111111',
@@ -68,5 +68,53 @@ describe('createBridgeClient', () => {
     await expect(
       client.createMintOrder({ destChain: 'ethereum', destAddress: ORDER.destAddress, amount: '1' }),
     ).rejects.toBeInstanceOf(BridgeApiError)
+  })
+})
+
+const RELEASE: ReleaseOrder = {
+  id: '22222222-2222-2222-2222-222222222222',
+  status: 'burn_detected',
+  sourceChain: 'ethereum',
+  bthAddress: 'tbotho://2/releasedest',
+  amount: '5000000000000',
+  fee: '100000000',
+  tokenAddress: '0x49b985ec427ee771a601f11b18f7d4402fa2dd7b',
+  sourceTx: '0xburntx',
+  destTx: null,
+  expiresAt: 1_760_000_000,
+  failureReason: null,
+}
+
+describe('createBridgeClient — release orders (#1032)', () => {
+  it('POSTs release-order create to the normalized base and returns the order', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(RELEASE))
+    const client = createBridgeClient('https://bridge.test/', fetchImpl as unknown as typeof fetch)
+
+    const order = await client.createReleaseOrder({
+      sourceChain: 'ethereum',
+      bthAddress: RELEASE.bthAddress,
+      amount: RELEASE.amount,
+    })
+
+    expect(order).toEqual(RELEASE)
+    const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('https://bridge.test/api/bridge/release-orders')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body as string)).toEqual({
+      sourceChain: 'ethereum',
+      bthAddress: RELEASE.bthAddress,
+      amount: RELEASE.amount,
+    })
+  })
+
+  it('GETs release-order status by id (url-encoded)', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ ...RELEASE, status: 'released' }))
+    const client = createBridgeClient('https://bridge.test', fetchImpl as unknown as typeof fetch)
+
+    const order = await client.getReleaseOrderStatus(RELEASE.id)
+
+    expect(order.status).toBe('released')
+    const [url] = fetchImpl.mock.calls[0] as unknown as [string]
+    expect(url).toBe(`https://bridge.test/api/bridge/release-orders/${RELEASE.id}`)
   })
 })

--- a/web/packages/features/src/bridge/bridge-client.ts
+++ b/web/packages/features/src/bridge/bridge-client.ts
@@ -18,14 +18,26 @@
  *
  * This client codifies the contract that fast-follow must honor so the UI is
  * complete and correct the moment the endpoint lands:
- *   - `POST {base}/api/bridge/orders`       → 200 {@link MintOrder}
- *   - `GET  {base}/api/bridge/orders/{id}`  → 200 {@link MintOrder}
+ *   - `POST {base}/api/bridge/orders`               → 200 {@link MintOrder}
+ *   - `GET  {base}/api/bridge/orders/{id}`          → 200 {@link MintOrder}
+ *   - `POST {base}/api/bridge/release-orders`       → 200 {@link ReleaseOrder}
+ *   - `GET  {base}/api/bridge/release-orders/{id}`  → 200 {@link ReleaseOrder}
+ *
+ * The release-order endpoints (Unwrap, #1032) share the same #1036 backend
+ * fast-follow — the burn happens in the user's OWN counterparty wallet, and the
+ * order only registers the intent (source chain + BTH release address + amount)
+ * so the bridge can correlate the burn and track the release to `released`.
  *
  * Until a base URL is configured (`VITE_BRIDGE_API_BASE`), the wallet passes a
- * `null` client and the panel renders an explicit "endpoint not wired yet"
- * state — it never silently pretends to work.
+ * `null` client and the panels render an explicit "endpoint not wired yet"
+ * state — they never silently pretend to work.
  */
-import type { CreateMintOrderRequest, MintOrder } from './types'
+import type {
+  CreateMintOrderRequest,
+  CreateReleaseOrderRequest,
+  MintOrder,
+  ReleaseOrder,
+} from './types'
 
 /** Error thrown by {@link BridgeClient} calls that reach the network. */
 export class BridgeApiError extends Error {
@@ -42,8 +54,12 @@ export class BridgeApiError extends Error {
 export interface BridgeClient {
   /** Open a mint order; returns the deposit address + memo to send BTH to. */
   createMintOrder(req: CreateMintOrderRequest): Promise<MintOrder>
-  /** Fetch the latest state of an order by id. */
+  /** Fetch the latest state of a mint order by id. */
   getOrderStatus(id: string): Promise<MintOrder>
+  /** Open a release order (Unwrap, #1032); registers the burn intent. */
+  createReleaseOrder(req: CreateReleaseOrderRequest): Promise<ReleaseOrder>
+  /** Fetch the latest state of a release order by id. */
+  getReleaseOrderStatus(id: string): Promise<ReleaseOrder>
 }
 
 /** Strip a single trailing slash so `${base}/api/...` never doubles up. */
@@ -101,6 +117,24 @@ export function createBridgeClient(
         `${base}/api/bridge/orders/${encodeURIComponent(id)}`,
       )
       return (await parseJson(res)) as MintOrder
+    },
+
+    async createReleaseOrder(
+      req: CreateReleaseOrderRequest,
+    ): Promise<ReleaseOrder> {
+      const res = await fetchImpl(`${base}/api/bridge/release-orders`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(req),
+      })
+      return (await parseJson(res)) as ReleaseOrder
+    },
+
+    async getReleaseOrderStatus(id: string): Promise<ReleaseOrder> {
+      const res = await fetchImpl(
+        `${base}/api/bridge/release-orders/${encodeURIComponent(id)}`,
+      )
+      return (await parseJson(res)) as ReleaseOrder
     },
   }
 }

--- a/web/packages/features/src/bridge/components/bridge-view.tsx
+++ b/web/packages/features/src/bridge/components/bridge-view.tsx
@@ -4,7 +4,15 @@ import { ReserveProofCard } from '../../network/components/reserve-proof-card'
 import type { ReserveProof, ReserveProofState } from '../../network/types'
 import { VenueDirectory } from './venue-directory'
 import { ExportExplainer } from './export-panel'
-import type { DestinationChain, ExportController, Translate, Venue, VenueChain } from '../types'
+import { UnwrapExplainer } from './unwrap-panel'
+import type {
+  DestinationChain,
+  ExportController,
+  Translate,
+  UnwrapController,
+  Venue,
+  VenueChain,
+} from '../types'
 
 export interface BridgeViewProps {
   /** Venues to list (from `useBridgeVenues`). */
@@ -21,6 +29,12 @@ export interface BridgeViewProps {
    * still renders without it (the panel shows a "not configured" state).
    */
   exportController?: ExportController
+  /**
+   * Unwrap wiring (#1032): the wallet + release-order client the `UnwrapPanel`
+   * needs, injected by the page. Optional so the discovery page still renders
+   * without it (the panel shows the destination + guidance, tracking degrades).
+   */
+  unwrapController?: UnwrapController
   className?: string
 }
 
@@ -45,10 +59,13 @@ export function BridgeView({
   reserveState,
   t,
   exportController,
+  unwrapController,
   className,
 }: BridgeViewProps) {
   const venuesRef = useRef<HTMLDivElement>(null)
   const [highlightChain, setHighlightChain] = useState<VenueChain | null>(null)
+  // Export/Unwrap direction toggle (#1032): the two legs of the round trip.
+  const [tab, setTab] = useState<'export' | 'unwrap'>('export')
 
   const onTradeNow = (chain: DestinationChain) => {
     setHighlightChain(chain)
@@ -88,13 +105,52 @@ export function BridgeView({
         />
       </div>
 
-      {/* Guided export explainer + the Tier 1 integrated export panel. */}
-      <ExportExplainer
-        t={t}
-        controller={exportController}
-        onTradeNow={onTradeNow}
-        className="mt-10"
-      />
+      {/* Export / Unwrap direction toggle — the two legs of the round trip. */}
+      <section className="mt-10">
+        <div
+          role="tablist"
+          aria-label={t('tabs.ariaLabel')}
+          className="inline-flex rounded-xl border border-[--color-steel] bg-[--color-abyss]/40 p-1"
+        >
+          <button
+            role="tab"
+            type="button"
+            aria-selected={tab === 'export'}
+            onClick={() => setTab('export')}
+            className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${
+              tab === 'export'
+                ? 'bg-[--color-pulse]/15 text-[--color-light]'
+                : 'text-[--color-dim] hover:text-[--color-soft]'
+            }`}
+          >
+            {t('tabs.export')}
+          </button>
+          <button
+            role="tab"
+            type="button"
+            aria-selected={tab === 'unwrap'}
+            onClick={() => setTab('unwrap')}
+            className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${
+              tab === 'unwrap'
+                ? 'bg-[--color-pulse]/15 text-[--color-light]'
+                : 'text-[--color-dim] hover:text-[--color-soft]'
+            }`}
+          >
+            {t('tabs.unwrap')}
+          </button>
+        </div>
+
+        {tab === 'export' ? (
+          <ExportExplainer
+            t={t}
+            controller={exportController}
+            onTradeNow={onTradeNow}
+            className="mt-6"
+          />
+        ) : (
+          <UnwrapExplainer t={t} controller={unwrapController} className="mt-6" />
+        )}
+      </section>
     </div>
   )
 }

--- a/web/packages/features/src/bridge/components/unwrap-panel.test.tsx
+++ b/web/packages/features/src/bridge/components/unwrap-panel.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Unwrap panel (#1032). The bridge RELEASE-order API is mocked — there is no
+ * running bridge service in unit tests, and (per the epic #1029 custody model)
+ * the wBTH BURN happens in the user's OWN counterparty wallet, which is external
+ * to this code entirely. So the contract under test is the wiring: the wallet
+ * surfaces the Botho release destination + chain-aware burn guidance, opens a
+ * release order via the injected client, tracks it to `released`, and confirms
+ * the BTH arrived. NO EVM/Solana signing happens here.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { UnwrapPanel } from './unwrap-panel'
+import type { ReleaseOrder, Translate, UnwrapController } from '../types'
+
+// Passthrough translator: returns the key so assertions are locale-independent.
+const t: Translate = (key) => key
+
+const RELEASE_ADDR = 'tbotho://2/releasedestinationaddress'
+
+const BURN_DETECTED: ReleaseOrder = {
+  id: '22222222-2222-2222-2222-222222222222',
+  status: 'burn_detected',
+  sourceChain: 'ethereum',
+  bthAddress: RELEASE_ADDR,
+  amount: '5000000000000',
+  fee: '100000000',
+  tokenAddress: '0x49b985ec427ee771a601f11b18f7d4402fa2dd7b',
+  sourceTx: '0xburntxhash',
+  destTx: null,
+  expiresAt: 1_760_000_000,
+  failureReason: null,
+}
+
+const RELEASED: ReleaseOrder = {
+  ...BURN_DETECTED,
+  status: 'released',
+  destTx: 'btcreleasetxhash',
+}
+
+function makeController(over: Partial<UnwrapController> = {}): UnwrapController {
+  return {
+    client: {
+      createReleaseOrder: vi.fn(async () => BURN_DETECTED),
+      getReleaseOrderStatus: vi.fn(async () => BURN_DETECTED),
+    },
+    network: 'testnet',
+    wallet: {
+      hasWallet: true,
+      isLocked: false,
+      releaseAddress: RELEASE_ADDR,
+    },
+    requestWallet: vi.fn(),
+    ...over,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('UnwrapPanel gate states', () => {
+  it('prompts to open a wallet when none exists', () => {
+    const controller = makeController({
+      wallet: { hasWallet: false, isLocked: false, releaseAddress: null },
+    })
+    render(<UnwrapPanel t={t} controller={controller} />)
+    expect(screen.getByText('unwrap.panel.noWallet.title')).toBeTruthy()
+  })
+
+  it('prompts to unlock when no release address is available', () => {
+    const controller = makeController({
+      wallet: { hasWallet: true, isLocked: true, releaseAddress: null },
+    })
+    render(<UnwrapPanel t={t} controller={controller} />)
+    expect(screen.getByText('unwrap.panel.locked.title')).toBeTruthy()
+  })
+})
+
+describe('UnwrapPanel destination + burn guidance', () => {
+  it('shows the Botho release address and the bridgeBurn guidance for the source chain', () => {
+    render(<UnwrapPanel t={t} controller={makeController()} />)
+    // The release destination is the wallet's own address (reused, not signed).
+    const dest = screen.getByDisplayValue(RELEASE_ADDR)
+    expect(dest).toBeTruthy()
+    // The wBTH token to burn + the burn call are surfaced.
+    expect(screen.getByDisplayValue('0x49b985ec427ee771a601f11b18f7d4402fa2dd7b')).toBeTruthy()
+    expect(screen.getByText(/bridgeBurn\(/)).toBeTruthy()
+    // A deep-link to where the user executes the burn themselves.
+    expect(screen.getByText('unwrap.panel.form.openApp')).toBeTruthy()
+  })
+
+  it('keeps destination + guidance visible but disables tracking when no client is wired', () => {
+    render(<UnwrapPanel t={t} controller={makeController({ client: null })} />)
+    // Destination + guidance still render (they need no backend)…
+    expect(screen.getByDisplayValue(RELEASE_ADDR)).toBeTruthy()
+    expect(screen.getByText(/bridgeBurn\(/)).toBeTruthy()
+    // …but the live-tracking action degrades to an explicit notice.
+    expect(screen.getByText('unwrap.panel.form.notConfigured.title')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /unwrap\.panel\.form\.track/ })).toBeNull()
+  })
+})
+
+describe('UnwrapPanel release tracking', () => {
+  it('blocks track until an amount is entered', () => {
+    render(<UnwrapPanel t={t} controller={makeController()} />)
+    const track = screen.getByRole('button', { name: /unwrap\.panel\.form\.track/ })
+    expect((track as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '5' } })
+    expect((track as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('opens a release order with the release address, tracks it to released', async () => {
+    vi.useFakeTimers()
+    const controller = makeController()
+    render(<UnwrapPanel t={t} controller={controller} />)
+
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '5' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /unwrap\.panel\.form\.track/ }))
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    // Order was opened with the source chain, the wallet's release address, and
+    // the picocredit amount — no counterparty-chain signing involved.
+    expect(controller.client!.createReleaseOrder).toHaveBeenCalledWith({
+      sourceChain: 'ethereum',
+      bthAddress: RELEASE_ADDR,
+      amount: '5000000000000',
+    })
+
+    // Now tracking: the order id and the burn-detected step are shown.
+    expect(screen.getByText(BURN_DETECTED.id)).toBeTruthy()
+
+    // Advance the poll; the next status is `released`.
+    ;(controller.client!.getReleaseOrderStatus as ReturnType<typeof vi.fn>).mockResolvedValue(
+      RELEASED,
+    )
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8_000)
+    })
+
+    // Receive confirmation: released → check your wallet balance.
+    expect(screen.getByText('unwrap.panel.released.title')).toBeTruthy()
+  })
+})

--- a/web/packages/features/src/bridge/components/unwrap-panel.tsx
+++ b/web/packages/features/src/bridge/components/unwrap-panel.tsx
@@ -1,0 +1,729 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Button, Card, CardContent, Input } from '@botho/ui'
+import { formatBTH, parseBTH } from '@botho/core'
+import {
+  AlertCircle,
+  ArrowUpRight,
+  CheckCircle2,
+  Circle,
+  Copy,
+  Check,
+  Download,
+  ExternalLink,
+  Flame,
+  Loader2,
+  Lock,
+  Repeat,
+  TriangleAlert,
+  Wallet,
+} from 'lucide-react'
+import type {
+  ReleaseOrder,
+  SourceChain,
+  Translate,
+  UnwrapController,
+} from '../types'
+import { getBurnTarget } from '../venues'
+import {
+  RELEASE_PROGRESSION,
+  isTerminalReleaseStatus,
+  releaseProgressionIndex,
+  sourceTxUrl,
+} from '../release-status'
+
+/** Step icons for the "how unwrap works" flow, in render order. */
+const STEP_KEYS = ['destination', 'burn', 'track', 'receive'] as const
+const STEP_ICON = {
+  destination: Wallet,
+  burn: Flame,
+  track: Repeat,
+  receive: Download,
+} as const
+
+/** Unwrap sources offered by the chain picker (Hyperliquid = coming-soon). */
+const UNWRAP_CHAINS: readonly SourceChain[] = ['ethereum', 'solana'] as const
+
+export interface UnwrapExplainerProps {
+  /** `bridge`-namespace translator supplied by the page. */
+  t: Translate
+  /**
+   * Unwrap wiring (#1032): wallet + release-order client injected by the page.
+   * When omitted the panel degrades to a "not configured" tracking state, but
+   * the destination + burn guidance still render (they need no backend).
+   */
+  controller?: UnwrapController
+  className?: string
+}
+
+/**
+ * Guided wBTH→BTH unwrap explainer (#1032) + the integrated {@link UnwrapPanel}.
+ *
+ * The return leg WITHOUT EVM/Solana signing in the Botho wallet: the wallet
+ * provides the Botho release destination + guides the user to burn wBTH in
+ * THEIR OWN counterparty wallet, then tracks the release order and confirms the
+ * received BTH. NO counterparty-chain code lives here.
+ */
+export function UnwrapExplainer({ t, controller, className }: UnwrapExplainerProps) {
+  return (
+    <section className={className}>
+      <h2 className="font-display text-xl font-semibold text-[--color-light]">
+        {t('unwrap.heading')}
+      </h2>
+      <p className="mt-1 max-w-2xl text-sm text-[--color-dim]">{t('unwrap.intro')}</p>
+
+      {/* How it works — numbered flow. */}
+      <ol className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {STEP_KEYS.map((key, i) => {
+          const Icon = STEP_ICON[key]
+          return (
+            <li key={key}>
+              <Card className="h-full">
+                <CardContent className="p-4">
+                  <div className="flex items-center gap-2">
+                    <span className="flex h-6 w-6 items-center justify-center rounded-full bg-[--color-pulse]/10 text-xs font-semibold text-[--color-pulse]">
+                      {i + 1}
+                    </span>
+                    <Icon className="h-4 w-4 text-[--color-pulse]" />
+                  </div>
+                  <div className="mt-2.5 text-sm font-semibold text-[--color-light]">
+                    {t(`unwrap.steps.${key}.title`)}
+                  </div>
+                  <p className="mt-1 text-xs text-[--color-dim]">
+                    {t(`unwrap.steps.${key}.body`)}
+                  </p>
+                </CardContent>
+              </Card>
+            </li>
+          )
+        })}
+      </ol>
+
+      <UnwrapPanel t={t} controller={controller} className="mt-6" />
+    </section>
+  )
+}
+
+export interface UnwrapPanelProps {
+  /** `bridge`-namespace translator supplied by the page. */
+  t: Translate
+  /** Unwrap wiring (#1032); `undefined` still renders destination + guidance. */
+  controller?: UnwrapController
+  className?: string
+}
+
+/** Panel chrome shared by every state — a titled card with a testnet badge. */
+function PanelShell({
+  t,
+  network,
+  children,
+}: {
+  t: Translate
+  network?: string
+  children: React.ReactNode
+}) {
+  return (
+    <Card>
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[--color-pulse]/10">
+              <Flame className="h-5 w-5 text-[--color-pulse]" />
+            </div>
+            <div>
+              <div className="font-display text-base font-semibold text-[--color-light]">
+                {t('unwrap.panel.title')}
+              </div>
+              <p className="mt-1 max-w-xl text-sm text-[--color-dim]">
+                {t('unwrap.panel.subtitle')}
+              </p>
+            </div>
+          </div>
+          {network === 'testnet' && (
+            <span className="shrink-0 rounded-full bg-[--color-warning]/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[--color-warning]">
+              {t('unwrap.panel.testnetBadge')}
+            </span>
+          )}
+        </div>
+        <div className="mt-4">{children}</div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/**
+ * Integrated wBTH→BTH unwrap (#1032).
+ *
+ * Provides the Botho release destination + chain-aware burn guidance, then (when
+ * a release-order endpoint is configured) tracks the release state machine to
+ * `released` and confirms the BTH arrived. The wallet NEVER signs on the
+ * counterparty chain — the user burns wBTH in their own wallet.
+ */
+export function UnwrapPanel({ t, controller, className }: UnwrapPanelProps) {
+  return (
+    <div className={className}>
+      <UnwrapPanelInner t={t} controller={controller} />
+    </div>
+  )
+}
+
+function UnwrapPanelInner({
+  t,
+  controller,
+}: {
+  t: Translate
+  controller?: UnwrapController
+}) {
+  const [chain, setChain] = useState<SourceChain>('ethereum')
+  const [amount, setAmount] = useState('')
+  const [order, setOrder] = useState<ReleaseOrder | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const network = controller?.network
+  const client = controller?.client ?? null
+  const wallet = controller?.wallet
+
+  // ── Gate states (no wallet / locked → no release address) ─────────────────
+  if (!controller || !wallet?.hasWallet) {
+    return (
+      <PanelShell t={t} network={network}>
+        <Notice
+          icon={Wallet}
+          tone="muted"
+          title={t('unwrap.panel.noWallet.title')}
+          body={t('unwrap.panel.noWallet.body')}
+          action={
+            controller?.requestWallet && (
+              <Button variant="secondary" onClick={controller.requestWallet}>
+                {t('unwrap.panel.noWallet.cta')}
+              </Button>
+            )
+          }
+        />
+      </PanelShell>
+    )
+  }
+
+  if (!wallet.releaseAddress) {
+    return (
+      <PanelShell t={t} network={network}>
+        <Notice
+          icon={Lock}
+          tone="muted"
+          title={t('unwrap.panel.locked.title')}
+          body={t('unwrap.panel.locked.body')}
+          action={
+            controller.requestWallet && (
+              <Button variant="secondary" onClick={controller.requestWallet}>
+                {t('unwrap.panel.locked.cta')}
+              </Button>
+            )
+          }
+        />
+      </PanelShell>
+    )
+  }
+
+  // ── Tracking an open release order ────────────────────────────────────────
+  if (order) {
+    return (
+      <PanelShell t={t} network={network}>
+        <ReleaseTracker
+          t={t}
+          controller={controller}
+          order={order}
+          setOrder={setOrder}
+          onReset={() => {
+            setOrder(null)
+            setError(null)
+            setAmount('')
+          }}
+        />
+      </PanelShell>
+    )
+  }
+
+  // ── The form ──────────────────────────────────────────────────────────────
+  const onTrack = async () => {
+    if (!client) return
+    setError(null)
+    let amountPico: bigint
+    try {
+      amountPico = parseBTH(amount)
+    } catch {
+      setError(t('unwrap.panel.form.amountRequired'))
+      return
+    }
+    if (amountPico <= 0n) {
+      setError(t('unwrap.panel.form.amountRequired'))
+      return
+    }
+    setSubmitting(true)
+    try {
+      const created = await client.createReleaseOrder({
+        sourceChain: chain,
+        bthAddress: wallet.releaseAddress!,
+        amount: amountPico.toString(),
+      })
+      setOrder(created)
+    } catch (e) {
+      setError(errorMessage(e, t))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <PanelShell t={t} network={network}>
+      <UnwrapForm
+        t={t}
+        chain={chain}
+        setChain={setChain}
+        amount={amount}
+        setAmount={setAmount}
+        releaseAddress={wallet.releaseAddress}
+        hasClient={client != null}
+        submitting={submitting}
+        error={error}
+        onTrack={onTrack}
+      />
+    </PanelShell>
+  )
+}
+
+/** Source picker + release destination + amount + burn guidance. */
+function UnwrapForm({
+  t,
+  chain,
+  setChain,
+  amount,
+  setAmount,
+  releaseAddress,
+  hasClient,
+  submitting,
+  error,
+  onTrack,
+}: {
+  t: Translate
+  chain: SourceChain
+  setChain: (c: SourceChain) => void
+  amount: string
+  setAmount: (a: string) => void
+  releaseAddress: string
+  hasClient: boolean
+  submitting: boolean
+  error: string | null
+  onTrack: () => void
+}) {
+  const target = getBurnTarget(chain)
+
+  const amountPico = useMemo(() => {
+    if (!amount) return null
+    try {
+      const v = parseBTH(amount)
+      return v > 0n ? v : null
+    } catch {
+      return null
+    }
+  }, [amount])
+
+  const canTrack = hasClient && !submitting && amountPico != null
+
+  const chainLabel = (c: SourceChain) => t(`unwrap.panel.chains.${c}`)
+
+  return (
+    <div className="space-y-4">
+      {/* Source chain picker. */}
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-[--color-ghost]">
+          {t('unwrap.panel.form.chainLabel')}
+        </label>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {UNWRAP_CHAINS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setChain(c)}
+              aria-pressed={chain === c}
+              className={`rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                chain === c
+                  ? 'border-[--color-pulse] bg-[--color-pulse]/10 text-[--color-light]'
+                  : 'border-[--color-steel] text-[--color-soft] hover:border-[--color-pulse]/50'
+              }`}
+            >
+              {chainLabel(c)}
+            </button>
+          ))}
+          {/* Hyperliquid — discovery-only until HIP-1 spot lands (#877). */}
+          <button
+            type="button"
+            disabled
+            title={t('unwrap.panel.form.comingSoon')}
+            className="flex items-center justify-center gap-1 rounded-lg border border-dashed border-[--color-steel] px-3 py-2 text-sm text-[--color-dim]"
+          >
+            {t('unwrap.panel.chains.hyperliquid')}
+            <span className="text-[10px] uppercase">{t('unwrap.panel.form.comingSoon')}</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Release destination — the wallet's own Botho receive address. */}
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-[--color-ghost]">
+          {t('unwrap.panel.form.destinationLabel')}
+        </label>
+        <div className="flex gap-2">
+          <input
+            readOnly
+            value={releaseAddress}
+            onFocus={(e) => e.currentTarget.select()}
+            className="min-w-0 flex-1 rounded-lg border border-[--color-steel] bg-[--color-abyss] px-3 py-2 font-mono text-xs text-[--color-light]"
+          />
+          <CopyButton t={t} value={releaseAddress} ariaLabel={t('unwrap.panel.form.copy')} />
+        </div>
+        <p className="mt-1 text-xs text-[--color-dim]">{t('unwrap.panel.form.destinationHint')}</p>
+      </div>
+
+      {/* Amount to burn. */}
+      <div>
+        <label className="mb-1.5 block text-sm font-medium text-[--color-ghost]">
+          {t('unwrap.panel.form.amountLabel')}
+        </label>
+        <div className="relative">
+          <Input
+            type="text"
+            placeholder="0.00"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            className="pr-16 font-mono"
+          />
+          <span className="absolute right-4 top-1/2 -translate-y-1/2 text-sm font-medium text-[--color-dim]">
+            wBTH
+          </span>
+        </div>
+        <p className="mt-1 text-xs text-[--color-dim]">{t('unwrap.panel.form.amountHint')}</p>
+      </div>
+
+      {/* Burn guidance — the user's own-wallet action. */}
+      {target && (
+        <div className="space-y-3 rounded-lg border border-[--color-steel] bg-[--color-abyss]/40 p-4">
+          <div className="flex items-center gap-2">
+            <Flame className="h-4 w-4 shrink-0 text-[--color-pulse]" />
+            <div className="text-sm font-semibold text-[--color-light]">
+              {t('unwrap.panel.form.burnHeading', { chain: chainLabel(chain) })}
+            </div>
+          </div>
+          <p className="text-xs text-[--color-dim]">{t('unwrap.panel.form.burnIntro')}</p>
+
+          <BurnRow label={t('unwrap.panel.form.tokenLabel')} value={target.tokenAddress} t={t} />
+          <div>
+            <div className="mb-1 text-xs text-[--color-dim]">{t('unwrap.panel.form.callLabel')}</div>
+            <code className="block overflow-x-auto rounded-md border border-[--color-steel] bg-[--color-slate]/40 px-3 py-2 font-mono text-xs text-[--color-soft]">
+              bridgeBurn({amountPico != null ? amountPico.toString() : t('unwrap.panel.form.amountToken')}, &quot;{shorten(releaseAddress)}&quot;)
+            </code>
+            <p className="mt-1 text-xs text-[--color-dim]">{t('unwrap.panel.form.callHint')}</p>
+          </div>
+
+          <a
+            href={target.appUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-[--color-pulse] transition-colors hover:text-[--color-light]"
+          >
+            {t('unwrap.panel.form.openApp', { chain: chainLabel(chain) })}
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-[--color-danger]/30 bg-[--color-danger]/10 p-3 text-sm text-[--color-danger]">
+          {error}
+        </div>
+      )}
+
+      {/* Track action (client-gated) OR the inert "tracking not wired" notice. */}
+      {hasClient ? (
+        <div className="space-y-1.5">
+          <Button onClick={onTrack} disabled={!canTrack} className="w-full">
+            {submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t('unwrap.panel.form.submitting')}
+              </>
+            ) : (
+              <>
+                <Repeat className="h-4 w-4" />
+                {t('unwrap.panel.form.track')}
+              </>
+            )}
+          </Button>
+          <p className="text-center text-xs text-[--color-dim]">
+            {t('unwrap.panel.form.trackHint')}
+          </p>
+        </div>
+      ) : (
+        <Notice
+          icon={TriangleAlert}
+          tone="warning"
+          title={t('unwrap.panel.form.notConfigured.title')}
+          body={t('unwrap.panel.form.notConfigured.body')}
+        />
+      )}
+    </div>
+  )
+}
+
+/** Live release tracker: polls status and renders the release state machine. */
+function ReleaseTracker({
+  t,
+  controller,
+  order,
+  setOrder,
+  onReset,
+}: {
+  t: Translate
+  controller: UnwrapController
+  order: ReleaseOrder
+  setOrder: (o: ReleaseOrder) => void
+  onReset: () => void
+}) {
+  const client = controller.client
+  const orderId = order.id
+  const status = order.status
+
+  // Poll status until a terminal state. Mirrors the export tracker's
+  // cancelled-flag cleanup so an unmount/reset can't set state late.
+  useEffect(() => {
+    if (!client || isTerminalReleaseStatus(status)) return
+    let cancelled = false
+    const poll = async () => {
+      try {
+        const next = await client.getReleaseOrderStatus(orderId)
+        if (!cancelled) setOrder(next)
+      } catch {
+        // Transient fetch failure — keep the last known state and retry.
+      }
+    }
+    const id = setInterval(poll, 8_000)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [client, orderId, status, setOrder])
+
+  const amount = BigInt(order.amount)
+  const fee = BigInt(order.fee)
+  const net = amount > fee ? amount - fee : 0n
+  const currentIndex = releaseProgressionIndex(status)
+  const isReleased = status === 'released'
+  const isFailed = status === 'failed'
+  const isExpired = status === 'expired'
+
+  return (
+    <div className="space-y-4">
+      {/* Order summary. */}
+      <div className="rounded-lg border border-[--color-steel] bg-[--color-slate]/40 p-3 text-sm">
+        <Row
+          label={t('unwrap.panel.order.id')}
+          value={<span className="font-mono text-xs">{order.id}</span>}
+        />
+        <Row
+          label={t('unwrap.panel.order.source')}
+          value={t(`unwrap.panel.chains.${order.sourceChain}`)}
+        />
+        <Row
+          label={t('unwrap.panel.order.destination')}
+          value={<span className="font-mono text-xs">{shorten(order.bthAddress)}</span>}
+        />
+        <Row label={t('unwrap.panel.order.amount')} value={`${formatBTH(amount)} wBTH`} />
+        <Row label={t('unwrap.panel.order.fee')} value={`${formatBTH(fee)} BTH`} />
+        <Row
+          label={t('unwrap.panel.order.receive')}
+          value={<span className="font-semibold text-[--color-pulse]">{formatBTH(net)} BTH</span>}
+        />
+      </div>
+
+      {/* Terminal off-ramps. */}
+      {isExpired && (
+        <Notice
+          icon={TriangleAlert}
+          tone="warning"
+          title={t('unwrap.panel.status.expired')}
+          body={t('unwrap.panel.status.expiredNote')}
+        />
+      )}
+      {isFailed && (
+        <Notice
+          icon={AlertCircle}
+          tone="danger"
+          title={t('unwrap.panel.status.failed')}
+          body={t('unwrap.panel.status.failedNote', { reason: order.failureReason ?? '' })}
+        />
+      )}
+
+      {/* State-machine stepper (happy path). */}
+      {!isExpired && !isFailed && (
+        <ol className="space-y-2">
+          {RELEASE_PROGRESSION.map((step, i) => {
+            const done = currentIndex >= 0 && i < currentIndex
+            const active = currentIndex >= 0 && i === currentIndex
+            return (
+              <li key={step} className="flex items-center gap-2 text-sm">
+                {done || (isReleased && i === currentIndex) ? (
+                  <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-400" />
+                ) : active ? (
+                  <Loader2 className="h-4 w-4 shrink-0 animate-spin text-[--color-pulse]" />
+                ) : (
+                  <Circle className="h-4 w-4 shrink-0 text-[--color-steel]" />
+                )}
+                <span className={done || active ? 'text-[--color-light]' : 'text-[--color-dim]'}>
+                  {t(`unwrap.panel.status.${step}`)}
+                </span>
+              </li>
+            )
+          })}
+        </ol>
+      )}
+
+      {/* Burn tx link (once detected). */}
+      {order.sourceTx && sourceTxUrl(order.sourceChain, order.sourceTx) && (
+        <a
+          href={sourceTxUrl(order.sourceChain, order.sourceTx)!}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-sm text-[--color-ghost] transition-colors hover:text-[--color-light]"
+        >
+          {t('unwrap.panel.order.viewBurnTx')}
+          <ArrowUpRight className="h-3.5 w-3.5" />
+        </a>
+      )}
+
+      {/* Released: confirm the BTH arrived — the wallet scans owned outputs. */}
+      {isReleased && (
+        <div className="space-y-2 rounded-lg border border-emerald-400/30 bg-emerald-400/5 p-3">
+          <div className="flex items-start gap-2">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-400" />
+            <div>
+              <div className="text-sm font-semibold text-[--color-light]">
+                {t('unwrap.panel.released.title')}
+              </div>
+              <p className="mt-0.5 text-xs text-[--color-dim]">
+                {t('unwrap.panel.released.body')}
+              </p>
+            </div>
+          </div>
+          {order.destTx && (
+            <div className="pl-7 font-mono text-xs text-[--color-dim]">
+              {t('unwrap.panel.released.releaseTx', { tx: shorten(order.destTx) })}
+            </div>
+          )}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onReset}
+        className="text-xs text-[--color-ghost] transition-colors hover:text-[--color-light]"
+      >
+        {t('unwrap.panel.order.newUnwrap')}
+      </button>
+    </div>
+  )
+}
+
+// ── small presentational helpers ────────────────────────────────────────────
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-0.5">
+      <span className="text-[--color-dim]">{label}</span>
+      <span className="text-[--color-soft]">{value}</span>
+    </div>
+  )
+}
+
+/** A copyable long value (token address / burn address). */
+function BurnRow({ label, value, t }: { label: string; value: string; t: Translate }) {
+  return (
+    <div>
+      <div className="mb-1 text-xs text-[--color-dim]">{label}</div>
+      <div className="flex gap-2">
+        <input
+          readOnly
+          value={value}
+          onFocus={(e) => e.currentTarget.select()}
+          className="min-w-0 flex-1 rounded-md border border-[--color-steel] bg-[--color-slate]/40 px-3 py-2 font-mono text-xs text-[--color-soft]"
+        />
+        <CopyButton t={t} value={value} ariaLabel={t('unwrap.panel.form.copy')} />
+      </div>
+    </div>
+  )
+}
+
+/** Clipboard-copy button with a transient "copied" checkmark. */
+function CopyButton({ t, value, ariaLabel }: { t: Translate; value: string; ariaLabel: string }) {
+  const [copied, setCopied] = useState(false)
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard may be unavailable; the value is still selectable in the field.
+    }
+  }
+  return (
+    <Button variant="secondary" size="sm" onClick={onCopy} aria-label={ariaLabel}>
+      {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+      <span className="ml-1 hidden sm:inline">
+        {copied ? t('unwrap.panel.form.copied') : t('unwrap.panel.form.copy')}
+      </span>
+    </Button>
+  )
+}
+
+function Notice({
+  icon: Icon,
+  tone,
+  title,
+  body,
+  action,
+}: {
+  icon: typeof TriangleAlert
+  tone: 'warning' | 'danger' | 'muted'
+  title: string
+  body: string
+  action?: React.ReactNode
+}) {
+  const toneClass =
+    tone === 'warning'
+      ? 'border-[--color-warning]/30 bg-[--color-warning]/5 text-[--color-warning]'
+      : tone === 'danger'
+        ? 'border-[--color-danger]/30 bg-[--color-danger]/10 text-[--color-danger]'
+        : 'border-[--color-steel] bg-[--color-abyss]/40 text-[--color-soft]'
+  return (
+    <div className={`flex flex-col gap-3 rounded-xl border px-4 py-3 ${toneClass}`}>
+      <div className="flex items-start gap-2">
+        <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+        <div>
+          <div className="text-sm font-medium">{title}</div>
+          <p className="mt-1 text-xs text-[--color-dim]">{body}</p>
+        </div>
+      </div>
+      {action}
+    </div>
+  )
+}
+
+/** `abcdef…wxyz` — compact display of a long address / tx hash. */
+function shorten(addr: string): string {
+  if (addr.length <= 16) return addr
+  return `${addr.slice(0, 8)}…${addr.slice(-6)}`
+}
+
+/** Extract a human message from a thrown value, falling back to generic copy. */
+function errorMessage(e: unknown, t: Translate): string {
+  if (e instanceof Error && e.message) return e.message
+  return t('unwrap.panel.error.generic')
+}

--- a/web/packages/features/src/bridge/index.ts
+++ b/web/packages/features/src/bridge/index.ts
@@ -3,6 +3,7 @@ export * from './venues'
 export * from './hooks'
 export * from './address'
 export * from './order-status'
+export * from './release-status'
 export { createBridgeClient, BridgeApiError, type BridgeClient } from './bridge-client'
 export { BridgeView, type BridgeViewProps } from './components/bridge-view'
 export { VenueDirectory, type VenueDirectoryProps } from './components/venue-directory'
@@ -13,3 +14,9 @@ export {
   ExportPanel,
   type ExportPanelProps,
 } from './components/export-panel'
+export {
+  UnwrapExplainer,
+  type UnwrapExplainerProps,
+  UnwrapPanel,
+  type UnwrapPanelProps,
+} from './components/unwrap-panel'

--- a/web/packages/features/src/bridge/release-status.test.ts
+++ b/web/packages/features/src/bridge/release-status.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RELEASE_PROGRESSION,
+  isTerminalReleaseStatus,
+  releaseProgressionIndex,
+  sourceTxUrl,
+} from './release-status'
+
+describe('release-status', () => {
+  it('orders the happy-path progression to match the Rust burn-side state machine', () => {
+    expect([...RELEASE_PROGRESSION]).toEqual([
+      'burn_detected',
+      'burn_confirmed',
+      'release_pending',
+      'released',
+    ])
+  })
+
+  it('treats released/expired/failed as terminal, others as non-terminal', () => {
+    expect(isTerminalReleaseStatus('released')).toBe(true)
+    expect(isTerminalReleaseStatus('expired')).toBe(true)
+    expect(isTerminalReleaseStatus('failed')).toBe(true)
+    expect(isTerminalReleaseStatus('burn_detected')).toBe(false)
+    expect(isTerminalReleaseStatus('release_pending')).toBe(false)
+  })
+
+  it('indexes progression states and returns -1 for off-path terminals', () => {
+    expect(releaseProgressionIndex('burn_detected')).toBe(0)
+    expect(releaseProgressionIndex('released')).toBe(3)
+    expect(releaseProgressionIndex('expired')).toBe(-1)
+    expect(releaseProgressionIndex('failed')).toBe(-1)
+  })
+
+  it('builds testnet burn-tx explorer URLs (and null for unknown chains)', () => {
+    expect(sourceTxUrl('ethereum', '0xabc')).toBe('https://sepolia.etherscan.io/tx/0xabc')
+    expect(sourceTxUrl('solana', 'sig123')).toBe(
+      'https://explorer.solana.com/tx/sig123?cluster=devnet',
+    )
+    // @ts-expect-error — exhaustiveness guard: unknown chains yield no link.
+    expect(sourceTxUrl('dogecoin', 'x')).toBeNull()
+  })
+})

--- a/web/packages/features/src/bridge/release-status.ts
+++ b/web/packages/features/src/bridge/release-status.ts
@@ -1,0 +1,55 @@
+/**
+ * Release-order state-machine helpers (Unwrap, #1032).
+ *
+ * The status strings mirror the Rust `OrderStatus::Display` impl exactly
+ * (`bridge/core/src/order.rs`) for the burn side: `burn_detected →
+ * burn_confirmed → release_pending → released`, with `expired` / `failed` as
+ * off-path terminal states. Keeping the strings identical means the client can
+ * consume the release API verbatim once #1036 exposes it. This is the burn-side
+ * twin of `order-status.ts` (the mint side).
+ */
+import type { ReleaseOrderStatus, SourceChain } from './types'
+
+/**
+ * The happy-path progression, in order. The tracking UI renders these as a
+ * stepper and marks each as done/active/pending relative to the current status.
+ * `expired`/`failed` are intentionally excluded — they are terminal off-ramps
+ * rendered separately.
+ */
+export const RELEASE_PROGRESSION: readonly ReleaseOrderStatus[] = [
+  'burn_detected',
+  'burn_confirmed',
+  'release_pending',
+  'released',
+] as const
+
+/** Terminal states — no further polling is useful once reached. */
+export function isTerminalReleaseStatus(status: ReleaseOrderStatus): boolean {
+  return status === 'released' || status === 'expired' || status === 'failed'
+}
+
+/**
+ * Index of `status` within {@link RELEASE_PROGRESSION}, or `-1` for the off-path
+ * terminal states (`expired`/`failed`). Used to decide which stepper rows are
+ * complete.
+ */
+export function releaseProgressionIndex(status: ReleaseOrderStatus): number {
+  return RELEASE_PROGRESSION.indexOf(status)
+}
+
+/**
+ * Canonical block-explorer transaction URL for the wBTH BURN tx on the source
+ * chain. Hosts mirror `venues.ts` (Sepolia etherscan / Solana devnet explorer).
+ * Testnet-only today; returns `null` for chains without a known host so the
+ * caller can omit the link rather than build a broken URL.
+ */
+export function sourceTxUrl(chain: SourceChain, tx: string): string | null {
+  switch (chain) {
+    case 'ethereum':
+      return `https://sepolia.etherscan.io/tx/${tx}`
+    case 'solana':
+      return `https://explorer.solana.com/tx/${tx}?cluster=devnet`
+    default:
+      return null
+  }
+}

--- a/web/packages/features/src/bridge/types.ts
+++ b/web/packages/features/src/bridge/types.ts
@@ -193,3 +193,134 @@ export interface BridgeClientLike {
   createMintOrder(req: CreateMintOrderRequest): Promise<MintOrder>
   getOrderStatus(id: string): Promise<MintOrder>
 }
+
+// ─── Unwrap: wBTH → BTH return leg (#1032) ──────────────────────────────────
+
+/**
+ * Source chains the wallet can UNWRAP from (the chain the user burns wBTH on).
+ * Mirrors {@link DestinationChain}: Hyperliquid is discovery-only
+ * (`coming-soon`) until its HIP-1 spot market lands (#877), so it is not an
+ * unwrap source yet.
+ */
+export type SourceChain = 'ethereum' | 'solana'
+
+/**
+ * Release-order status. Strings are byte-identical to the Rust
+ * `OrderStatus::Display` impl (`bridge/core/src/order.rs`) for the burn side —
+ * `burn_detected → burn_confirmed → release_pending → released`, with
+ * `expired` / `failed` as off-path terminal states. Keeping the strings
+ * identical means the client consumes the release API verbatim once #1036
+ * exposes it.
+ */
+export type ReleaseOrderStatus =
+  | 'burn_detected'
+  | 'burn_confirmed'
+  | 'release_pending'
+  | 'released'
+  | 'expired'
+  | 'failed'
+
+/**
+ * Request body for opening a release order. The wallet registers its INTENT to
+ * unwrap — the source chain, the Botho address the released BTH should land at
+ * (the wallet's own receive address, ADR 0004), and the wBTH amount it will
+ * burn. The user then executes the `bridgeBurn(amount, bthAddress)` call in
+ * THEIR OWN counterparty wallet; the bridge correlates that burn to this order
+ * by the `bthAddress` + `amount` and releases the BTH. The Botho wallet never
+ * signs on the counterparty chain.
+ */
+export interface CreateReleaseOrderRequest {
+  /** Chain the user burns wBTH on. */
+  sourceChain: SourceChain
+  /** The Botho address released BTH is sent to (the wallet's receive address). */
+  bthAddress: string
+  /**
+   * Gross wBTH to burn, in picocredits, as a decimal STRING to preserve the
+   * full u64 range across JSON without precision loss (mirrors
+   * {@link CreateMintOrderRequest}).
+   */
+  amount: string
+}
+
+/**
+ * A release order as returned by the bridge order API (#1036 fast-follow).
+ * Amounts are picocredit strings (u64-safe); field names are camelCase to match
+ * the bridge's `serde(rename_all = "camelCase")` HTTP responses.
+ */
+export interface ReleaseOrder {
+  /** Order UUID. */
+  id: string
+  /** Current release state-machine status. */
+  status: ReleaseOrderStatus
+  /** Chain the user burns wBTH on. */
+  sourceChain: SourceChain
+  /** The Botho address released BTH is sent to. */
+  bthAddress: string
+  /** Gross wBTH to burn, picocredits (string). */
+  amount: string
+  /** Bridge fee, picocredits (string). */
+  fee: string
+  /** wBTH token/mint address the user must burn on `sourceChain`. */
+  tokenAddress: string
+  /** Source-chain burn tx hash, once the burn is detected. */
+  sourceTx?: string | null
+  /** Botho release tx hash, once the BTH is released. */
+  destTx?: string | null
+  /** Unix seconds after which an unburned order expires. */
+  expiresAt?: number | null
+  /** Failure reason when `status === 'failed'`. */
+  failureReason?: string | null
+}
+
+/**
+ * Structural subset of `BridgeClient` for the release side. Declared here so
+ * `types.ts` stays dependency-free; the concrete client satisfies it. Kept
+ * separate from {@link BridgeClientLike} so the mint-only `ExportController`
+ * mocks stay valid (they need not implement release methods).
+ */
+export interface ReleaseClientLike {
+  createReleaseOrder(req: CreateReleaseOrderRequest): Promise<ReleaseOrder>
+  getReleaseOrderStatus(id: string): Promise<ReleaseOrder>
+}
+
+/**
+ * Everything the {@link UnwrapPanel} needs from the host app, injected by the
+ * `/trade` page so `@botho/features` keeps NO dependency on the wallet context
+ * or the bridge client wiring (mirroring {@link ExportController}).
+ *
+ * There is deliberately NO signing hook here: the wallet does not sign on the
+ * counterparty chain, and the released BTH simply arrives at `releaseAddress`
+ * (which the wallet already scans for owned outputs). The wallet's whole job is
+ * destination + guidance + tracking + receipt.
+ */
+export interface UnwrapController {
+  /**
+   * The release-order API client, or `null` when no endpoint is configured
+   * (`VITE_BRIDGE_API_BASE` unset). `null` keeps the destination + burn
+   * guidance visible (they need no backend — the bridge watches the chain and
+   * releases regardless) but disables live order tracking, mirroring how the
+   * export panel degrades when unconfigured.
+   */
+  client: ReleaseClientLike | null
+  /** Active bridge network — drives testnet labeling. */
+  network: BridgeNetwork
+  /** Snapshot of the wallet state relevant to unwrapping. */
+  wallet: UnwrapWalletState
+  /** Navigate the user to the wallet (to create/open or unlock it). */
+  requestWallet?: () => void
+}
+
+/** Wallet fields the unwrap panel reads (no secrets, no signing keys). */
+export interface UnwrapWalletState {
+  /** Whether a wallet exists in this browser. */
+  hasWallet: boolean
+  /** Whether the wallet is locked. */
+  isLocked: boolean
+  /**
+   * The wallet's Botho receive address for the released BTH — a stealth address
+   * (ADR 0004), reused from the wallet context (the same value the Receive
+   * modal shows). `null` when no wallet exists or it is locked and the address
+   * is unavailable.
+   */
+  releaseAddress: string | null
+}

--- a/web/packages/features/src/bridge/venues.ts
+++ b/web/packages/features/src/bridge/venues.ts
@@ -16,7 +16,7 @@
  * - Solana devnet: https://explorer.solana.com (with `?cluster=devnet`)
  * - HyperEVM test: https://testnet.purrsec.com
  */
-import type { BridgeNetwork, Venue, VenueDirectory } from './types'
+import type { BridgeNetwork, SourceChain, Venue, VenueDirectory } from './types'
 
 // --- Ethereum Sepolia (Uniswap v3 wBTH/WETH) --------------------------------
 const WBTH_SEPOLIA = '0x49b985ec427ee771a601f11b18f7d4402fa2dd7b'
@@ -83,4 +83,84 @@ export const ACTIVE_BRIDGE_NETWORK: BridgeNetwork = 'testnet'
 /** Venues for a given network (defaults to the active/testnet set). */
 export function getVenues(network: BridgeNetwork = ACTIVE_BRIDGE_NETWORK): Venue[] {
   return VENUES[network]
+}
+
+// ─── Unwrap: burn targets (#1032) ───────────────────────────────────────────
+
+/**
+ * Where + how the user burns wBTH to redeem native BTH. The Botho wallet never
+ * signs this call — the user executes `bridgeBurn(amount, bthAddress)` in THEIR
+ * OWN counterparty wallet (MetaMask / Phantom / Anchor client), pasting the
+ * wallet-provided BTH release address as `bthAddress`. This config drives the
+ * unwrap panel's burn guidance (token to burn + a deep-link to where the user
+ * executes it), so it stays config-driven and mainnet-swappable like `VENUES`.
+ *
+ * `bridgeBurn` is the ONLY burn path on both chains:
+ * - Ethereum: `function bridgeBurn(uint256 amount, string bthAddress)`
+ *   (`contracts/ethereum/contracts/WrappedBTH.sol`).
+ * - Solana:   the `bridgeBurn(amount, bthAddress)` Anchor instruction
+ *   (`contracts/solana/tests/wbth.ts`).
+ */
+export interface BurnTarget {
+  /** Source chain the user burns on. */
+  chain: SourceChain
+  /** Human chain + network, e.g. "Ethereum Sepolia". */
+  chainLabel: string
+  /** wBTH token/mint address the user burns. */
+  tokenAddress: string
+  /**
+   * The exact burn call the user makes, e.g. `bridgeBurn(amount, bthAddress)`.
+   * `bthAddress` is the wallet-provided BTH release destination; `amount` is in
+   * picocredits (u64), matching the token's on-chain decimals.
+   */
+  burnCall: string
+  /**
+   * Deep-link to where the user executes the burn: the block-explorer
+   * write-contract tab on Ethereum, or the token/program page on Solana (Solana
+   * explorers have no generic write UI — the burn is an Anchor instruction).
+   */
+  appUrl: string
+  /** Block-explorer address page for the wBTH token. */
+  explorerUrl: string
+}
+
+const TESTNET_BURN_TARGETS: BurnTarget[] = [
+  {
+    chain: 'ethereum',
+    chainLabel: 'Ethereum Sepolia',
+    tokenAddress: WBTH_SEPOLIA,
+    burnCall: 'bridgeBurn(amount, bthAddress)',
+    // Etherscan "Write Contract" tab, where the user calls bridgeBurn directly.
+    appUrl: `https://sepolia.etherscan.io/address/${WBTH_SEPOLIA}#writeContract`,
+    explorerUrl: `https://sepolia.etherscan.io/address/${WBTH_SEPOLIA}`,
+  },
+  {
+    chain: 'solana',
+    chainLabel: 'Solana devnet',
+    tokenAddress: WBTH_SOLANA_MINT,
+    burnCall: 'bridgeBurn(amount, bthAddress)',
+    appUrl: `https://explorer.solana.com/address/${WBTH_SOLANA_MINT}?cluster=devnet`,
+    explorerUrl: `https://explorer.solana.com/address/${WBTH_SOLANA_MINT}?cluster=devnet`,
+  },
+]
+
+/** Burn targets keyed by network. Mainnet is empty until a production peg exists. */
+export const BURN_TARGETS: Record<BridgeNetwork, BurnTarget[]> = {
+  testnet: TESTNET_BURN_TARGETS,
+  mainnet: [],
+}
+
+/** Burn targets for a given network (defaults to the active/testnet set). */
+export function getBurnTargets(
+  network: BridgeNetwork = ACTIVE_BRIDGE_NETWORK,
+): BurnTarget[] {
+  return BURN_TARGETS[network]
+}
+
+/** The burn target for a specific source chain, or `undefined` if unsupported. */
+export function getBurnTarget(
+  chain: SourceChain,
+  network: BridgeNetwork = ACTIVE_BRIDGE_NETWORK,
+): BurnTarget | undefined {
+  return BURN_TARGETS[network].find((b) => b.chain === chain)
 }

--- a/web/packages/web-wallet/src/locales/en/bridge.json
+++ b/web/packages/web-wallet/src/locales/en/bridge.json
@@ -7,6 +7,11 @@
   "nav": {
     "trade": "Trade"
   },
+  "tabs": {
+    "ariaLabel": "Bridge direction",
+    "export": "Export BTH → wBTH",
+    "unwrap": "Unwrap wBTH → BTH"
+  },
   "hero": {
     "title": "Trade wrapped BTH",
     "subtitle": "wBTH is Botho wrapped 1:1 onto other chains so it can trade on their DEXs. This page lists where wBTH lives today and explains how to bridge BTH across.",
@@ -134,6 +139,101 @@
         "body": "Your wBTH is now in your {{chain}} wallet.",
         "viewTx": "View mint transaction",
         "tradeNow": "Trade wBTH now"
+      },
+      "error": {
+        "generic": "Something went wrong. Please try again."
+      }
+    }
+  },
+  "unwrap": {
+    "heading": "How to unwrap wBTH → BTH",
+    "intro": "Unwrapping burns wBTH on its chain and releases the locked BTH back to you. You burn in your own wallet — this wallet only provides the Botho release address, guides the burn, and tracks the release. It never signs on the other chain.",
+    "steps": {
+      "destination": {
+        "title": "1. Get your release address",
+        "body": "This wallet gives you a Botho address to receive the released BTH — a fresh stealth address, private by default."
+      },
+      "burn": {
+        "title": "2. Burn wBTH yourself",
+        "body": "In your own wallet, call bridgeBurn(amount, bthAddress) on the wBTH token, pasting the release address above as bthAddress."
+      },
+      "track": {
+        "title": "3. Track the release",
+        "body": "The bridge detects your burn, confirms it, and releases an equal amount of BTH (minus the bridge fee) to your address."
+      },
+      "receive": {
+        "title": "4. Receive BTH",
+        "body": "The released BTH lands at your release address. This wallet already scans for it — check your balance once the release completes."
+      }
+    },
+    "panel": {
+      "title": "Unwrap wBTH → BTH",
+      "subtitle": "Get your Botho release address and burn wBTH in your own wallet. The bridge releases the locked BTH to you — this wallet never signs on the other chain.",
+      "testnetBadge": "Testnet",
+      "noWallet": {
+        "title": "Open your wallet to unwrap",
+        "body": "Unwrapping releases BTH to your Botho address. Create or open your wallet first to get a release address.",
+        "cta": "Go to wallet"
+      },
+      "locked": {
+        "title": "Unlock your wallet to unwrap",
+        "body": "Your wallet is locked, so a release address is unavailable. Unlock it to get the Botho address to release BTH to.",
+        "cta": "Unlock wallet"
+      },
+      "chains": {
+        "ethereum": "Ethereum",
+        "solana": "Solana",
+        "hyperliquid": "Hyperliquid"
+      },
+      "form": {
+        "chainLabel": "Source chain (where you burn wBTH)",
+        "comingSoon": "Soon",
+        "destinationLabel": "Your BTH release address",
+        "destinationHint": "Copy this into your burn call as bthAddress. The released BTH lands here.",
+        "copy": "Copy",
+        "copied": "Copied",
+        "amountLabel": "Amount to unwrap",
+        "amountToken": "amount",
+        "amountHint": "The wBTH amount you will burn. You receive an equal amount of BTH minus the bridge fee.",
+        "amountRequired": "Enter an amount to unwrap.",
+        "burnHeading": "Burn wBTH on {{chain}}",
+        "burnIntro": "Do this in your OWN wallet (MetaMask / Phantom). bridgeBurn is the only burn path — it releases your BTH; a plain transfer does not.",
+        "tokenLabel": "wBTH token to burn",
+        "callLabel": "Burn call",
+        "callHint": "amount is in picocredits (u64); bthAddress is your release address above.",
+        "openApp": "Open {{chain}} to burn",
+        "track": "I've started the burn — track release",
+        "trackHint": "Opens a release order and tracks it. Your BTH arrives whether or not you track it here.",
+        "submitting": "Opening…",
+        "notConfigured": {
+          "title": "Live release tracking not wired yet",
+          "body": "The public bridge order API (create/status, CORS) is not exposed on this deployment yet. You can still burn wBTH using the guidance above — the bridge watches the chain and releases BTH to your address regardless. Check your wallet balance after the release completes."
+        }
+      },
+      "order": {
+        "id": "Order",
+        "source": "Source chain",
+        "destination": "Release to",
+        "amount": "Amount",
+        "fee": "Bridge fee",
+        "receive": "You receive",
+        "viewBurnTx": "View burn transaction",
+        "newUnwrap": "Start another unwrap"
+      },
+      "status": {
+        "burn_detected": "Burn detected",
+        "burn_confirmed": "Burn confirmed",
+        "release_pending": "Releasing BTH",
+        "released": "Released",
+        "expired": "Expired",
+        "failed": "Failed",
+        "expiredNote": "This order expired before a detected burn. Start a new unwrap.",
+        "failedNote": "This order failed: {{reason}}"
+      },
+      "released": {
+        "title": "BTH released to your wallet",
+        "body": "The BTH has been released to your address. This wallet scans owned outputs — check your balance to see it arrive.",
+        "releaseTx": "Release tx: {{tx}}"
       },
       "error": {
         "generic": "Something went wrong. Please try again."

--- a/web/packages/web-wallet/src/locales/es/bridge.json
+++ b/web/packages/web-wallet/src/locales/es/bridge.json
@@ -7,6 +7,11 @@
   "nav": {
     "trade": "Trade"
   },
+  "tabs": {
+    "ariaLabel": "Bridge direction",
+    "export": "Export BTH → wBTH",
+    "unwrap": "Unwrap wBTH → BTH"
+  },
   "hero": {
     "title": "Trade wrapped BTH",
     "subtitle": "wBTH is Botho wrapped 1:1 onto other chains so it can trade on their DEXs. This page lists where wBTH lives today and explains how to bridge BTH across.",
@@ -134,6 +139,101 @@
         "body": "Your wBTH is now in your {{chain}} wallet.",
         "viewTx": "View mint transaction",
         "tradeNow": "Trade wBTH now"
+      },
+      "error": {
+        "generic": "Something went wrong. Please try again."
+      }
+    }
+  },
+  "unwrap": {
+    "heading": "How to unwrap wBTH → BTH",
+    "intro": "Unwrapping burns wBTH on its chain and releases the locked BTH back to you. You burn in your own wallet — this wallet only provides the Botho release address, guides the burn, and tracks the release. It never signs on the other chain.",
+    "steps": {
+      "destination": {
+        "title": "1. Get your release address",
+        "body": "This wallet gives you a Botho address to receive the released BTH — a fresh stealth address, private by default."
+      },
+      "burn": {
+        "title": "2. Burn wBTH yourself",
+        "body": "In your own wallet, call bridgeBurn(amount, bthAddress) on the wBTH token, pasting the release address above as bthAddress."
+      },
+      "track": {
+        "title": "3. Track the release",
+        "body": "The bridge detects your burn, confirms it, and releases an equal amount of BTH (minus the bridge fee) to your address."
+      },
+      "receive": {
+        "title": "4. Receive BTH",
+        "body": "The released BTH lands at your release address. This wallet already scans for it — check your balance once the release completes."
+      }
+    },
+    "panel": {
+      "title": "Unwrap wBTH → BTH",
+      "subtitle": "Get your Botho release address and burn wBTH in your own wallet. The bridge releases the locked BTH to you — this wallet never signs on the other chain.",
+      "testnetBadge": "Testnet",
+      "noWallet": {
+        "title": "Open your wallet to unwrap",
+        "body": "Unwrapping releases BTH to your Botho address. Create or open your wallet first to get a release address.",
+        "cta": "Go to wallet"
+      },
+      "locked": {
+        "title": "Unlock your wallet to unwrap",
+        "body": "Your wallet is locked, so a release address is unavailable. Unlock it to get the Botho address to release BTH to.",
+        "cta": "Unlock wallet"
+      },
+      "chains": {
+        "ethereum": "Ethereum",
+        "solana": "Solana",
+        "hyperliquid": "Hyperliquid"
+      },
+      "form": {
+        "chainLabel": "Source chain (where you burn wBTH)",
+        "comingSoon": "Soon",
+        "destinationLabel": "Your BTH release address",
+        "destinationHint": "Copy this into your burn call as bthAddress. The released BTH lands here.",
+        "copy": "Copy",
+        "copied": "Copied",
+        "amountLabel": "Amount to unwrap",
+        "amountToken": "amount",
+        "amountHint": "The wBTH amount you will burn. You receive an equal amount of BTH minus the bridge fee.",
+        "amountRequired": "Enter an amount to unwrap.",
+        "burnHeading": "Burn wBTH on {{chain}}",
+        "burnIntro": "Do this in your OWN wallet (MetaMask / Phantom). bridgeBurn is the only burn path — it releases your BTH; a plain transfer does not.",
+        "tokenLabel": "wBTH token to burn",
+        "callLabel": "Burn call",
+        "callHint": "amount is in picocredits (u64); bthAddress is your release address above.",
+        "openApp": "Open {{chain}} to burn",
+        "track": "I've started the burn — track release",
+        "trackHint": "Opens a release order and tracks it. Your BTH arrives whether or not you track it here.",
+        "submitting": "Opening…",
+        "notConfigured": {
+          "title": "Live release tracking not wired yet",
+          "body": "The public bridge order API (create/status, CORS) is not exposed on this deployment yet. You can still burn wBTH using the guidance above — the bridge watches the chain and releases BTH to your address regardless. Check your wallet balance after the release completes."
+        }
+      },
+      "order": {
+        "id": "Order",
+        "source": "Source chain",
+        "destination": "Release to",
+        "amount": "Amount",
+        "fee": "Bridge fee",
+        "receive": "You receive",
+        "viewBurnTx": "View burn transaction",
+        "newUnwrap": "Start another unwrap"
+      },
+      "status": {
+        "burn_detected": "Burn detected",
+        "burn_confirmed": "Burn confirmed",
+        "release_pending": "Releasing BTH",
+        "released": "Released",
+        "expired": "Expired",
+        "failed": "Failed",
+        "expiredNote": "This order expired before a detected burn. Start a new unwrap.",
+        "failedNote": "This order failed: {{reason}}"
+      },
+      "released": {
+        "title": "BTH released to your wallet",
+        "body": "The BTH has been released to your address. This wallet scans owned outputs — check your balance to see it arrive.",
+        "releaseTx": "Release tx: {{tx}}"
       },
       "error": {
         "generic": "Something went wrong. Please try again."

--- a/web/packages/web-wallet/src/locales/zh/bridge.json
+++ b/web/packages/web-wallet/src/locales/zh/bridge.json
@@ -7,6 +7,11 @@
   "nav": {
     "trade": "Trade"
   },
+  "tabs": {
+    "ariaLabel": "Bridge direction",
+    "export": "Export BTH → wBTH",
+    "unwrap": "Unwrap wBTH → BTH"
+  },
   "hero": {
     "title": "Trade wrapped BTH",
     "subtitle": "wBTH is Botho wrapped 1:1 onto other chains so it can trade on their DEXs. This page lists where wBTH lives today and explains how to bridge BTH across.",
@@ -134,6 +139,101 @@
         "body": "Your wBTH is now in your {{chain}} wallet.",
         "viewTx": "View mint transaction",
         "tradeNow": "Trade wBTH now"
+      },
+      "error": {
+        "generic": "Something went wrong. Please try again."
+      }
+    }
+  },
+  "unwrap": {
+    "heading": "How to unwrap wBTH → BTH",
+    "intro": "Unwrapping burns wBTH on its chain and releases the locked BTH back to you. You burn in your own wallet — this wallet only provides the Botho release address, guides the burn, and tracks the release. It never signs on the other chain.",
+    "steps": {
+      "destination": {
+        "title": "1. Get your release address",
+        "body": "This wallet gives you a Botho address to receive the released BTH — a fresh stealth address, private by default."
+      },
+      "burn": {
+        "title": "2. Burn wBTH yourself",
+        "body": "In your own wallet, call bridgeBurn(amount, bthAddress) on the wBTH token, pasting the release address above as bthAddress."
+      },
+      "track": {
+        "title": "3. Track the release",
+        "body": "The bridge detects your burn, confirms it, and releases an equal amount of BTH (minus the bridge fee) to your address."
+      },
+      "receive": {
+        "title": "4. Receive BTH",
+        "body": "The released BTH lands at your release address. This wallet already scans for it — check your balance once the release completes."
+      }
+    },
+    "panel": {
+      "title": "Unwrap wBTH → BTH",
+      "subtitle": "Get your Botho release address and burn wBTH in your own wallet. The bridge releases the locked BTH to you — this wallet never signs on the other chain.",
+      "testnetBadge": "Testnet",
+      "noWallet": {
+        "title": "Open your wallet to unwrap",
+        "body": "Unwrapping releases BTH to your Botho address. Create or open your wallet first to get a release address.",
+        "cta": "Go to wallet"
+      },
+      "locked": {
+        "title": "Unlock your wallet to unwrap",
+        "body": "Your wallet is locked, so a release address is unavailable. Unlock it to get the Botho address to release BTH to.",
+        "cta": "Unlock wallet"
+      },
+      "chains": {
+        "ethereum": "Ethereum",
+        "solana": "Solana",
+        "hyperliquid": "Hyperliquid"
+      },
+      "form": {
+        "chainLabel": "Source chain (where you burn wBTH)",
+        "comingSoon": "Soon",
+        "destinationLabel": "Your BTH release address",
+        "destinationHint": "Copy this into your burn call as bthAddress. The released BTH lands here.",
+        "copy": "Copy",
+        "copied": "Copied",
+        "amountLabel": "Amount to unwrap",
+        "amountToken": "amount",
+        "amountHint": "The wBTH amount you will burn. You receive an equal amount of BTH minus the bridge fee.",
+        "amountRequired": "Enter an amount to unwrap.",
+        "burnHeading": "Burn wBTH on {{chain}}",
+        "burnIntro": "Do this in your OWN wallet (MetaMask / Phantom). bridgeBurn is the only burn path — it releases your BTH; a plain transfer does not.",
+        "tokenLabel": "wBTH token to burn",
+        "callLabel": "Burn call",
+        "callHint": "amount is in picocredits (u64); bthAddress is your release address above.",
+        "openApp": "Open {{chain}} to burn",
+        "track": "I've started the burn — track release",
+        "trackHint": "Opens a release order and tracks it. Your BTH arrives whether or not you track it here.",
+        "submitting": "Opening…",
+        "notConfigured": {
+          "title": "Live release tracking not wired yet",
+          "body": "The public bridge order API (create/status, CORS) is not exposed on this deployment yet. You can still burn wBTH using the guidance above — the bridge watches the chain and releases BTH to your address regardless. Check your wallet balance after the release completes."
+        }
+      },
+      "order": {
+        "id": "Order",
+        "source": "Source chain",
+        "destination": "Release to",
+        "amount": "Amount",
+        "fee": "Bridge fee",
+        "receive": "You receive",
+        "viewBurnTx": "View burn transaction",
+        "newUnwrap": "Start another unwrap"
+      },
+      "status": {
+        "burn_detected": "Burn detected",
+        "burn_confirmed": "Burn confirmed",
+        "release_pending": "Releasing BTH",
+        "released": "Released",
+        "expired": "Expired",
+        "failed": "Failed",
+        "expiredNote": "This order expired before a detected burn. Start a new unwrap.",
+        "failedNote": "This order failed: {{reason}}"
+      },
+      "released": {
+        "title": "BTH released to your wallet",
+        "body": "The BTH has been released to your address. This wallet scans owned outputs — check your balance to see it arrive.",
+        "releaseTx": "Release tx: {{tx}}"
       },
       "error": {
         "generic": "Something went wrong. Please try again."

--- a/web/packages/web-wallet/src/pages/trade.tsx
+++ b/web/packages/web-wallet/src/pages/trade.tsx
@@ -9,6 +9,7 @@ import {
   useBridgeVenues,
   useReserveProof,
   type ExportController,
+  type UnwrapController,
 } from '@botho/features'
 import { ArrowLeft } from 'lucide-react'
 import { METRICS_API_BASE } from '../config/fleet'
@@ -36,7 +37,7 @@ export function TradePage() {
   const { venues } = useBridgeVenues()
   const { proof: reserve, state: reserveState } = useReserveProof(METRICS_API_BASE)
 
-  const { hasWallet, isLocked, balance, send } = useWallet()
+  const { hasWallet, isLocked, balance, send, address } = useWallet()
 
   // The bridge order client — `null` until a CORS-enabled public order endpoint
   // is configured (see config/bridge.ts). A null client makes the export panel
@@ -65,6 +66,24 @@ export function TradePage() {
       requestWallet: () => navigate('/wallet'),
     }),
     [client, hasWallet, isLocked, balance, send, navigate],
+  )
+
+  // Unwrap (#1032): the wallet provides the Botho release destination (its own
+  // receive address — a stealth address, ADR 0004, the same value the Receive
+  // modal shows) + guides the burn, then tracks the release order. The wallet
+  // NEVER signs on the counterparty chain, so there is no signing hook here.
+  const unwrapController = useMemo<UnwrapController>(
+    () => ({
+      client,
+      network: ACTIVE_BRIDGE_NETWORK,
+      wallet: {
+        hasWallet,
+        isLocked,
+        releaseAddress: address,
+      },
+      requestWallet: () => navigate('/wallet'),
+    }),
+    [client, hasWallet, isLocked, address, navigate],
   )
 
   // On the wallet subdomain the landing lives at `/home`; keep `/` elsewhere so
@@ -116,6 +135,7 @@ export function TradePage() {
             reserveState={reserveState}
             t={t}
             exportController={exportController}
+            unwrapController={unwrapController}
           />
         </div>
       </main>


### PR DESCRIPTION
## Summary

Adds the **Unwrap** (wBTH → BTH return leg) to the `/trade` page — the third sub-issue of epic #1029 — building directly on the Tier 0 (#1034) + Tier 1 (#1035) scaffold. Per the epic's non-negotiable custody model, the Botho wallet does **NOT** sign any EVM/Solana transaction and gains no wallet-connect: the user's wBTH **burn happens in their own counterparty wallet** (MetaMask/Phantom). The wallet's job is destination + guidance + tracking + receipt.

An Export/Unwrap tab toggle in `bridge-view.tsx` switches between the two legs, so they are visually and structurally consistent.

## Changes

- **`UnwrapPanel`** (`components/unwrap-panel.tsx`) — sibling to `ExportPanel`, mirroring its `PanelShell`/`Notice`/tracker idioms:
  1. **Release destination** — shows the wallet's own Botho receive address (a stealth address, ADR 0004) reused from the wallet context (the same value the Receive modal shows), with a copy button. The user pastes it as `bthAddress` in their burn call.
  2. **Burn guidance** — chain-aware instructions to call `bridgeBurn(amount, bthAddress)` on the source chain, showing the wBTH token to burn + a concrete rendered call + a deep-link to where the user executes it themselves. Driven by a new **`BURN_TARGETS`** table added to the Tier 0 `venues.ts` (config-driven, mainnet-swappable).
  3. **Release-order tracking** — reuses the Tier 1 `bridge-client.ts` feature-flag pattern. Adds `createReleaseOrder`/`getReleaseOrderStatus` (`POST`/`GET /api/bridge/release-orders`) + a new `release-status.ts` state machine (`burn_detected → burn_confirmed → release_pending → released`) whose strings are byte-identical to the Rust `OrderStatus` Display impl (`bridge/core/src/order.rs`). **Inert when `VITE_BRIDGE_API_BASE` is unset** — destination + guidance still render (they need no backend; the bridge watches the chain and releases regardless), and only live tracking degrades to an explicit notice.
  4. **Receive confirmation** — on `released`, surfaces "BTH released → check your wallet balance" plus burn/release tx explorer links; the wallet already scans owned outputs.
- **`types.ts`** — added `SourceChain`, `ReleaseOrderStatus`, `CreateReleaseOrderRequest`, `ReleaseOrder`, `ReleaseClientLike`, `UnwrapController`, `UnwrapWalletState`. `ReleaseClientLike` is kept separate from `BridgeClientLike` so the mint-only export mocks stay valid.
- **`trade.tsx`** — builds an `UnwrapController` from the wallet context (reusing `address` as the release destination; **no signing hook**).
- **i18n** — new `tabs` + `unwrap` namespaces in `locales/{en,es,zh}/bridge.json`. en authored; es/zh mirror en verbatim (consistent with the existing Tier 0/1 placeholder state — translation is a tracked follow-up). Verified zero missing/extra keys across all three.
- Testnet labeling throughout (testnet badge + burn targets point at Sepolia/Solana-devnet explorers).

### Release-order contract (shared #1036 backend fast-follow)

The release endpoints share the **same** not-yet-exposed public bridge order API as the Tier 1 mint endpoints (#1036). The client codifies the contract so the UI is correct the moment the endpoint lands; until then the panel is inert exactly like `ExportPanel`.

## Acceptance Criteria Verification

| Criterion (issue #1032) | Status | Verification |
|---|---|---|
| Release destination: wallet shows a Botho stealth address (ADR 0004) | ✅ | Reuses wallet-context `address`; unit test asserts it renders + is copyable |
| Burn guidance: `bridgeBurn(amount, bthAddress)` + token address + deep-link | ✅ | `BURN_TARGETS` config; unit test asserts token, rendered call, and open-app link |
| Release tracking: `burn_detected → … → released`, feature-flagged + inert | ✅ | `release-status.ts` matches Rust Display; client tests + inert-state test |
| Receive confirmation on `released` | ✅ | "released → check balance" + tx links; unit test asserts released title |
| No EVM/Solana signing or web3 libs | ✅ | `git diff` grep: only etherscan deep-link strings, no signing/libs |
| Testnet labeling + edge cases (copy, amount, expiry) | ✅ | Testnet badge; amount-gated track button; expired/failed off-ramps |
| i18n en/es/zh, no missing keys | ✅ | Key-parity script: 0 missing / 0 extra for es + zh |

## Test Plan

Verified in the worktree (real, not mocked): `pnpm -r typecheck` (all 8 packages green), `pnpm test:run` (955 passed / 10 skipped, incl. 6 new `unwrap-panel` + 2 new `bridge-client` release + 4 new `release-status` tests), `pnpm build:web` (built OK).

**Mocked** (no running backend + the user's real burn are external): the release-order API client and the wallet state are injected/mocked in `unwrap-panel.test.tsx`, mirroring the Tier 1 `export-panel.test.tsx`. A live release requires the #1036 backend to be stood up and the user to execute the burn in their own wallet — both out of scope for a unit test and for this PR.

Closes #1032
Part of #1029