### PR TITLE
chore(web): pre-declare pnpm allowBuilds so install stops mutating pnpm-workspace.yaml

### DIFF
--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,2 +1,17 @@
 packages:
   - 'packages/*'
+
+# Pre-declared dependency build-script approvals (issue #1045).
+#
+# pnpm >= 10 blocks dependency install/postinstall scripts by default and
+# auto-injects a placeholder block here on every `pnpm install` for any dep
+# it flagged, causing spurious diffs in every web PR. Declaring the decisions
+# up front means a fresh `pnpm install` leaves this file unchanged.
+#
+# - esbuild: installs/validates its platform-specific binary (vite dev/build)
+# - sharp: installs prebuilt native image-processing binaries
+# - workerd: downloads the Cloudflare Workers runtime binary (wrangler dev)
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## Summary
pnpm 11.13.1 blocks dependency build scripts by default and, on every `pnpm install`, auto-injects a placeholder `allowBuilds` block into `web/pnpm-workspace.yaml` (`esbuild: set this to true or false`, ...). Every web-touching builder (#1030, #1031, #1032, #1037) had to manually revert this spurious diff. This PR commits the curated approvals up front so a fresh install produces no diff.

Note: the issue was written anticipating an `onlyBuiltDependencies` block (the pnpm 10 format), but pnpm 11.13.1 actually injects the newer `allowBuilds` map — that is what is pre-declared here. The deps pnpm flagged in this tree were esbuild, sharp, and workerd (not bufferutil/utf-8-validate); all three genuinely need their install/postinstall scripts:
- **esbuild** — installs/validates its platform binary (vite dev/build)
- **sharp** — installs prebuilt native image-processing binaries
- **workerd** — downloads the Cloudflare Workers runtime binary (wrangler dev / baas-worker dry-run)

## Changes
- `web/pnpm-workspace.yaml`: add a commented `allowBuilds` block approving esbuild, sharp, and workerd build scripts.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fresh `pnpm install` in `web/` leaves `pnpm-workspace.yaml` unchanged | ✅ | Ran `pnpm install` twice with the block committed, then once more after `rm -rf node_modules packages/*/node_modules`; verified the file byte-identical each time via `shasum -c` |
| No auto-injected block / spurious revert for builders | ✅ | `git status` after fresh install shows no new modification beyond this PR's own change; `ERR_PNPM_IGNORED_BUILDS` warning gone (scripts now run) |
| Curated set (only deps that genuinely need builds) | ✅ | Only the three deps pnpm actually flagged are approved; each needs its script (native/binary install). Nothing else was flagged, so no `ignoredBuiltDependencies`/`false` entries were needed |

## Test Plan
- `pnpm install` (warm), `pnpm install` again, and `pnpm install` after wiping `node_modules` — all leave `web/pnpm-workspace.yaml` byte-identical and exit 0 with build scripts running
- `pnpm typecheck` in `web/` — all packages pass

Closes #1045