### PR TITLE
feat(wasm-signer): embed destination memo on deposit for bridge matching

### DIFF
--- a/botho/src/consensus/validation.rs
+++ b/botho/src/consensus/validation.rs
@@ -1077,6 +1077,7 @@ mod tests {
                 amount: 4_000_000_000,
                 fee: MIN_TX_FEE,
                 created_at_height: 1000,
+                bridge_deposit_memo: None,
             };
 
             // Build + CLSAG-sign exactly as the browser does.

--- a/bridge/service/src/bth_scan.rs
+++ b/bridge/service/src/bth_scan.rs
@@ -537,6 +537,63 @@ mod tests {
         assert_eq!(tx.inputs.len(), 1);
     }
 
+    /// #1037 round-trip proof: a deposit built the way the WASM signer builds it
+    /// — a hybrid output to the reserve carrying the order memo via
+    /// `MemoPayload::destination_bytes` (the exact call
+    /// `bth_wasm_signer::core` makes) — is view-key-matched by the watcher back
+    /// to its order UUID.
+    ///
+    /// The memo is the *real* wire memo `BridgeOrder::generate_memo` produces
+    /// (UUID in the first 16 bytes), so this asserts the wallet embed format
+    /// and the watcher read format agree end to end: `scan_deposit_output`
+    /// decrypts the memo and `BridgeOrder::order_id_from_memo` recovers the
+    /// order's id.
+    #[test]
+    fn scan_matches_wallet_built_deposit_memo_to_order() {
+        use bth_bridge_core::{BridgeOrder, Chain};
+
+        let mut rng = StdRng::from_seed([37u8; 32]);
+        let reserve = AccountKey::random(&mut rng);
+        let kem = MlKem768KeyPair::from_seed(&[0x51u8; 32]);
+
+        // A real mint order; its generated memo carries the order UUID.
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bth_deposit_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        let order_memo: [u8; 64] = order.generate_memo();
+
+        // The wallet embeds the 64-byte memo via `destination_bytes` (the exact
+        // WASM construction path) on a hybrid deposit output to the reserve.
+        let deposit = TxOutput::new_hybrid(
+            1_000_000_000_000,
+            &reserve.default_subaddress(),
+            kem.public_key(),
+            0,
+            Some(MemoPayload::destination_bytes(&order_memo)),
+            ClusterTagVector::empty(),
+        );
+        let rpc = rpc_output_from_txoutput(&deposit, "0xdeposit", 0);
+
+        // The watcher scans it with the reserve account + KEM secret.
+        let scanned = scan_deposit_output(&rpc, &reserve, Some(&kem))
+            .unwrap()
+            .expect("reserve detects its hybrid deposit");
+        let memo = scanned.memo.expect("the deposit carries a decodable memo");
+        assert_eq!(memo, order_memo, "decrypted memo must equal the order memo");
+
+        // The watcher recovers the order UUID and it matches the order.
+        let recovered =
+            BridgeOrder::order_id_from_memo(&memo).expect("watcher recovers a UUID from the memo");
+        assert_eq!(
+            recovered, order.id,
+            "the recovered order id must match the order the wallet was told to reference"
+        );
+    }
+
     #[test]
     fn scan_detects_owned_output_and_decrypts_memo() {
         let mut rng = StdRng::from_seed([3u8; 32]);

--- a/mobile/rust-bridge/src/lib.rs
+++ b/mobile/rust-bridge/src/lib.rs
@@ -891,6 +891,7 @@ mod send_acceptance_tests {
             amount: send_amount,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
+            bridge_deposit_memo: None,
         };
 
         let tx = build_and_sign_with_rng(&request, &mut rng).expect("mobile build+sign");

--- a/mobile/rust-bridge/src/wallet_ops.rs
+++ b/mobile/rust-bridge/src/wallet_ops.rs
@@ -282,6 +282,10 @@ pub async fn send(
         amount,
         fee,
         created_at_height: height,
+        // The mobile wallet has no bridge-deposit flow, so it never sets the
+        // dedicated bridge order-memo channel (#1037). An ordinary send carries
+        // no on-chain memo — byte-identical to before.
+        bridge_deposit_memo: None,
     };
 
     let tx_hex = build_and_sign_inner(&request).map_err(SendError::Other)?;

--- a/mobile/rust-bridge/tests/wallet_core_offline.rs
+++ b/mobile/rust-bridge/tests/wallet_core_offline.rs
@@ -289,6 +289,7 @@ fn build_and_sign_produces_node_verifiable_tx() {
         amount,
         fee: MIN_TX_FEE,
         created_at_height: 1,
+        bridge_deposit_memo: None,
     })
     // `build_and_sign_inner` self-verifies structure + ring signatures + the
     // balance equation under the node's own verifier before returning, so a
@@ -346,6 +347,7 @@ fn build_and_sign_rejects_insufficient_inputs() {
         amount: 50_000_000_000,
         fee: MIN_TX_FEE,
         created_at_height: 1,
+        bridge_deposit_memo: None,
     });
 
     assert!(

--- a/transaction/clsag/src/lib.rs
+++ b/transaction/clsag/src/lib.rs
@@ -256,6 +256,28 @@ impl MemoPayload {
         Self { data }
     }
 
+    /// Create a destination memo carrying raw 64-byte binary data.
+    ///
+    /// Unlike [`MemoPayload::destination`] (which takes a UTF-8 `&str` and
+    /// truncates/pads it), this preserves an arbitrary 64-byte payload exactly.
+    /// It is used to embed a bridge deposit's **order memo** — a 64-byte value
+    /// whose first 16 bytes are the mint-order UUID
+    /// (`BridgeOrder::generate_memo` in `bridge/core`) — because those
+    /// bytes are raw binary (a UUID), not UTF-8. The memo `type` is set to
+    /// `[0x02, 0x00]` (Destination) so the output is not treated as
+    /// "unused" ([`MemoPayload::is_unused`]), and
+    /// [`MemoPayload::memo_data`] returns the 64 bytes byte-for-byte — exactly
+    /// what the bridge watcher reads before recovering the order UUID
+    /// (`bridge/service/src/bth_scan.rs`).
+    pub fn destination_bytes(data: &[u8; 64]) -> Self {
+        let mut buf = [0u8; ENCRYPTED_MEMO_SIZE];
+        // Type: 0x0200 = Destination memo (non-zero => not "unused").
+        buf[0] = 0x02;
+        buf[1] = 0x00;
+        buf[2..ENCRYPTED_MEMO_SIZE].copy_from_slice(data);
+        Self { data: buf }
+    }
+
     /// Get the memo type bytes (first 2 bytes)
     pub fn memo_type(&self) -> [u8; 2] {
         [self.data[0], self.data[1]]
@@ -1692,6 +1714,48 @@ mod tests {
 
     /// Default test amount that's above the dust threshold
     const TEST_AMOUNT: u64 = DUST_THRESHOLD * 10;
+
+    /// A destination memo built from raw 64 bytes preserves them byte-for-byte
+    /// in `memo_data()`, is not "unused", and survives an encrypt -> on-chain
+    /// output -> `decrypt_memo` round-trip. This is the exact path a
+    /// wallet-built bridge deposit uses to carry the order UUID for the
+    /// watcher to match.
+    #[test]
+    fn destination_bytes_roundtrips_through_output_memo() {
+        use bth_account_keys::AccountKey;
+        use rand::{rngs::StdRng, SeedableRng};
+
+        // A 64-byte order memo: first 16 bytes a UUID-like value, rest zero
+        // (mirrors `BridgeOrder::generate_memo`).
+        let mut order_memo = [0u8; 64];
+        order_memo[..16].copy_from_slice(&[
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54,
+            0x32, 0x10,
+        ]);
+
+        let memo = MemoPayload::destination_bytes(&order_memo);
+        assert!(!memo.is_unused(), "a destination memo must not be 'unused'");
+        assert_eq!(memo.memo_type(), [0x02, 0x00], "destination memo type");
+        assert_eq!(
+            memo.memo_data(),
+            &order_memo,
+            "memo_data must equal the raw 64 order bytes byte-for-byte"
+        );
+
+        // Encrypt onto an output for a recipient and decrypt it back with the
+        // recipient's view key — the exact read the watcher performs.
+        let mut rng = StdRng::from_seed([37u8; 32]);
+        let recipient = AccountKey::random(&mut rng);
+        let out = TxOutput::new_with_memo(TEST_AMOUNT, &recipient.default_subaddress(), Some(memo));
+        let decrypted = out
+            .decrypt_memo(&recipient)
+            .expect("recipient decrypts its own memo");
+        assert_eq!(
+            decrypted.memo_data(),
+            &order_memo,
+            "decrypted memo_data must recover the raw order bytes"
+        );
+    }
 
     /// Helper to create a minimal test ring member
     fn test_ring_member(id: u8) -> RingMember {

--- a/web/packages/wasm-signer/src/core.rs
+++ b/web/packages/wasm-signer/src/core.rs
@@ -273,24 +273,31 @@ pub struct SignRequest {
     pub fee: u64,
     /// Chain height to stamp the transaction with (replay protection).
     pub created_at_height: u64,
-    /// Optional destination memo (hex-encoded 64 bytes) to embed on the
+    /// Optional BRIDGE DEPOSIT memo (hex-encoded 64 bytes) to embed on the
     /// RECIPIENT output (index 0).
     ///
-    /// This is the bridge deposit hook (#1037, epic #1029): a BTH→wBTH mint
-    /// deposit must carry the order memo — a 64-byte value whose first 16 bytes
-    /// are the mint-order UUID (`BridgeOrder::generate_memo`, returned by the
-    /// public order API as a 128-char hex string) — so the bridge watcher can
-    /// view-key-match the deposit to its order
-    /// (`bridge/service/src/bth_scan.rs` `scan_deposit_output`). When
-    /// present the signer encrypts it into the recipient output's `e_memo`
-    /// via [`MemoPayload::destination_bytes`], the exact format the watcher
-    /// decrypts + reads.
+    /// This is a DEDICATED, TYPED channel for the bridge deposit hook (#1037,
+    /// epic #1029) — deliberately distinct from any human free-text "note" a
+    /// wallet UI might collect. A BTH→wBTH mint deposit must carry the order
+    /// memo — a 64-byte value whose first 16 bytes are the mint-order UUID
+    /// (`BridgeOrder::generate_memo`, returned by the public order API as a
+    /// 128-char hex string) — so the bridge watcher can view-key-match the
+    /// deposit to its order (`bridge/service/src/bth_scan.rs`
+    /// `scan_deposit_output`). When present the signer encrypts it into the
+    /// recipient output's `e_memo` via [`MemoPayload::destination_bytes`], the
+    /// exact format the watcher decrypts + reads.
+    ///
+    /// Because this channel carries a binary order-id (NOT a UTF-8 note), a
+    /// present value MUST be exactly 64 bytes of hex — anything else is a hard
+    /// error (see [`parse_memo`]). Free-text UI notes must NOT be routed here;
+    /// they belong to a separate cosmetic channel that never reaches the
+    /// signer.
     ///
     /// When absent or empty the recipient output carries NO memo —
     /// byte-identical to an ordinary (non-bridge) send, preserving privacy.
     /// Defaults to `None` for back-compat with callers that never set it.
     #[serde(default)]
-    pub memo: Option<String>,
+    pub bridge_deposit_memo: Option<String>,
 }
 
 fn parse_hex_32(field: &str, s: &str) -> Result<[u8; 32], String> {
@@ -331,15 +338,17 @@ fn parse_kem_public_key(field: &str, s: &str) -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
-/// Parse an optional hex-encoded 64-byte destination memo into a
+/// Parse an optional hex-encoded 64-byte BRIDGE DEPOSIT memo into a
 /// [`MemoPayload`].
 ///
-/// Returns `Ok(None)` when the memo is absent or an empty string (an ordinary
-/// send: no memo, byte-identical to today). A present memo MUST hex-decode to
-/// exactly 64 bytes — the fixed order-memo width the bridge watcher reads
-/// (`bth_scan.rs`) and the public order API emits (`generate_memo`, 128 hex
-/// chars). Any other length is a hard error rather than a silently truncated /
-/// zero-padded memo that would fail to match the order UUID.
+/// This is the strict validator for the dedicated bridge channel ONLY (never a
+/// free-text UI note — those never reach here). Returns `Ok(None)` when the
+/// memo is absent or an empty string (an ordinary send: no memo, byte-identical
+/// to today). A present memo MUST hex-decode to exactly 64 bytes — the fixed
+/// order-memo width the bridge watcher reads (`bth_scan.rs`) and the public
+/// order API emits (`generate_memo`, 128 hex chars). Any other length is a hard
+/// error rather than a silently truncated / zero-padded memo that would fail to
+/// match the order UUID.
 fn parse_memo(field: &str, memo: &Option<String>) -> Result<Option<MemoPayload>, String> {
     match memo {
         None => Ok(None),
@@ -463,11 +472,12 @@ pub fn build_and_sign_with_rng<R: RngCore + CryptoRng>(
     // the output's position in the tx (recipient=0, change=1). A recipient (or
     // sender) address that lacks a well-formed ML-KEM key is a hard error, never
     // a silent KEM-less output that 6.0.0 consensus would reject.
-    // Optional destination memo on the RECIPIENT output (index 0): the bridge
-    // deposit hook (#1037). Encrypted to the recipient's view key like any memo,
-    // so only the deposit account (the bridge reserve) can read it. `None` for
-    // an ordinary send => no memo, unchanged privacy.
-    let recipient_memo = parse_memo("memo", &req.memo)?;
+    // Optional bridge-deposit memo on the RECIPIENT output (index 0): the bridge
+    // deposit hook (#1037), a dedicated channel separate from any free-text UI
+    // note. Encrypted to the recipient's view key like any memo, so only the
+    // deposit account (the bridge reserve) can read it. `None` for an ordinary
+    // send => no memo, unchanged privacy.
+    let recipient_memo = parse_memo("bridgeDepositMemo", &req.bridge_deposit_memo)?;
     let recipient_output = TxOutput::new_hybrid_to_address(
         req.amount,
         &recipient,
@@ -969,7 +979,7 @@ mod tests {
             amount: send_amount,
             fee,
             created_at_height: 1000,
-            memo: None,
+            bridge_deposit_memo: None,
         }
     }
 
@@ -1064,7 +1074,7 @@ mod tests {
             amount: 5_000_000_000,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
-            memo: None,
+            bridge_deposit_memo: None,
         };
         let tx = build_and_sign_with_rng(&req, &mut rng).unwrap();
         let signed_ki = hex::encode(tx.inputs.clsag()[0].key_image());
@@ -1447,7 +1457,7 @@ mod tests {
             amount: send_amount,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
-            memo: None,
+            bridge_deposit_memo: None,
         };
 
         let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
@@ -1512,7 +1522,7 @@ mod tests {
             amount: 4_000_000_000,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
-            memo: None,
+            bridge_deposit_memo: None,
         };
 
         let err = build_and_sign_with_rng(&req, &mut rng)
@@ -1583,7 +1593,7 @@ mod tests {
             amount: send_amount,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
-            memo: None,
+            bridge_deposit_memo: None,
         };
         let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
         assert_eq!(tx.outputs.len(), 2, "recipient (0) + change (1)");
@@ -1671,7 +1681,7 @@ mod tests {
             amount: send_amount,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
-            memo: None,
+            bridge_deposit_memo: None,
         };
         let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
         assert_eq!(tx.outputs.len(), 2);
@@ -1760,7 +1770,7 @@ mod tests {
             amount: 4_000_000_000,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
-            memo: None,
+            bridge_deposit_memo: None,
         };
         let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
 
@@ -1822,7 +1832,7 @@ mod tests {
             amount: 5_000_000_000,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
-            memo: Some(memo_hex),
+            bridge_deposit_memo: Some(memo_hex),
         };
         let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
 
@@ -1867,7 +1877,7 @@ mod tests {
 
         // Absent memo (None) via the shared helper.
         let req_none = make_request(&sender, 10_000_000_000, 5_000_000_000, MIN_TX_FEE, &mut rng);
-        assert!(req_none.memo.is_none());
+        assert!(req_none.bridge_deposit_memo.is_none());
         let tx_none = build_and_sign_with_rng(&req_none, &mut rng).unwrap();
         for o in &tx_none.outputs {
             assert!(
@@ -1879,7 +1889,7 @@ mod tests {
         // Empty-string memo is treated as no memo, not a zero-length memo.
         let mut req_empty =
             make_request(&sender, 10_000_000_000, 5_000_000_000, MIN_TX_FEE, &mut rng);
-        req_empty.memo = Some(String::new());
+        req_empty.bridge_deposit_memo = Some(String::new());
         let tx_empty = build_and_sign_with_rng(&req_empty, &mut rng).unwrap();
         for o in &tx_empty.outputs {
             assert!(
@@ -1898,7 +1908,7 @@ mod tests {
         let sender = AccountKey::random(&mut rng);
         let mut req = make_request(&sender, 10_000_000_000, 5_000_000_000, MIN_TX_FEE, &mut rng);
         // 16 bytes, not 64.
-        req.memo = Some(hex::encode([7u8; 16]));
+        req.bridge_deposit_memo = Some(hex::encode([7u8; 16]));
         let err = build_and_sign_with_rng(&req, &mut rng).unwrap_err();
         assert!(err.contains("expected a 64-byte memo"), "got: {err}");
     }

--- a/web/packages/wasm-signer/src/core.rs
+++ b/web/packages/wasm-signer/src/core.rs
@@ -9,8 +9,8 @@
 use bth_account_keys::{AccountKey, PublicAddress};
 use bth_crypto_keys::{RistrettoPrivate, RistrettoPublic};
 use bth_transaction_clsag::{
-    ClsagRingInput, RingMember, Transaction, TxOutput, DEFAULT_RING_SIZE, DUST_THRESHOLD,
-    MIN_TX_FEE,
+    ClsagRingInput, MemoPayload, RingMember, Transaction, TxOutput, DEFAULT_RING_SIZE,
+    DUST_THRESHOLD, MIN_TX_FEE,
 };
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -273,6 +273,24 @@ pub struct SignRequest {
     pub fee: u64,
     /// Chain height to stamp the transaction with (replay protection).
     pub created_at_height: u64,
+    /// Optional destination memo (hex-encoded 64 bytes) to embed on the
+    /// RECIPIENT output (index 0).
+    ///
+    /// This is the bridge deposit hook (#1037, epic #1029): a BTH→wBTH mint
+    /// deposit must carry the order memo — a 64-byte value whose first 16 bytes
+    /// are the mint-order UUID (`BridgeOrder::generate_memo`, returned by the
+    /// public order API as a 128-char hex string) — so the bridge watcher can
+    /// view-key-match the deposit to its order
+    /// (`bridge/service/src/bth_scan.rs` `scan_deposit_output`). When
+    /// present the signer encrypts it into the recipient output's `e_memo`
+    /// via [`MemoPayload::destination_bytes`], the exact format the watcher
+    /// decrypts + reads.
+    ///
+    /// When absent or empty the recipient output carries NO memo —
+    /// byte-identical to an ordinary (non-bridge) send, preserving privacy.
+    /// Defaults to `None` for back-compat with callers that never set it.
+    #[serde(default)]
+    pub memo: Option<String>,
 }
 
 fn parse_hex_32(field: &str, s: &str) -> Result<[u8; 32], String> {
@@ -311,6 +329,34 @@ fn parse_kem_public_key(field: &str, s: &str) -> Result<Vec<u8>, String> {
         ));
     }
     Ok(bytes)
+}
+
+/// Parse an optional hex-encoded 64-byte destination memo into a
+/// [`MemoPayload`].
+///
+/// Returns `Ok(None)` when the memo is absent or an empty string (an ordinary
+/// send: no memo, byte-identical to today). A present memo MUST hex-decode to
+/// exactly 64 bytes — the fixed order-memo width the bridge watcher reads
+/// (`bth_scan.rs`) and the public order API emits (`generate_memo`, 128 hex
+/// chars). Any other length is a hard error rather than a silently truncated /
+/// zero-padded memo that would fail to match the order UUID.
+fn parse_memo(field: &str, memo: &Option<String>) -> Result<Option<MemoPayload>, String> {
+    match memo {
+        None => Ok(None),
+        Some(s) if s.trim().is_empty() => Ok(None),
+        Some(s) => {
+            let bytes = hex::decode(s.trim()).map_err(|e| format!("{field}: invalid hex: {e}"))?;
+            if bytes.len() != 64 {
+                return Err(format!(
+                    "{field}: expected a 64-byte memo (128 hex chars), got {} bytes",
+                    bytes.len()
+                ));
+            }
+            let mut arr = [0u8; 64];
+            arr.copy_from_slice(&bytes);
+            Ok(Some(MemoPayload::destination_bytes(&arr)))
+        }
+    }
 }
 
 /// Reconstruct a [`RingMember`] from a chain output's keys + amount.
@@ -417,9 +463,19 @@ pub fn build_and_sign_with_rng<R: RngCore + CryptoRng>(
     // the output's position in the tx (recipient=0, change=1). A recipient (or
     // sender) address that lacks a well-formed ML-KEM key is a hard error, never
     // a silent KEM-less output that 6.0.0 consensus would reject.
-    let recipient_output =
-        TxOutput::new_hybrid_to_address(req.amount, &recipient, 0, None, Default::default())
-            .map_err(|e| format!("recipient address is not post-quantum (v2): {e}"))?;
+    // Optional destination memo on the RECIPIENT output (index 0): the bridge
+    // deposit hook (#1037). Encrypted to the recipient's view key like any memo,
+    // so only the deposit account (the bridge reserve) can read it. `None` for
+    // an ordinary send => no memo, unchanged privacy.
+    let recipient_memo = parse_memo("memo", &req.memo)?;
+    let recipient_output = TxOutput::new_hybrid_to_address(
+        req.amount,
+        &recipient,
+        0,
+        recipient_memo,
+        Default::default(),
+    )
+    .map_err(|e| format!("recipient address is not post-quantum (v2): {e}"))?;
     let mut outputs = vec![recipient_output];
     let actual_fee = if change >= DUST_THRESHOLD {
         let change_output =
@@ -913,6 +969,7 @@ mod tests {
             amount: send_amount,
             fee,
             created_at_height: 1000,
+            memo: None,
         }
     }
 
@@ -1007,6 +1064,7 @@ mod tests {
             amount: 5_000_000_000,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
+            memo: None,
         };
         let tx = build_and_sign_with_rng(&req, &mut rng).unwrap();
         let signed_ki = hex::encode(tx.inputs.clsag()[0].key_image());
@@ -1389,6 +1447,7 @@ mod tests {
             amount: send_amount,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
+            memo: None,
         };
 
         let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
@@ -1453,6 +1512,7 @@ mod tests {
             amount: 4_000_000_000,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
+            memo: None,
         };
 
         let err = build_and_sign_with_rng(&req, &mut rng)
@@ -1523,6 +1583,7 @@ mod tests {
             amount: send_amount,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
+            memo: None,
         };
         let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
         assert_eq!(tx.outputs.len(), 2, "recipient (0) + change (1)");
@@ -1610,6 +1671,7 @@ mod tests {
             amount: send_amount,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
+            memo: None,
         };
         let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
         assert_eq!(tx.outputs.len(), 2);
@@ -1698,6 +1760,7 @@ mod tests {
             amount: 4_000_000_000,
             fee: MIN_TX_FEE,
             created_at_height: 1000,
+            memo: None,
         };
         let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
 
@@ -1713,5 +1776,130 @@ mod tests {
             owned.is_empty(),
             "an output addressed to another wallet must not be detected"
         );
+    }
+
+    /// #1037: a send carrying a bridge order memo embeds it on the RECIPIENT
+    /// output (index 0) in the exact format the bridge watcher reads. The
+    /// deposit account (bridge reserve) recovers the 64-byte memo via
+    /// `decrypt_memo` — the same call `bth_scan::scan_deposit_output` makes —
+    /// and the first 16 bytes are the order UUID
+    /// (`BridgeOrder::order_id_from_memo`). The change output carries NO
+    /// memo. This is the wallet half of the deposit-matching round trip.
+    #[test]
+    fn bridge_order_memo_is_embedded_on_recipient_output() {
+        let mut rng = StdRng::from_seed([203u8; 32]);
+        let sender = AccountKey::random(&mut rng);
+        // The recipient is the bridge deposit account (the reserve).
+        let deposit_account = AccountKey::random(&mut rng);
+        let deposit_pq = pq_keys(0x5a);
+
+        // A 64-byte order memo: first 16 bytes the order UUID, rest zero
+        // (mirrors `BridgeOrder::generate_memo`; the public API hands this back
+        // as a 128-char hex string).
+        let mut order_memo = [0u8; 64];
+        order_memo[..16].copy_from_slice(&[
+            0xde, 0xad, 0xbe, 0xef, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99,
+            0xaa, 0xbb,
+        ]);
+        let memo_hex = hex::encode(order_memo);
+
+        let owned_amount = 10_000_000_000u64;
+        let owned = TxOutput::new(owned_amount, &sender.default_subaddress());
+        let decoys = make_decoys(DEFAULT_RING_SIZE - 1, owned_amount, &mut rng);
+
+        let req = SignRequest {
+            spend_private_key: hex::encode(sender.spend_private_key().to_bytes()),
+            view_private_key: hex::encode(sender.view_private_key().to_bytes()),
+            inputs: vec![SpendInput {
+                target_key: hex::encode(owned.target_key),
+                public_key: hex::encode(owned.public_key),
+                amount: owned_amount,
+                subaddress_index: 0,
+                decoys,
+            }],
+            recipient: recipient_of_with_pq(&deposit_account, &deposit_pq),
+            sender_kem_public_key: kem_public_hex(&pq_keys(0xcd)),
+            amount: 5_000_000_000,
+            fee: MIN_TX_FEE,
+            created_at_height: 1000,
+            memo: Some(memo_hex),
+        };
+        let tx = build_and_sign_with_rng(&req, &mut rng).expect("build+sign should succeed");
+
+        // The recipient (deposit) output is index 0 and carries the memo.
+        let recipient_out = &tx.outputs[0];
+        assert!(
+            recipient_out.e_memo.is_some(),
+            "the deposit output must carry the order memo"
+        );
+        let decrypted = recipient_out
+            .decrypt_memo(&deposit_account)
+            .expect("deposit account decrypts the memo with its view key");
+        assert!(!decrypted.is_unused(), "the memo must not read as 'unused'");
+        assert_eq!(
+            decrypted.memo_data(),
+            &order_memo,
+            "decrypted memo must equal the 64 order bytes byte-for-byte"
+        );
+        // The first 16 bytes are the order UUID the watcher binds to.
+        assert_eq!(&decrypted.memo_data()[..16], &order_memo[..16]);
+
+        // The change output (index 1) must NOT carry a memo — no privacy leak.
+        assert_eq!(tx.outputs.len(), 2, "recipient + change");
+        assert!(
+            tx.outputs[1].e_memo.is_none(),
+            "the change output must not carry a memo"
+        );
+
+        // The deposit output must NOT be detectable by the sender/stranger and the
+        // tx must still verify under the node's verifier.
+        tx.verify_ring_signatures().unwrap();
+        tx.is_valid_structure().unwrap();
+    }
+
+    /// #1037 no-regression: an ordinary send (no memo) produces outputs with NO
+    /// encrypted memo — byte-identical to the pre-#1037 behaviour. Both an
+    /// absent memo and an empty-string memo take the no-memo path.
+    #[test]
+    fn absent_or_empty_memo_produces_no_output_memo() {
+        let mut rng = StdRng::from_seed([204u8; 32]);
+        let sender = AccountKey::random(&mut rng);
+
+        // Absent memo (None) via the shared helper.
+        let req_none = make_request(&sender, 10_000_000_000, 5_000_000_000, MIN_TX_FEE, &mut rng);
+        assert!(req_none.memo.is_none());
+        let tx_none = build_and_sign_with_rng(&req_none, &mut rng).unwrap();
+        for o in &tx_none.outputs {
+            assert!(
+                o.e_memo.is_none(),
+                "no output may carry a memo for a plain send"
+            );
+        }
+
+        // Empty-string memo is treated as no memo, not a zero-length memo.
+        let mut req_empty =
+            make_request(&sender, 10_000_000_000, 5_000_000_000, MIN_TX_FEE, &mut rng);
+        req_empty.memo = Some(String::new());
+        let tx_empty = build_and_sign_with_rng(&req_empty, &mut rng).unwrap();
+        for o in &tx_empty.outputs {
+            assert!(
+                o.e_memo.is_none(),
+                "an empty memo must not attach an e_memo"
+            );
+        }
+    }
+
+    /// #1037: a memo that does not hex-decode to exactly 64 bytes is a hard
+    /// error rather than a silently truncated/padded memo that would fail to
+    /// match the order UUID.
+    #[test]
+    fn malformed_memo_length_is_rejected() {
+        let mut rng = StdRng::from_seed([205u8; 32]);
+        let sender = AccountKey::random(&mut rng);
+        let mut req = make_request(&sender, 10_000_000_000, 5_000_000_000, MIN_TX_FEE, &mut rng);
+        // 16 bytes, not 64.
+        req.memo = Some(hex::encode([7u8; 16]));
+        let err = build_and_sign_with_rng(&req, &mut rng).unwrap_err();
+        assert!(err.contains("expected a 64-byte memo"), "got: {err}");
     }
 }

--- a/web/packages/wasm-signer/src/index.ts
+++ b/web/packages/wasm-signer/src/index.ts
@@ -96,15 +96,18 @@ export interface SignRequest {
   /** Chain height to stamp the transaction with (replay protection). */
   createdAtHeight: bigint | number
   /**
-   * Optional destination memo (hex-encoded 64 bytes) embedded on the RECIPIENT
-   * output. This is the bridge deposit hook (#1037): a BTH→wBTH mint deposit
-   * carries the order memo (first 16 bytes = the mint-order UUID, from
+   * Optional BRIDGE DEPOSIT memo (hex-encoded 64 bytes) embedded on the
+   * RECIPIENT output. This is a DEDICATED, typed channel for the bridge deposit
+   * hook (#1037) — distinct from any human free-text "note" a wallet UI
+   * collects, which must NEVER be routed here. A BTH→wBTH mint deposit carries
+   * the order memo (first 16 bytes = the mint-order UUID, from
    * `BridgeOrder::generate_memo`, returned as a 128-char hex string by the
    * public order API) so the bridge watcher can view-key-match the deposit to
    * its order (`bth_scan.rs`). Encrypted to the recipient's view key like any
-   * memo. Omit / empty for an ordinary send — no memo, unchanged privacy.
+   * memo. A present value MUST be exactly 64 bytes of hex (the signer hard-errors
+   * otherwise). Omit / empty for an ordinary send — no memo, unchanged privacy.
    */
-  memo?: string
+  bridgeDepositMemo?: string
 }
 
 /** A chain output (as returned by `chain_getOutputs`) to test for ownership. */

--- a/web/packages/wasm-signer/src/index.ts
+++ b/web/packages/wasm-signer/src/index.ts
@@ -95,6 +95,16 @@ export interface SignRequest {
   fee: bigint | number
   /** Chain height to stamp the transaction with (replay protection). */
   createdAtHeight: bigint | number
+  /**
+   * Optional destination memo (hex-encoded 64 bytes) embedded on the RECIPIENT
+   * output. This is the bridge deposit hook (#1037): a BTH→wBTH mint deposit
+   * carries the order memo (first 16 bytes = the mint-order UUID, from
+   * `BridgeOrder::generate_memo`, returned as a 128-char hex string by the
+   * public order API) so the bridge watcher can view-key-match the deposit to
+   * its order (`bth_scan.rs`). Encrypted to the recipient's view key like any
+   * memo. Omit / empty for an ordinary send — no memo, unchanged privacy.
+   */
+  memo?: string
 }
 
 /** A chain output (as returned by `chain_getOutputs`) to test for ownership. */

--- a/web/packages/wasm-signer/src/send.ts
+++ b/web/packages/wasm-signer/src/send.ts
@@ -460,12 +460,15 @@ export interface BuildSendParams {
   /** Fee, in picocredits. Must be >= the network minimum. */
   fee: bigint
   /**
-   * Optional destination memo (hex-encoded 64 bytes) to embed on the recipient
-   * output. Used for a BTH→wBTH bridge deposit: pass the mint order's `memo`
-   * (from the public order API) so the bridge watcher can match the deposit to
-   * its order (#1037). Omit for an ordinary send.
+   * Optional BRIDGE DEPOSIT memo (hex-encoded 64 bytes) to embed on the
+   * recipient output. This is a DEDICATED channel for a BTH→wBTH bridge deposit
+   * ONLY: pass the mint order's `memo` (from the public order API) so the bridge
+   * watcher can match the deposit to its order (#1037). It is NOT a free-text
+   * note — a present value must be exactly 64 bytes of hex. Omit for an ordinary
+   * send (including any human note, which is handled cosmetically upstream and
+   * never reaches the signer).
    */
-  memo?: string
+  bridgeDepositMemo?: string
   /** Node RPC accessor. */
   rpc: SendRpc
 }
@@ -511,7 +514,8 @@ function selectInputs(owned: OwnedOutput[], target: bigint): OwnedOutput[] | nul
 export async function buildSendTransaction(
   params: BuildSendParams,
 ): Promise<BuildSendResult> {
-  const { keys, recipient, senderKemPublicKey, amount, fee, memo, rpc } = params
+  const { keys, recipient, senderKemPublicKey, amount, fee, bridgeDepositMemo, rpc } =
+    params
 
   if (amount <= 0n) throw new Error('Amount must be greater than 0')
   if (!recipient.kem_public_key) {
@@ -617,9 +621,11 @@ export async function buildSendTransaction(
     amount,
     fee,
     createdAtHeight: height,
-    // Thread the (optional) destination memo through to the signer so a bridge
-    // deposit carries the order memo the watcher matches on (#1037).
-    memo,
+    // Thread the (optional) bridge-deposit memo through to the signer so a
+    // bridge deposit carries the order memo the watcher matches on (#1037).
+    // Free-text UI notes never reach here — they use a separate cosmetic
+    // channel and are not embedded on-chain.
+    bridgeDepositMemo,
   }
 
   // 4. Build + CLSAG-sign inside wasm. The signer self-verifies the produced tx

--- a/web/packages/wasm-signer/src/send.ts
+++ b/web/packages/wasm-signer/src/send.ts
@@ -459,6 +459,13 @@ export interface BuildSendParams {
   amount: bigint
   /** Fee, in picocredits. Must be >= the network minimum. */
   fee: bigint
+  /**
+   * Optional destination memo (hex-encoded 64 bytes) to embed on the recipient
+   * output. Used for a BTH→wBTH bridge deposit: pass the mint order's `memo`
+   * (from the public order API) so the bridge watcher can match the deposit to
+   * its order (#1037). Omit for an ordinary send.
+   */
+  memo?: string
   /** Node RPC accessor. */
   rpc: SendRpc
 }
@@ -504,7 +511,7 @@ function selectInputs(owned: OwnedOutput[], target: bigint): OwnedOutput[] | nul
 export async function buildSendTransaction(
   params: BuildSendParams,
 ): Promise<BuildSendResult> {
-  const { keys, recipient, senderKemPublicKey, amount, fee, rpc } = params
+  const { keys, recipient, senderKemPublicKey, amount, fee, memo, rpc } = params
 
   if (amount <= 0n) throw new Error('Amount must be greater than 0')
   if (!recipient.kem_public_key) {
@@ -610,6 +617,9 @@ export async function buildSendTransaction(
     amount,
     fee,
     createdAtHeight: height,
+    // Thread the (optional) destination memo through to the signer so a bridge
+    // deposit carries the order memo the watcher matches on (#1037).
+    memo,
   }
 
   // 4. Build + CLSAG-sign inside wasm. The signer self-verifies the produced tx

--- a/web/packages/wasm-signer/test/send-memo.test.ts
+++ b/web/packages/wasm-signer/test/send-memo.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  buildSendTransaction,
+  resetSigner,
+  setSigner,
+  type BuildSendParams,
+  type SignRequest,
+  type WasmSigner,
+} from '../src/index'
+
+/**
+ * #1037: `buildSendTransaction` must thread an optional destination memo through
+ * to the wasm signer's `buildAndSign` request, so a BTH→wBTH bridge deposit
+ * carries the order memo the watcher matches on. These tests use a FAKE signer
+ * (injected via {@link setSigner}) that captures the `SignRequest` it is handed,
+ * so they assert the plumbing without needing the compiled wasm artifact.
+ */
+
+const INPUT_KEY = 'a'.repeat(64)
+const DECOY_KEY = 'c'.repeat(64)
+const PUB_KEY = 'b'.repeat(64)
+const KEM_PUBLIC = 'ee'.repeat(1184)
+
+/**
+ * A fake {@link WasmSigner} that returns a fixed owned output as spendable and
+ * records the last `buildAndSign` request. Ring size is 2 so a single decoy
+ * suffices.
+ */
+function fakeSigner(): { signer: WasmSigner; lastRequest: () => SignRequest | null } {
+  let captured: SignRequest | null = null
+  const owned = {
+    targetKey: INPUT_KEY,
+    publicKey: PUB_KEY,
+    amount: 1_000_000_000_000n,
+    subaddressIndex: 0n,
+  }
+  const signer = {
+    ringSize: () => 2,
+    minFee: () => 100_000_000n,
+    scanOwnedOutputs: () => [owned],
+    computeOwnedOutputKeyImages: () => [{ ...owned, keyImage: 'ff'.repeat(32) }],
+    buildAndSign: (request: SignRequest) => {
+      captured = request
+      return 'deadbeef'
+    },
+    derivePqPublicKeysFromSeed: () => ({ kemPublicKey: '', dsaPublicKey: '' }),
+    deriveAddressFromSeed: () => '',
+  } as unknown as WasmSigner
+  return { signer, lastRequest: () => captured }
+}
+
+function params(memo?: string): BuildSendParams {
+  return {
+    keys: { spendPrivateKey: '11'.repeat(32), viewPrivateKey: '22'.repeat(32) },
+    recipient: {
+      spend_public_key: '33'.repeat(32),
+      view_public_key: '44'.repeat(32),
+      kem_public_key: KEM_PUBLIC,
+    },
+    senderKemPublicKey: KEM_PUBLIC,
+    amount: 500_000_000_000n,
+    fee: 100_000_000n,
+    memo,
+    rpc: {
+      getChainHeight: async () => 100,
+      getOutputs: async () => [
+        { targetKey: INPUT_KEY, publicKey: PUB_KEY, amount: 1_000_000_000_000n },
+        { targetKey: DECOY_KEY, publicKey: PUB_KEY, amount: 1_000_000_000_000n },
+      ],
+      areKeyImagesSpent: async (keyImages) =>
+        keyImages.map((keyImage) => ({
+          keyImage,
+          spent: false,
+          spentHeight: null,
+          pending: false,
+        })),
+    },
+  }
+}
+
+describe('buildSendTransaction memo threading (#1037)', () => {
+  afterEach(() => resetSigner())
+
+  it('passes the destination memo into the buildAndSign request', async () => {
+    const { signer, lastRequest } = fakeSigner()
+    setSigner(signer)
+
+    const orderMemo = 'deadbeef001122334455667788990011'.padEnd(128, '0')
+    const { txHex } = await buildSendTransaction(params(orderMemo))
+
+    expect(txHex).toBe('deadbeef')
+    const req = lastRequest()
+    expect(req).not.toBeNull()
+    expect(req?.memo).toBe(orderMemo)
+  })
+
+  it('leaves memo undefined for an ordinary send', async () => {
+    const { signer, lastRequest } = fakeSigner()
+    setSigner(signer)
+
+    await buildSendTransaction(params())
+
+    expect(lastRequest()?.memo).toBeUndefined()
+  })
+})

--- a/web/packages/wasm-signer/test/send-memo.test.ts
+++ b/web/packages/wasm-signer/test/send-memo.test.ts
@@ -10,11 +10,14 @@ import {
 } from '../src/index'
 
 /**
- * #1037: `buildSendTransaction` must thread an optional destination memo through
- * to the wasm signer's `buildAndSign` request, so a BTH→wBTH bridge deposit
- * carries the order memo the watcher matches on. These tests use a FAKE signer
- * (injected via {@link setSigner}) that captures the `SignRequest` it is handed,
- * so they assert the plumbing without needing the compiled wasm artifact.
+ * #1037: `buildSendTransaction` must thread the optional, DEDICATED bridge
+ * deposit memo (`bridgeDepositMemo`) through to the wasm signer's `buildAndSign`
+ * request, so a BTH→wBTH bridge deposit carries the order memo the watcher
+ * matches on. Crucially, this is a channel SEPARATE from any human free-text
+ * note, so an ordinary send never routes text into the signer's strict 64-byte
+ * validator. These tests use a FAKE signer (injected via {@link setSigner}) that
+ * captures the `SignRequest` it is handed, so they assert the plumbing without
+ * needing the compiled wasm artifact.
  */
 
 const INPUT_KEY = 'a'.repeat(64)
@@ -50,7 +53,7 @@ function fakeSigner(): { signer: WasmSigner; lastRequest: () => SignRequest | nu
   return { signer, lastRequest: () => captured }
 }
 
-function params(memo?: string): BuildSendParams {
+function params(bridgeDepositMemo?: string): BuildSendParams {
   return {
     keys: { spendPrivateKey: '11'.repeat(32), viewPrivateKey: '22'.repeat(32) },
     recipient: {
@@ -61,7 +64,7 @@ function params(memo?: string): BuildSendParams {
     senderKemPublicKey: KEM_PUBLIC,
     amount: 500_000_000_000n,
     fee: 100_000_000n,
-    memo,
+    bridgeDepositMemo,
     rpc: {
       getChainHeight: async () => 100,
       getOutputs: async () => [
@@ -79,10 +82,10 @@ function params(memo?: string): BuildSendParams {
   }
 }
 
-describe('buildSendTransaction memo threading (#1037)', () => {
+describe('buildSendTransaction bridge-deposit memo threading (#1037)', () => {
   afterEach(() => resetSigner())
 
-  it('passes the destination memo into the buildAndSign request', async () => {
+  it('passes the bridge deposit memo into the buildAndSign request', async () => {
     const { signer, lastRequest } = fakeSigner()
     setSigner(signer)
 
@@ -92,15 +95,15 @@ describe('buildSendTransaction memo threading (#1037)', () => {
     expect(txHex).toBe('deadbeef')
     const req = lastRequest()
     expect(req).not.toBeNull()
-    expect(req?.memo).toBe(orderMemo)
+    expect(req?.bridgeDepositMemo).toBe(orderMemo)
   })
 
-  it('leaves memo undefined for an ordinary send', async () => {
+  it('leaves bridgeDepositMemo undefined for an ordinary send', async () => {
     const { signer, lastRequest } = fakeSigner()
     setSigner(signer)
 
     await buildSendTransaction(params())
 
-    expect(lastRequest()?.memo).toBeUndefined()
+    expect(lastRequest()?.bridgeDepositMemo).toBeUndefined()
   })
 })

--- a/web/packages/web-wallet/src/contexts/wallet.test.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { render, screen, waitFor, act, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { WalletProvider, useWallet } from './wallet'
+import { buildSendTransaction } from '@botho/wasm-signer'
 
 // Mock @botho/wasm-signer so these context tests never depend on the generated
 // wasm artifact (`packages/wasm-signer/pkg/`, produced by `build:wasm` and
@@ -34,7 +35,12 @@ vi.mock('@botho/wasm-signer', () => ({
   spendableBalance: vi.fn().mockResolvedValue(0n),
   // No owned outputs => empty client-side history.
   buildOwnedHistory: vi.fn().mockResolvedValue([]),
-  buildSendTransaction: vi.fn().mockResolvedValue({ txHex: '0xstub' }),
+  netOwnedHistory: vi.fn(() => []),
+  ownedOutputTargetKeys: vi.fn().mockResolvedValue([]),
+  mnemonicToSeedHex: vi.fn(() => '00'.repeat(64)),
+  // Captured so the #1037 send-channel test can assert what the signer received.
+  // Returns a valid-hex tx so `hexToBytes(txHex)` in `send()` succeeds.
+  buildSendTransaction: vi.fn().mockResolvedValue({ txHex: 'ab' }),
   // Sender's own ML-KEM key for change encapsulation (#978); stubbed.
   deriveKemPublicKey: vi.fn().mockResolvedValue('00'.repeat(1184)),
 }))
@@ -61,6 +67,15 @@ vi.mock('@botho/adapters', () => ({
     getNodeInfo = vi.fn().mockReturnValue({ version: '1.0.0', network: 'testnet' })
     getBalance = vi.fn().mockResolvedValue({ available: 1000000000000n, pending: 0n, total: 1000000000000n })
     getTransactionHistory = vi.fn().mockResolvedValue([])
+    // Send-path methods (#1037 channel test). buildSendTransaction is mocked, so
+    // the fee/cluster/rpc calls only need to resolve; submitTransaction returns a
+    // success so `send()` reaches its return.
+    getBlockHeight = vi.fn().mockResolvedValue(100)
+    getRawOutputs = vi.fn().mockResolvedValue([])
+    areKeyImagesSpent = vi.fn().mockResolvedValue([])
+    getClusterWealth = vi.fn().mockResolvedValue(0n)
+    estimateFee = vi.fn().mockResolvedValue({ fee: 100_000_000n })
+    submitTransaction = vi.fn().mockResolvedValue({ success: true, txHash: '0xhash' })
     onNewBlock = vi.fn().mockReturnValue(() => {})
     onTransaction = vi.fn().mockReturnValue(() => {})
     onMempoolUpdate = vi.fn().mockReturnValue(() => {})
@@ -454,6 +469,62 @@ describe('WalletContext', () => {
       expect(created!.url).toContain('/claim')
       expect(created!.amount).toBe(1_000_000n)
       expect(created!.fundingTxHash).toBe('0xfundinghash')
+    })
+  })
+
+  // #1037: `send(to, amount, options)` carries two DISTINCT channels — a human
+  // free-text `note` (cosmetic, dropped, never on-chain) and the bridge
+  // `bridgeDepositMemo` (64-byte hex, embedded on-chain). Before the fix the
+  // single `memo` arg was routed straight into the signer's strict 64-byte-hex
+  // validator, so a plain note like "lunch" made the transaction fail
+  // ("memo: invalid hex"). These tests lock the channels apart.
+  describe('send memo channels (#1037)', () => {
+    // Canonical testnet v2 address (the node's derivation for the abandon…about
+    // mnemonic) so the real `parseAddress` in `send()` succeeds.
+    const GOLDEN_TESTNET_ADDRESS =
+      'tbotho://2/apm8kqabmyjn7V6R35S7ZN2bAYoupZGbqQX4u5H62LRih6vDZu2ZvAAJXiUSXN6amQPusu9gEGwWwP22fdeJeU4PZ5ikmjKB8FfgeQjEEBnqr117z2pxXo96jLEH2Q7HjxFWkHLCTzLKmkHhQPL2c5uSCAxzrSXRZkdvGsFfy7kkC2YR5121SgghjSFzX3ThA2Jf6xU9ZMwHxDJbHHA7GhytiB7197BNNhicsTQ26GAUDEAikKPFV2pkWUqnXHF7zX9fRfvTURUZqrGeWskvYCKTngN753rJtjMWwoqCVs2MmaJAnrfTb56rpwNHZiQgbhF7S4zFVYXYwUUSs1uJYCZrUZ2qJeZC4USMX9MCkzJbuizJHeNoWVKfe1eqdkLiX9TQBU1W44QdnNM6N65ve157hDe6ATUD4K8FiqARLz8VgMRvj1Ai4xYDaJGo38oC1d2dSunNwkUYMr6ucFyF2fv4WtAXgNUaDxsFT8Hpxqd4mTGjBKA7dBNtWQfn1zAQHqKZpehaPE3eHP3MujYi62iHme1JkcRpbwjAuLPXWRrD8WBbzVctrsMbnRwVE8uttAbX3CHRwVHBDodUWGXyRGib1wocMLW3WrnRGXdnnEtD7PzLK2rJ25zdm8ZTyMSE1aEPpp5W7HKLv8iFkWhitCDasUagv7VGkNjizp26rFpm3osimjUapAVSY1ShrAXeqbw5PWH3nS5KXmUtPivB1FNifGcTm3Soiziq4twPqBKmMey3vTU6edULkZB1wiXWEeFmJ3uziqFKfitzjYYsgbk5mgTetzTgx13WrAhwfJK5rFkU3ZGKPVEdg6ARB94UGXZWScNdi8S1fspJoaTvDydMmFrgvsGHYVpFfNyjYwU7uD9aVfVHsEwwoPQt9KNGoZbUxLBJ5VzbkaRaers8zRtU25yx8Qakr5oTZFwbA4xnGtuSCXqaEiu2dNnha6RXSvJ5J8XsnGydCvvqW1UfkjdpNVGbgPDh1Vc77T46zDE1VaTGjKxwBoiqMz6YaUF61nCXXcJL3QeDDs8HZH6DBeD6HEwHQoCJRNZ9VGNiFx3699yziLuJXHECTRbwpdqy3ybhWrjL43xTPJnJRXY62ye3XpWPUH4Wmyns8WYzBS3T6ay9Xyf4zrFTC8MUYyCMUfPFqwak1jZ7uh7JYvGuLGcd1TjV3sgngmy5nx349rQAZXUhapTFF5QtdePXPunQxK6QzvGqk7Aeuxtr317NxT77M1AMHC3N9zbMtjaKypUW5RrkJfuTA3S2h45Cz4n74fbmrRc54TktsonGkMzNTTkQre79sQRZXgQtXYNghrPyNzEmo8CTwUMkThw3fkkPfVppaw9VPZpoqonQLG8SCNmwj9YteUM5BYWKQvoRMXy4kBW95jMCPXXkXjkjFLC1qpCiRjXUZd6wd64u2sXKfLJ9fMgz54NknAuYiZawUZLWWkehkdfgwpeXgWd48FL6ZmV2xBZmA3s8JGPiYbAqRYwNySKsKNaDNd7rsh4xbKb2QR6vVuBkgrryVgAKeTymf8hEAE3tpq9puKhu1jGp4q61n6SUyWsXka8ekrjyJVFNXXPF6XpFGC6D5wY8n9kzVgq6kupxZAep4qyFHtudFcqRzNwm1eqeFoRxuCZhyyFFynGJTMWgLBTQ1oQQSX7gD3h2bFFGxtcZp8EEdFZG4faZwXgw79qz1Ft5N2FwfGKwjBcjWVAdVH85Fm7piKdoMSnfwBAqfLPhPQd31qvNZ7F4abRcMTUhjMPDoWD5g8TbDSnQcj9fcw8uE4s7C59xufYibpKxBP4o52pe8pWaNsCrjC6xG2Ss7ZZuU8z2X9sVxkaw37opneLkbwd9CMLLvEYFzQJMv32DM66m6HnKgijtwgUBbyrgYwwc7UzPVteG4VCjMnoeQbAWPNEVDZmnQ5k2HtpEa6K1jvKUS2zT3gxoktmBD17d9a9GzwjMB8jDBn9vRqTogzaJLXyNBbAkTmrZWJoVDNSqEYZQntX3RsCnTVdauCXnFx11NTpZ9tFoKeoQs9r7N6u1ur2Rg5mhRoGUy6iCm4Ndfj4ukNXh1heSUf4cTHDeHTCeeSQbquYNYR7VtagLnGEogA2neETexLzuYtDpE5UsCmJW6JD3tXmL5vtwUJgiwzgHoRUgCyFTQcX5sRax27AWewwmzWUBH1A374S3CogyunE6Ar1Mdoq98rgtNZyctjXXkBxfrF2wQ7rV4dTpAWx8vNVzdMLvQYqipkdWRG7NKrLtfe2VndZvULuQpDJT1QcjqXFb65DeEhbsJGZQ2GyqBNnKDPCNA8ToHYJG3UgePqqT5vZqz4eo29heS1i1raFmeadkFss2HtY6PToVXPJGcJRT9dSHPHD4Mab4TcfziydCgPiWEVQMbxdVV34K8K81gEjjMFr3bs66beHMgB54mCm4pd9rYQaQY63bfHT1Hk6nzD2TvAsVCW6hCcpja5vYxMTy1BJ1LXqfvrysvwDsTKHcqK1eicoJhqiCV48PeLthsdfPDNJP3ynsQvYoN66RVZHSRN7K63u75ZANiMDCFSZN7M4c5WyoLTyWHcB7Q2F93c2HEHBjNuuJQHmhXt3sHccG36ejcZtzcnBcmRSSZ5bHNEDo2oJuuiyRQnCEQ29CCwoGwunxNijkuD75rDdiBUedKZjyaqjAS4sZJZeHe6NCMEDzh4qgTUDUmjgZz1dyx7S45RHsdB7CEbnyiDeBYEinwTtEqQbPKJY6FJwQ4ctbovNTGZBRdhLFQD5DwEHHk7Fmmm3pfXF8cZB9qhTFYstVBJaGUfUGLHwGuzqH8qeEJ8sec9F4JZAr3DrVY42krBBJDiMPru866tZkqjGvzQLP8xQz2XcgcvDwWuEsbF34bTFi5HzfreycywGoLfcN2L69FEny4knrbSpNCmn8qXcV1k5qq6WkLwr9SneY2BEKZxd29Ug5fpbtGoT3jjxbVccNuEhQDqJ2TxQzEgXTPBFZbgYMVo8HxFrqGczMwwZMDTeMRMGS7Br8rsmU45zk1rR22aWho1yTTwD2WGhpcPuxvqjWfy93gvmEoRS1nT8MvDvCktRkXwCtoCoRz4ZQwE5L3JzhtFzh3Vmo8Gnqj7jqxHKDmCfjPqd4DZrySucCcKYs1yr4Nk59T8DSzmZ7J2HdnRUPuD3yLt2tMVNDVESaNkviyVmCdb2R5N67XKfhDAxp3v3UzF1sbFHLYH7tgfKQw6rtiCT7g4ZHGafawwZDZb1dgJByDkCaSjdaiKCB7aQMKmjq9g6gAMcwD1pbGz9FvbhWL25n6J7m2DhLDCo5fnQR4FVqaNoB5trVc2wv2X96RcWzZp4QQPAum7p7CBk6kwRqr8sGdvh3ko55WvYTZG3oDjAd3VfScRTFMo3BTTrNgVJpwAdWZsnikL2ewKyLDjHxKPnB5EB3iGbKXrjkrgPMJ3M7spB3T3HqVafXmgfyKmwuPhvEUNn77mr4X8dsDMGnLB3vaeQRZP1RSAWFgZusDFKvYY8JwFcEBswUb5JgjSNvUSU2T5pFcc8mqTB53nAzCNoHvX5FBnQCXrWpN3E359PBiiuJmeBdQhjWh7yCh3NzdxNhKcsySgiNDUXkQSnGirmPMMiwKrXRrv6XXFyyxsdBErWGKzc2cDqYbzygiyBYeYk8SB9cJioJ6S4DRbZs7NxY2jsNK9JUPGDeUeVuDNdVwSuBucwDhjeCBtSzUCQy8ET6Lyu6SduG6cF9xb6JC693nsgx7VENQApY3Bc8bLkKDXz8JYuSXnQbSouXLgperYLQS3rjd3ZLUmKYyW3pr75R79ZEwftqtNQzRaPNAohCBJaCvA2BdG8SPaWbJZ6UdSxLzm3tJ1uYC2kaHhzub4jmnYAGuCVHLBwbppShmsVKxnfUyo2L8fDguzPc2kr6CBjcsxLgBaAUiE9tk2S6DDngBZ3f3UNdrv4yy5dp2p1nWHN9FRtVgybRvCYvdm8wspsRWH23muUN2FrGgFV5WTeigrgoQ8DRZpn7zpLYwMvwzbtZFWHcN5b9xFbNnzh27A3X5eGuvF1tbUXA21Rk2Ey9myfdSrDxpxFkFWNbdxpVLoSdDKLu5Frq9yrvxafjwP3DvBCZsvZ4gpDva7qSGaEEXnuDPycPWBgUpwYpDs1vPdBAef1U3EvznqZ6HTgG9C8znD47E9MURoaxwwxZq448cEdHtor9Rdz7iCHTrsJW9PxyVB9cnsze1tdYPzBMwvd1tts8r27nzWegNhUpDr8D2E8qBqkPLU4UZzfz1gL5roGdNyt5dQSeig1JsBU62imeYQ753eNCbiLW8uvcKyJKCBwoYVVB46UAoc3nfAGa1vfboZYBNp9AovLsqvn5JxiNxu2cLNNSA9'
+
+    async function mountWithWallet(): Promise<ReturnType<typeof useWallet>> {
+      let walletRef: ReturnType<typeof useWallet> | null = null
+      render(
+        <WalletProvider>
+          <TestConsumer onMount={(w) => { walletRef = w }} />
+        </WalletProvider>
+      )
+      await waitFor(() => { expect(walletRef).not.toBeNull() })
+      await act(async () => { await walletRef!.createWallet(TEST_MNEMONIC_12) })
+      return walletRef!
+    }
+
+    it('a free-text note does NOT reach the signer (no regression: "lunch" still sends)', async () => {
+      const wallet = await mountWithWallet()
+      vi.mocked(buildSendTransaction).mockClear()
+
+      // A human note like "lunch" would fail the signer's 64-byte-hex validator
+      // if routed on-chain. It must send successfully and carry NO on-chain memo.
+      let txHash: string | undefined
+      await act(async () => {
+        txHash = await wallet.send(GOLDEN_TESTNET_ADDRESS, 1_000_000n, { note: 'lunch' })
+      })
+
+      expect(txHash).toBe('0xhash')
+      expect(buildSendTransaction).toHaveBeenCalledTimes(1)
+      const arg = vi.mocked(buildSendTransaction).mock.calls[0][0]
+      expect(arg.bridgeDepositMemo).toBeUndefined()
+    })
+
+    it('the bridge deposit memo IS threaded on-chain (64-byte hex)', async () => {
+      const wallet = await mountWithWallet()
+      vi.mocked(buildSendTransaction).mockClear()
+
+      const orderMemo = 'deadbeef001122334455667788990011'.padEnd(128, '0')
+      await act(async () => {
+        await wallet.send(GOLDEN_TESTNET_ADDRESS, 1_000_000n, { bridgeDepositMemo: orderMemo })
+      })
+
+      expect(buildSendTransaction).toHaveBeenCalledTimes(1)
+      const arg = vi.mocked(buildSendTransaction).mock.calls[0][0]
+      expect(arg.bridgeDepositMemo).toBe(orderMemo)
     })
   })
 })

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -54,6 +54,30 @@ export interface CreatedClaimLink {
   id: string
 }
 
+/**
+ * Optional, TYPED extras for a {@link WalletContextValue.send}. The two fields
+ * are DELIBERATELY distinct channels for two incompatible meanings (#1037):
+ *
+ * - `note` is a human free-text note (e.g. the Send-modal "Add a note…" field or
+ *   a payment-request note). It is COSMETIC only and is NOT embedded on-chain —
+ *   preserving the pre-#1037 behavior where the note was dropped, so a plain
+ *   note like "lunch" never causes the send to fail.
+ * - `bridgeDepositMemo` is the bridge deposit order memo: a 64-byte hex value
+ *   (from the public order API, `BridgeOrder::generate_memo`) that IS embedded
+ *   on the recipient output's encrypted `e_memo` so the bridge watcher can match
+ *   the deposit to its mint order. Only the bridge ExportPanel sets this.
+ *
+ * Keeping them separate stops the free-text note from ever reaching the WASM
+ * signer's strict 64-byte-hex validator (which is correct for the bridge memo
+ * but would reject an ordinary note).
+ */
+export interface SendOptions {
+  /** Human free-text note. Cosmetic; never embedded on-chain (#1037). */
+  note?: string
+  /** Bridge deposit order memo (64-byte hex), embedded on-chain (#1037). */
+  bridgeDepositMemo?: string
+}
+
 interface WalletContextValue extends WalletState {
   // Connection
   connect: () => Promise<void>
@@ -120,7 +144,7 @@ interface WalletContextValue extends WalletState {
   getVaultKey: () => VaultKey | null
 
   // Transactions
-  send: (to: string, amount: bigint, memo?: string) => Promise<string>
+  send: (to: string, amount: bigint, options?: SendOptions) => Promise<string>
   /**
    * Estimate the fee for a send, returning both the fee and the node-computed
    * cluster fee factor display string (#635). Mirrors the {@link send} flow:
@@ -1003,7 +1027,12 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     setState(s => ({ ...s, isEncrypted: true, isLocked: false }))
   }, [state.isEncrypted, state.isLocked, rewrapUnderNewKey])
 
-  const send = useCallback(async (to: string, amount: bigint, memo?: string): Promise<string> => {
+  const send = useCallback(async (to: string, amount: bigint, options?: SendOptions): Promise<string> => {
+    // Two DISTINCT channels (#1037): a human free-text `note` is cosmetic and is
+    // intentionally NOT threaded into the signer (preserving pre-#1037 behavior,
+    // where a note like "lunch" is dropped and never fails the send). Only the
+    // bridge deposit order memo (64-byte hex) is embedded on-chain.
+    const bridgeDepositMemo = options?.bridgeDepositMemo
     const adapter = adapterRef.current
     if (!adapter.isConnected()) {
       throw new Error('Not connected to a node')
@@ -1086,10 +1115,11 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       senderKemPublicKey,
       amount,
       fee,
-      // Optional destination memo: for a BTH→wBTH bridge deposit this is the
-      // mint order memo, embedded on-chain so the bridge watcher can match the
-      // deposit to its order (#1037). Undefined for an ordinary send.
-      memo,
+      // Bridge deposit order memo: for a BTH→wBTH bridge deposit this is the
+      // mint order memo (64-byte hex), embedded on-chain so the bridge watcher
+      // can match the deposit to its order (#1037). Undefined for an ordinary
+      // send or a free-text note.
+      bridgeDepositMemo,
       rpc: {
         getChainHeight: () => adapter.getBlockHeight(),
         getOutputs: (start, end) => adapter.getRawOutputs(start, end),

--- a/web/packages/web-wallet/src/contexts/wallet.tsx
+++ b/web/packages/web-wallet/src/contexts/wallet.tsx
@@ -1003,7 +1003,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     setState(s => ({ ...s, isEncrypted: true, isLocked: false }))
   }, [state.isEncrypted, state.isLocked, rewrapUnderNewKey])
 
-  const send = useCallback(async (to: string, amount: bigint, _memo?: string): Promise<string> => {
+  const send = useCallback(async (to: string, amount: bigint, memo?: string): Promise<string> => {
     const adapter = adapterRef.current
     if (!adapter.isConnected()) {
       throw new Error('Not connected to a node')
@@ -1086,6 +1086,10 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       senderKemPublicKey,
       amount,
       fee,
+      // Optional destination memo: for a BTH→wBTH bridge deposit this is the
+      // mint order memo, embedded on-chain so the bridge watcher can match the
+      // deposit to its order (#1037). Undefined for an ordinary send.
+      memo,
       rpc: {
         getChainHeight: () => adapter.getBlockHeight(),
         getOutputs: (start, end) => adapter.getRawOutputs(start, end),

--- a/web/packages/web-wallet/src/pages/pay.tsx
+++ b/web/packages/web-wallet/src/pages/pay.tsx
@@ -26,7 +26,7 @@ import {
   UserCheck,
   UserPlus,
 } from 'lucide-react'
-import { useWallet } from '../contexts/wallet'
+import { useWallet, type SendOptions } from '../contexts/wallet'
 import { useNetwork } from '../contexts/network'
 import { PasswordFields, isPasswordValid } from '../components/PasswordSettingsModal'
 import { LocaleSwitcher } from '../components/LocaleSwitcher'
@@ -206,7 +206,7 @@ function PayConfirm({
   balance: import('@botho/core').Balance | null
   contacts: Contact[]
   addContact: (name: string, address: string, notes?: string) => Promise<Contact>
-  send: (to: string, amount: bigint, memo?: string) => Promise<string>
+  send: (to: string, amount: bigint, options?: SendOptions) => Promise<string>
   refreshBalance: () => Promise<void>
   refreshTransactions: () => Promise<void>
   explorerBase?: string
@@ -268,7 +268,11 @@ function PayConfirm({
     setError(null)
     setIsSending(true)
     try {
-      const hash = await send(request.to, amount, request.memo)
+      // A payment-request note is human free-text: send it on the cosmetic
+      // `note` channel so it is never routed into the signer's strict bridge
+      // memo validator (#1037). It is not embedded on-chain (unchanged from
+      // pre-#1037 behavior).
+      const hash = await send(request.to, amount, { note: request.memo })
       setTxHash(hash)
       await Promise.allSettled([refreshBalance(), refreshTransactions()])
     } catch (err) {

--- a/web/packages/web-wallet/src/pages/trade.tsx
+++ b/web/packages/web-wallet/src/pages/trade.tsx
@@ -60,9 +60,11 @@ export function TradePage() {
         spendableBalance: balance ? balance.available : null,
       },
       // Reuse the wallet's real wasm-signer send path for the BTH deposit: send
-      // to the reserve deposit address carrying the order memo. No new signing.
+      // to the reserve deposit address carrying the order memo on the DEDICATED
+      // on-chain bridge channel (#1037), so the watcher can match the deposit to
+      // its order. This is the only caller that sets `bridgeDepositMemo`.
       submitDeposit: ({ depositAddress, amount, memo }) =>
-        send(depositAddress, amount, memo),
+        send(depositAddress, amount, { bridgeDepositMemo: memo }),
       requestWallet: () => navigate('/wallet'),
     }),
     [client, hasWallet, isLocked, balance, send, navigate],

--- a/web/packages/web-wallet/src/pages/wallet.tsx
+++ b/web/packages/web-wallet/src/pages/wallet.tsx
@@ -354,7 +354,11 @@ function WalletDashboard() {
       // Drive the real client-side send path: derive keys -> scan owned
       // outputs -> build + CLSAG-sign in wasm -> submit to the node. Keys never
       // leave the browser. Returns the node-assigned tx hash.
-      const txHash = await send(data.recipient, data.amount, data.memo)
+      // The Send-modal "Memo — Add a note…" field is a human free-text note. It
+      // rides the cosmetic `note` channel (dropped, never embedded on-chain), so
+      // a note like "lunch" never fails the send (#1037). Only the bridge
+      // ExportPanel uses the on-chain `bridgeDepositMemo` channel.
+      const txHash = await send(data.recipient, data.amount, { note: data.memo })
       // Reflect the spend in the UI: refresh balance + history (best effort).
       await Promise.allSettled([refreshBalance(), refreshTransactions()])
       return { success: true, txHash }


### PR DESCRIPTION
## Summary

Second Tier-1 fast-follow of epic #1029 (with the merged #1036 backend and the #1041 public order API): make the wallet export flow functional end to end by embedding the bridge **order memo** on-chain in the WASM signer, so a wallet-built BTH deposit is matchable by the bridge deposit-scan watcher.

Before this change, `@botho/wasm-signer`'s `buildSendTransaction` attached no destination memo and `wallet.send(to, amount, memo?)` dropped its `memo` arg, so a deposit built by the wallet was invisible to `bridge/service/src/bth_scan.rs::scan_deposit_output`.

## Exact memo format (wallet embed ⇄ watcher read)

- The public order API (`bridge/service/src/public_api.rs`) returns `memo` as `hex::encode(order.memo)` — a **64-byte** value (128 hex chars). `BridgeOrder::generate_memo` puts the mint-order **UUID in the first 16 bytes**, the remaining 48 zero.
- The watcher reads it via `TxOutput::decrypt_memo(account)` → filters `!is_unused()` → `*memo_data()` (the 64 data bytes), then `BridgeOrder::order_id_from_memo` recovers the UUID from the first 16 bytes.
- So the wallet must produce an output whose `memo_data()` equals those 64 raw bytes, with a non-zero (Destination) memo type. Because the bytes are a raw UUID (not UTF-8), the existing `MemoPayload::destination(&str)` cannot carry them — this PR adds `MemoPayload::destination_bytes(&[u8;64])` (type `0x0200`, 64 raw bytes) for exactly this.

## Where it is embedded

`buildAndSign` (`web/packages/wasm-signer/src/core.rs`) puts the memo on the **recipient output (index 0)** via `TxOutput::new_hybrid_to_address(amount, recipient, 0, Some(memo), ..)`. The memo is AES-CTR-encrypted to the recipient's classical DH shared secret (view key) — the same `e_memo` any memo uses — so **only the bridge reserve (deposit account) can read it**. The change output carries no memo.

## Watcher-match proof

- **Rust (bridge)** `bth_scan::scan_matches_wallet_built_deposit_memo_to_order`: builds a real `BridgeOrder`, takes its `generate_memo()`, embeds it via `MemoPayload::destination_bytes` on a hybrid deposit output to the reserve (the identical construction path the WASM uses), scans with the reserve account+KEM secret, and asserts `BridgeOrder::order_id_from_memo(scanned.memo)` == `order.id`.
- **Rust (wasm-signer)** `core::bridge_order_memo_is_embedded_on_recipient_output`: full `build_and_sign` with a memo; the deposit account decrypts the recipient output's memo and recovers the 64 order bytes; change output has no memo; tx still verifies.
- **TS** `send-memo.test.ts`: `buildSendTransaction` threads the memo into the `buildAndSign` `SignRequest` (and leaves it undefined for a plain send), via the `setSigner` seam.

A live WASM-artifact ↔ live-watcher integration test needs the testnet bridge (per the issue's acceptance note); that remains the live-infra step. Everything above is real and green locally.

## Privacy

No weakening. The memo rides the existing per-output encrypted `e_memo` (one-time, recipient-only, ADR 0004 hybrid outputs). When no memo is provided the recipient output is byte-identical to today (no `e_memo`), so ordinary transfers are unchanged. Malformed (non-64-byte) memos are a hard error rather than a silently truncated/padded memo.

## Changes

- `transaction/clsag/src/lib.rs`: add `MemoPayload::destination_bytes`; unit test.
- `web/packages/wasm-signer/src/core.rs`: `SignRequest.memo` (optional hex), `parse_memo`, embed on recipient output; embed / no-regression / malformed tests.
- `web/packages/wasm-signer/src/index.ts`, `src/send.ts`: `memo` on `SignRequest` / `BuildSendParams`, threaded into `buildAndSign`.
- `web/packages/web-wallet/src/contexts/wallet.tsx`: un-ignore `send(to, amount, memo)`.
- `web/packages/wasm-signer/test/send-memo.test.ts`: new.
- `bridge/service/src/bth_scan.rs`: watcher-match proof test.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `buildSendTransaction` attaches the destination memo in the exact format `bth_scan.rs` decrypts | ✅ | `destination_bytes` → `new_hybrid_to_address` on recipient output; `bth_scan` test recovers the order UUID |
| Round-trip: wallet-built deposit matched + bound to the order by the watcher | ✅ | `scan_matches_wallet_built_deposit_memo_to_order` (real `BridgeOrder`, same construction path) |
| Normal (no-memo) sends unaffected | ✅ | `absent_or_empty_memo_produces_no_output_memo`; empty ⇒ no `e_memo` |
| `wallet.send()` threads the memo (un-ignore `_memo`) | ✅ | `wallet.tsx` diff + `send-memo.test.ts` |
| Reuse chain memo/payment-id format, no new format, no privacy weakening | ✅ | Reuses `MemoPayload` + `e_memo` encryption; change output memo-free |

## Test Plan

- `cargo test -p bth-transaction-clsag -p bth-wasm-signer -p bth-bridge-service` — green
- `cargo clippy` (touched crates, `--all-targets`) + `cargo fmt --check` — clean
- `pnpm --filter @botho/wasm-signer build:wasm` — builds
- `pnpm -r typecheck`, `pnpm build:web`, `pnpm test:run` (961 passed / 6 skipped) — green

Closes #1037
Part of epic #1029