### PR TITLE
feat(bridge): signed mint order-record replication across federation members

### DIFF
--- a/bridge/core/src/lib.rs
+++ b/bridge/core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod election;
 mod happy_path_tests;
 pub mod nonce;
 pub mod order;
+pub mod order_sync;
 
 /// Adversarial / cross-domain attestation tests (bridge epic #816, Phase 3).
 #[cfg(test)]
@@ -46,3 +47,7 @@ pub use election::{
 };
 pub use nonce::{NonceStore, ReserveOutcome};
 pub use order::{derive_order_id, BridgeOrder, OrderStatus, OrderType};
+pub use order_sync::{
+    sign_order_record_ed25519, MintOrderShell, OrderRecordEnvelope, OrderRecordRejectReason,
+    ORDER_RECORD_DOMAIN_TAG,
+};

--- a/bridge/core/src/order_sync.rs
+++ b/bridge/core/src/order_sync.rs
@@ -1,0 +1,620 @@
+// Copyright (c) 2024 The Botho Foundation
+
+//! Signed mint order-record replication (#1050 Phase 2).
+//!
+//! # Why this exists
+//!
+//! The #858 attestation transport ([`crate::attestation`]) exchanges
+//! *envelopes* only — the order **records** they bind to never replicate
+//! between federation members. For the RELEASE/burn leg that is fine:
+//! deterministic burn-order ids ([`crate::order::derive_burn_order_uuid`],
+//! Phase 1) let every member independently reconstruct the identical burn
+//! record from the same finalized on-chain event, so envelopes aggregate with
+//! zero cross-member trust.
+//!
+//! The MINT leg cannot be fixed that way. A mint order is created by a user
+//! against ONE member's public API; its id lives in a user-chosen deposit memo
+//! (not in independently-observable chain data), and each member's BTH watcher
+//! only ever *matches* a deposit to an order it already has on record — it
+//! never creates the order. So a member that never saw the order returns
+//! `refused:unknown_order` and a genuinely distributed (multi-host,
+//! separate-DB) federation can never reach threshold on a mint. This module is
+//! the missing piece: the originating member replicates the mint order
+//! **record** to its ≤5 elected peers (ADR 0010 / #1060) so each peer's own
+//! watcher has something to independently confirm against.
+//!
+//! # The trust boundary (safety-critical)
+//!
+//! Accepting a replicated record grants **no trust whatsoever**. The wire
+//! format ([`MintOrderShell`]) is *structurally incapable* of carrying trust:
+//! it has no `status`, no `mint_authorization`, no `dest_tx`, no `source_tx`
+//! field. A received record is reconstituted only ever as a fresh
+//! `AwaitingDeposit` shell ([`MintOrderShell::into_awaiting_deposit_order`]).
+//! Each receiving member still independently confirms the on-chain BTH deposit
+//! through its OWN watcher before it will attest. The signature authenticates
+//! only *which elected member proposed the order*, never the deposit's
+//! validity — the difference between "seed a shell for my own watcher to
+//! confirm" and "trust a peer's claim about funds". A compromised member can
+//! therefore, at worst, seed order shells that go nowhere unless a real deposit
+//! independently lands; it can never cause a mint.
+//!
+//! # Authentication
+//!
+//! A record is signed with the originating member's Ed25519 federation key
+//! (the same identity used for BTH release attestations — the elected
+//! multisig set). On receipt the signature is verified against the configured
+//! federation member set; a record signed by a key that is not an elected
+//! member is rejected (`unknown_signer`) before it is ever persisted. The
+//! verify is parse-after-verify: the record JSON is parsed only after its
+//! signature is confirmed over exactly the received bytes, and the parser
+//! rejects unknown/duplicate keys so one signed byte string can never carry a
+//! second logical record.
+
+use chrono::{TimeZone, Utc};
+use ed25519_dalek::{Signature as Ed25519Signature, Signer as _, SigningKey, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use uuid::Uuid;
+
+use crate::{
+    chains::Chain,
+    order::{BridgeOrder, OrderStatus, OrderType},
+};
+
+/// Domain-separation tag mixed in before the record bytes when signing a
+/// replicated order record. Distinct from the attestation domains so an
+/// order-record signature can never be replayed as an attestation (or vice
+/// versa). Changing this tag is a bridge-breaking change for in-flight
+/// replication.
+pub const ORDER_RECORD_DOMAIN_TAG: &[u8] = b"botho-bridge-order-record-v1";
+
+/// The minimal, trust-free projection of a mint order that is replicated to
+/// peers. Deliberately carries ONLY the fields a receiving member needs to
+/// reconstruct an `AwaitingDeposit` shell for its own BTH watcher to match a
+/// deposit against — and NOTHING that could advance an order or authorize a
+/// mint. There is no `status`, `mint_authorization`, `dest_tx` or `source_tx`
+/// field: the type itself is the trust boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MintOrderShell {
+    /// Order id (matches the id embedded in the deposit memo).
+    pub id: Uuid,
+    /// Destination chain the wBTH is minted on.
+    pub dest_chain: Chain,
+    /// Gross amount in picocredits.
+    pub amount: u64,
+    /// Bridge fee in picocredits.
+    pub fee: u64,
+    /// The bridge's BTH deposit (stealth) address the user pays into.
+    pub bth_deposit_address: String,
+    /// Destination address that receives the minted wBTH.
+    pub dest_address: String,
+    /// The 64-byte deposit memo (its first 16 bytes are the order id).
+    pub memo: [u8; 64],
+    /// Order creation time as Unix seconds — replicated so every member's
+    /// expiry clock agrees.
+    pub created_at_unix: i64,
+}
+
+impl MintOrderShell {
+    /// Project a mint order into its replicable shell.
+    ///
+    /// Fails for anything that must never be replicated: a non-mint order, an
+    /// order that has already advanced past `AwaitingDeposit` (replicating a
+    /// confirmed/authorized order would be a trust-boundary violation — peers
+    /// derive confirmation independently), or a mint order with no memo (the
+    /// memo is how peers' watchers match the deposit).
+    pub fn from_order(order: &BridgeOrder) -> Result<Self, String> {
+        if order.order_type != OrderType::Mint {
+            return Err("only mint orders are replicated".to_string());
+        }
+        if order.status != OrderStatus::AwaitingDeposit {
+            return Err(format!(
+                "only AwaitingDeposit mint orders are replicated (status is {})",
+                order.status
+            ));
+        }
+        let memo = order
+            .memo
+            .ok_or_else(|| "mint order has no deposit memo to replicate".to_string())?;
+        Ok(Self {
+            id: order.id,
+            dest_chain: order.dest_chain,
+            amount: order.amount,
+            fee: order.fee,
+            bth_deposit_address: order.source_address.clone(),
+            dest_address: order.dest_address.clone(),
+            memo,
+            created_at_unix: order.created_at.timestamp(),
+        })
+    }
+
+    /// Reconstruct a fresh `AwaitingDeposit` mint order from the shell.
+    ///
+    /// This is the ONLY way a replicated record enters a receiving member's
+    /// state, and it forces every safety-relevant field: status is
+    /// `AwaitingDeposit`, and `mint_authorization` / `dest_tx` / `source_tx`
+    /// are all `None` (via [`BridgeOrder::new_mint`]). The peer's own watcher
+    /// must independently confirm the deposit before the order can advance.
+    pub fn into_awaiting_deposit_order(self) -> BridgeOrder {
+        let created_at = Utc
+            .timestamp_opt(self.created_at_unix, 0)
+            .single()
+            .unwrap_or_else(Utc::now);
+        let mut order = BridgeOrder::new_mint(
+            self.dest_chain,
+            self.amount,
+            self.fee,
+            self.bth_deposit_address,
+            self.dest_address,
+        );
+        // new_mint already fixes: status = AwaitingDeposit, mint_authorization
+        // = None, source_tx = None, dest_tx = None, dest_confirmed_at = None.
+        // Override only the identity/timing/memo the shell replicates.
+        order.id = self.id;
+        order.memo = Some(self.memo);
+        order.created_at = created_at;
+        order.updated_at = created_at;
+        order
+    }
+
+    /// The canonical (lexicographically key-ordered, whitespace-free,
+    /// integers-only, memo-as-hex) JSON string that is signed. Both signer and
+    /// verifier build the SAME bytes so verification is over an exact byte
+    /// string.
+    pub fn canonical_json(&self) -> String {
+        let s = |v: &str| serde_json::to_string(v).expect("string serialization is infallible");
+        format!(
+            "{{\"amount\":{amount},\"bthDepositAddress\":{deposit},\"createdAt\":{created},\
+             \"destAddress\":{dest},\"destChain\":{chain},\"fee\":{fee},\"id\":{id},\
+             \"memo\":{memo}}}",
+            amount = self.amount,
+            deposit = s(&self.bth_deposit_address),
+            created = self.created_at_unix,
+            dest = s(&self.dest_address),
+            chain = s(&self.dest_chain.to_string()),
+            fee = self.fee,
+            id = s(&self.id.to_string()),
+            memo = s(&hex::encode(self.memo)),
+        )
+    }
+
+    /// Parse a canonical record string, REJECTING unknown or duplicate keys
+    /// and any type/shape error (parse-after-verify feeds this only bytes
+    /// whose signature already verified).
+    fn from_canonical_json(bytes: &str) -> Result<Self, String> {
+        reject_duplicate_keys(bytes)?;
+        let value: Value =
+            serde_json::from_str(bytes).map_err(|e| format!("record is not valid JSON: {e}"))?;
+        let obj: &Map<String, Value> = value
+            .as_object()
+            .ok_or_else(|| "record must be a JSON object".to_string())?;
+
+        const KNOWN_KEYS: &[&str] = &[
+            "amount",
+            "bthDepositAddress",
+            "createdAt",
+            "destAddress",
+            "destChain",
+            "fee",
+            "id",
+            "memo",
+        ];
+        for key in obj.keys() {
+            if !KNOWN_KEYS.contains(&key.as_str()) {
+                return Err(format!("unknown record field `{key}`"));
+            }
+        }
+
+        let amount = get_u64(obj, "amount")?;
+        let fee = get_u64(obj, "fee")?;
+        let bth_deposit_address = get_str(obj, "bthDepositAddress")?.to_string();
+        let dest_address = get_str(obj, "destAddress")?.to_string();
+        let created_at_unix = obj
+            .get("createdAt")
+            .and_then(Value::as_i64)
+            .ok_or_else(|| "field `createdAt` must be an integer".to_string())?;
+        let dest_chain = get_str(obj, "destChain")?
+            .parse::<Chain>()
+            .map_err(|e| format!("bad destChain: {e}"))?;
+        let id = get_str(obj, "id")?
+            .parse::<Uuid>()
+            .map_err(|_| "`id` is not a valid UUID".to_string())?;
+        let memo_bytes = hex::decode(get_str(obj, "memo")?)
+            .map_err(|_| "`memo` is not valid hex".to_string())?;
+        let memo: [u8; 64] = memo_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| "`memo` must be 64 bytes".to_string())?;
+
+        // Structural bind: the memo's first 16 bytes must equal the order id,
+        // exactly as the deposit-matching path (`BridgeOrder::order_id_from_memo`)
+        // will read it. A record whose memo does not carry its own id could
+        // never be matched by a watcher and is rejected as malformed.
+        match BridgeOrder::order_id_from_memo(&memo) {
+            Some(memo_id) if memo_id == id => {}
+            _ => return Err("record memo does not embed its own order id".to_string()),
+        }
+
+        Ok(Self {
+            id,
+            dest_chain,
+            amount,
+            fee,
+            bth_deposit_address,
+            dest_address,
+            memo,
+            created_at_unix,
+        })
+    }
+}
+
+/// A signed, replicable mint order record: the canonical record string exactly
+/// as the originating member signed it, the signer's identity, and a detached
+/// Ed25519 signature over `ORDER_RECORD_DOMAIN_TAG || record_bytes`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrderRecordEnvelope {
+    /// The canonical record JSON, verbatim, as signed.
+    pub record: String,
+    /// Signer identity: lowercase hex of the Ed25519 public key (64 chars).
+    /// A routing hint only — a lying value selects a key the signature then
+    /// fails to verify against.
+    pub signer_key_id: String,
+    /// Detached Ed25519 signature (lowercase hex, 64 bytes) over the
+    /// domain-separated record bytes.
+    pub signature_hex: String,
+}
+
+/// Why a replicated order record was refused. Mirrors the attestation reject
+/// taxonomy so the transport can map each to a stable tag / HTTP status.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OrderRecordRejectReason {
+    /// Structurally invalid before any signature work (bad hex, bad JSON).
+    Malformed(String),
+    /// The signature did not verify against the selected member key.
+    BadSignature,
+    /// The `signer_key_id` names no configured (elected) federation member.
+    UnknownSigner,
+    /// The signature verified but the record body is not an acceptable
+    /// replicable shell.
+    InvalidRecord(String),
+}
+
+impl OrderRecordRejectReason {
+    /// Stable machine tag (`refused:<tag>`), aligned with the attestation
+    /// reject tags used on `/api/attest`.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            OrderRecordRejectReason::Malformed(_) => "malformed",
+            OrderRecordRejectReason::BadSignature => "bad_signature",
+            OrderRecordRejectReason::UnknownSigner => "unknown_signer",
+            OrderRecordRejectReason::InvalidRecord(_) => "invalid_record",
+        }
+    }
+
+    /// Human-facing detail (safe to return to the submitter).
+    pub fn message(&self) -> String {
+        match self {
+            OrderRecordRejectReason::Malformed(m) => format!("malformed order record: {m}"),
+            OrderRecordRejectReason::BadSignature => {
+                "order record signature did not verify".to_string()
+            }
+            OrderRecordRejectReason::UnknownSigner => {
+                "order record signer is not a federation member".to_string()
+            }
+            OrderRecordRejectReason::InvalidRecord(m) => format!("invalid order record: {m}"),
+        }
+    }
+}
+
+/// Build and sign a replicable order record from an `AwaitingDeposit` mint
+/// order. The signer identity is the lowercase hex of the Ed25519 public key.
+pub fn sign_order_record_ed25519(
+    order: &BridgeOrder,
+    signing_key: &SigningKey,
+) -> Result<OrderRecordEnvelope, String> {
+    let shell = MintOrderShell::from_order(order)?;
+    let record = shell.canonical_json();
+    let msg = signed_message(record.as_bytes());
+    Ok(OrderRecordEnvelope {
+        signer_key_id: hex::encode(signing_key.verifying_key().as_bytes()),
+        signature_hex: hex::encode(signing_key.sign(&msg).to_bytes()),
+        record,
+    })
+}
+
+impl OrderRecordEnvelope {
+    /// Verify a replicated order record against the elected federation member
+    /// set and, on success, return the trust-free [`MintOrderShell`].
+    ///
+    /// Pipeline (no secret-dependent check precedes signature verification):
+    /// 1. decode the signature (`Malformed` on bad hex/length);
+    /// 2. select the member key named by `signer_key_id` — a name that is not
+    ///    in the elected set is `UnknownSigner` (never trusted);
+    /// 3. verify the signature over `domain || record_bytes` (`verify_strict`,
+    ///    rejecting malleable/low-order signatures);
+    /// 4. parse-after-verify the record bytes into a shell (unknown/duplicate
+    ///    keys and any shape error rejected).
+    pub fn verify_ed25519(
+        &self,
+        federation: &[VerifyingKey],
+    ) -> Result<MintOrderShell, OrderRecordRejectReason> {
+        let sig_bytes: [u8; 64] = hex::decode(self.signature_hex.trim())
+            .map_err(|_| {
+                OrderRecordRejectReason::Malformed("signature is not valid hex".to_string())
+            })?
+            .as_slice()
+            .try_into()
+            .map_err(|_| {
+                OrderRecordRejectReason::Malformed("signature must be 64 bytes".to_string())
+            })?;
+
+        // Select the member key named by the (unverified) signer id. Not a
+        // trust decision on its own: a lying id selects a key the signature
+        // then fails to verify against.
+        let key = federation
+            .iter()
+            .find(|k| hex::encode(k.as_bytes()) == self.signer_key_id)
+            .ok_or(OrderRecordRejectReason::UnknownSigner)?;
+
+        let msg = signed_message(self.record.as_bytes());
+        key.verify_strict(&msg, &Ed25519Signature::from_bytes(&sig_bytes))
+            .map_err(|_| OrderRecordRejectReason::BadSignature)?;
+
+        // Parse-after-verify: signature is valid over exactly these bytes.
+        MintOrderShell::from_canonical_json(&self.record)
+            .map_err(OrderRecordRejectReason::InvalidRecord)
+    }
+}
+
+/// The domain-separated message that is signed / verified.
+fn signed_message(record_bytes: &[u8]) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(ORDER_RECORD_DOMAIN_TAG.len() + record_bytes.len());
+    msg.extend_from_slice(ORDER_RECORD_DOMAIN_TAG);
+    msg.extend_from_slice(record_bytes);
+    msg
+}
+
+fn get_u64(obj: &Map<String, Value>, key: &str) -> Result<u64, String> {
+    obj.get(key)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| format!("field `{key}` must be an unsigned integer"))
+}
+
+fn get_str<'a>(obj: &'a Map<String, Value>, key: &str) -> Result<&'a str, String> {
+    obj.get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("field `{key}` must be a string"))
+}
+
+/// Reject a JSON object with duplicate keys (a serde_json `Map` silently keeps
+/// the last), so one signed byte string cannot smuggle a second value.
+fn reject_duplicate_keys(bytes: &str) -> Result<(), String> {
+    let mut de = serde_json::Deserializer::from_str(bytes);
+    let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    serde::Deserializer::deserialize_map(&mut de, DuplicateKeyGuard { seen: &mut seen })
+        .map_err(|e| e.to_string())
+}
+
+/// A serde visitor that only walks the top-level object keys and errors on the
+/// first duplicate. It does not build a value — it is used purely for the
+/// duplicate-key check before the real parse.
+struct DuplicateKeyGuard<'a> {
+    seen: &'a mut std::collections::BTreeSet<String>,
+}
+
+impl<'de> serde::de::Visitor<'de> for DuplicateKeyGuard<'_> {
+    type Value = ();
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("a JSON object with unique keys")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<(), A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        while let Some(key) = map.next_key::<String>()? {
+            if !self.seen.insert(key.clone()) {
+                return Err(serde::de::Error::custom(format!("duplicate key `{key}`")));
+            }
+            // Consume (and ignore) the value.
+            let _ = map.next_value::<serde::de::IgnoredAny>()?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn sample_order() -> BridgeOrder {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bth_deposit_stealth_addr".to_string(),
+            format!("0x{}", hex::encode([0x11u8; 20])),
+        );
+        order.generate_memo();
+        order
+    }
+
+    #[test]
+    fn sign_verify_round_trip_yields_awaiting_deposit_shell() {
+        let signer = key(1);
+        let federation = vec![signer.verifying_key(), key(2).verifying_key()];
+        let order = sample_order();
+
+        let env = sign_order_record_ed25519(&order, &signer).unwrap();
+        let shell = env
+            .verify_ed25519(&federation)
+            .expect("valid record verifies");
+
+        assert_eq!(shell.id, order.id);
+        assert_eq!(shell.amount, order.amount);
+        assert_eq!(shell.fee, order.fee);
+        assert_eq!(shell.dest_chain, order.dest_chain);
+        assert_eq!(shell.dest_address, order.dest_address);
+        assert_eq!(shell.memo, order.memo.unwrap());
+
+        // Reconstruction is ALWAYS an AwaitingDeposit shell with no trust
+        // carried over the wire.
+        let rebuilt = shell.into_awaiting_deposit_order();
+        assert_eq!(rebuilt.id, order.id);
+        assert_eq!(rebuilt.status, OrderStatus::AwaitingDeposit);
+        assert!(rebuilt.mint_authorization.is_none());
+        assert!(rebuilt.source_tx.is_none());
+        assert!(rebuilt.dest_tx.is_none());
+        assert_eq!(rebuilt.order_type, OrderType::Mint);
+        // The reconstructed memo still embeds the id the watcher matches on.
+        assert_eq!(
+            BridgeOrder::order_id_from_memo(&rebuilt.memo.unwrap()),
+            Some(order.id)
+        );
+    }
+
+    #[test]
+    fn record_from_unknown_signer_is_rejected() {
+        // Signed by a key that is NOT in the elected federation set.
+        let outsider = key(99);
+        let federation = vec![key(1).verifying_key(), key(2).verifying_key()];
+        let env = sign_order_record_ed25519(&sample_order(), &outsider).unwrap();
+        assert_eq!(
+            env.verify_ed25519(&federation).unwrap_err(),
+            OrderRecordRejectReason::UnknownSigner
+        );
+    }
+
+    #[test]
+    fn tampered_record_body_is_rejected() {
+        let signer = key(1);
+        let federation = vec![signer.verifying_key()];
+        let order = sample_order();
+        let mut env = sign_order_record_ed25519(&order, &signer).unwrap();
+
+        // Tamper the signed body (inflate the amount) while keeping the
+        // signature — verification must fail.
+        env.record = env
+            .record
+            .replace(&order.amount.to_string(), &(order.amount + 1).to_string());
+        assert_eq!(
+            env.verify_ed25519(&federation).unwrap_err(),
+            OrderRecordRejectReason::BadSignature
+        );
+    }
+
+    #[test]
+    fn relabeled_signer_id_is_rejected() {
+        // A valid signature from member A, relabeled to claim member B's id.
+        // B is in the set (so not UnknownSigner) but B did not sign these
+        // bytes, so verify_strict fails.
+        let (a, b) = (key(1), key(2));
+        let federation = vec![a.verifying_key(), b.verifying_key()];
+        let mut env = sign_order_record_ed25519(&sample_order(), &a).unwrap();
+        env.signer_key_id = hex::encode(b.verifying_key().as_bytes());
+        assert_eq!(
+            env.verify_ed25519(&federation).unwrap_err(),
+            OrderRecordRejectReason::BadSignature
+        );
+    }
+
+    #[test]
+    fn only_awaiting_deposit_mint_orders_replicate() {
+        // A confirmed mint order must never be projected into a shell — peers
+        // derive confirmation independently, never from replication.
+        let mut order = sample_order();
+        order.set_status(OrderStatus::DepositConfirmed);
+        assert!(MintOrderShell::from_order(&order).is_err());
+
+        // Burn orders are never replicated through this path.
+        let burn = BridgeOrder::new_burn(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            0,
+            "0xsource".to_string(),
+            "bth_addr".to_string(),
+            "0xburntx".to_string(),
+            0,
+        );
+        assert!(MintOrderShell::from_order(&burn).is_err());
+    }
+
+    #[test]
+    fn malformed_signature_hex_is_rejected() {
+        let signer = key(1);
+        let federation = vec![signer.verifying_key()];
+        let mut env = sign_order_record_ed25519(&sample_order(), &signer).unwrap();
+        env.signature_hex = "not-hex".to_string();
+        assert!(matches!(
+            env.verify_ed25519(&federation).unwrap_err(),
+            OrderRecordRejectReason::Malformed(_)
+        ));
+    }
+
+    #[test]
+    fn record_with_duplicate_keys_is_rejected() {
+        let signer = key(1);
+        let federation = vec![signer.verifying_key()];
+        // Craft a record with a duplicated key and sign it, so the signature
+        // verifies but the parse-after-verify duplicate guard rejects it.
+        let shell = MintOrderShell::from_order(&sample_order()).unwrap();
+        let base = shell.canonical_json();
+        let dup = base.replacen('{', "{\"fee\":1,", 1);
+        let env = OrderRecordEnvelope {
+            signature_hex: hex::encode(signer.sign(&signed_message(dup.as_bytes())).to_bytes()),
+            signer_key_id: hex::encode(signer.verifying_key().as_bytes()),
+            record: dup,
+        };
+        assert!(matches!(
+            env.verify_ed25519(&federation).unwrap_err(),
+            OrderRecordRejectReason::InvalidRecord(_)
+        ));
+    }
+
+    #[test]
+    fn record_memo_must_embed_its_own_id() {
+        // A record whose memo does not carry its own id is malformed: no
+        // watcher could ever match it, and it must not be persisted as a shell.
+        let signer = key(1);
+        let federation = vec![signer.verifying_key()];
+        let mut shell = MintOrderShell::from_order(&sample_order()).unwrap();
+        shell.memo = [0xabu8; 64]; // memo id no longer equals shell.id
+        let record = shell.canonical_json();
+        let env = OrderRecordEnvelope {
+            signature_hex: hex::encode(signer.sign(&signed_message(record.as_bytes())).to_bytes()),
+            signer_key_id: hex::encode(signer.verifying_key().as_bytes()),
+            record,
+        };
+        assert!(matches!(
+            env.verify_ed25519(&federation).unwrap_err(),
+            OrderRecordRejectReason::InvalidRecord(_)
+        ));
+    }
+
+    #[test]
+    fn canonical_json_is_stable() {
+        // The signed byte string must be reproducible field-for-field.
+        let mut order = sample_order();
+        // Pin every field so the vector is deterministic.
+        order.id = Uuid::parse_str("00000000-0000-0000-0000-0000000000aa").unwrap();
+        order.amount = 5;
+        order.fee = 1;
+        order.source_address = "deposit".to_string();
+        order.dest_address = "dest".to_string();
+        order.created_at = Utc.timestamp_opt(1_700_000_000, 0).single().unwrap();
+        order.generate_memo();
+        let shell = MintOrderShell::from_order(&order).unwrap();
+        let expected = format!(
+            "{{\"amount\":5,\"bthDepositAddress\":\"deposit\",\"createdAt\":1700000000,\
+             \"destAddress\":\"dest\",\"destChain\":\"ethereum\",\"fee\":1,\
+             \"id\":\"00000000-0000-0000-0000-0000000000aa\",\"memo\":\"{}\"}}",
+            hex::encode(order.memo.unwrap())
+        );
+        assert_eq!(shell.canonical_json(), expected);
+    }
+}

--- a/bridge/service/src/attestation.rs
+++ b/bridge/service/src/attestation.rs
@@ -278,8 +278,29 @@ pub struct FederationAttestationProvider {
     peer_push: Option<Arc<dyn EnvelopePush>>,
 }
 
+/// Load this node's local Ed25519 attestation signing key from the configured
+/// key file, if any. Shared by the attestation provider and the #1050 order
+/// replication path (both authenticate as the same elected-member identity).
+pub(crate) fn load_local_ed25519(config: &BridgeConfig) -> Result<Option<SigningKey>, String> {
+    match config.bridge.attestation_ed25519_key_file.as_deref() {
+        Some(path) => {
+            let raw = std::fs::read_to_string(path)
+                .map_err(|e| format!("cannot read attestation_ed25519_key_file: {}", e))?;
+            let bytes: [u8; 32] = hex::decode(raw.trim())
+                .map_err(|e| format!("bad ed25519 attestation key hex: {}", e))?
+                .try_into()
+                .map_err(|_| "ed25519 attestation key is not 32 bytes".to_string())?;
+            Ok(Some(SigningKey::from_bytes(&bytes)))
+        }
+        None => Ok(None),
+    }
+}
+
 /// Parse a hex-encoded 32-byte Ed25519 public key list into verifying keys.
-fn parse_ed25519_federation(signers: &[String], what: &str) -> Result<Vec<VerifyingKey>, String> {
+pub(crate) fn parse_ed25519_federation(
+    signers: &[String],
+    what: &str,
+) -> Result<Vec<VerifyingKey>, String> {
     let mut keys = Vec::with_capacity(signers.len());
     for hex_key in signers {
         let bytes: [u8; 32] = hex::decode(hex_key.trim())
@@ -445,18 +466,7 @@ impl FederationAttestationProvider {
             return Ok(None);
         }
 
-        let local_ed25519 = match config.bridge.attestation_ed25519_key_file.as_deref() {
-            Some(path) => {
-                let raw = std::fs::read_to_string(path)
-                    .map_err(|e| format!("cannot read attestation_ed25519_key_file: {}", e))?;
-                let bytes: [u8; 32] = hex::decode(raw.trim())
-                    .map_err(|e| format!("bad ed25519 attestation key hex: {}", e))?
-                    .try_into()
-                    .map_err(|_| "ed25519 attestation key is not 32 bytes".to_string())?;
-                Some(SigningKey::from_bytes(&bytes))
-            }
-            None => None,
-        };
+        let local_ed25519 = load_local_ed25519(config)?;
         let local_secp256k1 = match config.bridge.attestation_secp256k1_key_file.as_deref() {
             Some(path) => {
                 let raw = std::fs::read_to_string(path)

--- a/bridge/service/src/engine.rs
+++ b/bridge/service/src/engine.rs
@@ -10,11 +10,11 @@ use tracing::{debug, error, info, warn};
 use crate::{
     api,
     attestation::{
-        AttestationProvider, DisabledAttestationProvider, FederationAttestationProvider,
-        StubAttestationProvider,
+        load_local_ed25519, parse_ed25519_federation, AttestationProvider,
+        DisabledAttestationProvider, FederationAttestationProvider, StubAttestationProvider,
     },
     db::{Database, LimitCheck, LimitViolation},
-    federation::{self, AttestState, PeerBroadcaster},
+    federation::{self, AttestState, OrderBroadcaster, OrderSyncState, PeerBroadcaster},
     mint::{ethereum::EthMinter, solana::SolMinter, ConfirmationStatus, Minter},
     public_api::{self, PublicApiConfig, PublicApiState},
     release::{bth::BthReleaser, PreparedRelease, ReleaseConfirmation, Releaser},
@@ -357,8 +357,42 @@ impl BridgeEngine {
             None
         } else {
             let addr = self.config.public_api.listen.clone();
-            let state =
+            let mut state =
                 PublicApiState::new(self.db.clone(), PublicApiConfig::from_config(&self.config));
+
+            // #1050 Phase 2: replicate created mint orders (signed) to the
+            // elected federation peers so their own watchers can independently
+            // confirm the deposit. Enabled only when this node has a local
+            // Ed25519 federation key, an elected member set (bth.release_signers),
+            // AND peers to push to. Any missing piece just disables replication
+            // (single-node development is unaffected).
+            let local_ed25519 = match load_local_ed25519(&self.config) {
+                Ok(key) => key,
+                Err(e) => {
+                    warn!(
+                        "order replication disabled: cannot load local ed25519 key: {}",
+                        e
+                    );
+                    None
+                }
+            };
+            let order_broadcaster = OrderBroadcaster::new(
+                &self.config.federation.peers,
+                self.config.federation.peer_auth_token.clone(),
+                Duration::from_secs(self.config.federation.peer_push_timeout_secs.max(1)),
+            );
+            if let (Some(key), Some(broadcaster), false) = (
+                local_ed25519,
+                order_broadcaster,
+                self.config.bth.release_signers.is_empty(),
+            ) {
+                info!(
+                    "public order API: replicating mint orders to {} federation peer(s) (#1050 Phase 2)",
+                    self.config.federation.peers.len()
+                );
+                state = state.with_order_replication(key, broadcaster);
+            }
+
             let public_shutdown = self.shutdown_tx.subscribe();
             Some(tokio::spawn(async move {
                 if let Err(e) = public_api::serve_public(addr, state, public_shutdown).await {
@@ -384,9 +418,35 @@ impl BridgeEngine {
                     db: self.db.clone(),
                     inbound_auth_token: self.config.federation.inbound_auth_token.clone(),
                 };
+                // #1050 Phase 2: co-mount the signed order-record replication
+                // endpoint (`POST /api/order`) on the same federation listener.
+                // The elected member set that authenticates a mint order
+                // record is the BTH release-signer set (the Ed25519 identity of
+                // each elected machine). Disabled when no such set is
+                // configured (nothing could authenticate a record).
+                let order_sync = match parse_ed25519_federation(
+                    &self.config.bth.release_signers,
+                    "bth.release_signers",
+                ) {
+                    Ok(keys) if !keys.is_empty() => Some(OrderSyncState {
+                        federation: Arc::new(keys),
+                        db: self.db.clone(),
+                        inbound_auth_token: self.config.federation.inbound_auth_token.clone(),
+                    }),
+                    Ok(_) => None,
+                    Err(e) => {
+                        warn!(
+                            "order-record endpoint disabled: bad bth.release_signers: {}",
+                            e
+                        );
+                        None
+                    }
+                };
                 let attest_shutdown = self.shutdown_tx.subscribe();
                 Some(tokio::spawn(async move {
-                    if let Err(e) = federation::serve(addr, state, attest_shutdown).await {
+                    if let Err(e) =
+                        federation::serve(addr, state, order_sync, attest_shutdown).await
+                    {
                         error!("Bridge attestation endpoint error: {}", e);
                     }
                 }))

--- a/bridge/service/src/federation.rs
+++ b/bridge/service/src/federation.rs
@@ -48,7 +48,8 @@ use axum::{
     http::{HeaderMap, StatusCode},
     Json,
 };
-use bth_bridge_core::{peek_order_id, AttestationEnvelope};
+use bth_bridge_core::{peek_order_id, AttestationEnvelope, OrderRecordEnvelope};
+use ed25519_dalek::VerifyingKey;
 use serde::Serialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, warn};
@@ -268,24 +269,225 @@ pub fn router(state: AttestState) -> axum::Router {
         .with_state(state)
 }
 
-/// Serve the inbound attestation endpoint until shutdown. Empty `addr`
-/// disables the endpoint (the caller checks this before spawning).
+/// Serve the inbound federation endpoints until shutdown. Empty `addr`
+/// disables the endpoint (the caller checks this before spawning). Mounts
+/// `POST /api/attest` always, and `POST /api/order` (mint order-record
+/// replication, #1050 Phase 2) when `order_sync` is configured.
 pub async fn serve(
     addr: String,
     state: AttestState,
+    order_sync: Option<OrderSyncState>,
     mut shutdown: tokio::sync::broadcast::Receiver<()>,
 ) -> Result<(), String> {
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .map_err(|e| format!("bind {addr} (attest) failed: {e}"))?;
     tracing::info!("Bridge attestation endpoint listening on {addr}");
-    axum::serve(listener, router(state))
+    let app = match order_sync {
+        Some(os) => router(state).merge(order_router(os)),
+        None => router(state),
+    };
+    axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             let _ = shutdown.recv().await;
             tracing::info!("Bridge attestation endpoint shutting down");
         })
         .await
         .map_err(|e| format!("attest server error: {e}"))
+}
+
+/// Shared state of the inbound `POST /api/order` endpoint (#1050 Phase 2:
+/// signed mint order-record replication).
+#[derive(Clone)]
+pub struct OrderSyncState {
+    /// The elected federation member set (Ed25519 verifying keys). A record
+    /// signed by a key not in this set is rejected as `unknown_signer` before
+    /// it is ever persisted — never accept an order record from an
+    /// unelected peer.
+    pub federation: Arc<Vec<VerifyingKey>>,
+    /// Local order store: a verified record is persisted only as an
+    /// `AwaitingDeposit` shell for THIS node's own watcher to confirm.
+    pub db: Database,
+    /// Shared bearer secret a peer must present (anti-DoS fence, same as the
+    /// attest endpoint). `None` disables the gate (trusted private network).
+    pub inbound_auth_token: Option<String>,
+}
+
+/// The JSON body returned by the inbound order-record endpoint.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderSyncResponse {
+    /// Whether the shell was accepted (persisted, or already on record).
+    pub accepted: bool,
+    /// Stable machine tag: `accepted`, `accepted:already_present`, or
+    /// `refused:<reason-tag>`.
+    pub tag: String,
+    /// Human-facing detail (safe to return to the submitter).
+    pub message: String,
+}
+
+/// Inbound order-record replication endpoint: `POST /api/order`.
+///
+/// Authenticated, fail-closed transport that seeds an `AwaitingDeposit` mint
+/// **shell** so this node's own BTH watcher has an order to match a deposit
+/// against — closing the `refused:unknown_order` gap for a genuinely
+/// distributed (separate-DB) federation WITHOUT sharing a store.
+///
+/// The trust boundary is the whole point: a verified record grants NO trust.
+/// The wire type ([`bth_bridge_core::MintOrderShell`]) cannot carry a status,
+/// an authorization, or a dest tx, and the record is reconstituted only ever
+/// as a fresh `AwaitingDeposit` order. The signature authenticates only WHICH
+/// elected member proposed the order; this node still independently confirms
+/// the on-chain deposit before it will attest. A record whose id already
+/// exists locally is a no-op — an existing order (which may have already
+/// advanced) is NEVER overwritten or downgraded by a replicated shell.
+///
+/// Verdict → HTTP status: `200` accepted / already present, `401` bad bearer,
+/// `400` malformed / bad-signature / unknown-signer / invalid record, `503`
+/// an internal error.
+pub async fn receive_order(
+    State(state): State<OrderSyncState>,
+    headers: HeaderMap,
+    Json(envelope): Json<OrderRecordEnvelope>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    // 1. Bearer-auth gate (anti-DoS). Only enforced when configured.
+    if let Some(expected) = &state.inbound_auth_token {
+        match bearer(&headers) {
+            Some(presented) if token_matches(expected, &presented) => {}
+            _ => {
+                return (
+                    StatusCode::UNAUTHORIZED,
+                    Json(OrderSyncResponse {
+                        accepted: false,
+                        tag: "refused:unauthorized".to_string(),
+                        message: "missing or invalid bearer token".to_string(),
+                    }),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    // 2. Verify the signature against the elected federation set, then
+    //    parse-after-verify into a trust-free shell.
+    let shell = match envelope.verify_ed25519(&state.federation) {
+        Ok(shell) => shell,
+        Err(reason) => {
+            let status = match reason {
+                bth_bridge_core::OrderRecordRejectReason::UnknownSigner
+                | bth_bridge_core::OrderRecordRejectReason::BadSignature
+                | bth_bridge_core::OrderRecordRejectReason::Malformed(_)
+                | bth_bridge_core::OrderRecordRejectReason::InvalidRecord(_) => {
+                    StatusCode::BAD_REQUEST
+                }
+            };
+            warn!(
+                "order-record replication refused: {} ({})",
+                reason.tag(),
+                reason.message()
+            );
+            return (
+                status,
+                Json(OrderSyncResponse {
+                    accepted: false,
+                    tag: format!("refused:{}", reason.tag()),
+                    message: reason.message(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    // 3. Idempotent, NON-destructive persist. If an order with this id already
+    //    exists locally we do nothing — a replicated shell must never overwrite
+    //    (and thus never downgrade) an order that may have already advanced through
+    //    this node's own pipeline.
+    let order_id = shell.id;
+    match state.db.get_order(&order_id) {
+        Ok(Some(_)) => {
+            debug!("order-record {order_id} already on record; replication is a no-op");
+            return (
+                StatusCode::OK,
+                Json(OrderSyncResponse {
+                    accepted: true,
+                    tag: "accepted:already_present".to_string(),
+                    message: format!("order {order_id} already on record"),
+                }),
+            )
+                .into_response();
+        }
+        Ok(None) => {}
+        Err(e) => {
+            warn!("order-record endpoint: order lookup failed: {e}");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(OrderSyncResponse {
+                    accepted: false,
+                    tag: "refused:internal".to_string(),
+                    message: "order lookup failed".to_string(),
+                }),
+            )
+                .into_response();
+        }
+    }
+
+    let order = shell.into_awaiting_deposit_order();
+    if let Err(e) = state.db.insert_order(&order) {
+        // A racing insert of the same id (unique constraint) is benign: the
+        // order is now on record either way. Surface other errors as 503.
+        if state.db.get_order(&order_id).ok().flatten().is_some() {
+            return (
+                StatusCode::OK,
+                Json(OrderSyncResponse {
+                    accepted: true,
+                    tag: "accepted:already_present".to_string(),
+                    message: format!("order {order_id} already on record"),
+                }),
+            )
+                .into_response();
+        }
+        warn!("order-record endpoint: failed to persist replicated shell: {e}");
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(OrderSyncResponse {
+                accepted: false,
+                tag: "refused:internal".to_string(),
+                message: "failed to persist order record".to_string(),
+            }),
+        )
+            .into_response();
+    }
+    if let Err(e) = state.db.log_audit(
+        Some(&order_id),
+        "order_replicated",
+        &format!(
+            "replicated AwaitingDeposit mint shell from federation member {}",
+            envelope.signer_key_id
+        ),
+    ) {
+        warn!("order-record endpoint: audit log failed: {e}");
+    }
+
+    (
+        StatusCode::OK,
+        Json(OrderSyncResponse {
+            accepted: true,
+            tag: "accepted".to_string(),
+            message: format!(
+                "order {order_id} shell persisted (awaiting independent deposit confirmation)"
+            ),
+        }),
+    )
+        .into_response()
+}
+
+/// Build the inbound order-record router (`POST /api/order`).
+pub fn order_router(state: OrderSyncState) -> axum::Router {
+    axum::Router::new()
+        .route("/api/order", axum::routing::post(receive_order))
+        .with_state(state)
 }
 
 /// Outbound transport ([`EnvelopePush`]): pushes each accepted local envelope
@@ -463,11 +665,80 @@ impl EnvelopePush for PeerBroadcaster {
     }
 }
 
-/// Parse a peer base URL into a raw-socket target. Accepts `http://` and
-/// `https://` schemes (the scheme only informs the default port here — TLS
-/// termination for `https` peers is expected at a reverse proxy / mTLS layer
-/// in front of the plain endpoint for v1). Rejects anything without a host.
+/// Outbound order-record replication (#1050 Phase 2): pushes a signed mint
+/// order record to every configured peer's inbound `POST /api/order`
+/// endpoint. Fire-and-forget with the same guarantees as [`PeerBroadcaster`]:
+/// a slow or unreachable peer never wedges or fails the local order-create
+/// path. The record is self-authenticating (Ed25519 over the domain-separated
+/// bytes), so plain HTTP integrity + the bearer fence suffice for v1.
+pub struct OrderBroadcaster {
+    peers: Vec<PeerEndpoint>,
+    auth_token: Option<String>,
+    timeout: std::time::Duration,
+}
+
+impl OrderBroadcaster {
+    /// Build from configured peer base URLs. Unparseable peers are skipped
+    /// with a warning (a bad entry must not disable the whole outbound path).
+    /// Returns `None` when no peer parses (nothing to replicate to).
+    pub fn new(
+        peers: &[String],
+        auth_token: Option<String>,
+        timeout: std::time::Duration,
+    ) -> Option<Self> {
+        let parsed: Vec<PeerEndpoint> = peers
+            .iter()
+            .filter_map(|p| match parse_peer_to(p, "/api/order") {
+                Ok(ep) => Some(ep),
+                Err(e) => {
+                    warn!("federation order-sync peer `{p}` ignored: {e}");
+                    None
+                }
+            })
+            .collect();
+        if parsed.is_empty() {
+            return None;
+        }
+        Some(Self {
+            peers: parsed,
+            auth_token,
+            timeout,
+        })
+    }
+
+    /// Replicate one signed order record to every peer. Fire-and-forget: each
+    /// push is spawned and only its result logged.
+    pub fn broadcast(&self, envelope: &OrderRecordEnvelope) {
+        let body = match serde_json::to_string(envelope) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("cannot serialize order record for peer push: {e}");
+                return;
+            }
+        };
+        for peer in &self.peers {
+            let peer = peer.clone();
+            let body = body.clone();
+            let auth_token = self.auth_token.clone();
+            let timeout = self.timeout;
+            // Fire-and-forget: never block or fail the local order-create path.
+            tokio::spawn(PeerBroadcaster::push_one(peer, body, auth_token, timeout));
+        }
+    }
+}
+
+/// Parse a peer base URL into a raw-socket target for the attestation
+/// endpoint (`/api/attest`). Thin wrapper over [`parse_peer_to`].
 fn parse_peer(url: &str) -> Result<PeerEndpoint, String> {
+    parse_peer_to(url, "/api/attest")
+}
+
+/// Parse a peer base URL into a raw-socket target for `endpoint`. Accepts
+/// `http://` and `https://` schemes (the scheme only informs the default port
+/// here — TLS termination for `https` peers is expected at a reverse proxy /
+/// mTLS layer in front of the plain endpoint for v1). Rejects anything without
+/// a host.
+fn parse_peer_to(url: &str, endpoint: &str) -> Result<PeerEndpoint, String> {
     let url = url.trim();
     let (scheme, rest) = match url.split_once("://") {
         Some((s, r)) => (s, r),
@@ -493,7 +764,7 @@ fn parse_peer(url: &str) -> Result<PeerEndpoint, String> {
     } else {
         format!("{authority}:{default_port}")
     };
-    let path = format!("{base_path}/api/attest");
+    let path = format!("{base_path}{endpoint}");
     Ok(PeerEndpoint {
         authority: connect,
         host_header: authority.to_string(),
@@ -572,7 +843,9 @@ mod federation_transport_tests {
         signers::local::PrivateKeySigner,
     };
     use async_trait::async_trait;
-    use bth_bridge_core::{BridgeOrder, Chain, OrderStatus, OrderType};
+    use bth_bridge_core::{
+        sign_order_record_ed25519, BridgeOrder, Chain, OrderRecordEnvelope, OrderStatus, OrderType,
+    };
     use ed25519_dalek::SigningKey;
     use std::time::Duration;
     use tokio::sync::broadcast;
@@ -1285,5 +1558,480 @@ mod federation_transport_tests {
         let reader = std::io::Cursor::new(Vec::<u8>::new());
         let status = read_status_line(reader).await.unwrap();
         assert_eq!(status, 0);
+    }
+
+    // ── #1050 Phase 2: signed mint order-record replication ───────────────
+
+    /// An `AwaitingDeposit` mint order (with its deposit memo) that a public
+    /// API would create and then replicate to peers.
+    fn await_mint_order() -> BridgeOrder {
+        let mut order = BridgeOrder::new_mint(
+            Chain::Ethereum,
+            1_000_000_000_000,
+            1_000_000_000,
+            "bth_deposit_addr".to_string(),
+            format!("0x{}", hex::encode([0x11u8; 20])),
+        );
+        order.generate_memo();
+        order
+    }
+
+    /// A fresh, EMPTY in-memory DB (the separate-DB, no-shared-store topology).
+    fn empty_db() -> Database {
+        let db = Database::open_in_memory().unwrap();
+        db.migrate().unwrap();
+        db
+    }
+
+    /// POST a raw JSON body to a node's `/api/order` and return (status, body).
+    async fn post_order(base_url: &str, auth: Option<&str>, body: &str) -> (u16, String) {
+        let addr = base_url.trim_start_matches("http://");
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let auth_hdr = match auth {
+            Some(t) => format!("Authorization: Bearer {t}\r\n"),
+            None => String::new(),
+        };
+        let request = format!(
+            "POST /api/order HTTP/1.1\r\nHost: {addr}\r\nContent-Type: application/json\r\n\
+             {auth_hdr}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        let text = String::from_utf8_lossy(&response).to_string();
+        let status: u16 = text
+            .split_whitespace()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        let body = text
+            .split_once("\r\n\r\n")
+            .map(|(_, b)| b.to_string())
+            .unwrap_or_default();
+        (status, body)
+    }
+
+    /// Serve ONLY the order-record endpoint on an ephemeral port.
+    async fn spawn_order_endpoint(
+        state: OrderSyncState,
+    ) -> (String, broadcast::Sender<()>, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let (tx, rx) = broadcast::channel(1);
+        let app = order_router(state);
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let mut rx = rx;
+                    let _ = rx.recv().await;
+                })
+                .await
+                .unwrap();
+        });
+        (url, tx, handle)
+    }
+
+    /// Serve BOTH the attest and order endpoints on a pre-bound listener.
+    fn serve_pending_combined(
+        node: PendingNode,
+        provider: Arc<FederationAttestationProvider>,
+        order_sync: OrderSyncState,
+    ) -> (broadcast::Sender<()>, tokio::task::JoinHandle<()>) {
+        let (tx, rx) = broadcast::channel(1);
+        let attest = AttestState {
+            provider,
+            db: node.db,
+            inbound_auth_token: Some(AUTH.to_string()),
+        };
+        let app = router(attest).merge(order_router(order_sync));
+        let handle = tokio::spawn(async move {
+            axum::serve(node.listener, app)
+                .with_graceful_shutdown(async move {
+                    let mut rx = rx;
+                    let _ = rx.recv().await;
+                })
+                .await
+                .unwrap();
+        });
+        (tx, handle)
+    }
+
+    /// A pending node with a pre-bound listener but an EMPTY db (the receiving
+    /// member that will learn an order only via replication).
+    async fn pending_empty_node() -> PendingNode {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        PendingNode {
+            listener,
+            url: format!("http://{addr}"),
+            db: empty_db(),
+        }
+    }
+
+    /// A valid record from an elected member seeds a SEPARATE (empty) db as a
+    /// trust-free `AwaitingDeposit` shell — the core of Phase 2.
+    #[tokio::test]
+    async fn order_record_replicates_to_a_separate_db_as_a_trust_free_shell() {
+        let (ka, kb) = (ed_key(11), ed_key(22));
+        let federation = Arc::new(vec![ka.verifying_key(), kb.verifying_key()]);
+        let order = await_mint_order();
+
+        let db_b = empty_db();
+        let state = OrderSyncState {
+            federation,
+            db: db_b.clone(),
+            inbound_auth_token: Some(AUTH.to_string()),
+        };
+        let (url, sd, srv) = spawn_order_endpoint(state).await;
+        assert!(
+            db_b.get_order(&order.id).unwrap().is_none(),
+            "receiver starts with no order (separate DB, no shared store)"
+        );
+
+        // An elected member (A) signs the record and replicates it over the wire.
+        let env = sign_order_record_ed25519(&order, &ka).unwrap();
+        let (status, body) =
+            post_order(&url, Some(AUTH), &serde_json::to_string(&env).unwrap()).await;
+        assert_eq!(status, 200, "{body}");
+        assert!(body.contains("accepted"), "{body}");
+
+        // The receiver now has an AwaitingDeposit shell carrying NO trust.
+        let got = db_b.get_order(&order.id).unwrap().expect("shell persisted");
+        assert_eq!(got.id, order.id);
+        assert_eq!(got.status, OrderStatus::AwaitingDeposit);
+        assert_eq!(got.amount, order.amount);
+        assert_eq!(got.fee, order.fee);
+        assert_eq!(got.dest_address, order.dest_address);
+        assert!(
+            got.source_tx.is_none(),
+            "no deposit is trusted from a record"
+        );
+        assert!(got.mint_authorization.is_none());
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+
+    /// A record signed by a key that is NOT an elected member is rejected and
+    /// never persisted — the trust boundary at the network edge.
+    #[tokio::test]
+    async fn order_record_from_a_non_member_is_rejected_and_not_persisted() {
+        let (ka, kb) = (ed_key(11), ed_key(22));
+        let federation = Arc::new(vec![ka.verifying_key(), kb.verifying_key()]);
+        let outsider = ed_key(99);
+        let order = await_mint_order();
+
+        let db_b = empty_db();
+        let state = OrderSyncState {
+            federation,
+            db: db_b.clone(),
+            inbound_auth_token: Some(AUTH.to_string()),
+        };
+        let (url, sd, srv) = spawn_order_endpoint(state).await;
+
+        let env = sign_order_record_ed25519(&order, &outsider).unwrap();
+        let (status, body) =
+            post_order(&url, Some(AUTH), &serde_json::to_string(&env).unwrap()).await;
+        assert_eq!(status, 400, "{body}");
+        assert!(body.contains("unknown_signer"), "{body}");
+        assert!(
+            db_b.get_order(&order.id).unwrap().is_none(),
+            "an unelected peer's record must never be persisted"
+        );
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+
+    /// A record whose signed body was tampered after signing (mis-signed) is
+    /// rejected and never persisted.
+    #[tokio::test]
+    async fn order_record_tampered_body_is_rejected_and_not_persisted() {
+        let ka = ed_key(11);
+        let federation = Arc::new(vec![ka.verifying_key()]);
+        let order = await_mint_order();
+
+        let db_b = empty_db();
+        let state = OrderSyncState {
+            federation,
+            db: db_b.clone(),
+            inbound_auth_token: Some(AUTH.to_string()),
+        };
+        let (url, sd, srv) = spawn_order_endpoint(state).await;
+
+        // Keep the valid signature but inflate the amount in the signed body.
+        let env = sign_order_record_ed25519(&order, &ka).unwrap();
+        let tampered = OrderRecordEnvelope {
+            record: env
+                .record
+                .replace("\"amount\":1000000000000", "\"amount\":2000000000000"),
+            signer_key_id: env.signer_key_id.clone(),
+            signature_hex: env.signature_hex.clone(),
+        };
+        assert_ne!(tampered.record, env.record, "the body must actually change");
+        let (status, body) =
+            post_order(&url, Some(AUTH), &serde_json::to_string(&tampered).unwrap()).await;
+        assert_eq!(status, 400, "{body}");
+        assert!(body.contains("bad_signature"), "{body}");
+        assert!(db_b.get_order(&order.id).unwrap().is_none());
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+
+    /// The bearer fence gates the order endpoint exactly like `/api/attest`.
+    #[tokio::test]
+    async fn order_record_bad_bearer_is_rejected() {
+        let ka = ed_key(11);
+        let federation = Arc::new(vec![ka.verifying_key()]);
+        let order = await_mint_order();
+
+        let db_b = empty_db();
+        let state = OrderSyncState {
+            federation,
+            db: db_b.clone(),
+            inbound_auth_token: Some(AUTH.to_string()),
+        };
+        let (url, sd, srv) = spawn_order_endpoint(state).await;
+
+        let env = sign_order_record_ed25519(&order, &ka).unwrap();
+        let body = serde_json::to_string(&env).unwrap();
+        let (status, _) = post_order(&url, Some("wrong"), &body).await;
+        assert_eq!(status, 401);
+        let (status, _) = post_order(&url, None, &body).await;
+        assert_eq!(status, 401);
+        assert!(db_b.get_order(&order.id).unwrap().is_none());
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+
+    /// A replicated shell must NEVER overwrite (and thus never downgrade) an
+    /// order that already exists locally and may have advanced — the
+    /// exactly-once / no-double-mint guard.
+    #[tokio::test]
+    async fn order_record_does_not_overwrite_an_existing_advanced_order() {
+        let ka = ed_key(11);
+        let federation = Arc::new(vec![ka.verifying_key()]);
+        let order = await_mint_order();
+
+        // The receiver ALREADY has this order, independently advanced to
+        // DepositConfirmed with a real deposit tx.
+        let db_b = empty_db();
+        let mut advanced = order.clone();
+        advanced.source_tx = Some("bth_deposit_tx".to_string());
+        advanced.set_status(OrderStatus::DepositConfirmed);
+        db_b.insert_order(&advanced).unwrap();
+
+        let state = OrderSyncState {
+            federation,
+            db: db_b.clone(),
+            inbound_auth_token: Some(AUTH.to_string()),
+        };
+        let (url, sd, srv) = spawn_order_endpoint(state).await;
+
+        // A late AwaitingDeposit record for the same id is a benign no-op.
+        let env = sign_order_record_ed25519(&order, &ka).unwrap();
+        let (status, body) =
+            post_order(&url, Some(AUTH), &serde_json::to_string(&env).unwrap()).await;
+        assert_eq!(status, 200, "{body}");
+        assert!(body.contains("already_present"), "{body}");
+
+        // The local order is UNCHANGED — never downgraded to AwaitingDeposit.
+        let got = db_b.get_order(&order.id).unwrap().unwrap();
+        assert_eq!(got.status, OrderStatus::DepositConfirmed);
+        assert_eq!(got.source_tx.as_deref(), Some("bth_deposit_tx"));
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+
+    /// Trust boundary: a replicated shell whose deposit the receiver has NOT
+    /// independently confirmed cannot authorize a mint — a valid federation
+    /// mint attestation binds against the on-record order and is refused
+    /// because the shell carries no confirmed source tx.
+    #[tokio::test]
+    async fn replicated_shell_without_independent_confirmation_does_not_authorize() {
+        use crate::attestation::sign_attestation_secp256k1;
+        use alloy::primitives::Address;
+
+        const NONCE: u64 = 7;
+        let (oa, ob) = (eth_key(11), eth_key(22));
+        let owners = vec![oa.address(), ob.address()];
+        let safe = Address::repeat_byte(0x5a);
+        let wbth = Address::repeat_byte(0xeb);
+        let chain_id = 1u64;
+        let ka = ed_key(11); // elected member identity for the record
+        let federation_ed = Arc::new(vec![ka.verifying_key()]);
+        let order = await_mint_order();
+
+        // Receiver B: eth-mint provider (owner ob) + order-sync, EMPTY db.
+        let provider_b = Arc::new(FederationAttestationProvider::new_eth_for_test(
+            &owners,
+            2,
+            chain_id,
+            safe,
+            wbth,
+            Arc::new(FixedNonce(NONCE)),
+            ob.clone(),
+        ));
+        let db_b = empty_db();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let node = PendingNode {
+            listener,
+            url: url.clone(),
+            db: db_b.clone(),
+        };
+        let os = OrderSyncState {
+            federation: federation_ed,
+            db: db_b.clone(),
+            inbound_auth_token: Some(AUTH.to_string()),
+        };
+        let (sd, srv) = serve_pending_combined(node, provider_b.clone(), os);
+
+        // Replicate the AwaitingDeposit shell (no source_tx on record).
+        let rec = sign_order_record_ed25519(&order, &ka).unwrap();
+        let (status, body) =
+            post_order(&url, Some(AUTH), &serde_json::to_string(&rec).unwrap()).await;
+        assert_eq!(status, 200, "{body}");
+
+        // A VALID owner attestation referencing a deposit tx the receiver never
+        // saw. It routes to the shell (no longer `unknown_order`) but binding
+        // fails: the shell has no independently-confirmed source tx.
+        let mut confirmed = order.clone();
+        confirmed.source_tx = Some("bth_deposit_tx".to_string());
+        let kind = eth_mint_kind(&confirmed, NONCE);
+        let now = chrono::Utc::now().timestamp().max(0) as u64;
+        let env = sign_attestation_secp256k1(
+            &kind,
+            &oa,
+            chain_id,
+            safe,
+            wbth,
+            "no-confirm",
+            now,
+            now + 120,
+        )
+        .unwrap();
+        let (status, body) =
+            post_attest(&url, Some(AUTH), &serde_json::to_string(&env).unwrap()).await;
+        assert_eq!(status, 409, "{body}");
+        assert!(body.contains("wrong_order"), "{body}");
+        // The shell never advanced and never collected a signer.
+        assert_eq!(
+            provider_b.distinct_signers_for_test(order.id, "bridge.mint_wbth"),
+            0
+        );
+        assert_eq!(
+            db_b.get_order(&order.id).unwrap().unwrap().status,
+            OrderStatus::AwaitingDeposit
+        );
+
+        let _ = sd.send(());
+        let _ = srv.await;
+    }
+
+    /// Headline acceptance: a two-instance federation with SEPARATE databases
+    /// completes a mint attestation to threshold OVER THE WIRE, where the
+    /// receiving instance learned the order ONLY via signed replication (no
+    /// shared store), then independently confirmed the deposit itself.
+    #[tokio::test]
+    async fn two_node_mint_reaches_threshold_across_separate_dbs_via_replication() {
+        use alloy::primitives::Address;
+
+        const NONCE: u64 = 7;
+        let (oa, ob) = (eth_key(11), eth_key(22));
+        let owners = vec![oa.address(), ob.address()];
+        let safe = Address::repeat_byte(0x5a);
+        let wbth = Address::repeat_byte(0xeb);
+        let chain_id = 1u64;
+        let (ka, kb) = (ed_key(11), ed_key(22));
+        let federation_ed = Arc::new(vec![ka.verifying_key(), kb.verifying_key()]);
+        let order_await = await_mint_order();
+
+        let mk = |local| {
+            FederationAttestationProvider::new_eth_for_test(
+                &owners,
+                2,
+                chain_id,
+                safe,
+                wbth,
+                Arc::new(FixedNonce(NONCE)),
+                local,
+            )
+        };
+
+        // Node A already has the order (its public API created it). Node B's
+        // db is EMPTY — it will learn the order only via replication.
+        let pending_a = pending_node(&order_await).await;
+        let pending_b = pending_empty_node().await;
+        let url_b = pending_b.url.clone();
+        let db_a = pending_a.db.clone();
+        let db_b = pending_b.db.clone();
+
+        let node_a = Arc::new(mk(oa).with_peer_push(push_to(&pending_b.url)));
+        let node_b = Arc::new(mk(ob).with_peer_push(push_to(&pending_a.url)));
+
+        let os_a = OrderSyncState {
+            federation: federation_ed.clone(),
+            db: db_a.clone(),
+            inbound_auth_token: Some(AUTH.to_string()),
+        };
+        let os_b = OrderSyncState {
+            federation: federation_ed.clone(),
+            db: db_b.clone(),
+            inbound_auth_token: Some(AUTH.to_string()),
+        };
+        let (sd_a, srv_a) = serve_pending_combined(pending_a, node_a.clone(), os_a);
+        let (sd_b, srv_b) = serve_pending_combined(pending_b, node_b.clone(), os_b);
+
+        assert!(
+            db_b.get_order(&order_await.id).unwrap().is_none(),
+            "B starts with no knowledge of the order"
+        );
+
+        // 1) A replicates the signed order record to B over the wire.
+        let rec = sign_order_record_ed25519(&order_await, &ka).unwrap();
+        let (status, body) =
+            post_order(&url_b, Some(AUTH), &serde_json::to_string(&rec).unwrap()).await;
+        assert_eq!(status, 200, "{body}");
+        assert_eq!(
+            db_b.get_order(&order_await.id).unwrap().unwrap().status,
+            OrderStatus::AwaitingDeposit
+        );
+
+        // 2) INDEPENDENT deposit confirmation on BOTH nodes (each node's own watcher
+        //    observes the same on-chain deposit).
+        for db in [&db_a, &db_b] {
+            assert!(db
+                .record_deposit_detected(&order_await.id, "bth_deposit_tx", order_await.amount)
+                .unwrap());
+            db.update_order_status(&order_await.id, &OrderStatus::DepositConfirmed, None)
+                .unwrap();
+        }
+
+        // 3) The confirmed order drives the mint attestation over the wire.
+        let mut order = order_await.clone();
+        order.source_tx = Some("bth_deposit_tx".to_string());
+        order.set_status(OrderStatus::DepositConfirmed);
+
+        assert!(
+            node_a.authorize_mint(&order).await.is_err(),
+            "A alone is 1/2"
+        );
+        wait_for(|| node_b.distinct_signers_for_test(order.id, "bridge.mint_wbth") == 1).await;
+        let auth = node_b
+            .authorize_mint(&order)
+            .await
+            .expect("B — which learned the order only via replication — reaches threshold");
+        assert_eq!(auth.signatures.len(), 2);
+        assert!(auth.meets_threshold());
+
+        let _ = sd_a.send(());
+        let _ = sd_b.send(());
+        let _ = srv_a.await;
+        let _ = srv_b.await;
     }
 }

--- a/bridge/service/src/public_api.rs
+++ b/bridge/service/src/public_api.rs
@@ -86,14 +86,21 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use bth_bridge_core::{BridgeConfig, BridgeOrder, Chain, ChainAddress, OrderStatus, OrderType};
+use bth_bridge_core::{
+    sign_order_record_ed25519, BridgeConfig, BridgeOrder, Chain, ChainAddress, OrderStatus,
+    OrderType,
+};
 use chrono::Utc;
+use ed25519_dalek::SigningKey;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::db::{ActivityAggregate, ActivityBreakdown, Database, ReleaseIntent};
+use crate::{
+    db::{ActivityAggregate, ActivityBreakdown, Database, ReleaseIntent},
+    federation::OrderBroadcaster,
+};
 
 /// Runtime configuration snapshot for the public order API, derived from
 /// [`BridgeConfig`] at startup. Held behind an `Arc` in [`PublicApiState`].
@@ -184,6 +191,21 @@ pub struct PublicApiState {
     limiter: Arc<RateLimiter>,
     /// Cached `/api/bridge/stats` aggregate + when it was computed (#1054).
     stats_cache: Arc<Mutex<Option<(Instant, BridgeStatsResponse)>>>,
+    /// Optional signed mint order-record replication to the elected federation
+    /// peers (#1050 Phase 2). `None` (single-node dev, or no local signing
+    /// key / no peers configured) simply disables replication — order-create
+    /// still works, it just is not mirrored to peers.
+    order_replication: Option<Arc<OrderReplication>>,
+}
+
+/// The local signing key + peer broadcaster used to replicate a freshly
+/// created mint order to the elected federation members (#1050 Phase 2).
+pub(crate) struct OrderReplication {
+    /// This node's Ed25519 federation signing key (the elected-member
+    /// identity that authenticates the replicated record).
+    pub signing_key: SigningKey,
+    /// Fan-out to the peers' `POST /api/order` endpoints.
+    pub broadcaster: OrderBroadcaster,
 }
 
 impl PublicApiState {
@@ -194,7 +216,23 @@ impl PublicApiState {
             cfg: Arc::new(cfg),
             limiter: Arc::new(RateLimiter::new()),
             stats_cache: Arc::new(Mutex::new(None)),
+            order_replication: None,
         }
+    }
+
+    /// Enable #1050 Phase 2 order-record replication: every mint order created
+    /// through this API is signed with `signing_key` and pushed to the
+    /// elected peers via `broadcaster`.
+    pub fn with_order_replication(
+        mut self,
+        signing_key: SigningKey,
+        broadcaster: OrderBroadcaster,
+    ) -> Self {
+        self.order_replication = Some(Arc::new(OrderReplication {
+            signing_key,
+            broadcaster,
+        }));
+        self
     }
 }
 
@@ -653,6 +691,22 @@ async fn create_mint_order(
         &format!("public API mint order: dest={} amount={}", chain, amount),
     ) {
         warn!("public api: audit log failed: {}", e);
+    }
+
+    // #1050 Phase 2: replicate the AwaitingDeposit shell to the elected
+    // federation peers so their own watchers can independently confirm the
+    // deposit (closing the `refused:unknown_order` gap for a separate-DB
+    // federation). Signed with this node's federation identity; fire-and-forget
+    // (a slow/unreachable peer must never fail order-create). Peers gain NO
+    // trust from the record — see `federation::receive_order`.
+    if let Some(repl) = &state.order_replication {
+        match sign_order_record_ed25519(&order, &repl.signing_key) {
+            Ok(env) => repl.broadcaster.broadcast(&env),
+            Err(e) => warn!(
+                "public api: could not sign order record for replication: {}",
+                e
+            ),
+        }
     }
 
     (

--- a/scripts/bridge-testnet-federation.sh
+++ b/scripts/bridge-testnet-federation.sh
@@ -16,17 +16,24 @@
 # asserting exactly-once, factor-1 amounts (ADR 0003), and the live
 # proof-of-reserves invariant (Σ wBTH == locked reserve).
 #
-# TOPOLOGY (single-host federation). The N instances run on one host and
-# share ONE SQLite order store (WAL + busy-timeout, see
-# bridge/service/src/db.rs). Sharing the order store is what today's code
-# supports: order records do NOT replicate between instances over the network
-# (the #858 transport exchanges attestation envelopes only — an envelope for
-# an order a peer has never heard of is refused `unknown_order`). The
-# CRYPTOGRAPHIC custody is still genuinely t-of-n over the wire: each process
-# signs with only ITS key, envelopes travel through the real authenticated
-# HTTP endpoint, and no mint/release is prepared until `threshold` distinct
-# federation signatures verify. Cross-host order replication is the tracked
-# follow-up (see the #868 findings issue).
+# TOPOLOGY. The N instances run on one host. By default they share ONE SQLite
+# order store (WAL + busy-timeout, see bridge/service/src/db.rs) — the
+# historical topology that papered over cross-member order-record convergence.
+# The CRYPTOGRAPHIC custody is genuinely t-of-n over the wire either way: each
+# process signs with only ITS key, envelopes travel through the real
+# authenticated HTTP endpoint, and no mint/release is prepared until
+# `threshold` distinct federation signatures verify.
+#
+# SEPARATE-DB topology (BRIDGE_FED_SEPARATE_DB=1, #1050): each member gets its
+# OWN store ($RUN_DIR/member-<i>.db) — a genuinely distributed deployment with
+# NO shared store. The burn/release leg converges via deterministic order ids
+# (Phase 1). The mint leg now converges via signed order-record replication
+# (Phase 2): a mint order created on member 1's public API is signed with that
+# member's ed25519 federation key and pushed to every peer's `POST /api/order`,
+# which persists a trust-free AwaitingDeposit shell so each peer's OWN watcher
+# can independently confirm the deposit and attest. A record from a non-member
+# is refused; a replicated shell grants NO trust (no mint without independent
+# on-chain confirmation).
 #
 # SECRETS. Everything lives under .secrets/bridge-testnet/ (git-ignored,
 # testnet-disposable). NEVER point this at .secrets/bridge-mainnet.
@@ -60,6 +67,9 @@
 # ENV KNOBS (defaults target the LIVE testnet):
 #   BRIDGE_FED_NODES=3                 federation size n
 #   BRIDGE_FED_THRESHOLD=2             threshold t
+#   BRIDGE_FED_SEPARATE_DB=0           1 = per-member DBs, no shared store
+#                                      (#1050: exercises signed order-record
+#                                      replication for the mint leg)
 #   BRIDGE_BTH_RPC_URL=https://seed.botho.io/rpc
 #   SEPOLIA_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
 #   SOLANA_RPC_URL=https://api.devnet.solana.com
@@ -127,6 +137,22 @@ RUN_DIR="${BRIDGE_FED_RUN_DIR:-$SECRETS_DIR/federation-run}"
 
 N="${BRIDGE_FED_NODES:-3}"
 T="${BRIDGE_FED_THRESHOLD:-2}"
+
+# Separate-DB topology (#1050 Phase 2). Default 0 = the historical single-host
+# topology where every instance shares one SQLite store ($RUN_DIR/shared.db),
+# which papered over cross-member order-record convergence. Set to 1 to give
+# each member its OWN database ($RUN_DIR/member-<i>.db): a genuinely
+# distributed deployment where a mint order created on one member must
+# REPLICATE (signed, over the wire) to the others' /api/order endpoints before
+# they can reach threshold. This exercises the real Phase-2 path. Burn/release
+# already converges via deterministic ids (Phase 1) with no shared store.
+SEPARATE_DB="${BRIDGE_FED_SEPARATE_DB:-0}"
+
+# The SQLite path for instance <i>: a shared store, or a per-member store in
+# the separate-DB topology.
+db_path_for() {
+    if [[ "$SEPARATE_DB" == "1" ]]; then echo "$RUN_DIR/member-$1.db"; else echo "$RUN_DIR/shared.db"; fi
+}
 
 BTH_RPC="${BRIDGE_BTH_RPC_URL:-https://seed.botho.io/rpc}"
 # Per-instance BTH RPC endpoints (comma-separated). Each federation member
@@ -374,7 +400,7 @@ $sol_block
 
 [bridge]
 mnemonic_file = "$RUN_DIR/unused-mnemonic"
-db_path = "$RUN_DIR/shared.db"
+db_path = "$(db_path_for "$i")"
 fee_bps = 10
 max_order_amount = $MAX_ORDER_PC
 daily_limit_per_address = $DAILY_LIMIT_PC
@@ -410,10 +436,19 @@ cmd_up() {
         render_config "$i"
     done
 
-    # Initialize the SHARED database once (schema + persistent WAL mode)
-    # before any instance races to create it.
-    "$BRIDGE_BIN" --config "$RUN_DIR/bridge-1.toml" --migrate >/dev/null 2>&1 ||
-        die "database migration failed (see $RUN_DIR/bridge-1.toml)"
+    # Initialize the database(s): the shared store once, or every member's
+    # own store in the separate-DB topology (#1050 Phase 2), before any
+    # instance races to create it.
+    if [[ "$SEPARATE_DB" == "1" ]]; then
+        log "separate-DB topology: each member gets its own store (order records replicate over /api/order)"
+        for i in $(seq 1 "$N"); do
+            "$BRIDGE_BIN" --config "$RUN_DIR/bridge-$i.toml" --migrate >/dev/null 2>&1 ||
+                die "database migration failed for member $i (see $RUN_DIR/bridge-$i.toml)"
+        done
+    else
+        "$BRIDGE_BIN" --config "$RUN_DIR/bridge-1.toml" --migrate >/dev/null 2>&1 ||
+            die "database migration failed (see $RUN_DIR/bridge-1.toml)"
+    fi
 
     # Staggered start: wait for each instance's /health before the next, so
     # concurrent first-boot writes never contend on the shared store.
@@ -490,9 +525,22 @@ cmd_order_status() {
     curl -sf "$(public_api)/api/bridge/orders/$id" | jq .
 }
 
-db_query() { sqlite3 -readonly "$RUN_DIR/shared.db" "$1"; }
+# db_query <sql> [member-index]. Reads the shared store, or a specific
+# member's store in the separate-DB topology (default member 1, the public-API
+# creator). Pass a member index to inspect a peer's own replicated view.
+db_query() { sqlite3 -readonly "$(db_path_for "${2:-1}")" "$1"; }
 
 cmd_orders() {
+    if [[ "$SEPARATE_DB" == "1" ]]; then
+        local i
+        for i in $(seq 1 "$N"); do
+            log "── member $i order table ($(db_path_for "$i")) ──"
+            db_query "SELECT id, order_type, source_chain || '->' || dest_chain, amount, fee, status,
+                             COALESCE(source_tx,'-'), COALESCE(dest_tx,'-')
+                      FROM bridge_orders ORDER BY created_at;" "$i" | column -t -s '|'
+        done
+        return
+    fi
     db_query "SELECT id, order_type, source_chain || '->' || dest_chain, amount, fee, status,
                      COALESCE(source_tx,'-'), COALESCE(dest_tx,'-')
               FROM bridge_orders ORDER BY created_at;" | column -t -s '|'


### PR DESCRIPTION
## Summary

Phase 2 of #1050. The #858 attestation transport exchanges *envelopes* only — mint order **records** never replicate between members, so a genuinely distributed (multi-host, separate-DB) t-of-n federation refuses a peer's mint envelope with `refused:unknown_order` and can never reach threshold. Phase 1 (deterministic burn ids, merged PR #1072) already closed the release/burn leg; this closes the **mint leg** with a signed, trust-bounded order-record replication path sized for the ≤5-machine elected multisig (ADR 0010 / #1060).

Security-first: accepting a replicated record grants **no trust**. The wire type is structurally incapable of carrying a status, an authorization, or a dest/source tx; each receiving member still independently confirms the on-chain deposit through its own watcher before it will attest. The signature only authenticates *which elected member proposed the order*.

## Changes

**Core (`bth-bridge-core`, new `order_sync` module):**
- `MintOrderShell` — the minimal, trust-free projection of a mint order (id, dest chain, amount, fee, deposit/dest addresses, memo, created-at). No `status` / `mint_authorization` / `dest_tx` / `source_tx` field: the type *is* the trust boundary. Reconstitution is always a fresh `AwaitingDeposit` order.
- `OrderRecordEnvelope` + `sign_order_record_ed25519` / `verify_ed25519` — domain-separated Ed25519 signature (`botho-bridge-order-record-v1`, distinct from the attestation domains). Parse-after-verify with unknown/duplicate-key rejection; a non-member signer is refused `unknown_signer`; the memo must embed its own order id.

**Service:**
- `POST /api/order` (`federation.rs`) — authenticated inbound endpoint (same bearer fence as `/api/attest`). Verifies against the elected member set, persists **only** an `AwaitingDeposit` shell, and is idempotent + **non-destructive**: a record for an id that already exists locally is a no-op, so a replicated shell can never overwrite or downgrade an order that already advanced (exactly-once / no-double-mint guard).
- `OrderBroadcaster` — fire-and-forget fan-out to peers' `/api/order` (mirrors `PeerBroadcaster`; never blocks/fails order-create).
- `public_api.rs` broadcasts the signed shell on mint-order create; `engine.rs` co-mounts the endpoint on the federation listener and wires the broadcaster + local Ed25519 key. Replication is enabled only when a local key, an elected member set (`bth.release_signers`), and peers are all configured; otherwise it is silently disabled (single-node dev unaffected).

**Script:** `BRIDGE_FED_SEPARATE_DB=1` gives each member its own SQLite store (`member-<i>.db`) instead of the shared `shared.db`, exercising the real Phase-2 replication path end-to-end.

## Acceptance Criteria Verification

| Criterion (from issue / task) | Status | Verification |
|---|---|---|
| Replicated records are authenticated (signed by originating member) and validated against the ≤5-member set; never accept from an unelected peer | ✅ | `verify_ed25519` selects the member key by id and `verify_strict`; unit `record_from_unknown_signer_is_rejected` + service `order_record_from_a_non_member_is_rejected_and_not_persisted` |
| Preserve exactly-once / no-double-mint; a replicated record must not let a receiver independently mint | ✅ | Shell type carries no confirmation; endpoint persists `AwaitingDeposit` only and never overwrites an existing order; `replicated_shell_without_independent_confirmation_does_not_authorize`, `order_record_does_not_overwrite_an_existing_advanced_order` |
| Unit test: valid replication reaches threshold across separate DBs | ✅ | `two_node_mint_reaches_threshold_across_separate_dbs_via_replication` (B learns the order only via `/api/order`, independently confirms, reaches 2-of-2 over the wire) |
| Unit test: unknown-peer order record rejected | ✅ | core + service tests above |
| Unit test: tampered / mis-signed record rejected | ✅ | `tampered_record_body_is_rejected`, `relabeled_signer_id_is_rejected`, `order_record_tampered_body_is_rejected_and_not_persisted` |
| Script gains a mode without the shared DB | ✅ | `BRIDGE_FED_SEPARATE_DB=1` → per-member stores, per-member migrate, per-member `orders` snapshot |

## Test Plan

- `cargo test -p bth-bridge-core -p bth-bridge-service` — core 106 pass, service 258 pass (7 new Phase-2 tests + 9 new core tests).
- `cargo clippy -p bth-bridge-core -p bth-bridge-service --all-targets` — clean.
- `cargo fmt` applied; `bash -n scripts/bridge-testnet-federation.sh` clean.

## Scope note

Implements the full in-scope Phase-2 surface from the curation (signed `/api/order` replication, the `AwaitingDeposit`-shell trust boundary, closing the `unknown_order` gap, separate-DB script mode, two-node separate-DB mint tests). Out of scope per the curation and untouched here: election mechanics, key rotation/handover, on-chain Safe changes, and any live-infra/mainnet action.

Closes #1050