### PR TITLE
feat(snap): transaction history view derived from persisted scan state

### DIFF
--- a/web/packages/snap/README.md
+++ b/web/packages/snap/README.md
@@ -25,9 +25,11 @@ All params/results are JSON-safe; amounts are string-encoded `u64` picocredits
 |---|---|---|---|
 | `botho_getAddress` | — | none | `{ address, derivation }` |
 | `botho_getBalance` | `{ rpcUrl }` | none | `{ spendablePicocredits }` |
+| `botho_getHistory` | `{ rpcUrl }` | none | `{ entries }` |
 | `botho_send` | `{ rpcUrl, recipientAddress, amountPicocredits, feePicocredits? }` | confirmation | `{ txHash, txBytes }` |
 | `botho_showReceive` | — | alert (address) | `{ address }` |
 | `botho_showBalance` | `{ rpcUrl }` | alert (balance) | `{ spendablePicocredits }` |
+| `botho_showHistory` | `{ rpcUrl }` | alert (history) | `{ entries, count }` |
 | `botho_showMnemonic` | — | confirm → alert | `{ revealed }` |
 
 `rpcUrl` is the **user-selected ingress node**, carrying over the web wallet's
@@ -97,6 +99,49 @@ Snap, so on resume the scan re-covers a small trailing `REORG_BUFFER` of blocks
 below the checkpoint; the target-key dedupe makes the overlap idempotent (never
 double-counts).
 
+## Transaction history (#1092)
+
+`botho_getHistory` (silent) and `botho_showHistory` (dialog) surface the wallet's
+**receive history**. History is a **pure projection over the persisted scan state
+above** — it reads `scan.ownedOutputs` (which already carry `blockHeight` +
+`txHash`, cached by #1091 for exactly this) and adds a **live** spent-check. There
+is **no rescan, no new persisted key, and no `STATE_VERSION` bump** — history is
+*derived*, not stored, so it extends the #1091 schema without a migration. Both
+methods run the same incremental scan as the balance path, so a history read at
+the same tip resumes from the persisted checkpoint (only the trailing
+reorg-buffer window is re-fetched) rather than re-scanning from genesis.
+
+Each entry is JSON-safe:
+
+```jsonc
+{
+  "txHash": "…",                 // creating tx hash
+  "blockHeight": 42,             // receive height
+  "amountPicocredits": "1500000000000",  // decimal-string u64
+  "direction": "received",       // or "spent" (live chain_areKeyImagesSpent check)
+  "confirmations": 160           // max(0, tip - blockHeight) — finality depth
+}
+```
+
+Entries are sorted newest-first (descending `blockHeight`). **`direction`** is
+recomputed **live** each read — an owned output the node reports as spent renders
+as `spent` (value that has left the wallet); spent status is **never persisted**,
+consistent with #1091. **`confirmations`** is the finality depth `tip -
+blockHeight` (clamped at 0), so a shallow, reorg-prone receive near the tip is
+*visibly* flagged without mutating persisted state.
+
+> **Scope.** Outgoing/"sent" transfer records (recipient + amount per `botho_send`)
+> are **deferred** — they need a new persisted namespace *and* live owned-output
+> fixtures to test (the same `#1051` betanet gate that blocks live-send
+> validation). History here is receive-history + a live spent annotation.
+>
+> The `mergeOwnedOutputs` merge is monotonic (add-only). A reorg that drops an
+> already-persisted owned output leaves it stale in **both** balance and history;
+> a **destructive** prune-on-rescan / finality-depth prune is deliberately **out
+> of scope** here (it is balance-critical) and tracked as a dedicated follow-up.
+> The **non-destructive** half — surfacing per-entry `confirmations` so a shallow
+> receive is visible — is what this view ships.
+
 ## Key derivation: MetaMask SRP → Botho RootIdentity
 
 ```
@@ -149,8 +194,8 @@ alternative:
 | `src/derivation.ts` | SIP-6 entropy → Botho `SnapWallet` (SLIP-10 + PQ keys + address) |
 | `src/signer.ts` | Inject the inlined bundler wasm into `@botho/wasm-signer` via `setSigner` |
 | `src/node.ts` | JSON-RPC node client, `isValidRpcUrl`, wrong-network guard, `SendRpc`, meta-carrying windowed fetch (`getOutputsWithMeta`) |
-| `src/state.ts` | Persisted `snap_manageState` blob (`{ version, scan }`) + windowed/incremental-scan orchestrator (#1091) |
-| `src/ui.ts` | Snaps custom-UI dialog content (receive / balance / send / mnemonic) |
+| `src/state.ts` | Persisted `snap_manageState` blob (`{ version, scan }`), shared windowed/incremental-scan core (#1091), and the pure `deriveHistory` projection (#1092) |
+| `src/ui.ts` | Snaps custom-UI dialog content (receive / balance / history / send / mnemonic) |
 | `src/format.ts` | SES-safe (Intl-free) picocredit → BTH formatting |
 
 The wasm is `wasm-pack build --target bundler` output, base64-inlined into the
@@ -192,6 +237,13 @@ Coverage:
   target-key dedupe, window boundaries, reorg-buffer resume, network/version
   invalidation) plus the incremental-scan win driven off `node.calls`: a second
   read at the same tip fetches no new windows beyond the reorg buffer.
+- `history.snap.ts` — transaction-history projection (#1092): pure-logic
+  `deriveHistory` / `spentTargetKeys` (descending block-height order, clamped
+  `confirmations`, decimal-string amounts, received-vs-spent from a spent-set,
+  empty scan) plus behavioural `botho_getHistory` (empty chain → `[]`),
+  `botho_showHistory` (empty-state dialog), and the persisted-reuse property
+  (history after a balance read issues no window below the reorg-buffer resume
+  point — no rescan).
 
 ## Deferred (out of scope for this MVP)
 
@@ -202,13 +254,17 @@ Coverage:
   live-send validation is a follow-up, **blocked on betanet resume (#1051)**.
   (The spike demonstrated a working real send against a throwaway solo node; that
   path relied on spike-only test hooks that are intentionally absent here.)
-- **Phase 2 parity** (per the issue): transaction history (#1092), contacts
-  (#1093), in-Snap ingress selection UX, i18n, and a dedicated **security pass**
-  for the new key-handling surface (cf. the web-wallet at-rest audit, #474/#475).
+- **Phase 2 parity** (per the issue): contacts (#1093), in-Snap ingress selection
+  UX, i18n, and a dedicated **security pass** for the new key-handling surface
+  (cf. the web-wallet at-rest audit, #474/#475).
   **Shipped:** incremental/windowed scanning with persisted, encrypted scan state
-  (`snap_manageState`) — the shared scaling concern with the web wallet — is now
-  live (#1091; see "Persisted state & incremental scanning" above). It is the
-  foundation #1092 (history) and #1093 (contacts) build on.
+  (`snap_manageState`) — the shared scaling concern with the web wallet (#1091) —
+  and the **transaction-history view** (#1092; see "Transaction history" above),
+  a pure projection over that persisted state with a live spent-check. Outgoing
+  "sent" records remain deferred (new persisted namespace + live owned-output
+  fixtures, gated on betanet resume #1051), as does a destructive
+  prune-on-rescan / finality-depth prune for `mergeOwnedOutputs` reorg staleness
+  (balance-critical — dedicated follow-up).
 - **Publishing / distribution** — npm publish + MetaMask allowlist, and pinning
   the production snap id (see the snap-id pinning trade-off above).
 

--- a/web/packages/snap/snap.manifest.json
+++ b/web/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Manage a privacy-by-default Botho wallet from inside MetaMask. Keys are derived from your MetaMask Secret Recovery Phrase and never leave the Snap sandbox.",
   "proposedName": "Botho Wallet",
   "source": {
-    "shasum": "QtVwYZJx++kxtG84ca/iXOWupzw/wmdbRZXm7Y/9nW4=",
+    "shasum": "UYrZ+P7zVVYWDghE1YXhfSDIlKL/Vmnmq6rQOgA3lQ4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/web/packages/snap/src/index.ts
+++ b/web/packages/snap/src/index.ts
@@ -18,9 +18,11 @@
  * u64 picocredits):
  *   - botho_getAddress  — the wallet's stealth receive address (silent read)
  *   - botho_getBalance  — spendable balance via scan (silent read)
+ *   - botho_getHistory  — receive history projected from persisted scan state (silent read, #1092)
  *   - botho_send        — build + sign + submit, behind a confirmation dialog
  *   - botho_showReceive — receive dialog (stealth address, copyable)
  *   - botho_showBalance — balance dialog
+ *   - botho_showHistory — transaction-history dialog (#1092)
  *   - botho_showMnemonic — reveal the derived recovery phrase (confirmed backup)
  *
  * Live-testnet send validation is deferred to a follow-up (betanet is frozen at
@@ -46,10 +48,17 @@ import { parseAddress } from '@botho/core';
 import { ensureSigner, wasm } from './signer';
 import { deriveWallet, revealMnemonic, DERIVATION_DESCRIPTION } from './derivation';
 import { connectAndGuard, getOutputsWithMeta, makeSendRpc, EXPECTED_NETWORK_ID } from './node';
-import { incrementalScanBalance } from './state';
+import {
+  incrementalScan,
+  incrementalScanBalance,
+  deriveHistory,
+  spentTargetKeys,
+  type HistoryEntry,
+} from './state';
 import {
   receiveContent,
   balanceContent,
+  historyContent,
   sendConfirmContent,
   mnemonicBackupContent,
 } from './ui';
@@ -141,6 +150,29 @@ async function scanBalance(rpcUrl: string): Promise<bigint> {
   });
 }
 
+/**
+ * Derive the wallet's transaction history via the SAME persisted-state,
+ * incremental scan as {@link scanBalance} (#1091) — history is a pure projection
+ * over the already-persisted owned set (no rescan, no persisted history record).
+ * The receive facts come off persisted state; the spent annotation and the tip
+ * (for confirmations/finality depth) are recomputed live, exactly as the balance
+ * is. Shared by `botho_getHistory` and `botho_showHistory`.
+ */
+async function scanHistory(rpcUrl: string): Promise<HistoryEntry[]> {
+  const { call, status } = await connectAndGuard(rpcUrl);
+  const wallet = await deriveWallet();
+  const signer = await loadSigner();
+  const { ownedOutputs, spendable, tip } = await incrementalScan({
+    signer,
+    keys: wallet.keys,
+    network: status.network ?? EXPECTED_NETWORK_ID,
+    tip: status.chainHeight,
+    fetchWindow: getOutputsWithMeta(call),
+    sendRpc: makeSendRpc(call),
+  });
+  return deriveHistory(ownedOutputs, spentTargetKeys(ownedOutputs, spendable), tip);
+}
+
 /** Ask the user to approve/reject a confirmation dialog. */
 async function confirm(content: unknown): Promise<boolean> {
   return (await snap.request({
@@ -176,6 +208,12 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return { spendablePicocredits: balance.toString() } as Json;
     }
 
+    case 'botho_getHistory': {
+      const rpcUrl = requireString(params, 'rpcUrl');
+      const entries = await scanHistory(rpcUrl);
+      return { entries } as unknown as Json;
+    }
+
     /* ------------------------------------------------------------------ */
     /* Dialog-driven flows                                                */
     /* ------------------------------------------------------------------ */
@@ -190,6 +228,13 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       const balance = await scanBalance(rpcUrl);
       await alert(balanceContent(balance, rpcUrl));
       return { spendablePicocredits: balance.toString() } as Json;
+    }
+
+    case 'botho_showHistory': {
+      const rpcUrl = requireString(params, 'rpcUrl');
+      const entries = await scanHistory(rpcUrl);
+      await alert(historyContent(entries, rpcUrl));
+      return { entries, count: entries.length } as unknown as Json;
     }
 
     case 'botho_showMnemonic': {

--- a/web/packages/snap/src/state.ts
+++ b/web/packages/snap/src/state.ts
@@ -265,19 +265,32 @@ export interface IncrementalScanArgs {
   sendRpc: SendRpc;
 }
 
+/** The full result of one incremental scan — the shared core of balance + history. */
+export interface IncrementalScanResult {
+  /** The FULL persisted owned set after this scan (spent AND unspent). */
+  ownedOutputs: PersistedOwnedOutput[];
+  /** The live-checked spendable (unspent, non-pending) subset for this read. */
+  spendable: OwnedOutput[];
+  /** The chain tip this scan resolved against (for confirmations/finality depth). */
+  tip: number;
+}
+
 /**
- * The persisted-state, incremental-scan replacement for `spendableBalance`.
+ * The persisted-state, incremental-scan CORE shared by both the balance path and
+ * the transaction-history path (#1092).
  *
  *   read state -> (in)validate vs network/version -> windowed scan of the
  *   `(checkpoint - reorg buffer, tip]` tail -> merge + persist -> live
- *   spent-status filter over the FULL persisted owned set -> summed balance.
+ *   spent-status split over the FULL persisted owned set.
  *
  * The first read on a fresh wallet scans `[0, tip]` and persists a checkpoint; a
  * second read at the same tip fetches only the reorg-buffer window (or nothing)
- * and reuses the persisted outputs, yet returns the same balance — the
- * observable incremental win.
+ * and reuses the persisted outputs — the observable incremental win. Returning
+ * BOTH the full owned set and the live-spendable subset lets balance sum the
+ * subset while history projects the full set with a per-entry spent annotation,
+ * from a single scan (one tip, one live spent-check — no divergent scanner).
  */
-export async function incrementalScanBalance(args: IncrementalScanArgs): Promise<bigint> {
+export async function incrementalScan(args: IncrementalScanArgs): Promise<IncrementalScanResult> {
   const { signer, keys, network, tip, fetchWindow, sendRpc } = args;
 
   const persisted = await readState();
@@ -330,5 +343,85 @@ export async function incrementalScanBalance(args: IncrementalScanArgs): Promise
     ownedOutputs.map(toOwnedOutput),
     sendRpc,
   );
+  return { ownedOutputs, spendable, tip };
+}
+
+/**
+ * The persisted-state, incremental-scan replacement for `spendableBalance`. A
+ * thin sum over the shared {@link incrementalScan} core's live-spendable subset,
+ * so balance and history stay consistent (same tip, same live spent-check).
+ */
+export async function incrementalScanBalance(args: IncrementalScanArgs): Promise<bigint> {
+  const { spendable } = await incrementalScan(args);
   return spendable.reduce((sum, o) => sum + BigInt(o.amount), 0n);
+}
+
+/* ------------------------------------------------------------------ */
+/* Transaction history (#1092): a PURE projection over persisted state */
+/* ------------------------------------------------------------------ */
+
+/**
+ * A single client-side transaction-history entry — a projection over one
+ * persisted owned output plus its LIVE spent status and the current tip. Every
+ * field is JSON-safe (bigint amounts as decimal strings) for the RPC surface.
+ */
+export interface HistoryEntry {
+  /** Creating transaction hash (hex). */
+  txHash: string;
+  /** Receive block height of the output. */
+  blockHeight: number;
+  /** JSON-safe u64 picocredits (bigint serialised as a decimal string). */
+  amountPicocredits: string;
+  /**
+   * `received` for an owned output still unspent on-chain; `spent` for one whose
+   * value has since left the wallet (live `chain_areKeyImagesSpent` check).
+   */
+  direction: 'received' | 'spent';
+  /**
+   * Finality depth: `max(0, tip - blockHeight)`. A small value flags a shallow,
+   * reorg-prone receive near the tip. Clamped at 0 so a post-reorg chain that
+   * shrank below an output's receive height never reports a negative depth.
+   */
+  confirmations: number;
+}
+
+/**
+ * Compute the set of owned-output target keys that are SPENT for this read: every
+ * persisted owned output whose target key is not in the live-spendable subset.
+ * (Spendable = unspent + non-pending; anything else is spent value that has left
+ * the wallet.) Never persisted — recomputed live each read, like the balance.
+ */
+export function spentTargetKeys(
+  ownedOutputs: PersistedOwnedOutput[],
+  spendable: OwnedOutput[],
+): Set<string> {
+  const spendableKeys = new Set(spendable.map((o) => o.targetKey));
+  const spent = new Set<string>();
+  for (const o of ownedOutputs) {
+    if (!spendableKeys.has(o.targetKey)) spent.add(o.targetKey);
+  }
+  return spent;
+}
+
+/**
+ * Project the persisted owned set + a live spent-set + the current tip into a
+ * transaction-history list, newest first. PURE (no `snap`, no network): the
+ * receive facts come straight off persisted state (no rescan), the spent
+ * annotation is supplied by the caller's live check, and confirmations are a
+ * clamped `tip - blockHeight`. Amounts stay decimal strings (JSON-safe).
+ */
+export function deriveHistory(
+  ownedOutputs: PersistedOwnedOutput[],
+  spentTargetKeySet: ReadonlySet<string>,
+  tip: number,
+): HistoryEntry[] {
+  return ownedOutputs
+    .map((o): HistoryEntry => ({
+      txHash: o.txHash,
+      blockHeight: o.blockHeight,
+      amountPicocredits: o.amount,
+      direction: spentTargetKeySet.has(o.targetKey) ? 'spent' : 'received',
+      confirmations: Math.max(0, tip - o.blockHeight),
+    }))
+    .sort((a, b) => b.blockHeight - a.blockHeight);
 }

--- a/web/packages/snap/src/ui.ts
+++ b/web/packages/snap/src/ui.ts
@@ -19,6 +19,7 @@ import {
 } from '@metamask/snaps-sdk/jsx';
 
 import { formatBTHWithUnit } from './format';
+import type { HistoryEntry } from './state';
 
 /** Host component of an endpoint URL (for compact display), or the raw string. */
 function hostOf(rpcUrl: string): string {
@@ -27,6 +28,11 @@ function hostOf(rpcUrl: string): string {
   } catch {
     return rpcUrl;
   }
+}
+
+/** Abbreviate a long hex tx hash for compact dialog display (head…tail). */
+function shortHash(txHash: string): string {
+  return txHash.length > 20 ? `${txHash.slice(0, 10)}…${txHash.slice(-10)}` : txHash;
 }
 
 /** Receive dialog: the wallet's stealth receive address. */
@@ -77,6 +83,46 @@ export function sendConfirmContent(view: SendConfirmView): JSXElement {
       Text({ children: 'Recipient' }),
       Copyable({ value: view.recipientAddress }),
       Row({ label: 'Node', children: Text({ children: hostOf(view.rpcUrl) }) }),
+    ],
+  });
+}
+
+/**
+ * Transaction-history dialog: the wallet's receive history, newest first, each
+ * entry annotated with its live spent/received direction and its finality depth
+ * (`confirmations`). A low confirmation count flags a shallow, reorg-prone
+ * receive near the tip. Renders an explicit empty-state when there is no history.
+ *
+ * History is a PURE projection over the persisted scan state (#1091) plus a live
+ * spent-check — no rescan, no persisted history record (see `src/state.ts`).
+ */
+export function historyContent(entries: HistoryEntry[], rpcUrl: string): JSXElement {
+  if (entries.length === 0) {
+    return Box({
+      children: [
+        Heading({ children: 'Transaction history' }),
+        Text({ children: 'No transactions yet. Payments you receive will appear here.' }),
+        Divider({}),
+        Row({ label: 'Node', children: Text({ children: hostOf(rpcUrl) }) }),
+      ],
+    });
+  }
+  return Box({
+    children: [
+      Heading({ children: 'Transaction history' }),
+      ...entries.flatMap((entry) => [
+        Row({
+          label: entry.direction === 'spent' ? 'Spent' : 'Received',
+          children: Text({ children: formatBTHWithUnit(BigInt(entry.amountPicocredits)) }),
+        }),
+        Text({
+          children:
+            `Block ${entry.blockHeight} · ${entry.confirmations} ` +
+            `confirmation${entry.confirmations === 1 ? '' : 's'} · ${shortHash(entry.txHash)}`,
+        }),
+        Divider({}),
+      ]),
+      Row({ label: 'Node', children: Text({ children: hostOf(rpcUrl) }) }),
     ],
   });
 }

--- a/web/packages/snap/test/history.snap.ts
+++ b/web/packages/snap/test/history.snap.ts
@@ -1,0 +1,216 @@
+/**
+ * Transaction history view (issue #1092).
+ *
+ * History is a PURE projection over the scan state #1091 already persists
+ * (`scan.ownedOutputs`, each carrying `blockHeight`/`txHash`) plus a LIVE
+ * spent-check — no schema migration, no `STATE_VERSION` bump, no rescan.
+ *
+ * Two layers, mirroring `state.snap.ts`:
+ *
+ *  1. PURE-LOGIC tests of `deriveHistory` / `spentTargetKeys` (no `installSnap`,
+ *     no wasm): descending block-height order, clamped `confirmations`,
+ *     decimal-string amounts, received-vs-spent direction from a supplied
+ *     spent-set, and `[]` for an empty scan.
+ *
+ *  2. BEHAVIOURAL tests through the real SES `@metamask/snaps-jest` harness
+ *     against the mocked node: `botho_getHistory` on a fresh/empty chain returns
+ *     `{ entries: [] }`; `botho_showHistory` renders a dialog with the empty
+ *     state; and a history read AFTER a balance read reuses the persisted scan
+ *     (issuing no `chain_getOutputs` window below the reorg-buffer resume point).
+ */
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+
+import { startMockNode, type MockNode } from './mock-node';
+import {
+  STATE_VERSION,
+  REORG_BUFFER,
+  scanStartHeight,
+  deriveHistory,
+  spentTargetKeys,
+  type PersistedOwnedOutput,
+} from '../src/state';
+import type { OwnedOutput } from '@botho/wasm-signer';
+
+function unwrap<T>(response: { response: unknown }): T {
+  const res = response.response as { result?: T; error?: { message?: string } };
+  if (res.error) {
+    throw new Error(`snap returned error: ${JSON.stringify(res.error)}`);
+  }
+  return res.result as T;
+}
+
+/** Count / inspect the windowed output fetches the Snap issued. */
+function outputWindows(node: MockNode): Array<{ start: number; end: number }> {
+  return node.calls
+    .filter((c) => c.method === 'chain_getOutputs')
+    .map((c) => {
+      const p = c.params as { start_height: number; end_height: number };
+      return { start: p.start_height, end: p.end_height };
+    });
+}
+
+/** A persisted owned output fixture at a given block/amount/target key. */
+function persisted(
+  targetKey: string,
+  blockHeight: number,
+  amount: string,
+  txHash = `${targetKey.slice(0, 2)}`.repeat(32),
+): PersistedOwnedOutput {
+  return {
+    targetKey,
+    publicKey: 'bb'.repeat(32),
+    amount,
+    subaddressIndex: '0',
+    outputIndex: 0,
+    kemCiphertext: null,
+    blockHeight,
+    txHash,
+  };
+}
+
+/* ================================================================== */
+/* 1. Pure-logic projection (no SES install)                          */
+/* ================================================================== */
+
+describe('deriveHistory / spentTargetKeys projection (#1092)', () => {
+  const a = persisted('aa'.repeat(32), 10, '1000000000000'); // 1 BTH @ block 10
+  const b = persisted('bb'.repeat(32), 50, '2500000000000'); // 2.5 BTH @ block 50
+  const c = persisted('cc'.repeat(32), 30, '500000000000'); //  0.5 BTH @ block 30
+
+  it('sorts entries by block height descending (newest receive first)', () => {
+    const entries = deriveHistory([a, b, c], new Set(), 100);
+    expect(entries.map((e) => e.blockHeight)).toEqual([50, 30, 10]);
+    expect(entries.map((e) => e.txHash)).toEqual([b.txHash, c.txHash, a.txHash]);
+  });
+
+  it('computes confirmations = max(0, tip - blockHeight) and clamps below zero', () => {
+    const entries = deriveHistory([a, b], new Set(), 60);
+    const byHeight = new Map(entries.map((e) => [e.blockHeight, e.confirmations]));
+    expect(byHeight.get(50)).toBe(10); // 60 - 50
+    expect(byHeight.get(10)).toBe(50); // 60 - 10
+
+    // Post-reorg shrink: an output whose receive height is now ABOVE the tip
+    // must clamp to 0 confirmations, never a negative depth.
+    const shrunk = deriveHistory([b], new Set(), 40);
+    expect(shrunk[0].confirmations).toBe(0);
+  });
+
+  it('carries amounts as decimal strings (JSON-safe), not bigints', () => {
+    const entries = deriveHistory([a], new Set(), 100);
+    expect(entries[0].amountPicocredits).toBe('1000000000000');
+    expect(typeof entries[0].amountPicocredits).toBe('string');
+  });
+
+  it('marks entries in the supplied spent-set as spent, the rest as received', () => {
+    const entries = deriveHistory([a, b, c], new Set([b.targetKey]), 100);
+    const dir = new Map(entries.map((e) => [e.blockHeight, e.direction]));
+    expect(dir.get(50)).toBe('spent'); // b is in the spent-set
+    expect(dir.get(30)).toBe('received');
+    expect(dir.get(10)).toBe('received');
+  });
+
+  it('returns [] for an empty scan', () => {
+    expect(deriveHistory([], new Set(), 100)).toEqual([]);
+  });
+
+  it('does not bump STATE_VERSION (history is derived, not stored)', () => {
+    // Guard the schema-extension-without-migration property #1092 relies on.
+    expect(STATE_VERSION).toBe(1);
+  });
+
+  it('derives the spent-set as owned minus live-spendable (by target key)', () => {
+    const spendable: OwnedOutput[] = [
+      { targetKey: a.targetKey, publicKey: a.publicKey, amount: 1_000_000_000_000n, subaddressIndex: 0n },
+      { targetKey: c.targetKey, publicKey: c.publicKey, amount: 500_000_000_000n, subaddressIndex: 0n },
+    ];
+    // b is owned but NOT spendable => spent (value left the wallet).
+    const spent = spentTargetKeys([a, b, c], spendable);
+    expect(spent.has(b.targetKey)).toBe(true);
+    expect(spent.has(a.targetKey)).toBe(false);
+    expect(spent.has(c.targetKey)).toBe(false);
+
+    // Feeding that spent-set through deriveHistory flips only b to 'spent'.
+    const entries = deriveHistory([a, b, c], spent, 100);
+    expect(entries.find((e) => e.blockHeight === 50)?.direction).toBe('spent');
+    expect(entries.find((e) => e.blockHeight === 10)?.direction).toBe('received');
+  });
+});
+
+/* ================================================================== */
+/* 2. Behavioural: history through the SES harness                    */
+/* ================================================================== */
+
+interface HistoryEntryJson {
+  txHash: string;
+  blockHeight: number;
+  amountPicocredits: string;
+  direction: 'received' | 'spent';
+  confirmations: number;
+}
+
+describe('botho snap: transaction history against a mocked node (#1092)', () => {
+  let node: MockNode;
+
+  afterEach(async () => {
+    if (node) await node.close();
+  });
+
+  it('botho_getHistory on a fresh/empty chain returns { entries: [] }', async () => {
+    node = await startMockNode({ chainHeight: 100 });
+    const { request } = await installSnap();
+
+    const { entries } = unwrap<{ entries: HistoryEntryJson[] }>(
+      await request({ method: 'botho_getHistory', params: { rpcUrl: node.url } }),
+    );
+    expect(entries).toEqual([]);
+
+    const methods = node.calls.map((c) => c.method);
+    expect(methods).toContain('node_getStatus'); // wrong-network guard ran
+    expect(methods).toContain('chain_getOutputs'); // scanned the chain
+  });
+
+  it('botho_showHistory renders a dialog with the empty-state', async () => {
+    node = await startMockNode({ chainHeight: 100 });
+    const { request } = await installSnap();
+
+    const response = request({ method: 'botho_showHistory', params: { rpcUrl: node.url } });
+    const ui = await response.getInterface();
+    expect(ui.type).toBe('alert');
+    const rendered = JSON.stringify(ui.content);
+    expect(rendered).toContain('Transaction history');
+    expect(rendered).toContain('No transactions yet');
+
+    await (ui as { ok(): Promise<void> }).ok();
+    const result = unwrap<{ entries: HistoryEntryJson[]; count: number }>(await response);
+    expect(result.entries).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  it('reuses persisted scan state: history after a balance read issues no window below the reorg buffer', async () => {
+    // Multi-window tip so the incremental win is visible in call counts.
+    const tip = 3000;
+    node = await startMockNode({ chainHeight: tip });
+    const { request } = await installSnap();
+
+    // Seed persisted scan state with a full genesis scan via the balance path.
+    unwrap(await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }));
+    const afterBalance = outputWindows(node).length;
+    expect(afterBalance).toBeGreaterThan(1); // genuinely multi-window genesis scan
+
+    // History at the SAME tip must resume from the persisted checkpoint, not
+    // rescan from genesis: only the trailing reorg-buffer window is re-fetched.
+    const { entries } = unwrap<{ entries: HistoryEntryJson[] }>(
+      await request({ method: 'botho_getHistory', params: { rpcUrl: node.url } }),
+    );
+    expect(entries).toEqual([]); // empty chain, but the persisted-reuse property is what we assert
+
+    const historyWindows = outputWindows(node).slice(afterBalance);
+    expect(historyWindows).toEqual([{ start: scanStartHeight(tip), end: tip }]);
+    // No window reaches back below the reorg-buffer resume point (no rescan).
+    for (const w of historyWindows) {
+      expect(w.start).toBeGreaterThanOrEqual(tip - REORG_BUFFER);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a receive-history surface to the Botho MetaMask Snap (`web/packages/snap`) as a **pure projection over the scan state #1091 already persists** — no schema migration, no `STATE_VERSION` bump, no new persisted key, no rescan. Both new RPC methods run the same incremental scan as the balance path, so a history read at the same tip resumes from the persisted checkpoint (only the trailing reorg-buffer window is re-fetched) rather than re-scanning from genesis.

## Changes

- **`src/state.ts`** — Extracted a shared `incrementalScan` core returning `{ ownedOutputs, spendable, tip }`; `incrementalScanBalance` now sums the live-spendable subset (behaviour-preserving pure extract). Added the pure `deriveHistory` + `spentTargetKeys` helpers and the `HistoryEntry` type. `mergeOwnedOutputs` and `STATE_VERSION` untouched.
- **`src/index.ts`** — Added `botho_getHistory` (silent, `{ entries }`) and `botho_showHistory` (alert dialog, `{ entries, count }`) RPC cases, wired through a shared `scanHistory` helper.
- **`src/ui.ts`** — Added the `historyContent(entries, rpcUrl)` dialog (direct-factory JSX, Intl-free `formatBTHWithUnit` amounts, explicit empty-state, per-entry confirmations/finality depth).
- **`test/history.snap.ts`** (new) — pure-logic + behavioural coverage.
- **`README.md`** — documented both methods and the derived-history model.
- **`snap.manifest.json`** — shasum refreshed by `build:snap` (bundle legitimately changed).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `deriveHistory` maps persisted owned outputs + live spent-status + tip → `HistoryEntry[]` sorted by `blockHeight` desc, JSON-safe amounts | ✅ | pure-logic tests (order, decimal-string amounts) |
| Each entry carries `txHash`, `blockHeight`, `amountPicocredits`, `direction`, `confirmations = max(0, tip - blockHeight)` | ✅ | `HistoryEntry` type + confirmations/clamp tests |
| History reads persisted outputs (no full rescan); no `chain_getOutputs` window below the reorg-buffer resume point | ✅ | behavioural test asserts history-after-balance windows == `[{start: scanStartHeight(tip), end: tip}]` off `node.calls` |
| `STATE_VERSION` unchanged, no new persisted key | ✅ | guard test `STATE_VERSION === 1`; no `writeState` shape change |
| `botho_getHistory` returns `{ entries }`; `botho_showHistory` renders alert + returns entries/count | ✅ | behavioural tests (empty `[]`, dialog `getInterface()`) |
| `historyContent` renders Intl-free amounts + explicit empty-state | ✅ | dialog test asserts "No transactions yet"; reuses `formatBTHWithUnit` |
| Live spent-status re-check flips `direction`; spent status not persisted | ✅ | `spentTargetKeys` (owned minus live-spendable) test + `deriveHistory` flip; spent never written |
| Balance path behaviour-preserving after scan-core extract | ✅ | existing `state.snap.ts` / `balance.snap.ts` stay green |
| Follow-up filed + linked; no destructive `mergeOwnedOutputs` change | ✅ | #1099 filed and linked on #1092 |
| README documents both methods (derived, live spent-check, no rescan) | ✅ | RPC table + "Transaction history" section |

## Test Plan

`pnpm --filter @botho/wasm-signer build:wasm:bundler`, then in `web/packages/snap`:
- `pnpm typecheck` — pass
- `pnpm build:snap` — pass (shasum auto-refreshed)
- `pnpm test:snap` — **6 suites / 36 tests pass**

Out of scope (documented, deferred): outgoing "sent" records (new namespace + live owned-output fixtures, gated on #1051); destructive `mergeOwnedOutputs` prune-on-rescan / finality-depth (#1099).

Closes #1092