### PR TITLE
feat(snap): claim-link ingress (preview + sweep) for the Botho Snap

### DIFF
--- a/web/packages/snap/README.md
+++ b/web/packages/snap/README.md
@@ -30,6 +30,8 @@ All params/results are JSON-safe; amounts are string-encoded `u64` picocredits
 | `botho_addContact` | `{ label, address }` | none | `{ contact, contacts }` |
 | `botho_removeContact` | `{ id }` | none | `{ contacts }` |
 | `botho_send` | `{ rpcUrl, recipientAddress, amountPicocredits, feePicocredits? }` | confirmation | `{ txHash, txBytes }` |
+| `botho_previewClaimLink` | `{ rpcUrl, link }` | alert (claim) | `{ grossPicocredits, feePicocredits, netPicocredits }` |
+| `botho_claimLink` | `{ rpcUrl, link }` | confirmation | `{ txHash, netPicocredits }` |
 | `botho_showReceive` | — | alert (address) | `{ address }` |
 | `botho_showBalance` | `{ rpcUrl }` | alert (balance) | `{ spendablePicocredits }` |
 | `botho_showHistory` | `{ rpcUrl }` | alert (history) | `{ entries, count }` |
@@ -173,6 +175,58 @@ checkpoint). Add/remove are dApp-driven; the dialog is view-only. This is the
 Snap analogue of the web wallet's `@botho/core` `EncryptedAddressBook` (#476) — a
 different runtime/storage surface, so it reuses only the address-validation
 utility, not the localStorage implementation.
+
+## Claim-link ingress (#1094)
+
+A Botho **claim link** is a *bearer instrument*: the link fragment IS an
+ephemeral 12-word BIP39 mnemonic that owns the funded output(s) — whoever holds
+the link owns the funds, so **treat it like cash**. Claiming is **100%
+client-side** and reuses the normal CLSAG scan/send path — **no new node RPC, no
+consensus change**. Two methods surface it inside MetaMask (`src/claim.ts` +
+`src/ui.ts`):
+
+1. **Parse** the fragment → ephemeral mnemonic (+ optional non-authoritative
+   amount hint) via `@botho/core` `parseClaimLinkFragment` (accepts a full URL, a
+   bare fragment, or a leading-`#` fragment). A malformed / unsupported-version /
+   empty fragment fails with a typed `InvalidParamsError` **before any network
+   call or dialog**.
+2. **Derive** the ephemeral keys (`deriveKeypairs` + `mnemonicToSeedHex`).
+3. **Scan** the ephemeral wallet's spendable balance (`spendableBalance` — the
+   same `chain_getOutputs` + `chain_areKeyImagesSpent` surface as
+   `botho_getBalance`), yielding gross / fee / net.
+4. **Sweep** (`botho_claimLink` only): build + submit a CLSAG send FROM the
+   ephemeral keys TO the user's OWN derived address, the sweep fee paid from the
+   funded output so the user nets `gross − fee`.
+
+- `botho_previewClaimLink` is a **pure read** (parse → derive → scan → alert). It
+  is fully deterministic against the mocked node (an empty chain → net `0` → the
+  "nothing to claim" state), exactly like `botho_getBalance` — **no #1051
+  caveat**.
+- `botho_claimLink` mirrors `botho_send`: parse → wrong-network guard → scan →
+  **confirmation dialog** → sweep. Its submit plumbing is mock-tested (confirm,
+  approve/reject, "nothing to claim" surfaced, never submits without funds), and
+  **live on-chain claim validation inherits the existing `#1051` betanet gate**
+  (a real funded ephemeral output needs a live minting node) — the same gate as
+  live-send, **not a new blocker**.
+
+The scanned amount is **always authoritative**; the link's optional `amountHint`
+is shown only as a pre-scan cosmetic and is explicitly labelled non-authoritative.
+
+**Bearer-secret hygiene (cf. #474/#475).** The ephemeral mnemonic lives only
+in-memory for the duration of the RPC call — it is **never persisted** (claim
+ingress adds no `snap_manageState` key), **never put in a dialog / returned
+result / error message**, and never logged. `snap.manifest.json` needs **no**
+permission change (`endowment:network-access` + `snap_dialog` + `snap_getEntropy`
+already cover it).
+
+> **Not built here (deferred siblings).** The **request-link / pull** flow
+> (`/pay#…`, where the payer keeps custody until they approve) is a *request*
+> feature, not receive ingress; its encoder lives in the web wallet
+> (`web-wallet/src/lib/payment-request.ts`), not `@botho/core`, and would need
+> promotion + an SES-safe base64 pass — filed as a separate follow-up. An
+> **address QR** is **infeasible**: Botho v2 post-quantum stealth addresses
+> (`tbotho://2/…`) are too large for a scannable QR (see the web wallet's
+> `ReceiveModal.tsx`) — the `Copyable` field is the correct affordance.
 
 ## Key derivation: MetaMask SRP → Botho RootIdentity
 

--- a/web/packages/snap/snap.manifest.json
+++ b/web/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Manage a privacy-by-default Botho wallet from inside MetaMask. Keys are derived from your MetaMask Secret Recovery Phrase and never leave the Snap sandbox.",
   "proposedName": "Botho Wallet",
   "source": {
-    "shasum": "yRROti+nkaYaloq5kGQ8eLH/aGExMYVM2kcBplS3pB4=",
+    "shasum": "RmkO/QR5gGFhHOBcL2r8CM0ximLyjTyOtyasCPl0+lk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/web/packages/snap/src/claim.ts
+++ b/web/packages/snap/src/claim.ts
@@ -1,0 +1,157 @@
+/**
+ * Claim-link ingress for the Botho Snap (phase 2, #1094).
+ *
+ * A Botho **claim link** is a *bearer instrument*: the link fragment IS an
+ * ephemeral 12-word BIP39 mnemonic that owns the funded output(s). Claiming is
+ * 100% client-side and reuses the normal CLSAG send/scan path — NO new node RPC,
+ * no consensus change. The flow mirrors the web wallet's
+ * `web-wallet/src/lib/claim-link-ops.ts` (`scanEphemeral` / `sweepEphemeral`),
+ * but the web reference is bound to `RemoteNodeAdapter`; the Snap has its own
+ * `NodeCall` / `makeSendRpc` (`src/node.ts`), so this module is the thin
+ * Snap-local glue over the shared `SendRpc` slice.
+ *
+ *   1. PARSE  the link fragment -> ephemeral mnemonic (+ non-authoritative
+ *             amount hint) via `parseClaimLinkFragment` from `@botho/core`.
+ *   2. DERIVE the ephemeral keys (`deriveKeypairs` + `mnemonicToSeedHex`).
+ *   3. SCAN   the ephemeral wallet's spendable balance (`spendableBalance`, the
+ *             same `chain_getOutputs` + `chain_areKeyImagesSpent` surface as
+ *             `botho_getBalance`). gross/fee/net.
+ *   4. SWEEP  build + submit a CLSAG send FROM the ephemeral keys TO the user's
+ *             own address (`buildSendTransaction`), fee paid from the funded
+ *             output so the user nets `gross - fee`.
+ *
+ * BEARER-SECRET HYGIENE (cf. #474/#475): the ephemeral mnemonic lives only
+ * in-memory for the duration of the RPC call. It is NEVER persisted, NEVER put
+ * in a dialog or a returned result, and NEVER included in an error message.
+ */
+
+import { InvalidParamsError } from '@metamask/snaps-sdk';
+import { parseClaimLinkFragment, deriveKeypairs, parseAddress } from '@botho/core';
+import {
+  buildSendTransaction,
+  spendableBalance,
+  deriveKemPublicKey,
+  mnemonicToSeedHex,
+  type SignerKeys,
+  type SendRpc,
+} from '@botho/wasm-signer';
+
+import { wasm } from './signer';
+
+const toHex = (b: Uint8Array): string =>
+  Array.from(b)
+    .map((x) => x.toString(16).padStart(2, '0'))
+    .join('');
+
+/** The parsed contents of a claim link: the ephemeral secret + optional hint. */
+export interface ParsedClaimLink {
+  /**
+   * The ephemeral 12-word BIP39 mnemonic that owns the funded output(s). Bearer
+   * secret — never surface it (dialog / result / error / log).
+   */
+  mnemonic: string;
+  /**
+   * Optional, non-authoritative cosmetic amount hint (picocredits) carried in
+   * the link. NEVER trust it for the claimed value — the on-chain scan is always
+   * authoritative (see `@botho/core` `claim-link.ts`).
+   */
+  amountHint?: bigint;
+}
+
+/** The result of scanning an ephemeral claim-link wallet. */
+export interface ClaimScan {
+  /** Gross spendable picocredits owned by the ephemeral wallet. */
+  grossPicocredits: bigint;
+  /** Sweep fee (network minimum) that will be charged. */
+  feePicocredits: bigint;
+  /** Net picocredits the user receives after the sweep fee (clamped at 0). */
+  netPicocredits: bigint;
+}
+
+/**
+ * Parse a claim link (full URL, bare fragment, or leading-`#` fragment — all
+ * accepted by `parseClaimLinkFragment`) into its ephemeral secret. Throws a
+ * typed {@link InvalidParamsError} on a malformed / unsupported-version / empty
+ * fragment so a bad link fails BEFORE any network round-trip and BEFORE any
+ * dialog. The underlying parser fails before the mnemonic is reconstructed, so
+ * its message never carries the bearer secret.
+ */
+export function parseClaimLink(link: string): ParsedClaimLink {
+  let secret;
+  try {
+    secret = parseClaimLinkFragment(link);
+  } catch (err) {
+    throw new InvalidParamsError(
+      `Invalid claim link: ${err instanceof Error ? err.message : 'unparseable fragment'}.`,
+    );
+  }
+  return { mnemonic: secret.mnemonic, amountHint: secret.amountHint };
+}
+
+/** Derive the ephemeral wallet's signing keys from its mnemonic. */
+function ephemeralKeys(mnemonic: string): SignerKeys {
+  const kp = deriveKeypairs(mnemonic, 0);
+  return {
+    spendPrivateKey: toHex(kp.spendPrivate),
+    viewPrivateKey: toHex(kp.viewPrivate),
+    seed: mnemonicToSeedHex(mnemonic),
+  };
+}
+
+/**
+ * Scan an ephemeral claim-link wallet for its spendable balance and compute
+ * gross/fee/net. `gross === 0n` means the link is empty, already claimed (the
+ * output's key image is spent), or the funding tx has not confirmed yet — all
+ * three yield an empty spendable set, distinguished by UX, not here. Pure read:
+ * reuses the same RPC surface as `botho_getBalance` (no `tx_submit`).
+ */
+export async function scanClaimLink(mnemonic: string, rpc: SendRpc): Promise<ClaimScan> {
+  const grossPicocredits = await spendableBalance(ephemeralKeys(mnemonic), rpc);
+  const feePicocredits = wasm.minFee();
+  const netPicocredits =
+    grossPicocredits > feePicocredits ? grossPicocredits - feePicocredits : 0n;
+  return { grossPicocredits, feePicocredits, netPicocredits };
+}
+
+/**
+ * Build a CLSAG sweep transaction FROM the ephemeral claim-link keys TO
+ * `destinationAddress` (the user's own wallet), paying the sweep fee out of the
+ * funded output so the user nets `gross - fee`. Re-scans at sweep time to get
+ * the live gross/fee (mirrors the web wallet's `sweepEphemeral`). Throws — before
+ * building or submitting anything — if there is nothing spendable (empty /
+ * already claimed / unconfirmed) or the funded amount cannot cover the fee.
+ * Returns the unsigned-then-signed tx hex ready for `tx_submit`.
+ */
+export async function buildSweep(
+  mnemonic: string,
+  destinationAddress: string,
+  rpc: SendRpc,
+): Promise<{ txHex: string; scan: ClaimScan }> {
+  const scan = await scanClaimLink(mnemonic, rpc);
+  if (scan.grossPicocredits === 0n) {
+    throw new Error(
+      'Nothing to claim — this link is empty, already claimed, or not yet confirmed.',
+    );
+  }
+  if (scan.netPicocredits <= 0n) {
+    throw new Error('The claimed amount does not cover the sweep fee.');
+  }
+
+  const destKeys = parseAddress(destinationAddress);
+  const senderKemPublicKey = await deriveKemPublicKey(mnemonic);
+
+  const { txHex } = await buildSendTransaction({
+    keys: ephemeralKeys(mnemonic),
+    recipient: {
+      spend_public_key: toHex(destKeys.spendPublic),
+      view_public_key: toHex(destKeys.viewPublic),
+      kem_public_key: toHex(destKeys.kemPublic),
+    },
+    senderKemPublicKey,
+    amount: scan.netPicocredits,
+    fee: scan.feePicocredits,
+    rpc,
+  });
+
+  return { txHex, scan };
+}

--- a/web/packages/snap/src/index.ts
+++ b/web/packages/snap/src/index.ts
@@ -23,6 +23,8 @@
  *   - botho_addContact  — save a validated (label, address) contact (#1093)
  *   - botho_removeContact — drop a saved contact by id (#1093)
  *   - botho_send        — build + sign + submit, behind a confirmation dialog
+ *   - botho_previewClaimLink — scan a claim link (parse → derive → scan → alert), pure read (#1094)
+ *   - botho_claimLink   — sweep a claim link into this wallet, behind a confirmation (#1094)
  *   - botho_showReceive — receive dialog (stealth address, copyable)
  *   - botho_showBalance — balance dialog
  *   - botho_showHistory — transaction-history dialog (#1092)
@@ -71,8 +73,11 @@ import {
   historyContent,
   contactsContent,
   sendConfirmContent,
+  claimPreviewContent,
+  claimConfirmContent,
   mnemonicBackupContent,
 } from './ui';
+import { parseClaimLink, scanClaimLink, buildSweep } from './claim';
 
 declare const snap: {
   request(args: { method: string; params?: unknown }): Promise<unknown>;
@@ -335,6 +340,59 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       const { txHash } = await call<{ txHash: string }>('tx_submit', { tx_hex: txHex });
       return { txHash, txBytes: txHex.length / 2 } as Json;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Claim-link ingress (#1094): parse -> derive -> scan -> [sweep]      */
+    /* A claim link is a bearer instrument (an ephemeral mnemonic); the    */
+    /* bearer secret lives only in-memory for this call — never persisted, */
+    /* never surfaced in a dialog / result / error.                        */
+    /* ------------------------------------------------------------------ */
+    case 'botho_previewClaimLink': {
+      const rpcUrl = requireString(params, 'rpcUrl');
+      const link = requireString(params, 'link');
+
+      // Parse BEFORE any network round-trip so a malformed link fails without
+      // a call or a dialog (typed InvalidParamsError).
+      const { mnemonic, amountHint } = parseClaimLink(link);
+
+      // Node-trust / wrong-network guard before we scan.
+      const { call } = await connectAndGuard(rpcUrl);
+      const scan = await scanClaimLink(mnemonic, makeSendRpc(call));
+
+      await alert(claimPreviewContent({ ...scan, amountHint, rpcUrl }));
+      return {
+        grossPicocredits: scan.grossPicocredits.toString(),
+        feePicocredits: scan.feePicocredits.toString(),
+        netPicocredits: scan.netPicocredits.toString(),
+      } as Json;
+    }
+
+    case 'botho_claimLink': {
+      const rpcUrl = requireString(params, 'rpcUrl');
+      const link = requireString(params, 'link');
+
+      const { mnemonic, amountHint } = parseClaimLink(link);
+
+      // Wrong-network guard fires first, before anything touches funds.
+      const { call } = await connectAndGuard(rpcUrl);
+      const rpc = makeSendRpc(call);
+
+      // Scan so the confirmation shows the authoritative claimable/net amount.
+      const scan = await scanClaimLink(mnemonic, rpc);
+
+      const approved = await confirm(claimConfirmContent({ ...scan, amountHint, rpcUrl }));
+      if (!approved) {
+        throw new UserRejectedRequestError('User rejected the claim.');
+      }
+
+      // Sweep into the user's OWN derived address. `buildSweep` re-scans and
+      // surfaces "nothing to claim" (never submitting) when the link is empty.
+      const wallet = await deriveWallet();
+      const { txHex, scan: sweptScan } = await buildSweep(mnemonic, wallet.address, rpc);
+
+      const { txHash } = await call<{ txHash: string }>('tx_submit', { tx_hex: txHex });
+      return { txHash, netPicocredits: sweptScan.netPicocredits.toString() } as Json;
     }
 
     default:

--- a/web/packages/snap/src/ui.ts
+++ b/web/packages/snap/src/ui.ts
@@ -158,6 +158,81 @@ export function contactsContent(book: ContactBook): JSXElement {
   });
 }
 
+/** Amounts + context rendered in the claim-link preview / confirm dialogs. */
+export interface ClaimView {
+  /** Gross spendable picocredits the ephemeral link wallet holds. */
+  grossPicocredits: bigint;
+  /** Sweep fee (network minimum) charged from the funded output. */
+  feePicocredits: bigint;
+  /** Net picocredits the user receives after the sweep fee. */
+  netPicocredits: bigint;
+  /** Optional cosmetic hint carried in the link (never authoritative). */
+  amountHint?: bigint;
+  /** The ingress node the scan / sweep runs against. */
+  rpcUrl: string;
+}
+
+/**
+ * Shared body rows for the claim-link dialogs: the scanned claimable / fee / net
+ * amounts, an optional cosmetic hint line, and the ingress node. The SCANNED
+ * amount is always authoritative; the `amountHint` (if present) is shown only as
+ * a secondary, pre-scan cosmetic and is explicitly labelled as non-authoritative
+ * (per `@botho/core` `claim-link.ts`). The bearer secret (mnemonic) is NEVER
+ * rendered.
+ */
+function claimBodyRows(view: ClaimView): JSXElement[] {
+  const empty = view.grossPicocredits === 0n;
+  const rows: JSXElement[] = [
+    empty
+      ? Text({
+          children:
+            'Nothing to claim — this link is empty, already claimed, or not yet confirmed.',
+        })
+      : Text({
+          children:
+            'This claim link holds funds that will be swept into your wallet. The ' +
+            'sweep fee is paid from the link.',
+        }),
+    Row({ label: 'Claimable', children: Text({ children: formatBTHWithUnit(view.grossPicocredits) }) }),
+    Row({ label: 'Sweep fee', children: Text({ children: formatBTHWithUnit(view.feePicocredits) }) }),
+    Row({ label: 'You receive', children: Text({ children: formatBTHWithUnit(view.netPicocredits) }) }),
+  ];
+  if (view.amountHint !== undefined) {
+    rows.push(
+      Text({
+        children:
+          `Link hint: ${formatBTHWithUnit(view.amountHint)} ` +
+          '(cosmetic — the scanned amount above is authoritative)',
+      }),
+    );
+  }
+  rows.push(Divider({}));
+  rows.push(Row({ label: 'Node', children: Text({ children: hostOf(view.rpcUrl) }) }));
+  return rows;
+}
+
+/**
+ * Claim-link PREVIEW dialog (alert): a read-only scan of what a claim link holds
+ * (`botho_previewClaimLink`). Renders the scanned claimable / fee / net and the
+ * ingress node; does not submit anything.
+ */
+export function claimPreviewContent(view: ClaimView): JSXElement {
+  return Box({
+    children: [Heading({ children: 'Claim link' }), ...claimBodyRows(view)],
+  });
+}
+
+/**
+ * Claim-link CONFIRM dialog (confirmation): the same figures as the preview, but
+ * gated behind an explicit approve/reject before the sweep is built + submitted
+ * (`botho_claimLink`). Mirrors the `botho_send` confirmation.
+ */
+export function claimConfirmContent(view: ClaimView): JSXElement {
+  return Box({
+    children: [Heading({ children: 'Confirm claim' }), ...claimBodyRows(view)],
+  });
+}
+
 /** Mnemonic-backup dialog: the derived 24-word Botho recovery phrase. */
 export function mnemonicBackupContent(mnemonic: string): JSXElement {
   return Box({

--- a/web/packages/snap/test/claim.snap.ts
+++ b/web/packages/snap/test/claim.snap.ts
@@ -1,0 +1,265 @@
+/**
+ * Claim-link ingress against a MOCKED node RPC (issue #1094), through the
+ * `@metamask/snaps-jest` SES harness.
+ *
+ * A claim link is a bearer instrument: the fragment IS an ephemeral 12-word
+ * mnemonic that owns the funds. Claiming reuses the normal CLSAG scan/send path
+ * (no new node RPC). As with `botho_send`, a live on-chain sweep needs real
+ * owned-output fixtures only a live minting node produces (betanet is frozen at
+ * height 202 — #1051), so these tests validate the full claim PLUMBING against
+ * the empty mock: the parse/derive/scan reads, the preview + confirm dialogs, the
+ * approve/reject branches, and that the sweep pipeline reaches the node yet never
+ * `tx_submit`s without funds. LIVE claim validation is inherited from the
+ * existing #1051 send gap, not a new blocker (README.md).
+ *
+ * The wrong-network guard is loopback-exempt (the mock binds to 127.0.0.1), so
+ * its throwing behaviour is covered at the pure level in `units.snap.ts`
+ * (`assertNetworkAllowed`); here we assert both methods run `node_getStatus`
+ * (i.e. route through `connectAndGuard`) before scanning.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+import {
+  createClaimLinkMnemonic,
+  encodeClaimLinkFragment,
+  buildClaimLink,
+} from '@botho/core';
+
+import { startMockNode, type MockNode } from './mock-node';
+
+function unwrap<T>(response: { response: unknown }): T {
+  const res = response.response as { result?: T; error?: { message?: string } };
+  if (res.error) {
+    throw new Error(`snap returned error: ${JSON.stringify(res.error)}`);
+  }
+  return res.result as T;
+}
+
+function errorOf(response: { response: unknown }): { message?: string } | undefined {
+  return (response.response as { error?: { message?: string } }).error;
+}
+
+/** A fresh, well-formed claim link fragment (empty mock => 0 spendable). */
+function freshLink(amountHint?: bigint): { mnemonic: string; fragment: string } {
+  const mnemonic = createClaimLinkMnemonic();
+  return { mnemonic, fragment: encodeClaimLinkFragment(mnemonic, amountHint) };
+}
+
+interface ClaimScanResult {
+  grossPicocredits: string;
+  feePicocredits: string;
+  netPicocredits: string;
+}
+
+describe('botho snap: claim-link ingress against a mocked node (#1094)', () => {
+  let node: MockNode;
+
+  beforeEach(async () => {
+    node = await startMockNode(); // empty testnet chain
+  });
+  afterEach(async () => {
+    await node.close();
+  });
+
+  /* ================================================================== */
+  /* botho_previewClaimLink (pure read — zero #1051 caveat)             */
+  /* ================================================================== */
+
+  it('previews a well-formed link: alert dialog + deterministic 0 net on the empty mock', async () => {
+    const { request } = await installSnap();
+    const { fragment } = freshLink();
+
+    const response = request({
+      method: 'botho_previewClaimLink',
+      params: { rpcUrl: node.url, link: fragment },
+    });
+
+    const ui = await response.getInterface();
+    expect(ui.type).toBe('alert');
+    const rendered = JSON.stringify(ui.content);
+    expect(rendered).toContain('Claim link');
+    expect(rendered).toContain('BTH'); // amount rows rendered
+    expect(rendered).toContain('Nothing to claim'); // empty-state on the empty mock
+
+    await (ui as { ok(): Promise<void> }).ok();
+    const result = unwrap<ClaimScanResult>(await response);
+    expect(result.netPicocredits).toBe('0');
+    expect(result.grossPicocredits).toBe('0');
+    expect(BigInt(result.feePicocredits)).toBeGreaterThan(0n); // network min fee
+
+    // The scan reached the node (wrong-network guard + output fetch).
+    const methods = node.calls.map((c) => c.method);
+    expect(methods).toContain('node_getStatus');
+    expect(methods).toContain('chain_getOutputs');
+    expect(methods).not.toContain('tx_submit'); // pure read
+  });
+
+  it('accepts a full URL, a bare fragment, and a leading-# fragment alike', async () => {
+    // One install (SES lockdown + wasm is slow); previewClaimLink is a pure read
+    // that persists nothing, so all three link shapes reuse the same snap.
+    const { request } = await installSnap();
+    const { mnemonic, fragment } = freshLink();
+    const url = buildClaimLink('https://botho.io', mnemonic);
+    for (const link of [fragment, `#${fragment}`, url]) {
+      const response = request({
+        method: 'botho_previewClaimLink',
+        params: { rpcUrl: node.url, link },
+      });
+      // Preview shows an alert; acknowledge it so the request resolves.
+      const ui = await response.getInterface();
+      await (ui as { ok(): Promise<void> }).ok();
+      const result = unwrap<ClaimScanResult>(await response);
+      expect(result.netPicocredits).toBe('0');
+    }
+  });
+
+  it('renders the cosmetic amount hint pre-scan but the scanned amount stays authoritative', async () => {
+    const { request } = await installSnap();
+    const { fragment } = freshLink(5_000_000_000_000n); // 5 BTH hint
+
+    const response = request({
+      method: 'botho_previewClaimLink',
+      params: { rpcUrl: node.url, link: fragment },
+    });
+    const ui = await response.getInterface();
+    const rendered = JSON.stringify(ui.content);
+    expect(rendered).toContain('Link hint'); // cosmetic hint shown
+    expect(rendered).toContain('5 BTH'); // the hint value
+    expect(rendered).toContain('authoritative'); // labelled non-authoritative
+
+    await (ui as { ok(): Promise<void> }).ok();
+    // Scanned net overrides the 5 BTH hint: the empty mock yields 0.
+    const result = unwrap<ClaimScanResult>(await response);
+    expect(result.netPicocredits).toBe('0');
+  });
+
+  it('rejects a malformed link with InvalidParamsError — no network call, no dialog', async () => {
+    const { request } = await installSnap();
+    const response = await request({
+      method: 'botho_previewClaimLink',
+      params: { rpcUrl: node.url, link: 'not-a-valid-claim-link' },
+    });
+    expect(errorOf(response)?.message).toMatch(/invalid claim link/i);
+    // Failed before any node round-trip.
+    expect(node.calls).toHaveLength(0);
+  });
+
+  it('rejects an unsupported claim-link version before any network call', async () => {
+    const { request } = await installSnap();
+    const response = await request({
+      method: 'botho_previewClaimLink',
+      params: { rpcUrl: node.url, link: 'v9.abcdef' },
+    });
+    expect(errorOf(response)?.message).toMatch(/invalid claim link|version/i);
+    expect(node.calls).toHaveLength(0);
+  });
+
+  it('rejects an empty link param before any network call', async () => {
+    const { request } = await installSnap();
+    const response = await request({
+      method: 'botho_previewClaimLink',
+      params: { rpcUrl: node.url, link: '' },
+    });
+    expect(errorOf(response)?.message).toBeTruthy();
+    expect(node.calls).toHaveLength(0);
+  });
+
+  /* ================================================================== */
+  /* botho_claimLink (sweep — botho_send fidelity, live gated on #1051) */
+  /* ================================================================== */
+
+  it('shows a confirmation dialog and, on cancel, aborts without submitting', async () => {
+    const { request } = await installSnap();
+    const { fragment } = freshLink();
+
+    const response = request({
+      method: 'botho_claimLink',
+      params: { rpcUrl: node.url, link: fragment },
+    });
+
+    const ui = await response.getInterface();
+    expect(ui.type).toBe('confirmation');
+    const rendered = JSON.stringify(ui.content);
+    expect(rendered).toContain('Confirm claim');
+    expect(rendered).toContain('BTH');
+
+    await (ui as { cancel(): Promise<void> }).cancel();
+    const rejected = await response;
+    expect(errorOf(rejected)?.message).toMatch(/reject/i);
+    expect(node.calls.map((c) => c.method)).not.toContain('tx_submit');
+  });
+
+  it('on approval, runs the sweep pipeline and surfaces "nothing to claim" without submitting', async () => {
+    const { request } = await installSnap();
+    const { fragment } = freshLink();
+
+    const response = request({
+      method: 'botho_claimLink',
+      params: { rpcUrl: node.url, link: fragment },
+    });
+    const ui = await response.getInterface();
+    await (ui as { ok(): Promise<void> }).ok();
+
+    const result = await response;
+    // Empty mocked chain => the ephemeral wallet has nothing to sweep.
+    expect(errorOf(result)?.message).toMatch(/nothing to claim|no spendable|no outputs|insufficient/i);
+    const methods = node.calls.map((c) => c.method);
+    expect(methods).toContain('chain_getOutputs'); // pipeline reached the node (scan)
+    expect(methods).not.toContain('tx_submit'); // but never submitted without funds
+  });
+
+  /* ================================================================== */
+  /* Bearer-secret hygiene (#474/#475)                                  */
+  /* ================================================================== */
+
+  it('never surfaces the ephemeral mnemonic in a dialog, result, or error', async () => {
+    const { mnemonic, fragment } = freshLink();
+
+    // The dialog/error templates legitimately share a few common English tokens
+    // with the BIP39 wordlist (e.g. "claim", "empty"); exclude those so a random
+    // mnemonic that happens to contain one does not false-fail. We then assert
+    // (a) no remaining secret word appears as a standalone token in the output,
+    // and (b) the whole mnemonic string never appears verbatim.
+    const templateVocab =
+      'claim link nothing to this is empty already claimed or not yet confirmed holds ' +
+      'funds that will be swept into your wallet the sweep fee is paid from claimable ' +
+      'you receive hint cosmetic scanned amount above authoritative node confirm invalid ' +
+      'bth does cover';
+    const templateTokens = new Set(templateVocab.match(/[a-z]+/g));
+    const secretWords = mnemonic.split(' ').filter((w) => !templateTokens.has(w));
+    expect(secretWords.length).toBeGreaterThan(0); // guard: filtering did not empty it
+
+    const assertNoLeak = (blob: string): void => {
+      const tokens = new Set((blob.toLowerCase().match(/[a-z]+/g) ?? []));
+      for (const w of secretWords) expect(tokens.has(w)).toBe(false);
+      expect(blob.includes(mnemonic)).toBe(false); // no verbatim secret
+    };
+
+    // Preview: check the dialog content AND the returned result.
+    {
+      const { request } = await installSnap();
+      const response = request({
+        method: 'botho_previewClaimLink',
+        params: { rpcUrl: node.url, link: fragment },
+      });
+      const ui = await response.getInterface();
+      assertNoLeak(JSON.stringify(ui.content));
+      await (ui as { ok(): Promise<void> }).ok();
+      assertNoLeak(JSON.stringify((await response).response));
+    }
+
+    // Claim (approve → "nothing to claim" error): the error must not leak it.
+    {
+      const { request } = await installSnap();
+      const response = request({
+        method: 'botho_claimLink',
+        params: { rpcUrl: node.url, link: fragment },
+      });
+      const ui = await response.getInterface();
+      assertNoLeak(JSON.stringify(ui.content));
+      await (ui as { ok(): Promise<void> }).ok();
+      assertNoLeak(JSON.stringify((await response).response));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds in-Snap **claim-link ingress** to the Botho MetaMask Snap (`web/packages/snap`) — the real content of phase-2 "ingress" (the receive address is already shipped via `botho_showReceive`). A Botho claim link is a bearer instrument: the fragment IS an ephemeral 12-word mnemonic that owns the funds. Claiming is 100% client-side and reuses the shipped CLSAG scan/send path — **no new node RPC, no consensus change, no manifest permission change**.

Two new RPC methods:

- **`botho_previewClaimLink`** (pure read): parse fragment (`parseClaimLinkFragment`) → derive ephemeral keys → scan spendable (`spendableBalance`) → alert dialog. Deterministic against the mocked node (empty chain → net `0` → "nothing to claim"), exactly like `botho_getBalance` — **no #1051 caveat**.
- **`botho_claimLink`** (sweep): parse → wrong-network guard → scan → **confirmation** dialog → CLSAG send FROM the ephemeral keys TO the user's own derived address, fee paid from the funded output. Mirrors `botho_send`; submit plumbing is mock-tested, and **live on-chain claim validation inherits the existing #1051 betanet gate** (a real funded ephemeral output needs a live minting node) — inherited, not a new blocker.

## Changes

- **New `src/claim.ts`** — Snap-local claim glue (`parseClaimLink` / `scanClaimLink` / `buildSweep`) over the Snap's own `makeSendRpc`. The web wallet's `claim-link-ops.ts` is `RemoteNodeAdapter`-bound and can't be imported, so this mirrors it against the shared `SendRpc` slice. Reuses `@botho/core` (`parseClaimLinkFragment`, `deriveKeypairs`, `parseAddress`) + `@botho/wasm-signer` (`spendableBalance`, `buildSendTransaction`, `deriveKemPublicKey`, `mnemonicToSeedHex`).
- **`src/index.ts`** — wire both handlers following the `botho_send` structure (validate params up front, parse before any network call, wrong-network guard before touching funds, confirm before submit, `UserRejectedRequestError` on cancel).
- **`src/ui.ts`** — `claimPreviewContent` / `claimConfirmContent` dialog builders (SES-safe `formatBTHWithUnit`, no QR). Cosmetic `amountHint` shown pre-scan but explicitly labelled non-authoritative; scanned amount always wins.
- **New `test/claim.snap.ts`** — 9 tests through the real `@metamask/snaps-jest` SES harness against `startMockNode` (mirrors `send.snap.ts` + `history.snap.ts`).
- **`README.md`** — documents the two methods, the "claim = ephemeral-wallet sweep" model, the #1051 live deferral, and the carved-out request-link / QR scope.
- **`snap.manifest.json`** — shasum refreshed by `mm-snap build` (only field changed; no permission change).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `botho_previewClaimLink` well-formed link → alert with BTH amount; empty mock net `0`; scan reached `chain_getOutputs` | ✅ | test: "previews a well-formed link" |
| Preview rejects malformed / empty / unsupported-version link with `InvalidParamsError`, no network call, no dialog | ✅ | tests: malformed / unsupported-version / empty-param (all assert `node.calls` empty) |
| `botho_claimLink` confirmation dialog; on cancel aborts with `reject`, never `tx_submit`s | ✅ | test: "shows a confirmation dialog and, on cancel, aborts without submitting" |
| On approve, sweep pipeline surfaces "nothing to claim" without `tx_submit` (reaches node, never submits without funds) | ✅ | test: "on approval, runs the sweep pipeline…" |
| Wrong-network guard fires before scan/sweep | ✅ | both methods route through `connectAndGuard` (asserted `node_getStatus`); throwing behaviour covered at pure level in `units.snap.ts` (mock is loopback-exempt) |
| Bearer-secret hygiene: mnemonic never in result, dialog, or error | ✅ | test: "never surfaces the ephemeral mnemonic…" (token-level + verbatim checks over preview + claim) |
| Full-URL vs bare vs leading-`#` fragment all accepted; `amountHint` cosmetic only | ✅ | tests: "accepts a full URL…" and "renders the cosmetic amount hint…" |
| No manifest permission change | ✅ | `snap.manifest.json` diff = shasum only |
| Address QR not attempted (infeasible) | ✅ | no QR code; documented in README |
| Request-link (pull) flow deferred | ✅ | not built; documented as a separate follow-up |

## Test Plan

- `pnpm --filter @botho/snap typecheck` → clean.
- `pnpm --filter @botho/snap build:snap` → bundle evaluates; shasum auto-refreshed (pre-existing warnings only: icon, repository, platform-version, webpack critical-dependency).
- `pnpm --filter @botho/snap test:snap` → **56/56 passing** (9 new claim tests + 47 existing, no regressions), all against the mocked node under the real SES executor.

Out of scope for CI (documented, not tested here): a real funded ephemeral output swept on-chain (live claim validation — deferred to #1051, inherited from the live-send gap); the request-link / pull `/pay#…` flow (separate follow-up); address QR (infeasible — v2 PQ addresses too large).

Closes #1094