### PR TITLE
feat(snap): contacts / address book (phase 2)

### DIFF
--- a/web/packages/snap/README.md
+++ b/web/packages/snap/README.md
@@ -26,10 +26,14 @@ All params/results are JSON-safe; amounts are string-encoded `u64` picocredits
 | `botho_getAddress` | — | none | `{ address, derivation }` |
 | `botho_getBalance` | `{ rpcUrl }` | none | `{ spendablePicocredits }` |
 | `botho_getHistory` | `{ rpcUrl }` | none | `{ entries }` |
+| `botho_listContacts` | — | none | `{ contacts }` |
+| `botho_addContact` | `{ label, address }` | none | `{ contact, contacts }` |
+| `botho_removeContact` | `{ id }` | none | `{ contacts }` |
 | `botho_send` | `{ rpcUrl, recipientAddress, amountPicocredits, feePicocredits? }` | confirmation | `{ txHash, txBytes }` |
 | `botho_showReceive` | — | alert (address) | `{ address }` |
 | `botho_showBalance` | `{ rpcUrl }` | alert (balance) | `{ spendablePicocredits }` |
 | `botho_showHistory` | `{ rpcUrl }` | alert (history) | `{ entries, count }` |
+| `botho_showContacts` | — | alert (contacts) | `{ contacts, count }` |
 | `botho_showMnemonic` | — | confirm → alert | `{ revealed }` |
 
 `rpcUrl` is the **user-selected ingress node**, carrying over the web wallet's
@@ -141,6 +145,34 @@ blockHeight` (clamped at 0), so a shallow, reorg-prone receive near the tip is
 > of scope** here (it is balance-critical) and tracked as a dedicated follow-up.
 > The **non-destructive** half — surfacing per-entry `confirmations` so a shallow
 > receive is visible — is what this view ships.
+
+## Contacts / address book (#1093)
+
+`botho_addContact` / `botho_listContacts` / `botho_removeContact` (silent) and
+`botho_showContacts` (dialog) manage a small **address book** so a user does not
+have to re-paste an opaque `botho://2/…` stealth address every time they send to
+the same counterparty. Each entry is a validated `(label, address)` pair:
+
+```jsonc
+{
+  "id": "1a2b3c4d",              // stable id (FNV-1a hash of the normalized address)
+  "label": "My other wallet",   // trimmed, non-empty, ≤ 64 chars
+  "address": "tbotho://2/…"      // validated via @botho/core isValidAddress
+}
+```
+
+Contacts live under a **new `contacts` sibling key** in the *same* encrypted
+`snap_manageState` blob as `scan` (`{ version, scan, contacts }`). This is
+**purely additive**: `botho_addContact` validates the address with the shared
+`isValidAddress` (rejecting an invalid address / empty / over-length label with
+`InvalidParamsError`), then read-modify-writes the book while **spreading the
+persisted blob first** so it **never clobbers the `scan` checkpoint** — and
+symmetrically, a balance/history write preserves `contacts`. There is **no
+`STATE_VERSION` bump and no migration** (a bump would wrongly discard the scan
+checkpoint). Add/remove are dApp-driven; the dialog is view-only. This is the
+Snap analogue of the web wallet's `@botho/core` `EncryptedAddressBook` (#476) — a
+different runtime/storage surface, so it reuses only the address-validation
+utility, not the localStorage implementation.
 
 ## Key derivation: MetaMask SRP → Botho RootIdentity
 

--- a/web/packages/snap/snap.manifest.json
+++ b/web/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Manage a privacy-by-default Botho wallet from inside MetaMask. Keys are derived from your MetaMask Secret Recovery Phrase and never leave the Snap sandbox.",
   "proposedName": "Botho Wallet",
   "source": {
-    "shasum": "UYrZ+P7zVVYWDghE1YXhfSDIlKL/Vmnmq6rQOgA3lQ4=",
+    "shasum": "yRROti+nkaYaloq5kGQ8eLH/aGExMYVM2kcBplS3pB4=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/web/packages/snap/src/contacts.ts
+++ b/web/packages/snap/src/contacts.ts
@@ -1,0 +1,153 @@
+/**
+ * Snap contacts / address book (Phase-2, issue #1093).
+ *
+ * A small, self-contained store of `(label, address)` pairs so a user does not
+ * have to re-paste an opaque `botho://2/…` stealth address every time they send
+ * to the same counterparty. It is the Snap analogue of the web wallet's
+ * `@botho/core` `EncryptedAddressBook` (#476) — a DIFFERENT runtime and storage
+ * surface (`snap_manageState` vs browser localStorage/`VaultKey`), so it reuses
+ * the shared address-validation utility but not that localStorage implementation.
+ *
+ * Design (mirrors the pure-helper + thin-handler split of `state.ts`/`index.ts`):
+ *
+ *  - **Independent of scan/history.** Contacts carry no on-chain facts, need no
+ *    rescan and no wasm. This module depends ONLY on `readState`/`writeState`/
+ *    `STATE_VERSION` from `state.ts`.
+ *
+ *  - **Purely additive persistence, NO `STATE_VERSION` bump.** The book is stored
+ *    under a new `contacts` sibling key alongside `scan` in the same encrypted
+ *    `{ version, scan, contacts }` blob. `usableScanState()` only version-gates
+ *    the `scan` namespace, and `incrementalScan()` spreads the persisted blob
+ *    before writing `scan`, so a `contacts` key survives every balance/history
+ *    write. {@link writeContacts} MUST honour that invariant symmetrically — it
+ *    spreads the persisted blob (preserving `scan`) so writing contacts never
+ *    clobbers the scan checkpoint. Bumping the version would wrongly discard the
+ *    scan checkpoint and force a full genesis rescan, so the version stays `1`.
+ *
+ *  - **Validated + normalized.** Addresses are validated with the shared
+ *    `isValidAddress` from `@botho/core` (no hand-rolled regex); labels are
+ *    trimmed, rejected if empty, and length-capped so a runaway label can't bloat
+ *    the encrypted blob. An invalid address / bad label throws the same
+ *    `InvalidParamsError` the RPC param helpers already use.
+ */
+
+import { InvalidParamsError } from '@metamask/snaps-sdk';
+import { isValidAddress } from '@botho/core';
+
+import { readState, writeState, STATE_VERSION } from './state';
+
+/**
+ * Maximum stored contact-label length (characters, after trimming). Caps the
+ * per-entry size so a pathological label can't inflate the encrypted state blob.
+ */
+export const MAX_LABEL_LENGTH = 64;
+
+/**
+ * A single saved contact. Deliberately LEAN — the Snap tracks only a validated
+ * Botho address + a user label, NOT the richer `@botho/core` `Contact`
+ * (`txCount`/`lastTxAt`/`notes`) the web wallet keeps. Every field is JSON-safe.
+ */
+export interface SnapContact {
+  /** Stable id, derived deterministically from the normalized address. */
+  id: string;
+  /** User-supplied label: trimmed, non-empty, length-capped. */
+  label: string;
+  /** A validated `botho://2/…` (or `tbotho://2/…`) address. */
+  address: string;
+}
+
+/** The persisted contacts collection (the `contacts` state namespace). */
+export type ContactBook = SnapContact[];
+
+/* ------------------------------------------------------------------ */
+/* Pure helpers (unit-testable without the SES `snap` global)         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Normalize a user-supplied label: trim surrounding whitespace, reject an
+ * empty/whitespace-only value, and cap the length at {@link MAX_LABEL_LENGTH}.
+ * Throws {@link InvalidParamsError} on an empty or over-length label.
+ */
+export function normalizeLabel(label: string): string {
+  const trimmed = (label ?? '').trim();
+  if (trimmed.length === 0) {
+    throw new InvalidParamsError('Contact label must be a non-empty string.');
+  }
+  if (trimmed.length > MAX_LABEL_LENGTH) {
+    throw new InvalidParamsError(
+      `Contact label must be at most ${MAX_LABEL_LENGTH} characters.`,
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Derive a stable, deterministic id for a contact from its (already-normalized)
+ * address via a 32-bit FNV-1a hash rendered as fixed-width hex. Deterministic so
+ * {@link addContact} stays pure (no `crypto` global needed) and the same address
+ * always maps to the same id — which pairs naturally with the address-dedupe.
+ */
+export function contactId(address: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < address.length; i++) {
+    hash ^= address.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+/**
+ * Add a `(label, address)` pair to the book, returning a NEW array (never
+ * mutates the input). Validates the address with the shared `isValidAddress`
+ * (rejecting an invalid one with {@link InvalidParamsError}), normalizes the
+ * label, and rejects a duplicate address (same normalized address already saved)
+ * to keep the book clean.
+ */
+export function addContact(
+  book: ContactBook,
+  entry: { label: string; address: string },
+): ContactBook {
+  const address = (entry.address ?? '').trim();
+  if (!isValidAddress(address)) {
+    throw new InvalidParamsError(
+      'Contact address is not a valid Botho address (expected botho://2/ or tbotho://2/).',
+    );
+  }
+  const label = normalizeLabel(entry.label);
+  if (book.some((c) => c.address === address)) {
+    throw new InvalidParamsError('A contact with this address already exists.');
+  }
+  return [...book, { id: contactId(address), label, address }];
+}
+
+/**
+ * Remove the contact with the given id, returning a NEW array (never mutates the
+ * input). Removing a non-existent id is a no-op that returns an equivalent book.
+ */
+export function removeContact(book: ContactBook, id: string): ContactBook {
+  return book.filter((c) => c.id !== id);
+}
+
+/* ------------------------------------------------------------------ */
+/* State wrappers (enforce the scan-preserving invariant)             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Read the persisted contact book, or `[]` if the Snap has never written one.
+ * A silent read — no dialog, no network.
+ */
+export async function readContacts(): Promise<ContactBook> {
+  const state = await readState();
+  return state?.contacts ?? [];
+}
+
+/**
+ * Persist the contact book under the `contacts` namespace. CRITICAL: spreads the
+ * existing persisted blob first so the sibling `scan` checkpoint (and any other
+ * namespace) is preserved — writing contacts must NEVER clobber scan/history
+ * state. `STATE_VERSION` is written unchanged (no bump, no migration).
+ */
+export async function writeContacts(book: ContactBook): Promise<void> {
+  const state = await readState();
+  await writeState({ version: STATE_VERSION, ...(state ?? {}), contacts: book });
+}

--- a/web/packages/snap/src/index.ts
+++ b/web/packages/snap/src/index.ts
@@ -19,10 +19,14 @@
  *   - botho_getAddress  — the wallet's stealth receive address (silent read)
  *   - botho_getBalance  — spendable balance via scan (silent read)
  *   - botho_getHistory  — receive history projected from persisted scan state (silent read, #1092)
+ *   - botho_listContacts — saved address book (silent read, #1093)
+ *   - botho_addContact  — save a validated (label, address) contact (#1093)
+ *   - botho_removeContact — drop a saved contact by id (#1093)
  *   - botho_send        — build + sign + submit, behind a confirmation dialog
  *   - botho_showReceive — receive dialog (stealth address, copyable)
  *   - botho_showBalance — balance dialog
  *   - botho_showHistory — transaction-history dialog (#1092)
+ *   - botho_showContacts — contacts dialog (#1093)
  *   - botho_showMnemonic — reveal the derived recovery phrase (confirmed backup)
  *
  * Live-testnet send validation is deferred to a follow-up (betanet is frozen at
@@ -56,9 +60,16 @@ import {
   type HistoryEntry,
 } from './state';
 import {
+  addContact,
+  removeContact,
+  readContacts,
+  writeContacts,
+} from './contacts';
+import {
   receiveContent,
   balanceContent,
   historyContent,
+  contactsContent,
   sendConfirmContent,
   mnemonicBackupContent,
 } from './ui';
@@ -214,6 +225,34 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       return { entries } as unknown as Json;
     }
 
+    case 'botho_listContacts': {
+      // Silent read of the saved address book.
+      const contacts = await readContacts();
+      return { contacts } as unknown as Json;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Contacts: validated read-modify-write over the `contacts` namespace */
+    /* (spreads the persisted blob so `scan` is never clobbered — #1093).  */
+    /* ------------------------------------------------------------------ */
+    case 'botho_addContact': {
+      const label = requireString(params, 'label');
+      const address = requireString(params, 'address');
+      // `addContact` validates the address via `isValidAddress` and rejects an
+      // invalid address / empty / over-length label with InvalidParamsError.
+      const book = addContact(await readContacts(), { label, address });
+      await writeContacts(book);
+      const contact = book[book.length - 1];
+      return { contact, contacts: book } as unknown as Json;
+    }
+
+    case 'botho_removeContact': {
+      const id = requireString(params, 'id');
+      const book = removeContact(await readContacts(), id);
+      await writeContacts(book);
+      return { contacts: book } as unknown as Json;
+    }
+
     /* ------------------------------------------------------------------ */
     /* Dialog-driven flows                                                */
     /* ------------------------------------------------------------------ */
@@ -235,6 +274,12 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       const entries = await scanHistory(rpcUrl);
       await alert(historyContent(entries, rpcUrl));
       return { entries, count: entries.length } as unknown as Json;
+    }
+
+    case 'botho_showContacts': {
+      const contacts = await readContacts();
+      await alert(contactsContent(contacts));
+      return { contacts, count: contacts.length } as unknown as Json;
     }
 
     case 'botho_showMnemonic': {

--- a/web/packages/snap/src/state.ts
+++ b/web/packages/snap/src/state.ts
@@ -49,6 +49,8 @@ import type {
 } from '@botho/wasm-signer';
 import { spendableOwnedOutputs } from '@botho/wasm-signer';
 
+import type { ContactBook } from './contacts';
+
 declare const snap: {
   request(args: { method: string; params?: unknown }): Promise<unknown>;
 };
@@ -126,8 +128,12 @@ export interface SnapState {
   version: number;
   /** Incremental-scan state (absent until the first balance read). */
   scan?: ScanState;
-  // Reserved for sibling consumers (do NOT implement here):
-  // contacts?: ContactBook;          // #1093
+  /**
+   * Saved `(label, address)` contacts (#1093). A sibling namespace independent
+   * of `scan` — additive, so it needs no `STATE_VERSION` bump. See `contacts.ts`.
+   */
+  contacts?: ContactBook;
+  // Reserved for a future sibling consumer (do NOT implement here):
   // settings?: { rpcUrl?: string };  // in-Snap ingress selection
 }
 

--- a/web/packages/snap/src/ui.ts
+++ b/web/packages/snap/src/ui.ts
@@ -18,8 +18,11 @@ import {
   type JSXElement,
 } from '@metamask/snaps-sdk/jsx';
 
+import { shortenAddress } from '@botho/core';
+
 import { formatBTHWithUnit } from './format';
 import type { HistoryEntry } from './state';
+import type { ContactBook } from './contacts';
 
 /** Host component of an endpoint URL (for compact display), or the raw string. */
 function hostOf(rpcUrl: string): string {
@@ -123,6 +126,34 @@ export function historyContent(entries: HistoryEntry[], rpcUrl: string): JSXElem
         Divider({}),
       ]),
       Row({ label: 'Node', children: Text({ children: hostOf(rpcUrl) }) }),
+    ],
+  });
+}
+
+/**
+ * Contacts dialog: the saved address book, each entry rendering its label, a
+ * compact shortened address line, and a `Copyable` of the full address for reuse
+ * in a send. Renders an explicit empty-state when no contacts are saved. Add /
+ * remove are driven by the `botho_addContact` / `botho_removeContact` RPC methods
+ * (dApp-driven); this dialog is view-only (#1093).
+ */
+export function contactsContent(book: ContactBook): JSXElement {
+  if (book.length === 0) {
+    return Box({
+      children: [
+        Heading({ children: 'Contacts' }),
+        Text({ children: 'No saved contacts yet. Add one to reuse a Botho address without re-pasting it.' }),
+      ],
+    });
+  }
+  return Box({
+    children: [
+      Heading({ children: 'Contacts' }),
+      ...book.flatMap((contact) => [
+        Row({ label: contact.label, children: Text({ children: shortenAddress(contact.address) }) }),
+        Copyable({ value: contact.address }),
+        Divider({}),
+      ]),
     ],
   });
 }

--- a/web/packages/snap/test/contacts.snap.ts
+++ b/web/packages/snap/test/contacts.snap.ts
@@ -1,0 +1,234 @@
+/**
+ * Contacts / address book (issue #1093).
+ *
+ * Contacts are a self-contained, encrypted `(label, address)` store under a new
+ * `contacts` sibling namespace in the SAME `snap_manageState` blob as `scan` —
+ * additive, so NO `STATE_VERSION` bump and no migration. The critical invariant
+ * is cross-namespace isolation: writing contacts must NEVER clobber the persisted
+ * `scan` checkpoint (and vice versa).
+ *
+ * Two layers, mirroring `state.snap.ts` / `history.snap.ts`:
+ *
+ *  1. PURE-LOGIC tests of `addContact` / `removeContact` / `normalizeLabel` (no
+ *     `installSnap`, no wasm): validation, dedupe, non-mutation, label caps.
+ *
+ *  2. BEHAVIOURAL tests through the real SES `@metamask/snaps-jest` harness:
+ *     add -> list round-trips through `snap_manageState`; remove empties the book;
+ *     a malformed address is a JSON-RPC error; the empty-state dialog renders; and
+ *     the cross-namespace isolation guarantee — a contact write between two
+ *     balance reads leaves the scan checkpoint intact (the second balance read
+ *     still resumes from the reorg buffer rather than rescanning from genesis).
+ */
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+
+import { startMockNode, type MockNode } from './mock-node';
+import {
+  addContact,
+  removeContact,
+  normalizeLabel,
+  contactId,
+  MAX_LABEL_LENGTH,
+  type ContactBook,
+} from '../src/contacts';
+import { STATE_VERSION, REORG_BUFFER, scanStartHeight } from '../src/state';
+
+function unwrap<T>(response: { response: unknown }): T {
+  const res = response.response as { result?: T; error?: { message?: string } };
+  if (res.error) {
+    throw new Error(`snap returned error: ${JSON.stringify(res.error)}`);
+  }
+  return res.result as T;
+}
+
+/** Whether a snap response carried a JSON-RPC error (for negative-path asserts). */
+function isError(response: { response: unknown }): boolean {
+  return Boolean((response.response as { error?: unknown }).error);
+}
+
+/** Count / inspect the windowed output fetches the Snap issued. */
+function outputWindows(node: MockNode): Array<{ start: number; end: number }> {
+  return node.calls
+    .filter((c) => c.method === 'chain_getOutputs')
+    .map((c) => {
+      const p = c.params as { start_height: number; end_height: number };
+      return { start: p.start_height, end: p.end_height };
+    });
+}
+
+// Two well-formed testnet v2 addresses (from the address-codec fixtures). Only
+// their FORMAT matters here — the Snap validates format via `isValidAddress`.
+const ADDR_A =
+  'tbotho://2/' +
+  '11111111111111111111111111111111111111111111111111111111111111111111111111111111';
+
+/* ================================================================== */
+/* 1. Pure-logic contract (no SES install)                            */
+/* ================================================================== */
+
+describe('contacts pure helpers (#1093)', () => {
+  // These cover the validation + normalization surface that does NOT need a real
+  // encoded address (label caps, malformed-address rejection, id stability,
+  // non-mutating removal). The happy-path add of a VALID address is exercised in
+  // layer 2 against the Snap's own derived (guaranteed-valid) stealth address.
+
+  it('normalizeLabel trims and rejects empty / whitespace-only labels', () => {
+    expect(normalizeLabel('  Alice  ')).toBe('Alice');
+    expect(() => normalizeLabel('')).toThrow();
+    expect(() => normalizeLabel('   ')).toThrow();
+  });
+
+  it('normalizeLabel caps the label length at MAX_LABEL_LENGTH', () => {
+    const atCap = 'x'.repeat(MAX_LABEL_LENGTH);
+    expect(normalizeLabel(atCap)).toBe(atCap); // exactly at the cap is allowed
+    expect(() => normalizeLabel('x'.repeat(MAX_LABEL_LENGTH + 1))).toThrow();
+  });
+
+  it('addContact rejects a malformed / non-Botho address', () => {
+    expect(() => addContact([], { label: 'Bad', address: 'not-an-address' })).toThrow();
+    expect(() => addContact([], { label: 'Bad', address: '' })).toThrow();
+  });
+
+  it('contactId is deterministic and stable per address', () => {
+    expect(contactId('abc')).toBe(contactId('abc'));
+    expect(contactId('abc')).not.toBe(contactId('abd'));
+    expect(contactId('abc')).toMatch(/^[0-9a-f]{8}$/u);
+  });
+
+  it('removeContact filters by id, returns a NEW array, and no-ops an unknown id', () => {
+    const book: ContactBook = [
+      { id: 'aaaa1111', label: 'Alice', address: ADDR_A },
+      { id: 'bbbb2222', label: 'Bob', address: ADDR_A },
+    ];
+    const removed = removeContact(book, 'aaaa1111');
+    expect(removed).toHaveLength(1);
+    expect(removed[0].id).toBe('bbbb2222');
+    expect(book).toHaveLength(2); // input not mutated
+
+    // Removing an id that isn't present is a no-op returning an equivalent book.
+    expect(removeContact(book, 'no-such-id')).toHaveLength(2);
+  });
+
+  it('does not bump STATE_VERSION (contacts are an additive sibling namespace)', () => {
+    expect(STATE_VERSION).toBe(1);
+  });
+});
+
+/* ================================================================== */
+/* 2. Behavioural: contacts through the SES harness                   */
+/* ================================================================== */
+
+interface SnapContactJson {
+  id: string;
+  label: string;
+  address: string;
+}
+
+describe('botho snap: contacts / address book against a mocked node (#1093)', () => {
+  let node: MockNode;
+
+  afterEach(async () => {
+    if (node) await node.close();
+  });
+
+  /** The Snap's own derived stealth address — a guaranteed-valid Botho address. */
+  type Request = Awaited<ReturnType<typeof installSnap>>['request'];
+  async function derivedAddress(request: Request): Promise<string> {
+    const { address } = unwrap<{ address: string }>(
+      await request({ method: 'botho_getAddress' }),
+    );
+    return address;
+  }
+
+  it('addContact then listContacts round-trips through snap_manageState', async () => {
+    const { request } = await installSnap();
+    const address = await derivedAddress(request);
+
+    const added = unwrap<{ contact: SnapContactJson; contacts: SnapContactJson[] }>(
+      await request({ method: 'botho_addContact', params: { label: 'My other wallet', address } }),
+    );
+    expect(added.contact.label).toBe('My other wallet');
+    expect(added.contact.address).toBe(address);
+    expect(added.contact.id).toMatch(/^[0-9a-f]{8}$/u);
+
+    const { contacts } = unwrap<{ contacts: SnapContactJson[] }>(
+      await request({ method: 'botho_listContacts' }),
+    );
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0]).toEqual(added.contact);
+  });
+
+  it('removeContact drops the entry (listContacts then returns [])', async () => {
+    const { request } = await installSnap();
+    const address = await derivedAddress(request);
+
+    const added = unwrap<{ contact: SnapContactJson }>(
+      await request({ method: 'botho_addContact', params: { label: 'Alice', address } }),
+    );
+    unwrap(await request({ method: 'botho_removeContact', params: { id: added.contact.id } }));
+
+    const { contacts } = unwrap<{ contacts: SnapContactJson[] }>(
+      await request({ method: 'botho_listContacts' }),
+    );
+    expect(contacts).toEqual([]);
+  });
+
+  it('addContact with a malformed address returns a JSON-RPC error', async () => {
+    const { request } = await installSnap();
+    const response = await request({
+      method: 'botho_addContact',
+      params: { label: 'Typo', address: 'botho://2/not-a-real-address' },
+    });
+    expect(isError(response)).toBe(true);
+  });
+
+  it('botho_showContacts renders the empty-state dialog', async () => {
+    const { request } = await installSnap();
+    const response = request({ method: 'botho_showContacts' });
+    const ui = await response.getInterface();
+    expect(ui.type).toBe('alert');
+    const rendered = JSON.stringify(ui.content);
+    expect(rendered).toContain('Contacts');
+    expect(rendered).toContain('No saved contacts yet');
+
+    await (ui as { ok(): Promise<void> }).ok();
+    const result = unwrap<{ contacts: SnapContactJson[]; count: number }>(await response);
+    expect(result.contacts).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  it('cross-namespace isolation: a contact write does NOT clobber the scan checkpoint', async () => {
+    // A multi-window tip makes a full genesis rescan visible in call counts.
+    const tip = 3000;
+    node = await startMockNode({ chainHeight: tip });
+    const { request } = await installSnap();
+
+    // 1. Seed a persisted scan checkpoint via a full genesis balance scan.
+    unwrap(await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }));
+    const afterBalance = outputWindows(node).length;
+    expect(afterBalance).toBeGreaterThan(1); // genuinely multi-window genesis scan
+
+    // 2. Write a contact IN BETWEEN the two balance reads.
+    const address = await derivedAddress(request);
+    unwrap(await request({ method: 'botho_addContact', params: { label: 'Saved', address } }));
+
+    // 3. A second balance read at the SAME tip must still RESUME from the
+    //    persisted checkpoint (only the trailing reorg-buffer window), proving
+    //    the contact write preserved `scan` rather than discarding it.
+    unwrap(await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }));
+    const resumeWindows = outputWindows(node).slice(afterBalance);
+    expect(resumeWindows).toEqual([{ start: scanStartHeight(tip), end: tip }]);
+    for (const w of resumeWindows) {
+      expect(w.start).toBeGreaterThanOrEqual(tip - REORG_BUFFER);
+    }
+
+    // 4. And the contact itself survived the intervening balance write
+    //    (scan write must not clobber `contacts` either).
+    const { contacts } = unwrap<{ contacts: SnapContactJson[] }>(
+      await request({ method: 'botho_listContacts' }),
+    );
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].address).toBe(address);
+  });
+});


### PR DESCRIPTION
Closes #1093

## What this builds

A self-contained **contacts / address book** for the Botho MetaMask Snap (`web/packages/snap`), so a user can save `(label, address)` pairs once and reuse them instead of re-pasting an opaque `botho://2/…` stealth address on every send. This is the Snap analogue of the web wallet's `@botho/core` `EncryptedAddressBook` (#476) — a different runtime/storage surface (`snap_manageState` vs browser localStorage/`VaultKey`), so it reuses only the shared address-validation utility.

## Changes

- **`src/contacts.ts` (new)** — `SnapContact`/`ContactBook` types; pure, unit-testable `addContact` / `removeContact` / `normalizeLabel` / `contactId` helpers (validate, dedupe by address, non-mutating, label trimmed + capped at 64 chars); and `readContacts` / `writeContacts` state wrappers. Address validation reuses `isValidAddress` from `@botho/core` (no hand-rolled regex); invalid address / empty / over-length label throw `InvalidParamsError`.
- **`src/state.ts`** — `SnapState` gains a `contacts?: ContactBook` field (replacing the reserved comment). **`STATE_VERSION` stays `1`** — no bump, no migration.
- **`src/index.ts`** — `botho_addContact` / `botho_listContacts` / `botho_removeContact` RPC handlers (read-modify-write) + a `botho_showContacts` view-only dialog.
- **`src/ui.ts`** — `contactsContent(book)` renderer with an explicit empty-state, mirroring `historyContent`'s JSX-factory style (`shortenAddress` for a compact line + `Copyable` of the full address).
- **`test/contacts.snap.ts` (new)** — two-layer pure-logic + `@metamask/snaps-jest` behavioural tests, mirroring `test/history.snap.ts`.
- **`README.md`** — documents the four new methods + a Contacts section.
- **`snap.manifest.json`** — only the rebuilt bundle `shasum` updated; **no permission change** (`snap_manageState`, `snap_dialog`, `endowment:rpc` already granted).

## The critical invariant (curator-flagged)

Contacts persist under a **new `contacts` sibling key** in the *same* encrypted blob as `scan` (`{ version, scan, contacts }`). The write path is symmetric:
- `writeContacts` spreads the persisted blob first, so writing contacts **never clobbers the `scan` checkpoint**.
- `incrementalScan` already spreads persisted state before writing `scan`, so a balance/history write preserves `contacts`.

A dedicated **cross-namespace isolation test** proves both directions: seed a multi-window genesis scan via `botho_getBalance`, write a contact in between, then a second `botho_getBalance` at the same tip still **resumes from the reorg-buffer window** (not a genesis rescan) — and the contact still round-trips after the intervening scan write.

## Test results

`pnpm typecheck && pnpm build:snap && pnpm test:snap` — all green.

```
Test Suites: 7 passed, 7 total
Tests:       47 passed, 47 total
```

New `test/contacts.snap.ts`: **11 passed** (6 pure-logic + 5 behavioural), including `cross-namespace isolation: a contact write does NOT clobber the scan checkpoint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)