### PR TITLE
feat(bridge): deterministic burn-order ids (#1050 Phase 1)

### DIFF
--- a/bridge/core/src/adversarial_tests.rs
+++ b/bridge/core/src/adversarial_tests.rs
@@ -61,6 +61,7 @@ fn burn_order() -> BridgeOrder {
         "0x1234567890abcdef1234567890abcdef12345678".to_string(),
         "bth_user_stealth_addr".to_string(),
         "0xburntx".to_string(),
+        0,
     )
 }
 

--- a/bridge/core/src/attestation.rs
+++ b/bridge/core/src/attestation.rs
@@ -1638,6 +1638,7 @@ mod tests {
             "0x1234567890abcdef1234567890abcdef12345678".to_string(),
             "bth_user_stealth_addr".to_string(),
             "0xburntx".to_string(),
+            0,
         )
     }
 
@@ -1978,13 +1979,18 @@ mod tests {
     fn test_order_binding_rejects_cross_order_reuse() {
         let sk = signing_key(1);
         let order_a = burn_order_from_eth();
-        let order_b = burn_order_from_eth(); // fresh UUID, same shape
+        // Same shape but a DIFFERENT id. Since #1050 made burn ids
+        // deterministic over the source tuple, a second order with an
+        // identical source tuple would derive the same id; we set a distinct
+        // id explicitly to exercise the id-mismatch branch in isolation.
+        let mut order_b = burn_order_from_eth();
+        order_b.id = Uuid::from_u128(order_b.id.as_u128() ^ 1);
 
         let env = sign(&release_kind(&order_a), &sk, "aa");
         let parsed = env.verify_and_parse_ed25519(&sk.verifying_key()).unwrap();
 
-        // Bound to order A: order B is rejected even though every other
-        // field (amount, recipient, chains, source tx) matches.
+        // Bound to order A: order B is rejected on the id mismatch even though
+        // every other field (amount, recipient, chains, source tx) matches.
         assert!(check_order_binding(&parsed, &order_a).is_ok());
         assert!(matches!(
             check_order_binding(&parsed, &order_b),
@@ -2072,8 +2078,11 @@ mod tests {
         assert!(set.is_threshold_met(2));
         assert_eq!(set.signatures().len(), 2);
 
-        // A different order's attestation cannot enter this set.
-        let other = burn_order_from_eth();
+        // A different order's attestation cannot enter this set. Burn ids are
+        // now deterministic (#1050), so a genuinely different order has a
+        // different source tuple / id; set a distinct id to model that.
+        let mut other = burn_order_from_eth();
+        other.id = Uuid::from_u128(other.id.as_u128() ^ 1);
         let env = sign(&release_kind(&other), &k1, "n4");
         let p_other = env.verify_and_parse_ed25519(&k1.verifying_key()).unwrap();
         assert!(set.insert(&p_other, sig_of(&k1)).is_err());

--- a/bridge/core/src/order.rs
+++ b/bridge/core/src/order.rs
@@ -14,6 +14,12 @@ use crate::{attestation::MintAuthorization, chains::Chain};
 /// orders would derive different on-chain ids.
 const ORDER_ID_DOMAIN_TAG: &[u8] = b"botho-bridge-order-id-v1";
 
+/// Domain-separation tag for deriving a burn order's UUID from its stable
+/// on-chain burn-source tuple. Changing this tag is a bridge-breaking change:
+/// in-flight burn orders would derive different UUIDs (same caveat as
+/// [`ORDER_ID_DOMAIN_TAG`]). Safe pre-mainnet.
+const BURN_ORDER_ID_DOMAIN_TAG: &[u8] = b"botho-bridge-burn-order-uuid-v1";
+
 /// Derive the deterministic 32-byte on-chain order id from an order UUID.
 ///
 /// Both destination chains bind mints to this same value: Ethereum passes it
@@ -26,6 +32,48 @@ pub fn derive_order_id(order_uuid: &Uuid) -> [u8; 32] {
     hasher.update(ORDER_ID_DOMAIN_TAG);
     hasher.update(order_uuid.as_bytes());
     hasher.finalize().into()
+}
+
+/// Derive a deterministic burn-order UUID from the stable on-chain burn-source
+/// tuple: `(source_chain, tx_hash, ordinal)`.
+///
+/// This triple uniquely identifies a single finalized on-chain burn — it is
+/// exactly the watchers' `burn_source_key` (`"<tx_hash>#<ordinal>"`) plus the
+/// source chain. Because it is chain-observable and identical for every
+/// federation member watching the same finalized burn, two independent bridge
+/// instances derive the **same** UUID for one burn. This lets their
+/// attestation envelopes — which bind via [`derive_order_id`] over this UUID —
+/// aggregate to threshold with zero cross-member trust and no shared store
+/// (see #1050 Phase 1).
+///
+/// The digest is domain-separated and length-prefixes the chain tag and tx
+/// hash so distinct tuples cannot collide by concatenation ambiguity. The
+/// resulting UUID has RFC-4122 version (5) and variant bits set.
+pub fn derive_burn_order_uuid(source_chain: Chain, tx_hash: &str, ordinal: u32) -> Uuid {
+    let mut hasher = Sha256::new();
+    hasher.update(BURN_ORDER_ID_DOMAIN_TAG);
+
+    // Chain tag, length-prefixed to avoid concatenation ambiguity.
+    let chain_tag = source_chain.to_string();
+    hasher.update((chain_tag.len() as u32).to_le_bytes());
+    hasher.update(chain_tag.as_bytes());
+
+    // Transaction hash / signature, length-prefixed.
+    hasher.update((tx_hash.len() as u32).to_le_bytes());
+    hasher.update(tx_hash.as_bytes());
+
+    // Per-transaction ordinal.
+    hasher.update(ordinal.to_le_bytes());
+
+    let digest: [u8; 32] = hasher.finalize().into();
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+
+    // Set RFC-4122 version (5, name-based SHA-1 family) and variant bits so
+    // the value is a well-formed UUID.
+    bytes[6] = (bytes[6] & 0x0f) | 0x50;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    Uuid::from_bytes(bytes)
 }
 
 /// Custom serde for memo field (fixed-size byte array)
@@ -323,6 +371,14 @@ impl BridgeOrder {
     }
 
     /// Create a new burn order (wBTH -> BTH).
+    ///
+    /// The order id is **deterministic**: it is derived from the stable
+    /// burn-source tuple `(source_chain, source_tx, ordinal)` via
+    /// [`derive_burn_order_uuid`], where `ordinal` is the burn event's index
+    /// among burn events of the same transaction (the watchers' per-tx
+    /// ordinal). Every federation member watching the same finalized on-chain
+    /// burn therefore constructs the identical order id, so their attestation
+    /// envelopes aggregate to threshold without a shared store (#1050 Phase 1).
     pub fn new_burn(
         source_chain: Chain,
         amount: u64,
@@ -330,10 +386,12 @@ impl BridgeOrder {
         source_address: String,
         bth_address: String,
         source_tx: String,
+        ordinal: u32,
     ) -> Self {
         let now = Utc::now();
+        let id = derive_burn_order_uuid(source_chain, &source_tx, ordinal);
         Self {
-            id: Uuid::new_v4(),
+            id,
             order_type: OrderType::Burn,
             source_chain,
             dest_chain: Chain::Bth,
@@ -523,6 +581,70 @@ mod tests {
     }
 
     #[test]
+    fn test_burn_order_id_is_deterministic_across_independent_instances() {
+        // #1050 Phase 1: two federation members independently observe the
+        // SAME finalized on-chain burn and each call new_burn. Their orders
+        // MUST carry the identical id so their attestation envelopes (bound
+        // via order_id_bytes -> derive_order_id) aggregate to threshold with
+        // no shared store.
+        let member_a = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            0,
+            "0xburner".to_string(),
+            "bth_recipient".to_string(),
+            "0xdeadbeef".to_string(),
+            2,
+        );
+        // A second, independent instance may observe different *non-source*
+        // details (fee policy, address casing from its own RPC decode) yet
+        // still reconstructs the same id from the source tuple alone.
+        let member_b = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            999, // different local fee policy
+            "0xburner".to_string(),
+            "bth_recipient".to_string(),
+            "0xdeadbeef".to_string(),
+            2,
+        );
+        assert_eq!(
+            member_a.id, member_b.id,
+            "same burn-source tuple must yield the same order id"
+        );
+        // And it equals the pure helper over the source tuple.
+        assert_eq!(
+            member_a.id,
+            derive_burn_order_uuid(Chain::Ethereum, "0xdeadbeef", 2)
+        );
+    }
+
+    #[test]
+    fn test_burn_order_id_differs_for_distinct_source_tuples() {
+        let base = derive_burn_order_uuid(Chain::Ethereum, "0xabc", 0);
+        // Different ordinal (second burn in the same tx).
+        assert_ne!(base, derive_burn_order_uuid(Chain::Ethereum, "0xabc", 1));
+        // Different tx hash.
+        assert_ne!(base, derive_burn_order_uuid(Chain::Ethereum, "0xdef", 0));
+        // Different source chain (same tx-hash string).
+        assert_ne!(base, derive_burn_order_uuid(Chain::Solana, "0xabc", 0));
+        // A burn on Solana with the same nominal fields is still distinct.
+        assert_ne!(
+            derive_burn_order_uuid(Chain::Solana, "sig123", 0),
+            derive_burn_order_uuid(Chain::Solana, "sig123", 1)
+        );
+    }
+
+    #[test]
+    fn test_burn_order_uuid_is_well_formed_v5() {
+        // Version nibble = 5, RFC-4122 variant bits = 0b10.
+        let id = derive_burn_order_uuid(Chain::Ethereum, "0xabc", 0);
+        let bytes = id.as_bytes();
+        assert_eq!(bytes[6] >> 4, 0x5, "version must be 5");
+        assert_eq!(bytes[8] >> 6, 0b10, "variant must be RFC-4122");
+    }
+
+    #[test]
     fn test_guarded_transitions_happy_path() {
         assert!(OrderStatus::DepositConfirmed.can_transition_to(&OrderStatus::MintPending));
         assert!(OrderStatus::MintPending.can_transition_to(&OrderStatus::Completed));
@@ -597,6 +719,7 @@ mod tests {
             "0xsource".to_string(),
             "bth_addr".to_string(),
             "0xburntx".to_string(),
+            0,
         );
         order.set_status(OrderStatus::ReleasePending);
         order.dest_tx = Some("bth_release_tx".to_string());

--- a/bridge/service/src/attestation.rs
+++ b/bridge/service/src/attestation.rs
@@ -1379,6 +1379,7 @@ mod tests {
             "0x1234567890abcdef1234567890abcdef12345678".to_string(),
             "bth_user_stealth_addr".to_string(),
             "0xburntx".to_string(),
+            0,
         );
         order.set_status(OrderStatus::BurnConfirmed);
         order
@@ -1494,7 +1495,10 @@ mod tests {
         let k1 = signing_key(1);
         let provider = bth_provider(&[&k1], 1, None);
         let order_a = burn_order();
-        let order_b = burn_order(); // distinct UUID
+        // Burn ids are deterministic over the source tuple (#1050); a
+        // genuinely different order has a different id, modeled here directly.
+        let mut order_b = burn_order();
+        order_b.id = Uuid::from_u128(order_b.id.as_u128() ^ 1);
 
         let envelope = release_envelope(&order_a, &k1, "nonce-d");
         let outcome = provider.submit_attestation_at(&envelope, &order_b, NOW);

--- a/bridge/service/src/chaos_tests.rs
+++ b/bridge/service/src/chaos_tests.rs
@@ -356,6 +356,7 @@ fn burn_order() -> BridgeOrder {
         "0x1234567890abcdef1234567890abcdef12345678".to_string(),
         "bth_user_stealth_addr".to_string(),
         "0xburntx".to_string(),
+        0,
     );
     order.set_status(OrderStatus::BurnConfirmed);
     order
@@ -770,6 +771,7 @@ async fn load_test_concurrent_orders_exactly_once() {
             format!("0xburner{:038}", i),
             "bth_user_stealth_addr".to_string(),
             format!("0xburntx{}", i),
+            0,
         );
         order.set_status(OrderStatus::BurnConfirmed);
         db.insert_order(&order).unwrap();

--- a/bridge/service/src/db.rs
+++ b/bridge/service/src/db.rs
@@ -543,21 +543,44 @@ impl Database {
     /// Execute the order INSERT against `conn` (also used inside
     /// transactions, e.g. [`Database::insert_burn_order`]).
     fn insert_order_stmt(conn: &Connection, order: &BridgeOrder) -> Result<(), String> {
+        Self::insert_order_stmt_impl(conn, order, false)
+    }
+
+    /// Like [`Database::insert_order_stmt`] but tolerates a pre-existing id
+    /// (`INSERT OR IGNORE`). Used by the burn path, whose ids are deterministic
+    /// over the source tuple (#1050) and therefore idempotent across replays
+    /// and concurrent watchers observing the same burn.
+    fn insert_order_stmt_or_ignore(conn: &Connection, order: &BridgeOrder) -> Result<(), String> {
+        Self::insert_order_stmt_impl(conn, order, true)
+    }
+
+    fn insert_order_stmt_impl(
+        conn: &Connection,
+        order: &BridgeOrder,
+        or_ignore: bool,
+    ) -> Result<(), String> {
         let mint_auth_json = order
             .mint_authorization
             .as_ref()
             .map(|a| serde_json::to_string(a).map_err(|e| format!("Serialize failed: {}", e)))
             .transpose()?;
 
+        let verb = if or_ignore {
+            "INSERT OR IGNORE"
+        } else {
+            "INSERT"
+        };
         conn.execute(
-            r#"
-            INSERT INTO bridge_orders (
+            &format!(
+                r#"
+            {verb} INTO bridge_orders (
                 id, order_type, source_chain, dest_chain, amount, fee,
                 source_tx, dest_tx, source_address, dest_address,
                 status, error_message, memo, mint_authorization,
                 dest_confirmed_at, created_at, updated_at
             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
-            "#,
+            "#
+            ),
             params![
                 order.id.to_string(),
                 order.order_type.to_string(),
@@ -1095,7 +1118,16 @@ impl Database {
             .transaction()
             .map_err(|e| format!("Transaction failed: {}", e))?;
 
-        Self::insert_order_stmt(&tx, order)?;
+        // Insert the order row idempotently. Burn order ids are deterministic
+        // over the source tuple (#1050 Phase 1) — the same finalized burn
+        // always derives the same id — so a replay or a concurrent watcher
+        // observing the same burn presents the SAME id. `INSERT OR IGNORE`
+        // makes that a no-op instead of hard-erroring on `bridge_orders.id`;
+        // the `processed_burns` insert below (gated on the stable, unique
+        // `source_key`) remains the exactly-once arbiter that decides the
+        // return value. The FK from `processed_burns.order_id` requires the
+        // order row to exist first, so this ordering is preserved.
+        Self::insert_order_stmt_or_ignore(&tx, order)?;
 
         let changed = tx
             .execute(
@@ -1116,8 +1148,8 @@ impl Database {
             .map_err(|e| format!("Insert failed: {}", e))?;
 
         if changed == 0 {
-            // Duplicate source_key: drop the transaction (rolls back the
-            // order insert) — the existing record wins.
+            // Duplicate source_key: drop the transaction (rolls back the order
+            // insert, if any) — the existing record wins.
             return Ok(false);
         }
 
@@ -2816,6 +2848,7 @@ mod tests {
             "0x1234567890abcdef1234567890abcdef12345678".to_string(),
             "bth_user_stealth_addr".to_string(),
             "0xburntx".to_string(),
+            0,
         );
         order.set_status(OrderStatus::BurnConfirmed);
         db.insert_order(&order).unwrap();
@@ -2990,6 +3023,7 @@ mod tests {
             "0x1234567890abcdef1234567890abcdef12345678".to_string(),
             "bth_stealth_addr".to_string(),
             source_tx.to_string(),
+            0,
         )
     }
 
@@ -3004,12 +3038,17 @@ mod tests {
             .unwrap());
 
         // Replay with the SAME source key (cursor rewind / reorg re-add):
-        // nothing is written, including the duplicate order.
+        // the second insert is a no-op. Burn ids are deterministic over the
+        // source tuple (#1050), so `dup` derives the SAME id as `first`; the
+        // idempotency guard must skip it rather than collide on the order id.
         let dup = burn_order("0xburn");
+        assert_eq!(dup.id, first.id, "same burn tuple must derive the same id");
         assert!(!db
             .insert_burn_order(&dup, "0xburn#0", 51, Some("0xblock51"))
             .unwrap());
-        assert!(db.get_order(&dup.id).unwrap().is_none());
+        // Exactly one order row exists, unchanged from the first insert (the
+        // replay did not overwrite block 50 with block 51).
+        assert!(db.get_order(&first.id).unwrap().is_some());
 
         let rec = db.get_burn_by_source("0xburn#0").unwrap().unwrap();
         assert_eq!(rec.order_id, first.id);
@@ -3481,6 +3520,7 @@ mod tests {
             "0x1234567890abcdef1234567890abcdef12345678".to_string(),
             "bth_dest".to_string(),
             "0xburn".to_string(),
+            0,
         );
         burning.set_status(OrderStatus::BurnConfirmed);
         db.insert_order(&burning).unwrap();
@@ -3552,6 +3592,7 @@ mod tests {
             "0xsource".to_string(),
             "bth_dest".to_string(),
             "0xburntx".to_string(),
+            0,
         );
         db.insert_order(&burn).unwrap();
         assert_eq!(db.count_awaiting_deposit_mint_orders().unwrap(), 1);
@@ -3639,6 +3680,7 @@ mod tests {
             "0xsource".to_string(),
             "bth_dest".to_string(),
             format!("0xburntx-{}", Uuid::new_v4()),
+            0,
         );
         o.status = status;
         o.created_at = Utc.timestamp_opt(created, 0).unwrap();

--- a/bridge/service/src/defi_round_trip_tests.rs
+++ b/bridge/service/src/defi_round_trip_tests.rs
@@ -620,6 +620,7 @@ async fn defi_round_trip_mint_wrap_pool_swap_repatriate() {
         event.from.clone(),
         event.bth_address.clone(),
         event.tx_hash.clone(),
+        0,
     );
     burn_order.set_status(OrderStatus::BurnConfirmed);
     db.insert_order(&burn_order).expect("insert burn order");

--- a/bridge/service/src/e2e_full_loop_tests.rs
+++ b/bridge/service/src/e2e_full_loop_tests.rs
@@ -536,6 +536,7 @@ async fn full_loop_wrap_mint_burn_release() {
         event.from.clone(),
         event.bth_address.clone(),
         event.tx_hash.clone(),
+        0,
     );
     burn_order.set_status(OrderStatus::BurnConfirmed);
     db.insert_order(&burn_order).expect("insert burn order");

--- a/bridge/service/src/engine.rs
+++ b/bridge/service/src/engine.rs
@@ -1685,6 +1685,7 @@ mod tests {
             "0x1234567890abcdef1234567890abcdef12345678".to_string(),
             "bth_user_stealth_addr".to_string(),
             "0xburntx".to_string(),
+            0,
         );
         order.set_status(OrderStatus::BurnConfirmed);
         db.insert_order(&order).unwrap();

--- a/bridge/service/src/federation.rs
+++ b/bridge/service/src/federation.rs
@@ -660,6 +660,7 @@ mod federation_transport_tests {
             "0x1234567890abcdef1234567890abcdef12345678".to_string(),
             "bth_user_stealth_addr".to_string(),
             "0xburntx".to_string(),
+            0,
         );
         order.set_status(OrderStatus::BurnConfirmed);
         order
@@ -974,8 +975,11 @@ mod federation_transport_tests {
             0
         );
 
-        // A completely absent order id routes to a 404 (unknown_order).
-        let absent = burn_order();
+        // A completely absent order id routes to a 404 (unknown_order). Burn
+        // ids are deterministic over the source tuple (#1050); give `absent`
+        // an id not present in the DB to model a truly unknown order.
+        let mut absent = burn_order();
+        absent.id = uuid::Uuid::from_u128(absent.id.as_u128() ^ 1);
         let kind2 = FederationAttestationProvider::release_kind_for_test(&absent);
         let env2 =
             bth_bridge_core::sign_attestation_ed25519(&kind2, &ka, "adv-absent", now, now + 120)

--- a/bridge/service/src/fork_tests.rs
+++ b/bridge/service/src/fork_tests.rs
@@ -529,6 +529,7 @@ async fn fork_eth_mint_and_burn_round_trip() {
         event.from.clone(),
         event.bth_address.clone(),
         event.tx_hash.clone(),
+        0,
     );
     assert_eq!(burn_order.status, OrderStatus::BurnDetected);
     burn_order

--- a/bridge/service/src/public_api.rs
+++ b/bridge/service/src/public_api.rs
@@ -1544,6 +1544,7 @@ mod tests {
             "0xsource".to_string(),
             bth_addr,
             "0xburntx".to_string(),
+            0,
         );
         burn.set_status(OrderStatus::BurnConfirmed);
         db.insert_order(&burn).unwrap();
@@ -1712,6 +1713,7 @@ mod tests {
             "0xsource".to_string(),
             test_bth_address(),
             "0xburntx".to_string(),
+            0,
         );
         burn.status = OrderStatus::Released;
         db.insert_order(&burn).unwrap();

--- a/bridge/service/src/release/bth.rs
+++ b/bridge/service/src/release/bth.rs
@@ -680,6 +680,7 @@ mod tests {
             "0x1234567890abcdef1234567890abcdef12345678".to_string(),
             "bth_user_stealth_addr".to_string(),
             "0xburntx".to_string(),
+            0,
         );
         order.set_status(bth_bridge_core::OrderStatus::BurnConfirmed);
         order

--- a/bridge/service/src/watchers/ethereum.rs
+++ b/bridge/service/src/watchers/ethereum.rs
@@ -400,6 +400,7 @@ impl EthereumWatcher {
             event.from.clone(),
             event.bth_address.clone(),
             event.tx_hash.clone(),
+            ordinal,
         );
 
         let inserted = self

--- a/bridge/service/src/watchers/solana.rs
+++ b/bridge/service/src/watchers/solana.rs
@@ -316,6 +316,7 @@ impl SolanaWatcher {
             bs58_encode_user(&burn.user),
             burn.bth_address.clone(),
             signature.to_string(),
+            ordinal,
         );
 
         let inserted = self.db.insert_burn_order(&order, &source_key, slot, None)?;


### PR DESCRIPTION
## Part of #1050 (Phase 1: deterministic burn-order ids)

Implements **Phase 1 only** of the curated 2-phase decomposition of #1050. Phase 2 (mint order-record replication / signed order-gossip / `POST /api/attest` changes) is intentionally **out of scope** and remains open.

### Problem
Each federation member's Ethereum/Solana burn watcher independently observes the *same* finalized on-chain burn and calls `BridgeOrder::new_burn`, which assigned a **random** `Uuid::new_v4()`. Two members therefore minted two different order ids for one burn, so their attestation envelopes — bound via `order_id_bytes` → `derive_order_id` — never aggregated to threshold on a genuinely distributed (separate-DB) federation.

### Change
Derive the burn-order UUID **deterministically** from the stable burn-source tuple `(source_chain, tx_hash, ordinal)` — exactly the watchers' existing `burn_source_key` (`"<tx_hash>#<ordinal>"`) plus the chain. Two independent instances observing the same finalized burn now derive the **identical** order id and aggregate attestations with zero cross-member trust and no shared store.

- **`bridge/core/src/order.rs`**: new `derive_burn_order_uuid()` — domain-separated SHA256 over the length-prefixed source tuple, RFC-4122 v5 version/variant bits (mirrors the existing `derive_order_id` pattern, no new Cargo feature). `new_burn()` gains an `ordinal` param and derives the id internally.
- **`bridge/service/src/watchers/ethereum.rs` / `watchers/solana.rs`**: pass the per-tx `ordinal` (already computed for `burn_source_key`).
- **`bridge/service/src/db.rs`**: `insert_burn_order` now inserts the order row with `INSERT OR IGNORE`, so a cursor replay or a concurrent watcher presenting the same deterministic id is a clean no-op instead of a `UNIQUE constraint` hard-error. `processed_burns` (unique `source_key`) remains the exactly-once arbiter; FK ordering (order row before `processed_burns`) is preserved.
- Updated all other `new_burn` callers for the new signature. Tests that previously relied on two same-shape orders having *different random ids* now set a distinct id explicitly to exercise cross-order rejection in isolation.

### Tests
New in `order.rs`:
- `test_burn_order_id_is_deterministic_across_independent_instances` — two independent `new_burn` calls for the same tuple (even with different local fee) yield the **same** id, equal to the pure helper.
- `test_burn_order_id_differs_for_distinct_source_tuples` — distinct ordinal / tx-hash / chain each yield distinct ids.
- `test_burn_order_uuid_is_well_formed_v5` — version + variant bits.

`cargo build`, `cargo test -p bth-bridge-core -p bth-bridge-service` (74 + 239 pass), and `cargo clippy` on both crates are green.

### Scope confirmation
Phase 2 (signed mint order-gossip endpoint, trust-boundary hardening) is **NOT** included here — it is a separate, security-sensitive follow-up under #1050. This PR uses "Part of #1050" (not "Closes") so the issue stays open for Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)