### PR TITLE
feat(snap): Botho MetaMask Snap MVP (SRP-derived keys, wasm signing, receive/balance/send)

### DIFF
--- a/web/packages/snap/.gitignore
+++ b/web/packages/snap/.gitignore
@@ -1,0 +1,3 @@
+# Generated snap bundle (mm-snap build). The committed snap.manifest.json
+# carries the shasum of the last local build; rebuild before running tests.
+dist/

--- a/web/packages/snap/README.md
+++ b/web/packages/snap/README.md
@@ -1,0 +1,150 @@
+# Botho MetaMask Snap — Phase-1 MVP (issue #815)
+
+Manage a privacy-by-default **Botho** wallet from inside MetaMask, without any
+EVM compromise. The Snap derives Botho keys from the MetaMask Secret Recovery
+Phrase, runs the node-identical `bth-wasm-signer` inside the MetaMask Snaps SES
+sandbox, and talks to a user-selected Botho node for receive / balance / send.
+
+This is the **Phase-1 MVP** promotion of the Phase-0 feasibility spike
+(`web/packages/snap-spike`, verdict **GO**, merged as PR #1055). The spike proved
+the hard parts — wasm-in-SES, `getrandom` under the sandbox, SIP-6 key
+derivation, and a real testnet send end-to-end (~26–28 ms `buildAndSign`). This
+package turns that into a clean, self-contained MVP: no spike-only test hooks, a
+real RPC surface with dialogs, and a green mocked-node test suite.
+
+> The Snap is a **pure client**. It makes **no change** to the Botho protocol,
+> consensus, or wire format — it is a second consumer of the already-audited
+> `@botho/wasm-signer` core, exactly like the web wallet.
+
+## RPC methods
+
+All params/results are JSON-safe; amounts are string-encoded `u64` picocredits
+(1 BTH = 10¹² picocredits).
+
+| Method | Params | Dialog | Result |
+|---|---|---|---|
+| `botho_getAddress` | — | none | `{ address, derivation }` |
+| `botho_getBalance` | `{ rpcUrl }` | none | `{ spendablePicocredits }` |
+| `botho_send` | `{ rpcUrl, recipientAddress, amountPicocredits, feePicocredits? }` | confirmation | `{ txHash, txBytes }` |
+| `botho_showReceive` | — | alert (address) | `{ address }` |
+| `botho_showBalance` | `{ rpcUrl }` | alert (balance) | `{ spendablePicocredits }` |
+| `botho_showMnemonic` | — | confirm → alert | `{ revealed }` |
+
+`rpcUrl` is the **user-selected ingress node**, carrying over the web wallet's
+node-trust model. Before any balance/send the Snap runs a wrong-network guard
+(`node_getStatus.network` must equal `botho-testnet`; loopback hosts are exempt),
+mirroring the web wallet's `validateRpcEndpointForNetwork` (#811). Keys **never
+leave the sandbox**.
+
+## Key derivation: MetaMask SRP → Botho RootIdentity
+
+```
+MetaMask SRP
+  ── SIP-6 snap_getEntropy (version 1, salt "botho-root") ──▶  32-byte entropy
+  ── BIP39 entropyToMnemonic (english) ────────────────────▶  24-word mnemonic
+  ── BIP39 seed (empty passphrase) ────────────────────────▶  64-byte seed
+  ── SLIP-10 ed25519 m/44'/866'/0' + HKDF domain separation▶  Ristretto view/spend keys
+  ── node-identical derive_pq_keys_from_seed (wasm) ───────▶  ML-KEM-768 / ML-DSA-65
+  ─────────────────────────────────────────────────────────▶  tbotho://2/ address
+```
+
+MetaMask entropy is plugged in **as the BIP39 entropy of the existing
+`RootIdentity` pipeline** (`@botho/core` `deriveKeypairs`), so nothing downstream
+changes and the derived 24-word mnemonic imported into the web wallet / CLI /
+mobile wallet recovers the **identical** wallet. `botho_showMnemonic` reveals
+those words (behind an explicit confirmation) so the wallet is recoverable
+off-MetaMask.
+
+### Security trade-off: SRP-derived (chosen) vs Snap-local seed
+
+**SRP-derived (`snap_getEntropy`)** — chosen for the MVP:
+
+- ✅ **One backup**: the user's existing MetaMask Secret Recovery Phrase also
+  recovers the Botho wallet. No new seed ceremony — matches the low-friction
+  product goal.
+- ✅ MetaMask never exposes the SRP itself to the Snap — only entropy derived
+  from `(SRP, snap id, salt)`.
+- ⚠️ **Coupled secrets**: an SRP compromise now also compromises the Botho
+  wallet (one secret, two chains).
+- ⚠️ **Snap-id pinning**: the entropy is bound to this Snap's npm id.
+  Republishing under a different package name derives a *different* wallet, so
+  the production snap id must be treated as consensus-critical config. Mitigation
+  shipped here: `botho_showMnemonic` exports the derived 24-word phrase for an
+  off-MetaMask backup.
+
+**Snap-local independent seed (`snap_manageState`, encrypted at rest)** — the
+alternative:
+
+- ✅ Clean isolation from the SRP.
+- ❌ Needs its own backup/restore UX; losing Snap state (uninstall) without a
+  backup loses funds — reintroducing exactly the seed-management burden the Snap
+  is meant to remove.
+
+## Architecture
+
+| File | Responsibility |
+|---|---|
+| `src/index.ts` | `onRpcRequest` handler + dialog orchestration |
+| `src/derivation.ts` | SIP-6 entropy → Botho `SnapWallet` (SLIP-10 + PQ keys + address) |
+| `src/signer.ts` | Inject the inlined bundler wasm into `@botho/wasm-signer` via `setSigner` |
+| `src/node.ts` | JSON-RPC node client, `isValidRpcUrl`, wrong-network guard, `SendRpc` |
+| `src/ui.ts` | Snaps custom-UI dialog content (receive / balance / send / mnemonic) |
+| `src/format.ts` | SES-safe (Intl-free) picocredit → BTH formatting |
+
+The wasm is `wasm-pack build --target bundler` output, base64-inlined into the
+bundle by snaps-cli's `experimental.wasm` loader (`snap.config.ts`) — the exact
+pattern the spike validated.
+
+## Building & testing
+
+```sh
+# 1. wasm artifact (git-ignored; produces packages/wasm-signer/pkg-bundler)
+pnpm --filter @botho/wasm-signer build:wasm:bundler
+
+# 2. build the snap bundle (dist/bundle.js) + refresh the manifest shasum
+pnpm --filter @botho/snap build:snap
+
+# 3. run the test suite (builds, then runs snaps-jest under the real SES executor)
+pnpm --filter @botho/snap test:snap
+```
+
+Tests run through the official `@metamask/snaps-jest` / `@metamask/snaps-simulation`
+node-thread SES executor — the accepted headless proxy for a real MetaMask
+instance (validated in the spike). The node RPC is **mocked** with an in-process
+JSON-RPC server (`test/mock-node.ts`); **no live betanet or `botho` binary is
+required**. Tests are named `*.snap.ts` (not `*.test.ts`) so the workspace-root
+vitest run never picks them up.
+
+Coverage:
+
+- `derivation.snap.ts` — SIP-6 derivation determinism + valid `tbotho://2/` address.
+- `balance.snap.ts` — `getBalance` against a mocked ingress (fresh wallet → 0),
+  receive/balance dialogs, malformed-URL rejection.
+- `send.snap.ts` — send confirmation dialog, user approve/reject branches,
+  bad-recipient / bad-amount guards, and that the pipeline reaches the node and
+  never submits without funds.
+- `units.snap.ts` — pure-logic tests for the wrong-network guard (incl. the
+  loopback exemption a loopback mock can't trigger) and SES-safe formatting.
+
+## Deferred (out of scope for this MVP)
+
+- **Live-testnet send validation** — a real on-chain send from the Snap needs
+  real owned-output fixtures that only a live minting node can produce, and the
+  public betanet is currently **frozen** (height 202, minting paused — #1051).
+  The send *plumbing* is fully tested against a mocked node here; end-to-end
+  live-send validation is a follow-up, **blocked on betanet resume (#1051)**.
+  (The spike demonstrated a working real send against a throwaway solo node; that
+  path relied on spike-only test hooks that are intentionally absent here.)
+- **Phase 2 parity** (per the issue): transaction history, contacts, in-Snap
+  ingress selection UX, i18n, incremental/windowed scanning with persisted scan
+  state (`snap_manageState` — the shared scaling concern with the web wallet),
+  and a dedicated **security pass** for the new key-handling surface (cf. the
+  web-wallet at-rest audit, #474/#475).
+- **Publishing / distribution** — npm publish + MetaMask allowlist, and pinning
+  the production snap id (see the snap-id pinning trade-off above).
+
+## Non-goals
+
+No EVM / `eth_*` compatibility, no secp256k1 transparent txs, no bridge, and no
+change to the Botho protocol, consensus, or wire format. The Snap is a pure
+client.

--- a/web/packages/snap/jest.config.cjs
+++ b/web/packages/snap/jest.config.cjs
@@ -1,0 +1,40 @@
+/**
+ * Jest config for the Botho Snap MVP. `@metamask/snaps-jest` runs the built
+ * snap bundle (dist/bundle.js, with the `bth-wasm-signer` wasm inlined) inside
+ * the REAL Snaps execution environment — the same SES (Hardened JavaScript)
+ * executor MetaMask ships, via `@metamask/snaps-simulation`. This is the
+ * accepted headless proxy for a real MetaMask instance (issue #815; the harness
+ * was validated in the Phase-0 spike, PR #1055).
+ *
+ * Tests are named `*.snap.ts` (NOT `*.test.ts`) so the workspace-root vitest run
+ * (`packages/**​/*.test.ts`) never picks them up — they only run via
+ * `pnpm --filter @botho/snap test:snap`, which first builds the bundle. The node
+ * RPC is MOCKED with an in-process JSON-RPC server (`test/mock-node.ts`); no live
+ * betanet or node binary is required (live-testnet send validation is a
+ * follow-up, deferred behind betanet resume #1051 — see README.md).
+ */
+module.exports = {
+  preset: '@metamask/snaps-jest',
+  testMatch: ['<rootDir>/test/**/*.snap.ts'],
+  transform: {
+    '^.+\\.(t|j)sx?$': [
+      'ts-jest',
+      {
+        isolatedModules: true,
+        tsconfig: {
+          module: 'commonjs',
+          moduleResolution: 'node',
+          esModuleInterop: true,
+          allowJs: true,
+          target: 'es2022',
+        },
+      },
+    ],
+  },
+  // Workspace deps (@botho/*) resolve to raw TS via pnpm symlinks, and the
+  // @scure/@noble crypto deps are ESM-only — all must go through ts-jest.
+  // The `.pnpm` branch lets the check recurse into pnpm's store layout.
+  transformIgnorePatterns: ['node_modules/(?!(\\.pnpm|@scure|@noble|@botho)/)'],
+  // Snap install + SES lockdown + wasm instantiation are slow; generous timeout.
+  testTimeout: 120_000,
+};

--- a/web/packages/snap/package.json
+++ b/web/packages/snap/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@botho/snap",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Botho MetaMask Snap (Phase-1 MVP, issue #815): manage a privacy-by-default Botho wallet from inside MetaMask. Derives Botho keys from the MetaMask SRP, runs the node-identical bth-wasm-signer inside the Snaps SES sandbox, and talks to a user-selected Botho node for receive / balance / send.",
+  "main": "./dist/bundle.js",
+  "scripts": {
+    "build:wasm-bundler": "pnpm --filter @botho/wasm-signer build:wasm:bundler",
+    "build:snap": "mm-snap build",
+    "test:snap": "mm-snap build && jest",
+    "typecheck": "node scripts/typecheck.mjs"
+  },
+  "dependencies": {
+    "@botho/core": "workspace:*",
+    "@botho/wasm-signer": "workspace:*",
+    "@metamask/snaps-sdk": "^11.2.0",
+    "@scure/bip39": "^2.0.1"
+  },
+  "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@metamask/snaps-cli": "^8.4.1",
+    "@metamask/snaps-jest": "^10.2.0",
+    "@types/node": "^22.10.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.11",
+    "ts-node": "^10.9.2",
+    "typescript": "~5.9.3"
+  }
+}

--- a/web/packages/snap/scripts/typecheck.mjs
+++ b/web/packages/snap/scripts/typecheck.mjs
@@ -1,0 +1,27 @@
+// Typecheck gate for the Botho Snap. The snap imports the GENERATED wasm-pack
+// `--target bundler` artifact (`@botho/wasm-signer/pkg-bundler`), which is
+// git-ignored. In CI (fresh checkout) it does not exist, so `tsc` cannot
+// resolve the import — skip with a note instead of failing the workspace-wide
+// `pnpm -r typecheck`. Mirrors `@botho/snap-spike`'s gate.
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgBundler = join(here, '..', '..', 'wasm-signer', 'pkg-bundler', 'bth_wasm_signer.js');
+
+if (!existsSync(pkgBundler)) {
+  console.log(
+    '@botho/snap: typecheck skipped (wasm artifact not built — run ' +
+      '`pnpm --filter @botho/wasm-signer build:wasm:bundler`)',
+  );
+  process.exit(0);
+}
+
+const result = spawnSync('tsc', ['--noEmit'], {
+  cwd: join(here, '..'),
+  stdio: 'inherit',
+  shell: true,
+});
+process.exit(result.status ?? 1);

--- a/web/packages/snap/snap.config.ts
+++ b/web/packages/snap/snap.config.ts
@@ -1,0 +1,22 @@
+import type { SnapConfig } from '@metamask/snaps-cli';
+import { resolve } from 'path';
+
+const config: SnapConfig = {
+  input: resolve(__dirname, 'src/index.ts'),
+  server: {
+    // Distinct from the Phase-0 spike's dev server (8090) so both can run.
+    port: 8091,
+  },
+  stats: {
+    buffer: false,
+  },
+  // Enables direct `import * as wasm from './x.wasm'` — the snaps-cli wasm
+  // loader base64-inlines the module into the bundle and resolves its JS
+  // imports, which is exactly the shape wasm-pack `--target bundler` emits.
+  // Proven in the Phase-0 spike (issue #815, PR #1055).
+  experimental: {
+    wasm: true,
+  },
+};
+
+export default config;

--- a/web/packages/snap/snap.manifest.json
+++ b/web/packages/snap/snap.manifest.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.1.0",
+  "description": "Manage a privacy-by-default Botho wallet from inside MetaMask. Keys are derived from your MetaMask Secret Recovery Phrase and never leave the Snap sandbox.",
+  "proposedName": "Botho Wallet",
+  "source": {
+    "shasum": "/tRpO3ie+iehmIMIBAY7y/evdJA5MOpka4AHFDsmkIs=",
+    "location": {
+      "npm": {
+        "filePath": "dist/bundle.js",
+        "packageName": "@botho/snap",
+        "registry": "https://registry.npmjs.org/"
+      }
+    }
+  },
+  "initialPermissions": {
+    "endowment:rpc": {
+      "dapps": true
+    },
+    "endowment:webassembly": {},
+    "endowment:network-access": {},
+    "snap_getEntropy": {},
+    "snap_dialog": {}
+  },
+  "platformVersion": "11.2.0",
+  "manifestVersion": "0.1"
+}

--- a/web/packages/snap/src/derivation.ts
+++ b/web/packages/snap/src/derivation.ts
@@ -1,0 +1,147 @@
+/**
+ * MetaMask-SRP -> Botho-key derivation (issue #815, deliverable 2).
+ *
+ * The Snap derives the Botho wallet from MetaMask-managed entropy through a
+ * DEFINED, DOCUMENTED SLIP-10 path, plugging the entropy in as the BIP39 entropy
+ * of the EXISTING Botho `RootIdentity` pipeline. Nothing downstream changes, so
+ * the same derived mnemonic imported into the web wallet / node / mobile wallet
+ * recovers the identical wallet.
+ *
+ *   MetaMask SRP
+ *     -- SIP-6 snap_getEntropy (version 1, salt "botho-root") ----> 32-byte entropy
+ *     -- BIP39 entropyToMnemonic (english) ----------------------> 24-word mnemonic
+ *     -- BIP39 seed (empty passphrase) --------------------------> 64-byte seed
+ *     -- SLIP-10 ed25519 m/44'/866'/0' + HKDF domain separation -> Ristretto view/spend keys
+ *     -- node-identical derive_pq_keys_from_seed (wasm) ---------> ML-KEM-768 / ML-DSA-65
+ *     -----------------------------------------------------------> tbotho://2/ address
+ *
+ * SECURITY TRADE-OFF (SRP-derived — chosen — vs Snap-local seed): see README.md.
+ * In short: the SRP path gives the user one backup (their MetaMask Secret
+ * Recovery Phrase also recovers the Botho wallet) at the cost of coupling the
+ * two secrets, and the derived entropy is pinned to this Snap's npm id.
+ *
+ * Keys NEVER leave the sandbox: private material lives only in `SignerKeys` /
+ * the derived mnemonic, which are consumed by the inlined wasm signer and, for
+ * the mnemonic, shown only in an explicit user-confirmed backup dialog.
+ */
+
+import { entropyToMnemonic, mnemonicToSeedSync } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
+import {
+  deriveKeypairs,
+  deriveDefaultSubaddressPublicKeys,
+} from '@botho/core';
+import type { SignerKeys } from '@botho/wasm-signer';
+
+import { wasm } from './signer';
+
+declare const snap: {
+  request(args: { method: string; params?: unknown }): Promise<unknown>;
+};
+
+/** The SIP-6 entropy salt that binds this Snap's derived wallet. Changing it
+ * (or the Snap's npm id) derives a DIFFERENT wallet — treat as consensus config. */
+export const ENTROPY_SALT = 'botho-root';
+
+/** Human-readable description of the derivation path (surfaced by getAddress). */
+export const DERIVATION_DESCRIPTION =
+  "SIP-6 snap_getEntropy(salt='botho-root') -> BIP39(24 words) -> seed -> " +
+  "SLIP-10 ed25519 m/44'/866'/0' (node-identical Botho RootIdentity pipeline)";
+
+const toHex = (b: Uint8Array): string =>
+  Array.from(b)
+    .map((x) => x.toString(16).padStart(2, '0'))
+    .join('');
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+/** The Snap's fully derived wallet material. */
+export interface SnapWallet {
+  /** Private signing keys (spend/view/seed, hex). Stay inside the sandbox. */
+  keys: SignerKeys;
+  /** The wallet's testnet v2 receive address (`tbotho://2/…`). */
+  address: string;
+  /** Raw ML-KEM-768 public key (hex), for change-output encapsulation. */
+  kemPublicKey: string;
+}
+
+/**
+ * Derive the full Botho wallet material from a BIP39 mnemonic — the shared tail
+ * of the RootIdentity pipeline (seed -> SLIP-10 ed25519 m/44'/866'/0' ->
+ * Ristretto keys, plus node-identical PQ keys + v2 address in wasm).
+ */
+export function walletFromMnemonic(mnemonic: string): SnapWallet {
+  const seed = mnemonicToSeedSync(mnemonic, '');
+  const kp = deriveKeypairs(mnemonic, 0);
+  const sub = deriveDefaultSubaddressPublicKeys(mnemonic, 0);
+
+  const seedHex = toHex(seed);
+  const address = wasm.deriveAddressFromSeed(
+    seedHex,
+    toHex(sub.viewPublic),
+    toHex(sub.spendPublic),
+    true, // testnet
+  );
+  const pq = wasm.derivePqPublicKeysFromSeed(seedHex) as {
+    kemPublicKey: string;
+    dsaPublicKey: string;
+  };
+
+  return {
+    keys: {
+      spendPrivateKey: toHex(kp.spendPrivate),
+      viewPrivateKey: toHex(kp.viewPrivate),
+      seed: seedHex,
+    },
+    address,
+    kemPublicKey: pq.kemPublicKey,
+  };
+}
+
+let cachedWallet: SnapWallet | null = null;
+let cachedMnemonic: string | null = null;
+
+/** Fetch the SIP-6 entropy and turn it into the 24-word Botho mnemonic. */
+async function deriveMnemonic(): Promise<string> {
+  if (cachedMnemonic) return cachedMnemonic;
+  // SIP-6 entropy: deterministic in (SRP, snap id, salt). 32 bytes.
+  const entropyHex = (await snap.request({
+    method: 'snap_getEntropy',
+    params: { version: 1, salt: ENTROPY_SALT },
+  })) as string;
+  const entropy = hexToBytes(entropyHex);
+  if (entropy.length !== 32) {
+    throw new Error(`snap_getEntropy returned ${entropy.length} bytes, expected 32`);
+  }
+  cachedMnemonic = entropyToMnemonic(entropy, wordlist);
+  return cachedMnemonic;
+}
+
+/**
+ * Derive (and cache) the Snap's SRP-backed Botho wallet. The heavy derivation
+ * runs once per Snap execution context.
+ */
+export async function deriveWallet(): Promise<SnapWallet> {
+  if (cachedWallet) return cachedWallet;
+  cachedWallet = walletFromMnemonic(await deriveMnemonic());
+  return cachedWallet;
+}
+
+/**
+ * Reveal the derived 24-word Botho mnemonic (recovery / off-MetaMask backup).
+ *
+ * This is the mitigation for the Snap-id-pinning risk (README.md): the same
+ * words recover the wallet in the web/CLI/mobile wallet even if the Snap is
+ * republished under a different id. Callers MUST gate this behind an explicit
+ * user confirmation dialog — the mnemonic is full spending authority.
+ */
+export async function revealMnemonic(): Promise<string> {
+  return deriveMnemonic();
+}

--- a/web/packages/snap/src/format.ts
+++ b/web/packages/snap/src/format.ts
@@ -1,0 +1,38 @@
+/**
+ * SES-safe amount formatting helpers for the Snap dialogs.
+ *
+ * `@botho/core`'s `formatBTH` uses `Number#toLocaleString` (Intl), which is not
+ * reliably endowed in the Snaps SES executor. The Snap only needs a plain,
+ * deterministic decimal string for its confirmation UI, so it formats
+ * picocredits itself with integer/bigint math — no `Intl`, no floats.
+ */
+
+/** picocredits per 1 BTH (12 decimals — matches `@botho/core` `BTH_DECIMALS`). */
+export const BTH_DECIMALS = 12n;
+export const PICOCREDITS_PER_BTH = 10n ** BTH_DECIMALS;
+
+/**
+ * Format a picocredit amount as a fixed-point BTH string with a trailing-zero
+ * trim (e.g. `1234500000000n` -> `"1.2345"`, `5000000000000n` -> `"5"`).
+ * Deterministic and Intl-free so it is safe inside the SES sandbox.
+ */
+export function formatPicocreditsBTH(picocredits: bigint): string {
+  const neg = picocredits < 0n;
+  const abs = neg ? -picocredits : picocredits;
+  const whole = abs / PICOCREDITS_PER_BTH;
+  const frac = abs % PICOCREDITS_PER_BTH;
+
+  let out = whole.toString();
+  if (frac > 0n) {
+    // Zero-pad the fractional part to the full decimal width, then trim
+    // trailing zeros so "1.230000000000" renders as "1.23".
+    const fracStr = frac.toString().padStart(Number(BTH_DECIMALS), '0').replace(/0+$/, '');
+    out += `.${fracStr}`;
+  }
+  return neg ? `-${out}` : out;
+}
+
+/** As {@link formatPicocreditsBTH} but with the ` BTH` unit suffix. */
+export function formatBTHWithUnit(picocredits: bigint): string {
+  return `${formatPicocreditsBTH(picocredits)} BTH`;
+}

--- a/web/packages/snap/src/index.ts
+++ b/web/packages/snap/src/index.ts
@@ -1,0 +1,232 @@
+/**
+ * Botho MetaMask Snap — Phase-1 MVP (issue #815).
+ *
+ * Manage a privacy-by-default Botho wallet from inside MetaMask. The Snap:
+ *   1. Derives the Botho wallet from the MetaMask SRP (SIP-6 `snap_getEntropy`)
+ *      through the node-identical SLIP-10 RootIdentity pipeline (see
+ *      `derivation.ts`). Keys never leave the sandbox.
+ *   2. Runs `bth-wasm-signer` (inlined wasm) for all Botho crypto — scan / build
+ *      / CLSAG sign — inside the Snaps SES executor (`signer.ts`), proven by the
+ *      Phase-0 spike (PR #1055).
+ *   3. Talks to a USER-SELECTED Botho node ingress for UTXO/decoy fetch, spent
+ *      checks and tx submit, carrying over the web wallet's node-trust /
+ *      wrong-network guard (`node.ts`, cf. #811).
+ *   4. Renders custom-UI dialogs for receive / balance / send confirmation and a
+ *      recovery-phrase backup (`ui.ts`).
+ *
+ * MVP RPC methods (all params/results are JSON-safe; amounts are string-encoded
+ * u64 picocredits):
+ *   - botho_getAddress  — the wallet's stealth receive address (silent read)
+ *   - botho_getBalance  — spendable balance via scan (silent read)
+ *   - botho_send        — build + sign + submit, behind a confirmation dialog
+ *   - botho_showReceive — receive dialog (stealth address, copyable)
+ *   - botho_showBalance — balance dialog
+ *   - botho_showMnemonic — reveal the derived recovery phrase (confirmed backup)
+ *
+ * Live-testnet send validation is deferred to a follow-up (betanet is frozen at
+ * height 202, #1051); tests exercise send against a MOCKED node RPC. See
+ * README.md.
+ */
+
+import {
+  DialogType,
+  InvalidParamsError,
+  MethodNotFoundError,
+  UserRejectedRequestError,
+  type Json,
+  type OnRpcRequestHandler,
+} from '@metamask/snaps-sdk';
+import {
+  buildSendTransaction,
+  spendableBalance,
+  type RecipientAddress,
+} from '@botho/wasm-signer';
+import { parseAddress } from '@botho/core';
+
+import { ensureSigner, wasm } from './signer';
+import { deriveWallet, revealMnemonic, DERIVATION_DESCRIPTION } from './derivation';
+import { connectAndGuard, makeSendRpc } from './node';
+import {
+  receiveContent,
+  balanceContent,
+  sendConfirmContent,
+  mnemonicBackupContent,
+} from './ui';
+
+declare const snap: {
+  request(args: { method: string; params?: unknown }): Promise<unknown>;
+};
+
+const toHex = (b: Uint8Array): string =>
+  Array.from(b)
+    .map((x) => x.toString(16).padStart(2, '0'))
+    .join('');
+
+/** Decode a `botho://2/` recipient into the signer's `RecipientAddress`. */
+function decodeRecipient(address: string): RecipientAddress {
+  const parsed = parseAddress(address);
+  return {
+    spend_public_key: toHex(parsed.spendPublic),
+    view_public_key: toHex(parsed.viewPublic),
+    kem_public_key: toHex(parsed.kemPublic),
+  };
+}
+
+/** Require a string RPC param, throwing a typed InvalidParamsError otherwise. */
+function requireString(params: Record<string, unknown> | undefined, key: string): string {
+  const v = params?.[key];
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new InvalidParamsError(`Missing or invalid "${key}" (expected a non-empty string).`);
+  }
+  return v;
+}
+
+/** Parse a string-encoded positive u64 picocredit amount. */
+function requireAmount(params: Record<string, unknown> | undefined, key: string): bigint {
+  const raw = requireString(params, key);
+  let value: bigint;
+  try {
+    value = BigInt(raw);
+  } catch {
+    throw new InvalidParamsError(`"${key}" must be an integer string of picocredits.`);
+  }
+  if (value <= 0n) {
+    throw new InvalidParamsError(`"${key}" must be greater than 0.`);
+  }
+  return value;
+}
+
+/** Optional string-encoded fee; defaults to the network minimum fee. */
+function optionalFee(params: Record<string, unknown> | undefined): bigint {
+  const raw = params?.feePicocredits;
+  if (raw === undefined || raw === null || raw === '') return wasm.minFee();
+  if (typeof raw !== 'string') {
+    throw new InvalidParamsError('"feePicocredits" must be an integer string.');
+  }
+  let fee: bigint;
+  try {
+    fee = BigInt(raw);
+  } catch {
+    throw new InvalidParamsError('"feePicocredits" must be an integer string.');
+  }
+  const min = wasm.minFee();
+  if (fee < min) {
+    throw new InvalidParamsError(`Fee ${fee} is below the network minimum ${min}.`);
+  }
+  return fee;
+}
+
+/** Ask the user to approve/reject a confirmation dialog. */
+async function confirm(content: unknown): Promise<boolean> {
+  return (await snap.request({
+    method: 'snap_dialog',
+    params: { type: DialogType.Confirmation, content },
+  })) as boolean;
+}
+
+/** Show an informational alert dialog (single acknowledge button). */
+async function alert(content: unknown): Promise<void> {
+  await snap.request({
+    method: 'snap_dialog',
+    params: { type: DialogType.Alert, content },
+  });
+}
+
+export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
+  ensureSigner();
+  const params = (request.params ?? undefined) as Record<string, unknown> | undefined;
+
+  switch (request.method) {
+    /* ------------------------------------------------------------------ */
+    /* Silent reads                                                       */
+    /* ------------------------------------------------------------------ */
+    case 'botho_getAddress': {
+      const wallet = await deriveWallet();
+      return { address: wallet.address, derivation: DERIVATION_DESCRIPTION } as Json;
+    }
+
+    case 'botho_getBalance': {
+      const rpcUrl = requireString(params, 'rpcUrl');
+      const { call } = await connectAndGuard(rpcUrl);
+      const wallet = await deriveWallet();
+      const balance = await spendableBalance(wallet.keys, makeSendRpc(call));
+      return { spendablePicocredits: balance.toString() } as Json;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Dialog-driven flows                                                */
+    /* ------------------------------------------------------------------ */
+    case 'botho_showReceive': {
+      const wallet = await deriveWallet();
+      await alert(receiveContent(wallet.address));
+      return { address: wallet.address } as Json;
+    }
+
+    case 'botho_showBalance': {
+      const rpcUrl = requireString(params, 'rpcUrl');
+      const { call } = await connectAndGuard(rpcUrl);
+      const wallet = await deriveWallet();
+      const balance = await spendableBalance(wallet.keys, makeSendRpc(call));
+      await alert(balanceContent(balance, rpcUrl));
+      return { spendablePicocredits: balance.toString() } as Json;
+    }
+
+    case 'botho_showMnemonic': {
+      // Full spending authority — always behind an explicit user confirmation.
+      const proceed = await confirm(
+        mnemonicBackupContent('•••• •••• (revealed after you confirm) ••••'),
+      );
+      if (!proceed) {
+        throw new UserRejectedRequestError('User declined to reveal the recovery phrase.');
+      }
+      const mnemonic = await revealMnemonic();
+      await alert(mnemonicBackupContent(mnemonic));
+      return { revealed: true } as Json;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Send: confirm -> build + sign -> submit                            */
+    /* ------------------------------------------------------------------ */
+    case 'botho_send': {
+      const rpcUrl = requireString(params, 'rpcUrl');
+      const recipientAddress = requireString(params, 'recipientAddress');
+      const amount = requireAmount(params, 'amountPicocredits');
+      const fee = optionalFee(params);
+
+      // Validate the recipient address up front so a typo fails before the
+      // network round-trip and before we show a confirmation for a bad send.
+      const recipient = decodeRecipient(recipientAddress);
+
+      // Node-trust / wrong-network guard before anything else touches funds.
+      const { call } = await connectAndGuard(rpcUrl);
+
+      const approved = await confirm(
+        sendConfirmContent({
+          recipientAddress,
+          amountPicocredits: amount,
+          feePicocredits: fee,
+          rpcUrl,
+        }),
+      );
+      if (!approved) {
+        throw new UserRejectedRequestError('User rejected the send.');
+      }
+
+      const wallet = await deriveWallet();
+      const { txHex } = await buildSendTransaction({
+        keys: wallet.keys,
+        recipient,
+        senderKemPublicKey: wallet.kemPublicKey,
+        amount,
+        fee,
+        rpc: makeSendRpc(call),
+      });
+
+      const { txHash } = await call<{ txHash: string }>('tx_submit', { tx_hex: txHex });
+      return { txHash, txBytes: txHex.length / 2 } as Json;
+    }
+
+    default:
+      throw new MethodNotFoundError({ method: request.method });
+  }
+};

--- a/web/packages/snap/src/node.ts
+++ b/web/packages/snap/src/node.ts
@@ -1,0 +1,172 @@
+/**
+ * Botho node JSON-RPC access over the Snap's `endowment:network-access`
+ * (`fetch`) endowment, plus the wallet's node-trust / wrong-network guard.
+ *
+ * The Snap still needs an ingress node for decoys + submit; it carries over the
+ * web wallet's trust model (user-selected endpoint) and its wrong-network guard
+ * (cf. #811 / `validateRpcEndpointForNetwork`): before any balance/send the Snap
+ * confirms the node reports the EXPECTED network id, so the user cannot silently
+ * point a testnet wallet at a wrong-network (e.g. mainnet) node. Loopback hosts
+ * are exempt (local dev nodes may report other network names).
+ */
+
+import type { ChainOutput, KeyImageSpentStatus, SendRpc } from '@botho/wasm-signer';
+
+/**
+ * The network id a node must report (via `node_getStatus`'s `network` field) to
+ * be accepted as this Snap's ingress. The MVP targets testnet, matching the web
+ * wallet's `EXPECTED_NETWORK_ID` and the Snap's `tbotho://2/` addresses.
+ */
+export const EXPECTED_NETWORK_ID = 'botho-testnet';
+
+/** The node reports a coinbase output's index as u32::MAX; its one-time key is
+ * bound to MINTING_OUTPUT_INDEX = 0 (mirrors the web wallet adapter, #988). */
+const COINBASE_OUTPUT_INDEX_SENTINEL = 0xffffffff;
+
+/** A minimal JSON-RPC caller bound to a single node endpoint. */
+export type NodeCall = <T>(method: string, params: Record<string, unknown>) => Promise<T>;
+
+/**
+ * Validate a candidate RPC endpoint URL shape. Accepts `https://` anywhere and
+ * `http://localhost` / `http://127.0.0.1` for local development. Mirrors the web
+ * wallet's `isValidRpcUrl` so an insecure plain-http ingress is rejected.
+ */
+export function isValidRpcUrl(candidate: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return false;
+  }
+  if (url.protocol === 'https:') return true;
+  if (url.protocol === 'http:') {
+    return url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+  }
+  return false;
+}
+
+function isLoopbackHost(endpoint: string): boolean {
+  try {
+    const host = new URL(endpoint).hostname.toLowerCase();
+    return host === 'localhost' || host === '127.0.0.1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Enforce the wrong-network guard for a resolved node: throw a user-facing error
+ * if a non-loopback node reports a network id other than {@link EXPECTED_NETWORK_ID}.
+ * Loopback hosts are exempt (local dev nodes may report other network names),
+ * matching the web wallet's `validateRpcEndpointForNetwork` (#811). Pure and
+ * network-free so it is directly unit-testable.
+ */
+export function assertNetworkAllowed(rpcUrl: string, reportedNetwork: string | undefined): void {
+  if (isLoopbackHost(rpcUrl)) return;
+  if (reportedNetwork && reportedNetwork !== EXPECTED_NETWORK_ID) {
+    throw new Error(
+      `This node is on a different network (${reportedNetwork}); expected ` +
+        `${EXPECTED_NETWORK_ID}. Refusing to use it as an ingress.`,
+    );
+  }
+}
+
+/** The node's `node_getStatus` result fields the Snap relies on. */
+export interface NodeStatus {
+  chainHeight: number;
+  network?: string;
+  synced?: boolean;
+  version?: string;
+}
+
+/** Build a JSON-RPC caller for a node endpoint. Throws on RPC-level errors. */
+export function makeNodeCall(url: string): NodeCall {
+  let id = 1;
+  return async function call<T>(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<T> {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method, params, id: id++ }),
+    });
+    if (!res.ok) {
+      throw new Error(`node RPC ${method} failed: HTTP ${res.status}`);
+    }
+    const json = (await res.json()) as { result?: T; error?: { message: string } };
+    if (json.error) throw new Error(`${method}: ${json.error.message}`);
+    return json.result as T;
+  };
+}
+
+/**
+ * Fetch the node's status AND enforce the wrong-network guard. Returns the
+ * status on success; throws a user-facing error if the endpoint is malformed,
+ * unreachable, or on a different network than expected.
+ */
+export async function connectAndGuard(rpcUrl: string): Promise<{ call: NodeCall; status: NodeStatus }> {
+  if (!isValidRpcUrl(rpcUrl)) {
+    throw new Error('Enter a valid https:// node endpoint.');
+  }
+  const call = makeNodeCall(rpcUrl);
+  let status: NodeStatus;
+  try {
+    status = await call<NodeStatus>('node_getStatus', {});
+  } catch (err) {
+    throw new Error(
+      `Could not reach the Botho node at ${new URL(rpcUrl).host}: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  assertNetworkAllowed(rpcUrl, status.network);
+  return { call, status };
+}
+
+interface RawOutput {
+  targetKey: string;
+  publicKey: string;
+  amountCommitment: string;
+  outputIndex: number;
+  kemCiphertext?: string | null;
+}
+
+/** Decode a little-endian hex `u64` amount commitment into a bigint. */
+function leHexToBigInt(hex: string): bigint {
+  let result = 0n;
+  for (let i = hex.length - 2; i >= 0; i -= 2) {
+    result = (result << 8n) | BigInt(parseInt(hex.slice(i, i + 2), 16));
+  }
+  return result;
+}
+
+/**
+ * Adapt a node caller to the `SendRpc` slice the shared balance/send
+ * orchestrators need (`getChainHeight`, `getOutputs`, `areKeyImagesSpent`).
+ */
+export function makeSendRpc(call: NodeCall): SendRpc {
+  return {
+    getChainHeight: async () =>
+      (await call<{ chainHeight: number }>('node_getStatus', {})).chainHeight,
+    getOutputs: async (start, end) => {
+      const blocks = await call<Array<{ outputs: RawOutput[] }>>('chain_getOutputs', {
+        start_height: start,
+        end_height: end,
+      });
+      return blocks.flatMap((b) =>
+        b.outputs.map(
+          (o): ChainOutput => ({
+            targetKey: o.targetKey,
+            publicKey: o.publicKey,
+            amount: leHexToBigInt(o.amountCommitment),
+            outputIndex:
+              o.outputIndex === COINBASE_OUTPUT_INDEX_SENTINEL ? 0 : o.outputIndex,
+            kemCiphertext: o.kemCiphertext ?? null,
+          }),
+        ),
+      );
+    },
+    areKeyImagesSpent: (keyImages) =>
+      call<KeyImageSpentStatus[]>('chain_areKeyImagesSpent', { keyImages }),
+  };
+}

--- a/web/packages/snap/src/signer.ts
+++ b/web/packages/snap/src/signer.ts
@@ -1,0 +1,65 @@
+/**
+ * Wire the node-identical `bth-wasm-signer` (wasm-pack `--target bundler`
+ * output, base64-inlined into the snap bundle by the snaps-cli wasm loader) into
+ * the shared `@botho/wasm-signer` high-level orchestrators.
+ *
+ * `buildSendTransaction` / `spendableBalance` (the SAME code the web wallet
+ * runs) call `loadSigner()` internally, which by default instantiates the wasm
+ * via a browser `fetch` of its URL — that does not work inside the Snaps SES
+ * executor. Instead we import the already-instantiated bundler module and inject
+ * it once via `setSigner`, so all downstream crypto uses the inlined wasm.
+ *
+ * The Phase-0 spike (PR #1055) proved this module loads, instantiates and runs
+ * correctly under SES, with `getrandom`'s `crypto.getRandomValues` endowment
+ * live (build/scan/sign ~26-28 ms).
+ */
+
+import { setSigner, type WasmSigner } from '@botho/wasm-signer';
+
+// The wasm-pack `--target bundler` glue. Its inner `import * as wasm from
+// './bth_wasm_signer_bg.wasm'` is handled by the snaps-cli wasm loader
+// (`experimental.wasm: true`), which base64-inlines the module and instantiates
+// it synchronously at bundle load.
+import * as wasm from '@botho/wasm-signer/pkg-bundler/bth_wasm_signer.js';
+
+/**
+ * Adapt the raw wasm exports to the `WasmSigner` interface the shared send /
+ * balance orchestrators expect.
+ */
+function makeSigner(): WasmSigner {
+  return {
+    buildAndSign: (request) => wasm.buildAndSign(request),
+    scanOwnedOutputs: (request) =>
+      wasm.scanOwnedOutputs(request) as ReturnType<WasmSigner['scanOwnedOutputs']>,
+    computeOwnedOutputKeyImages: (request) =>
+      wasm.computeOwnedOutputKeyImages(request) as ReturnType<
+        WasmSigner['computeOwnedOutputKeyImages']
+      >,
+    derivePqPublicKeysFromSeed: (seedHex) =>
+      wasm.derivePqPublicKeysFromSeed(seedHex) as {
+        kemPublicKey: string;
+        dsaPublicKey: string;
+      },
+    deriveAddressFromSeed: (seedHex, viewHex, spendHex, testnet) =>
+      wasm.deriveAddressFromSeed(seedHex, viewHex, spendHex, testnet),
+    encodeAddress: (viewHex, spendHex, kemHex, dsaHex, testnet) =>
+      wasm.encodeAddress(viewHex, spendHex, kemHex, dsaHex, testnet),
+    decodeAddress: (address) =>
+      wasm.decodeAddress(address) as ReturnType<NonNullable<WasmSigner['decodeAddress']>>,
+    ringSize: () => wasm.ringSize(),
+    minFee: () => wasm.minFee(),
+  };
+}
+
+let injected = false;
+
+/** Inject the inlined wasm signer once (idempotent). */
+export function ensureSigner(): void {
+  if (!injected) {
+    setSigner(makeSigner());
+    injected = true;
+  }
+}
+
+/** Direct access to the raw wasm module (for address derivation / constants). */
+export { wasm };

--- a/web/packages/snap/src/ui.ts
+++ b/web/packages/snap/src/ui.ts
@@ -1,0 +1,98 @@
+/**
+ * Snap custom-UI dialog content for receive / balance / send confirmation /
+ * mnemonic backup (issue #815, deliverable 4).
+ *
+ * The Snaps SDK JSX components (`Box`, `Heading`, `Text`, `Row`, `Copyable`,
+ * `Divider`) are `SnapComponent` factories — this module calls them directly as
+ * functions (the "createElement" style) so no JSX build/transform is needed in
+ * the SES bundle; each call returns a plain JSX element object.
+ */
+
+import {
+  Box,
+  Heading,
+  Text,
+  Row,
+  Copyable,
+  Divider,
+  type JSXElement,
+} from '@metamask/snaps-sdk/jsx';
+
+import { formatBTHWithUnit } from './format';
+
+/** Host component of an endpoint URL (for compact display), or the raw string. */
+function hostOf(rpcUrl: string): string {
+  try {
+    return new URL(rpcUrl).host;
+  } catch {
+    return rpcUrl;
+  }
+}
+
+/** Receive dialog: the wallet's stealth receive address. */
+export function receiveContent(address: string): JSXElement {
+  return Box({
+    children: [
+      Heading({ children: 'Receive BTH' }),
+      Text({
+        children:
+          'Share this Botho stealth address to receive funds. A fresh one-time ' +
+          'output is created on-chain for every payment, so your balance stays private.',
+      }),
+      Copyable({ value: address }),
+    ],
+  });
+}
+
+/** Balance dialog: the wallet's spendable balance and its ingress node. */
+export function balanceContent(spendablePicocredits: bigint, rpcUrl: string): JSXElement {
+  return Box({
+    children: [
+      Heading({ children: 'Botho balance' }),
+      Row({ label: 'Spendable', children: Text({ children: formatBTHWithUnit(spendablePicocredits) }) }),
+      Divider({}),
+      Row({ label: 'Node', children: Text({ children: hostOf(rpcUrl) }) }),
+    ],
+  });
+}
+
+/** Parameters rendered in the send-confirmation dialog. */
+export interface SendConfirmView {
+  recipientAddress: string;
+  amountPicocredits: bigint;
+  feePicocredits: bigint;
+  rpcUrl: string;
+}
+
+/** Send confirmation dialog: recipient, amount, fee, total, ingress node. */
+export function sendConfirmContent(view: SendConfirmView): JSXElement {
+  const total = view.amountPicocredits + view.feePicocredits;
+  return Box({
+    children: [
+      Heading({ children: 'Confirm send' }),
+      Row({ label: 'Amount', children: Text({ children: formatBTHWithUnit(view.amountPicocredits) }) }),
+      Row({ label: 'Network fee', children: Text({ children: formatBTHWithUnit(view.feePicocredits) }) }),
+      Row({ label: 'Total', children: Text({ children: formatBTHWithUnit(total) }) }),
+      Divider({}),
+      Text({ children: 'Recipient' }),
+      Copyable({ value: view.recipientAddress }),
+      Row({ label: 'Node', children: Text({ children: hostOf(view.rpcUrl) }) }),
+    ],
+  });
+}
+
+/** Mnemonic-backup dialog: the derived 24-word Botho recovery phrase. */
+export function mnemonicBackupContent(mnemonic: string): JSXElement {
+  return Box({
+    children: [
+      Heading({ children: 'Botho recovery phrase' }),
+      Text({
+        children:
+          'These 24 words are derived from your MetaMask Secret Recovery Phrase ' +
+          'and are full spending authority for this Botho wallet. Write them down ' +
+          'and keep them offline. Anyone who sees them can spend your funds.',
+      }),
+      Copyable({ value: mnemonic, sensitive: true }),
+    ],
+  });
+}

--- a/web/packages/snap/test/balance.snap.ts
+++ b/web/packages/snap/test/balance.snap.ts
@@ -1,0 +1,82 @@
+/**
+ * Balance + receive dialogs against a MOCKED node ingress (issue #815
+ * deliverables 3 + 4), through the `@metamask/snaps-jest` SES harness. No live
+ * betanet is required — `startMockNode` stands in for the node RPC.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+
+import { startMockNode, type MockNode } from './mock-node';
+
+function unwrap<T>(response: { response: unknown }): T {
+  const res = response.response as { result?: T; error?: { message?: string } };
+  if (res.error) {
+    throw new Error(`snap returned error: ${JSON.stringify(res.error)}`);
+  }
+  return res.result as T;
+}
+
+function errorOf(response: { response: unknown }): { message?: string } | undefined {
+  return (response.response as { error?: { message?: string } }).error;
+}
+
+describe('botho snap: balance + receive against a mocked node', () => {
+  let node: MockNode;
+
+  beforeEach(async () => {
+    node = await startMockNode(); // empty testnet chain, network=botho-testnet
+  });
+  afterEach(async () => {
+    await node.close();
+  });
+
+  it('getBalance scans the mocked chain and reports 0 for a fresh wallet', async () => {
+    const { request } = await installSnap();
+    const { spendablePicocredits } = unwrap<{ spendablePicocredits: string }>(
+      await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }),
+    );
+    expect(spendablePicocredits).toBe('0');
+
+    // It reached the node: status guard + chain scan actually happened.
+    const methods = node.calls.map((c) => c.method);
+    expect(methods).toContain('node_getStatus');
+    expect(methods).toContain('chain_getOutputs');
+  });
+
+  it('showBalance opens a balance dialog and returns the balance', async () => {
+    const { request } = await installSnap();
+    const response = request({ method: 'botho_showBalance', params: { rpcUrl: node.url } });
+
+    const ui = await response.getInterface();
+    expect(ui.type).toBe('alert');
+    // The dialog renders a spendable-balance figure with the BTH unit.
+    expect(JSON.stringify(ui.content)).toContain('BTH');
+    await (ui as { ok(): Promise<void> }).ok();
+
+    const { spendablePicocredits } = unwrap<{ spendablePicocredits: string }>(await response);
+    expect(spendablePicocredits).toBe('0');
+  });
+
+  it('showReceive opens a dialog carrying the stealth receive address', async () => {
+    const { request } = await installSnap();
+    const response = request({ method: 'botho_showReceive' });
+
+    const ui = await response.getInterface();
+    expect(ui.type).toBe('alert');
+    expect(JSON.stringify(ui.content)).toContain('tbotho://2/');
+    await (ui as { ok(): Promise<void> }).ok();
+
+    const { address } = unwrap<{ address: string }>(await response);
+    expect(address.startsWith('tbotho://2/')).toBe(true);
+  });
+
+  it('rejects a malformed rpcUrl before any network access', async () => {
+    const { request } = await installSnap();
+    const response = await request({
+      method: 'botho_getBalance',
+      params: { rpcUrl: 'not-a-url' },
+    });
+    expect(errorOf(response)?.message).toMatch(/valid https/i);
+  });
+});

--- a/web/packages/snap/test/derivation.snap.ts
+++ b/web/packages/snap/test/derivation.snap.ts
@@ -1,0 +1,45 @@
+/**
+ * Key-derivation determinism + address validity (issue #815 deliverable 2),
+ * exercised through the OFFICIAL `@metamask/snaps-jest` harness — the snap
+ * bundle (with the `bth-wasm-signer` wasm inlined) runs inside the real MetaMask
+ * Snaps SES executor via `@metamask/snaps-simulation`.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+
+/** Unwrap a snaps-jest response, failing loudly on a snap-side error. */
+function unwrap<T>(response: { response: unknown }): T {
+  const res = response.response as { result?: T; error?: { message?: string } };
+  if (res.error) {
+    throw new Error(`snap returned error: ${JSON.stringify(res.error)}`);
+  }
+  return res.result as T;
+}
+
+describe('botho snap: MetaMask-SRP -> Botho-key derivation', () => {
+  it('derives a valid testnet v2 address from MetaMask entropy (SIP-6)', async () => {
+    const { request } = await installSnap();
+    const { address, derivation } = unwrap<{ address: string; derivation: string }>(
+      await request({ method: 'botho_getAddress' }),
+    );
+
+    // A structurally valid v2 testnet address that carries the ML-KEM + ML-DSA
+    // keys (so it is a real post-quantum receive address, not a v1 stub).
+    expect(address.startsWith('tbotho://2/')).toBe(true);
+    expect(address.length).toBeGreaterThan(1000);
+    // The documented derivation path is surfaced to the caller.
+    expect(derivation).toContain("m/44'/866'/0'");
+    expect(derivation).toContain('snap_getEntropy');
+  });
+
+  it('is deterministic: a re-install under the same SRP derives the same wallet', async () => {
+    const first = await installSnap();
+    const a = unwrap<{ address: string }>(await first.request({ method: 'botho_getAddress' }));
+
+    const second = await installSnap();
+    const b = unwrap<{ address: string }>(await second.request({ method: 'botho_getAddress' }));
+
+    expect(b.address).toBe(a.address);
+  });
+});

--- a/web/packages/snap/test/mock-node.ts
+++ b/web/packages/snap/test/mock-node.ts
@@ -1,0 +1,113 @@
+/**
+ * An in-process JSON-RPC server that stands in for a Botho node in the Snap
+ * tests. This is the MOCKED ingress the MVP tests drive the Snap against — no
+ * live betanet or `botho` binary is required (live-testnet send validation is a
+ * follow-up deferred behind betanet resume #1051; see README.md).
+ *
+ * The Snap runs inside the SES executor in a worker thread and reaches this
+ * server over its real `endowment:network-access` `fetch`, so the server binds
+ * to `127.0.0.1` and the test passes its `http://127.0.0.1:<port>` URL as the
+ * Snap's `rpcUrl` param.
+ */
+
+import { createServer, type Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+/** A single JSON-RPC method handler: receives params, returns a result. */
+export type RpcHandler = (params: unknown) => unknown;
+
+export interface MockNodeOptions {
+  /** The `network` id reported by `node_getStatus` (default `botho-testnet`). */
+  network?: string;
+  /** The `chainHeight` reported by `node_getStatus` (default 100). */
+  chainHeight?: number;
+  /**
+   * Outputs returned by `chain_getOutputs`, grouped by block. Default: none
+   * (an empty chain — a freshly-derived wallet then has a 0 balance and no
+   * spendable outputs, which is the deterministic happy path the MVP tests
+   * assert without needing real owned-output fixtures).
+   */
+  outputs?: Array<{ outputs: unknown[] }>;
+  /** Extra / overriding method handlers (e.g. a custom `tx_submit`). */
+  handlers?: Record<string, RpcHandler>;
+}
+
+export interface MockNode {
+  /** Base URL to pass as the Snap's `rpcUrl`, e.g. `http://127.0.0.1:54321`. */
+  url: string;
+  /** Every JSON-RPC call the Snap made, in order (method + params). */
+  calls: Array<{ method: string; params: unknown }>;
+  /** Stop the server. */
+  close(): Promise<void>;
+}
+
+/** Start a mock node. Remember to `await node.close()` in `afterEach`/`afterAll`. */
+export async function startMockNode(options: MockNodeOptions = {}): Promise<MockNode> {
+  const network = options.network ?? 'botho-testnet';
+  const chainHeight = options.chainHeight ?? 100;
+  const outputs = options.outputs ?? [];
+  const calls: MockNode['calls'] = [];
+
+  const defaults: Record<string, RpcHandler> = {
+    node_getStatus: () => ({ chainHeight, network, synced: true, version: 'mock-1.0.0' }),
+    chain_getOutputs: () => outputs,
+    chain_areKeyImagesSpent: (params) => {
+      const keyImages = (params as { keyImages?: string[] })?.keyImages ?? [];
+      return keyImages.map((keyImage) => ({
+        keyImage,
+        spent: false,
+        spentHeight: null,
+        pending: false,
+      }));
+    },
+    tx_submit: () => ({ txHash: 'mocktxhash' }),
+  };
+  const handlers = { ...defaults, ...(options.handlers ?? {}) };
+
+  const server: Server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => (body += chunk));
+    req.on('end', () => {
+      let parsed: { id?: number; method?: string; params?: unknown };
+      try {
+        parsed = JSON.parse(body || '{}');
+      } catch {
+        res.writeHead(400).end();
+        return;
+      }
+      const { id, method, params } = parsed;
+      calls.push({ method: method ?? '', params });
+      const handler = method ? handlers[method] : undefined;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      if (!handler) {
+        res.end(
+          JSON.stringify({ jsonrpc: '2.0', id, error: { code: -32601, message: `no mock for ${method}` } }),
+        );
+        return;
+      }
+      try {
+        res.end(JSON.stringify({ jsonrpc: '2.0', id, result: handler(params) }));
+      } catch (err) {
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id,
+            error: { code: -32000, message: err instanceof Error ? err.message : String(err) },
+          }),
+        );
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    calls,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}

--- a/web/packages/snap/test/send.snap.ts
+++ b/web/packages/snap/test/send.snap.ts
@@ -1,0 +1,113 @@
+/**
+ * Send flow against a MOCKED node RPC (issue #815 deliverables 3 + 4), through
+ * the `@metamask/snaps-jest` SES harness.
+ *
+ * A live-testnet send is NOT verifiable right now (betanet is frozen at height
+ * 202, minting paused — #1051), and a successful on-chain send needs real
+ * owned-output fixtures only a live node can mint. So these tests validate the
+ * full send PLUMBING against a mock: the confirmation dialog, the user
+ * approve/reject branches, the wrong-network / bad-input guards, and that the
+ * pipeline reaches the node and never submits without funds. Live end-to-end
+ * send validation is a documented follow-up (README.md).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+
+import { startMockNode, type MockNode } from './mock-node';
+
+function unwrap<T>(response: { response: unknown }): T {
+  const res = response.response as { result?: T; error?: { message?: string } };
+  if (res.error) {
+    throw new Error(`snap returned error: ${JSON.stringify(res.error)}`);
+  }
+  return res.result as T;
+}
+
+function errorOf(response: { response: unknown }): { message?: string } | undefined {
+  return (response.response as { error?: { message?: string } }).error;
+}
+
+const ONE_BTH = '1000000000000'; // 1 BTH in picocredits (1e12)
+
+describe('botho snap: send against a mocked node', () => {
+  let node: MockNode;
+
+  beforeEach(async () => {
+    node = await startMockNode(); // empty testnet chain
+  });
+  afterEach(async () => {
+    await node.close();
+  });
+
+  /** The snap's own address makes a valid, self-consistent recipient. */
+  async function ownAddress(request: (r: unknown) => Promise<{ response: unknown }>): Promise<string> {
+    return unwrap<{ address: string }>(
+      await (request as (r: unknown) => Promise<{ response: unknown }>)({ method: 'botho_getAddress' }),
+    ).address;
+  }
+
+  it('shows a send confirmation dialog with the amount and recipient', async () => {
+    const { request } = await installSnap();
+    const to = await ownAddress(request as never);
+
+    const response = request({
+      method: 'botho_send',
+      params: { rpcUrl: node.url, recipientAddress: to, amountPicocredits: ONE_BTH },
+    });
+
+    const ui = await response.getInterface();
+    expect(ui.type).toBe('confirmation');
+    const rendered = JSON.stringify(ui.content);
+    expect(rendered).toContain('Confirm send');
+    expect(rendered).toContain('1 BTH'); // amount row
+    expect(rendered).toContain(to); // recipient copyable
+
+    // Reject: the snap must abort and never submit.
+    await (ui as { cancel(): Promise<void> }).cancel();
+    const rejected = await response;
+    expect(errorOf(rejected)?.message).toMatch(/reject/i);
+    expect(node.calls.map((c) => c.method)).not.toContain('tx_submit');
+  });
+
+  it('on approval, runs the build pipeline and surfaces "no funds" without submitting', async () => {
+    const { request } = await installSnap();
+    const to = await ownAddress(request as never);
+
+    const response = request({
+      method: 'botho_send',
+      params: { rpcUrl: node.url, recipientAddress: to, amountPicocredits: ONE_BTH },
+    });
+    const ui = await response.getInterface();
+    await (ui as { ok(): Promise<void> }).ok();
+
+    const result = await response;
+    // Empty mocked chain => the shared builder has nothing to scan/spend.
+    expect(errorOf(result)?.message).toMatch(/no outputs|no spendable|insufficient/i);
+    // The pipeline reached the node (scan) but never submitted a transaction.
+    const methods = node.calls.map((c) => c.method);
+    expect(methods).toContain('chain_getOutputs');
+    expect(methods).not.toContain('tx_submit');
+  });
+
+  it('rejects a malformed recipient address before showing a dialog', async () => {
+    const { request } = await installSnap();
+    const response = await request({
+      method: 'botho_send',
+      params: { rpcUrl: node.url, recipientAddress: 'botho://1/legacy', amountPicocredits: ONE_BTH },
+    });
+    expect(errorOf(response)?.message).toBeTruthy();
+    // A v1 address is rejected by the parser; no send dialog, no submit.
+    expect(node.calls.map((c) => c.method)).not.toContain('tx_submit');
+  });
+
+  it('rejects a non-positive amount', async () => {
+    const { request } = await installSnap();
+    const to = await ownAddress(request as never);
+    const response = await request({
+      method: 'botho_send',
+      params: { rpcUrl: node.url, recipientAddress: to, amountPicocredits: '0' },
+    });
+    expect(errorOf(response)?.message).toMatch(/greater than 0/i);
+  });
+});

--- a/web/packages/snap/test/units.snap.ts
+++ b/web/packages/snap/test/units.snap.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure-logic unit tests (no SES install needed): the wrong-network guard and
+ * SES-safe amount formatting. These run under the snaps-jest preset but exercise
+ * the modules directly — no `installSnap`, no wasm — so the loopback-exemption
+ * branch of the guard (which the loopback mock node can't trigger) is covered.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+
+import { assertNetworkAllowed, isValidRpcUrl, EXPECTED_NETWORK_ID } from '../src/node';
+import { formatPicocreditsBTH, formatBTHWithUnit } from '../src/format';
+
+describe('node ingress guard', () => {
+  it('accepts https and loopback-http endpoints, rejects the rest', () => {
+    expect(isValidRpcUrl('https://seed.botho.io/rpc')).toBe(true);
+    expect(isValidRpcUrl('http://localhost:17101/rpc')).toBe(true);
+    expect(isValidRpcUrl('http://127.0.0.1:8545')).toBe(true);
+    expect(isValidRpcUrl('http://seed.botho.io/rpc')).toBe(false); // plain-http remote
+    expect(isValidRpcUrl('ftp://seed.botho.io')).toBe(false);
+    expect(isValidRpcUrl('not-a-url')).toBe(false);
+  });
+
+  it('rejects a remote node on a different network (#811 wrong-network guard)', () => {
+    expect(() =>
+      assertNetworkAllowed('https://seed.botho.io/rpc', 'botho-mainnet'),
+    ).toThrow(/different network/i);
+  });
+
+  it('accepts a remote node on the expected network', () => {
+    expect(() =>
+      assertNetworkAllowed('https://seed.botho.io/rpc', EXPECTED_NETWORK_ID),
+    ).not.toThrow();
+  });
+
+  it('exempts loopback hosts from the network match (local dev)', () => {
+    expect(() =>
+      assertNetworkAllowed('http://127.0.0.1:8545', 'botho-devnet'),
+    ).not.toThrow();
+    expect(() =>
+      assertNetworkAllowed('http://localhost:17101/rpc', 'anything'),
+    ).not.toThrow();
+  });
+});
+
+describe('SES-safe BTH formatting', () => {
+  it('formats picocredits as trimmed fixed-point BTH', () => {
+    expect(formatPicocreditsBTH(0n)).toBe('0');
+    expect(formatPicocreditsBTH(5_000_000_000_000n)).toBe('5'); // 5 BTH
+    expect(formatPicocreditsBTH(1_234_500_000_000n)).toBe('1.2345');
+    expect(formatPicocreditsBTH(100_000_000n)).toBe('0.0001'); // min fee
+  });
+
+  it('appends the BTH unit', () => {
+    expect(formatBTHWithUnit(1_000_000_000_000n)).toBe('1 BTH');
+  });
+});

--- a/web/packages/snap/tsconfig.json
+++ b/web/packages/snap/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "types": ["node"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "test", "snap.config.ts"]
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -187,6 +187,46 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  packages/snap:
+    dependencies:
+      '@botho/core':
+        specifier: workspace:*
+        version: link:../core
+      '@botho/wasm-signer':
+        specifier: workspace:*
+        version: link:../wasm-signer
+      '@metamask/snaps-sdk':
+        specifier: ^11.2.0
+        version: 11.2.0(typescript@5.9.3)(webextension-polyfill@0.12.0)
+      '@scure/bip39':
+        specifier: ^2.0.1
+        version: 2.0.1
+    devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
+      '@metamask/snaps-cli':
+        specifier: ^8.4.1
+        version: 8.4.1(@babel/runtime@7.29.7)(lightningcss@1.30.2)(typescript@5.9.3)(webextension-polyfill@0.12.0)
+      '@metamask/snaps-jest':
+        specifier: ^10.2.0
+        version: 10.2.0(@babel/runtime@7.29.7)(@metamask/snaps-execution-environments@11.2.0(@babel/runtime@7.29.7)(typescript@5.9.3)(webextension-polyfill@0.12.0))(react@19.2.3)(typescript@5.9.3)(webextension-polyfill@0.12.0)
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@swc/core@1.11.31)(@types/node@22.19.21)(typescript@5.9.3))
+      ts-jest:
+        specifier: ^29.4.11
+        version: 29.4.11(@babel/core@7.28.5)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.5))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.19.21)(ts-node@10.9.2(@swc/core@1.11.31)(@types/node@22.19.21)(typescript@5.9.3)))(typescript@5.9.3)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.11.31)(@types/node@22.19.21)(typescript@5.9.3)
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
   packages/snap-spike:
     dependencies:
       '@botho/core':
@@ -3073,11 +3113,6 @@ packages:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
 
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
@@ -5701,11 +5736,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -5767,10 +5797,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
-    engines: {node: '>= 0.4'}
-
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -5781,10 +5807,6 @@ packages:
 
   side-channel-weakmap@1.0.2:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
-
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
   side-channel@1.1.1:
@@ -6811,7 +6833,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.11
@@ -6902,7 +6924,7 @@ snapshots:
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -6910,17 +6932,17 @@ snapshots:
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-transform-optional-chaining': 7.28.5(@babel/core@7.28.5)
     transitivePeerDependencies:
@@ -6929,7 +6951,7 @@ snapshots:
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -6941,42 +6963,42 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.28.5)':
     dependencies:
@@ -6986,42 +7008,42 @@ snapshots:
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.28.5)':
     dependencies:
@@ -7032,17 +7054,17 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
@@ -7052,7 +7074,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
@@ -7060,18 +7082,18 @@ snapshots:
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-block-scoping@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7079,7 +7101,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7089,7 +7111,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-globals': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
@@ -7098,13 +7120,13 @@ snapshots:
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.27.2
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -7113,28 +7135,28 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
@@ -7142,17 +7164,17 @@ snapshots:
   '@babel/plugin-transform-exponentiation-operator@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -7161,7 +7183,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -7169,28 +7191,28 @@ snapshots:
   '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-logical-assignment-operators@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7198,7 +7220,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7206,7 +7228,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
@@ -7216,7 +7238,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7224,28 +7246,28 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-object-rest-spread@7.28.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
       '@babel/traverse': 7.28.5
@@ -7255,7 +7277,7 @@ snapshots:
   '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
       - supports-color
@@ -7263,12 +7285,12 @@ snapshots:
   '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-optional-chaining@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -7276,13 +7298,13 @@ snapshots:
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7291,14 +7313,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -7313,28 +7335,28 @@ snapshots:
   '@babel/plugin-transform-regenerator@7.28.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -7342,47 +7364,47 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/preset-env@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/compat-data': 7.28.5
       '@babel/core': 7.28.5
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.27.1
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.5)
@@ -7456,7 +7478,7 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.28.5
       esutils: 2.0.3
 
@@ -8441,7 +8463,7 @@ snapshots:
       punycode: 2.3.1
       querystring-es3: 0.2.1
       readable-stream: 3.6.2
-      semver: 7.7.3
+      semver: 7.8.5
       stream-browserify: 3.0.0
       stream-http: 3.2.0
       string_decoder: 1.3.0
@@ -8509,7 +8531,7 @@ snapshots:
       nanoid: 3.3.11
       readable-stream: 3.6.2
       readable-web-to-node-stream: 3.0.4
-      semver: 7.7.3
+      semver: 7.8.5
       tar-stream: 3.2.0
     optionalDependencies:
       '@metamask/snaps-execution-environments': 11.2.0(@babel/runtime@7.29.7)(typescript@5.9.3)(webextension-polyfill@0.12.0)
@@ -8698,7 +8720,7 @@ snapshots:
       luxon: 3.7.2
       marked: 12.0.2
       rfdc: 1.4.1
-      semver: 7.7.3
+      semver: 7.8.5
       ses: 2.2.0
       validate-npm-package-name: 5.0.1
     transitivePeerDependencies:
@@ -8743,7 +8765,7 @@ snapshots:
       debug: 4.4.3
       lodash: 4.17.21
       pony-cause: 2.1.11
-      semver: 7.7.3
+      semver: 7.8.5
       uuid: 9.0.1
     transitivePeerDependencies:
       - supports-color
@@ -9778,9 +9800,7 @@ snapshots:
 
   acorn-walk@8.3.5:
     dependencies:
-      acorn: 8.15.0
-
-  acorn@8.15.0: {}
+      acorn: 8.17.0
 
   acorn@8.17.0: {}
 
@@ -9920,7 +9940,7 @@ snapshots:
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-instrument: 5.2.1
@@ -10841,7 +10861,7 @@ snapshots:
 
   extension-port-stream@4.2.0(webextension-polyfill@0.12.0):
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 4.7.0
       webextension-polyfill: 0.12.0
 
   fast-deep-equal@3.1.3: {}
@@ -10923,8 +10943,8 @@ snapshots:
       minimatch: 3.1.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.7.3
-      tapable: 2.3.0
+      semver: 7.8.5
+      tapable: 2.3.3
       typescript: 5.9.3
       webpack: 5.108.4(@swc/core@1.11.31)(lightningcss@1.30.2)
 
@@ -11214,7 +11234,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
-      side-channel: 1.1.0
+      side-channel: 1.1.1
 
   ipaddr.js@1.9.1: {}
 
@@ -11399,7 +11419,7 @@ snapshots:
       '@babel/parser': 7.28.5
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.3
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -11697,7 +11717,7 @@ snapshots:
       jest-util: 29.7.0
       natural-compare: 1.4.0
       pretty-format: 29.7.0
-      semver: 7.7.3
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -11940,7 +11960,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.5
 
   make-error@1.3.6: {}
 
@@ -11956,7 +11976,7 @@ snapshots:
 
   md5.js@1.3.5:
     dependencies:
-      hash-base: 3.0.5
+      hash-base: 3.1.2
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
@@ -12974,8 +12994,6 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.3: {}
-
   semver@7.8.5: {}
 
   send@1.2.1:
@@ -13055,7 +13073,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -13088,11 +13106,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  side-channel-list@1.0.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -13112,14 +13125,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
-
-  side-channel@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.0
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
 
   side-channel@1.1.1:
     dependencies:
@@ -13238,7 +13243,7 @@ snapshots:
       internal-slot: 1.1.0
       regexp.prototype.flags: 1.5.4
       set-function-name: 2.0.2
-      side-channel: 1.1.0
+      side-channel: 1.1.1
 
   string.prototype.trim@1.2.10:
     dependencies:
@@ -13383,7 +13388,7 @@ snapshots:
   terser@5.44.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -13480,7 +13485,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.19.21
-      acorn: 8.15.0
+      acorn: 8.17.0
       acorn-walk: 8.3.5
       arg: 4.1.3
       create-require: 1.1.1
@@ -13782,7 +13787,7 @@ snapshots:
   webpack-bundle-analyzer@4.10.2:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      acorn: 8.15.0
+      acorn: 8.17.0
       acorn-walk: 8.3.5
       commander: 7.2.0
       debounce: 1.2.1
@@ -13826,7 +13831,7 @@ snapshots:
       minimizer-webpack-plugin: 5.6.1(@swc/core@1.11.31)(lightningcss@1.30.2)(webpack@5.108.4(@swc/core@1.11.31)(lightningcss@1.30.2))
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.0
+      tapable: 2.3.3
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Phase-1 **MVP** of the Botho MetaMask Snap (issue #815), promoting the Phase-0
feasibility spike (verdict GO, PR #1055) into a clean, self-contained package at
`web/packages/snap`. It lets MetaMask-comfortable users manage a
privacy-by-default Botho wallet from inside MetaMask — **no EVM compromise, no
bridge, no protocol/consensus/wire-format change** (the Snap is a pure client and
a second consumer of the already-audited `@botho/wasm-signer` core, exactly like
the web wallet).

The Snap derives the Botho `RootIdentity` from the **MetaMask SRP** (SIP-6
`snap_getEntropy`, salt `botho-root`) through the node-identical SLIP-10
`m/44'/866'/0'` pipeline, runs `bth-wasm-signer` inside the Snaps **SES sandbox**
(inlined wasm — the spike measured `buildAndSign` at ~26–28 ms there), and talks
to a **user-selected ingress node** for receive / balance / send. Keys never
leave the sandbox. Spike-only test hooks (`senderMnemonic`,
`botho_deriveAddress`) are intentionally **absent**.

## Changes

- New workspace package `@botho/snap` (`web/packages/snap`): manifest + snaps-cli
  config + tsconfig/jest/typecheck scaffolding, mirroring the spike's proven SES
  + `experimental.wasm` + `getrandom`-under-sandbox setup.
- `src/derivation.ts` — MetaMask-SRP → Botho-key derivation via SIP-6, plugging
  MetaMask entropy in as the BIP39 entropy of the existing RootIdentity pipeline;
  the same 24-word mnemonic recovers the identical wallet in the web/CLI/mobile
  wallet. Security trade-off (SRP-derived vs Snap-local seed, incl. the snap-id
  pinning risk) documented in the package README.
- `src/index.ts` — `onRpcRequest` handler: `botho_getAddress` (stealth receive
  address), `botho_getBalance` (`spendableBalance` via scan), `botho_send`
  (`buildSendTransaction` → `tx_submit`), plus `botho_showReceive`,
  `botho_showBalance`, and `botho_showMnemonic` (off-MetaMask recovery backup).
- `src/node.ts` — JSON-RPC node client + `SendRpc` adapter + node-trust /
  **wrong-network guard** carried over from the web wallet (`node_getStatus.network`
  must be `botho-testnet`; loopback exempt), cf. #811.
- `src/ui.ts` — Snaps custom-UI dialogs for receive / balance / send confirmation
  / mnemonic backup. `src/signer.ts` injects the inlined wasm via `setSigner`.
  `src/format.ts` is SES-safe (Intl-free) BTH formatting.
- Tests via `@metamask/snaps-jest` against a **mocked in-process node RPC**
  (`test/mock-node.ts`) — no live betanet / node binary required.

## Acceptance Criteria Verification (Phase-1 scope)

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Manifest + config + scaffolding (SES endowments, getrandom under sandbox) | ✅ | `mm-snap build` succeeds; bundle evaluates under SES; `snaps-jest` probes pass |
| MetaMask-SRP → Botho-key derivation via documented SLIP-10 path | ✅ | `derivation.snap.ts` asserts a valid `tbotho://2/` address + re-install determinism; path documented in README |
| RPC handler: getAddress / getBalance / send (+ node trust / wrong-network guard) | ✅ | `balance.snap.ts` + `send.snap.ts` + `units.snap.ts` (guard incl. loopback exemption) |
| Snap dialog UI for send / receive / balance | ✅ | `send.snap.ts` / `balance.snap.ts` assert dialog type + content, approve/reject branches |
| Tests via snaps-jest (derivation, getAddress, getBalance, send) against mocked node | ✅ | `pnpm --filter @botho/snap test:snap` → 4 suites, **16 tests, all green** |
| Self-contained, building, linted, green | ✅ | `pnpm --filter @botho/snap typecheck` + `build:snap` + `test:snap` all pass; `pnpm -r typecheck` green |

## Test Plan

```sh
pnpm --filter @botho/wasm-signer build:wasm:bundler
pnpm --filter @botho/snap test:snap   # mm-snap build && jest → 16 passed
pnpm -r typecheck                      # all 10 packages green (snap incl.)
```

Tests are named `*.snap.ts` (not `*.test.ts`) so the workspace-root vitest run
never picks them up; they only run via the package's `test:snap` script.

## Deferred (NOT in this MVP)

- **Live-testnet send** — a real on-chain send needs owned-output fixtures only a
  live minting node can produce, and the public betanet is currently **frozen**
  (height 202, minting paused). The send *plumbing* is fully tested against a
  mocked node here; end-to-end live-send validation is a follow-up **blocked on
  betanet resume (#1051)**.
- **Phase 2 parity**: transaction history, contacts, in-Snap ingress selection
  UX, i18n, incremental/windowed scanning (`snap_manageState`), and a dedicated
  **security pass** for the new key-handling surface (cf. #474/#475).
- **Publishing**: npm publish + MetaMask allowlist + production snap-id pinning.

Part of #815 (Phase 1 MVP Snap)