### PR TITLE
feat(bridge): Hyperliquid HIP-1 wBTH listing pipeline (hl-9..13) with verified exchange signing

### DIFF
--- a/contracts/ethereum/scripts/hl-10-deploy-hip1-wbth.ts
+++ b/contracts/ethereum/scripts/hl-10-deploy-hip1-wbth.ts
@@ -1,0 +1,141 @@
+// #877 step 2/5: deploy the WBTH HIP-1 spot token on Hyperliquid testnet
+// (HyperCore order book), with HIP-2 hyperliquidity opt-in.
+//
+// Five-step spotDeploy sequence (resumable — re-run after any failure and it
+// continues from where the on-chain deploy state left off):
+//   1. registerToken2      — pays the Dutch-auction gas (~500 spot HYPE!) and
+//                            allocates the token index. IRREVERSIBLE SPEND:
+//                            gated behind HL_CONFIRM=yes.
+//   2. userGenesis         — genesis-mints 999,000 WBTH to the token's Core
+//                            system (asset-bridge) address 0x2000..{index} so
+//                            EVM->Core bridge-ins are backed (issue #877 spec).
+//   3. genesis             — maxSupply 1,000,000 WBTH; the 1,000 WBTH residual
+//                            becomes the HIP-2 hyperliquidity balance.
+//   4. registerSpot        — deploys the WBTH/USDC spot pair.
+//   5. registerHyperliquidity — HIP-2: anchor 1.0 USDC, 100 ask levels x 10
+//                            WBTH, 2 bid levels seeded with deployer USDC
+//                            (~20 USDC, moved from perp automatically).
+// Then setDeployerTradingFeeShare 0% (all fees to the protocol; we take none).
+//
+// Decimals: szDecimals 2 + weiDecimals 8 (szDecimals+5 <= weiDecimals) and
+// evmExtraWeiDecimals = 12 - 8 = 4 against the 12-decimal HyperEVM PeerToken.
+//
+// Run: HL_CONFIRM=yes npx ts-node --compiler-options '{"module":"commonjs",
+//   "target":"ES2020","esModuleInterop":true,"skipLibCheck":true}' \
+//   scripts/hl-10-deploy-hip1-wbth.ts
+import {
+  CORE_SZ_DECIMALS, CORE_TOKEN_NAME, CORE_WEI_DECIMALS, DEPLOYER, fmt, info,
+  loadWallet, perpUsdc, sendL1Action, spotBalances, systemAddress,
+  usdClassTransfer, wire,
+} from "./hl-lib";
+
+// supply plan (wei = 8 decimals)
+const MAX_SUPPLY_WEI = "100000000000000"; // 1,000,000 WBTH
+const SYSTEM_GENESIS_WEI = "99900000000000"; // 999,000 WBTH -> asset-bridge address
+const HIP2_START_PX = "1"; // anchor: 1 WBTH ~ 1 USDC (testnet demo peg)
+const HIP2_ORDER_SZ = "10"; // WBTH per level
+const HIP2_N_ORDERS = 100; // 100 x 10 = the 1,000 WBTH hyperliquidity residual
+const HIP2_SEEDED_LEVELS = 2; // 2 bid levels seeded with ~20 deployer USDC
+
+async function deployState(): Promise<any | null> {
+  const st = await info({ type: "spotDeployState", user: DEPLOYER });
+  const s = (st.states ?? []).find((x: any) => x?.spec?.name === CORE_TOKEN_NAME);
+  return { state: s ?? null, gasAuction: st.gasAuction };
+}
+
+async function findSpotPair(tokenIndex: number): Promise<number | null> {
+  const meta = await info({ type: "spotMeta" });
+  const pair = (meta.universe ?? []).find((u: any) => u.tokens?.[0] === tokenIndex && u.tokens?.[1] === 0);
+  return pair ? pair.index : null;
+}
+
+async function main() {
+  const w = loadWallet();
+  if (w.address !== DEPLOYER) throw new Error(`expected deployer ${DEPLOYER}, got ${w.address}`);
+
+  let { state, gasAuction } = await deployState();
+  console.log("gas auction:", JSON.stringify(gasAuction));
+  console.log("deploy state:", JSON.stringify(state));
+
+  // step 1: registerToken2 (pays auction gas in spot HYPE)
+  if (!state) {
+    const spot = await spotBalances(DEPLOYER);
+    const haveHype = spot.get("HYPE") ?? 0;
+    const gas = parseFloat(gasAuction.currentGas);
+    console.log(`\nstep 1 registerToken2: auction ${gas} HYPE, deployer spot HYPE ${haveHype}`);
+    if (haveHype < gas) throw new Error(`insufficient spot HYPE (${haveHype} < ${gas}) — run hl-9 / fund first`);
+    if (process.env.HL_CONFIRM !== "yes") throw new Error("IRREVERSIBLE: spends the auction gas. Re-run with HL_CONFIRM=yes");
+    const maxGas = Math.round(Math.min(gas * 1.05 + 5, haveHype) * 1e8); // HYPE wei (8 dec) cap
+    const r = await sendL1Action(w, {
+      type: "spotDeploy",
+      registerToken2: {
+        spec: { name: CORE_TOKEN_NAME, szDecimals: CORE_SZ_DECIMALS, weiDecimals: CORE_WEI_DECIMALS },
+        maxGas,
+        fullName: "Wrapped Botho (testnet)",
+      },
+    });
+    console.log("registerToken2:", JSON.stringify(r));
+    ({ state } = await deployState());
+    if (!state) throw new Error("no deploy state after registerToken2 — inspect manually");
+  }
+  const token: number = state.token;
+  const sysAddr = systemAddress(token).toLowerCase();
+  console.log(`\ntoken index: ${token}  system (asset-bridge) address: ${sysAddr}`);
+
+  // step 2: userGenesis -> system address (skip if already recorded)
+  const genesisBalances: Array<[string, string]> = state.userGenesisBalances ?? [];
+  if (!genesisBalances.some(([u]) => u.toLowerCase() === sysAddr)) {
+    console.log(`step 2 userGenesis: ${fmt(Number(SYSTEM_GENESIS_WEI) / 1e8)} WBTH -> ${sysAddr}`);
+    const r = await sendL1Action(w, {
+      type: "spotDeploy",
+      userGenesis: { token, userAndWei: [[sysAddr, SYSTEM_GENESIS_WEI]], existingTokenAndWei: [] },
+    });
+    console.log("userGenesis:", JSON.stringify(r));
+  } else console.log("step 2 userGenesis: already done");
+
+  // step 3: genesis (sets max supply; residual 1,000 WBTH -> hyperliquidity)
+  if (!state.maxSupply) {
+    console.log(`step 3 genesis: maxSupply ${fmt(Number(MAX_SUPPLY_WEI) / 1e8)} WBTH, hyperliquidity residual enabled`);
+    const r = await sendL1Action(w, {
+      type: "spotDeploy",
+      genesis: { token, maxSupply: MAX_SUPPLY_WEI, noHyperliquidity: false },
+    });
+    console.log("genesis:", JSON.stringify(r));
+  } else console.log("step 3 genesis: already done");
+
+  // step 4: registerSpot (WBTH/USDC)
+  let pair = await findSpotPair(token);
+  if (pair === null) {
+    console.log("step 4 registerSpot: [WBTH, USDC]");
+    const r = await sendL1Action(w, { type: "spotDeploy", registerSpot: { tokens: [token, 0] } });
+    console.log("registerSpot:", JSON.stringify(r));
+    pair = await findSpotPair(token);
+  }
+  console.log(`spot pair index: ${pair} (order-book asset id ${pair !== null ? 10000 + pair : "?"})`);
+  if (pair === null) throw new Error("spot pair not found after registerSpot");
+
+  // step 5: registerHyperliquidity (HIP-2) — needs ~20 spot USDC for seeded bids
+  const seedUsdc = HIP2_SEEDED_LEVELS * parseFloat(HIP2_ORDER_SZ) * parseFloat(HIP2_START_PX);
+  const spotNow = await spotBalances(DEPLOYER);
+  if ((spotNow.get("USDC") ?? 0) < seedUsdc && (await perpUsdc(DEPLOYER)) > seedUsdc + 1) {
+    console.log(`moving ${seedUsdc} USDC perp -> spot for HIP-2 seeding...`);
+    await usdClassTransfer(w, wire(seedUsdc), false);
+  }
+  console.log(`step 5 registerHyperliquidity: px ${HIP2_START_PX}, ${HIP2_N_ORDERS} x ${HIP2_ORDER_SZ} WBTH asks, ${HIP2_SEEDED_LEVELS} USDC-seeded bid levels`);
+  const r5 = await sendL1Action(w, {
+    type: "spotDeploy",
+    registerHyperliquidity: {
+      spot: pair, startPx: wire(HIP2_START_PX), orderSz: wire(HIP2_ORDER_SZ),
+      nOrders: HIP2_N_ORDERS, nSeededLevels: HIP2_SEEDED_LEVELS,
+    },
+  });
+  console.log("registerHyperliquidity:", JSON.stringify(r5));
+
+  // fee share: keep nothing for the deployer
+  const r6 = await sendL1Action(w, { type: "spotDeploy", setDeployerTradingFeeShare: { token, share: "0%" } });
+  console.log("setDeployerTradingFeeShare 0%:", JSON.stringify(r6));
+
+  console.log(`\n=== WBTH LIVE ON HYPERCORE: token ${token}, pair @${pair} ===`);
+  console.log("record the token index in the runbook, then run hl-11-link-evm-wbth.ts");
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-11-link-evm-wbth.ts
+++ b/contracts/ethereum/scripts/hl-11-link-evm-wbth.ts
@@ -1,0 +1,79 @@
+// #877 step 3/5: link the HyperCore WBTH spot token (hl-10) to the HyperEVM
+// wBTH PeerToken (NTT spoke from #876/#1026) so Core <-> EVM transfers work.
+//
+// Two actions, both signed by 0x111018 (which is BOTH the Core spot deployer
+// AND the EVM contract deployer):
+//   1. requestEvmContract  — Core-side: propose the EVM address + decimal
+//                            mapping (evmExtraWeiDecimals = 12 - 8 = 4).
+//   2. finalizeEvmContract — EVM-deployer proof: the PeerToken was CREATE'd
+//                            by 0x111018 at nonce 0 (verified via
+//                            ethers.getCreateAddress), so input = create{0}.
+//
+// Decimal caveat (runbook): Core<->EVM transfer amounts must be round in the
+// 4 extra EVM wei decimals or the remainder is burned — keep every amount
+// 8-decimal-aligned end to end.
+//
+// Run: HL_TOKEN_INDEX=<idx from hl-10> npx ts-node --compiler-options
+//   '{"module":"commonjs","target":"ES2020","esModuleInterop":true,
+//   "skipLibCheck":true}' scripts/hl-11-link-evm-wbth.ts
+import { ethers } from "ethers";
+import {
+  CORE_TOKEN_NAME, DEPLOYER, EVM_EXTRA_WEI_DECIMALS, HYPEREVM_RPC, info,
+  loadWallet, PEER_TOKEN, PEER_TOKEN_CREATE_NONCE, sendL1Action,
+} from "./hl-lib";
+
+async function resolveTokenIndex(): Promise<number> {
+  if (process.env.HL_TOKEN_INDEX) return parseInt(process.env.HL_TOKEN_INDEX, 10);
+  // fall back to the deployer's completed deploys in spot meta
+  const meta = await info({ type: "spotMeta" });
+  const candidates = (meta.tokens ?? []).filter((t: any) => t.name === CORE_TOKEN_NAME);
+  for (const t of candidates) {
+    const det = await info({ type: "tokenDetails", tokenId: t.tokenId });
+    if (det?.deployer?.toLowerCase() === DEPLOYER.toLowerCase()) return t.index;
+  }
+  throw new Error(`could not find a ${CORE_TOKEN_NAME} token deployed by ${DEPLOYER}; pass HL_TOKEN_INDEX`);
+}
+
+async function main() {
+  const w = loadWallet();
+  if (w.address !== DEPLOYER) throw new Error(`expected deployer ${DEPLOYER}, got ${w.address}`);
+  const token = await resolveTokenIndex();
+  console.log(`Core token index: ${token}  EVM PeerToken: ${PEER_TOKEN}`);
+
+  // sanity: PeerToken decimals must match the 8 + 4 mapping, and the CREATE
+  // nonce proof must actually derive the PeerToken address.
+  const evm = new ethers.JsonRpcProvider(HYPEREVM_RPC);
+  const erc20 = new ethers.Contract(PEER_TOKEN, ["function decimals() view returns (uint8)"], evm);
+  const dec = Number(await erc20.decimals());
+  if (dec !== 8 + EVM_EXTRA_WEI_DECIMALS) throw new Error(`PeerToken decimals ${dec} != ${8 + EVM_EXTRA_WEI_DECIMALS}`);
+  const derived = ethers.getCreateAddress({ from: DEPLOYER, nonce: PEER_TOKEN_CREATE_NONCE });
+  if (derived.toLowerCase() !== PEER_TOKEN.toLowerCase()) throw new Error(`CREATE(nonce ${PEER_TOKEN_CREATE_NONCE}) derives ${derived}, not the PeerToken`);
+
+  console.log(`1. requestEvmContract (evmExtraWeiDecimals ${EVM_EXTRA_WEI_DECIMALS})...`);
+  const r1 = await sendL1Action(w, {
+    type: "requestEvmContract",
+    token,
+    address: PEER_TOKEN.toLowerCase(),
+    evmExtraWeiDecimals: EVM_EXTRA_WEI_DECIMALS,
+  });
+  console.log("requestEvmContract:", JSON.stringify(r1));
+
+  console.log(`2. finalizeEvmContract (create nonce ${PEER_TOKEN_CREATE_NONCE})...`);
+  const r2 = await sendL1Action(w, {
+    type: "finalizeEvmContract",
+    token,
+    input: { create: { nonce: PEER_TOKEN_CREATE_NONCE } },
+  });
+  console.log("finalizeEvmContract:", JSON.stringify(r2));
+
+  // verify the link landed in spot meta
+  const meta = await info({ type: "spotMeta" });
+  const entry = (meta.tokens ?? []).find((t: any) => t.index === token);
+  console.log("spotMeta evmContract:", JSON.stringify(entry?.evmContract ?? null));
+  if (entry?.evmContract?.address?.toLowerCase() !== PEER_TOKEN.toLowerCase()) {
+    throw new Error("link not reflected in spotMeta yet — re-check in a minute");
+  }
+  console.log("\n=== LINKED: HyperCore WBTH <-> HyperEVM wBTH PeerToken ===");
+  console.log("next: hl-12-bridge-in-wbth.ts");
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-12-bridge-in-wbth.ts
+++ b/contracts/ethereum/scripts/hl-12-bridge-in-wbth.ts
@@ -1,0 +1,64 @@
+// #877 step 4/5: bridge wBTH from HyperEVM into HyperCore spot.
+//
+// After hl-11's link, an ERC-20 transfer of the PeerToken to the token's Core
+// system address (0x2000..{index}) credits the SENDER's HyperCore spot
+// balance. The deployer holds 10 wBTH on HyperEVM (minted by the #1026 NTT
+// round trip, backed 1:1 by wBTH locked on Sepolia).
+//
+// Amounts MUST be multiples of 1e4 PeerToken wei (evmExtraWeiDecimals = 4) or
+// the non-round remainder is burned by the Core credit.
+//
+// Run: HL_TOKEN_INDEX=<idx> [HL_BRIDGE_WBTH=10] npx ts-node
+//   --compiler-options '{"module":"commonjs","target":"ES2020",
+//   "esModuleInterop":true,"skipLibCheck":true}' scripts/hl-12-bridge-in-wbth.ts
+import { ethers } from "ethers";
+import {
+  CORE_TOKEN_NAME, DEPLOYER, HYPEREVM_RPC, loadWallet, PEER_TOKEN,
+  spotBalances, systemAddress,
+} from "./hl-lib";
+
+const AMOUNT_WBTH = process.env.HL_BRIDGE_WBTH ?? "10"; // default: everything from the #1026 round trip
+
+async function main() {
+  const w = loadWallet();
+  if (w.address !== DEPLOYER) throw new Error(`expected deployer ${DEPLOYER}, got ${w.address}`);
+  const tokenIndex = parseInt(process.env.HL_TOKEN_INDEX ?? "", 10);
+  if (!Number.isInteger(tokenIndex)) throw new Error("set HL_TOKEN_INDEX to the hl-10 token index");
+  const sysAddr = systemAddress(tokenIndex);
+
+  const amount = ethers.parseUnits(AMOUNT_WBTH, 12);
+  if (amount % 10000n !== 0n) throw new Error("amount must be a multiple of 1e-8 wBTH (evmExtraWeiDecimals rounding burns the rest)");
+
+  const evm = new ethers.JsonRpcProvider(HYPEREVM_RPC);
+  const erc20 = new ethers.Contract(PEER_TOKEN, [
+    "function balanceOf(address) view returns (uint256)",
+    "function transfer(address,uint256) returns (bool)",
+  ], w.connect(evm));
+
+  const evmBefore = await erc20.balanceOf(DEPLOYER);
+  const coreBefore = (await spotBalances(DEPLOYER)).get(CORE_TOKEN_NAME) ?? 0;
+  console.log(`EVM wBTH: ${ethers.formatUnits(evmBefore, 12)}  Core ${CORE_TOKEN_NAME}: ${coreBefore}`);
+  if (evmBefore < amount) throw new Error("insufficient EVM wBTH");
+
+  console.log(`transferring ${AMOUNT_WBTH} wBTH -> Core system address ${sysAddr}...`);
+  const tx = await erc20.transfer(sysAddr, amount);
+  console.log("EVM tx:", tx.hash, `\n  https://testnet.purrsec.com/tx/${tx.hash}`);
+  const rc = await tx.wait();
+  if (!rc || rc.status !== 1) throw new Error("transfer reverted");
+
+  // Core credit arrives via a system transaction shortly after the EVM block
+  process.stdout.write("waiting for HyperCore credit");
+  for (let i = 0; i < 30; i++) {
+    await new Promise((r) => setTimeout(r, 4000));
+    const coreNow = (await spotBalances(DEPLOYER)).get(CORE_TOKEN_NAME) ?? 0;
+    process.stdout.write(".");
+    if (coreNow > coreBefore) {
+      console.log(`\nCore ${CORE_TOKEN_NAME} balance: ${coreBefore} -> ${coreNow}`);
+      console.log(`EVM wBTH left: ${ethers.formatUnits(await erc20.balanceOf(DEPLOYER), 12)}`);
+      console.log("\n=== wBTH BRIDGED ONTO HYPERCORE SPOT — run hl-13-swap-demo.ts ===");
+      return;
+    }
+  }
+  throw new Error("\nCore credit not observed within 2 min — check the link (hl-11) and system address");
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-13-swap-demo.ts
+++ b/contracts/ethereum/scripts/hl-13-swap-demo.ts
@@ -1,0 +1,92 @@
+// #877 step 5/5: order-book swap demo — buy and sell WBTH against spot USDC
+// on the HyperCore order book (against the HIP-2 hyperliquidity quotes),
+// capturing order ids, fills, and before/after balances for the runbook.
+//
+// Order sizes respect the 10 USDC exchange minimum order value (testnet
+// enforces it too — live-verified) and szDecimals 2.
+//
+// Run: HL_TOKEN_INDEX=<idx> npx ts-node --compiler-options
+//   '{"module":"commonjs","target":"ES2020","esModuleInterop":true,
+//   "skipLibCheck":true}' scripts/hl-13-swap-demo.ts
+import {
+  CORE_TOKEN_NAME, DEPLOYER, info, loadWallet, perpUsdc, sendL1Action,
+  spotBalances, usdClassTransfer, wire,
+} from "./hl-lib";
+
+const DEMO_SZ_WBTH = parseFloat(process.env.HL_DEMO_SZ ?? "11"); // ~$11 notional at the 1.0 anchor
+
+async function findPair(tokenIndex: number): Promise<number> {
+  const meta = await info({ type: "spotMeta" });
+  const pair = (meta.universe ?? []).find((u: any) => u.tokens?.[0] === tokenIndex && u.tokens?.[1] === 0);
+  if (!pair) throw new Error("WBTH/USDC pair not found — run hl-10 first");
+  return pair.index;
+}
+
+async function printBalances(label: string) {
+  const spot = await spotBalances(DEPLOYER);
+  console.log(`${label}: spot USDC ${spot.get("USDC") ?? 0} | spot ${CORE_TOKEN_NAME} ${spot.get(CORE_TOKEN_NAME) ?? 0}`);
+}
+
+async function book(pair: number) {
+  const b = await info({ type: "l2Book", coin: `@${pair}` });
+  const [bids, asks] = b.levels;
+  console.log("book:", `bid ${bids[0]?.px ?? "-"} x ${bids[0]?.sz ?? "-"}`, "|", `ask ${asks[0]?.px ?? "-"} x ${asks[0]?.sz ?? "-"}`);
+  return { bestBid: bids[0] ? parseFloat(bids[0].px) : null, bestAsk: asks[0] ? parseFloat(asks[0].px) : null };
+}
+
+async function ioc(w: any, asset: number, isBuy: boolean, px: string, sz: string) {
+  const r = await sendL1Action(w, {
+    type: "order",
+    orders: [{ a: asset, b: isBuy, p: px, s: sz, r: false, t: { limit: { tif: "Ioc" } } }],
+    grouping: "na",
+  });
+  const status = r?.response?.data?.statuses?.[0];
+  console.log(`${isBuy ? "BUY" : "SELL"} IOC ${sz} @ ${px}:`, JSON.stringify(status));
+  return status;
+}
+
+async function main() {
+  const w = loadWallet();
+  if (w.address !== DEPLOYER) throw new Error(`expected deployer ${DEPLOYER}, got ${w.address}`);
+  const tokenIndex = parseInt(process.env.HL_TOKEN_INDEX ?? "", 10);
+  if (!Number.isInteger(tokenIndex)) throw new Error("set HL_TOKEN_INDEX to the hl-10 token index");
+  const pair = await findPair(tokenIndex);
+  const asset = 10000 + pair;
+  console.log(`pair @${pair} (asset ${asset})`);
+
+  // make sure the buy leg is funded in SPOT USDC (>= min notional + fees)
+  const need = DEMO_SZ_WBTH * 1.1 + 1;
+  const spot = await spotBalances(DEPLOYER);
+  if ((spot.get("USDC") ?? 0) < need && (await perpUsdc(DEPLOYER)) > need + 1) {
+    console.log(`moving ${wire(need)} USDC perp -> spot...`);
+    await usdClassTransfer(w, wire(need), false);
+  }
+
+  await printBalances("before");
+  let { bestAsk, bestBid } = await book(pair);
+
+  // leg 1: BUY WBTH from the HIP-2 asks
+  if (bestAsk === null) throw new Error("no asks on the book — check registerHyperliquidity");
+  const buy = await ioc(w, asset, true, wire(Math.ceil(bestAsk * 1.05 * 1000) / 1000), wire(DEMO_SZ_WBTH));
+  if (!buy?.filled) throw new Error("buy leg did not fill");
+  await printBalances("after buy ");
+
+  // leg 2: SELL the same size into the bids (HIP-2 seeded levels)
+  ({ bestAsk, bestBid } = await book(pair));
+  if (bestBid === null) throw new Error("no bids on the book");
+  const sell = await ioc(w, asset, false, wire(Math.floor(bestBid * 0.95 * 1000) / 1000), wire(DEMO_SZ_WBTH));
+  if (!sell?.filled) throw new Error("sell leg did not fill (partial fills print above)");
+  await printBalances("after sell");
+
+  // pull the authoritative fill records (tx hashes, fees, crossing side)
+  const fills = (await info({ type: "userFills", user: DEPLOYER }))
+    .filter((f: any) => f.coin === `@${pair}`)
+    .slice(0, 4);
+  console.log("\nfills (newest first):");
+  for (const f of fills) {
+    console.log(`  ${f.side === "B" ? "BUY " : "SELL"} ${f.sz} @ ${f.px} oid ${f.oid} tid ${f.tid} hash ${f.hash} fee ${f.fee} ${f.feeToken}`);
+  }
+  console.log(`\n=== SWAP DEMO COMPLETE: WBTH traded on the Hyperliquid testnet order book ===`);
+  console.log(`UI: https://app.hyperliquid-testnet.xyz/trade/@${pair}`);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-9-fund-deploy-gas.ts
+++ b/contracts/ethereum/scripts/hl-9-fund-deploy-gas.ts
@@ -1,0 +1,116 @@
+// #877 step 1/5: acquire the HIP-1 deploy gas on Hyperliquid testnet.
+//
+// FINDING (2026-07-16): the spot deploy Dutch auction is denominated in HYPE,
+// not USDC ("Gas is deducted from the deployer's spot HYPE balance", floor
+// 500 HYPE), and testnet HYPE trades at ~$32-52 mock-USDC on the HYPE/USDC
+// book — so the "free testnet deploy" assumption in #877 is wrong: deploy gas
+// is ~16k-26k mock USDC worth of HYPE. Getting there needs operator help (see
+// the runbook); this script converts whatever the deployer DOES have into
+// spot HYPE and reports the remaining shortfall:
+//   1. bridges the deployer's HyperEVM native HYPE -> HyperCore spot HYPE
+//      (send to system address 0x2222...2222), keeping a little for EVM gas
+//   2. moves perp USDC -> spot USDC (usdClassTransfer)
+//   3. IOC-buys HYPE with spare spot USDC (keeps USDC_RESERVE for HIP-2
+//      seeding + the hl-13 swap demo)
+//
+// Optional funder mode: HL_FUNDER_KEYFILE=<key> HL_FUND_USDC=<amt> sends perp
+// USDC from a (mainnet-activated, drip-eligible) funder account to the
+// deployer first. claimDrip is UNSIGNED (plain info request) and is attempted
+// for the funder automatically. Run every drip cooldown until funded.
+//
+// Run: npx ts-node --compiler-options '{"module":"commonjs","target":"ES2020",
+//   "esModuleInterop":true,"skipLibCheck":true}' scripts/hl-9-fund-deploy-gas.ts
+import { ethers } from "ethers";
+import * as fs from "fs";
+import {
+  DEPLOYER, HYPEREVM_RPC, fmt, info, loadWallet, perpUsdc, sendL1Action,
+  spotBalances, usdClassTransfer, usdSend, wire,
+} from "./hl-lib";
+
+const HYPE_SYSTEM = "0x2222222222222222222222222222222222222222"; // EVM->Core HYPE bridge
+const HYPE_PAIR = "@1035"; // HYPE/USDC on testnet (tokens [1105, 0])
+const HYPE_ASSET = 10000 + 1035;
+const TARGET_HYPE = parseFloat(process.env.HL_TARGET_HYPE ?? "505"); // auction floor 500 + buffer
+const USDC_RESERVE = parseFloat(process.env.HL_USDC_RESERVE ?? "40"); // HIP-2 seed (~20) + swap demo (~12) + fees
+const EVM_GAS_KEEP = ethers.parseEther("0.3"); // HYPE kept on the EVM side for hl-12
+
+async function bestAsk(): Promise<number | null> {
+  const book = await info({ type: "l2Book", coin: HYPE_PAIR });
+  const ask = book?.levels?.[1]?.[0];
+  return ask ? parseFloat(ask.px) : null;
+}
+
+async function main() {
+  const w = loadWallet();
+  if (w.address !== DEPLOYER) throw new Error(`expected deployer ${DEPLOYER}, got ${w.address}`);
+
+  // optional funder leg (operator provides the keyfile; NOT run by automation)
+  const funderKeyfile = process.env.HL_FUNDER_KEYFILE;
+  if (funderKeyfile) {
+    const funder = new ethers.Wallet(fs.readFileSync(funderKeyfile, "utf8").trim());
+    console.log("funder:", funder.address);
+    const drip = await info({ type: "claimDrip", user: funder.address }); // unsigned faucet claim
+    console.log("claimDrip:", JSON.stringify(drip)); // null = claimed 1000 mock USDC; else the error string
+    const amt = process.env.HL_FUND_USDC;
+    if (amt) {
+      console.log(`usdSend ${amt} USDC funder -> deployer (1 USDC fee)...`);
+      console.log(JSON.stringify(await usdSend(funder, DEPLOYER, wire(amt))));
+    }
+  }
+
+  // status
+  const evm = new ethers.JsonRpcProvider(HYPEREVM_RPC);
+  const evmHype = await evm.getBalance(DEPLOYER);
+  const spot = await spotBalances(DEPLOYER);
+  const perp = await perpUsdc(DEPLOYER);
+  console.log(`deployer EVM HYPE: ${ethers.formatEther(evmHype)}  Core spot HYPE: ${spot.get("HYPE") ?? 0}`);
+  console.log(`deployer perp USDC: ${perp}  spot USDC: ${spot.get("USDC") ?? 0}`);
+  const auction = (await info({ type: "spotDeployState", user: DEPLOYER })).gasAuction;
+  console.log(`gas auction: current ${auction.currentGas} HYPE (start ${auction.startGas}, floor 500)`);
+
+  // 1. bridge EVM HYPE -> Core spot HYPE
+  if (evmHype > EVM_GAS_KEEP + ethers.parseEther("0.1")) {
+    const send = evmHype - EVM_GAS_KEEP;
+    console.log(`bridging ${ethers.formatEther(send)} HYPE EVM -> Core (to ${HYPE_SYSTEM})...`);
+    const tx = await w.connect(evm).sendTransaction({ to: HYPE_SYSTEM, value: send });
+    console.log("tx:", tx.hash);
+    await tx.wait();
+  }
+
+  // 2. perp USDC -> spot USDC (keep $1 in perp)
+  if (perp > 1.5) {
+    const amt = wire(Math.floor((perp - 1) * 100) / 100);
+    console.log(`usdClassTransfer ${amt} USDC perp -> spot...`);
+    console.log(JSON.stringify(await usdClassTransfer(w, amt, false)));
+  }
+
+  // 3. buy HYPE with spare spot USDC (leave USDC_RESERVE)
+  const spot2 = await spotBalances(DEPLOYER);
+  const usdcSpare = (spot2.get("USDC") ?? 0) - USDC_RESERVE;
+  const haveHype = spot2.get("HYPE") ?? 0;
+  const needHype = TARGET_HYPE - haveHype;
+  if (needHype > 0 && usdcSpare > 10.5) { // 10 USDC exchange minimum order value
+    const ask = await bestAsk();
+    if (!ask) throw new Error("no HYPE ask on the book");
+    const px = wire(Math.ceil(ask * 1.02 * 100) / 100);
+    const sz = wire(Math.min(needHype, Math.floor((usdcSpare / (ask * 1.02)) * 100) / 100));
+    console.log(`IOC buy ${sz} HYPE @ <= ${px} (~${fmt(parseFloat(sz) * parseFloat(px))} USDC)...`);
+    const r = await sendL1Action(w, {
+      type: "order",
+      orders: [{ a: HYPE_ASSET, b: true, p: px, s: sz, r: false, t: { limit: { tif: "Ioc" } } }],
+      grouping: "na",
+    });
+    console.log(JSON.stringify(r?.response?.data?.statuses ?? r));
+  }
+
+  const finalSpot = await spotBalances(DEPLOYER);
+  const finalHype = finalSpot.get("HYPE") ?? 0;
+  console.log(`\nspot HYPE: ${finalHype} / ${TARGET_HYPE} target  |  spot USDC: ${finalSpot.get("USDC") ?? 0}`);
+  if (finalHype >= parseFloat(auction.currentGas)) {
+    console.log("=== DEPLOY GAS FUNDED — run hl-10-deploy-hip1-wbth.ts ===");
+  } else {
+    console.log(`SHORTFALL: need ~${fmt(parseFloat(auction.currentGas) - finalHype)} more spot HYPE`);
+    console.log("(operator: drip-fund a mainnet-activated account, usdSend USDC here, re-run; see runbook)");
+  }
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-lib-selftest.ts
+++ b/contracts/ethereum/scripts/hl-lib-selftest.ts
@@ -1,0 +1,74 @@
+// Self-test for hl-lib.ts signing: verifies the vendored msgpack encoder,
+// action hashing, L1-action signatures, and user-signed-action signatures
+// against golden vectors generated with hyperliquid-python-sdk 0.x
+// (utils/signing.py) using the well-known throwaway hardhat key #0.
+// Run (no network, no secrets):
+//   npx ts-node --compiler-options '{"module":"commonjs","target":"ES2020",
+//     "esModuleInterop":true,"skipLibCheck":true}' scripts/hl-lib-selftest.ts
+import { ethers } from "ethers";
+import {
+  actionHash, signL1Action, signUserSignedAction,
+  USD_CLASS_TRANSFER_SIGN_TYPES, USD_SEND_SIGN_TYPES, systemAddress, wire,
+} from "./hl-lib";
+
+const w = new ethers.Wallet("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"); // hardhat #0, throwaway
+const NONCE = 1784260000000;
+
+// [action, expected actionHash, expected r] from the python SDK (testnet source "b")
+const VECTORS: Array<[any, string, string]> = [
+  [{ type: "spotDeploy", registerToken2: { spec: { name: "WBTH", szDecimals: 2, weiDecimals: 8 }, maxGas: 510000000, fullName: "Wrapped Botho (testnet)" } },
+    "0x3d8d233f268d5cc91656b8aec76e950e89081fbcc79c8eaf75bdaea4fc74defc", "0xa4fd2358703b030eee0a489b96b067d679ba9558b8fda490eeef16c0058fcd81"],
+  [{ type: "spotDeploy", userGenesis: { token: 1234, userAndWei: [["0x20000000000000000000000000000000000004d2", "99900000000000"]], existingTokenAndWei: [] } },
+    "0x0386997aff0f60faedfd91388672e43fb47b5f4a2e13811d8fc7f1e62c8a9779", "0xf35a2258997791fc28b6c568c96a7f48b0c6d58fa6547bc8ac0b732294dc5647"],
+  [{ type: "spotDeploy", genesis: { token: 1234, maxSupply: "100000000000000", noHyperliquidity: false } },
+    "0xb59f49834d31ba6582bfb5741cc380c24f220d6395f98713c18db403c5d909b5", "0x8017c2ca75ef957cd217918eb44b89827e5ddb4e66726d669be93a3681f53a26"],
+  [{ type: "spotDeploy", registerSpot: { tokens: [1234, 0] } },
+    "0x487e89262e54c3830ad76ed437781674e35df7e7521eb3c9b25d7407116856a5", "0xb435f405283ec5b42d287e2c9560f38479ab231f8d0e61ce86283cf7b1db97ff"],
+  [{ type: "spotDeploy", registerHyperliquidity: { spot: 5678, startPx: "1.0", orderSz: "10.0", nOrders: 100, nSeededLevels: 2 } },
+    "0xa2bc8083792a5a277be25b8b8522b0263b30787ff73a66ff5ea6ca8351b6dde7", "0xe3e2b38a3cc0822ee5066682d8f92b7d7daccd306a7d7dc7361b22a68836403b"],
+  [{ type: "requestEvmContract", token: 1234, address: "0x230f154ae33a53dcffededb2d92cc1f32bce7610", evmExtraWeiDecimals: 4 },
+    "0xa036cd702d359ab99452c5cab4dacfd8701ede01d08545193e25d0b700ae1489", "0x8670a8b07a932ceab6953eb1e8508e25aedc091900709c7fc4b4b8c72533536a"],
+  [{ type: "finalizeEvmContract", token: 1234, input: { create: { nonce: 0 } } },
+    "0xa9dff8d22abc2167468a8710f8d70a264be953ddf780eec7c81d12e0ba9af7c9", "0x95948fc4efb0133b88d24073299ead1a2d666555413e019a6e2089d25fb0ed1c"],
+  [{ type: "order", orders: [{ a: 11234, b: true, p: "1.05", s: "2.0", r: false, t: { limit: { tif: "Ioc" } } }], grouping: "na" },
+    "0xe513219cad7e28f90740d086fdd227c117e4b7d71bbfc23c6f3ef7ce948a42d5", "0x54fd3d44b87d128bae81db9882e874b91fe2cec18c31e65037a614765524e7cf"],
+];
+
+async function main() {
+  let fail = 0;
+  for (const [action, expHash, expR] of VECTORS) {
+    const h = actionHash(action, null, NONCE);
+    const sig = await signL1Action(w, action, NONCE);
+    const ok = h === expHash && sig.r === expR;
+    if (!ok) fail++;
+    console.log(`${ok ? "PASS" : "FAIL"} ${action.type}${action.type === "spotDeploy" ? ":" + Object.keys(action)[1] : ""}${ok ? "" : ` hash=${h} r=${sig.r}`}`);
+  }
+  const uct: any = { type: "usdClassTransfer", amount: "2.0", toPerp: false, nonce: NONCE };
+  const s1 = await signUserSignedAction(w, uct, USD_CLASS_TRANSFER_SIGN_TYPES, "HyperliquidTransaction:UsdClassTransfer");
+  const ok1 = s1.r === "0xe94cb7c2e8ac567d649e2167048ec247066036785adb24207baaa5d5e5e5a2d4";
+  console.log(`${ok1 ? "PASS" : "FAIL"} usdClassTransfer${ok1 ? "" : " r=" + s1.r}`);
+  if (!ok1) fail++;
+  const us: any = { destination: "0x111018cfe4523097B7f651f3A06fA9a2956CF155", amount: "510.0", time: NONCE, type: "usdSend" };
+  const s2 = await signUserSignedAction(w, us, USD_SEND_SIGN_TYPES, "HyperliquidTransaction:UsdSend");
+  const ok2 = s2.r === "0xca4f72969152e8628bef15c9bd963e771670035c9b41cecccc95545207e1d1f1";
+  console.log(`${ok2 ? "PASS" : "FAIL"} usdSend${ok2 ? "" : " r=" + s2.r}`);
+  if (!ok2) fail++;
+  // wire(): the exchange re-canonicalizes float strings before signature
+  // verification — live-confirmed: "53.0" breaks recovery, "53" verifies.
+  const wireCases: Array<[number | string, string]> = [
+    [53.0, "53"], ["0.02", "0.02"], [1.0, "1"], [10.0, "10"], [0.31, "0.31"], [2.5, "2.5"],
+  ];
+  for (const [input, expected] of wireCases) {
+    const got = wire(input);
+    const ok = got === expected;
+    console.log(`${ok ? "PASS" : "FAIL"} wire(${JSON.stringify(input)}) = ${got}`);
+    if (!ok) fail++;
+  }
+  const sys = systemAddress(200);
+  const ok3 = sys.toLowerCase() === "0x20000000000000000000000000000000000000c8"; // docs example
+  console.log(`${ok3 ? "PASS" : "FAIL"} systemAddress(200) = ${sys}`);
+  if (!ok3) fail++;
+  if (fail) { console.error(`${fail} FAILURES`); process.exit(1); }
+  console.log("all signing self-tests passed");
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/contracts/ethereum/scripts/hl-lib.ts
+++ b/contracts/ethereum/scripts/hl-lib.ts
@@ -1,0 +1,231 @@
+// Shared Hyperliquid TESTNET helpers for the hl-9..13 scripts (#877):
+// exchange-action signing (L1 + user-signed), info queries, and constants.
+//
+// Signing is a faithful port of hyperliquid-python-sdk's utils/signing.py:
+//   actionHash = keccak(msgpack(action) ++ nonce_u64_be ++ 0x00[no vault])
+//   phantomAgent = { source: "b" (testnet), connectionId: actionHash }
+//   EIP-712 sign over domain {Exchange, version 1, chainId 1337} type Agent.
+// The msgpack encoder is vendored below (subset: nil/bool/int/str/array/map,
+// map keys in insertion order — matching python msgpack.packb of a dict).
+// Verified byte-identical + signature-identical against the python SDK.
+
+import { ethers } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
+
+export const HL_API = "https://api.hyperliquid-testnet.xyz";
+export const IS_MAINNET = false;
+export const HYPEREVM_RPC = "https://rpc.hyperliquid-testnet.xyz/evm";
+
+// #876/#1026 deployment (contracts/wbth-ntt/deployment.json)
+export const DEPLOYER = "0x111018cfe4523097B7f651f3A06fA9a2956CF155";
+export const DEPLOYER_KEYFILE =
+  process.env.HL_DEPLOYER_KEYFILE ?? path.resolve(__dirname, "../../../.secrets/bridge-testnet/eth-deployer.key");
+export const PEER_TOKEN = "0x230f154Ae33A53dcFFEDedB2d92cc1F32BcE7610"; // HyperEVM wBTH (12 dec)
+export const PEER_TOKEN_CREATE_NONCE = 0; // CREATE by 0x111018 at nonce 0 (verified via getCreateAddress)
+
+// HyperCore wBTH spot listing parameters (see hyperliquid-ntt-runbook.md).
+// weiDecimals 8 on Core, PeerToken 12 on EVM => evmExtraWeiDecimals 4.
+export const CORE_TOKEN_NAME = "WBTH";
+export const CORE_SZ_DECIMALS = 2;
+export const CORE_WEI_DECIMALS = 8;
+export const EVM_EXTRA_WEI_DECIMALS = 4;
+
+export function loadWallet(keyfile: string = DEPLOYER_KEYFILE): ethers.Wallet {
+  return new ethers.Wallet(fs.readFileSync(keyfile, "utf8").trim());
+}
+
+// System (asset-bridge) address for a Core token index: 0x20 then zeros, index big-endian.
+export function systemAddress(tokenIndex: number): string {
+  const hex = tokenIndex.toString(16).padStart(38, "0");
+  return ethers.getAddress("0x20" + hex);
+}
+
+// ---------------------------------------------------------------------------
+// minimal msgpack encoder (only the types Hyperliquid actions use)
+// ---------------------------------------------------------------------------
+function msgpackEncode(v: any, out: number[]): void {
+  if (v === null || v === undefined) { out.push(0xc0); return; }
+  if (typeof v === "boolean") { out.push(v ? 0xc3 : 0xc2); return; }
+  if (typeof v === "number") {
+    if (!Number.isSafeInteger(v)) throw new Error(`non-integer number in action: ${v} (use a string)`);
+    if (v >= 0) {
+      if (v < 0x80) out.push(v);
+      else if (v < 0x100) out.push(0xcc, v);
+      else if (v < 0x10000) out.push(0xcd, v >>> 8, v & 0xff);
+      else if (v < 0x100000000) out.push(0xce, (v / 0x1000000) & 0xff, (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff);
+      else { // uint64
+        out.push(0xcf);
+        let big = BigInt(v);
+        for (let i = 7; i >= 0; i--) out.push(Number((big >> BigInt(8 * i)) & 0xffn));
+      }
+    } else {
+      if (v >= -32) out.push(0x100 + v);
+      else if (v >= -128) out.push(0xd0, v & 0xff);
+      else if (v >= -32768) out.push(0xd1, (v >> 8) & 0xff, v & 0xff);
+      else out.push(0xd2, (v >> 24) & 0xff, (v >> 16) & 0xff, (v >> 8) & 0xff, v & 0xff);
+    }
+    return;
+  }
+  if (typeof v === "string") {
+    const b = Buffer.from(v, "utf8");
+    if (b.length < 32) out.push(0xa0 | b.length);
+    else if (b.length < 0x100) out.push(0xd9, b.length);
+    else out.push(0xda, b.length >>> 8, b.length & 0xff);
+    for (const x of b) out.push(x);
+    return;
+  }
+  if (Array.isArray(v)) {
+    if (v.length < 16) out.push(0x90 | v.length);
+    else out.push(0xdc, v.length >>> 8, v.length & 0xff);
+    for (const e of v) msgpackEncode(e, out);
+    return;
+  }
+  if (typeof v === "object") {
+    const keys = Object.keys(v); // insertion order, matches python dict
+    if (keys.length < 16) out.push(0x80 | keys.length);
+    else out.push(0xde, keys.length >>> 8, keys.length & 0xff);
+    for (const k of keys) { msgpackEncode(k, out); msgpackEncode(v[k], out); }
+    return;
+  }
+  throw new Error(`unsupported msgpack type: ${typeof v}`);
+}
+
+export function packAction(action: any): Uint8Array {
+  const out: number[] = [];
+  msgpackEncode(action, out);
+  return Uint8Array.from(out);
+}
+
+// ---------------------------------------------------------------------------
+// signing
+// ---------------------------------------------------------------------------
+export function actionHash(action: any, vaultAddress: string | null, nonce: number): string {
+  const packed = packAction(action);
+  const nonceBuf = Buffer.alloc(8);
+  nonceBuf.writeBigUInt64BE(BigInt(nonce));
+  const vaultBuf = vaultAddress === null
+    ? Buffer.from([0x00])
+    : Buffer.concat([Buffer.from([0x01]), Buffer.from(vaultAddress.replace(/^0x/, ""), "hex")]);
+  return ethers.keccak256(Buffer.concat([Buffer.from(packed), nonceBuf, vaultBuf]));
+}
+
+export async function signL1Action(wallet: ethers.Wallet, action: any, nonce: number, vaultAddress: string | null = null) {
+  const hash = actionHash(action, vaultAddress, nonce);
+  const phantomAgent = { source: IS_MAINNET ? "a" : "b", connectionId: hash };
+  const domain = { chainId: 1337, name: "Exchange", verifyingContract: "0x0000000000000000000000000000000000000000", version: "1" };
+  const types = { Agent: [{ name: "source", type: "string" }, { name: "connectionId", type: "bytes32" }] };
+  const sig = ethers.Signature.from(await wallet.signTypedData(domain, types, phantomAgent));
+  return { r: sig.r, s: sig.s, v: sig.v };
+}
+
+// user-signed actions (usdSend, usdClassTransfer): EIP-712 over the named fields.
+export async function signUserSignedAction(
+  wallet: ethers.Wallet, action: any, payloadTypes: Array<{ name: string; type: string }>, primaryType: string,
+) {
+  action.signatureChainId = "0x66eee";
+  action.hyperliquidChain = IS_MAINNET ? "Mainnet" : "Testnet";
+  const domain = {
+    name: "HyperliquidSignTransaction", version: "1",
+    chainId: parseInt(action.signatureChainId, 16),
+    verifyingContract: "0x0000000000000000000000000000000000000000",
+  };
+  // sign over exactly the declared fields (the posted action carries extras like `type`)
+  const message: any = {};
+  for (const f of payloadTypes) message[f.name] = action[f.name];
+  const sig = ethers.Signature.from(await wallet.signTypedData(domain, { [primaryType]: payloadTypes } as any, message));
+  return { r: sig.r, s: sig.s, v: sig.v };
+}
+
+export const USD_SEND_SIGN_TYPES = [
+  { name: "hyperliquidChain", type: "string" },
+  { name: "destination", type: "string" },
+  { name: "amount", type: "string" },
+  { name: "time", type: "uint64" },
+];
+export const USD_CLASS_TRANSFER_SIGN_TYPES = [
+  { name: "hyperliquidChain", type: "string" },
+  { name: "amount", type: "string" },
+  { name: "toPerp", type: "bool" },
+  { name: "nonce", type: "uint64" },
+];
+
+// ---------------------------------------------------------------------------
+// API I/O
+// ---------------------------------------------------------------------------
+export async function info(request: any): Promise<any> {
+  const res = await fetch(HL_API + "/info", {
+    method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(request),
+  });
+  const text = await res.text();
+  try { return JSON.parse(text); } catch { return text; }
+}
+
+async function postExchange(payload: any): Promise<any> {
+  const res = await fetch(HL_API + "/exchange", {
+    method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
+  });
+  const text = await res.text();
+  let json: any;
+  try { json = JSON.parse(text); } catch { throw new Error(`exchange HTTP ${res.status}: ${text.slice(0, 400)}`); }
+  if (json?.status === "err") throw new Error(`exchange error: ${json.response}`);
+  if (json?.status !== "ok") throw new Error(`exchange unexpected: ${text.slice(0, 400)}`);
+  return json;
+}
+
+// Send an L1-signed action (order, spotDeploy, requestEvmContract, finalizeEvmContract, ...).
+export async function sendL1Action(wallet: ethers.Wallet, action: any): Promise<any> {
+  const nonce = Date.now();
+  const signature = await signL1Action(wallet, action, nonce);
+  return postExchange({ action, nonce, signature, vaultAddress: null });
+}
+
+// Send a user-signed action. `action` must already contain its time/nonce field.
+export async function sendUserSignedAction(
+  wallet: ethers.Wallet, action: any, payloadTypes: Array<{ name: string; type: string }>, primaryType: string, nonce: number,
+): Promise<any> {
+  const signature = await signUserSignedAction(wallet, action, payloadTypes, primaryType);
+  return postExchange({ action, nonce, signature, vaultAddress: null });
+}
+
+// convenience wrappers -------------------------------------------------------
+export async function usdClassTransfer(wallet: ethers.Wallet, amount: string, toPerp: boolean) {
+  const nonce = Date.now();
+  const action: any = { type: "usdClassTransfer", amount, toPerp, nonce };
+  return sendUserSignedAction(wallet, action, USD_CLASS_TRANSFER_SIGN_TYPES, "HyperliquidTransaction:UsdClassTransfer", nonce);
+}
+
+export async function usdSend(wallet: ethers.Wallet, destination: string, amount: string) {
+  const time = Date.now();
+  const action: any = { type: "usdSend", destination, amount, time };
+  return sendUserSignedAction(wallet, action, USD_SEND_SIGN_TYPES, "HyperliquidTransaction:UsdSend", time);
+}
+
+export async function spotBalances(user: string): Promise<Map<string, number>> {
+  const st = await info({ type: "spotClearinghouseState", user });
+  const m = new Map<string, number>();
+  for (const b of st.balances ?? []) m.set(b.coin, parseFloat(b.total));
+  return m;
+}
+
+export async function perpUsdc(user: string): Promise<number> {
+  const st = await info({ type: "clearinghouseState", user });
+  return parseFloat(st.marginSummary.accountValue);
+}
+
+export function fmt(n: number): string { return n.toLocaleString("en-US", { maximumFractionDigits: 8 }); }
+
+// Canonical Hyperliquid wire format for float fields inside L1 actions (px, sz,
+// startPx, orderSz, ...): the server re-canonicalizes these strings before
+// verifying the signature, so "53.0" MUST be sent as "53" (trailing zeros and
+// trailing dot stripped) or the recovered signer is garbage and the exchange
+// replies "User or API Wallet 0x... does not exist". Mirrors the python SDK's
+// float_to_wire. Integer wei amounts (e.g. genesis balances) are exempt.
+export function wire(x: number | string): string {
+  const n = typeof x === "number" ? x : parseFloat(x);
+  if (!isFinite(n)) throw new Error(`bad wire number: ${x}`);
+  let s = n.toFixed(8);
+  if (parseFloat(s) !== n) throw new Error(`wire rounding changed value: ${x}`);
+  s = s.replace(/0+$/, "").replace(/\.$/, "");
+  return s === "-0" ? "0" : s;
+}

--- a/docs/bridge/hyperliquid-ntt-runbook.md
+++ b/docs/bridge/hyperliquid-ntt-runbook.md
@@ -5,9 +5,12 @@ The testnet path that puts **wBTH** on Hyperliquid, covering issue **#876**
 swap demo). This is mostly ops + third-party (Wormhole / Hyperliquid) tooling,
 not core-bridge Rust.
 
-> Status: **DEPLOYED on testnet (2026-07-16, #1026)** — the NTT bridge is live
-> and a Sepolia→HyperEVM round trip is proven. Addresses below. #877 (HIP-1
-> spot) is next.
+> Status: **NTT DEPLOYED on testnet (2026-07-16, #1026)** — the bridge is live
+> and a Sepolia→HyperEVM round trip is proven. Addresses below.
+> **#877 (HIP-1 spot): tooling complete + signing/bridge legs live-verified
+> (2026-07-16), but the deploy is gated on ~500 testnet spot HYPE of auction
+> gas** — the spot-deploy auction is HYPE-denominated, not free (details in
+> the #877 section). Once the deployer is funded, run `hl-10` → `hl-13`.
 
 ## Deployed (testnet, 2026-07-16, #1026)
 
@@ -27,10 +30,11 @@ minted, 1:1. The Sepolia 2-of-3 Safe was **never touched** (locking uses
 `approve` + `transferFrom`, not the mint path). Peered both directions,
 inbound+outbound rate limits set.
 
-**Ops scripts** (`contracts/ethereum/scripts/hl-1..8`, keys read from gitignored
+**Ops scripts** (`contracts/ethereum/scripts/hl-1..13`, keys read from gitignored
 `.secrets/`): 1-3 = HYPE funding via the official HL route (bridge ETH→Arbitrum,
 swap→USDC, deposit to HL mainnet), 4 = forward HYPE to deployer, 5 = deploy
-PeerToken, 6 = set minter, 7 = mint demo wBTH via Safe, 8 = redeem VAA.
+PeerToken, 6 = set minter, 7 = mint demo wBTH via Safe, 8 = redeem VAA,
+9-13 = HIP-1 spot listing + HIP-2 + swap demo (#877 — see below).
 
 **Deploy caveats hit** (for a re-run): Sepolia `add-chain` needs `--skip-verify`
 (no etherscan verifier configured); HyperEVM burning mode does **not** auto-deploy
@@ -142,15 +146,71 @@ a Safe (`ntt transfer-ownership`).
 
 ## #877 — HIP-1 spot listing + swap (chains off #876)
 
-1. **Deploy Spot on HyperCore** via the testnet UI (`/deploySpot`) — irreversible,
-   consumes HyperCore testnet USDC: set `szDecimals`/`weiDecimals` with
-   `szDecimals + 5 <= weiDecimals`; save the **Token Index**; genesis-mint supply
-   to the asset-bridge address `0x2000…0{tokenIndex:4-hex}`; RegisterSpot; deploy
-   Hyperliquidity; trigger genesis.
-2. **Link** HyperCore spot ↔ HyperEVM PeerToken:
-   `ntt hype link --token-index <IDX> --evm-extra-wei-decimals <N>`.
-3. **Bridge + trade:** `ntt hype bridge-in/out`, then a spot order-book swap vs
-   spot USDC (API/SDK), capturing order/fill ids + balances.
+> Scripted end to end (2026-07-16) as `contracts/ethereum/scripts/hl-9..13`
+> with a self-contained exchange-signing library (`hl-lib.ts`, no new deps,
+> golden-tested against hyperliquid-python-sdk + live-verified). **Blocked on
+> deploy gas**: see "The real cost" below.
+
+### The real cost — the auction is HYPE-denominated (the "free testnet deploy" assumption was wrong)
+
+- The HIP-1 spot-deploy Dutch auction runs **once per 31h**, decays linearly to
+  a **500 HYPE floor**, and "gas is deducted from the deployer's **spot HYPE**
+  balance" (testnet deploy-UI text; live probe returns `Insufficient gas at
+  current auction price` with maxGas 501 HYPE and 0 spot HYPE held).
+- Testnet HYPE/USDC (pair `@1035`) trades at **~$32-52 mock USDC**, so 500 HYPE
+  ≈ **16k-26k mock USDC**. An earlier auction cycle today shows a real purchase
+  at ~848 HYPE (startGas 1696.98 = 2×), so testnet deployers do pay this.
+- The faucet (`/drip`) is an **unsigned** info request
+  `{"type":"claimDrip","user":<addr>}` (1000 mock USDC) but is gated on the
+  address **existing on HL mainnet** and rate-limited ("Drip already claimed").
+  Only the ops mainnet EOA `0x8e9043051a39bc87d969c060d5a2fa5f577844f3`
+  qualifies today (it holds ~480 perp + ~322 spot USDC + dust HYPE on testnet).
+
+**Operator gate — fund the deployer `0x111018…` with ≥505 spot HYPE**, any of:
+1. Ask Hyperliquid (Discord builder channel) for testnet HYPE — fastest.
+2. Drip-farm: claim 1000 USDC per cooldown on the mainnet-activated EOA
+   (`hl-9` auto-claims — the claim itself needs no signature), `usdSend` to the
+   deployer (needs the EOA key: `HL_FUNDER_KEYFILE=... HL_FUND_USDC=...`),
+   repeat to ~17k USDC, then `hl-9` buys HYPE at the ask. Multi-day at 1
+   claim/cooldown.
+3. Activate more mainnet addresses (≥5 real USDC deposit each via Bridge2,
+   `hl-3`) to parallelize drip claims.
+
+Also send/keep **≥60 USDC** on the deployer for HIP-2 bid seeding (~20) + the
+swap demo (10 USDC exchange minimum order value — enforced on testnet,
+live-verified) + fees.
+
+### Script sequence (each resumable/idempotent; keys from `.secrets/bridge-testnet/`)
+
+| Script | What it does | Status (2026-07-16) |
+|---|---|---|
+| `hl-lib.ts` | L1-action + user-signed-action signing (msgpack vendored), info/exchange I/O, wire-format canonicalizer | golden vs python SDK: 17/17; live-verified |
+| `hl-lib-selftest.ts` | offline signing self-test (no secrets/network) | PASS |
+| `hl-9-fund-deploy-gas.ts` | EVM HYPE→Core bridge + perp→spot USDC + IOC HYPE buy + shortfall report; optional funder mode (`HL_FUNDER_KEYFILE`) | **ran live**: 3.099 HYPE bridged to Core spot, 16 USDC→spot; shortfall ~497 HYPE |
+| `hl-10-deploy-hip1-wbth.ts` | 5-step HIP-1 deploy: registerToken2 (`HL_CONFIRM=yes`, spends auction gas) → userGenesis 999k WBTH to system addr `0x2000…{idx}` → genesis 1M max (1k residual→HIP-2) → registerSpot vs USDC → registerHyperliquidity (px 1, 100×10 asks, 2 USDC-seeded bids) + 0% deployer fee share | ready; blocked on gas |
+| `hl-11-link-evm-wbth.ts` | `requestEvmContract` (evmExtraWeiDecimals 4) + `finalizeEvmContract` create-nonce-0 proof; verifies via `spotMeta.evmContract` | ready (PeerToken CREATE nonce 0 verified) |
+| `hl-12-bridge-in-wbth.ts` | ERC-20 transfer of HyperEVM wBTH → Core system address, waits for Core credit | ready (mechanism proven live with HYPE by hl-9) |
+| `hl-13-swap-demo.ts` | IOC buy + sell WBTH vs spot USDC on the order book; captures oids/fills/hashes + before/after balances | ready |
+
+Decimals recap: Core `szDecimals 2` / `weiDecimals 8`, PeerToken 12 →
+`evmExtraWeiDecimals 4`; keep every bridged amount a multiple of 1e-8 wBTH or
+the non-round remainder is **burned** on Core↔EVM transfers.
+
+### Hard-won API facts (cost a debugging session each — do not rediscover)
+
+- **Wire-format canonicalization**: the exchange re-canonicalizes float strings
+  in L1 actions before signature verification. Sending `"53.0"` instead of
+  `"53"` makes recovery return a random address and the API replies
+  `User or API Wallet 0x… does not exist`. Use `wire()` from `hl-lib.ts` for
+  every px/sz/startPx/orderSz. (Integer wei strings are exempt.)
+- `spotMetaAndAssetCtxs` ctx entries do **not** align with `universe` order on
+  testnet (ctx `coin:"@907"` ≠ universe `@1035`) — price HYPE off `l2Book` /
+  `candleSnapshot`, not ctxs.
+- `maxGas` in `registerToken2` is in **HYPE wei (8 decimals)** (UI encodes
+  `currentGas.toFixed(8)` × 1e8).
+- 10 USDC minimum order value **is** enforced on testnet spot.
+- Deploy state is resumable via `{"type":"spotDeployState","user":…}` (also
+  exposes the live `gasAuction`).
 
 ## Trust surface (added by NTT)
 
@@ -169,8 +229,10 @@ a Safe (`ntt transfer-ownership`).
 - [ ] HyperEVM **HYPE** gas for the deployer (third-party faucet — Chainstack/
       QuickNode; the official faucet gates on a prior mainnet deposit).
 - [ ] Opt the deployer into **big blocks** before deploying.
-- [ ] (#877) HyperCore testnet **USDC** for Deploy Spot (official faucet, same
-      mainnet-deposit gate) + the irreversible UI flow.
+- [ ] (#877) **≥505 spot HYPE** on the deployer's HyperCore account for the
+      Deploy Spot auction gas (NOT USDC — see the #877 section for options),
+      plus ≥60 USDC for HIP-2 seeding + the swap demo. Everything else is
+      scripted (`hl-9..13`) — no UI flow needed.
 
 ## Sources
 Wormhole NTT: deploy-to-hyperliquid, deploy-to-evm, cli-commands, get-started,


### PR DESCRIPTION
## Summary
Scripts the entire #877 Hyperliquid testnet flow — HIP-1 spot deploy for wBTH, HIP-2 hyperliquidity opt-in, HyperCore↔HyperEVM link to the NTT PeerToken, bridge-in, and an order-book swap demo — on top of a new self-contained exchange-signing library. The live deploy itself is **gated on ~500 testnet spot HYPE of auction gas** (operator sub-issue #1048): the issue's "free testnet deploy" premise turned out to be wrong — the auction is HYPE-denominated (~16k-26k mock USDC at testnet HYPE prices).

This PR intentionally does NOT close #877 (the listing is not live yet); #877 is marked `loom:blocked` on #1048. Once funded, `hl-10`→`hl-13` complete the acceptance and close it.

## Changes
- `contracts/ethereum/scripts/hl-lib.ts` — Hyperliquid testnet signing/API library: vendored minimal msgpack, L1-action hashing + phantom-agent EIP-712 signing, user-signed actions (usdSend/usdClassTransfer), wire-format canonicalizer, info/exchange I/O, shared constants. No new npm dependencies.
- `contracts/ethereum/scripts/hl-lib-selftest.ts` — offline golden test (17 checks) against vectors generated with hyperliquid-python-sdk.
- `contracts/ethereum/scripts/hl-9-fund-deploy-gas.ts` — deploy-gas funding: HyperEVM HYPE→Core system-address bridge, perp→spot USDC, IOC HYPE buy, optional funder mode (unsigned claimDrip + usdSend); reports shortfall.
- `contracts/ethereum/scripts/hl-10-deploy-hip1-wbth.ts` — resumable 5-step HIP-1 deploy: registerToken2 (HL_CONFIRM gate) → userGenesis 999k WBTH to the asset-bridge address 0x2000…{idx} → genesis (1M max, 1k residual → HIP-2) → registerSpot vs USDC → registerHyperliquidity (anchor 1.0, 100×10 asks, 2 USDC-seeded bids) + 0% deployer fee share.
- `contracts/ethereum/scripts/hl-11-link-evm-wbth.ts` — requestEvmContract + finalizeEvmContract (CREATE-nonce-0 proof, evmExtraWeiDecimals 4 for the 12-dec PeerToken vs 8-dec Core token), verifies via spotMeta.
- `contracts/ethereum/scripts/hl-12-bridge-in-wbth.ts` — HyperEVM wBTH → HyperCore spot (ERC-20 transfer to the system address, waits for the Core credit, rejects non-8-decimal-aligned amounts that would burn).
- `contracts/ethereum/scripts/hl-13-swap-demo.ts` — IOC buy + sell WBTH vs spot USDC, captures oids/fills/tx hashes and before/after balances.
- `docs/bridge/hyperliquid-ntt-runbook.md` — #877 section rewritten with the real auction economics, the operator funding gate, the script sequence, and hard-won API facts (wire-format signature-recovery gotcha, misaligned testnet ctxs, maxGas units, 10 USDC min notional).

## Acceptance Criteria Verification

The #877 acceptance ("wBTH live as HIP-1 spot asset…") cannot be met without the operator-funded deploy gas, so this PR delivers the scriptable maximum and #877 stays open/blocked:

| Criterion | Status | Verification |
|-----------|--------|--------------|
| HIP-1 deploy scripted with valid szDecimals/weiDecimals + token index capture | ✅ (blocked live) | hl-10 implements the documented 5-step sequence; szDecimals 2 + 5 ≤ weiDecimals 8; live registerToken2 probe reached the real gas check (`Insufficient gas at current auction price`) proving action + signature validity |
| Link HIP-1 ↔ HyperEVM wBTH ERC-20 | ✅ (script ready) | hl-11; CREATE nonce 0 for the PeerToken verified on-chain via ethers.getCreateAddress; decimal mapping 12 = 8 + 4 verified against `decimals()` |
| HIP-2 liquidity opt-in | ✅ (script ready) | hl-10 step 5 (registerHyperliquidity, 1k WBTH residual, seeded bids); manual-seeding fallback unnecessary |
| Order-book swap demo w/ fill ids + balances | ✅ (script ready; order path live-verified) | hl-13; live order placement E2E-verified on the HYPE/USDC book (correct signer recovery, min-notional + IOC semantics observed) |
| Runbook documentation | ✅ | runbook §#877 rewritten (token-index recording, commands, costs, gotchas) |

## Test Plan
- `tsc --noEmit --strict` over all 7 scripts: clean.
- `hl-lib-selftest.ts`: 17/17 PASS (action hashes + signatures byte-identical to hyperliquid-python-sdk golden vectors; wire canonicalization; system-address derivation vs docs example).
- Live on Hyperliquid testnet with the testnet deployer key (mainnet keys untouched):
  - `usdClassTransfer` executed (perp→spot USDC observed on-chain),
  - order placement verified end-to-end (correct signature recovery; testnet enforces the 10 USDC min order value; non-crossing IOC correctly canceled),
  - `hl-9` ran live: bridged 3.099 HYPE HyperEVM→HyperCore via the 0x2222…2222 system address (tx 0x1d083ecbcdb9dc8925f91704a1cbc529cb9de0c5c7b41021e8b9fc11b99c0b7d) — the same mechanism hl-12 uses for wBTH — and correctly reported the ~497 HYPE shortfall.

Part of #877 (does not close it). Blocked continuation tracked in #1048.