### PR TITLE
test(bridge/solana): pin 2-of-3 Squads-PDA mint-authority boots guard cleanly

### DIFF
--- a/bridge/service/src/mint/solana.rs
+++ b/bridge/service/src/mint/solana.rs
@@ -1188,6 +1188,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_guard_passes_with_distinct_squads_pda_authority_2of3() {
+        // The intended post-migration federated posture (#1052): a full
+        // 2-of-3 federation (`mint_signers` = 3, `mint_threshold` = 2) whose
+        // on-chain `mint_authority` is a distinct Squads-style PDA (off-curve,
+        // derived from a program id — NOT any member key and NOT the local
+        // relayer key). This pins that such a config BOOTS the custody guard
+        // cleanly in strict mode, i.e. the ADR-0002 posture the operator will
+        // stand up once the on-chain authority is rotated to the multisig.
+        //
+        // NOTE (per #1052 architectural finding): the guard passing does NOT
+        // by itself let a federated devnet mint *complete* — a Squads PDA can
+        // only satisfy the on-chain `mint_authority: Signer` constraint via a
+        // Squads `invoke_signed` CPI, which `prepare_mint` does not yet
+        // assemble. This test covers boot-time custody posture only.
+        let (sk, pk) = test_signer();
+
+        // A genuine off-curve PDA (Squads authority PDAs are program-derived),
+        // distinct from the local key and from every configured member.
+        let squads_program = Pubkey([0xABu8; 32]);
+        let (squads_pda_authority, _bump) =
+            Pubkey::find_program_address(&[b"squad", &[0u8; 32]], &squads_program)
+                .expect("derive a squads-shaped PDA authority");
+        assert_ne!(
+            squads_pda_authority.0, pk.0,
+            "the multisig PDA must differ from the local relayer key"
+        );
+
+        let rpc = Arc::new(MockRpc::with_authorities(
+            squads_pda_authority,
+            Pubkey([0x33u8; 32]),
+        ));
+
+        // A 2-of-3 federation posture: three distinct member signers, t = 2.
+        let members = [
+            Pubkey([0xA1u8; 32]),
+            Pubkey([0xA2u8; 32]),
+            Pubkey([0xA3u8; 32]),
+        ];
+        let mut config = test_config();
+        config.mint_signers = members.iter().map(|m| m.to_base58()).collect();
+        config.mint_threshold = 2;
+        assert!(config.requires_multisig_authority());
+
+        let minter = SolMinter::with_parts(config, rpc, Some((sk, pk))).unwrap();
+        assert!(
+            minter
+                .verify_mint_authority_is_not_local_key()
+                .await
+                .is_ok(),
+            "a distinct Squads-PDA mint authority must boot the guard cleanly \
+             in the 2-of-3 federated posture"
+        );
+    }
+
+    #[tokio::test]
     async fn test_guard_skips_in_watch_only_mode() {
         // No local signer: nothing to compare, guard is a no-op even if the
         // on-chain authority happens to match some key.

--- a/contracts/solana/README.md
+++ b/contracts/solana/README.md
@@ -114,6 +114,54 @@ off at deploy:
    below. This custody gate and the upgrade-authority gate are the two deploy
    gates that must both be closed before mainnet.
 
+### Devnet mint-multisig migration (#1052) — operator-fillable scaffold
+
+The devnet `mint_authority` above is a **single key** (`97oZgGpd…`), so the
+federated Solana leg cannot run in its ADR-0002 `t`-of-`n` posture: the bridge
+service's startup custody guard (`verify_mint_authority_is_not_local_key`, #879)
+hard-fails a federation posture whose on-chain authority is a lone key. Migrating
+devnet to a real multisig closes that gap. The code-buildable scaffold lands
+here; an **operator** fills in the real addresses once the multisig exists and
+the on-chain rotation is done (needs the current devnet mint-authority signer key
+— it cannot be automated by a Builder).
+
+**Target: a 2-of-3 mint multisig** (Squads PDA or SPL Token multisig), members =
+the federation's Ed25519 signers, threshold `t = 2`, distinct from the admin and
+pauser authorities. Members map to the SCP federation validators one-to-one:
+
+| Slot | Federation signer (SCP validator) | Member Ed25519 pubkey (operator fills) |
+|------|-----------------------------------|----------------------------------------|
+| 1 | `<validator-1>` | `<MEMBER_PUBKEY_1>` |
+| 2 | `<validator-2>` | `<MEMBER_PUBKEY_2>` |
+| 3 | `<validator-3>` | `<MEMBER_PUBKEY_3>` |
+
+**Devnet mint multisig (operator fills after creation + rotation):**
+
+| Field | Value |
+|-------|-------|
+| Multisig kind | `<Squads PDA \| SPL Token multisig>` |
+| Multisig address | `<MINT_MULTISIG_ADDRESS>` |
+| Threshold | `2-of-3` |
+| Created (tx sig) | `<CREATE_TX_SIG>` |
+| `mint_authority` rotation tx (`spl-token authorize … mint`) | `<ROTATE_TX_SIG>` |
+| Previous authority (single key) | `97oZgGpd71du52gguVkWEe1xkPvXh5PZPB2Jq3yvNRyU` |
+| New authority verified on-chain (`getAccountInfo`) | `<yes/no + date>` |
+
+Once filled, also update the per-deployment table above (replace the Devnet
+`Mint authority` cell with `<MINT_MULTISIG_ADDRESS>`). The rotation itself is the
+`[OPERATOR]` half of the deploy custody gate (step 4 above) — verify the new
+authority is a **distinct multisig**, not the relayer key and not the admin
+authority, before flipping `BRIDGE_SOLANA_FEDERATION=1` in the #868 drill.
+
+> **Guard-pass ≠ mint-complete (path-1 vs. path-2, per #1052).** Rotating
+> `mint_authority` to a Squads PDA makes the startup guard *pass* (PDA ≠ local
+> key) and lets the federation leg **boot** (path 2), but it does **not** let a
+> federated mint **complete**: `bridge_mint` takes `mint_authority` as a
+> transaction `Signer`, and a PDA can only sign via a Squads `invoke_signed`
+> CPI — which `prepare_mint` (`bridge/service/src/mint/solana.rs`) does not yet
+> assemble. Completing an end-to-end federated devnet mint (path 1) requires that
+> Squads-gated mint-assembly code, tracked as a separate issue.
+
 ### Replay-proof, order-bound minting
 
 `bridge_mint(amount, order_id)` takes a 32-byte `order_id` (the bridge order

--- a/scripts/bridge-testnet-federation.sh
+++ b/scripts/bridge-testnet-federation.sh
@@ -69,13 +69,27 @@
 #   BRIDGE_ETH_CONFIRMATIONS=2         Sepolia depth before Completed
 #   BRIDGE_SOLANA_PROGRAM=CZDnzeywrqEM5ereWJmtYKUQ9uJXxX2PydqqKTQStxxE
 #   BRIDGE_SOLANA_FEDERATION=0         1 wires the Solana ed25519 federation +
-#                                      mint keypair. BLOCKED today: the devnet
-#                                      wbth mint_authority is a single key, and
-#                                      the startup custody guard HARD-FAILS a
-#                                      federation posture with a single-key
-#                                      authority (mint/solana.rs). Flip to 1
-#                                      only after the devnet authority migrates
-#                                      to a real multisig (Squads).
+#                                      mint keypair. Default stays 0: the devnet
+#                                      wbth mint_authority is still a single key
+#                                      (97oZgGpd…), and the startup custody guard
+#                                      HARD-FAILS a federation posture with a
+#                                      single-key authority (mint/solana.rs).
+#                                      Migration = #1052; the flip to 1 is an
+#                                      OPERATOR action, only AFTER the on-chain
+#                                      mint_authority is rotated to a distinct
+#                                      2-of-3 multisig (contracts/solana/README.md
+#                                      "Devnet mint-multisig migration").
+#                                      Two milestones, do not conflate:
+#                                        path 2 (boot): rotate to a Squads PDA and
+#                                          the guard PASSES + the Solana leg BOOTS
+#                                          federated — but a mint cannot COMPLETE,
+#                                          because a PDA only signs via a Squads
+#                                          invoke_signed CPI that prepare_mint does
+#                                          not yet build.
+#                                        path 1 (complete): needs that Squads-gated
+#                                          mint-assembly code (separate issue)
+#                                          before an end-to-end federated devnet
+#                                          mint lands exactly-once/factor-1.
 #   BRIDGE_BTH_RESERVE_VIEW_KEY / _SPEND_KEY / _PQ_SEED / _ADDRESS
 #                                      the funded factor-1 reserve (file paths +
 #                                      address). Auto-loaded from


### PR DESCRIPTION
## Summary

Lands the **code-buildable slice** of the devnet wBTH `mint_authority` migration (#1052). No devnet keys and no on-chain actions are involved — this pins the intended federated custody posture, adds an operator-fillable documentation scaffold, and refreshes the drill's inline doc **without** flipping any live default.

This does **not** complete the migration. Per the curator's architectural finding, "the startup guard passes" and "a federated devnet mint completes" are not jointly satisfiable by config alone: `bridge_mint` takes `mint_authority` as a transaction `Signer`, and a Squads PDA can only satisfy that via a Squads `invoke_signed` CPI that `prepare_mint` does not yet assemble. So the on-chain rotation is operator-only and the PDA mint-assembly is deferred (see follow-ups below).

## Changes

- **`bridge/service/src/mint/solana.rs`** — new strict-mode custody-guard test `test_guard_passes_with_distinct_squads_pda_authority_2of3`: a genuine off-curve Squads-style PDA authority, under a full 2-of-3 federation posture (`mint_signers` = 3, `mint_threshold` = 2), boots `verify_mint_authority_is_not_local_key()` cleanly. Documents that guard-pass is boot-time only, not mint-complete. No production behavior change.
- **`contracts/solana/README.md`** — new "Devnet mint-multisig migration (#1052)" section: members↔SCP validator mapping, operator-fillable 2-of-3 multisig address / threshold / rotation-record placeholders, cross-referenced to the deploy custody gate, plus an explicit path-1 vs. path-2 (boot vs. complete) note.
- **`scripts/bridge-testnet-federation.sh`** — refreshed the `BRIDGE_SOLANA_FEDERATION` inline doc to reflect the operator-driven migration and the boot-vs-complete distinction. **Default stays `0`** (`SOL_FED="${BRIDGE_SOLANA_FEDERATION:-0}"` unchanged) — the flip is an operator action once the on-chain authority is migrated.

## Acceptance Criteria Verification (code-buildable items only)

| Criterion (#1052) | Status | Verification |
|-------------------|--------|--------------|
| [CODE] Guard test: distinct multisig authority boots cleanly in federation posture | ✅ | `test_guard_passes_with_distinct_squads_pda_authority_2of3` (off-curve PDA, 2-of-3) — `cargo test -p bth-bridge-service mint::solana` green (25/25) |
| [CODE/DOCS] README devnet mint-multisig scaffold (placeholders, members↔SCP, 2-of-3, rotation record) | ✅ | New section + tables in `contracts/solana/README.md` |
| [CODE] Refresh `BRIDGE_SOLANA_FEDERATION` inline doc, do NOT change default | ✅ | Doc updated; `bash -n` clean; default still `0` (grep-verified) |
| [CODE — path 1] Squads CPI mint-assembly | ⏸ Deferred | Filed as #1087 (its own issue, per curator recommendation) |

## Out of scope / follow-ups

- **#1086** (`loom:operator-only`) — create the devnet Squads multisig, rotate `bridge.mint_authority`, flip `BRIDGE_SOLANA_FEDERATION=1`, drive the drill (needs devnet signer keys; the path-2 boot milestone).
- **#1087** — Squads-PDA `invoke_signed` mint-assembly in `prepare_mint` so a PDA mint authority can actually mint (the path-1 code work; unblocks end-to-end federated mint completion).

## Test Plan

- `cargo build -p bth-bridge-service -p bth-bridge-core` — clean.
- `cargo test -p bth-bridge-service mint::solana` — **25 passed, 0 failed** (incl. the new test).
- `cargo clippy -p bth-bridge-service` — clean.
- `cargo fmt -p bth-bridge-service` — applied.
- `bash -n scripts/bridge-testnet-federation.sh` — syntax OK; default `BRIDGE_SOLANA_FEDERATION=0` unchanged.

Part of #1052. (Leaves #1052 open — this is one slice of a multi-part migration.)