### PR TITLE
security(bridge): harden relayer/submit key at-rest loading (retire orphaned TODO #827)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,6 +2092,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/bridge/core/src/config.rs
+++ b/bridge/core/src/config.rs
@@ -341,8 +341,28 @@ pub struct EthereumConfig {
     /// Chain ID (1 for mainnet, 5 for goerli, etc.)
     pub chain_id: u64,
 
-    /// Path to encrypted private key file
+    /// Path to the relayer (submit) key file. The relayer EOA pays gas to
+    /// submit `Safe.execTransaction`; it is NOT a custody key (custody = the
+    /// Safe threshold, ADR 0002). On testnet this may be a plaintext hex file
+    /// (explicit opt-in). `None` (with no `private_key_env`) disables mint
+    /// submission (watch-only). At-rest hardening is tracked in #1077; see the
+    /// bridge ops runbook for provisioning.
     pub private_key_file: Option<String>,
+
+    /// Name of an environment variable holding the relayer key (hex secp256k1,
+    /// `0x`-optional). When set it takes PRECEDENCE over `private_key_file`, so
+    /// a mainnet deployment can inject the key at runtime (secrets manager /
+    /// systemd credential / OS keyring) with NO plaintext key file on disk
+    /// (#1077). A configured-but-unset var fails closed.
+    #[serde(default)]
+    pub private_key_env: Option<String>,
+
+    /// Hard-fail (rather than warn) when the relayer `private_key_file` is
+    /// group/world accessible. Default `false` keeps testnet drills working
+    /// with loosely-permissioned files while still logging the offending mode;
+    /// set `true` for mainnet so an insecure key file is refused (#1077).
+    #[serde(default)]
+    pub enforce_key_permissions: bool,
 
     /// Number of confirmations required
     #[serde(default = "default_eth_confirmations")]
@@ -382,8 +402,25 @@ pub struct SolanaConfig {
     /// wBTH program ID
     pub wbth_program: String,
 
-    /// Path to encrypted keypair file
+    /// Path to the submit keypair file (hex 32-byte seed or Solana CLI JSON
+    /// array). The local key assembles/relays the multisig transaction; per
+    /// ADR 0002 the on-chain `mint_authority` is a distinct SPL/Squads
+    /// multisig, so this is NOT a custody key. On testnet this may be a
+    /// plaintext file (explicit opt-in). At-rest hardening is tracked in #1077.
     pub keypair_file: Option<String>,
+
+    /// Name of an environment variable holding the submit key (hex 32-byte
+    /// seed or Solana CLI JSON array). When set it takes PRECEDENCE over
+    /// `keypair_file`, so a mainnet deployment needs NO plaintext key file on
+    /// disk (#1077). A configured-but-unset var fails closed.
+    #[serde(default)]
+    pub keypair_env: Option<String>,
+
+    /// Hard-fail (rather than warn) when `keypair_file` is group/world
+    /// accessible. Default `false` keeps testnet drills working while logging
+    /// the offending mode; set `true` for mainnet (#1077).
+    #[serde(default)]
+    pub enforce_key_permissions: bool,
 
     /// Commitment level
     #[serde(default)]
@@ -607,6 +644,8 @@ impl Default for BridgeConfig {
                 safe_address: None,
                 chain_id: 1,
                 private_key_file: None,
+                private_key_env: None,
+                enforce_key_permissions: false,
                 confirmations_required: 12,
                 gas_price_strategy: GasPriceStrategy::default(),
                 mint_signers: Vec::new(),
@@ -616,6 +655,8 @@ impl Default for BridgeConfig {
                 rpc_url: "http://localhost:8899".to_string(),
                 wbth_program: "11111111111111111111111111111111".to_string(),
                 keypair_file: None,
+                keypair_env: None,
+                enforce_key_permissions: false,
                 commitment: SolanaCommitment::default(),
                 mint_signers: Vec::new(),
                 mint_threshold: 0,
@@ -832,6 +873,62 @@ mod tests {
         assert_eq!(configured.min_order_amount, 1000);
         assert_eq!(configured.max_body_bytes, 2048);
         assert_eq!(configured.max_open_orders, 5);
+    }
+
+    #[test]
+    fn test_relayer_key_source_knobs_default_and_parse() {
+        // Defaults (#1077): no env-var override, permission enforcement off
+        // (testnet-compatible — files are only warned about, not refused).
+        let config = BridgeConfig::default();
+        assert!(config.ethereum.private_key_env.is_none());
+        assert!(!config.ethereum.enforce_key_permissions);
+        assert!(config.solana.keypair_env.is_none());
+        assert!(!config.solana.enforce_key_permissions);
+
+        // A pre-existing config without the new knobs still parses (the fields
+        // are `#[serde(default)]`, so testnet configs are unaffected).
+        let legacy: EthereumConfig = toml::from_str(
+            r#"
+            rpc_url = "http://localhost:8545"
+            wbth_contract = "0x0000000000000000000000000000000000000000"
+            chain_id = 1
+            "#,
+        )
+        .unwrap();
+        assert!(legacy.private_key_env.is_none());
+        assert!(!legacy.enforce_key_permissions);
+
+        // The knobs round-trip from TOML for both chains.
+        let eth: EthereumConfig = toml::from_str(
+            r#"
+            rpc_url = "http://localhost:8545"
+            wbth_contract = "0x0000000000000000000000000000000000000000"
+            chain_id = 1
+            private_key_env = "BTH_BRIDGE_ETH_RELAYER_KEY"
+            enforce_key_permissions = true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            eth.private_key_env.as_deref(),
+            Some("BTH_BRIDGE_ETH_RELAYER_KEY")
+        );
+        assert!(eth.enforce_key_permissions);
+
+        let sol: SolanaConfig = toml::from_str(
+            r#"
+            rpc_url = "http://localhost:8899"
+            wbth_program = "11111111111111111111111111111111"
+            keypair_env = "BTH_BRIDGE_SOL_SUBMIT_KEY"
+            enforce_key_permissions = true
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            sol.keypair_env.as_deref(),
+            Some("BTH_BRIDGE_SOL_SUBMIT_KEY")
+        );
+        assert!(sol.enforce_key_permissions);
     }
 
     #[test]

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -115,6 +115,10 @@ sha2 = { workspace = true, features = ["std"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { workspace = true, features = ["derive"] }
+# At-rest hardening of the relayer/submit signing keys (#1077): the raw key
+# buffer read from a file/env var is wrapped in `Zeroizing` so it is wiped from
+# memory after parsing into the chain signer.
+zeroize = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true, features = ["default-code-coverage"] }

--- a/bridge/service/src/mint/ethereum.rs
+++ b/bridge/service/src/mint/ethereum.rs
@@ -33,6 +33,7 @@ use bth_bridge_core::{
 };
 use tracing::{debug, info, warn};
 
+use super::keysource::{load_key_material, KeySourceConfig};
 use super::{ConfirmationStatus, MintError, Minter, PreparedMint};
 
 sol! {
@@ -275,15 +276,19 @@ impl EthMinter {
             .map_err(|e| MintError::Config(format!("invalid ethereum rpc_url: {}", e)))?;
         let provider = ProviderBuilder::new().connect_http(url).erased();
 
-        // TODO(#827): the relayer key file is currently read as plaintext
-        // hex; key provisioning/encryption is tracked in the ops runbook
-        // issue. The relayer is NOT a custody key — it only pays gas; the
-        // mint authority is the Safe threshold (ADR 0002).
-        let relayer = match config.private_key_file.as_deref() {
-            Some(path) => {
-                let raw = std::fs::read_to_string(path).map_err(|e| {
-                    MintError::Config(format!("cannot read private_key_file {}: {}", path, e))
-                })?;
+        // The relayer EOA only pays gas to submit `execTransaction`; it is NOT
+        // a custody key — the mint authority is the Safe threshold (ADR 0002).
+        // At-rest hardening of this key — file-permission preflight, a
+        // non-plaintext (env-var) load path, and buffer zeroization — is #1077
+        // (see `super::keysource`); provisioning is the bridge ops runbook. The
+        // raw hex is loaded into a zeroizing buffer and wiped once parsed.
+        let relayer = match load_key_material(KeySourceConfig {
+            file: config.private_key_file.as_deref(),
+            env_var: config.private_key_env.as_deref(),
+            enforce_permissions: config.enforce_key_permissions,
+            label: "ethereum.private_key",
+        })? {
+            Some(raw) => {
                 let signer: PrivateKeySigner = raw
                     .trim()
                     .parse()
@@ -592,6 +597,57 @@ mod tests {
 
     fn addr(byte: u8) -> Address {
         Address::from([byte; 20])
+    }
+
+    /// A minimal minter config; the relayer key source is filled in per test.
+    fn eth_config() -> EthereumConfig {
+        EthereumConfig {
+            rpc_url: "http://localhost:8545".to_string(),
+            wbth_contract: "0x00000000000000000000000000000000000000ee".to_string(),
+            safe_address: Some("0x00000000000000000000000000000000000000AA".to_string()),
+            chain_id: 1,
+            private_key_file: None,
+            private_key_env: None,
+            enforce_key_permissions: false,
+            confirmations_required: 1,
+            gas_price_strategy: Default::default(),
+            mint_signers: Vec::new(),
+            mint_threshold: 0,
+        }
+    }
+
+    /// #1077 AC: the non-plaintext (env-var) load path works end-to-end for the
+    /// Ethereum relayer key — no plaintext key file on disk. The well-known
+    /// Hardhat account #0 key derives its known address, proving the key was
+    /// loaded and parsed from the environment.
+    #[test]
+    fn relayer_key_loads_from_env_var() {
+        const HARDHAT0_KEY: &str =
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+        let hardhat0_addr: Address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+            .parse()
+            .unwrap();
+
+        let var = "BTH_TEST_ETH_RELAYER_KEY_1077";
+        std::env::set_var(var, HARDHAT0_KEY);
+
+        let mut config = eth_config();
+        config.private_key_env = Some(var.to_string());
+        let minter = EthMinter::new(config).expect("minter builds from env-var relayer key");
+
+        let (loaded_addr, _wallet) = minter.relayer.expect("relayer configured via env var");
+        assert_eq!(loaded_addr, hardhat0_addr);
+        std::env::remove_var(var);
+    }
+
+    /// A configured-but-unset relayer env var fails closed (no silent fallback).
+    #[test]
+    fn relayer_env_var_unset_fails_closed() {
+        let var = "BTH_TEST_ETH_RELAYER_KEY_UNSET_1077";
+        std::env::remove_var(var);
+        let mut config = eth_config();
+        config.private_key_env = Some(var.to_string());
+        assert!(EthMinter::new(config).is_err());
     }
 
     #[test]

--- a/bridge/service/src/mint/ethereum.rs
+++ b/bridge/service/src/mint/ethereum.rs
@@ -33,8 +33,10 @@ use bth_bridge_core::{
 };
 use tracing::{debug, info, warn};
 
-use super::keysource::{load_key_material, KeySourceConfig};
-use super::{ConfirmationStatus, MintError, Minter, PreparedMint};
+use super::{
+    keysource::{load_key_material, KeySourceConfig},
+    ConfirmationStatus, MintError, Minter, PreparedMint,
+};
 
 sol! {
     /// Typed binding for the wBTH token (`contracts/ethereum/contracts/WrappedBTH.sol`).
@@ -640,7 +642,8 @@ mod tests {
         std::env::remove_var(var);
     }
 
-    /// A configured-but-unset relayer env var fails closed (no silent fallback).
+    /// A configured-but-unset relayer env var fails closed (no silent
+    /// fallback).
     #[test]
     fn relayer_env_var_unset_fails_closed() {
         let var = "BTH_TEST_ETH_RELAYER_KEY_UNSET_1077";

--- a/bridge/service/src/mint/keysource.rs
+++ b/bridge/service/src/mint/keysource.rs
@@ -55,9 +55,7 @@ pub struct KeySourceConfig<'a> {
 /// watch-only deployment). Otherwise returns the secret in a [`Zeroizing`]
 /// buffer that is wiped on drop; the caller parses it into the chain-specific
 /// signer. The secret itself is never logged.
-pub fn load_key_material(
-    src: KeySourceConfig<'_>,
-) -> Result<Option<Zeroizing<String>>, MintError> {
+pub fn load_key_material(src: KeySourceConfig<'_>) -> Result<Option<Zeroizing<String>>, MintError> {
     // Env var takes precedence: it is the mainnet load path (no plaintext key
     // file on disk). A configured-but-missing var fails closed rather than
     // silently falling back to a file.

--- a/bridge/service/src/mint/keysource.rs
+++ b/bridge/service/src/mint/keysource.rs
@@ -1,0 +1,269 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! At-rest hardening for the relayer / submit signing keys (#1077).
+//!
+//! Both chain mint submitters need a signing key — a secp256k1 relayer EOA on
+//! Ethereum, an Ed25519 submit key on Solana — to pay gas and broadcast the
+//! threshold-authorized mint transaction. These are **not** custody keys:
+//! custody is the Gnosis Safe / Squads threshold per ADR 0002. But a
+//! compromised relayer/submit key still enables gas drain and submission
+//! griefing, so its at-rest handling is hardened here:
+//!
+//! 1. **Load source**. A key may come from a plaintext file on disk (an
+//!    explicit testnet opt-in) OR from an environment variable (`*_env`). When
+//!    an env-var name is configured it takes PRECEDENCE over the file, so a
+//!    mainnet deployment never needs a plaintext key file on disk — the secret
+//!    is injected at runtime by a secrets manager, a systemd `LoadCredential`,
+//!    or an OS keyring that exports into the process environment. A
+//!    configured-but-unset var fails closed rather than silently falling back
+//!    to a file.
+//! 2. **File-permission preflight**. A group- or world-accessible key file is a
+//!    leak surface an auditor will flag. The loader logs the offending octal
+//!    mode and, when `enforce_permissions` is set (recommended for mainnet),
+//!    refuses to load; otherwise it warns (the testnet-compatible default, so
+//!    existing drills with loosely-permissioned files keep working).
+//! 3. **Zeroization**. The raw secret buffer is returned inside a
+//!    [`zeroize::Zeroizing`] wrapper, so it is wiped from memory on drop once
+//!    the caller has parsed it into the chain-specific signer.
+//!
+//! Key material is NEVER logged (the mainnet key-hygiene posture): only the
+//! file path, its permission mode, and the env-var NAME ever appear in a
+//! message.
+
+use zeroize::Zeroizing;
+
+use super::MintError;
+
+/// Where a relayer / submit signing key is loaded from, plus the at-rest
+/// policy to apply.
+pub struct KeySourceConfig<'a> {
+    /// Path to a plaintext key file (an explicit testnet opt-in), if any.
+    pub file: Option<&'a str>,
+    /// Name of an environment variable holding the key (the non-plaintext,
+    /// no-key-file-on-disk load path). Takes precedence over `file`.
+    pub env_var: Option<&'a str>,
+    /// Hard-fail (vs. warn) when a key FILE is group/world accessible.
+    pub enforce_permissions: bool,
+    /// Human-readable label for messages (e.g. `ethereum.private_key`). Only
+    /// the label — never the secret — appears in errors/logs.
+    pub label: &'a str,
+}
+
+/// Load raw signing-key material from the configured source.
+///
+/// Returns `Ok(None)` when neither a file nor an env var is configured (a
+/// watch-only deployment). Otherwise returns the secret in a [`Zeroizing`]
+/// buffer that is wiped on drop; the caller parses it into the chain-specific
+/// signer. The secret itself is never logged.
+pub fn load_key_material(
+    src: KeySourceConfig<'_>,
+) -> Result<Option<Zeroizing<String>>, MintError> {
+    // Env var takes precedence: it is the mainnet load path (no plaintext key
+    // file on disk). A configured-but-missing var fails closed rather than
+    // silently falling back to a file.
+    if let Some(var) = src.env_var {
+        return match std::env::var(var) {
+            Ok(val) => Ok(Some(Zeroizing::new(val))),
+            Err(std::env::VarError::NotPresent) => Err(MintError::Config(format!(
+                "{}: env var {} is configured but not set",
+                src.label, var
+            ))),
+            Err(std::env::VarError::NotUnicode(_)) => Err(MintError::Config(format!(
+                "{}: env var {} is not valid UTF-8",
+                src.label, var
+            ))),
+        };
+    }
+
+    let Some(path) = src.file else {
+        return Ok(None);
+    };
+
+    preflight_permissions(path, src.enforce_permissions, src.label)?;
+
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| MintError::Config(format!("{}: cannot read {}: {}", src.label, path, e)))?;
+    Ok(Some(Zeroizing::new(raw)))
+}
+
+/// Refuse (or warn) when a key file is accessible beyond its owner.
+///
+/// A key file should be `0600` (or `0400`). Any group/world permission bit
+/// (`0o077`) is a leak surface. On non-Unix platforms file-mode bits are not
+/// meaningful, so the preflight is a no-op there.
+#[cfg(unix)]
+fn preflight_permissions(path: &str, enforce: bool, label: &str) -> Result<(), MintError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let meta = std::fs::metadata(path)
+        .map_err(|e| MintError::Config(format!("{}: cannot stat {}: {}", label, path, e)))?;
+    let mode = meta.permissions().mode() & 0o777;
+    if mode & 0o077 != 0 {
+        let msg = format!(
+            "{}: key file {} is group/world accessible (mode {:#o}); \
+             tighten it to 0600 (`chmod 600 {}`)",
+            label, path, mode, path
+        );
+        if enforce {
+            return Err(MintError::Config(format!(
+                "{} — refusing to load (enforce_key_permissions=true)",
+                msg
+            )));
+        }
+        tracing::warn!(
+            "{} — loading anyway (enforce_key_permissions=false; set it true for mainnet)",
+            msg
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn preflight_permissions(_path: &str, _enforce: bool, _label: &str) -> Result<(), MintError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A configured-but-unset env var fails closed (does NOT silently fall back
+    /// to a file): the operator asked for env loading, so a missing var is a
+    /// misconfiguration, not a reason to read a plaintext file.
+    #[test]
+    fn missing_env_var_fails_closed() {
+        let var = "BTH_TEST_KEYSOURCE_UNSET_1077";
+        std::env::remove_var(var);
+        let err = load_key_material(KeySourceConfig {
+            file: Some("/should/not/be/read"),
+            env_var: Some(var),
+            enforce_permissions: false,
+            label: "test.key",
+        })
+        .unwrap_err();
+        match err {
+            MintError::Config(m) => assert!(m.contains("not set"), "got: {m}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+
+    /// The env-var load path returns the secret (no key file on disk) and the
+    /// buffer is a `Zeroizing<String>` (wiped on drop).
+    #[test]
+    fn env_var_load_path_returns_secret() {
+        let var = "BTH_TEST_KEYSOURCE_SET_1077";
+        std::env::set_var(var, "  deadbeef\n");
+        let loaded = load_key_material(KeySourceConfig {
+            file: None,
+            env_var: Some(var),
+            enforce_permissions: true, // no file, so perms never checked
+            label: "test.key",
+        })
+        .unwrap()
+        .expect("env var is set");
+        assert_eq!(loaded.trim(), "deadbeef");
+        std::env::remove_var(var);
+    }
+
+    /// Neither source configured => watch-only (Ok(None), not an error).
+    #[test]
+    fn no_source_is_watch_only() {
+        assert!(load_key_material(KeySourceConfig {
+            file: None,
+            env_var: None,
+            enforce_permissions: true,
+            label: "test.key",
+        })
+        .unwrap()
+        .is_none());
+    }
+
+    /// A `0600` file loads cleanly under either policy.
+    #[cfg(unix)]
+    #[test]
+    fn secure_file_loads() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key.hex");
+        std::fs::write(&path, "cafebabe\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        for enforce in [false, true] {
+            let loaded = load_key_material(KeySourceConfig {
+                file: Some(path.to_str().unwrap()),
+                env_var: None,
+                enforce_permissions: enforce,
+                label: "test.key",
+            })
+            .unwrap()
+            .expect("0600 file loads");
+            assert_eq!(loaded.trim(), "cafebabe");
+        }
+    }
+
+    /// A group/world-readable file is REFUSED when enforcement is on and
+    /// merely WARNED about (still loads) when it is off — the two halves of the
+    /// AC. The error/warn message names the offending octal mode.
+    #[cfg(unix)]
+    #[test]
+    fn group_world_readable_file_rejected_when_enforced() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key.hex");
+        std::fs::write(&path, "feedface\n").unwrap();
+        // 0644: world-readable — the classic `echo > file` / editor default.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        // enforce=true => hard refusal, message carries the octal mode.
+        let err = load_key_material(KeySourceConfig {
+            file: Some(path.to_str().unwrap()),
+            env_var: None,
+            enforce_permissions: true,
+            label: "test.key",
+        })
+        .unwrap_err();
+        match err {
+            MintError::Config(m) => {
+                assert!(m.contains("group/world accessible"), "got: {m}");
+                assert!(m.contains("0o644"), "message names the mode: {m}");
+                assert!(m.contains("refusing to load"), "got: {m}");
+            }
+            other => panic!("expected Config error, got {other:?}"),
+        }
+
+        // enforce=false (testnet default) => warns but still loads, so existing
+        // drills are not broken.
+        let loaded = load_key_material(KeySourceConfig {
+            file: Some(path.to_str().unwrap()),
+            env_var: None,
+            enforce_permissions: false,
+            label: "test.key",
+        })
+        .unwrap()
+        .expect("testnet default warns but loads");
+        assert_eq!(loaded.trim(), "feedface");
+    }
+
+    /// A group-readable (but not world) file is also caught (`0o040` bit).
+    #[cfg(unix)]
+    #[test]
+    fn group_readable_file_also_flagged() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key.hex");
+        std::fs::write(&path, "abcd\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        let err = load_key_material(KeySourceConfig {
+            file: Some(path.to_str().unwrap()),
+            env_var: None,
+            enforce_permissions: true,
+            label: "test.key",
+        })
+        .unwrap_err();
+        match err {
+            MintError::Config(m) => assert!(m.contains("0o640"), "got: {m}"),
+            other => panic!("expected Config error, got {other:?}"),
+        }
+    }
+}

--- a/bridge/service/src/mint/mod.rs
+++ b/bridge/service/src/mint/mod.rs
@@ -17,6 +17,7 @@
 //!    -> DepositConfirmed` and re-submit.
 
 pub mod ethereum;
+mod keysource;
 pub mod solana;
 
 use async_trait::async_trait;

--- a/bridge/service/src/mint/solana.rs
+++ b/bridge/service/src/mint/solana.rs
@@ -49,8 +49,10 @@ use std::sync::Arc;
 use tracing::{debug, info, warn};
 use zeroize::{Zeroize, Zeroizing};
 
-use super::keysource::{load_key_material, KeySourceConfig};
-use super::{ConfirmationStatus, MintError, Minter, PreparedMint};
+use super::{
+    keysource::{load_key_material, KeySourceConfig},
+    ConfirmationStatus, MintError, Minter, PreparedMint,
+};
 use crate::solana_rpc::{
     AccountMeta, HttpSolanaRpc, Instruction, LegacyMessage, Pubkey, SignatureState, SolanaRpc,
     Transaction, ALREADY_PROCESSED_MARKER, SYSTEM_PROGRAM_ID, TOKEN_PROGRAM_ID,

--- a/bridge/service/src/mint/solana.rs
+++ b/bridge/service/src/mint/solana.rs
@@ -47,7 +47,9 @@ use ed25519_dalek::{Signer as _, SigningKey};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
+use zeroize::{Zeroize, Zeroizing};
 
+use super::keysource::{load_key_material, KeySourceConfig};
 use super::{ConfirmationStatus, MintError, Minter, PreparedMint};
 use crate::solana_rpc::{
     AccountMeta, HttpSolanaRpc, Instruction, LegacyMessage, Pubkey, SignatureState, SolanaRpc,
@@ -252,8 +254,18 @@ impl SolMinter {
         let (bridge_pda, _bump) = Pubkey::find_program_address(&[BRIDGE_PDA_SEED], &program_id)
             .ok_or_else(|| MintError::Config("could not derive bridge PDA".to_string()))?;
 
-        let signer = match config.keypair_file.as_deref() {
-            Some(path) => Some(load_signer(path)?),
+        // The local submit key assembles/relays the multisig transaction; per
+        // ADR 0002 it is NOT a custody key (custody = the SPL/Squads multisig
+        // `mint_authority`). At-rest hardening — permission preflight, an
+        // env-var load path so mainnet needs no plaintext key on disk, and
+        // buffer zeroization — is #1077 (see `super::keysource`).
+        let signer = match load_key_material(KeySourceConfig {
+            file: config.keypair_file.as_deref(),
+            env_var: config.keypair_env.as_deref(),
+            enforce_permissions: config.enforce_key_permissions,
+            label: "solana.keypair",
+        })? {
+            Some(raw) => Some(parse_signer(&raw)?),
             None => None,
         };
 
@@ -403,39 +415,52 @@ impl SolMinter {
     }
 }
 
-/// Load an Ed25519 signing key from a file. Accepts either a 64-char hex
-/// 32-byte seed (parity with `bridge.attestation_ed25519_key_file`) or a
-/// Solana CLI JSON keypair array of 64 bytes (`[secret_scalar(32) ||
-/// pub(32)]`).
-fn load_signer(path: &str) -> Result<(SigningKey, Pubkey), MintError> {
-    let raw = std::fs::read_to_string(path).map_err(|e| {
-        MintError::Config(format!("cannot read solana keypair_file {}: {}", path, e))
-    })?;
+/// Parse an Ed25519 signing key from raw key material (loaded from a file or an
+/// env var by [`super::keysource`], #1077). Accepts either a 64-char hex
+/// 32-byte seed (parity with `bridge.attestation_ed25519_key_file`) or a Solana
+/// CLI JSON keypair array of 64 bytes (`[secret_scalar(32) || pub(32)]`).
+///
+/// Every intermediate secret buffer — the decoded bytes and the extracted seed
+/// — is zeroized before this function returns, so the only surviving copy of
+/// the secret is inside the returned [`SigningKey`]. The caller's `raw` buffer
+/// is a `Zeroizing<String>` wiped on drop.
+fn parse_signer(raw: &str) -> Result<(SigningKey, Pubkey), MintError> {
     let trimmed = raw.trim();
 
-    let seed: [u8; 32] = if trimmed.starts_with('[') {
+    let mut seed: [u8; 32] = if trimmed.starts_with('[') {
         // Solana CLI JSON array: 64 bytes, the first 32 are the seed.
-        let bytes: Vec<u8> = serde_json::from_str(trimmed)
-            .map_err(|e| MintError::Config(format!("invalid keypair JSON: {}", e)))?;
+        let bytes: Zeroizing<Vec<u8>> = Zeroizing::new(
+            serde_json::from_str::<Vec<u8>>(trimmed)
+                .map_err(|e| MintError::Config(format!("invalid keypair JSON: {}", e)))?,
+        );
         if bytes.len() != 64 {
             return Err(MintError::Config(format!(
                 "solana keypair JSON must be 64 bytes, got {}",
                 bytes.len()
             )));
         }
-        bytes[..32]
-            .try_into()
-            .map_err(|_| MintError::Config("keypair seed slice error".to_string()))?
+        let mut s = [0u8; 32];
+        s.copy_from_slice(&bytes[..32]);
+        s
     } else {
-        let bytes = hex::decode(trimmed)
-            .map_err(|e| MintError::Config(format!("invalid keypair hex: {}", e)))?;
-        bytes.try_into().map_err(|v: Vec<u8>| {
-            MintError::Config(format!("keypair seed must be 32 bytes, got {}", v.len()))
-        })?
+        let bytes: Zeroizing<Vec<u8>> = Zeroizing::new(
+            hex::decode(trimmed)
+                .map_err(|e| MintError::Config(format!("invalid keypair hex: {}", e)))?,
+        );
+        if bytes.len() != 32 {
+            return Err(MintError::Config(format!(
+                "keypair seed must be 32 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut s = [0u8; 32];
+        s.copy_from_slice(&bytes[..]);
+        s
     };
 
     let sk = SigningKey::from_bytes(&seed);
     let pubkey = Pubkey(sk.verifying_key().to_bytes());
+    seed.zeroize();
     Ok((sk, pubkey))
 }
 
@@ -654,6 +679,65 @@ mod tests {
         (order, auth)
     }
 
+    /// `parse_signer` accepts both accepted encodings — a 64-char hex seed and
+    /// a Solana CLI 64-byte JSON array — and derives the SAME key from each
+    /// (the JSON's first 32 bytes are the seed). Guards the #1077 zeroizing
+    /// refactor against a behavior change.
+    #[test]
+    fn parse_signer_accepts_hex_and_json() {
+        let seed = [0x24u8; 32];
+        let expected = SigningKey::from_bytes(&seed);
+        let pub_bytes = expected.verifying_key().to_bytes();
+
+        // Hex form.
+        let (sk_hex, pk_hex) = parse_signer(&hex::encode(seed)).unwrap();
+        assert_eq!(sk_hex.to_bytes(), seed);
+        assert_eq!(pk_hex.0, pub_bytes);
+
+        // Solana CLI JSON array (secret_scalar(32) || pub(32)).
+        let mut json_bytes = seed.to_vec();
+        json_bytes.extend_from_slice(&pub_bytes);
+        let json = serde_json::to_string(&json_bytes).unwrap();
+        let (sk_json, pk_json) = parse_signer(&json).unwrap();
+        assert_eq!(sk_json.to_bytes(), seed);
+        assert_eq!(pk_json.0, pub_bytes);
+
+        // Malformed inputs are rejected.
+        assert!(parse_signer("not-hex").is_err());
+        assert!(parse_signer("[1,2,3]").is_err());
+    }
+
+    /// #1077 AC: the non-plaintext (env-var) load path works end-to-end for the
+    /// Solana submit key — no plaintext key file on disk. `SolMinter::new`
+    /// reads the hex seed from the environment and derives the expected signer.
+    #[test]
+    fn submit_key_loads_from_env_var() {
+        let seed = [0x31u8; 32];
+        let expected = SigningKey::from_bytes(&seed);
+
+        let var = "BTH_TEST_SOL_SUBMIT_KEY_1077";
+        std::env::set_var(var, hex::encode(seed));
+
+        let mut config = test_config();
+        config.keypair_env = Some(var.to_string());
+        let minter = SolMinter::new(config).expect("minter builds from env-var submit key");
+
+        let (sk, pk) = minter.signer.expect("submit key configured via env var");
+        assert_eq!(sk.to_bytes(), seed);
+        assert_eq!(pk.0, expected.verifying_key().to_bytes());
+        std::env::remove_var(var);
+    }
+
+    /// A configured-but-unset submit env var fails closed (no silent fallback).
+    #[test]
+    fn submit_key_env_var_unset_fails_closed() {
+        let var = "BTH_TEST_SOL_SUBMIT_KEY_UNSET_1077";
+        std::env::remove_var(var);
+        let mut config = test_config();
+        config.keypair_env = Some(var.to_string());
+        assert!(SolMinter::new(config).is_err());
+    }
+
     #[test]
     fn test_attestation_validation() {
         let (order, auth) = order_and_auth();
@@ -842,6 +926,8 @@ mod tests {
             // A valid base58 32-byte program id.
             wbth_program: Pubkey([8u8; 32]).to_base58(),
             keypair_file: None,
+            keypair_env: None,
+            enforce_key_permissions: false,
             commitment: SolanaCommitment::Finalized,
             mint_signers: Vec::new(),
             mint_threshold: 0,

--- a/bridge/service/src/solana_devnet_tests.rs
+++ b/bridge/service/src/solana_devnet_tests.rs
@@ -55,6 +55,8 @@ fn config_from_env() -> Option<SolanaConfig> {
         rpc_url,
         wbth_program,
         keypair_file: env::var("BRIDGE_SOLANA_KEYPAIR").ok(),
+        keypair_env: None,
+        enforce_key_permissions: false,
         commitment: SolanaCommitment::Finalized,
         mint_signers: Vec::new(),
         mint_threshold: 0,

--- a/bridge/service/src/watchers/adversarial_tests.rs
+++ b/bridge/service/src/watchers/adversarial_tests.rs
@@ -164,6 +164,8 @@ fn watcher(confirmations_required: u32) -> (EthereumWatcher, Database) {
         safe_address: None,
         chain_id: 1,
         private_key_file: None,
+        private_key_env: None,
+        enforce_key_permissions: false,
         confirmations_required,
         gas_price_strategy: Default::default(),
         mint_signers: Vec::new(),

--- a/bridge/service/src/watchers/ethereum.rs
+++ b/bridge/service/src/watchers/ethereum.rs
@@ -747,6 +747,8 @@ mod tests {
             safe_address: None,
             chain_id: 1,
             private_key_file: None,
+            private_key_env: None,
+            enforce_key_permissions: false,
             confirmations_required,
             gas_price_strategy: Default::default(),
             mint_signers: Vec::new(),

--- a/bridge/service/src/watchers/solana.rs
+++ b/bridge/service/src/watchers/solana.rs
@@ -546,6 +546,8 @@ mod tests {
             rpc_url: "http://localhost:8899".to_string(),
             wbth_program: "So11111111111111111111111111111111111111112".to_string(),
             keypair_file: None,
+            keypair_env: None,
+            enforce_key_permissions: false,
             commitment: SolanaCommitment::Finalized,
             mint_signers: Vec::new(),
             mint_threshold: 0,

--- a/docs/bridge/security.md
+++ b/docs/bridge/security.md
@@ -57,25 +57,62 @@ mapping is in the [bridge threat model](../security/bridge-threat-model.md).
 
 ## Hot Wallet Security
 
-### Key Storage Requirements
+### Relayer / Submit Key At-Rest Handling (#1077)
+
+The Ethereum **relayer** key (`ethereum.private_key_file` / `..._env`) and the
+Solana **submit** key (`solana.keypair_file` / `..._env`) are **not** custody
+keys — custody is the Gnosis Safe / Squads threshold per
+[ADR 0002](../decisions/0002-bridge-custody-scp-validator-federation.md). They
+only pay gas and broadcast the threshold-authorized mint transaction. A
+compromised relayer/submit key still enables **gas drain** and **submission
+griefing**, so the loader hardens their at-rest handling:
+
+- **Load source.** A key may come from a plaintext file on disk (an explicit
+  testnet opt-in) OR from an **environment variable** (`private_key_env` /
+  `keypair_env`). When an env-var name is configured it takes **precedence** over
+  the file, so a mainnet deployment never needs a plaintext key file on disk —
+  the secret is injected at runtime by a secrets manager, a systemd
+  `LoadCredential=`, or an OS keyring that exports into the process environment.
+  A configured-but-unset var **fails closed** (no silent fallback to a file).
+- **File-permission preflight.** A group- or world-accessible key file is
+  refused when `enforce_key_permissions = true` (recommended for mainnet) and
+  otherwise **warned** about (the testnet-compatible default), always logging the
+  offending octal mode. Tighten key files to `chmod 600`.
+- **Zeroization.** The raw key buffer is wiped from memory after it is parsed
+  into the signer. Key material is **never logged** — only the file path, its
+  permission mode, and the env-var name appear in messages.
 
 **Production Environment:**
-- Keys stored in encrypted files with strong passphrase
-- Passphrase loaded from environment variable (not command line)
-- File permissions: `chmod 600` (owner read/write only)
+- Prefer the **env-var** load path (`*_env`) so no plaintext key file is on disk
+- Set `enforce_key_permissions = true` so an insecure key file is refused
+- If a file is used, `chmod 600` (owner read/write only)
+- Passphrase / secret loaded from the environment (not command line)
 - HSM recommended for high-value deployments
 
-**Configuration Example:**
+**Configuration Example (mainnet — env-var keys, permission enforcement on):**
 ```toml
 [bth]
 view_key_file = "/secure/bridge/bth_view.enc"
 spend_key_file = "/secure/bridge/bth_spend.enc"
 
 [ethereum]
-private_key_file = "/secure/bridge/eth_key.enc"
+# No plaintext key file on disk: the relayer key is injected via the environment
+# (e.g. systemd LoadCredential / secrets manager) under this variable name.
+private_key_env = "BTH_BRIDGE_ETH_RELAYER_KEY"
+enforce_key_permissions = true
 
 [solana]
-keypair_file = "/secure/bridge/sol_keypair.enc"
+keypair_env = "BTH_BRIDGE_SOL_SUBMIT_KEY"
+enforce_key_permissions = true
+```
+
+**Configuration Example (testnet — plaintext file opt-in, still supported):**
+```toml
+[ethereum]
+private_key_file = "/secure/bridge/eth_key.hex"   # chmod 600
+
+[solana]
+keypair_file = "/secure/bridge/sol_keypair.json"  # chmod 600
 ```
 
 ### Key Rotation


### PR DESCRIPTION
## Summary

Both chain mint submitters loaded their signing key from a **plaintext file on
disk**, and `bridge/service/src/mint/ethereum.rs` carried a `TODO(#827)` that
pointed at an already-closed issue, so the hardening was orphaned. These are
**relayer/submit** keys — NOT custody keys (custody = the Gnosis Safe / Squads
threshold per [ADR 0002](docs/decisions/0002-bridge-custody-scp-validator-federation.md)) —
but a compromised relayer key still enables **gas drain** and **submission
griefing**, and plaintext key files are a gap an auditor will flag.

This PR adds a shared at-rest loader (`bridge/service/src/mint/keysource.rs`)
used by both `EthMinter` and `SolMinter`, without touching the custody/threshold
model or the signing logic — only the at-rest **loading** of the key.

## Design decisions

**Non-plaintext format = environment variable** (`*_env` knobs). I chose an env
var over age-encrypted files / OS keyring for the first increment because it:
- adds **no new dependency** (keeps the bridge's audited dep surface unchanged),
- is the standard injection point for secrets managers, systemd
  `LoadCredential=`, and keyrings that export into the process environment, and
- means a mainnet deployment has **no plaintext key file on disk at all**.

When an env-var name is configured it takes **precedence** over the file. A
configured-but-unset var **fails closed** (no silent fallback to a file). Age /
keyring backends can be layered on later behind the same `KeySourceConfig`.

**Permission policy is behind a config knob** (`enforce_key_permissions`,
default `false`). Refusing group/world-readable files by default would break
existing testnet drills whose files are `0644`; instead the default **warns**
(logging the octal mode) and mainnet sets it `true` to **refuse**. This satisfies
the AC ("rejected *or* warns") while keeping testnet working.

## Testnet-compatibility story

Plaintext files remain a fully supported, explicit opt-in: `private_key_file` /
`keypair_file` still load, permission enforcement is off by default, and the new
config fields are `#[serde(default)]` so pre-existing configs parse unchanged.
The 250-test bridge-service suite is green, including the federation / e2e
drills.

## Changes

- **`bridge/service/src/mint/keysource.rs`** (new): `load_key_material` — source
  selection (env precedence, fail-closed), Unix permission preflight
  (warn/refuse, logs the mode), returns a `Zeroizing<String>` wiped on drop.
- **`mint/ethereum.rs`**: relayer key now loads via `keysource`; stale
  `TODO(#827)` removed; buffer zeroized after parse.
- **`mint/solana.rs`**: `load_signer(path)` → `parse_signer(&raw)` fed by
  `keysource`; decoded-bytes and seed intermediates zeroized (`Zeroizing` +
  explicit `zeroize()`).
- **`bridge/core/src/config.rs`**: new `private_key_env` / `keypair_env` /
  `enforce_key_permissions` knobs on `EthereumConfig` / `SolanaConfig`.
- **`bridge/service/Cargo.toml`**: add workspace `zeroize`.
- **`docs/bridge/security.md`**: document the load knobs, mainnet vs testnet
  examples, and the #1077 posture; replaces the orphaned TODO reference.

## Test Plan

New tests (all green):
- `keysource`: permission preflight — `0600` loads; `0644`/`0640` refused when
  enforced (message names the octal mode) and warned-but-loaded when not;
  env-var load path; missing-var fails closed; no-source = watch-only.
- `mint::ethereum::relayer_key_loads_from_env_var` — Hardhat acct #0 key from an
  env var derives its known address end-to-end (no file on disk).
- `mint::solana::submit_key_loads_from_env_var` + `parse_signer_accepts_hex_and_json`.
- `config::test_relayer_key_source_knobs_default_and_parse` — round-trip + legacy parse.

```
cargo test -p bth-bridge-core config      # 13 passed
cargo test -p bth-bridge-service          # 250 passed, 10 ignored
cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets  # clean
```

## Acceptance criteria

- [x] Group/world-readable key file rejected (enforced) or warned (default),
      clear message; unit test with temp file + permission bits.
- [x] Non-plaintext (env-var) load path works end-to-end for BOTH Ethereum and
      Solana submitters.
- [x] Key material zeroized after use.
- [x] `TODO(#827)` removed from `mint/ethereum.rs`; Solana path gets equivalent
      treatment.

Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)