### PR TITLE
feat(bridge): global order-create cap + expired-order pruning, strict BTH address validation, release-intent audit parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,6 +2045,7 @@ dependencies = [
 name = "bth-bridge-core"
 version = "0.6.0"
 dependencies = [
+ "bs58 0.4.0",
  "chrono",
  "ed25519-dalek",
  "hex",

--- a/bridge/core/Cargo.toml
+++ b/bridge/core/Cargo.toml
@@ -14,6 +14,10 @@ std = []
 [dependencies]
 serde = { workspace = true, features = ["derive", "alloc"] }
 chrono = { workspace = true, features = ["serde", "std", "clock"] }
+# Structural BTH address validation (#1042): base58-decode the address body so
+# junk destinations are rejected at order-create. Tiny, already in the
+# workspace lockfile (the bridge service uses it for recipient decoding).
+bs58 = { workspace = true }
 uuid = { version = "1", features = ["v4", "serde"] }
 toml = { workspace = true }
 hex = { workspace = true }

--- a/bridge/core/src/chains/mod.rs
+++ b/bridge/core/src/chains/mod.rs
@@ -55,16 +55,14 @@ impl ChainAddress {
     }
 
     /// Validate the address format for the chain.
+    ///
+    /// This is a STRUCTURAL check (prefix, base58 alphabet, payload size)
+    /// meant to reject junk before it is persisted — e.g. at public
+    /// order-create (#1042). It does not verify key material; the service's
+    /// address codec does full validation when an address is actually used.
     pub fn validate(&self) -> Result<(), String> {
         match self.chain {
-            Chain::Bth => {
-                // BTH addresses are base58-encoded public addresses
-                if self.address.is_empty() {
-                    return Err("BTH address cannot be empty".to_string());
-                }
-                // Basic validation - actual validation would check base58 and structure
-                Ok(())
-            }
+            Chain::Bth => validate_bth_address(&self.address),
             Chain::Ethereum => {
                 // Ethereum addresses are 0x-prefixed 40-char hex strings
                 if !self.address.starts_with("0x") {
@@ -104,6 +102,104 @@ impl std::fmt::Display for ChainAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}:{}", self.chain, self.address)
     }
+}
+
+/// Hard cap on the accepted BTH address string length. A v2 hybrid address
+/// body (base58 of an ML-KEM/ML-DSA public-key payload, ~3.2 KB) encodes to
+/// roughly 4,400 characters; 8 KiB leaves ample headroom while still bounding
+/// abusive input.
+const MAX_BTH_ADDRESS_LEN: usize = 8 * 1024;
+
+/// Retired BTH address URI prefixes (ADR 0008): rejected outright so a stale
+/// wallet gets a clear error instead of a never-matching order.
+const RETIRED_BTH_PREFIXES: &[&str] = &[
+    "botho://1/",
+    "tbotho://1/",
+    "botho://1q/",
+    "tbotho://1q/",
+    "botho-pq://",
+];
+
+/// Structural validation for a BTH address (#1042).
+///
+/// Accepts the two shapes the bridge's recipient decoder
+/// (`decode_recipient_address` in the service) accepts:
+///
+///   * a v2 hybrid address URI — `botho://2/<base58>` (mainnet) or
+///     `tbotho://2/<base58>` (testnet) — whose base58 body must decode to a
+///     plausibly-sized key payload, and
+///   * a legacy bare base58 body that decodes to exactly 64 bytes (`view32 ||
+///     spend32`, the classical layout).
+///
+/// Everything else — empty strings, non-base58 junk, retired v1/quantum
+/// prefixes, unrecognized URI schemes, oversized input — is rejected, so an
+/// invalid BTH destination fails at order-create instead of surfacing later
+/// as an order that can never match.
+fn validate_bth_address(address: &str) -> Result<(), String> {
+    if address.is_empty() {
+        return Err("BTH address cannot be empty".to_string());
+    }
+    if address.len() > MAX_BTH_ADDRESS_LEN {
+        return Err(format!(
+            "BTH address too long ({} chars, max {})",
+            address.len(),
+            MAX_BTH_ADDRESS_LEN
+        ));
+    }
+    if !address.is_ascii()
+        || address
+            .bytes()
+            .any(|b| b.is_ascii_whitespace() || b.is_ascii_control())
+    {
+        return Err("BTH address contains illegal characters".to_string());
+    }
+    for retired in RETIRED_BTH_PREFIXES {
+        if address.starts_with(retired) {
+            return Err(format!(
+                "BTH address uses the retired {} prefix (ADR 0008); \
+                 ask the recipient for a botho://2/ address",
+                retired
+            ));
+        }
+    }
+
+    let (body, is_v2_uri) = if let Some(body) = address.strip_prefix("botho://2/") {
+        (body, true)
+    } else if let Some(body) = address.strip_prefix("tbotho://2/") {
+        (body, true)
+    } else if address.contains("://") {
+        return Err(
+            "unrecognized BTH address prefix (expected botho://2/ or tbotho://2/)".to_string(),
+        );
+    } else {
+        (address, false)
+    };
+
+    if body.is_empty() {
+        return Err("BTH address has an empty base58 body".to_string());
+    }
+    let payload = bs58::decode(body)
+        .into_vec()
+        .map_err(|e| format!("BTH address is not valid base58: {}", e))?;
+
+    if is_v2_uri {
+        // A v2 payload carries hybrid public keys; require at least the
+        // classical 64 bytes so trivially short junk cannot pass. Exact key
+        // validation is the address codec's job, not this structural check.
+        if payload.len() < 64 {
+            return Err(format!(
+                "BTH v2 address payload too short ({} bytes)",
+                payload.len()
+            ));
+        }
+    } else if payload.len() != 64 {
+        // Bare bodies are the legacy classical layout: view32 || spend32.
+        return Err(format!(
+            "bare BTH address must decode to 64 bytes (view||spend), got {}",
+            payload.len()
+        ));
+    }
+    Ok(())
 }
 
 /// Ethereum-specific types
@@ -161,6 +257,75 @@ mod tests {
         assert_eq!("eth".parse::<Chain>().unwrap(), Chain::Ethereum);
         assert_eq!("solana".parse::<Chain>().unwrap(), Chain::Solana);
         assert_eq!("sol".parse::<Chain>().unwrap(), Chain::Solana);
+    }
+
+    #[test]
+    fn test_bth_address_validation_accepts_valid_shapes() {
+        // Legacy bare base58 of exactly 64 bytes (view32 || spend32).
+        let bare = bs58::encode([7u8; 64]).into_string();
+        assert!(ChainAddress::new(Chain::Bth, bare).validate().is_ok());
+
+        // v2 URI forms with a plausible hybrid-key payload.
+        let body = bs58::encode(vec![9u8; 3200]).into_string();
+        for prefix in ["botho://2/", "tbotho://2/"] {
+            let addr = format!("{}{}", prefix, body);
+            assert!(
+                ChainAddress::new(Chain::Bth, addr).validate().is_ok(),
+                "{} address must validate",
+                prefix
+            );
+        }
+    }
+
+    #[test]
+    fn test_bth_address_validation_rejects_junk() {
+        // Empty.
+        assert!(ChainAddress::new(Chain::Bth, "")
+            .validate()
+            .unwrap_err()
+            .contains("empty"));
+
+        // Underscores are not base58 (the old validator accepted this).
+        assert!(ChainAddress::new(Chain::Bth, "bth_user_receive_addr")
+            .validate()
+            .is_err());
+
+        // Base58 but the wrong payload size for a bare body.
+        let short = bs58::encode([1u8; 10]).into_string();
+        assert!(ChainAddress::new(Chain::Bth, short)
+            .validate()
+            .unwrap_err()
+            .contains("64 bytes"));
+
+        // Retired prefixes (ADR 0008).
+        let v1 = format!("botho://1/{}", bs58::encode([2u8; 64]).into_string());
+        assert!(ChainAddress::new(Chain::Bth, v1)
+            .validate()
+            .unwrap_err()
+            .contains("retired"));
+
+        // Unknown scheme.
+        assert!(ChainAddress::new(Chain::Bth, "http://evil.example/x")
+            .validate()
+            .unwrap_err()
+            .contains("unrecognized"));
+
+        // v2 URI with a too-short payload.
+        let stub = format!("botho://2/{}", bs58::encode([3u8; 8]).into_string());
+        assert!(ChainAddress::new(Chain::Bth, stub)
+            .validate()
+            .unwrap_err()
+            .contains("too short"));
+
+        // Whitespace / control characters.
+        assert!(ChainAddress::new(Chain::Bth, "abc def").validate().is_err());
+
+        // Oversized input.
+        let huge = "1".repeat(MAX_BTH_ADDRESS_LEN + 1);
+        assert!(ChainAddress::new(Chain::Bth, huge)
+            .validate()
+            .unwrap_err()
+            .contains("too long"));
     }
 
     #[test]

--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -90,6 +90,16 @@ pub struct PublicApiSettings {
     /// against oversized-payload abuse). Defaults to 8 KiB.
     #[serde(default = "default_public_max_body_bytes")]
     pub max_body_bytes: usize,
+
+    /// GLOBAL ceiling on outstanding public order-create records (#1042):
+    /// when the number of mint orders still awaiting their deposit — or,
+    /// independently, of unexpired release-tracking intents — reaches this
+    /// value, further creates are refused with 503 until the backlog drains
+    /// (deposits arrive, or the engine expires and prunes the residue). The
+    /// per-IP rate limits bound per-client rate; this is the backstop against
+    /// DISTRIBUTED spam growing the DB without bound. 0 disables the ceiling.
+    #[serde(default = "default_public_max_open_orders")]
+    pub max_open_orders: u64,
 }
 
 fn default_create_rate_limit() -> u32 {
@@ -104,6 +114,10 @@ fn default_public_max_body_bytes() -> usize {
     8 * 1024
 }
 
+fn default_public_max_open_orders() -> u64 {
+    10_000
+}
+
 impl Default for PublicApiSettings {
     fn default() -> Self {
         Self {
@@ -113,6 +127,7 @@ impl Default for PublicApiSettings {
             rate_limit_per_min: default_public_rate_limit(),
             min_order_amount: 0,
             max_body_bytes: default_public_max_body_bytes(),
+            max_open_orders: default_public_max_open_orders(),
         }
     }
 }
@@ -788,12 +803,14 @@ mod tests {
         assert_eq!(config.public_api.rate_limit_per_min, 120);
         assert_eq!(config.public_api.min_order_amount, 0);
         assert_eq!(config.public_api.max_body_bytes, 8 * 1024);
+        assert_eq!(config.public_api.max_open_orders, 10_000);
 
         // A pre-existing config without a [public_api] section still parses.
         let legacy: PublicApiSettings = toml::from_str("").unwrap();
         assert!(legacy.listen.is_empty());
         assert_eq!(legacy.create_rate_limit_per_min, 10);
         assert_eq!(legacy.max_body_bytes, 8 * 1024);
+        assert_eq!(legacy.max_open_orders, 10_000);
 
         // The knobs round-trip from TOML.
         let configured: PublicApiSettings = toml::from_str(
@@ -804,6 +821,7 @@ mod tests {
             rate_limit_per_min = 30
             min_order_amount = 1000
             max_body_bytes = 2048
+            max_open_orders = 5
             "#,
         )
         .unwrap();
@@ -813,6 +831,7 @@ mod tests {
         assert_eq!(configured.rate_limit_per_min, 30);
         assert_eq!(configured.min_order_amount, 1000);
         assert_eq!(configured.max_body_bytes, 2048);
+        assert_eq!(configured.max_open_orders, 5);
     }
 
     #[test]

--- a/bridge/core/src/happy_path_tests.rs
+++ b/bridge/core/src/happy_path_tests.rs
@@ -312,8 +312,13 @@ fn test_solana_address_validation_bounds() {
 
 #[test]
 fn test_bth_address_validation() {
-    let valid = ChainAddress::new(Chain::Bth, "bth_some_base58_address");
+    // A bare base58 body must decode to exactly 64 bytes (view || spend);
+    // arbitrary non-base58 strings are rejected (#1042 tightened this).
+    let valid = ChainAddress::new(Chain::Bth, bs58::encode([5u8; 64]).into_string());
     assert!(valid.validate().is_ok());
+
+    let junk = ChainAddress::new(Chain::Bth, "bth_some_base58_address");
+    assert!(junk.validate().is_err());
 
     let empty = ChainAddress::new(Chain::Bth, "");
     assert!(empty.validate().unwrap_err().contains("empty"));

--- a/bridge/service/src/db.rs
+++ b/bridge/service/src/db.rs
@@ -644,6 +644,82 @@ impl Database {
         Ok(result)
     }
 
+    /// Number of mint orders still awaiting their BTH deposit.
+    ///
+    /// Backs the public API's GLOBAL order-create ceiling (#1042): the
+    /// per-IP rate limiter bounds per-client rate, but only this bounds the
+    /// total outstanding created orders under distributed spam.
+    pub fn count_awaiting_deposit_mint_orders(&self) -> Result<u64, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let count: i64 = conn
+            .query_row(
+                r#"
+                SELECT COUNT(*) FROM bridge_orders
+                WHERE order_type = 'mint' AND status = 'awaiting_deposit'
+                "#,
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Count failed: {}", e))?;
+        Ok(count.max(0) as u64)
+    }
+
+    /// Number of release-tracking intents that have not yet expired.
+    ///
+    /// Backs the public API's GLOBAL order-create ceiling (#1042) for the
+    /// release-intent surface, mirroring
+    /// [`Database::count_awaiting_deposit_mint_orders`].
+    pub fn count_active_release_intents(&self, now: i64) -> Result<u64, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM release_intents WHERE expires_at > ?1",
+                params![now],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Count failed: {}", e))?;
+        Ok(count.max(0) as u64)
+    }
+
+    /// Delete EXPIRED mint orders that never saw a deposit, once they are
+    /// older than `retain_secs` (#1042).
+    ///
+    /// Only rows where `status = 'expired'`, `order_type = 'mint'` and
+    /// `source_tx IS NULL` qualify — i.e. abandoned order-create residue
+    /// where no funds ever moved. Orders that saw a deposit (or any burn /
+    /// settled order) are NEVER pruned; they are the bridge's accounting
+    /// record. Audit-log rows are kept (append-only history). Returns the
+    /// number of pruned rows.
+    pub fn prune_expired_mint_orders(&self, retain_secs: i64) -> Result<usize, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let cutoff = Utc::now().timestamp() - retain_secs;
+        conn.execute(
+            r#"
+            DELETE FROM bridge_orders
+            WHERE status = 'expired'
+              AND order_type = 'mint'
+              AND source_tx IS NULL
+              AND updated_at < ?1
+            "#,
+            params![cutoff],
+        )
+        .map_err(|e| format!("Prune failed: {}", e))
+    }
+
+    /// Delete release-tracking intents that expired more than `retain_secs`
+    /// ago (#1042). Intents are non-custodial UX correlation records (never
+    /// read by the release pipeline), so pruning them can never affect a
+    /// release. Returns the number of pruned rows.
+    pub fn prune_expired_release_intents(&self, retain_secs: i64) -> Result<usize, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let cutoff = Utc::now().timestamp() - retain_secs;
+        conn.execute(
+            "DELETE FROM release_intents WHERE expires_at < ?1",
+            params![cutoff],
+        )
+        .map_err(|e| format!("Prune failed: {}", e))
+    }
+
     /// Correlate a release intent to the watcher-created burn order (#1036).
     ///
     /// Burn orders are created by the counterparty-chain watchers keyed by the
@@ -3327,5 +3403,94 @@ mod tests {
 
         let latest = db.latest_reserve_snapshot().unwrap().unwrap();
         assert_eq!(latest, second);
+    }
+
+    #[test]
+    fn test_count_and_prune_expired_mint_orders() {
+        // #1042: expired, deposit-less mint orders are countable (global
+        // create ceiling) and prunable (bounded DB growth); anything that
+        // saw funds move is never pruned.
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bth_reserve_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        db.insert_order(&order).unwrap();
+        assert_eq!(db.count_awaiting_deposit_mint_orders().unwrap(), 1);
+
+        // A burn order does not count toward the mint-create ceiling.
+        let burn = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            500,
+            0,
+            "0xsource".to_string(),
+            "bth_dest".to_string(),
+            "0xburntx".to_string(),
+        );
+        db.insert_order(&burn).unwrap();
+        assert_eq!(db.count_awaiting_deposit_mint_orders().unwrap(), 1);
+
+        // Expire the mint order; the count drops, the row still exists.
+        db.update_order_status(&order.id, &OrderStatus::Expired, None)
+            .unwrap();
+        assert_eq!(db.count_awaiting_deposit_mint_orders().unwrap(), 0);
+        assert!(db.get_order(&order.id).unwrap().is_some());
+
+        // Within the retention window nothing is pruned (updated_at is
+        // "now"; a large retain_secs puts the cutoff in the past).
+        assert_eq!(db.prune_expired_mint_orders(3600).unwrap(), 0);
+        assert!(db.get_order(&order.id).unwrap().is_some());
+
+        // Past the retention window (negative retention pushes the cutoff
+        // into the future) the expired residue is deleted...
+        assert_eq!(db.prune_expired_mint_orders(-1).unwrap(), 1);
+        assert!(db.get_order(&order.id).unwrap().is_none());
+        // ...but the burn order (funds moved) is untouched.
+        assert!(db.get_order(&burn.id).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_count_and_prune_expired_release_intents() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let now = Utc::now().timestamp();
+        let live = ReleaseIntent {
+            id: Uuid::new_v4(),
+            source_chain: Chain::Ethereum,
+            bth_address: "bth_addr_live".to_string(),
+            amount: 100,
+            fee: 1,
+            token_address: "0xtoken".to_string(),
+            created_at: now,
+            expires_at: now + 3_600,
+        };
+        let stale = ReleaseIntent {
+            id: Uuid::new_v4(),
+            source_chain: Chain::Ethereum,
+            bth_address: "bth_addr_stale".to_string(),
+            amount: 200,
+            fee: 1,
+            token_address: "0xtoken".to_string(),
+            created_at: now - 10_000,
+            expires_at: now - 5_000,
+        };
+        db.insert_release_intent(&live).unwrap();
+        db.insert_release_intent(&stale).unwrap();
+
+        // Only the unexpired intent counts toward the global ceiling.
+        assert_eq!(db.count_active_release_intents(now).unwrap(), 1);
+
+        // Retention keeps recently-expired intents pollable...
+        assert_eq!(db.prune_expired_release_intents(10_000).unwrap(), 0);
+        // ...and prunes them once the window elapses; the live intent stays.
+        assert_eq!(db.prune_expired_release_intents(1_000).unwrap(), 1);
+        assert!(db.get_release_intent(&stale.id).unwrap().is_none());
+        assert!(db.get_release_intent(&live.id).unwrap().is_some());
     }
 }

--- a/bridge/service/src/engine.rs
+++ b/bridge/service/src/engine.rs
@@ -28,6 +28,12 @@ pub type ShutdownSignal = broadcast::Receiver<()>;
 /// Delay between re-broadcast attempts of an already-signed mint tx.
 const BROADCAST_RETRY_DELAY: Duration = Duration::from_secs(2);
 
+/// How long expired, deposit-less mint orders and expired release intents
+/// are retained before the processing loop deletes them (#1042). Long enough
+/// for any wallet to observe the terminal `expired` status; short enough
+/// that abandoned public order-create residue cannot accumulate forever.
+const EXPIRED_ORDER_RETENTION_SECS: i64 = 7 * 24 * 60 * 60;
+
 /// The main bridge engine that coordinates all components.
 pub struct BridgeEngine {
     config: BridgeConfig,
@@ -584,6 +590,10 @@ impl OrderProcessor {
 
         // Check for expired orders
         self.expire_stale_orders()?;
+
+        // Prune long-expired order-create residue (#1042) so distributed
+        // spam against the public API cannot grow the DB without bound.
+        self.prune_expired_public_orders()?;
 
         // Alert on orders stuck past the age threshold (funds have moved;
         // they must never auto-expire — an operator has to act).
@@ -1303,6 +1313,32 @@ impl OrderProcessor {
             }
         }
 
+        Ok(())
+    }
+
+    /// Prune long-expired public order-create residue (#1042).
+    ///
+    /// The public order API (#1036) lets anonymous clients create
+    /// `AwaitingDeposit` mint orders and release-tracking intents; per-IP
+    /// rate limits and the global create ceiling bound the RATE and the
+    /// OUTSTANDING count, but abandoned rows would still accumulate forever
+    /// without this. Expired, deposit-less mint orders and expired intents
+    /// are kept for [`EXPIRED_ORDER_RETENTION_SECS`] so a wallet can still
+    /// poll the terminal `expired` status, then deleted. Rows where funds
+    /// ever moved are never pruned (see the `Database` prune docs).
+    fn prune_expired_public_orders(&self) -> Result<(), String> {
+        let orders = self
+            .db
+            .prune_expired_mint_orders(EXPIRED_ORDER_RETENTION_SECS)?;
+        let intents = self
+            .db
+            .prune_expired_release_intents(EXPIRED_ORDER_RETENTION_SECS)?;
+        if orders > 0 || intents > 0 {
+            info!(
+                "Pruned {} expired mint order(s) and {} expired release intent(s)",
+                orders, intents
+            );
+        }
         Ok(())
     }
 }

--- a/bridge/service/src/public_api.rs
+++ b/bridge/service/src/public_api.rs
@@ -37,7 +37,28 @@
 //!     un-listed origin is refused the `Access-Control-Allow-Origin` header.
 //!   * Per-IP rate limiting (a tight cap on order-create specifically) plus a
 //!     request body-size cap blunt spam/flooding.
+//!   * A GLOBAL order-create ceiling (`public_api.max_open_orders`, #1042)
+//!     backstops the per-IP limits against distributed spam, and the engine
+//!     loop prunes expired/abandoned create residue so the DB stays bounded.
 //!   * The kill switch and ops detail are simply not routed here.
+//!
+//! ─── Information-exposure scope (#1042) ────────────────────────────────────
+//! These endpoints are UNAUTHENTICATED, so everything they return must be
+//! either (a) data the caller supplied, or (b) derivable from PUBLIC on-chain
+//! state. Today that holds:
+//!   * The mint GET returns only mint-order fields the creator supplied plus
+//!     the reserve deposit address (published) and tx hashes (on-chain).
+//!   * The release-intent GET echoes the caller-registered intent and
+//!     correlates it to a watcher-created burn order by `(bthAddress, amount)`.
+//!     Anyone can register an intent for an arbitrary pair and poll it to learn
+//!     whether a matching burn exists and its status/tx hashes — ALL of which
+//!     is already public on the counterparty chain and the BTH chain, so no
+//!     confidentiality is lost.
+//!
+//! Any future field added to these responses must preserve that invariant:
+//! never surface operator/ops state (pause reason, backlog, reserve detail),
+//! internal error strings, or anything not reconstructible from public
+//! chain data. Ops detail belongs on the loopback `api.rs` surface only.
 //!
 //! CORS + IP rate limiting assume the bind is either direct or behind a
 //! trusted reverse proxy that preserves the peer address; behind an untrusted
@@ -99,6 +120,9 @@ pub struct PublicApiConfig {
     rate_limit_per_min: u32,
     /// Max request body size, bytes.
     max_body_bytes: usize,
+    /// Global ceiling on outstanding order-create records (0 = unlimited).
+    /// See [`bth_bridge_core::PublicApiSettings::max_open_orders`] (#1042).
+    max_open_orders: u64,
 }
 
 impl PublicApiConfig {
@@ -117,6 +141,7 @@ impl PublicApiConfig {
             create_rate_limit_per_min: config.public_api.create_rate_limit_per_min,
             rate_limit_per_min: config.public_api.rate_limit_per_min,
             max_body_bytes: config.public_api.max_body_bytes.max(1),
+            max_open_orders: config.public_api.max_open_orders,
         }
     }
 
@@ -464,6 +489,30 @@ async fn create_mint_order(
         );
     }
 
+    // GLOBAL create ceiling (#1042): the per-IP limiter bounds per-client
+    // rate, but a distributed source could otherwise grow the DB without
+    // bound. The engine loop expires and prunes abandoned orders, so a full
+    // backlog drains on its own.
+    if state.cfg.max_open_orders > 0 {
+        match state.db.count_awaiting_deposit_mint_orders() {
+            Ok(open) if open >= state.cfg.max_open_orders => {
+                warn!(
+                    "public api: mint order-create refused: {} open orders >= global cap {}",
+                    open, state.cfg.max_open_orders
+                );
+                return err(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "order backlog is full; retry later",
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                warn!("public api: open-order count failed: {}", e);
+                return err(StatusCode::INTERNAL_SERVER_ERROR, "failed to create order");
+            }
+        }
+    }
+
     let mut order = BridgeOrder::new_mint(
         chain,
         amount,
@@ -596,6 +645,33 @@ async fn create_release_order(
     }
 
     let now = Utc::now().timestamp();
+
+    // GLOBAL create ceiling (#1042), mirroring the mint path: unexpired
+    // intents are counted; expired ones stop counting immediately and are
+    // pruned by the engine loop after a retention window.
+    if state.cfg.max_open_orders > 0 {
+        match state.db.count_active_release_intents(now) {
+            Ok(open) if open >= state.cfg.max_open_orders => {
+                warn!(
+                    "public api: release-intent create refused: {} active intents >= global cap {}",
+                    open, state.cfg.max_open_orders
+                );
+                return err(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "release-order backlog is full; retry later",
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                warn!("public api: active-intent count failed: {}", e);
+                return err(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "failed to register release order",
+                );
+            }
+        }
+    }
+
     let expires_at = now.saturating_add(state.cfg.order_expiry_minutes.max(0).saturating_mul(60));
     let intent = ReleaseIntent {
         id: Uuid::new_v4(),
@@ -615,6 +691,19 @@ async fn create_release_order(
             "failed to register release order",
         );
     }
+    // Audit-log symmetry with mint create (#1042). Intents are not
+    // `bridge_orders` rows, so the id travels in the details instead of the
+    // (FK-referencing) order_id column.
+    if let Err(e) = state.db.log_audit(
+        None,
+        "release_intent_created",
+        &format!(
+            "public API release intent {}: source={} amount={}",
+            intent.id, chain, amount
+        ),
+    ) {
+        warn!("public api: audit log failed: {}", e);
+    }
 
     (
         StatusCode::OK,
@@ -624,6 +713,19 @@ async fn create_release_order(
 }
 
 /// `GET /api/bridge/release-orders/{id}`: release order status.
+///
+/// Information-exposure scope (#1042): this endpoint returns ONLY
+///   * the caller-registered intent fields echoed back (chain, bthAddress,
+///     amount, fee, token address, expiry), and
+///   * when a burn order correlates by `(bthAddress, amount)`: its status tag,
+///     burn tx hash (`sourceTx`), release tx hash (`destTx`), and failure
+///     reason — all reconstructible from public on-chain data.
+///
+/// Because intents are unauthenticated, anyone can register an arbitrary
+/// `(bthAddress, amount)` pair and poll this endpoint; that reveals nothing
+/// non-public (burns and releases are public on both chains). Keep it that
+/// way: never add operator/ops state, internal errors, or per-user data
+/// here — see the module-level "Information-exposure scope" section.
 async fn get_release_order(
     State(state): State<PublicApiState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
@@ -803,7 +905,15 @@ mod tests {
             create_rate_limit_per_min: 100,
             rate_limit_per_min: 1_000,
             max_body_bytes: 8 * 1024,
+            max_open_orders: 10_000,
         }
+    }
+
+    /// A structurally valid bare BTH address (base58 of 64 bytes, the
+    /// legacy `view32 || spend32` layout) — #1042 tightened
+    /// `ChainAddress::validate`, so tests must use decodable addresses.
+    fn test_bth_address() -> String {
+        bs58::encode([7u8; 64]).into_string()
     }
 
     fn test_state() -> (PublicApiState, Database) {
@@ -1095,9 +1205,19 @@ mod tests {
         let (addr, shutdown_tx, server) = spawn_public_server(state).await;
 
         // Register a release intent.
-        let body = r#"{"sourceChain":"ethereum","bthAddress":"bth_user_receive_addr","amount":"500000000000"}"#;
-        let (status, resp) =
-            http_request(addr, "POST", "/api/bridge/release-orders", Some(body), None).await;
+        let bth_addr = test_bth_address();
+        let body = format!(
+            r#"{{"sourceChain":"ethereum","bthAddress":"{}","amount":"500000000000"}}"#,
+            bth_addr
+        );
+        let (status, resp) = http_request(
+            addr,
+            "POST",
+            "/api/bridge/release-orders",
+            Some(body.as_str()),
+            None,
+        )
+        .await;
         assert_eq!(status, 200, "{}", resp);
         let json: serde_json::Value = serde_json::from_str(&resp).unwrap();
         assert_eq!(json["status"], "awaiting_burn");
@@ -1128,7 +1248,7 @@ mod tests {
             500_000_000_000,
             0,
             "0xsource".to_string(),
-            "bth_user_receive_addr".to_string(),
+            bth_addr,
             "0xburntx".to_string(),
         );
         burn.set_status(OrderStatus::BurnConfirmed);
@@ -1181,6 +1301,124 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&resp).unwrap();
         assert_eq!(json["status"], "failed");
         assert_eq!(json["failureReason"], "deposit never arrived");
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_global_create_cap_on_mint_orders() {
+        // #1042: the GLOBAL ceiling refuses order-create once the number of
+        // awaiting-deposit mint orders reaches the cap, independent of
+        // client IP (the per-IP limiter is generous here).
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let mut cfg = test_config();
+        cfg.max_open_orders = 2;
+        let state = PublicApiState::new(db, cfg);
+        let (addr, shutdown_tx, server) = spawn_public_server(state).await;
+
+        let body = r#"{"destChain":"ethereum","destAddress":"0x1234567890abcdef1234567890abcdef12345678","amount":"1000000000000"}"#;
+        for _ in 0..2 {
+            let (status, _) =
+                http_request(addr, "POST", "/api/bridge/orders", Some(body), None).await;
+            assert_eq!(status, 200);
+        }
+        let (status, resp) =
+            http_request(addr, "POST", "/api/bridge/orders", Some(body), None).await;
+        assert_eq!(status, 503, "create past the global cap must be refused");
+        assert!(resp.contains("backlog"), "{}", resp);
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_global_create_cap_on_release_intents() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let mut cfg = test_config();
+        cfg.max_open_orders = 1;
+        let state = PublicApiState::new(db, cfg);
+        let (addr, shutdown_tx, server) = spawn_public_server(state).await;
+
+        let body = format!(
+            r#"{{"sourceChain":"ethereum","bthAddress":"{}","amount":"500000000000"}}"#,
+            test_bth_address()
+        );
+        let (status, _) = http_request(
+            addr,
+            "POST",
+            "/api/bridge/release-orders",
+            Some(body.as_str()),
+            None,
+        )
+        .await;
+        assert_eq!(status, 200);
+
+        let (status, resp) = http_request(
+            addr,
+            "POST",
+            "/api/bridge/release-orders",
+            Some(body.as_str()),
+            None,
+        )
+        .await;
+        assert_eq!(status, 503, "intent create past the global cap refused");
+        assert!(resp.contains("backlog"), "{}", resp);
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_create_release_order_rejects_invalid_bth_address() {
+        // #1042: the strengthened BTH validator rejects junk destinations at
+        // order-create (the old validator only rejected empty strings).
+        let (state, _db) = test_state();
+        let (addr, shutdown_tx, server) = spawn_public_server(state).await;
+
+        for bad in ["bth_user_receive_addr", "not base58!", "botho://1/abc"] {
+            let body = format!(
+                r#"{{"sourceChain":"ethereum","bthAddress":"{}","amount":"500000000000"}}"#,
+                bad
+            );
+            let (status, _) = http_request(
+                addr,
+                "POST",
+                "/api/bridge/release-orders",
+                Some(body.as_str()),
+                None,
+            )
+            .await;
+            assert_eq!(status, 400, "junk BTH address {:?} must be rejected", bad);
+        }
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_release_intent_create_writes_audit_row() {
+        // #1042 audit symmetry: release-intent create logs an audit line
+        // like mint create does.
+        let (state, db) = test_state();
+        let (addr, shutdown_tx, server) = spawn_public_server(state).await;
+
+        let body = format!(
+            r#"{{"sourceChain":"ethereum","bthAddress":"{}","amount":"500000000000"}}"#,
+            test_bth_address()
+        );
+        let (status, _) = http_request(
+            addr,
+            "POST",
+            "/api/bridge/release-orders",
+            Some(body.as_str()),
+            None,
+        )
+        .await;
+        assert_eq!(status, 200);
+        assert_eq!(db.count_audit_action("release_intent_created").unwrap(), 1);
 
         let _ = shutdown_tx.send(());
         server.await.unwrap();


### PR DESCRIPTION
## Summary

Implements all four hardening follow-ups the #1041 security judge flagged on the public order API (`bridge/service/src/public_api.rs`), so the surface is safe to enable on a live node. Part of epic #1029.

## Changes

**1. Global order-create cap + expired-order pruning (Low)**
- New `public_api.max_open_orders` setting (default 10,000; 0 = unlimited): `POST /api/bridge/orders` is refused with 503 once the count of mint orders still awaiting their deposit reaches the cap; `POST /api/bridge/release-orders` independently caps on unexpired release intents. This backstops the per-IP limiter against distributed spam (which only bounds per-client rate).
- New DB prunes wired into the engine's 10s processing loop (right after `expire_stale_orders`): `prune_expired_mint_orders` deletes expired mint orders where no deposit ever arrived (`status='expired' AND order_type='mint' AND source_tx IS NULL`), and `prune_expired_release_intents` deletes long-expired intents — both after a 7-day retention window (`EXPIRED_ORDER_RETENTION_SECS`) so wallets can still poll the terminal `expired` status. Orders where funds ever moved are NEVER pruned.

**2. Strict BTH address validation in shared core (Low)**
- `ChainAddress::validate(Chain::Bth)` (in `bridge/core/src/chains/mod.rs`) previously only rejected empty strings. It now does a real structural check mirroring the service's `decode_recipient_address`: accepts `botho://2/<base58>` / `tbotho://2/<base58>` URIs whose body decodes to a plausible key payload (>= 64 bytes), or a legacy bare base58 body decoding to exactly 64 bytes (view||spend). Rejects non-base58 junk, retired v1/quantum prefixes (ADR 0008), unknown URI schemes, whitespace/control chars, and oversized input (> 8 KiB). Invalid BTH destinations now fail at order-create with a 400.
- `bs58` (already in the workspace lockfile) added to `bth-bridge-core` for the decode.

**3. Release-intent GET information-exposure scope documented (Info)**
- New "Information-exposure scope" section in the module header + a scope contract on the `get_release_order` handler doc: the endpoints must only ever return caller-supplied data or data derivable from public on-chain state, and must never grow to surface operator/ops state, internal errors, or per-user data. Docs only — no behavior change, per the issue.

**4. Audit-log symmetry (Nit)**
- `create_release_order` now writes a `release_intent_created` audit row, mirroring mint create's `order_created`. Intents are not `bridge_orders` rows, so the intent UUID travels in the details field rather than the FK-referencing `order_id` column.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Global create ceiling + expired-order DB pruning | ✅ | `test_global_create_cap_on_mint_orders`, `test_global_create_cap_on_release_intents`, `test_count_and_prune_expired_mint_orders`, `test_count_and_prune_expired_release_intents`; prunes wired into the engine loop |
| Strengthened `ChainAddress::validate` for BTH rejects invalid destinations at order-create | ✅ | `test_bth_address_validation_accepts_valid_shapes`, `test_bth_address_validation_rejects_junk` (core); `test_create_release_order_rejects_invalid_bth_address` (API-level 400) |
| Release-intent GET scope documented | ✅ | Module-header "Information-exposure scope (#1042)" section + `get_release_order` doc contract |
| Audit-log symmetry on release-intent create | ✅ | `test_release_intent_create_writes_audit_row` |

## Test Plan

- `cargo build -p bth-bridge-core -p bth-bridge-service` — green.
- `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets -- -D warnings` — green.
- `cargo fmt --all --check` — green.
- `cargo test -p bth-bridge-core -p bth-bridge-service` — green (71 + 230 passing; 8 new tests, plus the pre-existing suite updated for the tightened validator).

Closes #1042