### PR TITLE
feat(bridge+web): public bridge stats endpoint + bridge-activity card on /network

### DIFF
--- a/bridge/service/src/db.rs
+++ b/bridge/service/src/db.rs
@@ -142,6 +142,31 @@ pub struct ReleaseIntent {
     pub expires_at: i64,
 }
 
+/// Count + gross volume (picocredits) for one activity bucket (#1054).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ActivityAggregate {
+    /// Number of orders in the bucket.
+    pub count: u64,
+    /// Sum of gross order amounts, picocredits.
+    pub volume: u64,
+}
+
+/// Wrap/unwrap activity aggregates for one order type over one window
+/// (#1054). Produced by [`Database::aggregate_order_activity`]; buckets are
+/// disjoint and cover every order of the type, so the bucket sums equal the
+/// window total.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ActivityBreakdown {
+    /// Settled orders (`completed` mints / `released` burns).
+    pub completed: ActivityAggregate,
+    /// In-flight orders (every non-terminal status).
+    pub pending: ActivityAggregate,
+    /// Orders that timed out.
+    pub expired: ActivityAggregate,
+    /// Terminal failures.
+    pub failed: ActivityAggregate,
+}
+
 /// A row in the `reserve_ledger` table (#825).
 ///
 /// The locked BTH reserve is derived from bridge-controlled outputs, never
@@ -703,6 +728,70 @@ impl Database {
             )
             .map_err(|e| format!("Count failed: {}", e))?;
         Ok(count.max(0) as u64)
+    }
+
+    /// Aggregate wrap/unwrap activity for one order type (#1054).
+    ///
+    /// Backs the public `GET /api/bridge/stats` endpoint: counts and gross
+    /// BTH volumes (picocredits, `SUM(amount)`) over `bridge_orders` rows of
+    /// `order_type`, bucketed by outcome:
+    ///
+    /// * `completed` — settled orders (`completed` for mints, `released` for
+    ///   burns; both strings map here so either type aggregates correctly).
+    /// * `expired`   — orders that timed out (`expired`).
+    /// * `failed`    — terminal failures (stored as `failed: <reason>`).
+    /// * `pending`   — every other (in-flight) status.
+    ///
+    /// `since` bounds the window: only rows with `created_at >= since` count
+    /// (INCLUSIVE edge — an order created exactly at the cutoff is in the
+    /// window). Pass `None` for all-time.
+    ///
+    /// AGGREGATES ONLY: no per-order field leaves this query, so the result
+    /// is safe for the unauthenticated public surface (#1042 scope rules).
+    pub fn aggregate_order_activity(
+        &self,
+        order_type: OrderType,
+        since: Option<i64>,
+    ) -> Result<ActivityBreakdown, String> {
+        let conn = self.conn.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT status, COUNT(*), COALESCE(SUM(amount), 0)
+                FROM bridge_orders
+                WHERE order_type = ?1 AND created_at >= ?2
+                GROUP BY status
+                "#,
+            )
+            .map_err(|e| format!("Prepare failed: {}", e))?;
+
+        let rows = stmt
+            .query_map(
+                params![order_type.to_string(), since.unwrap_or(i64::MIN)],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
+            )
+            .map_err(|e| format!("Query failed: {}", e))?;
+
+        let mut breakdown = ActivityBreakdown::default();
+        for row in rows {
+            let (status, count, volume) = row.map_err(|e| format!("Row failed: {}", e))?;
+            let bucket = match status.as_str() {
+                "completed" | "released" => &mut breakdown.completed,
+                "expired" => &mut breakdown.expired,
+                // Stored as `failed: <reason>` (OrderStatus::Display).
+                s if s.starts_with("failed") => &mut breakdown.failed,
+                _ => &mut breakdown.pending,
+            };
+            bucket.count = bucket.count.saturating_add(count.max(0) as u64);
+            bucket.volume = bucket.volume.saturating_add(volume.max(0) as u64);
+        }
+        Ok(breakdown)
     }
 
     /// Delete EXPIRED mint orders that never saw a deposit, once they are
@@ -3516,5 +3605,138 @@ mod tests {
         assert_eq!(db.prune_expired_release_intents(1_000).unwrap(), 1);
         assert!(db.get_release_intent(&stale.id).unwrap().is_none());
         assert!(db.get_release_intent(&live.id).unwrap().is_some());
+    }
+
+    /// Build a mint order with a forced status + creation time (bypassing
+    /// the state machine — these rows exercise the aggregation SQL only).
+    fn mint_at(amount: u64, status: OrderStatus, created: i64) -> BridgeOrder {
+        let mut o = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            amount,
+            1,
+            "bth_reserve".to_string(),
+            "0xdest".to_string(),
+        );
+        o.status = status;
+        o.created_at = Utc.timestamp_opt(created, 0).unwrap();
+        o
+    }
+
+    /// Build a burn order with a forced status + creation time.
+    fn burn_at(amount: u64, status: OrderStatus, created: i64) -> BridgeOrder {
+        let mut o = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            amount,
+            1,
+            "0xsource".to_string(),
+            "bth_dest".to_string(),
+            format!("0xburntx-{}", Uuid::new_v4()),
+        );
+        o.status = status;
+        o.created_at = Utc.timestamp_opt(created, 0).unwrap();
+        o
+    }
+
+    #[test]
+    fn test_aggregate_order_activity_buckets_mint_orders() {
+        // #1054: the wrap-side aggregation buckets by outcome and applies
+        // the window edge INCLUSIVELY on created_at.
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let now = Utc::now().timestamp();
+        let cutoff = now - 86_400;
+
+        // In-window: one of each bucket.
+        db.insert_order(&mint_at(100, OrderStatus::Completed, now - 10))
+            .unwrap();
+        db.insert_order(&mint_at(200, OrderStatus::AwaitingDeposit, now - 10))
+            .unwrap();
+        db.insert_order(&mint_at(300, OrderStatus::MintPending, now - 10))
+            .unwrap();
+        db.insert_order(&mint_at(400, OrderStatus::Expired, now - 10))
+            .unwrap();
+        db.insert_order(&mint_at(
+            500,
+            OrderStatus::Failed {
+                reason: "boom".to_string(),
+            },
+            now - 10,
+        ))
+        .unwrap();
+        // Window edge: created exactly AT the cutoff is IN the window...
+        db.insert_order(&mint_at(1_000, OrderStatus::Completed, cutoff))
+            .unwrap();
+        // ...one second earlier is all-time only.
+        db.insert_order(&mint_at(10_000, OrderStatus::Completed, cutoff - 1))
+            .unwrap();
+
+        let day = db
+            .aggregate_order_activity(OrderType::Mint, Some(cutoff))
+            .unwrap();
+        assert_eq!(day.completed.count, 2, "in-window + exact-cutoff order");
+        assert_eq!(day.completed.volume, 1_100);
+        assert_eq!(day.pending.count, 2, "awaiting_deposit + mint_pending");
+        assert_eq!(day.pending.volume, 500);
+        assert_eq!(day.expired.count, 1);
+        assert_eq!(day.expired.volume, 400);
+        assert_eq!(day.failed.count, 1);
+        assert_eq!(day.failed.volume, 500);
+
+        let all = db.aggregate_order_activity(OrderType::Mint, None).unwrap();
+        assert_eq!(all.completed.count, 3, "pre-cutoff order counts all-time");
+        assert_eq!(all.completed.volume, 11_100);
+        assert_eq!(all.pending, day.pending);
+        assert_eq!(all.expired, day.expired);
+        assert_eq!(all.failed, day.failed);
+    }
+
+    #[test]
+    fn test_aggregate_order_activity_buckets_burn_orders_separately() {
+        // #1054: unwraps aggregate over BURN orders only — `released` is
+        // their settled bucket — and never bleed into the mint side.
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+
+        let now = Utc::now().timestamp();
+        let cutoff = now - 86_400;
+
+        db.insert_order(&burn_at(700, OrderStatus::Released, now - 10))
+            .unwrap();
+        db.insert_order(&burn_at(800, OrderStatus::BurnConfirmed, now - 10))
+            .unwrap();
+        db.insert_order(&burn_at(900, OrderStatus::Released, cutoff - 1))
+            .unwrap();
+        // A completed MINT order must not appear in the burn aggregate.
+        db.insert_order(&mint_at(100, OrderStatus::Completed, now - 10))
+            .unwrap();
+
+        let day = db
+            .aggregate_order_activity(OrderType::Burn, Some(cutoff))
+            .unwrap();
+        assert_eq!(day.completed.count, 1);
+        assert_eq!(day.completed.volume, 700);
+        assert_eq!(day.pending.count, 1);
+        assert_eq!(day.pending.volume, 800);
+        assert_eq!(day.expired, ActivityAggregate::default());
+        assert_eq!(day.failed, ActivityAggregate::default());
+
+        let all = db.aggregate_order_activity(OrderType::Burn, None).unwrap();
+        assert_eq!(all.completed.count, 2);
+        assert_eq!(all.completed.volume, 1_600);
+
+        // And the mint aggregate sees only the mint order.
+        let mint_all = db.aggregate_order_activity(OrderType::Mint, None).unwrap();
+        assert_eq!(mint_all.completed.count, 1);
+        assert_eq!(mint_all.completed.volume, 100);
+        assert_eq!(mint_all.pending, ActivityAggregate::default());
+    }
+
+    #[test]
+    fn test_aggregate_order_activity_empty_db_is_all_zero() {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        let empty = db.aggregate_order_activity(OrderType::Mint, None).unwrap();
+        assert_eq!(empty, ActivityBreakdown::default());
     }
 }

--- a/bridge/service/src/public_api.rs
+++ b/bridge/service/src/public_api.rs
@@ -19,6 +19,7 @@
 //!   - `GET  /api/bridge/orders/{id}`         → mint order status
 //!   - `POST /api/bridge/release-orders`      → register an unwrap intent
 //!   - `GET  /api/bridge/release-orders/{id}` → release order status
+//!   - `GET  /api/bridge/stats`               → aggregate wrap/unwrap activity
 //!   - `GET  /health`                         → static liveness (leaks nothing)
 //!
 //! There is deliberately no code path from this router to the breaker, the
@@ -88,7 +89,7 @@ use tokio::sync::broadcast;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::db::{Database, ReleaseIntent};
+use crate::db::{ActivityAggregate, ActivityBreakdown, Database, ReleaseIntent};
 
 /// Runtime configuration snapshot for the public order API, derived from
 /// [`BridgeConfig`] at startup. Held behind an `Arc` in [`PublicApiState`].
@@ -161,6 +162,13 @@ impl PublicApiConfig {
     }
 }
 
+/// How long a computed `/api/bridge/stats` aggregate is served from memory
+/// before the orders DB is queried again (#1054). Polling clients therefore
+/// cannot use the endpoint to hammer the DB — at most one aggregation pass
+/// per TTL regardless of request rate (the per-IP limiter still applies on
+/// top).
+const STATS_CACHE_TTL: Duration = Duration::from_secs(30);
+
 /// Shared state of the public API router.
 #[derive(Clone)]
 pub struct PublicApiState {
@@ -170,6 +178,8 @@ pub struct PublicApiState {
     cfg: Arc<PublicApiConfig>,
     /// Per-IP fixed-window rate limiter.
     limiter: Arc<RateLimiter>,
+    /// Cached `/api/bridge/stats` aggregate + when it was computed (#1054).
+    stats_cache: Arc<Mutex<Option<(Instant, BridgeStatsResponse)>>>,
 }
 
 impl PublicApiState {
@@ -179,6 +189,7 @@ impl PublicApiState {
             db,
             cfg: Arc::new(cfg),
             limiter: Arc::new(RateLimiter::new()),
+            stats_cache: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -314,6 +325,74 @@ struct ReleaseOrderResponse {
     expires_at: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     failure_reason: Option<String>,
+}
+
+/// One `/api/bridge/stats` bucket: order count + gross BTH volume (#1054).
+/// The volume is a picocredit decimal STRING (u64-safe across JSON), matching
+/// the amount convention of every other public-API response.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatsAggregate {
+    count: u64,
+    volume: String,
+}
+
+impl From<ActivityAggregate> for StatsAggregate {
+    fn from(a: ActivityAggregate) -> Self {
+        Self {
+            count: a.count,
+            volume: a.volume.to_string(),
+        }
+    }
+}
+
+/// Per-window outcome split. Buckets are disjoint and cover every order of
+/// the side/window, so they sum to the window total.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatsWindow {
+    completed: StatsAggregate,
+    pending: StatsAggregate,
+    expired: StatsAggregate,
+    failed: StatsAggregate,
+}
+
+impl From<ActivityBreakdown> for StatsWindow {
+    fn from(b: ActivityBreakdown) -> Self {
+        Self {
+            completed: b.completed.into(),
+            pending: b.pending.into(),
+            expired: b.expired.into(),
+            failed: b.failed.into(),
+        }
+    }
+}
+
+/// One side of the bridge (wraps = mint orders, unwraps = burn orders) over
+/// both reporting windows.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StatsSide {
+    last_24h: StatsWindow,
+    all_time: StatsWindow,
+}
+
+/// `GET /api/bridge/stats` response (#1054). Field names match
+/// `web/packages/features/src/bridge/types.ts` (`BridgeStats`).
+///
+/// Information-exposure scope (#1042): AGGREGATES ONLY — counts and summed
+/// volumes, all derivable from public on-chain activity. No per-order detail,
+/// no addresses, no ops state may ever be added here.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BridgeStatsResponse {
+    /// When the aggregate was computed (unix seconds); with the cache TTL
+    /// this may lag "now" by up to [`STATS_CACHE_TTL`].
+    generated_at: i64,
+    /// BTH → wBTH exports (mint orders).
+    wraps: StatsSide,
+    /// wBTH → BTH releases (burn orders).
+    unwraps: StatsSide,
 }
 
 /// Error envelope; the web client surfaces `error` verbatim.
@@ -785,6 +864,89 @@ async fn get_release_order(
     }
 }
 
+/// `GET /api/bridge/stats`: aggregate wrap/unwrap activity (#1054).
+///
+/// Serves counts + gross BTH volumes for mint (wrap) and burn (unwrap)
+/// orders, split completed/pending/expired/failed over a 24-hour and an
+/// all-time window. The aggregate is cached for [`STATS_CACHE_TTL`] so the
+/// endpoint cannot be used to hammer the orders DB, and it sits behind the
+/// same per-IP limiter as the status polls.
+///
+/// Information-exposure scope (#1042): aggregates only — every number here
+/// is derivable from public on-chain data (deposits, mints, burns, releases
+/// are all public on their chains). Never add per-order detail, addresses,
+/// or ops state to this response.
+async fn get_bridge_stats(
+    State(state): State<PublicApiState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+) -> Response {
+    if !state
+        .limiter
+        .check(&rl_key(peer, "get"), state.cfg.rate_limit_per_min)
+    {
+        return err(
+            StatusCode::TOO_MANY_REQUESTS,
+            "rate limit exceeded; retry shortly",
+        );
+    }
+
+    // Serve from the cache while fresh.
+    {
+        let cache = state
+            .stats_cache
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Some((computed_at, cached)) = cache.as_ref() {
+            if computed_at.elapsed() < STATS_CACHE_TTL {
+                return (StatusCode::OK, Json(cached.clone())).into_response();
+            }
+        }
+    }
+
+    let now = Utc::now().timestamp();
+    let day_ago = now - 24 * 3600;
+    let compute = || -> Result<BridgeStatsResponse, String> {
+        Ok(BridgeStatsResponse {
+            generated_at: now,
+            wraps: StatsSide {
+                last_24h: state
+                    .db
+                    .aggregate_order_activity(OrderType::Mint, Some(day_ago))?
+                    .into(),
+                all_time: state
+                    .db
+                    .aggregate_order_activity(OrderType::Mint, None)?
+                    .into(),
+            },
+            unwraps: StatsSide {
+                last_24h: state
+                    .db
+                    .aggregate_order_activity(OrderType::Burn, Some(day_ago))?
+                    .into(),
+                all_time: state
+                    .db
+                    .aggregate_order_activity(OrderType::Burn, None)?
+                    .into(),
+            },
+        })
+    };
+
+    match compute() {
+        Ok(stats) => {
+            let mut cache = state
+                .stats_cache
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            *cache = Some((Instant::now(), stats.clone()));
+            (StatusCode::OK, Json(stats)).into_response()
+        }
+        Err(e) => {
+            warn!("public api: bridge stats aggregation failed: {}", e);
+            err(StatusCode::INTERNAL_SERVER_ERROR, "stats unavailable")
+        }
+    }
+}
+
 // ─────────────────────────────────── CORS ──────────────────────────────────
 
 /// Exact-match CORS middleware. Reflects the request `Origin` back only when it
@@ -847,6 +1009,7 @@ pub fn public_router(state: PublicApiState) -> Router {
         .route("/api/bridge/orders/:id", get(get_mint_order))
         .route("/api/bridge/release-orders", post(create_release_order))
         .route("/api/bridge/release-orders/:id", get(get_release_order))
+        .route("/api/bridge/stats", get(get_bridge_stats))
         .layer(DefaultBodyLimit::max(max_body))
         .layer(middleware::from_fn_with_state(cors_cfg, cors_mw))
         .with_state(state)
@@ -1366,6 +1529,115 @@ mod tests {
         .await;
         assert_eq!(status, 503, "intent create past the global cap refused");
         assert!(resp.contains("backlog"), "{}", resp);
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_bridge_stats_aggregates_both_sides() {
+        // #1054: /api/bridge/stats reports wrap (mint) and unwrap (burn)
+        // counts + volumes split by outcome over 24h and all-time windows —
+        // aggregates only, no per-order detail.
+        let (state, db) = test_state();
+
+        // Wrap side: one completed, one pending (awaiting deposit), plus a
+        // completed order OUTSIDE the 24h window.
+        let mut done = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000,
+            1,
+            "bth_reserve_deposit_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        done.status = OrderStatus::Completed;
+        db.insert_order(&done).unwrap();
+
+        let pending = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            2_000,
+            1,
+            "bth_reserve_deposit_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        db.insert_order(&pending).unwrap();
+
+        let mut old = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            4_000,
+            1,
+            "bth_reserve_deposit_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        old.status = OrderStatus::Completed;
+        old.created_at = Utc::now() - chrono::Duration::days(2);
+        db.insert_order(&old).unwrap();
+
+        // Unwrap side: one released burn order.
+        let mut burn = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            500,
+            1,
+            "0xsource".to_string(),
+            test_bth_address(),
+            "0xburntx".to_string(),
+        );
+        burn.status = OrderStatus::Released;
+        db.insert_order(&burn).unwrap();
+
+        let (addr, shutdown_tx, server) = spawn_public_server(state).await;
+        let (status, resp) = http_request(addr, "GET", "/api/bridge/stats", None, None).await;
+        assert_eq!(status, 200, "{}", resp);
+        let json: serde_json::Value = serde_json::from_str(&resp).unwrap();
+
+        assert_eq!(json["wraps"]["last24h"]["completed"]["count"], 1);
+        assert_eq!(json["wraps"]["last24h"]["completed"]["volume"], "1000");
+        assert_eq!(json["wraps"]["last24h"]["pending"]["count"], 1);
+        assert_eq!(json["wraps"]["last24h"]["pending"]["volume"], "2000");
+        assert_eq!(json["wraps"]["allTime"]["completed"]["count"], 2);
+        assert_eq!(json["wraps"]["allTime"]["completed"]["volume"], "5000");
+        assert_eq!(json["unwraps"]["last24h"]["completed"]["count"], 1);
+        assert_eq!(json["unwraps"]["last24h"]["completed"]["volume"], "500");
+        assert_eq!(json["unwraps"]["allTime"]["completed"]["count"], 1);
+        assert!(json["generatedAt"].as_i64().unwrap() > 0);
+
+        // Aggregates-only invariant: no order ids, addresses, memos, or tx
+        // hashes anywhere in the response body.
+        assert!(!resp.contains(&done.id.to_string()), "{}", resp);
+        assert!(!resp.contains("bth_reserve_deposit_addr"), "{}", resp);
+        assert!(!resp.contains("0xburntx"), "{}", resp);
+
+        let _ = shutdown_tx.send(());
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_bridge_stats_is_cached() {
+        // #1054: within the cache TTL the endpoint serves the memoized
+        // aggregate instead of re-querying the DB — new orders do not appear
+        // until the TTL lapses, so polling cannot hammer the DB.
+        let (state, db) = test_state();
+        let (addr, shutdown_tx, server) = spawn_public_server(state).await;
+
+        let (status, first) = http_request(addr, "GET", "/api/bridge/stats", None, None).await;
+        assert_eq!(status, 200, "{}", first);
+        let json: serde_json::Value = serde_json::from_str(&first).unwrap();
+        assert_eq!(json["wraps"]["allTime"]["completed"]["count"], 0);
+
+        // A new completed order lands after the first (cached) computation.
+        let mut done = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000,
+            1,
+            "bth_reserve_deposit_addr".to_string(),
+            "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+        );
+        done.status = OrderStatus::Completed;
+        db.insert_order(&done).unwrap();
+
+        let (status, second) = http_request(addr, "GET", "/api/bridge/stats", None, None).await;
+        assert_eq!(status, 200, "{}", second);
+        assert_eq!(first, second, "cached response must be served verbatim");
 
         let _ = shutdown_tx.send(());
         server.await.unwrap();

--- a/web/packages/features/src/bridge/bridge-client.test.ts
+++ b/web/packages/features/src/bridge/bridge-client.test.ts
@@ -118,3 +118,26 @@ describe('createBridgeClient — release orders (#1032)', () => {
     expect(url).toBe(`https://bridge.test/api/bridge/release-orders/${RELEASE.id}`)
   })
 })
+
+describe('createBridgeClient — bridge stats (#1054)', () => {
+  it('GETs the aggregate stats from the normalized base', async () => {
+    const zero = { count: 0, volume: '0' }
+    const window = { completed: zero, pending: zero, expired: zero, failed: zero }
+    const STATS = {
+      generatedAt: 1_760_000_000,
+      wraps: {
+        last24h: { ...window, completed: { count: 2, volume: '5000000000000' } },
+        allTime: window,
+      },
+      unwraps: { last24h: window, allTime: window },
+    }
+    const fetchImpl = vi.fn(async () => jsonResponse(STATS))
+    const client = createBridgeClient('https://bridge.test/', fetchImpl as unknown as typeof fetch)
+
+    const stats = await client.getBridgeStats()
+
+    expect(stats).toEqual(STATS)
+    const [url] = fetchImpl.mock.calls[0] as unknown as [string]
+    expect(url).toBe('https://bridge.test/api/bridge/stats')
+  })
+})

--- a/web/packages/features/src/bridge/bridge-client.ts
+++ b/web/packages/features/src/bridge/bridge-client.ts
@@ -30,6 +30,7 @@
  * state — they never silently pretend to work.
  */
 import type {
+  BridgeStats,
   CreateMintOrderRequest,
   CreateReleaseOrderRequest,
   MintOrder,
@@ -57,6 +58,8 @@ export interface BridgeClient {
   createReleaseOrder(req: CreateReleaseOrderRequest): Promise<ReleaseOrder>
   /** Fetch the latest state of a release order by id. */
   getReleaseOrderStatus(id: string): Promise<ReleaseOrder>
+  /** Fetch aggregate wrap/unwrap activity (#1054; server-cached ~30 s). */
+  getBridgeStats(): Promise<BridgeStats>
 }
 
 /** Strip a single trailing slash so `${base}/api/...` never doubles up. */
@@ -132,6 +135,11 @@ export function createBridgeClient(
         `${base}/api/bridge/release-orders/${encodeURIComponent(id)}`,
       )
       return (await parseJson(res)) as ReleaseOrder
+    },
+
+    async getBridgeStats(): Promise<BridgeStats> {
+      const res = await fetchImpl(`${base}/api/bridge/stats`)
+      return (await parseJson(res)) as BridgeStats
     },
   }
 }

--- a/web/packages/features/src/bridge/hooks.ts
+++ b/web/packages/features/src/bridge/hooks.ts
@@ -1,6 +1,12 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { ACTIVE_BRIDGE_NETWORK, getVenues } from './venues'
-import type { BridgeNetwork, Venue } from './types'
+import type {
+  BridgeNetwork,
+  BridgeStats,
+  BridgeStatsClientLike,
+  BridgeStatsState,
+  Venue,
+} from './types'
 
 /**
  * Bridge feature hooks (#1030), mirroring `network/hooks.ts`.
@@ -23,4 +29,65 @@ export function useBridgeVenues(
 ): UseBridgeVenuesResult {
   const venues = useMemo(() => getVenues(network), [network])
   return { venues, network }
+}
+
+export interface UseBridgeStatsOptions {
+  /** Stats refresh cadence in ms. The server caches the aggregate for ~30 s,
+   * so polling faster than that only re-reads the cache. */
+  refreshMs?: number
+}
+
+export interface UseBridgeStatsResult {
+  /** Latest aggregate, or null until the first successful poll. */
+  stats: BridgeStats | null
+  /** Discriminated fetch outcome (see {@link BridgeStatsState}). */
+  state: BridgeStatsState
+}
+
+/**
+ * Poll aggregate wrap/unwrap activity from the public bridge order API
+ * (#1054), mirroring `network/hooks.ts`'s `useReserveProof` poll +
+ * `cancelled` cleanup structure.
+ *
+ * `client === null` means no public bridge API is configured
+ * (`VITE_BRIDGE_API_BASE` unset — it is disabled by default on nodes); that
+ * maps to `absent`, the "hide the card" case. A configured-but-unreachable
+ * endpoint (network error / non-OK) maps to `unavailable` — the card renders
+ * a grayed placeholder and never fabricates values (#541 lesson).
+ */
+export function useBridgeStats(
+  client: BridgeStatsClientLike | null,
+  { refreshMs = 60_000 }: UseBridgeStatsOptions = {},
+): UseBridgeStatsResult {
+  const [stats, setStats] = useState<BridgeStats | null>(null)
+  const [state, setState] = useState<BridgeStatsState>(
+    client === null ? 'absent' : 'unavailable',
+  )
+
+  useEffect(() => {
+    if (client === null) {
+      setStats(null)
+      setState('absent')
+      return
+    }
+    let cancelled = false
+    const load = async () => {
+      try {
+        const data = await client.getBridgeStats()
+        if (cancelled) return
+        setStats(data)
+        setState('ok')
+      } catch {
+        if (!cancelled) setState('unavailable')
+      }
+    }
+    load()
+    const id = setInterval(load, refreshMs)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [client, refreshMs])
+
+  return { stats, state }
 }

--- a/web/packages/features/src/bridge/types.ts
+++ b/web/packages/features/src/bridge/types.ts
@@ -316,6 +316,74 @@ export interface UnwrapController {
   requestWallet?: () => void
 }
 
+// ─── Bridge activity stats (#1054) ──────────────────────────────────────────
+
+/**
+ * One `GET /api/bridge/stats` bucket: order count + gross BTH volume. The
+ * volume is a picocredit decimal STRING (u64-safe across JSON), matching the
+ * amount convention of every other bridge response.
+ */
+export interface BridgeStatsAggregate {
+  /** Number of orders in the bucket. */
+  count: number
+  /** Sum of gross order amounts, picocredits (string). */
+  volume: string
+}
+
+/**
+ * Per-window outcome split. Buckets are disjoint and cover every order of the
+ * side/window, so they sum to the window total.
+ */
+export interface BridgeStatsWindow {
+  /** Settled orders (`completed` mints / `released` burns). */
+  completed: BridgeStatsAggregate
+  /** In-flight orders (every non-terminal status). */
+  pending: BridgeStatsAggregate
+  /** Orders that timed out. */
+  expired: BridgeStatsAggregate
+  /** Terminal failures. */
+  failed: BridgeStatsAggregate
+}
+
+/** One side of the bridge over both reporting windows. */
+export interface BridgeStatsSide {
+  last24h: BridgeStatsWindow
+  allTime: BridgeStatsWindow
+}
+
+/**
+ * Aggregate wrap/unwrap activity as returned by the public bridge API's
+ * `GET /api/bridge/stats` (#1054). Field names match the Rust
+ * `BridgeStatsResponse` (`bridge/service/src/public_api.rs`). Aggregates
+ * only — the endpoint never serves per-order detail.
+ */
+export interface BridgeStats {
+  /** When the aggregate was computed (unix seconds; server-cached 30 s). */
+  generatedAt: number
+  /** BTH → wBTH exports (mint orders). */
+  wraps: BridgeStatsSide
+  /** wBTH → BTH releases (burn orders). */
+  unwraps: BridgeStatsSide
+}
+
+/**
+ * Structural subset of `BridgeClient` for the stats side. Declared here so
+ * `types.ts` stays dependency-free; the concrete client satisfies it.
+ */
+export interface BridgeStatsClientLike {
+  getBridgeStats(): Promise<BridgeStats>
+}
+
+/**
+ * Bridge-stats fetch outcome, mirroring `ReserveProofState` in `network/`:
+ * - `ok`          — `stats` holds a live aggregate.
+ * - `absent`      — no public bridge API is configured (client is `null`);
+ *   hide the card entirely.
+ * - `unavailable` — an endpoint is configured but unreachable/erroring;
+ *   render a grayed placeholder, never fabricated values (#541 lesson).
+ */
+export type BridgeStatsState = 'ok' | 'absent' | 'unavailable'
+
 /** Wallet fields the unwrap panel reads (no secrets, no signing keys). */
 export interface UnwrapWalletState {
   /** Whether a wallet exists in this browser. */

--- a/web/packages/features/src/network/components/bridge-activity-card.test.tsx
+++ b/web/packages/features/src/network/components/bridge-activity-card.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Bridge activity card contract (#1054): renders wrap/unwrap settled volumes
+ * + counts per window when stats are live; an `absent` state (no public
+ * bridge API configured — the default for nodes) renders NOTHING; an
+ * `unavailable` state (configured but unreachable) degrades to a grayed
+ * placeholder without fabricating values (#541 lesson).
+ */
+import { describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { BridgeActivityCard } from './bridge-activity-card'
+import type { BridgeStats, BridgeStatsWindow, Translate } from '../../bridge/types'
+
+// Passthrough translator: returns the key (plus interpolations for the
+// summary line) so assertions are locale-independent.
+const t: Translate = (key, options) => {
+  if (key === 'stats.bucketSummary' && options) {
+    return `${String(options.completed)} completed · ${String(options.pending)} pending`
+  }
+  return key
+}
+
+function mkWindow(over: Partial<BridgeStatsWindow> = {}): BridgeStatsWindow {
+  const zero = { count: 0, volume: '0' }
+  return { completed: zero, pending: zero, expired: zero, failed: zero, ...over }
+}
+
+function stats(): BridgeStats {
+  return {
+    generatedAt: Math.floor(Date.now() / 1000),
+    wraps: {
+      // 5 BTH settled today across 2 wraps, 1 more in flight.
+      last24h: mkWindow({
+        completed: { count: 2, volume: '5000000000000' },
+        pending: { count: 1, volume: '1000000000000' },
+      }),
+      // 123 BTH settled all-time.
+      allTime: mkWindow({ completed: { count: 7, volume: '123000000000000' } }),
+    },
+    unwraps: {
+      last24h: mkWindow({ completed: { count: 1, volume: '2000000000000' } }),
+      allTime: mkWindow({ completed: { count: 3, volume: '9000000000000' } }),
+    },
+  }
+}
+
+describe('BridgeActivityCard', () => {
+  it('renders settled volumes and counts for all four windows', () => {
+    cleanup()
+    render(<BridgeActivityCard stats={stats()} state="ok" t={t} />)
+
+    expect(screen.getByText('stats.title')).toBeDefined()
+    expect(screen.getByText('stats.wraps24h')).toBeDefined()
+    expect(screen.getByText('stats.wrapsAllTime')).toBeDefined()
+    expect(screen.getByText('stats.unwraps24h')).toBeDefined()
+    expect(screen.getByText('stats.unwrapsAllTime')).toBeDefined()
+
+    // Volumes are u64 picocredit strings formatted via BigInt.
+    expect(screen.getByText(/5\.00 BTH/)).toBeDefined()
+    expect(screen.getByText(/123\.00 BTH/)).toBeDefined()
+    expect(screen.getByText(/2\.00 BTH/)).toBeDefined()
+    expect(screen.getByText(/9\.00 BTH/)).toBeDefined()
+
+    // Counts surface in the per-window summary line.
+    expect(screen.getByText('2 completed · 1 pending')).toBeDefined()
+    expect(screen.getByText('7 completed · 0 pending')).toBeDefined()
+  })
+
+  it('renders NOTHING when the public bridge API is not configured (absent)', () => {
+    cleanup()
+    const { container } = render(<BridgeActivityCard stats={null} state="absent" t={t} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('degrades to an unavailable placeholder without fabricating values', () => {
+    cleanup()
+    render(<BridgeActivityCard stats={null} state="unavailable" t={t} />)
+    expect(screen.getByText('stats.title')).toBeDefined()
+    expect(screen.getByText('stats.unavailable')).toBeDefined()
+    // No fabricated zero volumes.
+    expect(screen.queryByText(/0\.00 BTH/)).toBeNull()
+    expect(screen.queryByText('stats.wraps24h')).toBeNull()
+  })
+
+  it('treats ok-with-null-stats as unavailable (never renders empty metrics)', () => {
+    cleanup()
+    render(<BridgeActivityCard stats={null} state="ok" t={t} />)
+    expect(screen.getByText('stats.unavailable')).toBeDefined()
+  })
+})

--- a/web/packages/features/src/network/components/bridge-activity-card.tsx
+++ b/web/packages/features/src/network/components/bridge-activity-card.tsx
@@ -1,0 +1,104 @@
+import { Card, CardContent } from '@botho/ui'
+import { ArrowLeftRight } from 'lucide-react'
+import { formatBTHWithSymbol } from '@botho/core'
+import type {
+  BridgeStats,
+  BridgeStatsState,
+  BridgeStatsWindow,
+  Translate,
+} from '../../bridge/types'
+
+export interface BridgeActivityCardProps {
+  /** Latest aggregate; ignored unless `state === 'ok'`. */
+  stats: BridgeStats | null
+  /** Fetch outcome from `useBridgeStats`. */
+  state: BridgeStatsState
+  /**
+   * `bridge`-namespace translator supplied by the page (`stats.*` keys), the
+   * same injection pattern as the bridge feature components — the network
+   * module keeps no dependency on react-i18next.
+   */
+  t: Translate
+  className?: string
+}
+
+/**
+ * Bridge activity panel (#1054): wrap (BTH → wBTH) and unwrap (wBTH → BTH)
+ * counts + settled volumes over 24h and all-time windows, next to the
+ * Proof-of-Reserves card on /network.
+ *
+ * Pure presentation, mirroring `ReserveProofCard`:
+ * - `absent` (no public bridge API configured — it is disabled by default on
+ *   nodes) renders nothing so the rest of the dashboard is unaffected.
+ * - `unavailable` (endpoint configured but unreachable) renders a grayed
+ *   placeholder rather than fabricating values (#541 lesson).
+ *
+ * Number contract: volumes are `u64` picocredit strings (possibly beyond
+ * `Number.MAX_SAFE_INTEGER`), converted via `BigInt(...)` before formatting.
+ */
+export function BridgeActivityCard({ stats, state, t, className }: BridgeActivityCardProps) {
+  // No public bridge API on the configured node — hide the card entirely.
+  if (state === 'absent') return null
+
+  if (state === 'unavailable' || stats === null) {
+    return (
+      <Card className={className}>
+        <CardContent className="p-4">
+          <div className="flex items-center gap-1.5 text-xs text-[--color-dim]">
+            <ArrowLeftRight className="h-4 w-4" />
+            {t('stats.title')}
+          </div>
+          <div className="mt-1 text-sm text-[--color-dim]">{t('stats.unavailable')}</div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className={className}>
+      <CardContent className="p-4">
+        <div className="flex items-center gap-1.5 text-xs text-[--color-dim]">
+          <ArrowLeftRight className="h-4 w-4" />
+          {t('stats.title')}
+        </div>
+
+        <div className="mt-3 grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <WindowMetric label={t('stats.wraps24h')} win={stats.wraps.last24h} t={t} />
+          <WindowMetric label={t('stats.wrapsAllTime')} win={stats.wraps.allTime} t={t} />
+          <WindowMetric label={t('stats.unwraps24h')} win={stats.unwraps.last24h} t={t} />
+          <WindowMetric label={t('stats.unwrapsAllTime')} win={stats.unwraps.allTime} t={t} />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+/**
+ * One window cell: the SETTLED volume as the headline (only completed value
+ * actually moved across the bridge) with the completed/pending counts as the
+ * sub line.
+ */
+function WindowMetric({
+  label,
+  win,
+  t,
+}: {
+  label: string
+  win: BridgeStatsWindow
+  t: Translate
+}) {
+  return (
+    <div>
+      <div className="text-xs text-[--color-dim]">{label}</div>
+      <div className="mt-1 font-display text-lg font-semibold text-[--color-light]">
+        {formatBTHWithSymbol(BigInt(win.completed.volume))}
+      </div>
+      <div className="text-xs text-[--color-dim]">
+        {t('stats.bucketSummary', {
+          completed: win.completed.count,
+          pending: win.pending.count,
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/packages/features/src/network/components/network-dashboard.tsx
+++ b/web/packages/features/src/network/components/network-dashboard.tsx
@@ -5,11 +5,13 @@ import type {
   ReserveProof,
   ReserveProofState,
 } from '../types'
+import type { BridgeStats, BridgeStatsState, Translate } from '../../bridge/types'
 import { deriveFleetSummary } from '../fleet'
 import { FleetSummaryStrip } from './fleet-summary'
 import { NodeCard } from './node-card'
 import { HistoryChart } from './history-chart'
 import { ReserveProofCard } from './reserve-proof-card'
+import { BridgeActivityCard } from './bridge-activity-card'
 
 export interface NetworkDashboardProps {
   nodes: FleetNode[]
@@ -26,6 +28,19 @@ export interface NetworkDashboardProps {
   reserve?: ReserveProof | null
   /** Reserve fetch outcome; `undefined`/`absent` hides the card. */
   reserveState?: ReserveProofState
+  /**
+   * Aggregate wrap/unwrap activity (#1054). Optional so surfaces that don't
+   * wire the bridge-stats hook simply omit the card.
+   */
+  bridgeStats?: BridgeStats | null
+  /** Bridge-stats fetch outcome; `undefined`/`absent` hides the card. */
+  bridgeStatsState?: BridgeStatsState
+  /**
+   * `bridge`-namespace translator for the activity card's strings. Required
+   * (alongside `bridgeStatsState`) for the card to render — the features
+   * package keeps no react-i18next dependency.
+   */
+  bridgeStatsT?: Translate
   className?: string
 }
 
@@ -42,6 +57,9 @@ export function NetworkDashboard({
   historyState,
   reserve,
   reserveState,
+  bridgeStats,
+  bridgeStatsState,
+  bridgeStatsT,
   className,
 }: NetworkDashboardProps) {
   const statusList = nodes
@@ -60,6 +78,14 @@ export function NetworkDashboard({
 
       {reserveState !== undefined && (
         <ReserveProofCard proof={reserve ?? null} state={reserveState} />
+      )}
+
+      {bridgeStatsState !== undefined && bridgeStatsT !== undefined && (
+        <BridgeActivityCard
+          stats={bridgeStats ?? null}
+          state={bridgeStatsState}
+          t={bridgeStatsT}
+        />
       )}
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/web/packages/features/src/network/index.ts
+++ b/web/packages/features/src/network/index.ts
@@ -9,6 +9,10 @@ export {
   type ReserveProofCardProps,
 } from './components/reserve-proof-card'
 export {
+  BridgeActivityCard,
+  type BridgeActivityCardProps,
+} from './components/bridge-activity-card'
+export {
   NetworkDashboard,
   type NetworkDashboardProps,
 } from './components/network-dashboard'

--- a/web/packages/web-wallet/src/locales/en/bridge.json
+++ b/web/packages/web-wallet/src/locales/en/bridge.json
@@ -21,6 +21,15 @@
     "heading": "Peg health",
     "subheading": "Live proof-of-reserves: BTH locked in the bridge reserve versus wBTH minted across chains. Green means the peg is intact."
   },
+  "stats": {
+    "title": "Bridge activity",
+    "unavailable": "Bridge activity unavailable — the node's public bridge API is not reachable.",
+    "wraps24h": "Wraps (24h)",
+    "wrapsAllTime": "Wraps (all time)",
+    "unwraps24h": "Unwraps (24h)",
+    "unwrapsAllTime": "Unwraps (all time)",
+    "bucketSummary": "{{completed}} completed · {{pending}} pending"
+  },
   "venues": {
     "heading": "Where to trade",
     "subheading": "Seeded wBTH pools across chains. Links open the venue in a new tab — Botho never brokers the swap.",

--- a/web/packages/web-wallet/src/locales/es/bridge.json
+++ b/web/packages/web-wallet/src/locales/es/bridge.json
@@ -21,6 +21,15 @@
     "heading": "Peg health",
     "subheading": "Live proof-of-reserves: BTH locked in the bridge reserve versus wBTH minted across chains. Green means the peg is intact."
   },
+  "stats": {
+    "title": "Actividad del puente",
+    "unavailable": "Actividad del puente no disponible: la API pública del puente del nodo no está accesible.",
+    "wraps24h": "Envolturas (24 h)",
+    "wrapsAllTime": "Envolturas (total)",
+    "unwraps24h": "Liberaciones (24 h)",
+    "unwrapsAllTime": "Liberaciones (total)",
+    "bucketSummary": "{{completed}} completadas · {{pending}} pendientes"
+  },
   "venues": {
     "heading": "Where to trade",
     "subheading": "Seeded wBTH pools across chains. Links open the venue in a new tab — Botho never brokers the swap.",

--- a/web/packages/web-wallet/src/locales/zh/bridge.json
+++ b/web/packages/web-wallet/src/locales/zh/bridge.json
@@ -21,6 +21,15 @@
     "heading": "Peg health",
     "subheading": "Live proof-of-reserves: BTH locked in the bridge reserve versus wBTH minted across chains. Green means the peg is intact."
   },
+  "stats": {
+    "title": "跨链桥活动",
+    "unavailable": "跨链桥活动不可用——无法访问该节点的公共跨链桥 API。",
+    "wraps24h": "封装（24 小时）",
+    "wrapsAllTime": "封装（累计）",
+    "unwraps24h": "解封（24 小时）",
+    "unwrapsAllTime": "解封（累计）",
+    "bucketSummary": "已完成 {{completed}} · 进行中 {{pending}}"
+  },
   "venues": {
     "heading": "Where to trade",
     "subheading": "Seeded wBTH pools across chains. Links open the venue in a new tab — Botho never brokers the swap.",

--- a/web/packages/web-wallet/src/pages/network.tsx
+++ b/web/packages/web-wallet/src/pages/network.tsx
@@ -1,13 +1,18 @@
+import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { Logo } from '@botho/ui'
 import {
   NetworkDashboard,
+  createBridgeClient,
+  useBridgeStats,
   useFleetHistory,
   useFleetStatus,
   useReserveProof,
 } from '@botho/features'
 import { ArrowLeft } from 'lucide-react'
 import { FLEET, METRICS_API_BASE } from '../config/fleet'
+import { BRIDGE_API_BASE } from '../config/bridge'
 
 export function NetworkPage() {
   // Polling/history wiring lives in @botho/features hooks (#706) so the
@@ -15,6 +20,15 @@ export function NetworkPage() {
   const { statuses, avgBlockSeconds } = useFleetStatus(FLEET)
   const { history, historyState } = useFleetHistory(FLEET, METRICS_API_BASE)
   const { proof: reserve, state: reserveState } = useReserveProof(METRICS_API_BASE)
+  // Bridge activity (#1054): same public order API the /trade page uses.
+  // Unconfigured (`VITE_BRIDGE_API_BASE` unset) → null client → the card is
+  // hidden; configured-but-unreachable degrades to an "unavailable" state.
+  const bridgeClient = useMemo(
+    () => (BRIDGE_API_BASE ? createBridgeClient(BRIDGE_API_BASE) : null),
+    [],
+  )
+  const { stats: bridgeStats, state: bridgeStatsState } = useBridgeStats(bridgeClient)
+  const { t: bridgeT } = useTranslation('bridge')
 
   return (
     <div className="min-h-screen">
@@ -55,6 +69,9 @@ export function NetworkPage() {
             historyState={historyState}
             reserve={reserve}
             reserveState={reserveState}
+            bridgeStats={bridgeStats}
+            bridgeStatsState={bridgeStatsState}
+            bridgeStatsT={bridgeT}
           />
         </div>
       </main>


### PR DESCRIPTION
## Summary

Adds aggregate wrap/unwrap reporting to the network surface (#1054): the bridge service gains a read-only `GET /api/bridge/stats` on the PUBLIC order router, and /network gains a bridge-activity card next to the Proof-of-Reserves panel.

## Changes

**Bridge service (Rust)**
- `db.rs`: new `Database::aggregate_order_activity(order_type, since)` — one GROUP-BY-status pass over `bridge_orders`, bucketed into disjoint `completed` (`completed`/`released`) / `pending` (non-terminal) / `expired` / `failed` aggregates of count + gross picocredit volume, with an INCLUSIVE `created_at >= since` window edge (`None` = all-time).
- `public_api.rs`: `GET /api/bridge/stats` serving wraps (mint orders) and unwraps (burn orders) over `last24h` + `allTime` windows. Aggregates only — no per-order detail, addresses, or ops state (per the #1042 information-exposure scope, everything served is derivable from public on-chain data). The computed aggregate is cached in-process for 30 s so polling cannot hammer the orders DB, and the route sits behind the existing per-IP limiter. Volumes are u64-safe decimal strings, matching every other public response.

**Web**
- `bridge/types.ts` + `bridge-client.ts`: `BridgeStats` wire types and `getBridgeStats()` on the bridge client.
- `bridge/hooks.ts`: `useBridgeStats(client)` poll hook mirroring `useReserveProof` — `null` client (no `VITE_BRIDGE_API_BASE`, the node default since the public API is disabled by default) maps to `absent`; a configured-but-unreachable endpoint maps to `unavailable`.
- `network/components/bridge-activity-card.tsx`: pure-presentation card mirroring `ReserveProofCard` — `absent` renders nothing, `unavailable` renders a grayed placeholder (never fabricated values, #541 lesson), `ok` renders settled volume + completed/pending counts for all four windows.
- `network-dashboard.tsx` renders it next to `reserve-proof-card` via optional props (operator surface unaffected); `/network` page wires the client + hook + `bridge`-namespace translator.
- i18n: `stats.*` strings added to `bridge.json` for en, es, zh.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Node with `[public_api].listen` serves `GET /api/bridge/stats` with wrap/unwrap counts + volumes (24h + all-time), covered by tests | ✅ | `test_bridge_stats_aggregates_both_sides` asserts counts/volumes per side/window/bucket over a live public router |
| No widening of the public surface beyond aggregates | ✅ | Response contains only counts + summed volumes; test asserts no order ids/addresses/tx hashes appear in the body; scope documented in module + handler docs |
| Endpoint cached and behind the per-IP limiter | ✅ | 30 s in-process memoization (`test_bridge_stats_is_cached` proves the cached body is served verbatim); handler checks the shared `"get"` limiter bucket first |
| Ops-isolation invariant test keeps passing | ✅ | `test_public_router_does_not_serve_ops_endpoints` untouched and green |
| /network renders a bridge-activity card; degrades cleanly without the public API | ✅ | `bridge-activity-card.test.tsx`: renders volumes/counts when `ok`, renders NOTHING when `absent` (API not configured), grayed "unavailable" placeholder on fetch failure |
| Rust unit tests for the aggregation SQL over both order tables incl. window edges | ✅ | `test_aggregate_order_activity_buckets_mint_orders` (exact-cutoff inclusive, cutoff−1 excluded, all buckets) + `test_aggregate_order_activity_buckets_burn_orders_separately` (released = settled, no cross-type bleed) + empty-DB zero test |
| i18n en + es + zh parity | ✅ | `stats` section added to all three `bridge.json` files (es/zh translated) |

## Test Plan

- `cargo test -p bth-bridge-service` — 235 passed (incl. 5 new tests)
- `cargo clippy -p bth-bridge-service --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean; `cargo check --workspace --all-targets` (CI-equivalent) — passes
- `pnpm typecheck` + `pnpm test:run` in `web/` — 964 tests passed (incl. 5 new)

Note: workspace-wide `cargo clippy --all-targets -- -D warnings` fails in `bth-cluster-tax` (181 pre-existing lints, reproduced on main, unrelated to this PR — this change's crates are clippy-clean).

Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)