### PR TITLE
feat(snap): i18n for the Snap UI (en/es/zh) via SES-safe message map (#1095)

### DIFF
--- a/web/packages/snap/README.md
+++ b/web/packages/snap/README.md
@@ -228,6 +228,48 @@ already cover it).
 > (`tbotho://2/…`) are too large for a scannable QR (see the web wallet's
 > `ReceiveModal.tsx`) — the `Copyable` field is the correct affordance.
 
+## Internationalization (i18n, #1095)
+
+Every user-facing dialog string — headings, row labels, empty-states, the
+claim/receive/mnemonic body copy, the plural-sensitive confirmations line, and
+the user-facing `UserRejectedRequestError` messages / mnemonic placeholder in
+`index.ts` — is sourced from a locale message map, reaching parity with the web
+wallet's `en`/`es`/`zh` support.
+
+**Supported locales:** `en` (fallback) + `es` + `zh`, matching the web wallet's
+`SUPPORTED_LOCALES`. The `es`/`zh` wording **reuses the web wallet's already-
+reviewed translations** (`web-wallet/src/locales/{es,zh}/{wallet,pay,claim,contacts}.json`)
+for equivalent keys so the Snap does not fork a second, drifting translation.
+
+**Why a hand-rolled map, not `i18next`.** The Snap bundle runs inside the
+MetaMask Snaps **SES (hardened) executor**, where `Intl` is not reliably endowed
+— the same casualty `src/format.ts` documents for `Number#toLocaleString`.
+`i18next`/`react-i18next` pull in runtime plural/interpolation machinery
+(`Intl.PluralRules`) and a mutable global singleton, so they are fragile-to-broken
+under SES lockdown and would bloat the bundle for ~30 static strings. Instead the
+Snap ships a self-contained, dependency-free layer (`src/i18n.ts` +
+`src/locales/{en,es,zh}.ts`): a frozen `locale → key → string` map, an Intl-free
+`t(key, locale, params?)` doing `{placeholder}` substitution via plain
+`String#split`/`join`, and an Intl-free `confirmationsPhrase` (picks a singular vs
+plural key by count; Chinese ships one count-neutral form). This mirrors the
+re-implement-the-primitive pattern `format.ts` already established.
+
+**Locale selection.** The dialog language is read at runtime from the MetaMask
+user's UI-language preference via **`snap_getPreferences.locale`**, narrowed to
+the supported set (`zh-CN → zh`, case-insensitive) and defaulting to `en` for
+anything unsupported or on any failure (older host, denied request). This method
+is a **restricted permission** in the current Snaps platform, so the manifest
+declares `"snap_getPreferences": {}` in `initialPermissions` — it is granted at
+install with no separate runtime prompt. `onRpcRequest` resolves the locale once
+per invocation and threads it into every content builder. (The
+`snap.manifest.json` `locales`/`$t(...)` mechanism localizes only the
+*install-prompt metadata* and is out of scope here.)
+
+**Deliberate English boundary.** The `InvalidParamsError` validation strings in
+`requireString`/`requireAmount`/`optionalFee` are **developer-facing dapp-
+integration errors**, not end-user dialog copy, so they are intentionally left
+English in this pass.
+
 ## Key derivation: MetaMask SRP → Botho RootIdentity
 
 ```

--- a/web/packages/snap/snap.manifest.json
+++ b/web/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Manage a privacy-by-default Botho wallet from inside MetaMask. Keys are derived from your MetaMask Secret Recovery Phrase and never leave the Snap sandbox.",
   "proposedName": "Botho Wallet",
   "source": {
-    "shasum": "RmkO/QR5gGFhHOBcL2r8CM0ximLyjTyOtyasCPl0+lk=",
+    "shasum": "FhdWd5tzZyOU/9f4KhZ4raofv4NmJIqG0SqXRzbw8gg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -20,7 +20,8 @@
     "endowment:network-access": {},
     "snap_getEntropy": {},
     "snap_dialog": {},
-    "snap_manageState": {}
+    "snap_manageState": {},
+    "snap_getPreferences": {}
   },
   "platformVersion": "11.2.0",
   "manifestVersion": "0.1"

--- a/web/packages/snap/src/i18n.ts
+++ b/web/packages/snap/src/i18n.ts
@@ -1,0 +1,114 @@
+/**
+ * Self-contained, SES-safe i18n for the Snap dialogs (issue #1095).
+ *
+ * WHY NOT i18next / react-i18next: the Snap bundle runs inside the MetaMask
+ * Snaps SES (hardened) executor. `Intl` is not reliably endowed there — the same
+ * casualty `src/format.ts` documents for `Number#toLocaleString`. `i18next`
+ * pulls in runtime plural/interpolation machinery (`Intl.PluralRules`) and
+ * expects a mutable global singleton, so it is fragile-to-broken under SES
+ * lockdown and would bloat the bundle for ~30 static strings. This module
+ * mirrors the `format.ts` pattern instead: a plain frozen `locale -> key ->
+ * string` lookup plus an Intl-free `{placeholder}` substitution (`String#split`/
+ * `join`, no `Intl`, no `RegExp` replacement pitfalls).
+ *
+ * Locale is chosen at runtime from the MetaMask user's preference
+ * (`snap_getPreferences.locale`; a restricted permission, so the manifest
+ * declares `snap_getPreferences` in `initialPermissions`), narrowed to the
+ * Snap's supported set, defaulting to `en`.
+ */
+import { en } from './locales/en';
+import { es } from './locales/es';
+import { zh } from './locales/zh';
+
+/** Locales the Snap ships — matches the web wallet's `SUPPORTED_LOCALES`. */
+export const SUPPORTED_LOCALES = ['en', 'es', 'zh'] as const;
+
+/** A locale the Snap can render. */
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+
+/** Fallback locale for any MetaMask locale the Snap does not ship. */
+export const DEFAULT_LOCALE: Locale = 'en';
+
+/** Every message key; `en` is the source of truth (`es`/`zh` are typed to it). */
+export type MessageKey = keyof typeof en;
+
+/** Values interpolated into a `{placeholder}` in a message. */
+export type TParams = Record<string, string | number>;
+
+/** Frozen message tables, keyed by locale. */
+const MESSAGES: Record<Locale, Record<MessageKey, string>> = {
+  en,
+  es,
+  zh,
+};
+
+/**
+ * Narrow an arbitrary MetaMask locale string to a supported Snap locale.
+ * Accepts region subtags (e.g. `zh-CN` -> `zh`) and is case-insensitive.
+ * Anything unsupported (or absent) falls back to {@link DEFAULT_LOCALE}.
+ */
+export function narrowLocale(raw: unknown): Locale {
+  if (typeof raw !== 'string') return DEFAULT_LOCALE;
+  const base = raw.toLowerCase().split('-')[0];
+  return (SUPPORTED_LOCALES as readonly string[]).includes(base) ? (base as Locale) : DEFAULT_LOCALE;
+}
+
+/**
+ * Intl-free `{placeholder}` substitution. Uses `split`/`join` so replacement
+ * values are inserted literally (no `RegExp` special-char interpretation) and
+ * no `Intl` is touched — safe inside the SES sandbox.
+ */
+function interpolate(template: string, params?: TParams): string {
+  if (!params) return template;
+  let out = template;
+  for (const key of Object.keys(params)) {
+    out = out.split(`{${key}}`).join(String(params[key]));
+  }
+  return out;
+}
+
+/**
+ * Look up `key` in `locale` (falling back to `en` for an unsupported locale or a
+ * missing key) and substitute any `{placeholder}` params. Pure and Intl-free.
+ */
+export function t(key: MessageKey, locale: Locale, params?: TParams): string {
+  const table = MESSAGES[locale] ?? MESSAGES[DEFAULT_LOCALE];
+  const template = table[key] ?? MESSAGES[DEFAULT_LOCALE][key];
+  return interpolate(template, params);
+}
+
+/**
+ * Render a count-aware confirmation phrase without `Intl.PluralRules`: picks the
+ * `One` message when `count === 1`, else the `Other` message (Chinese ships an
+ * identical form since it has no grammatical plural). `count` is exposed as the
+ * `{count}` placeholder.
+ */
+export function confirmationsPhrase(count: number, locale: Locale): string {
+  const key: MessageKey = count === 1 ? 'history.confirmationsOne' : 'history.confirmationsOther';
+  return t(key, locale, { count });
+}
+
+/** Minimal shape of the MetaMask `snap` global used for the preference read. */
+declare const snap: {
+  request(args: { method: string; params?: unknown }): Promise<unknown>;
+};
+
+/**
+ * Resolve the dialog locale from the MetaMask user's UI-language preference
+ * (`snap_getPreferences.locale`), narrowed to the Snap's supported set and
+ * defaulting to `en`. `snap_getPreferences` is a restricted permission declared
+ * in the manifest's `initialPermissions`. Any failure (older host that doesn't
+ * implement the method, denied request) degrades gracefully to
+ * {@link DEFAULT_LOCALE} so dialogs always render.
+ */
+export async function resolveLocale(): Promise<Locale> {
+  try {
+    const prefs = (await snap.request({ method: 'snap_getPreferences' })) as
+      | { locale?: unknown }
+      | null
+      | undefined;
+    return narrowLocale(prefs?.locale);
+  } catch {
+    return DEFAULT_LOCALE;
+  }
+}

--- a/web/packages/snap/src/index.ts
+++ b/web/packages/snap/src/index.ts
@@ -78,6 +78,7 @@ import {
   mnemonicBackupContent,
 } from './ui';
 import { parseClaimLink, scanClaimLink, buildSweep } from './claim';
+import { resolveLocale, t } from './i18n';
 
 declare const snap: {
   request(args: { method: string; params?: unknown }): Promise<unknown>;
@@ -209,6 +210,13 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
   ensureSigner();
   const params = (request.params ?? undefined) as Record<string, unknown> | undefined;
 
+  // Resolve the dialog locale once per invocation from the MetaMask user's
+  // preference (`snap_getPreferences.locale`, no extra manifest permission),
+  // narrowed to the Snap's supported set and defaulting to `en` (#1095). Threaded
+  // into every content builder and the user-facing rejection messages below.
+  // Silent-read methods simply don't use it.
+  const locale = await resolveLocale();
+
   switch (request.method) {
     /* ------------------------------------------------------------------ */
     /* Silent reads                                                       */
@@ -263,40 +271,40 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
     /* ------------------------------------------------------------------ */
     case 'botho_showReceive': {
       const wallet = await deriveWallet();
-      await alert(receiveContent(wallet.address));
+      await alert(receiveContent(wallet.address, locale));
       return { address: wallet.address } as Json;
     }
 
     case 'botho_showBalance': {
       const rpcUrl = requireString(params, 'rpcUrl');
       const balance = await scanBalance(rpcUrl);
-      await alert(balanceContent(balance, rpcUrl));
+      await alert(balanceContent(balance, rpcUrl, locale));
       return { spendablePicocredits: balance.toString() } as Json;
     }
 
     case 'botho_showHistory': {
       const rpcUrl = requireString(params, 'rpcUrl');
       const entries = await scanHistory(rpcUrl);
-      await alert(historyContent(entries, rpcUrl));
+      await alert(historyContent(entries, rpcUrl, locale));
       return { entries, count: entries.length } as unknown as Json;
     }
 
     case 'botho_showContacts': {
       const contacts = await readContacts();
-      await alert(contactsContent(contacts));
+      await alert(contactsContent(contacts, locale));
       return { contacts, count: contacts.length } as unknown as Json;
     }
 
     case 'botho_showMnemonic': {
       // Full spending authority — always behind an explicit user confirmation.
       const proceed = await confirm(
-        mnemonicBackupContent('•••• •••• (revealed after you confirm) ••••'),
+        mnemonicBackupContent(t('mnemonic.placeholder', locale), locale),
       );
       if (!proceed) {
-        throw new UserRejectedRequestError('User declined to reveal the recovery phrase.');
+        throw new UserRejectedRequestError(t('error.rejectMnemonic', locale));
       }
       const mnemonic = await revealMnemonic();
-      await alert(mnemonicBackupContent(mnemonic));
+      await alert(mnemonicBackupContent(mnemonic, locale));
       return { revealed: true } as Json;
     }
 
@@ -317,15 +325,18 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       const { call } = await connectAndGuard(rpcUrl);
 
       const approved = await confirm(
-        sendConfirmContent({
-          recipientAddress,
-          amountPicocredits: amount,
-          feePicocredits: fee,
-          rpcUrl,
-        }),
+        sendConfirmContent(
+          {
+            recipientAddress,
+            amountPicocredits: amount,
+            feePicocredits: fee,
+            rpcUrl,
+          },
+          locale,
+        ),
       );
       if (!approved) {
-        throw new UserRejectedRequestError('User rejected the send.');
+        throw new UserRejectedRequestError(t('error.rejectSend', locale));
       }
 
       const wallet = await deriveWallet();
@@ -360,7 +371,7 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       const { call } = await connectAndGuard(rpcUrl);
       const scan = await scanClaimLink(mnemonic, makeSendRpc(call));
 
-      await alert(claimPreviewContent({ ...scan, amountHint, rpcUrl }));
+      await alert(claimPreviewContent({ ...scan, amountHint, rpcUrl }, locale));
       return {
         grossPicocredits: scan.grossPicocredits.toString(),
         feePicocredits: scan.feePicocredits.toString(),
@@ -381,9 +392,9 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
       // Scan so the confirmation shows the authoritative claimable/net amount.
       const scan = await scanClaimLink(mnemonic, rpc);
 
-      const approved = await confirm(claimConfirmContent({ ...scan, amountHint, rpcUrl }));
+      const approved = await confirm(claimConfirmContent({ ...scan, amountHint, rpcUrl }, locale));
       if (!approved) {
-        throw new UserRejectedRequestError('User rejected the claim.');
+        throw new UserRejectedRequestError(t('error.rejectClaim', locale));
       }
 
       // Sweep into the user's OWN derived address. `buildSweep` re-scans and

--- a/web/packages/snap/src/locales/en.ts
+++ b/web/packages/snap/src/locales/en.ts
@@ -1,0 +1,74 @@
+/**
+ * English message map — the FALLBACK locale and the source of truth for the key
+ * set (issue #1095). `es`/`zh` are typed against `keyof typeof en`, so a missing
+ * translation is a compile error, and `test/i18n.snap.ts` asserts key parity at
+ * runtime as well.
+ *
+ * Values here reproduce the exact English literals that previously lived inline
+ * in `src/ui.ts` / `src/index.ts`, so English rendering is byte-for-byte
+ * unchanged.
+ *
+ * `{placeholder}` tokens are substituted by the Intl-free `t()` in `../i18n`
+ * (plain string replace — no `Intl`, matching the SES constraint documented in
+ * `src/format.ts`).
+ */
+export const en = {
+  // Receive dialog
+  'receive.heading': 'Receive BTH',
+  'receive.body':
+    'Share this Botho stealth address to receive funds. A fresh one-time ' +
+    'output is created on-chain for every payment, so your balance stays private.',
+
+  // Balance dialog
+  'balance.heading': 'Botho balance',
+  'balance.spendable': 'Spendable',
+
+  // Shared row labels
+  'common.node': 'Node',
+
+  // Send-confirmation dialog
+  'send.heading': 'Confirm send',
+  'send.amount': 'Amount',
+  'send.networkFee': 'Network fee',
+  'send.total': 'Total',
+  'send.recipient': 'Recipient',
+
+  // Transaction-history dialog
+  'history.heading': 'Transaction history',
+  'history.empty': 'No transactions yet. Payments you receive will appear here.',
+  'history.spent': 'Spent',
+  'history.received': 'Received',
+  // Count-aware confirmation phrase (Intl-free plural: caller picks One vs Other).
+  'history.confirmationsOne': '{count} confirmation',
+  'history.confirmationsOther': '{count} confirmations',
+  'history.line': 'Block {height} · {confirmations} · {hash}',
+
+  // Contacts dialog
+  'contacts.heading': 'Contacts',
+  'contacts.empty': 'No saved contacts yet. Add one to reuse a Botho address without re-pasting it.',
+
+  // Claim-link dialogs
+  'claim.previewHeading': 'Claim link',
+  'claim.confirmHeading': 'Confirm claim',
+  'claim.body':
+    'This claim link holds funds that will be swept into your wallet. The ' +
+    'sweep fee is paid from the link.',
+  'claim.empty': 'Nothing to claim — this link is empty, already claimed, or not yet confirmed.',
+  'claim.claimable': 'Claimable',
+  'claim.sweepFee': 'Sweep fee',
+  'claim.youReceive': 'You receive',
+  'claim.hint': 'Link hint: {amount} (cosmetic — the scanned amount above is authoritative)',
+
+  // Mnemonic-backup dialog
+  'mnemonic.heading': 'Botho recovery phrase',
+  'mnemonic.body':
+    'These 24 words are derived from your MetaMask Secret Recovery Phrase ' +
+    'and are full spending authority for this Botho wallet. Write them down ' +
+    'and keep them offline. Anyone who sees them can spend your funds.',
+  'mnemonic.placeholder': '•••• •••• (revealed after you confirm) ••••',
+
+  // User-facing rejection / decline errors surfaced to the dApp
+  'error.rejectMnemonic': 'User declined to reveal the recovery phrase.',
+  'error.rejectSend': 'User rejected the send.',
+  'error.rejectClaim': 'User rejected the claim.',
+} as const;

--- a/web/packages/snap/src/locales/es.ts
+++ b/web/packages/snap/src/locales/es.ts
@@ -1,0 +1,70 @@
+/**
+ * Spanish message map (issue #1095). Typed against `keyof typeof en`, so a
+ * missing/renamed key is a compile error.
+ *
+ * Wording reuses the web wallet's already-reviewed `es` locale files
+ * (`web-wallet/src/locales/es/{wallet,pay,claim,contacts}.json`) for equivalent
+ * strings — e.g. "Importe" (amount), "Comisión de red" (network fee),
+ * "Destinatario" (recipient), "frase de recuperación" (recovery phrase),
+ * "enlace de reclamación" (claim link) — so the Snap does not fork a second,
+ * drifting Spanish translation. Strings with no web-wallet equivalent (the
+ * receive privacy blurb, the balance/history empty-states, the sweep-fee copy)
+ * are translated to match that reviewed register.
+ */
+import type { en } from './en';
+
+export const es: Record<keyof typeof en, string> = {
+  'receive.heading': 'Recibir BTH',
+  'receive.body':
+    'Comparte esta dirección oculta de Botho para recibir fondos. Se crea en ' +
+    'la cadena una salida única y nueva para cada pago, por lo que tu saldo ' +
+    'permanece privado.',
+
+  'balance.heading': 'Saldo de Botho',
+  'balance.spendable': 'Disponible',
+
+  'common.node': 'Nodo',
+
+  'send.heading': 'Confirmar envío',
+  'send.amount': 'Importe',
+  'send.networkFee': 'Comisión de red',
+  'send.total': 'Total',
+  'send.recipient': 'Destinatario',
+
+  'history.heading': 'Historial de transacciones',
+  'history.empty': 'Aún no hay transacciones. Los pagos que recibas aparecerán aquí.',
+  'history.spent': 'Enviado',
+  'history.received': 'Recibido',
+  'history.confirmationsOne': '{count} confirmación',
+  'history.confirmationsOther': '{count} confirmaciones',
+  'history.line': 'Bloque {height} · {confirmations} · {hash}',
+
+  'contacts.heading': 'Contactos',
+  'contacts.empty':
+    'Aún no hay contactos guardados. Añade uno para reutilizar una dirección ' +
+    'de Botho sin volver a pegarla.',
+
+  'claim.previewHeading': 'Enlace de reclamación',
+  'claim.confirmHeading': 'Confirmar reclamación',
+  'claim.body':
+    'Este enlace de reclamación contiene fondos que se transferirán a tu ' +
+    'monedero. La comisión de barrido se paga desde el enlace.',
+  'claim.empty':
+    'No hay nada que reclamar: este enlace está vacío, ya se ha reclamado o ' +
+    'aún no se ha confirmado.',
+  'claim.claimable': 'Reclamable',
+  'claim.sweepFee': 'Comisión de barrido',
+  'claim.youReceive': 'Recibes',
+  'claim.hint': 'Pista del enlace: {amount} (cosmética: el importe escaneado de arriba es el que manda)',
+
+  'mnemonic.heading': 'Frase de recuperación de Botho',
+  'mnemonic.body':
+    'Estas 24 palabras se derivan de tu Frase de Recuperación Secreta de ' +
+    'MetaMask y otorgan plena autoridad de gasto sobre este monedero de Botho. ' +
+    'Anótalas y guárdalas sin conexión. Cualquiera que las vea puede gastar tus fondos.',
+  'mnemonic.placeholder': '•••• •••• (se revela después de confirmar) ••••',
+
+  'error.rejectMnemonic': 'El usuario rechazó revelar la frase de recuperación.',
+  'error.rejectSend': 'El usuario rechazó el envío.',
+  'error.rejectClaim': 'El usuario rechazó la reclamación.',
+};

--- a/web/packages/snap/src/locales/zh.ts
+++ b/web/packages/snap/src/locales/zh.ts
@@ -1,0 +1,62 @@
+/**
+ * Chinese (Simplified) message map (issue #1095). Typed against
+ * `keyof typeof en`, so a missing/renamed key is a compile error.
+ *
+ * Wording reuses the web wallet's already-reviewed `zh` locale files
+ * (`web-wallet/src/locales/zh/{wallet,pay,claim,contacts}.json`) for equivalent
+ * strings — e.g. "金额" (amount), "网络手续费" (network fee), "收款人" (recipient),
+ * "恢复助记词" (recovery phrase), "领取链接" (claim link) — so the Snap does not
+ * fork a second, drifting Chinese translation.
+ *
+ * Chinese has no grammatical singular/plural, so `history.confirmationsOne` and
+ * `history.confirmationsOther` are intentionally identical (measure word 个).
+ */
+import type { en } from './en';
+
+export const zh: Record<keyof typeof en, string> = {
+  'receive.heading': '接收 BTH',
+  'receive.body':
+    '分享此 Botho 隐私地址以接收资金。每笔付款都会在链上创建一个全新的一次性输出，' +
+    '因此你的余额保持私密。',
+
+  'balance.heading': 'Botho 余额',
+  'balance.spendable': '可用',
+
+  'common.node': '节点',
+
+  'send.heading': '确认发送',
+  'send.amount': '金额',
+  'send.networkFee': '网络手续费',
+  'send.total': '合计',
+  'send.recipient': '收款人',
+
+  'history.heading': '交易历史',
+  'history.empty': '暂无交易。你收到的付款将显示在此处。',
+  'history.spent': '已发送',
+  'history.received': '已接收',
+  'history.confirmationsOne': '{count} 个确认',
+  'history.confirmationsOther': '{count} 个确认',
+  'history.line': '区块 {height} · {confirmations} · {hash}',
+
+  'contacts.heading': '联系人',
+  'contacts.empty': '尚无已保存的联系人。添加一个即可重复使用某个 Botho 地址，无需重新粘贴。',
+
+  'claim.previewHeading': '领取链接',
+  'claim.confirmHeading': '确认领取',
+  'claim.body': '此领取链接包含将被扫入你钱包的资金。扫取手续费将从链接中支付。',
+  'claim.empty': '没有可领取的内容——此链接为空、已被领取或尚未确认。',
+  'claim.claimable': '可领取',
+  'claim.sweepFee': '扫取手续费',
+  'claim.youReceive': '你将收到',
+  'claim.hint': '链接提示：{amount}（仅供参考——以上方扫描到的金额为准）',
+
+  'mnemonic.heading': 'Botho 恢复助记词',
+  'mnemonic.body':
+    '这 24 个单词由你的 MetaMask 秘密恢复助记词派生而来，拥有此 Botho 钱包的全部支配权。' +
+    '请将它们记下并离线保管。任何看到它们的人都可以花费你的资金。',
+  'mnemonic.placeholder': '•••• •••• （确认后显示） ••••',
+
+  'error.rejectMnemonic': '用户拒绝显示恢复助记词。',
+  'error.rejectSend': '用户拒绝了发送。',
+  'error.rejectClaim': '用户拒绝了领取。',
+};

--- a/web/packages/snap/src/ui.ts
+++ b/web/packages/snap/src/ui.ts
@@ -6,6 +6,11 @@
  * `Divider`) are `SnapComponent` factories — this module calls them directly as
  * functions (the "createElement" style) so no JSX build/transform is needed in
  * the SES bundle; each call returns a plain JSX element object.
+ *
+ * i18n (issue #1095): every user-facing string is sourced from the SES-safe
+ * message map via `t(key, locale, params?)` (see `src/i18n.ts`). Each content
+ * builder takes the resolved `locale`; `src/index.ts` resolves it once per RPC
+ * invocation from `snap_getPreferences.locale`.
  */
 
 import {
@@ -21,6 +26,7 @@ import {
 import { shortenAddress } from '@botho/core';
 
 import { formatBTHWithUnit } from './format';
+import { t, confirmationsPhrase, type Locale } from './i18n';
 import type { HistoryEntry } from './state';
 import type { ContactBook } from './contacts';
 
@@ -39,28 +45,31 @@ function shortHash(txHash: string): string {
 }
 
 /** Receive dialog: the wallet's stealth receive address. */
-export function receiveContent(address: string): JSXElement {
+export function receiveContent(address: string, locale: Locale): JSXElement {
   return Box({
     children: [
-      Heading({ children: 'Receive BTH' }),
-      Text({
-        children:
-          'Share this Botho stealth address to receive funds. A fresh one-time ' +
-          'output is created on-chain for every payment, so your balance stays private.',
-      }),
+      Heading({ children: t('receive.heading', locale) }),
+      Text({ children: t('receive.body', locale) }),
       Copyable({ value: address }),
     ],
   });
 }
 
 /** Balance dialog: the wallet's spendable balance and its ingress node. */
-export function balanceContent(spendablePicocredits: bigint, rpcUrl: string): JSXElement {
+export function balanceContent(
+  spendablePicocredits: bigint,
+  rpcUrl: string,
+  locale: Locale,
+): JSXElement {
   return Box({
     children: [
-      Heading({ children: 'Botho balance' }),
-      Row({ label: 'Spendable', children: Text({ children: formatBTHWithUnit(spendablePicocredits) }) }),
+      Heading({ children: t('balance.heading', locale) }),
+      Row({
+        label: t('balance.spendable', locale),
+        children: Text({ children: formatBTHWithUnit(spendablePicocredits) }),
+      }),
       Divider({}),
-      Row({ label: 'Node', children: Text({ children: hostOf(rpcUrl) }) }),
+      Row({ label: t('common.node', locale), children: Text({ children: hostOf(rpcUrl) }) }),
     ],
   });
 }
@@ -74,18 +83,24 @@ export interface SendConfirmView {
 }
 
 /** Send confirmation dialog: recipient, amount, fee, total, ingress node. */
-export function sendConfirmContent(view: SendConfirmView): JSXElement {
+export function sendConfirmContent(view: SendConfirmView, locale: Locale): JSXElement {
   const total = view.amountPicocredits + view.feePicocredits;
   return Box({
     children: [
-      Heading({ children: 'Confirm send' }),
-      Row({ label: 'Amount', children: Text({ children: formatBTHWithUnit(view.amountPicocredits) }) }),
-      Row({ label: 'Network fee', children: Text({ children: formatBTHWithUnit(view.feePicocredits) }) }),
-      Row({ label: 'Total', children: Text({ children: formatBTHWithUnit(total) }) }),
+      Heading({ children: t('send.heading', locale) }),
+      Row({
+        label: t('send.amount', locale),
+        children: Text({ children: formatBTHWithUnit(view.amountPicocredits) }),
+      }),
+      Row({
+        label: t('send.networkFee', locale),
+        children: Text({ children: formatBTHWithUnit(view.feePicocredits) }),
+      }),
+      Row({ label: t('send.total', locale), children: Text({ children: formatBTHWithUnit(total) }) }),
       Divider({}),
-      Text({ children: 'Recipient' }),
+      Text({ children: t('send.recipient', locale) }),
       Copyable({ value: view.recipientAddress }),
-      Row({ label: 'Node', children: Text({ children: hostOf(view.rpcUrl) }) }),
+      Row({ label: t('common.node', locale), children: Text({ children: hostOf(view.rpcUrl) }) }),
     ],
   });
 }
@@ -99,33 +114,42 @@ export function sendConfirmContent(view: SendConfirmView): JSXElement {
  * History is a PURE projection over the persisted scan state (#1091) plus a live
  * spent-check — no rescan, no persisted history record (see `src/state.ts`).
  */
-export function historyContent(entries: HistoryEntry[], rpcUrl: string): JSXElement {
+export function historyContent(
+  entries: HistoryEntry[],
+  rpcUrl: string,
+  locale: Locale,
+): JSXElement {
   if (entries.length === 0) {
     return Box({
       children: [
-        Heading({ children: 'Transaction history' }),
-        Text({ children: 'No transactions yet. Payments you receive will appear here.' }),
+        Heading({ children: t('history.heading', locale) }),
+        Text({ children: t('history.empty', locale) }),
         Divider({}),
-        Row({ label: 'Node', children: Text({ children: hostOf(rpcUrl) }) }),
+        Row({ label: t('common.node', locale), children: Text({ children: hostOf(rpcUrl) }) }),
       ],
     });
   }
   return Box({
     children: [
-      Heading({ children: 'Transaction history' }),
+      Heading({ children: t('history.heading', locale) }),
       ...entries.flatMap((entry) => [
         Row({
-          label: entry.direction === 'spent' ? 'Spent' : 'Received',
+          label:
+            entry.direction === 'spent'
+              ? t('history.spent', locale)
+              : t('history.received', locale),
           children: Text({ children: formatBTHWithUnit(BigInt(entry.amountPicocredits)) }),
         }),
         Text({
-          children:
-            `Block ${entry.blockHeight} · ${entry.confirmations} ` +
-            `confirmation${entry.confirmations === 1 ? '' : 's'} · ${shortHash(entry.txHash)}`,
+          children: t('history.line', locale, {
+            height: entry.blockHeight,
+            confirmations: confirmationsPhrase(entry.confirmations, locale),
+            hash: shortHash(entry.txHash),
+          }),
         }),
         Divider({}),
       ]),
-      Row({ label: 'Node', children: Text({ children: hostOf(rpcUrl) }) }),
+      Row({ label: t('common.node', locale), children: Text({ children: hostOf(rpcUrl) }) }),
     ],
   });
 }
@@ -137,18 +161,18 @@ export function historyContent(entries: HistoryEntry[], rpcUrl: string): JSXElem
  * remove are driven by the `botho_addContact` / `botho_removeContact` RPC methods
  * (dApp-driven); this dialog is view-only (#1093).
  */
-export function contactsContent(book: ContactBook): JSXElement {
+export function contactsContent(book: ContactBook, locale: Locale): JSXElement {
   if (book.length === 0) {
     return Box({
       children: [
-        Heading({ children: 'Contacts' }),
-        Text({ children: 'No saved contacts yet. Add one to reuse a Botho address without re-pasting it.' }),
+        Heading({ children: t('contacts.heading', locale) }),
+        Text({ children: t('contacts.empty', locale) }),
       ],
     });
   }
   return Box({
     children: [
-      Heading({ children: 'Contacts' }),
+      Heading({ children: t('contacts.heading', locale) }),
       ...book.flatMap((contact) => [
         Row({ label: contact.label, children: Text({ children: shortenAddress(contact.address) }) }),
         Copyable({ value: contact.address }),
@@ -180,34 +204,34 @@ export interface ClaimView {
  * (per `@botho/core` `claim-link.ts`). The bearer secret (mnemonic) is NEVER
  * rendered.
  */
-function claimBodyRows(view: ClaimView): JSXElement[] {
+function claimBodyRows(view: ClaimView, locale: Locale): JSXElement[] {
   const empty = view.grossPicocredits === 0n;
   const rows: JSXElement[] = [
     empty
-      ? Text({
-          children:
-            'Nothing to claim — this link is empty, already claimed, or not yet confirmed.',
-        })
-      : Text({
-          children:
-            'This claim link holds funds that will be swept into your wallet. The ' +
-            'sweep fee is paid from the link.',
-        }),
-    Row({ label: 'Claimable', children: Text({ children: formatBTHWithUnit(view.grossPicocredits) }) }),
-    Row({ label: 'Sweep fee', children: Text({ children: formatBTHWithUnit(view.feePicocredits) }) }),
-    Row({ label: 'You receive', children: Text({ children: formatBTHWithUnit(view.netPicocredits) }) }),
+      ? Text({ children: t('claim.empty', locale) })
+      : Text({ children: t('claim.body', locale) }),
+    Row({
+      label: t('claim.claimable', locale),
+      children: Text({ children: formatBTHWithUnit(view.grossPicocredits) }),
+    }),
+    Row({
+      label: t('claim.sweepFee', locale),
+      children: Text({ children: formatBTHWithUnit(view.feePicocredits) }),
+    }),
+    Row({
+      label: t('claim.youReceive', locale),
+      children: Text({ children: formatBTHWithUnit(view.netPicocredits) }),
+    }),
   ];
   if (view.amountHint !== undefined) {
     rows.push(
       Text({
-        children:
-          `Link hint: ${formatBTHWithUnit(view.amountHint)} ` +
-          '(cosmetic — the scanned amount above is authoritative)',
+        children: t('claim.hint', locale, { amount: formatBTHWithUnit(view.amountHint) }),
       }),
     );
   }
   rows.push(Divider({}));
-  rows.push(Row({ label: 'Node', children: Text({ children: hostOf(view.rpcUrl) }) }));
+  rows.push(Row({ label: t('common.node', locale), children: Text({ children: hostOf(view.rpcUrl) }) }));
   return rows;
 }
 
@@ -216,9 +240,12 @@ function claimBodyRows(view: ClaimView): JSXElement[] {
  * (`botho_previewClaimLink`). Renders the scanned claimable / fee / net and the
  * ingress node; does not submit anything.
  */
-export function claimPreviewContent(view: ClaimView): JSXElement {
+export function claimPreviewContent(view: ClaimView, locale: Locale): JSXElement {
   return Box({
-    children: [Heading({ children: 'Claim link' }), ...claimBodyRows(view)],
+    children: [
+      Heading({ children: t('claim.previewHeading', locale) }),
+      ...claimBodyRows(view, locale),
+    ],
   });
 }
 
@@ -227,23 +254,21 @@ export function claimPreviewContent(view: ClaimView): JSXElement {
  * gated behind an explicit approve/reject before the sweep is built + submitted
  * (`botho_claimLink`). Mirrors the `botho_send` confirmation.
  */
-export function claimConfirmContent(view: ClaimView): JSXElement {
+export function claimConfirmContent(view: ClaimView, locale: Locale): JSXElement {
   return Box({
-    children: [Heading({ children: 'Confirm claim' }), ...claimBodyRows(view)],
+    children: [
+      Heading({ children: t('claim.confirmHeading', locale) }),
+      ...claimBodyRows(view, locale),
+    ],
   });
 }
 
 /** Mnemonic-backup dialog: the derived 24-word Botho recovery phrase. */
-export function mnemonicBackupContent(mnemonic: string): JSXElement {
+export function mnemonicBackupContent(mnemonic: string, locale: Locale): JSXElement {
   return Box({
     children: [
-      Heading({ children: 'Botho recovery phrase' }),
-      Text({
-        children:
-          'These 24 words are derived from your MetaMask Secret Recovery Phrase ' +
-          'and are full spending authority for this Botho wallet. Write them down ' +
-          'and keep them offline. Anyone who sees them can spend your funds.',
-      }),
+      Heading({ children: t('mnemonic.heading', locale) }),
+      Text({ children: t('mnemonic.body', locale) }),
       Copyable({ value: mnemonic, sensitive: true }),
     ],
   });

--- a/web/packages/snap/test/i18n.snap.ts
+++ b/web/packages/snap/test/i18n.snap.ts
@@ -1,0 +1,164 @@
+/**
+ * i18n for the Snap dialogs (issue #1095).
+ *
+ * Two layers:
+ *   1. PURE unit tests of the SES-safe message map + `t()` helper (no
+ *      `installSnap`, no wasm) — per-locale lookups, `{placeholder}`
+ *      substitution, `en` fallback for an unsupported locale, Intl-free
+ *      pluralization, and a key-parity assertion so a missing/renamed
+ *      translation fails CI instead of silently falling back.
+ *   2. A SES-harness render test: with the MetaMask user preference set to
+ *      `es`/`zh` (the harness honors `installSnap`'s `locale` option, which it
+ *      surfaces through `snap_getPreferences` — exactly the signal the Snap reads
+ *      at runtime), a dialog renders its localized heading; an unsupported locale
+ *      falls back to the English heading.
+ */
+
+import { describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+
+import {
+  t,
+  narrowLocale,
+  confirmationsPhrase,
+  SUPPORTED_LOCALES,
+  DEFAULT_LOCALE,
+  type MessageKey,
+} from '../src/i18n';
+import { en } from '../src/locales/en';
+import { es } from '../src/locales/es';
+import { zh } from '../src/locales/zh';
+
+describe('i18n: message map + t() (pure, SES-free)', () => {
+  it('returns the localized string per locale', () => {
+    expect(t('receive.heading', 'en')).toBe('Receive BTH');
+    expect(t('receive.heading', 'es')).toBe('Recibir BTH');
+    expect(t('receive.heading', 'zh')).toBe('接收 BTH');
+
+    expect(t('send.heading', 'es')).toBe('Confirmar envío');
+    expect(t('send.recipient', 'zh')).toBe('收款人');
+    expect(t('mnemonic.heading', 'es')).toBe('Frase de recuperación de Botho');
+  });
+
+  it('substitutes {placeholder} params without Intl', () => {
+    expect(t('claim.hint', 'en', { amount: '1.5 BTH' })).toBe(
+      'Link hint: 1.5 BTH (cosmetic — the scanned amount above is authoritative)',
+    );
+    expect(t('claim.hint', 'es', { amount: '1.5 BTH' })).toContain('1.5 BTH');
+
+    // The history line composes a nested, already-localized confirmation phrase.
+    expect(
+      t('history.line', 'en', { height: 42, confirmations: '3 confirmations', hash: 'abc…xyz' }),
+    ).toBe('Block 42 · 3 confirmations · abc…xyz');
+  });
+
+  it('inserts replacement values literally (no RegExp special-char pitfalls)', () => {
+    // A `$&`/`$1` in the substituted value must not be re-interpreted.
+    expect(t('claim.hint', 'en', { amount: '$1 & $&' })).toContain('$1 & $&');
+  });
+
+  it('falls back to en for an unsupported locale or a missing key', () => {
+    // `narrowLocale` is the runtime gate, but `t` is defensive too: an
+    // unsupported locale slipping through resolves against the en table.
+    const unsupported = 'fr' as unknown as Parameters<typeof t>[1];
+    expect(t('receive.heading', unsupported)).toBe('Receive BTH');
+  });
+
+  it('narrows an arbitrary MetaMask locale to a supported Snap locale', () => {
+    expect(narrowLocale('en')).toBe('en');
+    expect(narrowLocale('es')).toBe('es');
+    expect(narrowLocale('zh')).toBe('zh');
+    // Region subtags and case are normalized to the base language.
+    expect(narrowLocale('zh-CN')).toBe('zh');
+    expect(narrowLocale('ES')).toBe('es');
+    // Anything the Snap does not ship, or a non-string, falls back.
+    expect(narrowLocale('fr')).toBe(DEFAULT_LOCALE);
+    expect(narrowLocale('de-DE')).toBe(DEFAULT_LOCALE);
+    expect(narrowLocale(undefined)).toBe(DEFAULT_LOCALE);
+    expect(narrowLocale(42)).toBe(DEFAULT_LOCALE);
+  });
+
+  it('pluralizes the confirmation phrase Intl-free per locale', () => {
+    // English: singular vs plural.
+    expect(confirmationsPhrase(1, 'en')).toBe('1 confirmation');
+    expect(confirmationsPhrase(3, 'en')).toBe('3 confirmations');
+    // Spanish: singular vs plural.
+    expect(confirmationsPhrase(1, 'es')).toBe('1 confirmación');
+    expect(confirmationsPhrase(2, 'es')).toBe('2 confirmaciones');
+    // Chinese has no grammatical plural — one form for any count.
+    expect(confirmationsPhrase(1, 'zh')).toBe('1 个确认');
+    expect(confirmationsPhrase(5, 'zh')).toBe('5 个确认');
+  });
+
+  it('has full key parity across every shipped locale (missing key fails CI)', () => {
+    const enKeys = Object.keys(en).sort();
+    for (const [name, table] of [
+      ['es', es],
+      ['zh', zh],
+    ] as const) {
+      const keys = Object.keys(table).sort();
+      expect({ locale: name, keys }).toStrictEqual({ locale: name, keys: enKeys });
+      // No empty translations slipped in.
+      for (const key of enKeys) {
+        expect((table as Record<string, string>)[key].length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('ships the same supported locales as the web wallet (en + es + zh)', () => {
+    expect([...SUPPORTED_LOCALES]).toStrictEqual(['en', 'es', 'zh']);
+    // Every supported locale has a message table.
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(t('balance.heading', locale).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps every en key non-empty (source-of-truth sanity)', () => {
+    for (const key of Object.keys(en) as MessageKey[]) {
+      expect(t(key, 'en').length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('i18n: localized dialog rendering (SES harness via snap_getPreferences)', () => {
+  /** Render the receive dialog under a given MetaMask locale preference. */
+  async function receiveHeadingUnderLocale(locale?: string): Promise<string> {
+    // `installSnap({ options: { locale } })` sets the simulation's MetaMask user
+    // preference, which the harness surfaces through `snap_getPreferences` — the
+    // runtime signal the Snap reads. (The Snap's manifest declares the
+    // `snap_getPreferences` restricted permission, so the read is granted.)
+    const { request } =
+      locale === undefined
+        ? await installSnap()
+        : await installSnap({ options: { locale } });
+    const response = request({ method: 'botho_showReceive' });
+    const ui = await response.getInterface();
+    expect(ui.type).toBe('alert');
+    const rendered = JSON.stringify(ui.content);
+    await (ui as { ok(): Promise<void> }).ok();
+    await response;
+    return rendered;
+  }
+
+  it('renders the Spanish heading when the user preference is es', async () => {
+    const rendered = await receiveHeadingUnderLocale('es');
+    expect(rendered).toContain('Recibir BTH');
+    expect(rendered).not.toContain('Receive BTH');
+  });
+
+  it('renders the Chinese heading when the user preference is zh', async () => {
+    const rendered = await receiveHeadingUnderLocale('zh');
+    expect(rendered).toContain('接收 BTH');
+    expect(rendered).not.toContain('Receive BTH');
+  });
+
+  it('falls back to the English heading for an unsupported MetaMask locale', async () => {
+    const rendered = await receiveHeadingUnderLocale('fr');
+    expect(rendered).toContain('Receive BTH');
+  });
+
+  it('renders the English heading by default (no regression for en users)', async () => {
+    const rendered = await receiveHeadingUnderLocale();
+    expect(rendered).toContain('Receive BTH');
+  });
+});


### PR DESCRIPTION
Closes #1095

Internationalizes every user-facing Botho Snap dialog string, bringing the Snap to parity with the web wallet's `en`/`es`/`zh` support. A Spanish- or Chinese-locale MetaMask user now gets a fully localized Snap instead of English-only.

## Approach (SES-safe, dependency-free)

Mirrors the re-implement-the-primitive pattern `src/format.ts` already established (Intl is not reliably endowed in the Snaps SES executor), so **no `i18next`/`react-i18next` or any new runtime dep** is added.

- **`src/i18n.ts`** — a frozen `locale → key → string` map; an Intl-free `t(key, locale, params?)` doing `{placeholder}` substitution via `String#split`/`join` (no `Intl`, no RegExp special-char pitfalls); an Intl-free `confirmationsPhrase` (picks a singular vs plural key by count; Chinese ships one count-neutral form); `narrowLocale` (`zh-CN → zh`, case-insensitive, `en` fallback); and async `resolveLocale()` reading the MetaMask user preference.
- **`src/locales/{en,es,zh}.ts`** — frozen `as const` maps. `en` is the fallback and source of truth; `es`/`zh` are typed against `keyof typeof en` so a missing/renamed key is a compile error. `es`/`zh` wording **reuses the web wallet's already-reviewed locale JSON** (`web-wallet/src/locales/{es,zh}/{wallet,pay,claim,contacts}.json`) so we don't fork a second, drifting translation.
- **`src/ui.ts`** — every content builder takes the resolved `locale` and pulls all copy from the map (headings, row labels, empty-states, claim/receive/mnemonic body, the plural confirmations line).
- **`src/index.ts`** — resolves the locale once per `onRpcRequest` from `snap_getPreferences.locale` and threads it into every builder; localizes the user-facing `UserRejectedRequestError` messages and the mnemonic placeholder.

## Deliberate boundaries

- The `InvalidParamsError` validation strings in `requireString`/`requireAmount`/`optionalFee` are **developer-facing dapp-integration errors**, not end-user dialog copy — intentionally kept English (per the issue's curator note).

## Manifest note — deviation from the issue's assumption

The issue predicted `snap_getPreferences` needs **no** manifest permission. In the current Snaps platform (`@metamask/snaps-rpc-methods` 17.1.0) it is in fact a **restricted method** — verified via the SES harness (the read failed and silently fell back to `en` until the permission was declared). So `snap.manifest.json` now declares `"snap_getPreferences": {}` in `initialPermissions` (granted at install, no separate runtime prompt). This is the minimal change required for the feature to work; called out here so the boundary is deliberate.

## Tests — `test/i18n.snap.ts` (13 cases)

- **Pure (SES-free):** `t()` per-locale lookups, `{placeholder}` substitution (including literal `$&`/`$1` insertion), `en` fallback for an unsupported locale, `narrowLocale`, Intl-free pluralization, and a **key-parity** assertion so a missing translation fails CI instead of silently falling back.
- **SES harness (`snap_getPreferences`):** with the user preference set to `es`/`zh`, the receive dialog renders the localized heading; an unsupported locale and the default both render the English heading (no regression for `en` users).

## Verification

- `pnpm typecheck` — clean
- `pnpm build:snap` (`mm-snap build`) — bundle evaluates; manifest shasum refreshed
- `pnpm test:snap` — **69/69 passed across 9 suites** (existing balance/send/history/contacts/claim stay green under default `en`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)