### PR TITLE
feat(snap): persist scan state + windowed incremental scanning via snap_manageState

### DIFF
--- a/web/packages/snap/README.md
+++ b/web/packages/snap/README.md
@@ -36,6 +36,67 @@ node-trust model. Before any balance/send the Snap runs a wrong-network guard
 mirroring the web wallet's `validateRpcEndpointForNetwork` (#811). Keys **never
 leave the sandbox**.
 
+## Persisted state & incremental scanning (#1091)
+
+The Phase-1 MVP kept **no** persisted state: every `botho_getBalance` /
+`botho_showBalance` re-scanned the whole chain from genesis (`getOutputs(0, tip)`),
+which is O(chain height) per read and forgotten the moment the Snap execution
+context ends. Phase-2 adds the Snap's first persisted surface via the
+`snap_manageState` permission (`src/state.ts`) and makes scanning incremental and
+resumable.
+
+**Encrypted, versioned, network-bound blob.** State is stored with MetaMask's
+default `encrypted: true` (owned outputs leak amounts + one-time target keys, so
+they must be encrypted at rest — cf. the web-wallet at-rest audit #474/#475). The
+top-level shape is **namespaced** so the sibling Phase-2 consumers extend it
+without a migration:
+
+```jsonc
+{
+  "version": 1,               // schema version; a mismatch discards + rescans
+  "scan": {                   // #1091 (this issue)
+    "network": "botho-testnet",   // node network these outputs were found on
+    "lastScannedHeight": 202,      // resume checkpoint (highest block scanned)
+    "ownedOutputs": [
+      {
+        "targetKey": "…", "publicKey": "…",
+        "amount": "1500000000000",   // JSON-safe u64 picocredits (string)
+        "subaddressIndex": "1",       // preserved for key-image correctness
+        "outputIndex": 3, "kemCiphertext": "…|null",  // hybrid recovery (#988)
+        "blockHeight": 42, "txHash": "…"  // receive facts for history (#1092)
+      }
+    ]
+  }
+  // reserved (do NOT implement here):
+  // "contacts": { … }         // #1093
+  // "settings": { "rpcUrl": … } // in-Snap ingress selection
+}
+```
+
+**Only immutable receive facts are persisted.** Owned outputs and their receive
+`blockHeight`/`txHash` never change once mined, so they are cached. Spent status
+is **deliberately not persisted** — an output can be spent later, so it is
+recomputed **live** on every balance read via `chain_areKeyImagesSpent` (the
+`spendableOwnedOutputs` split modelled in `wasm-signer/src/send.ts`).
+
+**Windowed, resumable scan.** A balance read walks `(checkpoint − reorg buffer,
+tip]` in fixed-size windows (`WINDOW_SIZE`, via a meta-carrying `chain_getOutputs`
+fetch that preserves per-block height + per-output txHash), merges newly-owned
+outputs (deduped by target key), advances the checkpoint, then live-filters spent
+status over the **full** persisted owned set for the sum. A second read at the
+same tip fetches only the trailing reorg-buffer window instead of re-scanning
+from genesis.
+
+**Invalidation.** If the persisted `scan.network` differs from the connected
+node's reported network, or the schema `version` differs, the blob is discarded
+and the wallet rescans from height 0 — preventing cross-network / stale-schema
+contamination even for loopback nodes the wrong-network guard exempts.
+
+**Reorg safety.** betanet can reorg and exposes no explicit finality signal to the
+Snap, so on resume the scan re-covers a small trailing `REORG_BUFFER` of blocks
+below the checkpoint; the target-key dedupe makes the overlap idempotent (never
+double-counts).
+
 ## Key derivation: MetaMask SRP → Botho RootIdentity
 
 ```
@@ -87,7 +148,8 @@ alternative:
 | `src/index.ts` | `onRpcRequest` handler + dialog orchestration |
 | `src/derivation.ts` | SIP-6 entropy → Botho `SnapWallet` (SLIP-10 + PQ keys + address) |
 | `src/signer.ts` | Inject the inlined bundler wasm into `@botho/wasm-signer` via `setSigner` |
-| `src/node.ts` | JSON-RPC node client, `isValidRpcUrl`, wrong-network guard, `SendRpc` |
+| `src/node.ts` | JSON-RPC node client, `isValidRpcUrl`, wrong-network guard, `SendRpc`, meta-carrying windowed fetch (`getOutputsWithMeta`) |
+| `src/state.ts` | Persisted `snap_manageState` blob (`{ version, scan }`) + windowed/incremental-scan orchestrator (#1091) |
 | `src/ui.ts` | Snaps custom-UI dialog content (receive / balance / send / mnemonic) |
 | `src/format.ts` | SES-safe (Intl-free) picocredit → BTH formatting |
 
@@ -125,6 +187,11 @@ Coverage:
   never submits without funds.
 - `units.snap.ts` — pure-logic tests for the wrong-network guard (incl. the
   loopback exemption a loopback mock can't trigger) and SES-safe formatting.
+- `state.snap.ts` — persisted-state contract (namespaced `{ version, scan }`,
+  owned outputs carrying `blockHeight`/`txHash` with no persisted spent status,
+  target-key dedupe, window boundaries, reorg-buffer resume, network/version
+  invalidation) plus the incremental-scan win driven off `node.calls`: a second
+  read at the same tip fetches no new windows beyond the reorg buffer.
 
 ## Deferred (out of scope for this MVP)
 
@@ -135,11 +202,13 @@ Coverage:
   live-send validation is a follow-up, **blocked on betanet resume (#1051)**.
   (The spike demonstrated a working real send against a throwaway solo node; that
   path relied on spike-only test hooks that are intentionally absent here.)
-- **Phase 2 parity** (per the issue): transaction history, contacts, in-Snap
-  ingress selection UX, i18n, incremental/windowed scanning with persisted scan
-  state (`snap_manageState` — the shared scaling concern with the web wallet),
-  and a dedicated **security pass** for the new key-handling surface (cf. the
-  web-wallet at-rest audit, #474/#475).
+- **Phase 2 parity** (per the issue): transaction history (#1092), contacts
+  (#1093), in-Snap ingress selection UX, i18n, and a dedicated **security pass**
+  for the new key-handling surface (cf. the web-wallet at-rest audit, #474/#475).
+  **Shipped:** incremental/windowed scanning with persisted, encrypted scan state
+  (`snap_manageState`) — the shared scaling concern with the web wallet — is now
+  live (#1091; see "Persisted state & incremental scanning" above). It is the
+  foundation #1092 (history) and #1093 (contacts) build on.
 - **Publishing / distribution** — npm publish + MetaMask allowlist, and pinning
   the production snap id (see the snap-id pinning trade-off above).
 

--- a/web/packages/snap/snap.manifest.json
+++ b/web/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Manage a privacy-by-default Botho wallet from inside MetaMask. Keys are derived from your MetaMask Secret Recovery Phrase and never leave the Snap sandbox.",
   "proposedName": "Botho Wallet",
   "source": {
-    "shasum": "/tRpO3ie+iehmIMIBAY7y/evdJA5MOpka4AHFDsmkIs=",
+    "shasum": "QtVwYZJx++kxtG84ca/iXOWupzw/wmdbRZXm7Y/9nW4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -19,7 +19,8 @@
     "endowment:webassembly": {},
     "endowment:network-access": {},
     "snap_getEntropy": {},
-    "snap_dialog": {}
+    "snap_dialog": {},
+    "snap_manageState": {}
   },
   "platformVersion": "11.2.0",
   "manifestVersion": "0.1"

--- a/web/packages/snap/src/index.ts
+++ b/web/packages/snap/src/index.ts
@@ -38,14 +38,15 @@ import {
 } from '@metamask/snaps-sdk';
 import {
   buildSendTransaction,
-  spendableBalance,
+  loadSigner,
   type RecipientAddress,
 } from '@botho/wasm-signer';
 import { parseAddress } from '@botho/core';
 
 import { ensureSigner, wasm } from './signer';
 import { deriveWallet, revealMnemonic, DERIVATION_DESCRIPTION } from './derivation';
-import { connectAndGuard, makeSendRpc } from './node';
+import { connectAndGuard, getOutputsWithMeta, makeSendRpc, EXPECTED_NETWORK_ID } from './node';
+import { incrementalScanBalance } from './state';
 import {
   receiveContent,
   balanceContent,
@@ -116,6 +117,30 @@ function optionalFee(params: Record<string, unknown> | undefined): bigint {
   return fee;
 }
 
+/**
+ * Compute the wallet's spendable balance via the persisted-state, windowed
+ * incremental scan (#1091). Resumes from the last-scanned checkpoint in
+ * `snap_manageState` instead of re-scanning the whole chain from genesis; spent
+ * status is recomputed live on every read. Shared by `botho_getBalance` and
+ * `botho_showBalance`.
+ */
+async function scanBalance(rpcUrl: string): Promise<bigint> {
+  const { call, status } = await connectAndGuard(rpcUrl);
+  const wallet = await deriveWallet();
+  const signer = await loadSigner();
+  return incrementalScanBalance({
+    signer,
+    keys: wallet.keys,
+    // Bind persisted scan state to the node's reported network so a later read
+    // against a different network is invalidated (loopback dev nodes may not
+    // report one — fall back to the expected id to keep the binding stable).
+    network: status.network ?? EXPECTED_NETWORK_ID,
+    tip: status.chainHeight,
+    fetchWindow: getOutputsWithMeta(call),
+    sendRpc: makeSendRpc(call),
+  });
+}
+
 /** Ask the user to approve/reject a confirmation dialog. */
 async function confirm(content: unknown): Promise<boolean> {
   return (await snap.request({
@@ -147,9 +172,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
     case 'botho_getBalance': {
       const rpcUrl = requireString(params, 'rpcUrl');
-      const { call } = await connectAndGuard(rpcUrl);
-      const wallet = await deriveWallet();
-      const balance = await spendableBalance(wallet.keys, makeSendRpc(call));
+      const balance = await scanBalance(rpcUrl);
       return { spendablePicocredits: balance.toString() } as Json;
     }
 
@@ -164,9 +187,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
     case 'botho_showBalance': {
       const rpcUrl = requireString(params, 'rpcUrl');
-      const { call } = await connectAndGuard(rpcUrl);
-      const wallet = await deriveWallet();
-      const balance = await spendableBalance(wallet.keys, makeSendRpc(call));
+      const balance = await scanBalance(rpcUrl);
       await alert(balanceContent(balance, rpcUrl));
       return { spendablePicocredits: balance.toString() } as Json;
     }

--- a/web/packages/snap/src/node.ts
+++ b/web/packages/snap/src/node.ts
@@ -10,7 +10,12 @@
  * are exempt (local dev nodes may report other network names).
  */
 
-import type { ChainOutput, KeyImageSpentStatus, SendRpc } from '@botho/wasm-signer';
+import type {
+  ChainOutput,
+  ChainOutputWithMeta,
+  KeyImageSpentStatus,
+  SendRpc,
+} from '@botho/wasm-signer';
 
 /**
  * The network id a node must report (via `node_getStatus`'s `network` field) to
@@ -131,6 +136,11 @@ interface RawOutput {
   kemCiphertext?: string | null;
 }
 
+/** A `chain_getOutputs` output row that also carries its creating tx hash. */
+interface RawOutputWithMeta extends RawOutput {
+  txHash: string;
+}
+
 /** Decode a little-endian hex `u64` amount commitment into a bigint. */
 function leHexToBigInt(hex: string): bigint {
   let result = 0n;
@@ -168,5 +178,36 @@ export function makeSendRpc(call: NodeCall): SendRpc {
     },
     areKeyImagesSpent: (keyImages) =>
       call<KeyImageSpentStatus[]>('chain_areKeyImagesSpent', { keyImages }),
+  };
+}
+
+/**
+ * Fetch every output in the inclusive block range `[start, end]` WITH the
+ * metadata client-side history + the persisted scan-state need: each block's
+ * `height` and each output's creating `txHash`. This is the same
+ * `chain_getOutputs` RPC as {@link makeSendRpc}'s `getOutputs`, but preserves the
+ * per-block height + per-output txHash that the flat `getOutputs` drops. The
+ * windowed/incremental scanner (`state.ts`) calls this one window at a time.
+ */
+export function getOutputsWithMeta(call: NodeCall) {
+  return async (start: number, end: number): Promise<ChainOutputWithMeta[]> => {
+    const blocks = await call<Array<{ height: number; outputs: RawOutputWithMeta[] }>>(
+      'chain_getOutputs',
+      { start_height: start, end_height: end },
+    );
+    return blocks.flatMap((b) =>
+      b.outputs.map(
+        (o): ChainOutputWithMeta => ({
+          targetKey: o.targetKey,
+          publicKey: o.publicKey,
+          amount: leHexToBigInt(o.amountCommitment),
+          outputIndex:
+            o.outputIndex === COINBASE_OUTPUT_INDEX_SENTINEL ? 0 : o.outputIndex,
+          kemCiphertext: o.kemCiphertext ?? null,
+          txHash: o.txHash,
+          height: b.height,
+        }),
+      ),
+    );
   };
 }

--- a/web/packages/snap/src/state.ts
+++ b/web/packages/snap/src/state.ts
@@ -1,0 +1,334 @@
+/**
+ * Persisted Snap state + windowed/incremental scanning (Phase-2 foundation,
+ * issue #1091).
+ *
+ * The Phase-1 MVP kept **no** persisted state: every `botho_getBalance` /
+ * `botho_showBalance` re-scanned the whole chain from genesis
+ * (`spendableBalance` -> `getOutputs(0, tip)`), which is O(chain height) per read
+ * and forgets everything the moment the Snap execution context ends. This module
+ * introduces the Snap's first persisted surface via `snap_manageState` and turns
+ * scanning into an incremental, resumable operation.
+ *
+ * Design (see the issue for the full rationale):
+ *
+ *  - **Encrypted at rest.** Owned outputs leak amounts and one-time target keys,
+ *    so the blob is stored with MetaMask's default `encrypted: true` state (cf.
+ *    the web-wallet at-rest lessons #474/#475). Keys never leave the sandbox.
+ *
+ *  - **Namespaced + versioned.** The top-level blob is `{ version, scan }` so the
+ *    sibling Phase-2 consumers can extend it WITHOUT a migration: #1092 (history)
+ *    reads `scan.ownedOutputs` (which already carry `blockHeight`/`txHash`), and
+ *    #1093 (contacts) adds a `contacts` sibling key. `version` guards a future
+ *    breaking schema change.
+ *
+ *  - **Network-bound + invalidated.** `scan.network` records the node network the
+ *    outputs were discovered on. If a later read sees a different reported network
+ *    (or a `version` mismatch), the persisted scan is discarded and we rescan from
+ *    genesis. This prevents cross-network / stale-schema contamination even for
+ *    loopback nodes that the wrong-network guard intentionally exempts.
+ *
+ *  - **Only immutable receive facts are persisted.** We store the owned outputs
+ *    and their receive `blockHeight`/`txHash` — facts that never change once an
+ *    output is mined. We deliberately do NOT persist spent/unspent status: an
+ *    output can be spent later, so spent status is recomputed LIVE on every
+ *    balance read via `chain_areKeyImagesSpent` (the `spendableOwnedOutputs`
+ *    split already modelled in `wasm-signer/src/send.ts`).
+ *
+ *  - **Reorg safety.** betanet can reorg. On resume we conservatively re-scan a
+ *    small trailing `REORG_BUFFER` of blocks below the checkpoint so a shallow
+ *    reorg near the tip is picked up; merges dedupe by one-time target key so the
+ *    overlap never double-counts.
+ */
+
+import type {
+  ChainOutputWithMeta,
+  OwnedOutput,
+  SendRpc,
+  SignerKeys,
+  WasmSigner,
+} from '@botho/wasm-signer';
+import { spendableOwnedOutputs } from '@botho/wasm-signer';
+
+declare const snap: {
+  request(args: { method: string; params?: unknown }): Promise<unknown>;
+};
+
+/**
+ * Persisted-state schema version. Bump ONLY for a breaking change to the shape
+ * below; a mismatch triggers a clean discard + full rescan (never a silent
+ * mis-parse of an older blob).
+ */
+export const STATE_VERSION = 1;
+
+/**
+ * How many blocks per `chain_getOutputs` window. The scan walks `(start, tip]` in
+ * fixed-size windows rather than one whole-chain fetch, so a resumed scan only
+ * pulls the new tail. Large enough that a short chain is a single request.
+ */
+export const WINDOW_SIZE = 1000;
+
+/**
+ * Trailing blocks re-scanned below the checkpoint on resume, to absorb a shallow
+ * tip reorg (betanet can reorg). Small: the overlap is re-fetched every read, and
+ * merges dedupe by target key so it never double-counts. Chosen over trusting a
+ * finalized depth because betanet has no explicit finality signal in the Snap's
+ * RPC surface today.
+ */
+export const REORG_BUFFER = 10;
+
+/**
+ * A single owned output persisted across sessions. Only IMMUTABLE receive facts
+ * live here — never spent status (recomputed live each read).
+ */
+export interface PersistedOwnedOutput {
+  /** Hex one-time target key (unique per output; the dedupe/merge key). */
+  targetKey: string;
+  /** Hex ephemeral public key of the output. */
+  publicKey: string;
+  /** JSON-safe u64 picocredits (bigint serialised as a decimal string). */
+  amount: string;
+  /**
+   * Subaddress index that received the output (0 = default, 1 = change),
+   * serialised as a decimal string. Persisted because key-image recovery (hence
+   * the live spent-status check) is subaddress-dependent — dropping it would
+   * mis-derive change outputs' key images.
+   */
+  subaddressIndex: string;
+  /** Output position within its creating tx — hybrid recovery (#988). */
+  outputIndex: number;
+  /** Hex ML-KEM-768 ciphertext, or null for a classical output — #988. */
+  kemCiphertext: string | null;
+  /** Receive block height. Carried so #1092 renders history with no rescan. */
+  blockHeight: number;
+  /** Creating tx hash (hex). Carried so #1092 renders history with no rescan. */
+  txHash: string;
+}
+
+/** The incremental-scan checkpoint + discovered owned outputs. */
+export interface ScanState {
+  /** Node network id these outputs were discovered on (invalidation key). */
+  network: string;
+  /** Highest block height fully scanned (the resume checkpoint). */
+  lastScannedHeight: number;
+  /** Every owned output discovered so far (spent AND unspent — filtered live). */
+  ownedOutputs: PersistedOwnedOutput[];
+}
+
+/**
+ * The top-level persisted blob. Namespaced so Phase-2 siblings extend it without
+ * a migration:
+ *   - `scan`      — this issue (#1091)
+ *   - `contacts`  — #1093 (reserved; do NOT implement here)
+ *   - `settings`  — in-Snap ingress selection (reserved)
+ */
+export interface SnapState {
+  /** Schema version; see {@link STATE_VERSION}. */
+  version: number;
+  /** Incremental-scan state (absent until the first balance read). */
+  scan?: ScanState;
+  // Reserved for sibling consumers (do NOT implement here):
+  // contacts?: ContactBook;          // #1093
+  // settings?: { rpcUrl?: string };  // in-Snap ingress selection
+}
+
+/* ------------------------------------------------------------------ */
+/* snap_manageState wrappers (the only impure surface in this module) */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Read the persisted (encrypted) state blob, or `null` if the Snap has never
+ * written one (fresh install / after a clear).
+ */
+export async function readState(): Promise<SnapState | null> {
+  const state = (await snap.request({
+    method: 'snap_manageState',
+    params: { operation: 'get', encrypted: true },
+  })) as SnapState | null;
+  return state ?? null;
+}
+
+/** Persist the (encrypted) state blob, replacing any previous value. */
+export async function writeState(state: SnapState): Promise<void> {
+  await snap.request({
+    method: 'snap_manageState',
+    params: { operation: 'update', newState: state as unknown as Record<string, unknown>, encrypted: true },
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* Pure helpers (unit-testable without the SES `snap` global)         */
+/* ------------------------------------------------------------------ */
+
+/** A fresh, empty scan checkpoint bound to `network` (nothing scanned yet). */
+export function emptyScanState(network: string): ScanState {
+  return { network, lastScannedHeight: 0, ownedOutputs: [] };
+}
+
+/**
+ * Return the persisted scan state IFF it is safe to resume from: schema version
+ * matches AND it was discovered on the same network. Otherwise `null` — the
+ * caller must discard it and rescan from genesis (stale-schema / cross-network
+ * invalidation).
+ */
+export function usableScanState(state: SnapState | null, network: string): ScanState | null {
+  if (!state || state.version !== STATE_VERSION) return null;
+  if (!state.scan || state.scan.network !== network) return null;
+  return state.scan;
+}
+
+/**
+ * First block height to re-scan on resume: `lastScannedHeight - REORG_BUFFER`,
+ * clamped at 0. The buffer re-scans a few trailing blocks so a shallow tip reorg
+ * is absorbed; merges dedupe by target key so it never double-counts.
+ */
+export function scanStartHeight(lastScannedHeight: number): number {
+  return Math.max(0, lastScannedHeight - REORG_BUFFER);
+}
+
+/**
+ * Split the inclusive block range `[start, tip]` into fixed-size windows for
+ * `chain_getOutputs`. Returns `[]` when there is nothing to scan (`tip < start`,
+ * e.g. a chain that shrank below the checkpoint), so a no-op resume issues no
+ * output-window fetches at all.
+ */
+export function windows(start: number, tip: number, size: number = WINDOW_SIZE): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  if (tip < start) return out;
+  for (let lo = start; lo <= tip; lo += size) {
+    out.push([lo, Math.min(lo + size - 1, tip)]);
+  }
+  return out;
+}
+
+/** Convert a wasm `OwnedOutput` + its chain meta into a persisted record. */
+export function toPersistedOwnedOutput(
+  owned: OwnedOutput,
+  meta: { blockHeight: number; txHash: string },
+): PersistedOwnedOutput {
+  return {
+    targetKey: owned.targetKey,
+    publicKey: owned.publicKey,
+    amount: owned.amount.toString(),
+    subaddressIndex: owned.subaddressIndex.toString(),
+    outputIndex: owned.outputIndex ?? 0,
+    kemCiphertext: owned.kemCiphertext ?? null,
+    blockHeight: meta.blockHeight,
+    txHash: meta.txHash,
+  };
+}
+
+/** Rehydrate a persisted record into the `OwnedOutput` the signer/spent-check consumes. */
+export function toOwnedOutput(p: PersistedOwnedOutput): OwnedOutput {
+  return {
+    targetKey: p.targetKey,
+    publicKey: p.publicKey,
+    amount: BigInt(p.amount),
+    subaddressIndex: BigInt(p.subaddressIndex),
+    outputIndex: p.outputIndex,
+    kemCiphertext: p.kemCiphertext,
+  };
+}
+
+/**
+ * Merge newly-discovered owned outputs into the persisted set, deduped by
+ * one-time target key (which is globally unique per output). Existing records
+ * win, so a re-scanned reorg-buffer block never appends a duplicate. Returns a
+ * new array (does not mutate `existing`).
+ */
+export function mergeOwnedOutputs(
+  existing: PersistedOwnedOutput[],
+  discovered: PersistedOwnedOutput[],
+): PersistedOwnedOutput[] {
+  const byKey = new Map<string, PersistedOwnedOutput>();
+  for (const o of existing) byKey.set(o.targetKey, o);
+  for (const o of discovered) if (!byKey.has(o.targetKey)) byKey.set(o.targetKey, o);
+  return Array.from(byKey.values());
+}
+
+/* ------------------------------------------------------------------ */
+/* Orchestrator (keeps index.ts thin)                                 */
+/* ------------------------------------------------------------------ */
+
+/** Inputs to {@link incrementalScanBalance}. */
+export interface IncrementalScanArgs {
+  /** The injected wasm signer (node-identical ownership + key-image checks). */
+  signer: WasmSigner;
+  /** The wallet's private keys (stay in the sandbox). */
+  keys: SignerKeys;
+  /** The connected node's reported network id (the state-binding key). */
+  network: string;
+  /** The connected node's current chain tip. */
+  tip: number;
+  /** Windowed meta fetch over `chain_getOutputs` (block height + tx hash). */
+  fetchWindow: (lo: number, hi: number) => Promise<ChainOutputWithMeta[]>;
+  /** RPC slice for the LIVE spent-status filter (`chain_areKeyImagesSpent`). */
+  sendRpc: SendRpc;
+}
+
+/**
+ * The persisted-state, incremental-scan replacement for `spendableBalance`.
+ *
+ *   read state -> (in)validate vs network/version -> windowed scan of the
+ *   `(checkpoint - reorg buffer, tip]` tail -> merge + persist -> live
+ *   spent-status filter over the FULL persisted owned set -> summed balance.
+ *
+ * The first read on a fresh wallet scans `[0, tip]` and persists a checkpoint; a
+ * second read at the same tip fetches only the reorg-buffer window (or nothing)
+ * and reuses the persisted outputs, yet returns the same balance — the
+ * observable incremental win.
+ */
+export async function incrementalScanBalance(args: IncrementalScanArgs): Promise<bigint> {
+  const { signer, keys, network, tip, fetchWindow, sendRpc } = args;
+
+  const persisted = await readState();
+  const usable = usableScanState(persisted, network);
+  let ownedOutputs = usable ? usable.ownedOutputs : [];
+  const start = usable ? scanStartHeight(usable.lastScannedHeight) : 0;
+
+  for (const [lo, hi] of windows(start, tip)) {
+    const raw = await fetchWindow(lo, hi);
+    if (raw.length === 0) continue;
+
+    const metaByTargetKey = new Map<string, ChainOutputWithMeta>();
+    for (const c of raw) metaByTargetKey.set(c.targetKey, c);
+
+    const discovered = signer.scanOwnedOutputs({
+      spendPrivateKey: keys.spendPrivateKey,
+      viewPrivateKey: keys.viewPrivateKey,
+      seed: keys.seed ?? '',
+      outputs: raw.map((c) => ({
+        targetKey: c.targetKey,
+        publicKey: c.publicKey,
+        amount: c.amount,
+        outputIndex: c.outputIndex,
+        kemCiphertext: c.kemCiphertext,
+      })),
+    });
+
+    const persistedDiscovered = discovered.map((o) => {
+      const meta = metaByTargetKey.get(o.targetKey);
+      return toPersistedOwnedOutput(o, {
+        blockHeight: meta?.height ?? 0,
+        txHash: meta?.txHash ?? o.targetKey,
+      });
+    });
+    ownedOutputs = mergeOwnedOutputs(ownedOutputs, persistedDiscovered);
+  }
+
+  await writeState({
+    version: STATE_VERSION,
+    // Preserve any sibling namespaces a future consumer may have written.
+    ...(persisted ?? {}),
+    scan: { network, lastScannedHeight: Math.max(tip, 0), ownedOutputs },
+  });
+
+  // Spent status is NEVER persisted — recompute it live over the FULL owned set
+  // so a previously-counted output that has since been spent drops out.
+  const spendable = await spendableOwnedOutputs(
+    signer,
+    keys,
+    ownedOutputs.map(toOwnedOutput),
+    sendRpc,
+  );
+  return spendable.reduce((sum, o) => sum + BigInt(o.amount), 0n);
+}

--- a/web/packages/snap/test/mock-node.ts
+++ b/web/packages/snap/test/mock-node.ts
@@ -26,8 +26,15 @@ export interface MockNodeOptions {
    * (an empty chain — a freshly-derived wallet then has a 0 balance and no
    * spendable outputs, which is the deterministic happy path the MVP tests
    * assert without needing real owned-output fixtures).
+   *
+   * A block MAY carry a `height`; when present, the mock honours the RPC's
+   * `start_height`/`end_height` range (returning only in-range blocks), so the
+   * Snap's windowed/incremental scan (#1091) can be exercised against real
+   * window boundaries. Blocks without a `height` are always returned (back-compat
+   * with the flat MVP fixtures). Each output MAY carry a `txHash` for the
+   * meta-carrying fetch history + persisted scan-state rely on.
    */
-  outputs?: Array<{ outputs: unknown[] }>;
+  outputs?: Array<{ height?: number; outputs: unknown[] }>;
   /** Extra / overriding method handlers (e.g. a custom `tx_submit`). */
   handlers?: Record<string, RpcHandler>;
 }
@@ -50,7 +57,19 @@ export async function startMockNode(options: MockNodeOptions = {}): Promise<Mock
 
   const defaults: Record<string, RpcHandler> = {
     node_getStatus: () => ({ chainHeight, network, synced: true, version: 'mock-1.0.0' }),
-    chain_getOutputs: () => outputs,
+    chain_getOutputs: (params) => {
+      // Honour the RPC's inclusive [start_height, end_height] window for blocks
+      // that declare a height, so the Snap's windowed scan sees real boundaries.
+      // Height-less blocks (flat MVP fixtures) are always returned.
+      const { start_height, end_height } = (params ?? {}) as {
+        start_height?: number;
+        end_height?: number;
+      };
+      if (start_height === undefined || end_height === undefined) return outputs;
+      return outputs.filter(
+        (b) => b.height === undefined || (b.height >= start_height && b.height <= end_height),
+      );
+    },
     chain_areKeyImagesSpent: (params) => {
       const keyImages = (params as { keyImages?: string[] })?.keyImages ?? [];
       return keyImages.map((keyImage) => ({

--- a/web/packages/snap/test/state.snap.ts
+++ b/web/packages/snap/test/state.snap.ts
@@ -1,0 +1,222 @@
+/**
+ * Persisted state + windowed/incremental scanning (issue #1091).
+ *
+ * Two layers:
+ *
+ *  1. PURE-LOGIC tests of the `src/state.ts` helpers (no `installSnap`, no wasm),
+ *     the same pattern as `units.snap.ts`. These pin the persisted-state CONTRACT
+ *     the sibling consumers (#1092 history, #1093 contacts) depend on: the
+ *     namespaced `{ version, scan }` shape, owned outputs carrying
+ *     `blockHeight`/`txHash` with NO persisted spent status, target-key dedupe,
+ *     window boundaries, reorg-buffer resume, and network/version invalidation.
+ *
+ *  2. BEHAVIOURAL tests through the real SES `@metamask/snaps-jest` harness against
+ *     the mocked node. The simulation harness (v4.x) exposes no state getter, so
+ *     persistence is proven the observable way it matters — off `node.calls`: a
+ *     first read scans the whole `(0, tip]` range in windows; a second read at the
+ *     same tip fetches only the reorg-buffer window (state survived + resumed);
+ *     a read against a different network rescans from genesis (invalidation).
+ */
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+
+import { startMockNode, type MockNode } from './mock-node';
+import {
+  STATE_VERSION,
+  WINDOW_SIZE,
+  REORG_BUFFER,
+  emptyScanState,
+  usableScanState,
+  scanStartHeight,
+  windows,
+  mergeOwnedOutputs,
+  toPersistedOwnedOutput,
+  toOwnedOutput,
+  type PersistedOwnedOutput,
+  type SnapState,
+} from '../src/state';
+import type { OwnedOutput } from '@botho/wasm-signer';
+
+function unwrap<T>(response: { response: unknown }): T {
+  const res = response.response as { result?: T; error?: { message?: string } };
+  if (res.error) {
+    throw new Error(`snap returned error: ${JSON.stringify(res.error)}`);
+  }
+  return res.result as T;
+}
+
+/** Count / inspect the windowed output fetches the Snap issued. */
+function outputWindows(node: MockNode): Array<{ start: number; end: number }> {
+  return node.calls
+    .filter((c) => c.method === 'chain_getOutputs')
+    .map((c) => {
+      const p = c.params as { start_height: number; end_height: number };
+      return { start: p.start_height, end: p.end_height };
+    });
+}
+
+/* ================================================================== */
+/* 1. Pure-logic contract (no SES install)                            */
+/* ================================================================== */
+
+describe('persisted scan-state helpers (#1091)', () => {
+  const ownedFixture: OwnedOutput = {
+    targetKey: 'aa'.repeat(32),
+    publicKey: 'bb'.repeat(32),
+    amount: 1_500_000_000_000n, // 1.5 BTH
+    subaddressIndex: 1n, // change output — must survive persistence
+    outputIndex: 3,
+    kemCiphertext: 'cc'.repeat(8),
+  };
+
+  it('serialises an owned output with immutable receive facts and NO spent status', () => {
+    const p = toPersistedOwnedOutput(ownedFixture, { blockHeight: 42, txHash: 'de'.repeat(32) });
+
+    expect(p.amount).toBe('1500000000000'); // bigint -> JSON-safe string
+    expect(p.subaddressIndex).toBe('1'); // change index preserved (key-image correctness)
+    expect(p.outputIndex).toBe(3);
+    expect(p.kemCiphertext).toBe('cc'.repeat(8));
+    expect(p.blockHeight).toBe(42); // history (#1092) needs no rescan
+    expect(p.txHash).toBe('de'.repeat(32));
+    // Spent status is deliberately NOT persisted — recomputed live each read.
+    expect(Object.keys(p)).not.toContain('spent');
+    expect(Object.keys(p)).not.toContain('spentHeight');
+  });
+
+  it('round-trips a persisted output back into an OwnedOutput for the spent check', () => {
+    const p = toPersistedOwnedOutput(ownedFixture, { blockHeight: 42, txHash: 'de'.repeat(32) });
+    const back = toOwnedOutput(p);
+    expect(back.amount).toBe(1_500_000_000_000n);
+    expect(back.subaddressIndex).toBe(1n);
+    expect(back.outputIndex).toBe(3);
+    expect(back.targetKey).toBe(ownedFixture.targetKey);
+  });
+
+  it('dedupes merged owned outputs by one-time target key (reorg re-scan is idempotent)', () => {
+    const a = toPersistedOwnedOutput(ownedFixture, { blockHeight: 42, txHash: 'de'.repeat(32) });
+    const b: PersistedOwnedOutput = {
+      ...a,
+      targetKey: 'ff'.repeat(32),
+      blockHeight: 43,
+      txHash: 'ab'.repeat(32),
+    };
+    // Re-discovering `a` in the reorg buffer must not append a duplicate.
+    const merged = mergeOwnedOutputs([a], [a, b]);
+    expect(merged).toHaveLength(2);
+    expect(merged.map((o) => o.targetKey).sort()).toEqual([a.targetKey, b.targetKey].sort());
+  });
+
+  it('splits [start, tip] into fixed-size inclusive windows', () => {
+    expect(windows(0, 100)).toEqual([[0, 100]]); // short chain: one window
+    expect(windows(0, WINDOW_SIZE * 2 + 500)).toEqual([
+      [0, WINDOW_SIZE - 1],
+      [WINDOW_SIZE, WINDOW_SIZE * 2 - 1],
+      [WINDOW_SIZE * 2, WINDOW_SIZE * 2 + 500],
+    ]);
+    expect(windows(100, 100)).toEqual([[100, 100]]); // single-block tail
+    expect(windows(120, 100)).toEqual([]); // nothing to scan (chain shrank)
+  });
+
+  it('resumes a reorg-buffer below the checkpoint, clamped at genesis', () => {
+    expect(scanStartHeight(100)).toBe(100 - REORG_BUFFER);
+    expect(scanStartHeight(REORG_BUFFER - 1)).toBe(0); // clamp: never negative
+    expect(scanStartHeight(0)).toBe(0);
+  });
+
+  it('invalidates foreign-network or stale-schema state (forces a full rescan)', () => {
+    const good: SnapState = {
+      version: STATE_VERSION,
+      scan: emptyScanState('botho-testnet'),
+    };
+    expect(usableScanState(good, 'botho-testnet')).toBe(good.scan);
+    // Different network -> discard.
+    expect(usableScanState(good, 'botho-mainnet')).toBeNull();
+    // Version mismatch -> discard.
+    expect(usableScanState({ ...good, version: STATE_VERSION + 1 }, 'botho-testnet')).toBeNull();
+    // No prior state -> discard.
+    expect(usableScanState(null, 'botho-testnet')).toBeNull();
+  });
+
+  it('namespaces state as { version, scan } so siblings extend without migration', () => {
+    const state: SnapState = { version: STATE_VERSION, scan: emptyScanState('botho-testnet') };
+    // Top-level keys are the reserved namespace surface for #1092/#1093.
+    expect(state.version).toBe(1);
+    expect(state.scan?.ownedOutputs).toEqual([]);
+    expect(state.scan?.lastScannedHeight).toBe(0);
+  });
+});
+
+/* ================================================================== */
+/* 2. Behavioural: incremental scan through the SES harness           */
+/* ================================================================== */
+
+describe('botho snap: windowed incremental scan against a mocked node (#1091)', () => {
+  let node: MockNode;
+
+  afterEach(async () => {
+    if (node) await node.close();
+  });
+
+  it('fresh wallet on an empty chain: balance 0 via a single window', async () => {
+    node = await startMockNode({ chainHeight: 100 }); // < WINDOW_SIZE -> one window
+    const { request } = await installSnap();
+
+    const { spendablePicocredits } = unwrap<{ spendablePicocredits: string }>(
+      await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }),
+    );
+    expect(spendablePicocredits).toBe('0');
+
+    const methods = node.calls.map((c) => c.method);
+    expect(methods).toContain('node_getStatus'); // wrong-network guard ran
+    expect(outputWindows(node)).toEqual([{ start: 0, end: 100 }]); // scanned (0, tip]
+  });
+
+  it('resumes from the checkpoint: a second read at the same tip fetches no new windows', async () => {
+    // Tip spanning multiple windows makes the incremental win visible in call counts.
+    const tip = WINDOW_SIZE * 2 + 500;
+    node = await startMockNode({ chainHeight: tip });
+    const { request } = await installSnap();
+
+    // First read: full genesis scan across every window.
+    const first = unwrap<{ spendablePicocredits: string }>(
+      await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }),
+    );
+    expect(first.spendablePicocredits).toBe('0');
+    const firstWindows = outputWindows(node);
+    expect(firstWindows).toEqual(windows(0, tip).map(([start, end]) => ({ start, end })));
+    expect(firstWindows.length).toBeGreaterThan(1); // genuinely multi-window
+
+    // Second read at the SAME tip: state survived + resumed, so only the reorg
+    // buffer (a single trailing window) is re-fetched — NOT the whole chain.
+    const second = unwrap<{ spendablePicocredits: string }>(
+      await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }),
+    );
+    expect(second.spendablePicocredits).toBe('0'); // same balance
+
+    const resumeWindows = outputWindows(node).slice(firstWindows.length);
+    expect(resumeWindows).toEqual([{ start: scanStartHeight(tip), end: tip }]);
+    expect(resumeWindows.length).toBeLessThan(firstWindows.length);
+    // The resume window starts near the tip, never back at genesis.
+    expect(resumeWindows[0].start).toBeGreaterThanOrEqual(tip - REORG_BUFFER);
+  });
+
+  it('invalidates persisted state from another network and rescans from genesis', async () => {
+    // 1. Seed state on testnet.
+    node = await startMockNode({ network: 'botho-testnet', chainHeight: 100 });
+    const { request } = await installSnap();
+    unwrap(await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }));
+    await node.close();
+
+    // 2. Point the SAME Snap install at a loopback node reporting a DIFFERENT
+    //    network (loopback is exempt from the wrong-network guard, but the
+    //    persisted scan is still network-bound and must be discarded).
+    node = await startMockNode({ network: 'botho-devnet', chainHeight: 100 });
+    unwrap(await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }));
+
+    // The foreign-network read rescanned from genesis (start_height 0), rather
+    // than resuming the testnet checkpoint's reorg-buffer window near the tip.
+    const starts = outputWindows(node).map((w) => w.start);
+    expect(starts).toContain(0);
+  });
+});


### PR DESCRIPTION
## Summary

Foundational Phase-2 piece for the Botho MetaMask Snap (`web/packages/snap`).
The Phase-1 MVP kept **no** persisted state — every `botho_getBalance` /
`botho_showBalance` re-scanned the chain from genesis (`getOutputs(0, tip)`),
O(chain height) per read and forgotten when the execution context ends. This PR
adds the Snap's first persisted surface via `snap_manageState` and makes
scanning **incremental + resumable**, so #1092 (history) and #1093 (contacts)
have a state store to build on.

## Changes

- **`src/state.ts` (new)** — encrypted, versioned, network-bound `{ version, scan }`
  schema, namespaced so #1092/#1093 extend it without a migration. Persists owned
  outputs with `blockHeight` + `txHash` (history needs no rescan) but **not** spent
  status (recomputed live via `chain_areKeyImagesSpent`). Includes network/version
  invalidation, a `REORG_BUFFER`, target-key dedupe, windowing helpers, and the
  `incrementalScanBalance` orchestrator (keeps `index.ts` thin).
- **`src/node.ts`** — `getOutputsWithMeta`: a meta-carrying windowed `chain_getOutputs`
  fetch preserving per-block height + per-output txHash (the flat `getOutputs` drops them).
- **`src/index.ts`** — rewired both balance reads to `read state → windowed scan →
  persist → live spent-filter for the sum`. Derivation and the wrong-network guard
  are unchanged.
- **`snap.manifest.json`** — added `snap_manageState` permission; build refreshed the shasum.
- **`test/mock-node.ts`** — the mock now honours the `chain_getOutputs` `[start,end]`
  window and can carry per-block `height` / per-output `txHash`.
- **`test/state.snap.ts` (new)** — pure-logic contract tests + behavioural
  incremental-scan tests driven off `node.calls`.
- **`README.md`** — documented the permission, schema, and incremental-scan model;
  moved windowed scanning from Deferred to Shipped.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Manifest gains `snap_manageState`; shasum refreshed | ✅ | `initialPermissions.snap_manageState: {}`; `build:snap` recomputed the shasum |
| Typed, versioned, network-bound blob read/written encrypted; namespaced `{ version, scan }` | ✅ | `readState`/`writeState` use `snap_manageState` `encrypted: true`; `usableScanState` unit test |
| Owned outputs persist `blockHeight`+`txHash`; spent status not persisted | ✅ | `toPersistedOwnedOutput` test asserts fields present and `spent`/`spentHeight` absent |
| Balance scanning windowed + incremental; 2nd call at same tip fetches no new windows beyond reorg buffer, same balance | ✅ | `state.snap.ts` "resumes from the checkpoint" asserts window ranges off `node.calls` |
| Stale/foreign state invalidated → full rescan from 0 | ✅ | `usableScanState` unit test + "invalidates persisted state from another network" behavioural test (start_height 0) |
| Existing behavior preserved (empty chain → 0, guards, send/address/dialogs) | ✅ | `balance.snap.ts` / `send.snap.ts` / `derivation.snap.ts` / `units.snap.ts` all green, unchanged |
| README documents permission, schema, incremental-scan model; Deferred updated | ✅ | new "Persisted state & incremental scanning" section; Deferred list updated |

## Test Plan

- `pnpm --filter @botho/wasm-signer build:wasm:bundler` (artifact for the SES bundle)
- `pnpm --filter @botho/snap typecheck` — clean
- `pnpm --filter @botho/snap build:snap` — bundle built, manifest shasum refreshed
- `pnpm --filter @botho/snap test:snap` — **5 suites / 26 tests pass** (new `state.snap.ts` + no regressions)

`@botho/wasm-signer` source was not modified (reference only), so its suite was not re-run.

Closes #1091