### PR TITLE
fix(transaction/core): u128 wealth casts so cluster_fee tests compile under --all-features

### DIFF
--- a/transaction/core/src/validation/cluster_fee.rs
+++ b/transaction/core/src/validation/cluster_fee.rs
@@ -688,7 +688,8 @@ mod tests {
         // Calculate minimum fee
         let effective_wealth =
             compute_effective_cluster_wealth_from_tags(&input_tags, &input_values, &wealth_map);
-        let min_fee = fee_config.compute_fee(TransactionType::Hidden, 4000, effective_wealth, 0);
+        let min_fee =
+            fee_config.compute_fee(TransactionType::Hidden, 4000, effective_wealth as u128, 0);
 
         // Should pass with exact minimum
         let result = validate_cluster_fee_from_tags(
@@ -778,7 +779,7 @@ mod tests {
         let minimum_fee = fee_config.compute_fee(
             TransactionType::Hidden,
             tx_size_bytes,
-            effective_wealth,
+            effective_wealth as u128,
             num_memos,
         );
 
@@ -927,8 +928,13 @@ mod tests {
 
         // Calculate the required fee
         let max_wealth = compute_ring_max_cluster_wealth(&ring_tags, &ring_values, &wealth_map);
-        let min_fee =
-            fee_config.compute_fee_with_outputs(TransactionType::Hidden, 4000, max_wealth, 2, 0);
+        let min_fee = fee_config.compute_fee_with_outputs(
+            TransactionType::Hidden,
+            4000,
+            max_wealth as u128,
+            2,
+            0,
+        );
 
         // Should pass with exact minimum
         let result = validate_ring_cluster_fee(
@@ -1087,7 +1093,7 @@ mod tests {
         let min_fee = fee_config.compute_fee_with_dynamic_base_and_outputs(
             TransactionType::Hidden,
             4000,
-            max_wealth,
+            max_wealth as u128,
             2,
             0,
             dynamic_base,


### PR DESCRIPTION
## Summary

`cargo check -p bth-transaction-core --all-targets --all-features` failed with exactly four `E0308` errors in `transaction/core/src/validation/cluster_fee.rs` (lines 691, 781, 931, 1090). The `cluster_fee` module is gated behind the non-default `cluster-tax` feature, so default-feature CI never compiles it and the breakage is invisible to the normal pipeline. The fee methods in `cluster-tax/src/fee_curve.rs` take `cluster_wealth: u128`, but the cluster-wealth helpers in `cluster_fee.rs` still return `u64`, and four test-side call sites passed those `u64` values straight into the `u128` parameter.

## Changes

Applied surgical `as u128` casts at the four `compute_fee` / `compute_fee_with_outputs` / `compute_fee_with_dynamic_base_and_outputs` call sites only:

| Line | Enclosing fn | Value cast |
|------|--------------|-----------|
| 691 | `test_cluster_fee_sufficient` | `effective_wealth` |
| 781 | `validate_cluster_fee_from_tags` (test helper) | `effective_wealth` |
| 931 | `test_validate_ring_cluster_fee_sufficient` | `max_wealth` |
| 1090 | `test_ring_fee_with_dynamic_base` | `max_wealth` |

Deliberately did **not** widen the shared locals or the helper return types (`compute_effective_cluster_wealth_from_tags`, `compute_ring_max_cluster_wealth`). At line 781 the same `effective_wealth` local also flows into the `u64` `TransactionValidationError::InsufficientClusterFee.cluster_wealth` field (`validation/error.rs:184`); widening the local would only push the mismatch onto that field. No signature, return-type, or non-test code path changed. `cargo fmt` applied.

## Test Plan

- `cargo check -p bth-transaction-core --all-targets --all-features` — clean, 0 errors (was 4 `E0308`).
- `cargo check -p bth-transaction-core --all-targets` (default features) — still clean.
- `cargo test -p bth-transaction-core --all-features cluster_fee` — all four sites' test functions compile and pass.

## Known follow-up (out of scope — filed separately as #1068)

With the module now compiling, `cargo test --all-features` surfaces **two pre-existing latent runtime failures** — `test_validate_ring_cluster_fee_insufficient` and `test_ring_fee_gaming_prevention`. Neither contains any of the four cast sites; both exercise `validate_ring_cluster_fee`'s own production `as u128` cast (line 489), which this PR did not touch, and any valid compile fix produces the same failures. Fixing them requires changing production fee-curve logic or test expectations, which #1057's acceptance criteria explicitly excluded ("the fix is limited to `u128` casts at the four call sites"). Tracked in #1068.

Closes #1057