### PR TITLE
feat(bridge): on-chain ballot + deterministic tally tooling for elections (#1067)

### DIFF
--- a/bridge/core/Cargo.toml
+++ b/bridge/core/Cargo.toml
@@ -29,5 +29,11 @@ sha2 = { workspace = true, features = ["std"] }
 ed25519-dalek = { workspace = true, features = ["std"] }
 serde_json = { workspace = true, features = ["std"] }
 
+# The deterministic bridge-election tally CLI (ADR 0010 option C / A1). A thin,
+# dependency-free wrapper over the pure `election` module.
+[[bin]]
+name = "bridge-tally"
+path = "src/bin/bridge-tally.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/bridge/core/src/bin/bridge-tally.rs
+++ b/bridge/core/src/bin/bridge-tally.rs
@@ -1,0 +1,245 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! `bridge-tally` — the deterministic bridge-election tally CLI
+//! (ADR 0010 option C / A1).
+//!
+//! A thin, dependency-free wrapper over the pure [`bth_bridge_core::election`]
+//! library. Given a JSON bundle of `{ params, snapshot, ledger }`, it runs the
+//! `approval-top-N-v1` tally and prints the `elected`-status v2 term document
+//! (or the failure mode). It also builds/signs the two memo formats, so the
+//! #1063 drill and operators can produce ballots without re-implementing the
+//! canonical encoding.
+//!
+//! Everything is deterministic: same input → same output, byte for byte.
+//!
+//! ```text
+//! bridge-tally tally <input.json> [--ranking] [--out <file>]
+//! bridge-tally build-nomination --node-id <id> --term <n> [--secret-key-hex <hex>]
+//! bridge-tally build-ballot --node-id <id> --term <n> --approve <a,b,c> [--secret-key-hex <hex>]
+//! ```
+//!
+//! Exit codes for `tally`: 0 elected, 3 no-quorum, 4 insufficient candidates,
+//! 1 usage/parse error.
+
+use std::process::ExitCode;
+
+use bth_bridge_core::election::{
+    assemble_elected_term_doc, canonical_ballot_memo, canonical_nomination_memo,
+    sign_election_memo_ed25519, tally, CurationSnapshot, ElectionParams, MemoTransaction,
+    TallyResult, TallyStatus,
+};
+use ed25519_dalek::SigningKey;
+use serde::Deserialize;
+
+/// The JSON input bundle for the `tally` subcommand.
+#[derive(Debug, Deserialize)]
+struct TallyInput {
+    params: ElectionParams,
+    snapshot: CurationSnapshot,
+    ledger: Vec<MemoTransaction>,
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("{}", USAGE);
+        return ExitCode::from(1);
+    }
+
+    let result = match args[0].as_str() {
+        "tally" => cmd_tally(&args[1..]),
+        "build-nomination" => cmd_build_nomination(&args[1..]),
+        "build-ballot" => cmd_build_ballot(&args[1..]),
+        "-h" | "--help" | "help" => {
+            println!("{USAGE}");
+            return ExitCode::SUCCESS;
+        }
+        other => Err(format!("unknown subcommand `{other}`\n\n{USAGE}")),
+    };
+
+    match result {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+const USAGE: &str = "\
+bridge-tally — deterministic bridge-election tally (ADR 0010 option C / A1)
+
+USAGE:
+  bridge-tally tally <input.json> [--ranking] [--out <file>]
+  bridge-tally build-nomination --node-id <id> --term <n> [--secret-key-hex <hex>]
+  bridge-tally build-ballot --node-id <id> --term <n> --approve <a,b,c> [--secret-key-hex <hex>]
+
+The `tally` input is a JSON object { \"params\": {...}, \"snapshot\": {...}, \"ledger\": [...] }.
+On an elected result it prints the elected-status v2 term document to stdout.
+
+EXIT CODES (tally): 0 elected, 3 no-quorum, 4 insufficient candidates, 1 error.";
+
+fn cmd_tally(args: &[String]) -> Result<ExitCode, String> {
+    let mut input_path: Option<String> = None;
+    let mut out_path: Option<String> = None;
+    let mut show_ranking = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--ranking" => show_ranking = true,
+            "--out" => {
+                i += 1;
+                out_path = Some(args.get(i).ok_or("--out needs a value")?.clone());
+            }
+            other if other.starts_with("--") => return Err(format!("unknown flag `{other}`")),
+            other => {
+                if input_path.is_some() {
+                    return Err(format!("unexpected argument `{other}`"));
+                }
+                input_path = Some(other.to_string());
+            }
+        }
+        i += 1;
+    }
+
+    let path = input_path.ok_or("tally needs an <input.json> path")?;
+    let raw = std::fs::read_to_string(&path).map_err(|e| format!("cannot read {path}: {e}"))?;
+    let input: TallyInput =
+        serde_json::from_str(&raw).map_err(|e| format!("invalid tally input JSON: {e}"))?;
+
+    let result = tally(&input.snapshot, &input.params, &input.ledger)?;
+
+    if show_ranking {
+        eprintln!("ranking:");
+        for c in &result.ranking {
+            eprintln!("  {:>2}. {} ({} approvals)", c.rank, c.node_id, c.approvals);
+        }
+        eprintln!(
+            "turnout {}/{} (quorum {}), status {:?}, resultHash {}",
+            result.turnout,
+            result.eligible,
+            result.quorum_required,
+            result.status,
+            result.result_hash
+        );
+    }
+
+    match result.status {
+        TallyStatus::Elected => {
+            let doc = assemble_elected_term_doc(&input.snapshot, &input.params, &result)?;
+            let json = doc.to_json_pretty();
+            emit(&json, out_path.as_deref())?;
+            Ok(ExitCode::SUCCESS)
+        }
+        TallyStatus::NoQuorum => {
+            report_void(&result, "no-quorum");
+            Ok(ExitCode::from(3))
+        }
+        TallyStatus::InsufficientCandidates => {
+            report_void(&result, "insufficient-candidates");
+            Ok(ExitCode::from(4))
+        }
+    }
+}
+
+fn report_void(result: &TallyResult, tag: &str) {
+    eprintln!(
+        "election VOID ({tag}): turnout {}/{} (quorum {}), {} candidate(s), resultHash {}",
+        result.turnout,
+        result.eligible,
+        result.quorum_required,
+        result.ranking.len(),
+        result.result_hash
+    );
+}
+
+fn emit(json: &str, out_path: Option<&str>) -> Result<(), String> {
+    match out_path {
+        Some(p) => {
+            std::fs::write(p, format!("{json}\n")).map_err(|e| format!("cannot write {p}: {e}"))
+        }
+        None => {
+            println!("{json}");
+            Ok(())
+        }
+    }
+}
+
+fn cmd_build_nomination(args: &[String]) -> Result<ExitCode, String> {
+    let opts = parse_kv(args)?;
+    let node_id = opts.get("node-id").ok_or("--node-id is required")?;
+    let term = parse_term(&opts)?;
+    let memo = canonical_nomination_memo(node_id, term);
+    print_memo(&memo, opts.get("secret-key-hex"))?;
+    Ok(ExitCode::SUCCESS)
+}
+
+fn cmd_build_ballot(args: &[String]) -> Result<ExitCode, String> {
+    let opts = parse_kv(args)?;
+    let node_id = opts.get("node-id").ok_or("--node-id is required")?;
+    let term = parse_term(&opts)?;
+    let approvals: Vec<String> = opts
+        .get("approve")
+        .map(|s| {
+            s.split(',')
+                .map(|x| x.trim().to_string())
+                .filter(|x| !x.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+    let memo = canonical_ballot_memo(node_id, term, &approvals);
+    print_memo(&memo, opts.get("secret-key-hex"))?;
+    Ok(ExitCode::SUCCESS)
+}
+
+fn parse_term(opts: &std::collections::HashMap<String, String>) -> Result<u64, String> {
+    opts.get("term")
+        .ok_or("--term is required")?
+        .parse::<u64>()
+        .map_err(|_| "--term must be a non-negative integer".to_string())
+}
+
+/// Print a memo (and, if a secret key is supplied, its detached signature) as
+/// a JSON object ready to drop into a ledger fixture.
+fn print_memo(memo: &str, secret_key_hex: Option<&String>) -> Result<(), String> {
+    let signature_hex = match secret_key_hex {
+        Some(hex_str) => {
+            let raw = hex::decode(hex_str.trim()).map_err(|_| "secret key is not valid hex")?;
+            let bytes: [u8; 32] = raw
+                .as_slice()
+                .try_into()
+                .map_err(|_| "ed25519 secret key must be 32 bytes")?;
+            let key = SigningKey::from_bytes(&bytes);
+            Some(sign_election_memo_ed25519(memo, &key))
+        }
+        None => None,
+    };
+    match signature_hex {
+        Some(sig) => println!(
+            "{{\"memo\":{},\"signatureHex\":{}}}",
+            serde_json::to_string(memo).unwrap(),
+            serde_json::to_string(&sig).unwrap()
+        ),
+        None => println!("{{\"memo\":{}}}", serde_json::to_string(memo).unwrap()),
+    }
+    Ok(())
+}
+
+/// Parse `--key value` pairs into a map (keys without the `--` prefix).
+fn parse_kv(args: &[String]) -> Result<std::collections::HashMap<String, String>, String> {
+    let mut map = std::collections::HashMap::new();
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        let key = arg
+            .strip_prefix("--")
+            .ok_or_else(|| format!("expected a --flag, got `{arg}`"))?;
+        let value = args
+            .get(i + 1)
+            .ok_or_else(|| format!("flag `--{key}` needs a value"))?;
+        map.insert(key.to_string(), value.clone());
+        i += 2;
+    }
+    Ok(map)
+}

--- a/bridge/core/src/election/memo.rs
+++ b/bridge/core/src/election/memo.rs
@@ -1,0 +1,302 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Election memo-convention formats for the elected bridge multisig
+//! (ADR 0010 option C / sub-variant **A1** — ballots are memo-convention
+//! transactions on the Botho chain, no protocol change and no new tx type).
+//!
+//! Two memo kinds ride inside ordinary Botho transaction memos:
+//!
+//! - **Self-nomination** (`bridge.nominate`): a curated node stands for a term.
+//!   Valid only *before* `openHeight`; one nomination per curated identity (ADR
+//!   0010 "Candidacy = opt-in").
+//! - **Ballot** (`bridge.ballot`): approval voting — the voter approves a
+//!   subset of the candidates. One node, one vote; valid within
+//!   `openHeight..=closeHeight`.
+//!
+//! Both are **domain-separated, canonical-JSON** payloads signed by the
+//! node's long-lived curated identity key, mirroring the attestation-envelope
+//! discipline in [`crate::attestation`] (sorted keys, no whitespace,
+//! integers-only, unknown/duplicate keys rejected). The signed bytes are
+//! `ELECTION_MEMO_DOMAIN || memo_bytes`, so an election signature can never
+//! be replayed as an attestation, an operator action, or any other Ed25519
+//! payload a node key signs.
+//!
+//! Everything here is a **pure function** — no wall-clock, no randomness, no
+//! I/O — so the tally in [`crate::election::tally`] is reproducible by anyone
+//! replaying the ledger.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use serde_json::{Map, Value};
+
+/// The only election-memo version verifiers accept. Unknown versions are
+/// rejected fail-closed with no downgrade path.
+pub const ELECTION_MEMO_VERSION: u64 = 1;
+
+/// Domain-separation prefix every election-memo signature covers. Distinct
+/// from the attestation-envelope domains (`botho-bridge-attest-*`) and the
+/// term-document domain (`botho.bridge.term.v2:`), so an election signature is
+/// confined to elections.
+pub const ELECTION_MEMO_DOMAIN: &[u8] = b"botho.bridge.election.v1:";
+
+/// Wire `kind` for a self-nomination memo.
+pub const MEMO_KIND_NOMINATE: &str = "bridge.nominate";
+
+/// Wire `kind` for a ballot memo.
+pub const MEMO_KIND_BALLOT: &str = "bridge.ballot";
+
+/// A parsed, structurally-validated election memo (after — or independent of
+/// — signature verification). Field values are verbatim from the memo bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ElectionMemo {
+    /// A curated node stands for `term`. Valid only before `openHeight`.
+    Nomination {
+        /// The term this candidate stands for.
+        term: u64,
+        /// The standing node's curated identity id.
+        node_id: String,
+    },
+    /// An approval-voting ballot: `node_id` approves everyone in `approvals`.
+    Ballot {
+        /// The term this ballot is cast in.
+        term: u64,
+        /// The voting node's curated identity id.
+        node_id: String,
+        /// The approved candidate ids, as they appeared in the memo. The
+        /// canonical form is sorted+deduped; parsing does not re-canonicalise
+        /// (the tally deduplicates and drops non-candidates itself).
+        approvals: Vec<String>,
+    },
+}
+
+impl ElectionMemo {
+    /// The curated identity id that must have signed this memo.
+    pub fn node_id(&self) -> &str {
+        match self {
+            ElectionMemo::Nomination { node_id, .. } | ElectionMemo::Ballot { node_id, .. } => {
+                node_id
+            }
+        }
+    }
+
+    /// The term this memo pertains to.
+    pub fn term(&self) -> u64 {
+        match self {
+            ElectionMemo::Nomination { term, .. } | ElectionMemo::Ballot { term, .. } => *term,
+        }
+    }
+}
+
+/// Build the canonical (sorted-key, whitespace-free) self-nomination memo
+/// string for `node_id` standing in `term`.
+pub fn canonical_nomination_memo(node_id: &str, term: u64) -> String {
+    let s = |v: &str| serde_json::to_string(v).expect("string serialization is infallible");
+    format!(
+        "{{\"kind\":{kind},\"nodeId\":{node},\"term\":{term},\"v\":{v}}}",
+        kind = s(MEMO_KIND_NOMINATE),
+        node = s(node_id),
+        v = ELECTION_MEMO_VERSION,
+    )
+}
+
+/// Build the canonical (sorted-key, whitespace-free) ballot memo string. The
+/// `approvals` list is **sorted and de-duplicated** so one logical ballot has
+/// exactly one canonical byte encoding.
+pub fn canonical_ballot_memo(node_id: &str, term: u64, approvals: &[String]) -> String {
+    let s = |v: &str| serde_json::to_string(v).expect("string serialization is infallible");
+    let mut sorted: Vec<&String> = approvals.iter().collect();
+    sorted.sort();
+    sorted.dedup();
+    let arr = sorted.iter().map(|a| s(a)).collect::<Vec<_>>().join(",");
+    format!(
+        "{{\"approvals\":[{arr}],\"kind\":{kind},\"nodeId\":{node},\"term\":{term},\"v\":{v}}}",
+        kind = s(MEMO_KIND_BALLOT),
+        node = s(node_id),
+        v = ELECTION_MEMO_VERSION,
+    )
+}
+
+/// The exact byte string an election-memo signature covers:
+/// `ELECTION_MEMO_DOMAIN || memo_bytes`.
+pub fn election_signed_message(memo: &str) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(ELECTION_MEMO_DOMAIN.len() + memo.len());
+    msg.extend_from_slice(ELECTION_MEMO_DOMAIN);
+    msg.extend_from_slice(memo.as_bytes());
+    msg
+}
+
+/// Ed25519-sign an election memo with a node's long-lived curated identity
+/// key, returning the lowercase-hex detached signature.
+pub fn sign_election_memo_ed25519(memo: &str, signing_key: &SigningKey) -> String {
+    hex::encode(signing_key.sign(&election_signed_message(memo)).to_bytes())
+}
+
+/// Verify a detached election-memo signature against the signer's curated
+/// identity key (`verify_strict`, rejecting malleable / low-order signatures).
+pub fn verify_election_memo(
+    memo: &str,
+    signature_hex: &str,
+    verifying_key: &VerifyingKey,
+) -> Result<(), String> {
+    let raw =
+        hex::decode(signature_hex.trim()).map_err(|_| "signature is not valid hex".to_string())?;
+    let sig_bytes: [u8; 64] = raw
+        .as_slice()
+        .try_into()
+        .map_err(|_| "ed25519 signature must be 64 bytes".to_string())?;
+    let sig = Signature::from_bytes(&sig_bytes);
+    verifying_key
+        .verify_strict(&election_signed_message(memo), &sig)
+        .map_err(|_| "signature verification failed".to_string())
+}
+
+/// Decode a 32-byte Ed25519 public key from lowercase hex.
+pub fn verifying_key_from_hex(hex_str: &str) -> Result<VerifyingKey, String> {
+    let raw = hex::decode(hex_str.trim()).map_err(|_| "pubkey is not valid hex".to_string())?;
+    let bytes: [u8; 32] = raw
+        .as_slice()
+        .try_into()
+        .map_err(|_| "ed25519 pubkey must be 32 bytes".to_string())?;
+    VerifyingKey::from_bytes(&bytes).map_err(|_| "invalid ed25519 pubkey".to_string())
+}
+
+/// Parse canonical election-memo bytes, REJECTING unknown or duplicate keys
+/// (at any nesting level) and any type/shape error, so a single signed byte
+/// string can never carry two logical memos.
+pub fn parse_election_memo(bytes: &str) -> Result<ElectionMemo, String> {
+    reject_duplicate_keys(bytes)?;
+
+    let value: Value =
+        serde_json::from_str(bytes).map_err(|e| format!("memo is not valid JSON: {e}"))?;
+    let obj: &Map<String, Value> = value
+        .as_object()
+        .ok_or_else(|| "memo must be a JSON object".to_string())?;
+
+    let v = get_u64(obj, "v")?;
+    if v != ELECTION_MEMO_VERSION {
+        return Err(format!(
+            "unsupported memo version {v} (expected {ELECTION_MEMO_VERSION})"
+        ));
+    }
+
+    let kind = get_str(obj, "kind")?.to_string();
+    let term = get_u64(obj, "term")?;
+    let node_id = get_str(obj, "nodeId")?.to_string();
+
+    match kind.as_str() {
+        MEMO_KIND_NOMINATE => {
+            const KNOWN: &[&str] = &["kind", "nodeId", "term", "v"];
+            check_known_keys(obj, KNOWN)?;
+            Ok(ElectionMemo::Nomination { term, node_id })
+        }
+        MEMO_KIND_BALLOT => {
+            const KNOWN: &[&str] = &["approvals", "kind", "nodeId", "term", "v"];
+            check_known_keys(obj, KNOWN)?;
+            let raw = obj
+                .get("approvals")
+                .ok_or_else(|| "missing field `approvals`".to_string())?
+                .as_array()
+                .ok_or_else(|| "`approvals` must be an array".to_string())?;
+            let mut approvals = Vec::with_capacity(raw.len());
+            for a in raw {
+                approvals.push(
+                    a.as_str()
+                        .ok_or_else(|| "each approval must be a string".to_string())?
+                        .to_string(),
+                );
+            }
+            Ok(ElectionMemo::Ballot {
+                term,
+                node_id,
+                approvals,
+            })
+        }
+        other => Err(format!("memo kind `{other}` is not in the v1 allowlist")),
+    }
+}
+
+fn check_known_keys(obj: &Map<String, Value>, known: &[&str]) -> Result<(), String> {
+    for key in obj.keys() {
+        if !known.contains(&key.as_str()) {
+            return Err(format!("unknown memo field `{key}`"));
+        }
+    }
+    Ok(())
+}
+
+fn get_str<'a>(obj: &'a Map<String, Value>, key: &str) -> Result<&'a str, String> {
+    obj.get(key)
+        .ok_or_else(|| format!("missing field `{key}`"))?
+        .as_str()
+        .ok_or_else(|| format!("`{key}` must be a string"))
+}
+
+/// Read an integer field, REJECTING non-integers (`serde_json` parses `5.0`
+/// as a float, so `as_u64` returns `None` — fail-closed).
+fn get_u64(obj: &Map<String, Value>, key: &str) -> Result<u64, String> {
+    obj.get(key)
+        .ok_or_else(|| format!("missing field `{key}`"))?
+        .as_u64()
+        .ok_or_else(|| format!("`{key}` must be a non-negative integer"))
+}
+
+/// Reject any JSON value containing a duplicated object key at ANY nesting
+/// level. `serde_json::Map` silently collapses duplicates (last-wins), which
+/// would let two logical memos share one signed byte string. Mirrors the
+/// proven guard in [`crate::attestation`].
+fn reject_duplicate_keys(bytes: &str) -> Result<(), String> {
+    use serde::de::{DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
+
+    struct AnyChecker;
+    impl<'de> DeserializeSeed<'de> for AnyChecker {
+        type Value = ();
+        fn deserialize<D: Deserializer<'de>>(self, d: D) -> Result<(), D::Error> {
+            d.deserialize_any(AnyVisitor)
+        }
+    }
+
+    struct AnyVisitor;
+    impl<'de> Visitor<'de> for AnyVisitor {
+        type Value = ();
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("any JSON value with unique object keys")
+        }
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
+            let mut seen = std::collections::HashSet::new();
+            while let Some(key) = map.next_key::<String>()? {
+                map.next_value_seed(AnyChecker)?;
+                if !seen.insert(key.clone()) {
+                    return Err(serde::de::Error::custom(format!("duplicate key `{key}`")));
+                }
+            }
+            Ok(())
+        }
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
+            while seq.next_element_seed(AnyChecker)?.is_some() {}
+            Ok(())
+        }
+        fn visit_bool<E>(self, _: bool) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_i64<E>(self, _: i64) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_u64<E>(self, _: u64) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_f64<E>(self, _: f64) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_str<E>(self, _: &str) -> Result<(), E> {
+            Ok(())
+        }
+        fn visit_unit<E>(self) -> Result<(), E> {
+            Ok(())
+        }
+    }
+
+    let mut de = serde_json::Deserializer::from_str(bytes);
+    AnyChecker
+        .deserialize(&mut de)
+        .map_err(|e| format!("{e}"))?;
+    Ok(())
+}

--- a/bridge/core/src/election/mod.rs
+++ b/bridge/core/src/election/mod.rs
@@ -1,0 +1,40 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Bridge-multisig elections: on-chain ballots + deterministic tally
+//! (ADR 0010 option C / sub-variant A1).
+//!
+//! The mechanism, end to end:
+//!
+//! - [`memo`] — the two memo-convention formats (self-nomination and ballot)
+//!   that ride inside ordinary Botho transaction memos, plus their
+//!   domain-separated signing/verification.
+//! - [`snapshot`] — the pinned P4.4 curated-node electorate (#709) the tally
+//!   binds to, one node one vote.
+//! - [`tally`] — the deterministic `approval-top-N-v1` pure function:
+//!   reproducible from a ledger replay, no wall-clock, no randomness, with a
+//!   deterministic (ascending-`nodeId`) tie-break per ADR 0010 §6.3.
+//! - [`term_doc`] — assembly of the `elected`-status v2 term document
+//!   (membership only) that feeds the seal / keygen step (#1066).
+
+pub mod memo;
+pub mod snapshot;
+pub mod tally;
+pub mod term_doc;
+
+#[cfg(test)]
+mod tests;
+
+pub use memo::{
+    canonical_ballot_memo, canonical_nomination_memo, election_signed_message, parse_election_memo,
+    sign_election_memo_ed25519, verify_election_memo, verifying_key_from_hex, ElectionMemo,
+    ELECTION_MEMO_DOMAIN, ELECTION_MEMO_VERSION, MEMO_KIND_BALLOT, MEMO_KIND_NOMINATE,
+};
+pub use snapshot::{CuratedNode, CurationSnapshot};
+pub use tally::{
+    tally, CandidateStanding, ElectionKind, ElectionParams, MemoTransaction, RejectedMemo,
+    TallyResult, TallyStatus, Validity, TALLY_TRANSCRIPT_DOMAIN,
+};
+pub use term_doc::{
+    assemble_elected_term_doc, ElectedTermDoc, Electorate, Member, TallySummary, TermStatus,
+    ValidityDoc, TALLY_RULE, TERM_DOC_VERSION,
+};

--- a/bridge/core/src/election/snapshot.rs
+++ b/bridge/core/src/election/snapshot.rs
@@ -1,0 +1,89 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! The electorate snapshot the tally binds to: a pinned view of the P4.4
+//! operator-signed curated node set (#709).
+//!
+//! ADR 0010 fixes the electorate as "a snapshot of the P4.4 operator-curated
+//! node set at a pinned height" — one node, one vote. The tally never reads
+//! the *live* curation; it reads exactly this snapshot, so two verifiers who
+//! pin the same height compute the same electorate and therefore the same
+//! result. The snapshot also carries each node's long-lived Ed25519 curated
+//! identity key, which is what election-memo signatures are checked against.
+
+use ed25519_dalek::VerifyingKey;
+use serde::{Deserialize, Serialize};
+
+use super::memo::verifying_key_from_hex;
+
+/// One curated node in the electorate snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CuratedNode {
+    /// The node's stable curated identity id (the vote/candidacy identity).
+    pub node_id: String,
+    /// The node's long-lived curated identity Ed25519 public key, lowercase
+    /// hex (32 bytes). Election-memo signatures are verified against this.
+    pub identity_pubkey_hex: String,
+}
+
+/// A pinned snapshot of the operator-curated node set, the electorate for one
+/// election. `curation_doc_hash` + `snapshot_height` bind the tally to an
+/// exact, replayable curation state (folded into the term document's
+/// `electorate` block).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CurationSnapshot {
+    /// Hash of the operator-signed curation document this snapshot is taken
+    /// from (opaque to the tally; carried through to the term document).
+    pub curation_doc_hash: String,
+    /// The ledger height the curation set is pinned at.
+    pub snapshot_height: u64,
+    /// The curated nodes. Duplicate `node_id`s are rejected by
+    /// [`CurationSnapshot::validate`].
+    pub nodes: Vec<CuratedNode>,
+}
+
+impl CurationSnapshot {
+    /// Structural validation independent of any election: unique, non-empty
+    /// node ids and well-formed identity keys. Returns the offending detail.
+    pub fn validate(&self) -> Result<(), String> {
+        let mut seen = std::collections::HashSet::new();
+        for node in &self.nodes {
+            if node.node_id.is_empty() {
+                return Err("curation snapshot contains an empty nodeId".to_string());
+            }
+            if !seen.insert(node.node_id.as_str()) {
+                return Err(format!("duplicate curated nodeId `{}`", node.node_id));
+            }
+            verifying_key_from_hex(&node.identity_pubkey_hex)
+                .map_err(|e| format!("node `{}`: {e}", node.node_id))?;
+        }
+        Ok(())
+    }
+
+    /// The eligible-voter ids, **sorted** (the deterministic electorate list
+    /// the term document records).
+    pub fn eligible_ids(&self) -> Vec<String> {
+        let mut ids: Vec<String> = self.nodes.iter().map(|n| n.node_id.clone()).collect();
+        ids.sort();
+        ids
+    }
+
+    /// The number of eligible voters (the quorum denominator).
+    pub fn eligible_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Whether `node_id` is in the curated electorate.
+    pub fn contains(&self, node_id: &str) -> bool {
+        self.nodes.iter().any(|n| n.node_id == node_id)
+    }
+
+    /// The curated identity verifying key for `node_id`, if curated.
+    pub fn verifying_key(&self, node_id: &str) -> Option<VerifyingKey> {
+        self.nodes
+            .iter()
+            .find(|n| n.node_id == node_id)
+            .and_then(|n| verifying_key_from_hex(&n.identity_pubkey_hex).ok())
+    }
+}

--- a/bridge/core/src/election/tally.rs
+++ b/bridge/core/src/election/tally.rs
@@ -1,0 +1,406 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! The deterministic, off-consensus tally (`approval-top-N-v1`).
+//!
+//! [`tally`] is a **pure function**: given a curation snapshot and the ledger
+//! of election memos up to `closeHeight`, it returns the ranking and winners
+//! with:
+//!
+//! - **no wall-clock and no randomness** — validity timestamps are inputs;
+//! - **input-order independence** — memos are sorted by `(height, txid)` before
+//!   counting, so the same ledger in any order yields the same result;
+//! - a **deterministic, grind-free tie-break** — ties at the Nth seat break by
+//!   ascending lexicographic `nodeId` (ADR 0010 §6.3), never by ledger-derived
+//!   entropy a block producer could grind;
+//! - a **full ranking** (not just the top N), so a member who fails key
+//!   submission can be replaced by the next-ranked candidate without a re-vote
+//!   (ADR 0010 §6.2 exclusion-and-retry).
+//!
+//! Anyone replaying the ledger recomputes the identical `resultHash`.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::{
+    memo::{parse_election_memo, verify_election_memo, ElectionMemo},
+    snapshot::CurationSnapshot,
+};
+
+/// Domain prefix for the tally transcript hash (`resultHash`). Distinct from
+/// the memo-signing domain so the two can never collide.
+pub const TALLY_TRANSCRIPT_DOMAIN: &[u8] = b"botho.bridge.tally.v1:";
+
+/// The election kind, matching the term-document `electionKind` wire values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ElectionKind {
+    /// A regular scheduled (quarterly) election.
+    #[serde(rename = "scheduled")]
+    Scheduled,
+    /// A compressed-window emergency election (ADR 0010 §6.5).
+    #[serde(rename = "emergency")]
+    Emergency,
+    /// The #1063 drill's same-set mock (membership-stable, keys-fresh).
+    #[serde(rename = "mock-same-set")]
+    MockSameSet,
+}
+
+impl ElectionKind {
+    /// The wire string used in the term document's `electionKind` field.
+    pub fn wire(&self) -> &'static str {
+        match self {
+            ElectionKind::Scheduled => "scheduled",
+            ElectionKind::Emergency => "emergency",
+            ElectionKind::MockSameSet => "mock-same-set",
+        }
+    }
+}
+
+/// The term-document `validity` timestamps. These are POLICY INPUTS to the
+/// tally (Unix seconds), never read from the clock, so the emitted document is
+/// reproducible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Validity {
+    /// When the term is considered elected (Unix seconds).
+    pub elected_at: i64,
+    /// Hard handover deadline (Unix seconds); breach is objective (ADR 0010).
+    pub handover_deadline: i64,
+    /// Target term end (Unix seconds).
+    pub term_end: i64,
+}
+
+/// The parameters that pin one election: term, window, board shape, and the
+/// (input) validity timestamps. `seats` is N (target 5) and `threshold` is k
+/// (target 3) for the ratified 3-of-5 shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ElectionParams {
+    /// The term being elected (≥ 1).
+    pub term: u64,
+    /// The election kind.
+    pub election_kind: ElectionKind,
+    /// First height at which ballots are valid (and after which nominations
+    /// are closed).
+    pub open_height: u64,
+    /// Last height at which ballots are valid (the tally cutoff).
+    pub close_height: u64,
+    /// Board size N (number of seats to fill).
+    pub seats: usize,
+    /// Signing threshold k (the elected board must have at least this many
+    /// members to be viable).
+    pub threshold: u32,
+    /// Term-document validity timestamps (input, not clock-derived).
+    pub validity: Validity,
+}
+
+impl ElectionParams {
+    /// Structural validation of the parameters (independent of any ledger).
+    pub fn validate(&self) -> Result<(), String> {
+        if self.term < 1 {
+            return Err("term must be >= 1".to_string());
+        }
+        if self.close_height < self.open_height {
+            return Err("closeHeight precedes openHeight".to_string());
+        }
+        if self.seats < 2 {
+            return Err("seats (N) must be >= 2".to_string());
+        }
+        if self.threshold < 2 {
+            return Err("threshold (k) must be >= 2".to_string());
+        }
+        if (self.threshold as usize) > self.seats {
+            return Err("threshold (k) exceeds seats (N)".to_string());
+        }
+        Ok(())
+    }
+}
+
+/// One memo-convention transaction as it appears on the ledger. The tally
+/// treats `memo` as opaque signed bytes; `signature_hex` is the detached
+/// curated-identity signature over `ELECTION_MEMO_DOMAIN || memo`.
+///
+/// `txid` is the ledger transaction id — it fixes the deterministic ordering
+/// (with `height`) and is the unit recorded in the tally transcript.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoTransaction {
+    /// The ledger transaction id.
+    pub txid: String,
+    /// The height the transaction confirmed at.
+    pub height: u64,
+    /// The canonical election-memo JSON string, verbatim as signed.
+    pub memo: String,
+    /// The detached lowercase-hex Ed25519 signature over the domain-separated
+    /// memo bytes.
+    pub signature_hex: String,
+}
+
+/// Why a memo transaction did not count. Surfaced for observability and tests
+/// (never affects determinism — the set of rejects is itself a pure function
+/// of the inputs).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RejectedMemo {
+    /// The rejected transaction id.
+    pub txid: String,
+    /// A short, stable reason tag.
+    pub reason: String,
+}
+
+/// The high-level outcome of a tally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TallyStatus {
+    /// A viable board was elected (winners ≥ threshold).
+    Elected,
+    /// Turnout fell below the required majority of the electorate — void
+    /// election, incumbent term auto-extends (ADR 0010 §6.2).
+    NoQuorum,
+    /// Quorum was met but fewer than `threshold` candidates stood — no viable
+    /// multisig can be sealed (ADR 0010 §6.2, candidate-list exhaustion).
+    InsufficientCandidates,
+}
+
+/// A candidate's standing in the final ranking.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CandidateStanding {
+    /// 1-based rank (1 = most approvals; ties resolved by ascending nodeId).
+    pub rank: usize,
+    /// The candidate's curated identity id.
+    pub node_id: String,
+    /// Distinct valid ballots approving this candidate.
+    pub approvals: u32,
+}
+
+/// The complete, reproducible result of a tally.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TallyResult {
+    /// The election outcome.
+    pub status: TallyStatus,
+    /// The full ranking of every valid candidate (deterministic order).
+    pub ranking: Vec<CandidateStanding>,
+    /// The elected board — the top `seats` of `ranking` — empty unless
+    /// `status == Elected`.
+    pub winners: Vec<CandidateStanding>,
+    /// Distinct nodes that cast a valid ballot.
+    pub turnout: usize,
+    /// The electorate size (quorum denominator).
+    pub eligible: usize,
+    /// The minimum turnout for quorum (strict majority of the electorate).
+    pub quorum_required: usize,
+    /// The counted ballot txids, **sorted** — the tally transcript evidence.
+    pub counted_ballot_txids: Vec<String>,
+    /// Hash of the full transcript (counted ballot txids + derived ranking);
+    /// lets a verifier re-check the exact evidence set (schema `resultHash`).
+    pub result_hash: String,
+    /// Memos that were dropped, with reasons (observability; not hashed).
+    pub rejected: Vec<RejectedMemo>,
+}
+
+/// Run the deterministic `approval-top-N-v1` tally.
+///
+/// `ledger` is every memo-convention transaction confirmed up to (and
+/// including) `params.close_height`; extra transactions outside the windows
+/// are ignored (and recorded in `rejected`), so passing a superset of the
+/// ledger is safe. Returns `Err` only for structurally-invalid inputs
+/// (bad params or a malformed snapshot); election failure modes are carried by
+/// [`TallyStatus`], not errors.
+pub fn tally(
+    snapshot: &CurationSnapshot,
+    params: &ElectionParams,
+    ledger: &[MemoTransaction],
+) -> Result<TallyResult, String> {
+    params.validate()?;
+    snapshot.validate()?;
+
+    // Deterministic processing order — the ONLY ordering that matters. Input
+    // vector order is irrelevant after this sort.
+    let mut txs: Vec<&MemoTransaction> = ledger.iter().collect();
+    txs.sort_by(|a, b| a.height.cmp(&b.height).then_with(|| a.txid.cmp(&b.txid)));
+
+    let mut rejected: Vec<RejectedMemo> = Vec::new();
+    let reject = |rejected: &mut Vec<RejectedMemo>, txid: &str, reason: &str| {
+        rejected.push(RejectedMemo {
+            txid: txid.to_string(),
+            reason: reason.to_string(),
+        });
+    };
+
+    // --- Pass 1: nominations (before openHeight) → the candidate set. ---
+    // First valid nomination per curated identity wins; duplicates rejected.
+    let mut candidates: Vec<String> = Vec::new();
+    for tx in &txs {
+        let memo = match parse_election_memo(&tx.memo) {
+            Ok(m) => m,
+            Err(_) => continue, // not our concern here; handled in pass 2 if a ballot
+        };
+        let (term, node_id) = match &memo {
+            ElectionMemo::Nomination { term, node_id } => (*term, node_id.clone()),
+            ElectionMemo::Ballot { .. } => continue,
+        };
+        if term != params.term {
+            reject(&mut rejected, &tx.txid, "nomination_wrong_term");
+            continue;
+        }
+        if tx.height >= params.open_height {
+            reject(&mut rejected, &tx.txid, "nomination_after_open");
+            continue;
+        }
+        let vk = match snapshot.verifying_key(&node_id) {
+            Some(vk) => vk,
+            None => {
+                reject(&mut rejected, &tx.txid, "nomination_not_curated");
+                continue;
+            }
+        };
+        if verify_election_memo(&tx.memo, &tx.signature_hex, &vk).is_err() {
+            reject(&mut rejected, &tx.txid, "nomination_bad_signature");
+            continue;
+        }
+        if candidates.contains(&node_id) {
+            reject(&mut rejected, &tx.txid, "nomination_duplicate");
+            continue;
+        }
+        candidates.push(node_id);
+    }
+
+    // --- Pass 2: ballots (within openHeight..=closeHeight). ---
+    // First valid ballot per voter wins; later ballots by the same voter are
+    // rejected (per-term binding — no re-vote, ADR 0010 §6.3 Clique hygiene).
+    let mut approvals: std::collections::HashMap<String, u32> =
+        candidates.iter().map(|c| (c.clone(), 0u32)).collect();
+    let mut voted: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut counted_ballot_txids: Vec<String> = Vec::new();
+
+    for tx in &txs {
+        let memo = match parse_election_memo(&tx.memo) {
+            Ok(m) => m,
+            Err(_) => {
+                reject(&mut rejected, &tx.txid, "unparseable_memo");
+                continue;
+            }
+        };
+        let (term, node_id, ballot_approvals) = match &memo {
+            ElectionMemo::Ballot {
+                term,
+                node_id,
+                approvals,
+            } => (*term, node_id.clone(), approvals.clone()),
+            ElectionMemo::Nomination { .. } => continue, // handled in pass 1
+        };
+        if term != params.term {
+            reject(&mut rejected, &tx.txid, "ballot_wrong_term");
+            continue;
+        }
+        if tx.height < params.open_height || tx.height > params.close_height {
+            reject(&mut rejected, &tx.txid, "ballot_outside_window");
+            continue;
+        }
+        let vk = match snapshot.verifying_key(&node_id) {
+            Some(vk) => vk,
+            None => {
+                reject(&mut rejected, &tx.txid, "ballot_not_curated");
+                continue;
+            }
+        };
+        if verify_election_memo(&tx.memo, &tx.signature_hex, &vk).is_err() {
+            reject(&mut rejected, &tx.txid, "ballot_bad_signature");
+            continue;
+        }
+        if voted.contains(&node_id) {
+            reject(&mut rejected, &tx.txid, "ballot_duplicate_voter");
+            continue;
+        }
+
+        // Count the ballot. De-duplicate approvals and drop any that do not
+        // reference a standing candidate (a voter approving a non-candidate is
+        // not an error — the approval simply has no seat to land in).
+        voted.insert(node_id);
+        counted_ballot_txids.push(tx.txid.clone());
+        let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for approved in &ballot_approvals {
+            if !seen.insert(approved.as_str()) {
+                continue;
+            }
+            if let Some(count) = approvals.get_mut(approved) {
+                *count += 1;
+            }
+        }
+    }
+
+    // --- Rank: approvals desc, then ascending nodeId (deterministic tie-break).
+    // ---
+    let mut ranking_pairs: Vec<(String, u32)> = candidates
+        .iter()
+        .map(|c| (c.clone(), *approvals.get(c).unwrap_or(&0)))
+        .collect();
+    ranking_pairs.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let ranking: Vec<CandidateStanding> = ranking_pairs
+        .into_iter()
+        .enumerate()
+        .map(|(i, (node_id, approvals))| CandidateStanding {
+            rank: i + 1,
+            node_id,
+            approvals,
+        })
+        .collect();
+
+    counted_ballot_txids.sort();
+    let result_hash = compute_result_hash(&counted_ballot_txids, &ranking);
+
+    let eligible = snapshot.eligible_count();
+    let quorum_required = eligible / 2 + 1;
+    let turnout = voted_count(&counted_ballot_txids);
+
+    // --- Classify the outcome. ---
+    let (status, winners) = if turnout < quorum_required {
+        (TallyStatus::NoQuorum, Vec::new())
+    } else {
+        let take = params.seats.min(ranking.len());
+        let winners: Vec<CandidateStanding> = ranking.iter().take(take).cloned().collect();
+        if (winners.len() as u32) < params.threshold {
+            (TallyStatus::InsufficientCandidates, Vec::new())
+        } else {
+            (TallyStatus::Elected, winners)
+        }
+    };
+
+    Ok(TallyResult {
+        status,
+        ranking,
+        winners,
+        turnout,
+        eligible,
+        quorum_required,
+        counted_ballot_txids,
+        result_hash,
+        rejected,
+    })
+}
+
+/// Turnout is the number of counted ballots (one per distinct voter, enforced
+/// during counting).
+fn voted_count(counted_ballot_txids: &[String]) -> usize {
+    counted_ballot_txids.len()
+}
+
+/// Hash the full tally transcript: the sorted counted ballot txids followed by
+/// the derived ranking. Length-prefixed so no field boundary is ambiguous.
+fn compute_result_hash(counted_ballot_txids: &[String], ranking: &[CandidateStanding]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(TALLY_TRANSCRIPT_DOMAIN);
+    hasher.update((counted_ballot_txids.len() as u64).to_le_bytes());
+    for txid in counted_ballot_txids {
+        hasher.update((txid.len() as u64).to_le_bytes());
+        hasher.update(txid.as_bytes());
+    }
+    hasher.update((ranking.len() as u64).to_le_bytes());
+    for c in ranking {
+        hasher.update((c.node_id.len() as u64).to_le_bytes());
+        hasher.update(c.node_id.as_bytes());
+        hasher.update(c.approvals.to_le_bytes());
+    }
+    hex::encode(hasher.finalize())
+}

--- a/bridge/core/src/election/tally.rs
+++ b/bridge/core/src/election/tally.rs
@@ -105,6 +105,12 @@ impl ElectionParams {
         if self.seats < 2 {
             return Err("seats (N) must be >= 2".to_string());
         }
+        // Upper bound mirrors the v2 term-document schema (`members.maxItems: 5`,
+        // the ratified 3-of-5 shape). A larger board would emit a document that
+        // fails schema validation, so reject it here at parameter time.
+        if self.seats > 5 {
+            return Err("seats (N) must be <= 5".to_string());
+        }
         if self.threshold < 2 {
             return Err("threshold (k) must be >= 2".to_string());
         }

--- a/bridge/core/src/election/term_doc.rs
+++ b/bridge/core/src/election/term_doc.rs
@@ -1,0 +1,196 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Assembly of the `elected`-status v2 term document from a tally result.
+//!
+//! Per ADR 0010 §5.1 the election has a two-stage document lifecycle:
+//!
+//! 1. **`elected`** — produced *here*, by the tally. It pins **membership**
+//!    only: term, electorate snapshot reference, tally proof (`resultHash`),
+//!    threshold, and the elected member *identities* with their approval
+//!    counts. It carries **no keys** — fresh per-term keys do not exist yet.
+//! 2. **`sealed`** — produced by the seal / keygen step (issue #1066, out of
+//!    scope here). Each winner submits fresh per-surface keys bound to this
+//!    document, the outgoing federation counter-signs, and only then may the
+//!    handover execute.
+//!
+//! This module owns stage 1 exactly. The `elected` document it emits is the
+//! **input** to the seal step: `execution` intents, member `keys`,
+//! `keySubmissionSig`, and the `signatures` block are all added during
+//! sealing and are deliberately absent here. Keeping that seam clean is the
+//! whole point of the `elected` → `sealed` split.
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    snapshot::CurationSnapshot,
+    tally::{ElectionParams, TallyResult, TallyStatus},
+};
+
+/// The tally rule identifier recorded in the term document.
+pub const TALLY_RULE: &str = "approval-top-N-v1";
+
+/// The term-document schema version this assembler emits.
+pub const TERM_DOC_VERSION: u8 = 2;
+
+/// Document status. Only `elected` is produced here; `sealed` is the seal
+/// step's output (#1066).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TermStatus {
+    /// Membership pinned by the tally; no keys yet.
+    #[serde(rename = "elected")]
+    Elected,
+}
+
+/// The `electorate` block: a reference to the pinned curation snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Electorate {
+    /// Hash of the operator-signed curation document.
+    pub curation_doc_hash: String,
+    /// The height the electorate was pinned at.
+    pub snapshot_height: u64,
+    /// The eligible voter ids, sorted.
+    pub eligible: Vec<String>,
+}
+
+/// The `tally` block: the rule, window, ballot count, and result hash.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TallySummary {
+    /// The tally rule (`approval-top-N-v1`).
+    pub rule: String,
+    /// First height ballots were valid.
+    pub open_height: u64,
+    /// The tally cutoff height.
+    pub close_height: u64,
+    /// Number of counted ballots.
+    pub ballots: u32,
+    /// The tally transcript hash ([`TallyResult::result_hash`]).
+    pub result_hash: String,
+}
+
+/// One elected member. At `elected` status this is identity-only: `keys` and
+/// `keySubmissionSig` are added at seal time (#1066) and are absent here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Member {
+    /// 1-based seat index.
+    pub index: u32,
+    /// The member's curated identity id.
+    pub node_id: String,
+    /// Approvals the member received in the tally.
+    pub approvals: u32,
+}
+
+/// The `validity` block (Unix-seconds timestamps carried from the election
+/// parameters — never clock-derived here).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidityDoc {
+    /// When the term is considered elected.
+    pub elected_at: i64,
+    /// Hard handover deadline.
+    pub handover_deadline: i64,
+    /// Target term end.
+    pub term_end: i64,
+}
+
+/// An `elected`-status v2 term document (membership only).
+///
+/// Field order is fixed by struct declaration (serde serialises fields in
+/// declaration order regardless of the `serde_json` `preserve_order` feature),
+/// so the emitted JSON is deterministic. `execution` and `signatures` are
+/// intentionally omitted — they belong to the seal step (#1066), which
+/// consumes this document.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ElectedTermDoc {
+    /// Schema version (always `2`).
+    pub v: u8,
+    /// The elected term.
+    pub term: u64,
+    /// The election kind (`scheduled` / `emergency` / `mock-same-set`).
+    #[serde(rename = "electionKind")]
+    pub election_kind: String,
+    /// Document status (`elected`).
+    pub status: TermStatus,
+    /// Electorate snapshot reference.
+    pub electorate: Electorate,
+    /// Tally proof.
+    pub tally: TallySummary,
+    /// Signing threshold k.
+    pub threshold: u32,
+    /// The elected board, in seat order (rank 1 = seat index 1).
+    pub members: Vec<Member>,
+    /// Validity timestamps.
+    pub validity: ValidityDoc,
+}
+
+impl ElectedTermDoc {
+    /// Serialise to a pretty-printed JSON string (for the CLI / drills).
+    pub fn to_json_pretty(&self) -> String {
+        serde_json::to_string_pretty(self).expect("ElectedTermDoc serialises")
+    }
+
+    /// Serialise to a compact JSON string.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).expect("ElectedTermDoc serialises")
+    }
+}
+
+/// Assemble the `elected` term document from a successful tally.
+///
+/// Returns `Err` unless `result.status == Elected` — a term document can only
+/// be cut from an election that produced a viable board. The members are the
+/// tally winners in rank order (seat index = rank).
+pub fn assemble_elected_term_doc(
+    snapshot: &CurationSnapshot,
+    params: &ElectionParams,
+    result: &TallyResult,
+) -> Result<ElectedTermDoc, String> {
+    if result.status != TallyStatus::Elected {
+        return Err(format!(
+            "cannot assemble an elected term document from a {:?} tally",
+            result.status
+        ));
+    }
+    if result.winners.is_empty() {
+        return Err("elected tally has no winners".to_string());
+    }
+
+    let members = result
+        .winners
+        .iter()
+        .enumerate()
+        .map(|(i, w)| Member {
+            index: (i + 1) as u32,
+            node_id: w.node_id.clone(),
+            approvals: w.approvals,
+        })
+        .collect();
+
+    Ok(ElectedTermDoc {
+        v: TERM_DOC_VERSION,
+        term: params.term,
+        election_kind: params.election_kind.wire().to_string(),
+        status: TermStatus::Elected,
+        electorate: Electorate {
+            curation_doc_hash: snapshot.curation_doc_hash.clone(),
+            snapshot_height: snapshot.snapshot_height,
+            eligible: snapshot.eligible_ids(),
+        },
+        tally: TallySummary {
+            rule: TALLY_RULE.to_string(),
+            open_height: params.open_height,
+            close_height: params.close_height,
+            ballots: result.counted_ballot_txids.len() as u32,
+            result_hash: result.result_hash.clone(),
+        },
+        threshold: params.threshold,
+        members,
+        validity: ValidityDoc {
+            elected_at: params.validity.elected_at,
+            handover_deadline: params.validity.handover_deadline,
+            term_end: params.validity.term_end,
+        },
+    })
+}

--- a/bridge/core/src/election/tests.rs
+++ b/bridge/core/src/election/tests.rs
@@ -1,0 +1,598 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Unit tests over synthetic ledgers for the election tally + term-document
+//! assembly. No live chain is needed: nodes, curation snapshots, and
+//! memo-convention transactions are all constructed in-process.
+
+use ed25519_dalek::SigningKey;
+
+use super::*;
+
+/// A test node with a deterministic curated identity key.
+struct TestNode {
+    id: String,
+    key: SigningKey,
+}
+
+fn mk_node(id: &str, seed: u8) -> TestNode {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    bytes[31] = seed.wrapping_add(7);
+    TestNode {
+        id: id.to_string(),
+        key: SigningKey::from_bytes(&bytes),
+    }
+}
+
+fn snapshot_of(nodes: &[&TestNode], height: u64) -> CurationSnapshot {
+    CurationSnapshot {
+        curation_doc_hash: "curation-doc-hash-abc123".to_string(),
+        snapshot_height: height,
+        nodes: nodes
+            .iter()
+            .map(|n| CuratedNode {
+                node_id: n.id.clone(),
+                identity_pubkey_hex: hex::encode(n.key.verifying_key().as_bytes()),
+            })
+            .collect(),
+    }
+}
+
+fn nominate_tx(txid: &str, height: u64, node: &TestNode, term: u64) -> MemoTransaction {
+    let memo = canonical_nomination_memo(&node.id, term);
+    let signature_hex = sign_election_memo_ed25519(&memo, &node.key);
+    MemoTransaction {
+        txid: txid.to_string(),
+        height,
+        memo,
+        signature_hex,
+    }
+}
+
+fn ballot_tx(
+    txid: &str,
+    height: u64,
+    voter: &TestNode,
+    term: u64,
+    approvals: &[&str],
+) -> MemoTransaction {
+    let approvals: Vec<String> = approvals.iter().map(|s| s.to_string()).collect();
+    let memo = canonical_ballot_memo(&voter.id, term, &approvals);
+    let signature_hex = sign_election_memo_ed25519(&memo, &voter.key);
+    MemoTransaction {
+        txid: txid.to_string(),
+        height,
+        memo,
+        signature_hex,
+    }
+}
+
+fn params(term: u64, open: u64, close: u64, seats: usize, threshold: u32) -> ElectionParams {
+    ElectionParams {
+        term,
+        election_kind: ElectionKind::Scheduled,
+        open_height: open,
+        close_height: close,
+        seats,
+        threshold,
+        validity: Validity {
+            elected_at: 1_760_400_000,
+            handover_deadline: 1_760_659_200,
+            term_end: 1_768_435_200,
+        },
+    }
+}
+
+/// Build the canonical five-node scenario used by several tests. Electorate =
+/// {a,b,c,d,e} (quorum 3); candidates a,b,c,d nominate before openHeight.
+/// Approvals: a=5, b=3, c=1, d=1 — a clean top-2 plus a c/d tie at seat 3.
+fn five_node_scenario() -> (
+    Vec<TestNode>,
+    CurationSnapshot,
+    ElectionParams,
+    Vec<MemoTransaction>,
+) {
+    let nodes = vec![
+        mk_node("node-a", 1),
+        mk_node("node-b", 2),
+        mk_node("node-c", 3),
+        mk_node("node-d", 4),
+        mk_node("node-e", 5),
+    ];
+    let refs: Vec<&TestNode> = nodes.iter().collect();
+    let snap = snapshot_of(&refs, 41_800);
+    let p = params(3, 41_810, 42_520, 3, 2);
+
+    let (a, b, c, d, e) = (&nodes[0], &nodes[1], &nodes[2], &nodes[3], &nodes[4]);
+    let ledger = vec![
+        // Nominations (before openHeight 41_810).
+        nominate_tx("nom-a", 41_805, a, 3),
+        nominate_tx("nom-b", 41_805, b, 3),
+        nominate_tx("nom-c", 41_806, c, 3),
+        nominate_tx("nom-d", 41_806, d, 3),
+        // Ballots (within 41_810..=42_520).
+        ballot_tx("bal-a", 41_900, a, 3, &["node-a", "node-b"]),
+        ballot_tx("bal-b", 41_900, b, 3, &["node-a", "node-b"]),
+        ballot_tx("bal-c", 41_901, c, 3, &["node-a", "node-c"]),
+        ballot_tx("bal-d", 41_901, d, 3, &["node-a", "node-d"]),
+        ballot_tx("bal-e", 41_902, e, 3, &["node-a", "node-b"]),
+    ];
+    (nodes, snap, p, ledger)
+}
+
+#[test]
+fn clean_win_produces_correct_top_n() {
+    let (_nodes, snap, p, ledger) = five_node_scenario();
+    let result = tally(&snap, &p, &ledger).unwrap();
+
+    assert_eq!(result.status, TallyStatus::Elected);
+    assert_eq!(result.turnout, 5);
+    assert_eq!(result.eligible, 5);
+    assert_eq!(result.quorum_required, 3);
+
+    // a=5, b=3 clearly top-2; seat 3 is the c/d tie resolved to c.
+    let winners: Vec<&str> = result.winners.iter().map(|w| w.node_id.as_str()).collect();
+    assert_eq!(winners, vec!["node-a", "node-b", "node-c"]);
+    assert_eq!(result.winners[0].approvals, 5);
+    assert_eq!(result.winners[1].approvals, 3);
+    assert_eq!(result.winners[2].approvals, 1);
+
+    // Full ranking includes the loser d at rank 4.
+    assert_eq!(result.ranking.len(), 4);
+    assert_eq!(result.ranking[3].node_id, "node-d");
+    assert_eq!(result.ranking[3].rank, 4);
+}
+
+#[test]
+fn tie_break_is_ascending_node_id() {
+    let (_nodes, snap, p, ledger) = five_node_scenario();
+    let result = tally(&snap, &p, &ledger).unwrap();
+
+    // c and d both have exactly 1 approval; the Nth (3rd) seat must go to the
+    // lexicographically smaller nodeId — node-c — deterministically.
+    let c = result
+        .ranking
+        .iter()
+        .find(|r| r.node_id == "node-c")
+        .unwrap();
+    let d = result
+        .ranking
+        .iter()
+        .find(|r| r.node_id == "node-d")
+        .unwrap();
+    assert_eq!(c.approvals, d.approvals);
+    assert!(
+        c.rank < d.rank,
+        "node-c must outrank node-d on the tie-break"
+    );
+    assert_eq!(c.rank, 3);
+    assert_eq!(d.rank, 4);
+    assert!(result.winners.iter().any(|w| w.node_id == "node-c"));
+    assert!(!result.winners.iter().any(|w| w.node_id == "node-d"));
+}
+
+#[test]
+fn tie_break_is_symmetric_regardless_of_input() {
+    // Swap which of two equal candidates appears first in the ledger and
+    // confirm the deterministic tie-break still seats node-c, not whoever was
+    // processed first.
+    let (nodes, snap, p, mut ledger) = five_node_scenario();
+    let _ = &nodes;
+    ledger.reverse();
+    let result = tally(&snap, &p, &ledger).unwrap();
+    let winners: Vec<&str> = result.winners.iter().map(|w| w.node_id.as_str()).collect();
+    assert_eq!(winners, vec!["node-a", "node-b", "node-c"]);
+}
+
+#[test]
+fn reproducible_under_input_reordering() {
+    let (_nodes, snap, p, ledger) = five_node_scenario();
+    let baseline = tally(&snap, &p, &ledger).unwrap();
+
+    // Every rotation of the ledger must yield the identical result_hash and
+    // winners — the tally is order-independent.
+    for shift in 0..ledger.len() {
+        let mut rotated = ledger.clone();
+        rotated.rotate_left(shift);
+        let r = tally(&snap, &p, &rotated).unwrap();
+        assert_eq!(r.result_hash, baseline.result_hash, "shift={shift}");
+        assert_eq!(r.winners, baseline.winners, "shift={shift}");
+        assert_eq!(r.ranking, baseline.ranking, "shift={shift}");
+    }
+
+    // And running the exact same inputs twice is byte-identical.
+    let again = tally(&snap, &p, &ledger).unwrap();
+    assert_eq!(again, baseline);
+}
+
+#[test]
+fn no_quorum_when_turnout_below_majority() {
+    let (nodes, snap, p, _ledger) = five_node_scenario();
+    let (a, b, c, d) = (&nodes[0], &nodes[1], &nodes[2], &nodes[3]);
+    // Only two of five vote — below the quorum of 3.
+    let ledger = vec![
+        nominate_tx("nom-a", 41_805, a, 3),
+        nominate_tx("nom-b", 41_805, b, 3),
+        nominate_tx("nom-c", 41_806, c, 3),
+        nominate_tx("nom-d", 41_806, d, 3),
+        ballot_tx("bal-a", 41_900, a, 3, &["node-a", "node-b"]),
+        ballot_tx("bal-b", 41_900, b, 3, &["node-a", "node-b"]),
+    ];
+    let result = tally(&snap, &p, &ledger).unwrap();
+    assert_eq!(result.status, TallyStatus::NoQuorum);
+    assert_eq!(result.turnout, 2);
+    assert!(result.winners.is_empty());
+
+    // A term document cannot be cut from a no-quorum election.
+    assert!(assemble_elected_term_doc(&snap, &p, &result).is_err());
+}
+
+#[test]
+fn ineligible_voter_ballot_rejected() {
+    let (nodes, snap, p, mut ledger) = five_node_scenario();
+    let _ = &nodes;
+    // An outsider not in the curation snapshot casts a ballot.
+    let outsider = mk_node("node-intruder", 99);
+    ledger.push(ballot_tx("bal-x", 41_950, &outsider, 3, &["node-d"]));
+
+    let result = tally(&snap, &p, &ledger).unwrap();
+    assert_eq!(result.turnout, 5, "outsider must not count toward turnout");
+    assert!(result
+        .rejected
+        .iter()
+        .any(|r| r.txid == "bal-x" && r.reason == "ballot_not_curated"));
+    // node-d gained nothing from the outsider's approval.
+    let d = result
+        .ranking
+        .iter()
+        .find(|r| r.node_id == "node-d")
+        .unwrap();
+    assert_eq!(d.approvals, 1);
+}
+
+#[test]
+fn duplicate_voter_first_ballot_wins() {
+    let (nodes, snap, p, mut ledger) = five_node_scenario();
+    let e = &nodes[4];
+    // node-e already voted (bal-e approves a,b). A second ballot approving c
+    // must be rejected — one node, one vote — and c must not gain from it.
+    ledger.push(ballot_tx("bal-e2", 42_000, e, 3, &["node-c"]));
+
+    let result = tally(&snap, &p, &ledger).unwrap();
+    assert_eq!(result.turnout, 5);
+    assert!(result
+        .rejected
+        .iter()
+        .any(|r| r.txid == "bal-e2" && r.reason == "ballot_duplicate_voter"));
+    let c = result
+        .ranking
+        .iter()
+        .find(|r| r.node_id == "node-c")
+        .unwrap();
+    assert_eq!(c.approvals, 1, "the rejected second ballot must not count");
+}
+
+#[test]
+fn tampered_signature_rejected() {
+    let (nodes, snap, p, _ledger) = five_node_scenario();
+    let (a, b, c, d, e) = (&nodes[0], &nodes[1], &nodes[2], &nodes[3], &nodes[4]);
+    let mut bad = ballot_tx("bal-bad", 41_900, e, 3, &["node-a"]);
+    // Flip a byte of the signature.
+    bad.signature_hex.replace_range(0..2, "00");
+    let ledger = vec![
+        nominate_tx("nom-a", 41_805, a, 3),
+        nominate_tx("nom-b", 41_805, b, 3),
+        nominate_tx("nom-c", 41_806, c, 3),
+        nominate_tx("nom-d", 41_806, d, 3),
+        ballot_tx("bal-a", 41_900, a, 3, &["node-a"]),
+        ballot_tx("bal-b", 41_900, b, 3, &["node-b"]),
+        ballot_tx("bal-c", 41_901, c, 3, &["node-c"]),
+        bad,
+    ];
+    let result = tally(&snap, &p, &ledger).unwrap();
+    assert!(result
+        .rejected
+        .iter()
+        .any(|r| r.txid == "bal-bad" && r.reason == "ballot_bad_signature"));
+    assert_eq!(result.turnout, 3, "the forged ballot must not count");
+}
+
+#[test]
+fn nomination_after_open_height_rejected() {
+    let (nodes, snap, p, _ledger) = five_node_scenario();
+    let (a, b, c) = (&nodes[0], &nodes[1], &nodes[2]);
+    let ledger = vec![
+        nominate_tx("nom-a", 41_805, a, 3),
+        nominate_tx("nom-b", 41_805, b, 3),
+        // node-c nominates exactly at openHeight — too late.
+        nominate_tx("nom-c-late", 41_810, c, 3),
+        ballot_tx("bal-a", 41_900, a, 3, &["node-a", "node-b", "node-c"]),
+        ballot_tx("bal-b", 41_900, b, 3, &["node-a", "node-b", "node-c"]),
+        ballot_tx("bal-c", 41_900, c, 3, &["node-a", "node-b", "node-c"]),
+    ];
+    let result = tally(&snap, &p, &ledger).unwrap();
+    assert!(result
+        .rejected
+        .iter()
+        .any(|r| r.txid == "nom-c-late" && r.reason == "nomination_after_open"));
+    // node-c never became a candidate, so approvals for it were dropped.
+    assert!(!result.ranking.iter().any(|r| r.node_id == "node-c"));
+    assert_eq!(result.ranking.len(), 2);
+}
+
+#[test]
+fn ballot_outside_window_rejected() {
+    let (nodes, snap, p, _ledger) = five_node_scenario();
+    let (a, b, c, d, e) = (&nodes[0], &nodes[1], &nodes[2], &nodes[3], &nodes[4]);
+    let ledger = vec![
+        nominate_tx("nom-a", 41_805, a, 3),
+        nominate_tx("nom-b", 41_805, b, 3),
+        nominate_tx("nom-c", 41_806, c, 3),
+        nominate_tx("nom-d", 41_806, d, 3),
+        ballot_tx("bal-a", 41_900, a, 3, &["node-a"]),
+        ballot_tx("bal-b", 41_900, b, 3, &["node-b"]),
+        ballot_tx("bal-c", 41_901, c, 3, &["node-c"]),
+        // After closeHeight (42_520) — must be rejected.
+        ballot_tx("bal-late", 42_521, d, 3, &["node-d"]),
+        // Before openHeight — must be rejected.
+        ballot_tx("bal-early", 41_800, e, 3, &["node-a"]),
+    ];
+    let result = tally(&snap, &p, &ledger).unwrap();
+    assert!(result
+        .rejected
+        .iter()
+        .any(|r| r.txid == "bal-late" && r.reason == "ballot_outside_window"));
+    assert!(result
+        .rejected
+        .iter()
+        .any(|r| r.txid == "bal-early" && r.reason == "ballot_outside_window"));
+    assert_eq!(result.turnout, 3);
+}
+
+#[test]
+fn duplicate_nomination_rejected() {
+    let (nodes, snap, p, _ledger) = five_node_scenario();
+    let (a, b, c) = (&nodes[0], &nodes[1], &nodes[2]);
+    let ledger = vec![
+        nominate_tx("nom-a", 41_805, a, 3),
+        nominate_tx("nom-a-again", 41_806, a, 3),
+        nominate_tx("nom-b", 41_805, b, 3),
+        ballot_tx("bal-a", 41_900, a, 3, &["node-a", "node-b"]),
+        ballot_tx("bal-b", 41_900, b, 3, &["node-a", "node-b"]),
+        ballot_tx("bal-c", 41_900, c, 3, &["node-a"]),
+    ];
+    let result = tally(&snap, &p, &ledger).unwrap();
+    assert!(result
+        .rejected
+        .iter()
+        .any(|r| r.txid == "nom-a-again" && r.reason == "nomination_duplicate"));
+    // Exactly two candidates, node-a counted once.
+    assert_eq!(result.ranking.len(), 2);
+}
+
+#[test]
+fn insufficient_candidates_when_below_threshold() {
+    let (nodes, snap, p, _ledger) = five_node_scenario();
+    let (a, b, c) = (&nodes[0], &nodes[1], &nodes[2]);
+    // Quorum is met (3 voters) but only ONE candidate stands; threshold is 2.
+    let ledger = vec![
+        nominate_tx("nom-a", 41_805, a, 3),
+        ballot_tx("bal-a", 41_900, a, 3, &["node-a"]),
+        ballot_tx("bal-b", 41_900, b, 3, &["node-a"]),
+        ballot_tx("bal-c", 41_900, c, 3, &["node-a"]),
+    ];
+    let result = tally(&snap, &p, &ledger).unwrap();
+    assert_eq!(result.status, TallyStatus::InsufficientCandidates);
+    assert!(result.winners.is_empty());
+    assert!(assemble_elected_term_doc(&snap, &p, &result).is_err());
+}
+
+#[test]
+fn approval_of_non_candidate_is_dropped_but_ballot_counts() {
+    let (nodes, snap, p, _ledger) = five_node_scenario();
+    let (a, b, c) = (&nodes[0], &nodes[1], &nodes[2]);
+    let ledger = vec![
+        nominate_tx("nom-a", 41_805, a, 3),
+        nominate_tx("nom-b", 41_805, b, 3),
+        // node-c is NOT nominated; approvals for it must be dropped.
+        ballot_tx("bal-a", 41_900, a, 3, &["node-a", "node-c"]),
+        ballot_tx("bal-b", 41_900, b, 3, &["node-b", "node-c"]),
+        ballot_tx("bal-c", 41_900, c, 3, &["node-a", "node-b"]),
+    ];
+    let result = tally(&snap, &p, &ledger).unwrap();
+    assert_eq!(
+        result.turnout, 3,
+        "all three ballots still count as turnout"
+    );
+    assert!(!result.ranking.iter().any(|r| r.node_id == "node-c"));
+    let a_standing = result
+        .ranking
+        .iter()
+        .find(|r| r.node_id == "node-a")
+        .unwrap();
+    assert_eq!(a_standing.approvals, 2);
+}
+
+#[test]
+fn curation_snapshot_binding_is_the_electorate() {
+    // The tally binds to the snapshot, not to whoever holds a key. A ballot
+    // from a validly-signed node absent from THIS snapshot does not count,
+    // even though its signature is cryptographically valid.
+    let a = mk_node("node-a", 1);
+    let b = mk_node("node-b", 2);
+    let c = mk_node("node-c", 3);
+    // Snapshot pins only a and b.
+    let snap = snapshot_of(&[&a, &b], 41_800);
+    let p = params(3, 41_810, 42_520, 2, 2);
+    let ledger = vec![
+        nominate_tx("nom-a", 41_805, &a, 3),
+        nominate_tx("nom-b", 41_805, &b, 3),
+        // c is not in the snapshot — its nomination and ballot are ignored.
+        nominate_tx("nom-c", 41_805, &c, 3),
+        ballot_tx("bal-a", 41_900, &a, 3, &["node-a", "node-b"]),
+        ballot_tx("bal-b", 41_900, &b, 3, &["node-a", "node-b"]),
+        ballot_tx("bal-c", 41_900, &c, 3, &["node-a"]),
+    ];
+    let result = tally(&snap, &p, &ledger).unwrap();
+    assert_eq!(result.eligible, 2);
+    assert_eq!(result.quorum_required, 2);
+    assert_eq!(result.turnout, 2, "c is not in the electorate");
+    assert!(result
+        .rejected
+        .iter()
+        .any(|r| r.txid == "nom-c" && r.reason == "nomination_not_curated"));
+    assert!(result
+        .rejected
+        .iter()
+        .any(|r| r.txid == "bal-c" && r.reason == "ballot_not_curated"));
+    assert_eq!(result.status, TallyStatus::Elected);
+    assert_eq!(result.winners.len(), 2);
+}
+
+#[test]
+fn assemble_elected_term_document() {
+    let (_nodes, snap, p, ledger) = five_node_scenario();
+    let result = tally(&snap, &p, &ledger).unwrap();
+    let doc = assemble_elected_term_doc(&snap, &p, &result).unwrap();
+
+    assert_eq!(doc.v, 2);
+    assert_eq!(doc.term, 3);
+    assert_eq!(doc.election_kind, "scheduled");
+    assert_eq!(doc.status, TermStatus::Elected);
+    assert_eq!(doc.threshold, 2);
+
+    // Electorate = sorted eligible ids.
+    assert_eq!(
+        doc.electorate.eligible,
+        vec!["node-a", "node-b", "node-c", "node-d", "node-e"]
+    );
+    assert_eq!(doc.electorate.snapshot_height, 41_800);
+    assert_eq!(doc.electorate.curation_doc_hash, "curation-doc-hash-abc123");
+
+    // Tally block mirrors the result.
+    assert_eq!(doc.tally.rule, "approval-top-N-v1");
+    assert_eq!(doc.tally.open_height, 41_810);
+    assert_eq!(doc.tally.close_height, 42_520);
+    assert_eq!(doc.tally.ballots, 5);
+    assert_eq!(doc.tally.result_hash, result.result_hash);
+
+    // Members are the winners in seat order (index 1..=N), keys absent.
+    assert_eq!(doc.members.len(), 3);
+    assert_eq!(doc.members[0].index, 1);
+    assert_eq!(doc.members[0].node_id, "node-a");
+    assert_eq!(doc.members[2].index, 3);
+    assert_eq!(doc.members[2].node_id, "node-c");
+
+    // validity carried verbatim.
+    assert_eq!(doc.validity.elected_at, 1_760_400_000);
+
+    // Round-trips through JSON, and the emitted JSON is deterministic (no
+    // execution/signatures blocks — those belong to the seal step).
+    let json = doc.to_json();
+    let back: ElectedTermDoc = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, doc);
+    assert!(!json.contains("execution"));
+    assert!(!json.contains("signatures"));
+    assert!(json.contains("\"status\":\"elected\""));
+}
+
+// --- memo-format unit tests ---
+
+#[test]
+fn nomination_memo_round_trips() {
+    let memo = canonical_nomination_memo("node-a", 7);
+    assert_eq!(
+        memo,
+        r#"{"kind":"bridge.nominate","nodeId":"node-a","term":7,"v":1}"#
+    );
+    let parsed = parse_election_memo(&memo).unwrap();
+    assert_eq!(
+        parsed,
+        ElectionMemo::Nomination {
+            term: 7,
+            node_id: "node-a".to_string()
+        }
+    );
+}
+
+#[test]
+fn ballot_memo_sorts_and_dedups_approvals() {
+    let memo = canonical_ballot_memo(
+        "node-a",
+        7,
+        &[
+            "node-c".to_string(),
+            "node-a".to_string(),
+            "node-c".to_string(),
+            "node-b".to_string(),
+        ],
+    );
+    assert_eq!(
+        memo,
+        r#"{"approvals":["node-a","node-b","node-c"],"kind":"bridge.ballot","nodeId":"node-a","term":7,"v":1}"#
+    );
+    let parsed = parse_election_memo(&memo).unwrap();
+    match parsed {
+        ElectionMemo::Ballot { approvals, .. } => {
+            assert_eq!(approvals, vec!["node-a", "node-b", "node-c"]);
+        }
+        _ => panic!("expected a ballot"),
+    }
+}
+
+#[test]
+fn memo_parse_rejects_unknown_and_duplicate_and_bad_version() {
+    // Unknown field.
+    assert!(parse_election_memo(
+        r#"{"kind":"bridge.nominate","nodeId":"node-a","term":7,"v":1,"x":1}"#
+    )
+    .is_err());
+    // Duplicate key (serde would silently last-wins).
+    assert!(parse_election_memo(
+        r#"{"kind":"bridge.nominate","kind":"bridge.ballot","nodeId":"node-a","term":7,"v":1}"#
+    )
+    .is_err());
+    // Wrong version.
+    assert!(
+        parse_election_memo(r#"{"kind":"bridge.nominate","nodeId":"node-a","term":7,"v":2}"#)
+            .is_err()
+    );
+    // Unknown kind.
+    assert!(
+        parse_election_memo(r#"{"kind":"bridge.bribe","nodeId":"node-a","term":7,"v":1}"#).is_err()
+    );
+    // Float where an integer is required.
+    assert!(parse_election_memo(
+        r#"{"kind":"bridge.nominate","nodeId":"node-a","term":7.0,"v":1}"#
+    )
+    .is_err());
+}
+
+#[test]
+fn memo_signature_verify_roundtrip() {
+    let node = mk_node("node-a", 42);
+    let memo = canonical_nomination_memo("node-a", 3);
+    let sig = sign_election_memo_ed25519(&memo, &node.key);
+    let vk = node.key.verifying_key();
+    assert!(verify_election_memo(&memo, &sig, &vk).is_ok());
+
+    // A different memo does not verify under the same signature.
+    let other = canonical_nomination_memo("node-a", 4);
+    assert!(verify_election_memo(&other, &sig, &vk).is_err());
+
+    // A different key does not verify.
+    let other_key = mk_node("node-b", 43).key.verifying_key();
+    assert!(verify_election_memo(&memo, &sig, &other_key).is_err());
+}
+
+#[test]
+fn params_validation_rejects_bad_shapes() {
+    // close < open
+    assert!(params(1, 100, 50, 3, 2).validate().is_err());
+    // threshold > seats
+    assert!(params(1, 10, 20, 2, 3).validate().is_err());
+    // seats < 2
+    assert!(params(1, 10, 20, 1, 1).validate().is_err());
+    // valid
+    assert!(params(1, 10, 20, 5, 3).validate().is_ok());
+}

--- a/bridge/core/src/election/tests.rs
+++ b/bridge/core/src/election/tests.rs
@@ -593,6 +593,214 @@ fn params_validation_rejects_bad_shapes() {
     assert!(params(1, 10, 20, 2, 3).validate().is_err());
     // seats < 2
     assert!(params(1, 10, 20, 1, 1).validate().is_err());
-    // valid
+    // seats > 5 (schema caps members at maxItems: 5)
+    assert!(params(1, 10, 20, 6, 3).validate().is_err());
+    // valid (the ratified 3-of-5 shape is the upper bound)
     assert!(params(1, 10, 20, 5, 3).validate().is_ok());
+}
+
+// --- seam guard: the emitted `elected` doc must validate against the on-main
+// v2 JSON schema (docs/bridge/schemas/term-document.v2.schema.json), and the
+// schema must keep `execution`/`signatures` seal-only. This is the guard the
+// #1073 review asked for so the #1067 → #1066 seam can never silently regress.
+
+/// Resolve a path relative to the repository root (this crate lives at
+/// `bridge/core`, so the root is two levels up from `CARGO_MANIFEST_DIR`).
+fn repo_path(rel: &str) -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(rel)
+}
+
+/// Load and parse the checked-in v2 term-document schema.
+fn load_v2_schema() -> serde_json::Value {
+    let path = repo_path("docs/bridge/schemas/term-document.v2.schema.json");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("read schema {}: {e}", path.display()));
+    serde_json::from_str(&raw).expect("schema is valid JSON")
+}
+
+/// A small, offline JSON Schema (Draft 2020-12) validator covering exactly the
+/// keyword subset the term-document schema uses: `type`, `const`, `enum`,
+/// `minimum`, `required`, `properties`, `items`, `minItems`, `maxItems`,
+/// `allOf`, and `if`/`then`/`else`. Errors are accumulated into `errors`;
+/// an empty vec means the instance validates.
+fn validate_schema(
+    schema: &serde_json::Value,
+    inst: &serde_json::Value,
+    path: &str,
+    errors: &mut Vec<String>,
+) {
+    let obj = match schema.as_object() {
+        Some(o) => o,
+        None => return,
+    };
+
+    if let Some(t) = obj.get("type").and_then(|v| v.as_str()) {
+        let ok = match t {
+            "object" => inst.is_object(),
+            "array" => inst.is_array(),
+            "string" => inst.is_string(),
+            "integer" => inst.is_i64() || inst.is_u64(),
+            "number" => inst.is_number(),
+            "boolean" => inst.is_boolean(),
+            _ => true,
+        };
+        if !ok {
+            errors.push(format!("{path}: expected type {t}"));
+            return;
+        }
+    }
+
+    if let Some(c) = obj.get("const") {
+        if inst != c {
+            errors.push(format!("{path}: const mismatch"));
+        }
+    }
+
+    if let Some(vals) = obj.get("enum").and_then(|v| v.as_array()) {
+        if !vals.iter().any(|v| v == inst) {
+            errors.push(format!("{path}: not in enum"));
+        }
+    }
+
+    if let Some(min) = obj.get("minimum").and_then(|v| v.as_f64()) {
+        if let Some(n) = inst.as_f64() {
+            if n < min {
+                errors.push(format!("{path}: below minimum"));
+            }
+        }
+    }
+
+    if let (Some(req), Some(map)) = (
+        obj.get("required").and_then(|v| v.as_array()),
+        inst.as_object(),
+    ) {
+        for k in req.iter().filter_map(|k| k.as_str()) {
+            if !map.contains_key(k) {
+                errors.push(format!("{path}: '{k}' is a required property"));
+            }
+        }
+    }
+
+    if let (Some(props), Some(map)) = (
+        obj.get("properties").and_then(|v| v.as_object()),
+        inst.as_object(),
+    ) {
+        for (k, subschema) in props {
+            if let Some(child) = map.get(k) {
+                validate_schema(subschema, child, &format!("{path}/{k}"), errors);
+            }
+        }
+    }
+
+    if let (Some(items), Some(arr)) = (obj.get("items"), inst.as_array()) {
+        for (i, el) in arr.iter().enumerate() {
+            validate_schema(items, el, &format!("{path}/{i}"), errors);
+        }
+    }
+
+    if let (Some(mi), Some(arr)) = (
+        obj.get("minItems").and_then(|v| v.as_u64()),
+        inst.as_array(),
+    ) {
+        if (arr.len() as u64) < mi {
+            errors.push(format!("{path}: fewer than minItems {mi}"));
+        }
+    }
+    if let (Some(ma), Some(arr)) = (
+        obj.get("maxItems").and_then(|v| v.as_u64()),
+        inst.as_array(),
+    ) {
+        if (arr.len() as u64) > ma {
+            errors.push(format!("{path}: more than maxItems {ma}"));
+        }
+    }
+
+    if let Some(all) = obj.get("allOf").and_then(|v| v.as_array()) {
+        for sub in all {
+            validate_schema(sub, inst, path, errors);
+        }
+    }
+
+    if let Some(if_s) = obj.get("if") {
+        let mut probe = Vec::new();
+        validate_schema(if_s, inst, path, &mut probe);
+        if probe.is_empty() {
+            if let Some(then_s) = obj.get("then") {
+                validate_schema(then_s, inst, path, errors);
+            }
+        } else if let Some(else_s) = obj.get("else") {
+            validate_schema(else_s, inst, path, errors);
+        }
+    }
+}
+
+fn schema_errors(schema: &serde_json::Value, inst: &serde_json::Value) -> Vec<String> {
+    let mut errors = Vec::new();
+    validate_schema(schema, inst, "", &mut errors);
+    errors
+}
+
+#[test]
+fn emitted_elected_doc_validates_against_v2_schema() {
+    let schema = load_v2_schema();
+
+    // The exact JSON `assemble_elected_term_doc` emits must validate against the
+    // v2 schema that #1074 merged to `main` — this is the #1067 → #1066 seam.
+    let (_nodes, snap, p, ledger) = five_node_scenario();
+    let result = tally(&snap, &p, &ledger).unwrap();
+    let doc = assemble_elected_term_doc(&snap, &p, &result).unwrap();
+    let inst: serde_json::Value = serde_json::from_str(&doc.to_json()).unwrap();
+
+    let errs = schema_errors(&schema, &inst);
+    assert!(errs.is_empty(), "elected doc failed v2 schema: {errs:?}");
+
+    // The seam's whole point: an `elected` doc carries NO execution/signatures,
+    // and that must be legal (those are seal-only).
+    let map = inst.as_object().unwrap();
+    assert!(!map.contains_key("execution"));
+    assert!(!map.contains_key("signatures"));
+}
+
+#[test]
+fn sealed_example_fixture_validates_and_execution_is_seal_only() {
+    let schema = load_v2_schema();
+
+    // The checked-in sealed fixture must still validate (proves the conditional
+    // `execution`/`signatures` requirement moved to the sealed branch, not that
+    // it was dropped).
+    let sealed_raw = std::fs::read_to_string(repo_path(
+        "docs/bridge/schemas/examples/term-3.sealed.example.json",
+    ))
+    .expect("read sealed example");
+    let sealed: serde_json::Value = serde_json::from_str(&sealed_raw).unwrap();
+    let errs = schema_errors(&schema, &sealed);
+    assert!(errs.is_empty(), "sealed fixture failed v2 schema: {errs:?}");
+
+    // Teeth check #1: a sealed doc that omits `execution` / `signatures` MUST
+    // fail — otherwise the conditional requirement never moved.
+    let mut broken_sealed = sealed.clone();
+    let m = broken_sealed.as_object_mut().unwrap();
+    m.remove("execution");
+    m.remove("signatures");
+    let errs = schema_errors(&schema, &broken_sealed);
+    assert!(
+        errs.iter().any(|e| e.contains("'execution'"))
+            && errs.iter().any(|e| e.contains("'signatures'")),
+        "sealed doc without execution/signatures should fail: {errs:?}"
+    );
+
+    // Teeth check #2: the validator actually enforces top-level `required` — an
+    // elected doc missing `members` must fail, so the seam test above has bite.
+    let (_nodes, snap, p, ledger) = five_node_scenario();
+    let result = tally(&snap, &p, &ledger).unwrap();
+    let doc = assemble_elected_term_doc(&snap, &p, &result).unwrap();
+    let mut broken_elected: serde_json::Value = serde_json::from_str(&doc.to_json()).unwrap();
+    broken_elected.as_object_mut().unwrap().remove("members");
+    let errs = schema_errors(&schema, &broken_elected);
+    assert!(
+        errs.iter().any(|e| e.contains("'members'")),
+        "elected doc without members should fail: {errs:?}"
+    );
 }

--- a/bridge/core/src/lib.rs
+++ b/bridge/core/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod attestation;
 pub mod chains;
 pub mod config;
+pub mod election;
 #[cfg(test)]
 mod happy_path_tests;
 pub mod nonce;
@@ -36,6 +37,12 @@ pub use chains::{Chain, ChainAddress};
 pub use config::{
     BridgeConfig, BthConfig, EthereumConfig, FederationSettings, GasPriceStrategy,
     PublicApiSettings, ReserveSettings, SolanaCommitment, SolanaConfig,
+};
+pub use election::{
+    assemble_elected_term_doc, canonical_ballot_memo, canonical_nomination_memo,
+    parse_election_memo, sign_election_memo_ed25519, tally, verify_election_memo,
+    CandidateStanding, CuratedNode, CurationSnapshot, ElectedTermDoc, ElectionKind, ElectionMemo,
+    ElectionParams, MemoTransaction, TallyResult, TallyStatus, Validity,
 };
 pub use nonce::{NonceStore, ReserveOutcome};
 pub use order::{derive_order_id, BridgeOrder, OrderStatus, OrderType};

--- a/bridge/core/tests/tally_cli.rs
+++ b/bridge/core/tests/tally_cli.rs
@@ -1,0 +1,176 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! End-to-end test of the `bridge-tally` CLI: build a synthetic ledger with
+//! real signatures using the library, write the `{ params, snapshot, ledger }`
+//! bundle to a temp file, run the compiled binary, and assert it emits the
+//! correct `elected` term document with exit code 0.
+
+use std::process::Command;
+
+use bth_bridge_core::election::{
+    canonical_ballot_memo, canonical_nomination_memo, sign_election_memo_ed25519, CuratedNode,
+    CurationSnapshot, ElectionKind, ElectionParams, MemoTransaction, Validity,
+};
+use ed25519_dalek::SigningKey;
+use serde_json::json;
+
+fn key(seed: u8) -> SigningKey {
+    let mut b = [0u8; 32];
+    b[0] = seed;
+    b[31] = seed.wrapping_add(7);
+    SigningKey::from_bytes(&b)
+}
+
+fn nominate(txid: &str, height: u64, id: &str, k: &SigningKey, term: u64) -> MemoTransaction {
+    let memo = canonical_nomination_memo(id, term);
+    MemoTransaction {
+        txid: txid.into(),
+        height,
+        signature_hex: sign_election_memo_ed25519(&memo, k),
+        memo,
+    }
+}
+
+fn ballot(
+    txid: &str,
+    height: u64,
+    id: &str,
+    k: &SigningKey,
+    term: u64,
+    approve: &[&str],
+) -> MemoTransaction {
+    let a: Vec<String> = approve.iter().map(|s| s.to_string()).collect();
+    let memo = canonical_ballot_memo(id, term, &a);
+    MemoTransaction {
+        txid: txid.into(),
+        height,
+        signature_hex: sign_election_memo_ed25519(&memo, k),
+        memo,
+    }
+}
+
+#[test]
+fn cli_tally_emits_elected_term_document() {
+    let ids = ["node-a", "node-b", "node-c"];
+    let keys: Vec<SigningKey> = (0..3).map(|i| key((i + 1) as u8)).collect();
+
+    let snapshot = CurationSnapshot {
+        curation_doc_hash: "cli-curation-hash".into(),
+        snapshot_height: 100,
+        nodes: ids
+            .iter()
+            .zip(&keys)
+            .map(|(id, k)| CuratedNode {
+                node_id: id.to_string(),
+                identity_pubkey_hex: hex::encode(k.verifying_key().as_bytes()),
+            })
+            .collect(),
+    };
+
+    let params = ElectionParams {
+        term: 5,
+        election_kind: ElectionKind::Scheduled,
+        open_height: 110,
+        close_height: 200,
+        seats: 2,
+        threshold: 2,
+        validity: Validity {
+            elected_at: 1000,
+            handover_deadline: 2000,
+            term_end: 3000,
+        },
+    };
+
+    let ledger = vec![
+        nominate("nom-a", 105, "node-a", &keys[0], 5),
+        nominate("nom-b", 105, "node-b", &keys[1], 5),
+        nominate("nom-c", 106, "node-c", &keys[2], 5),
+        ballot("bal-a", 150, "node-a", &keys[0], 5, &["node-a", "node-b"]),
+        ballot("bal-b", 150, "node-b", &keys[1], 5, &["node-a", "node-b"]),
+        ballot("bal-c", 151, "node-c", &keys[2], 5, &["node-a"]),
+    ];
+
+    let input = json!({
+        "params": params,
+        "snapshot": snapshot,
+        "ledger": ledger,
+    });
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("input.json");
+    std::fs::write(&path, serde_json::to_string(&input).unwrap()).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_bridge-tally"))
+        .arg("tally")
+        .arg(&path)
+        .output()
+        .expect("run bridge-tally");
+
+    assert!(
+        out.status.success(),
+        "expected success, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let doc: serde_json::Value = serde_json::from_str(&stdout).expect("valid term-doc JSON");
+
+    assert_eq!(doc["v"], 2);
+    assert_eq!(doc["term"], 5);
+    assert_eq!(doc["status"], "elected");
+    assert_eq!(doc["members"].as_array().unwrap().len(), 2);
+    // node-a (3 approvals) and node-b (2) win; node-c (0) does not.
+    assert_eq!(doc["members"][0]["nodeId"], "node-a");
+    assert_eq!(doc["members"][0]["approvals"], 3);
+    assert_eq!(doc["members"][1]["nodeId"], "node-b");
+    // No key/execution/signature material at the elected stage.
+    assert!(doc.get("execution").is_none());
+    assert!(doc.get("signatures").is_none());
+}
+
+#[test]
+fn cli_tally_reports_no_quorum_exit_code() {
+    let ids = ["node-a", "node-b", "node-c", "node-d", "node-e"];
+    let keys: Vec<SigningKey> = (0..5).map(|i| key((i + 1) as u8)).collect();
+    let snapshot = CurationSnapshot {
+        curation_doc_hash: "h".into(),
+        snapshot_height: 100,
+        nodes: ids
+            .iter()
+            .zip(&keys)
+            .map(|(id, k)| CuratedNode {
+                node_id: id.to_string(),
+                identity_pubkey_hex: hex::encode(k.verifying_key().as_bytes()),
+            })
+            .collect(),
+    };
+    let params = ElectionParams {
+        term: 1,
+        election_kind: ElectionKind::Scheduled,
+        open_height: 110,
+        close_height: 200,
+        seats: 3,
+        threshold: 2,
+        validity: Validity {
+            elected_at: 1,
+            handover_deadline: 2,
+            term_end: 3,
+        },
+    };
+    // Electorate of 5 (quorum 3) but only one ballot.
+    let ledger = vec![
+        nominate("nom-a", 105, "node-a", &keys[0], 1),
+        nominate("nom-b", 105, "node-b", &keys[1], 1),
+        ballot("bal-a", 150, "node-a", &keys[0], 1, &["node-a", "node-b"]),
+    ];
+    let input = json!({ "params": params, "snapshot": snapshot, "ledger": ledger });
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("input.json");
+    std::fs::write(&path, serde_json::to_string(&input).unwrap()).unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_bridge-tally"))
+        .arg("tally")
+        .arg(&path)
+        .output()
+        .expect("run bridge-tally");
+    assert_eq!(out.status.code(), Some(3), "no-quorum must exit 3");
+}

--- a/docs/bridge/schemas/term-document.v2.schema.json
+++ b/docs/bridge/schemas/term-document.v2.schema.json
@@ -5,8 +5,7 @@
   "description": "Election-result artifact for the elected bridge multisig (ADR 0010, docs/bridge/election-dynamics.md §5.2). Two-stage lifecycle: an 'elected' document pins MEMBERSHIP (produced by the tally, #1067); a 'sealed' document additionally pins the fresh per-term KEYS (produced by the seal step after keygen). Only a 'sealed' document authorizes execution.",
   "type": "object",
   "required": ["v", "term", "electionKind", "status", "electorate",
-               "tally", "threshold", "members", "execution", "validity",
-               "signatures"],
+               "tally", "threshold", "members", "validity"],
   "properties": {
     "v": { "const": 2 },
     "term": { "type": "integer", "minimum": 1 },
@@ -125,12 +124,13 @@
   },
   "allOf": [
     {
-      "$comment": "Nit (a), #1064 review: per-term keys and the outgoing counter-signature are REQUIRED once the document is sealed. An 'elected' document (membership only, produced by the tally before keygen) legitimately carries neither.",
+      "$comment": "Nit (a), #1064 review + #1073 seam: per-term keys, execution intents, and the outgoing counter-signature are REQUIRED once the document is sealed. An 'elected' document (membership only, produced by the tally before keygen — #1067) legitimately carries none of them: `execution` and `signatures` are populated at seal time, so they are required only under `status == sealed`, not unconditionally at the top level.",
       "if": {
         "required": ["status"],
         "properties": { "status": { "const": "sealed" } }
       },
       "then": {
+        "required": ["execution", "signatures"],
         "properties": {
           "members": {
             "items": {


### PR DESCRIPTION
Implements the ADR 0010 **option C / sub-variant A1** election mechanism: ballots are memo-convention transactions on the Botho chain (no protocol change, no new tx type), tallied off-consensus by a **deterministic pure function** at a published cutoff height over a pinned snapshot of the P4.4 operator-curated node set (#709).

## What landed

New `bth_bridge_core::election` module (all additive, pure — no async/IO):

- **`memo`** — the two memo-convention formats: self-nomination (`bridge.nominate`, valid only before `openHeight`, one per curated identity) and approval ballot (`bridge.ballot`, one-node-one-vote, valid within `openHeight..=closeHeight`). Canonical sorted-key/whitespace-free JSON, signed by the node's long-lived curated identity key under a dedicated domain (`botho.bridge.election.v1:`). Unknown/duplicate keys and float-where-int rejected fail-closed, mirroring the existing attestation-envelope discipline.
- **`snapshot`** — the pinned P4.4 curated electorate the tally binds to (`curationDocHash` + `snapshotHeight` + per-node identity pubkeys). One node, one vote; the tally reads the snapshot, never the live curation.
- **`tally`** — the `approval-top-N-v1` **pure function**. No wall-clock, no randomness; **input-order-independent** (memos sorted by `(height, txid)`); **deterministic, grind-free tie-break** = ascending lexicographic `nodeId` (ADR 0010 §6.3, explicitly *not* ledger-derived entropy); **full ranking** (not just top-N) for §6.2 exclusion-and-retry; quorum = strict majority of the electorate; failure modes (`NoQuorum`, `InsufficientCandidates`) carried as status, not errors. Emits a `resultHash` over the counted-ballot transcript so anyone replaying the ledger recomputes the identical result.
- **`term_doc`** — assembly of the **`elected`-status v2 term document (membership only)** — the input to the seal/keygen step.

## The #1066 seam (kept clean)

This PR ends at emitting the `elected` document. Member `keys`, `execution` intents, `keySubmissionSig`, and the `signatures` block are **deliberately absent** — they belong to the seal step (elected → sealed), which is #1066's scope per ADR 0010 §5.1. `assemble_elected_term_doc` refuses to produce a document from a non-`Elected` tally.

## CLI

`bridge-tally` (thin wrapper over the pure library):
- `bridge-tally tally <input.json>` → prints the elected term doc; exit `0` elected / `3` no-quorum / `4` insufficient candidates.
- `bridge-tally build-nomination` / `build-ballot` → canonical (optionally signed) memo builders for the #1063 drill and operators.

## Tests

- **20 unit tests** over synthetic ledgers: clean win, **tie-break** + tie-break symmetry under reordering, **reproducibility** (identical `resultHash`/winners under every ledger rotation + byte-identical re-run), no-quorum, insufficient candidates, ineligible/duplicate/forged ballots, nomination + ballot window enforcement, duplicate nomination, curation-snapshot binding, non-candidate-approval drop, and memo parse/round-trip/signature.
- **2 integration tests** driving the compiled `bridge-tally` binary end-to-end (elected doc output + no-quorum exit code).

`cargo test -p bth-bridge-core`: 91 lib + 2 integration pass. `cargo clippy --all-targets` clean. `cargo fmt --check` clean.

Closes #1067
Part of #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)