### PR TITLE
test(cluster-fee): fix stale fee-gaming test expectations under --all-features (#1068)

### DIFF
--- a/.github/workflows/workspace-build.yml
+++ b/.github/workflows/workspace-build.yml
@@ -84,3 +84,14 @@ jobs:
       # fast (seconds) and deterministic, so run them for real.
       - name: Run doctests
         run: cargo test --workspace --doc
+
+      # The `cluster-tax`-gated code in `bth-transaction-core` only compiles —
+      # and its tests only run — under `--all-features`. The default workspace
+      # build/test above never exercises that path, so both a COMPILE break
+      # (#1057) and two latent RUNTIME fee-gaming test failures (#1068) sat
+      # green for a long time. `cargo check --all-features` alone was not
+      # enough to catch #1068 (the module compiled but its tests failed), so we
+      # RUN the crate's `--all-features` tests here. Scoped to the one crate to
+      # stay fast and deterministic (~seconds).
+      - name: Run bth-transaction-core --all-features tests (cluster-tax path)
+        run: cargo test -p bth-transaction-core --all-features

--- a/transaction/core/src/validation/cluster_fee.rs
+++ b/transaction/core/src/validation/cluster_fee.rs
@@ -965,6 +965,15 @@ mod tests {
 
     #[test]
     fn test_validate_ring_cluster_fee_insufficient() {
+        // Cluster wealth is denominated in PICOCREDITS and the fee curve pins
+        // its progressivity midpoint at W_MID = 100,000 BTH = 1e17 pico (#626).
+        // Wealth values must therefore straddle that threshold to exercise the
+        // curve's dynamic range: a poor cluster below the midpoint pays ~1x, a
+        // rich cluster above it pays a materially higher multiplier. (Bare
+        // integers like 100_000 are ~1e-7 BTH — dust — and collapse to the flat
+        // 1x floor, which is why the original expectations were vacuous.)
+        const PICO: u64 = 1_000_000_000_000;
+
         // Ring with one rich member
         let tags_rich = make_tag_vector(&[(1, TAG_WEIGHT_SCALE)]);
         let tags_poor = make_tag_vector(&[(2, TAG_WEIGHT_SCALE)]);
@@ -972,9 +981,12 @@ mod tests {
         let ring_tags: Vec<&ClusterTagVector> = vec![&tags_rich, &tags_poor];
         let ring_values = vec![1_000_000u64, 1_000_000];
 
+        let poor_wealth = 100 * PICO; // 100 BTH: below midpoint, ~1x
+        let rich_wealth = 1_000_000 * PICO; // 1,000,000 BTH: above midpoint
+
         let mut wealth_map = ClusterWealthMap::new();
-        wealth_map.set(ClusterId(1), 100_000_000); // Very rich
-        wealth_map.set(ClusterId(2), 100_000);
+        wealth_map.set(ClusterId(1), rich_wealth); // Very rich
+        wealth_map.set(ClusterId(2), poor_wealth);
 
         let fee_config = FeeConfig::default();
 
@@ -998,9 +1010,22 @@ mod tests {
         let poor_fee = fee_config.compute_fee_with_outputs(
             TransactionType::Hidden,
             4000,
-            100_000, // Poor cluster wealth
+            poor_wealth as u128, // Poor cluster wealth
             2,
             0,
+        );
+        // Sanity: the conservative (max) fee genuinely exceeds the poor fee, so
+        // the rejection below is meaningful and not a flat-curve coincidence.
+        let rich_fee = fee_config.compute_fee_with_outputs(
+            TransactionType::Hidden,
+            4000,
+            rich_wealth as u128,
+            2,
+            0,
+        );
+        assert!(
+            rich_fee > poor_fee,
+            "rich cluster must incur a strictly higher fee than the poor cluster"
         );
         let result = validate_ring_cluster_fee(
             poor_fee,
@@ -1020,7 +1045,17 @@ mod tests {
 
     #[test]
     fn test_ring_fee_gaming_prevention() {
-        // Test that attacker with rich coins cannot lower fees by selecting poor decoys
+        // Test that attacker with rich coins cannot lower fees by selecting poor
+        // decoys.
+        //
+        // Wealth is in PICOCREDITS; the curve's progressivity midpoint is
+        // W_MID = 100,000 BTH = 1e17 pico (#626). The attacker's cluster sits
+        // well above the midpoint (higher multiplier) and the decoys sit well
+        // below it (~1x), so the poor fee is genuinely cheaper — exactly the
+        // gap an attacker would try to exploit. The conservative max-wealth
+        // rule must close that gap.
+        const PICO: u64 = 1_000_000_000_000;
+
         let tags_attacker = make_tag_vector(&[(1, TAG_WEIGHT_SCALE)]); // Rich attacker
         let tags_decoy1 = make_tag_vector(&[(2, TAG_WEIGHT_SCALE)]); // Poor decoy
         let tags_decoy2 = make_tag_vector(&[(2, TAG_WEIGHT_SCALE)]); // Poor decoy
@@ -1029,19 +1064,38 @@ mod tests {
         let ring_tags: Vec<&ClusterTagVector> = vec![&tags_attacker, &tags_decoy1, &tags_decoy2];
         let ring_values = vec![1_000_000u64; 3];
 
+        let rich_wealth = 1_000_000 * PICO; // 1,000,000 BTH: above midpoint
+        let poor_wealth = 100 * PICO; // 100 BTH: below midpoint, ~1x
+
         let mut wealth_map = ClusterWealthMap::new();
-        wealth_map.set(ClusterId(1), 100_000_000); // Rich attacker cluster
-        wealth_map.set(ClusterId(2), 10_000); // Very poor decoy cluster
+        wealth_map.set(ClusterId(1), rich_wealth); // Rich attacker cluster
+        wealth_map.set(ClusterId(2), poor_wealth); // Poor decoy cluster
 
         let fee_config = FeeConfig::default();
 
         // Fee for the rich cluster (what attacker should pay)
-        let rich_fee =
-            fee_config.compute_fee_with_outputs(TransactionType::Hidden, 4000, 100_000_000, 2, 0);
+        let rich_fee = fee_config.compute_fee_with_outputs(
+            TransactionType::Hidden,
+            4000,
+            rich_wealth as u128,
+            2,
+            0,
+        );
 
         // Fee for the poor cluster (what attacker wants to pay)
-        let poor_fee =
-            fee_config.compute_fee_with_outputs(TransactionType::Hidden, 4000, 10_000, 2, 0);
+        let poor_fee = fee_config.compute_fee_with_outputs(
+            TransactionType::Hidden,
+            4000,
+            poor_wealth as u128,
+            2,
+            0,
+        );
+
+        // The attack only makes sense if the poor fee is actually cheaper.
+        assert!(
+            poor_fee < rich_fee,
+            "poor-decoy fee must be strictly cheaper for the gaming test to be meaningful"
+        );
 
         // Attacker tries to pay the poor fee - should fail!
         let result = validate_ring_cluster_fee(


### PR DESCRIPTION
Closes #1068

## Verdict: (B) STALE TEST EXPECTATIONS — not a security regression

The two `validate_ring_cluster_fee` tests failed at runtime under `--all-features` (newly surfaced once #1057 made the `cluster-tax`-gated module compile). Tracing the actual numbers shows the fee curve is behaving **correctly**; the test expectations predate the #626 picocredit calibration.

### The evidence (traced numerically)

Cluster wealth is denominated in **picocredits**, and the fee curve's progressivity midpoint is `W_MID = 100,000 BTH = 1e17 pico` (`ClusterFactorCurve::W_MID_PICO`, #626). The failing tests used bare integers as "wealth":

| Test "wealth" (pico) | In BTH | `factor()` | `compute_fee_with_outputs` |
|---|---|---|---|
| 10,000 | 1e-8 BTH | 1000 (1x) | 16000 |
| 100,000 | 1e-7 BTH | 1000 (1x) | 16000 |
| 100,000,000 | 1e-4 BTH | 1000 (1x) | 16000 |

Every value is orders of magnitude below the 100,000-BTH tax threshold, so all collapse to the **flat 1x floor** — identical fee (16000). "Rich" and "poor" clusters produced the *same* fee, so `poor_fee == minimum_fee` and paying it was correctly accepted. There was genuinely nothing to game: neither cluster is wealthy enough to be taxed above 1x.

The `max_cluster_wealth as u128` widening from #1057 is a value-preserving u64→u128 cast and changes none of this. Production logic (`compute_ring_max_cluster_wealth`, `validate_ring_cluster_fee`) is untouched and correct.

For contrast, with realistic pico-scale wealth the curve is properly progressive:

| Wealth | `factor()` | fee |
|---|---|---|
| 100 BTH (1e14 pico) | 1050 (~1.05x) | 16800 |
| 1,000,000 BTH (1e18 pico) | 5093 (~5.1x) | ~81k |
| 10,000,000 BTH (1e19 pico) | 5745 (~5.7x) | 91920 |

## The fix

Update the two stale tests to use realistic picocredit wealth that **straddles the tax threshold** (poor = 100 BTH → ~1.05x, rich = 1,000,000 BTH → ~5.1x). Now the rich/poor fee gap is real, and the tests prove the gaming-prevention invariant holds:

- `compute_ring_max_cluster_wealth` selects the **rich** member's high wealth (the max across the ring),
- `validate_ring_cluster_fee` computes the higher required fee from it,
- the attacker's poor-decoy fee is **rejected** (`poor_fee < minimum_fee`), and only the rich fee passes.

Added `assert!(rich_fee > poor_fee)` / `assert!(poor_fee < rich_fee)` guards so these tests can **never again pass vacuously** on a flat curve. No production code changed — gaming prevention was already intact; the tests simply weren't exercising it.

## Gaming-prevention: preserved ✅

The conservative max-cluster-wealth rule is the security mechanism, and it is untouched. The attacker cannot pay less by mixing rich coins with poor decoys because the ring's fee is computed from the **maximum** effective cluster wealth among all members. The updated tests now actually demonstrate this (previously they asserted it against a flat curve where the claim was trivially — and misleadingly — satisfied).

## CI guard (issue's suggested follow-up)

Added a `cargo test -p bth-transaction-core --all-features` step to `workspace-build.yml`. The `cluster-tax`-gated code only compiles and runs under `--all-features`; default CI never exercised it, so both the compile break (#1057) and these runtime failures (#1068) sat green. `cargo check --all-features` alone was insufficient (the module compiled but its tests failed), so the step **runs** the crate's tests. Scoped to the one crate to stay fast (~7s) and deterministic.

## Verification

```
cargo test -p bth-transaction-core --all-features cluster_fee   # 24 passed; 0 failed
cargo test -p bth-transaction-core --all-features               # 120 passed; 0 failed
cargo fmt -p bth-transaction-core -- --check                    # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)