### PR TITLE
test(snap): lock secret-handling invariants + zeroize transient key buffers

### DIFF
--- a/audits/2026-07-20-snap-keyhandling.md
+++ b/audits/2026-07-20-snap-keyhandling.md
@@ -1,0 +1,255 @@
+# Botho MetaMask Snap — Key-Handling Security Audit
+
+**Date**: 2026-07-20
+**Auditor**: Loom Builder (#1096)
+**Scope**: `web/packages/snap` — key-handling surface only (SIP-6 SRP → Botho keys,
+ephemeral claim-link bearer secrets, wasm signing under SES, and the Snap's
+`snap_manageState` persistence). The audited Rust `bth-wasm-signer` core and the
+org-wide external-audit engagement (#616) are explicitly out of scope.
+**Commit**: origin/main @ `b13184f9` (Phase-2 surface: #1091 state, #1092 history,
+#1093 contacts, #1094 claim-link, #1095 i18n).
+
+---
+
+## Executive Summary
+
+The Snap introduced a new key-handling surface (MetaMask SRP → Botho private keys,
+ephemeral claim-link secrets, wasm signing, and the Snap's first `snap_manageState`
+persistence). This audit enumerated that surface end-to-end and confirms the design
+is **sound**: the two at-rest finding classes from the closed web-wallet audit
+structurally **cannot recur** here.
+
+- **#474** (claim-link bearer secrets in plaintext `localStorage`, drainable):
+  cannot recur — claim-link secrets are transient in-memory only, re-derived per
+  RPC call, and never persisted (`claim.ts`).
+- **#475 / #476** (encrypt seed / address book at rest): the Snap **never writes
+  the seed or private keys to state at all** — MetaMask holds the SRP and the Snap
+  re-derives on demand via `snap_getEntropy`; the only persisted blob (`scan` +
+  `contacts`) holds public/derived data and is stored `encrypted: true`.
+
+The real gaps were (a) the invariants were *prose promises*, not *enforced tests*,
+and (b) minor defense-in-depth around transient key buffers. Both are addressed in
+this pass: a regression suite (`test/keyhandling.snap.ts`) now asserts the
+invariants, and `src/derivation.ts` was hardened (F1). No secret-leak vector was
+found in the RPC results, dialogs, error messages, or persisted state.
+
+**Overall Status**: Clean (design sound; invariants now test-enforced; F1 hardened)
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High | 0 |
+| Medium | 0 |
+| Low | 1 (F1 — fixed) |
+| Info | 5 (F2–F6 — F2–F4 test-locked, F5/F6 accepted) |
+
+---
+
+## Sections Reviewed
+
+- [x] 2. Key Derivation & Management — SIP-6 → Botho RootIdentity (`derivation.ts`)
+- [x] 7. Wallet Security — RPC results, dialogs, persisted state, claim-link ingress
+- [x] Logging — `git grep` confirms zero `console.*` in `src/`
+
+---
+
+## Key-handling surface (audited enumeration)
+
+Verified by `git grep` over `web/packages/snap/src/*.ts`:
+
+1. **SRP entropy → Botho keys** — `src/derivation.ts`.
+   `deriveMnemonic()`: `snap_getEntropy({version:1, salt:'botho-root'})` →
+   `entropyHex` (string) → `entropy` (Uint8Array, 32 B) → `entropyToMnemonic` →
+   24-word mnemonic. `walletFromMnemonic()`: `mnemonicToSeedSync` → `seed`
+   (Uint8Array) → `SignerKeys { spendPrivateKey, viewPrivateKey, seed }` (hex),
+   cached as `cachedWallet`.
+2. **Claim-link ephemeral bearer secret** — `src/claim.ts`. `parseClaimLink()` →
+   `{ mnemonic, amountHint }`; `ephemeralKeys()` re-derives `SignerKeys` on each
+   call (correctly **not** cached). Consumed by `scanClaimLink` / `buildSweep`.
+3. **wasm / SES boundary** — `src/signer.ts`. `SignerKeys` hex strings cross into
+   the inlined wasm (`buildAndSign`, `scanOwnedOutputs`,
+   `computeOwnedOutputKeyImages`) via `setSigner`. Rust-side zeroization inside
+   `bth-wasm-signer` is out of scope (that is the audited Rust core), but the trust
+   boundary is noted here.
+4. **Persisted state** — `src/state.ts` (`snap_manageState`, `encrypted: true`).
+   `SnapState = { version, scan?, contacts? }`. `PersistedOwnedOutput` stores target
+   keys / public keys / amounts / kem ciphertext — public/derived data.
+   `keys: SignerKeys` is an *input* to `incrementalScan` and is **never written**:
+   the write spreads the prior blob and sets only `version` / `scan`.
+5. **Contacts** — `src/contacts.ts` — labels + validated public addresses only; no
+   secret material; `writeContacts` spreads the prior blob so it never clobbers
+   `scan`.
+6. **RPC results & dialogs** — `src/index.ts`, `src/ui.ts`. Results return only
+   address / balances / txHash / entries / contacts / `{ revealed: true }`. The
+   mnemonic is surfaced **only** through `mnemonicBackupContent` as
+   `Copyable({ value: mnemonic, sensitive: true })`, gated behind a `confirm()`;
+   the pre-confirm dialog shows a masked placeholder. Error paths interpolate host /
+   method / node-error — not keys.
+7. **Logging** — zero `console.*` in `src/` (asserted by a guard test).
+
+---
+
+## Findings
+
+### [LOW] F1 — Transient key buffers not zeroized; mnemonic cached module-long
+
+**Location**: `src/derivation.ts` (`deriveMnemonic`, `walletFromMnemonic`)
+**Status**: Fixed
+
+**Description**: The transient `entropy` (raw SIP-6 secret) and `seed` (64-byte
+BIP39 seed) `Uint8Array`s were left on the heap after being consumed, and a
+module-level `cachedMnemonic` pinned the raw 24-word recovery phrase (full spending
+authority) for the entire Snap execution context even though it is only re-read on
+the rare `revealMnemonic` path.
+
+**Impact**: Defense-in-depth only. There is no known in-SES adversary that can read
+another execution context's heap, and MetaMask already holds the SRP; this reduces
+the residency window / copy-count of secret material.
+
+**Recommendation**: `.fill(0)` the transient byte arrays after use; stop caching the
+raw mnemonic (re-derive on demand — deterministic in `(SRP, snap id, salt)`, so no
+functional change), keeping only `cachedWallet` (the derived keys the signer needs).
+
+**Resolution**: Applied in this PR:
+- `walletFromMnemonic` computes `seedHex` then `seed.fill(0)` before deriving keys.
+- `deriveMnemonic` no longer caches; wipes `entropy` in a `finally`; re-derives on
+  demand. `deriveWallet` still caches the derived `cachedWallet` (the keys are
+  required in-memory to sign, so this residual copy is inherent and documented).
+
+**Residual (accepted, documented)**: the intermediate `entropyHex` string and the
+`SignerKeys` hex strings are **immutable JS strings** and cannot be zeroized in
+place; `cachedWallet.keys` necessarily lives for the execution context so the signer
+can build/scan without a re-derivation per call. The `@scure/bip39` /
+`@botho/core` internals also allocate their own transient buffers we do not control.
+These are inherent to a JS/SES wallet and are the accepted lower bound.
+
+### [INFO] F2 — Claim-link bearer-secret hygiene was untested (the #474 class)
+
+**Location**: `src/claim.ts`, `src/index.ts`
+**Status**: Fixed (test-locked)
+
+**Description**: The ephemeral claim-link mnemonic is correctly never persisted /
+dialogged / returned / errored, but this was asserted only in prose.
+
+**Resolution**: `test/keyhandling.snap.ts` drives `botho_previewClaimLink` and
+`botho_claimLink` with a known bearer mnemonic and asserts the secret appears in
+**no** RPC result, **no** `snap_dialog` content, and **no** thrown error (verbatim
+or as standalone BIP39 tokens, excluding template vocabulary).
+
+### [INFO] F3 — Mnemonic-reveal exposure was correctly gated but untested
+
+**Location**: `src/index.ts` (`botho_showMnemonic`), `src/ui.ts`
+**Status**: Fixed (test-locked)
+
+**Resolution**: Tests assert (a) the pre-confirm dialog shows only the masked
+placeholder (none of the real 24 words), (b) after confirm the phrase appears
+**only** inside a `sensitive: true` Copyable, (c) the RPC result is `{revealed:true}`
+and never contains the phrase, and (d) rejecting throws the fixed decline string
+with no secret.
+
+### [INFO] F4 — No proof that persisted state omits key material (the #475/#476 class)
+
+**Location**: `src/state.ts`, `src/contacts.ts`
+**Status**: Fixed (test-locked)
+
+**Description**: The Snap never writes seed/keys to `snap_manageState`, but nothing
+enforced it. The SES simulation harness (`@metamask/snaps-simulation` 4.x) exposes
+**no state getter**, so the blob cannot be read back through `installSnap`.
+
+**Resolution**: The invariant is enforced at the **write boundary** instead: a
+capturing `snap_manageState` stub records what `incrementalScan` (driven with a
+KNOWN `SignerKeys` and a discovered owned output) and `writeContacts` actually write.
+The tests assert the persisted blob **contains** the public receive facts / contact
+(non-vacuous) but **none** of the private spend/view-key or seed hex passed in. A
+complementary SES-harness test reveals the real derived phrase, derives its keys,
+and asserts none appear in any silent-read result after a persisted round-trip.
+
+### [INFO] F5 — Manifest permission least-privilege
+
+**Location**: `snap.manifest.json`
+**Status**: Acknowledged (no change — all permissions are used)
+
+**Description**: `initialPermissions` = `endowment:rpc` (dapps),
+`endowment:webassembly`, `endowment:network-access`, `snap_getEntropy`,
+`snap_dialog`, `snap_manageState`, `snap_getPreferences`. Each maps to a live
+consumer:
+
+| Permission | Used by |
+|---|---|
+| `endowment:rpc` (`dapps:true`) | `onRpcRequest` (the whole dApp API) |
+| `endowment:webassembly` | inlined `bth-wasm-signer` (`signer.ts`) |
+| `endowment:network-access` | node JSON-RPC `fetch` (`node.ts`) |
+| `snap_getEntropy` | SIP-6 SRP derivation (`derivation.ts`) |
+| `snap_dialog` | receive / balance / send / claim / mnemonic dialogs |
+| `snap_manageState` | persisted scan + contacts (`state.ts`) |
+| `snap_getPreferences` | i18n locale selection (#1095, `i18n.ts`) |
+
+No unused endowment found. In particular, `snap_getPreferences` (added by #1095) is
+actively read by `resolveLocale()` and MUST be retained.
+
+### [INFO] F6 — SIP-6 entropy is bound to the Snap's npm id
+
+**Location**: `src/derivation.ts` (`ENTROPY_SALT`, header trade-off note)
+**Status**: Accepted risk (documented)
+
+**Description**: `snap_getEntropy` is deterministic in `(SRP, snap id, salt)`, so
+republishing under a different npm id derives a **different** wallet. `revealMnemonic`
+(export the 24 words for an off-MetaMask backup) is the documented mitigation.
+Production snap-id pinning is operator-gated and tracked under umbrella #1089 — out
+of scope for this in-code pass.
+
+---
+
+## Comparison to the closed web-wallet at-rest audit (#474 / #475 / #476)
+
+| Web-wallet finding | Recurs in Snap? | Why |
+|---|---|---|
+| #474 — claim-link bearer secret plaintext in `localStorage`, drainable | **No (structural)** | Claim secrets are transient in-memory, re-derived per call, never persisted (`claim.ts`). Locked by F2 tests. |
+| #475 — encrypt seed at rest + KDF/password | **No (structural)** | The Snap never writes seed/keys to state; MetaMask holds the SRP and the Snap re-derives via `snap_getEntropy`. Persisted `scan` is `encrypted:true`. Locked by F4 tests. |
+| #476 — address-book encryption | **No (structural)** | Contacts live in the same `encrypted:true` blob and hold only public data (`contacts.ts`). Covered by the global "no secret in state" F4 test. |
+
+---
+
+## Fixes Applied During Audit
+
+| Finding | Severity | File | Fix |
+|---------|----------|------|-----|
+| F1 | LOW | `src/derivation.ts` | Zeroize transient `entropy`/`seed` buffers; drop `cachedMnemonic` (re-derive on demand) |
+| F2 | INFO | `test/keyhandling.snap.ts` | Assert bearer secret in no result/dialog/error |
+| F3 | INFO | `test/keyhandling.snap.ts` | Assert mnemonic-reveal gating (masked/sensitive/`{revealed}`) |
+| F4 | INFO | `test/keyhandling.snap.ts` | Assert no key material in the `snap_manageState` write |
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `pnpm --filter @botho/snap typecheck` | PASS |
+| `pnpm --filter @botho/snap build:snap` | PASS |
+| `pnpm --filter @botho/snap test:snap` | PASS (incl. new `keyhandling.snap.ts`) |
+| `git grep 'console\.' web/packages/snap/src` | 0 matches (guarded by test) |
+| `test/derivation.snap.ts` regression | PASS (F1 did not change the derived wallet) |
+
+---
+
+## Recommendations for Next Audit
+
+1. Re-run once the SES simulation harness exposes a state getter, to read the
+   `snap_manageState` blob back directly (currently proven at the write boundary).
+2. Live-send / live-claim validation (blocked on betanet resume #1051) — exercises
+   the wasm signing path with real owned-output fixtures.
+3. Production snap-id pinning + npm/allowlist publishing (operator-gated, #1089).
+4. Rust-side (`bth-wasm-signer`) key zeroization — the wasm/SES trust boundary
+   (item 3) is deferred to the audited Rust core.
+
+---
+
+## Time Spent
+
+| Activity | Hours |
+|----------|-------|
+| Code review | 1.5 |
+| Testing | 1.5 |
+| Documentation | 1.0 |
+| **Total** | **4.0** |

--- a/web/packages/snap/README.md
+++ b/web/packages/snap/README.md
@@ -314,6 +314,39 @@ alternative:
   backup loses funds — reintroducing exactly the seed-management burden the Snap
   is meant to remove.
 
+## Key-handling & at-rest (#1096)
+
+A dedicated key-handling security pass audited the Snap's secret surface end-to-end
+(SIP-6 SRP → Botho keys, the ephemeral claim-link bearer secret, the wasm/SES
+boundary, and `snap_manageState` persistence). Full writeup:
+[`audits/2026-07-20-snap-keyhandling.md`](../../../audits/2026-07-20-snap-keyhandling.md).
+
+The two at-rest finding classes from the closed web-wallet audit structurally
+**cannot recur** here: claim-link secrets are never persisted (the **#474** class),
+and the Snap **never writes the seed or private keys to state at all** — MetaMask
+holds the SRP and the Snap re-derives on demand via `snap_getEntropy` (the **#475 /
+#476** class). `test/keyhandling.snap.ts` turns those promises into enforced
+regression invariants:
+
+- **No secret in any RPC result** — no mnemonic / private-key / seed hex appears in
+  any method's JSON result (`botho_showMnemonic` returns only `{ revealed: true }`).
+- **No secret in any dialog** — the bearer mnemonic is never rendered; the recovery
+  phrase surfaces only inside a `sensitive: true` `Copyable` **after** an explicit
+  confirm (the pre-confirm dialog shows a masked placeholder).
+- **No secret in any error** — parse / wrong-network / rejection errors interpolate
+  host / method, never key material.
+- **No secret in persisted state** — the `snap_manageState` blob holds only
+  public/derived data; the private `SignerKeys` are an *input* to the scan, never
+  written out (asserted at the write boundary — the SES simulation harness exposes
+  no state getter).
+- **No logging** — `src/` has zero `console.*` sinks (guarded by a test).
+
+Defense-in-depth hardening (F1): `src/derivation.ts` zeroizes the transient
+`entropy` / `seed` byte buffers after use and no longer caches the raw recovery
+phrase at module scope (re-derived on demand — deterministic in `(SRP, snap id,
+salt)`, so the derived wallet is unchanged). Residual limits (immutable JS strings
+for hex keys; the required in-memory `cachedWallet`) are documented in the audit.
+
 ## Architecture
 
 | File | Responsibility |

--- a/web/packages/snap/snap.manifest.json
+++ b/web/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Manage a privacy-by-default Botho wallet from inside MetaMask. Keys are derived from your MetaMask Secret Recovery Phrase and never leave the Snap sandbox.",
   "proposedName": "Botho Wallet",
   "source": {
-    "shasum": "FhdWd5tzZyOU/9f4KhZ4raofv4NmJIqG0SqXRzbw8gg=",
+    "shasum": "YkefLNaYb+2JC9kP21c9IPU9yweFTbRSbaMlE9mp+nM=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/web/packages/snap/src/derivation.ts
+++ b/web/packages/snap/src/derivation.ts
@@ -79,10 +79,16 @@ export interface SnapWallet {
  */
 export function walletFromMnemonic(mnemonic: string): SnapWallet {
   const seed = mnemonicToSeedSync(mnemonic, '');
+  const seedHex = toHex(seed);
+  // Defense-in-depth (#1096, F1): wipe the transient 64-byte seed buffer now that
+  // its hex form is captured. The retained `keys.seed` hex IS the authoritative
+  // copy the signer consumes, so this only clears the extra raw-bytes copy off the
+  // heap — it does not (and must not) change the derived wallet.
+  seed.fill(0);
+
   const kp = deriveKeypairs(mnemonic, 0);
   const sub = deriveDefaultSubaddressPublicKeys(mnemonic, 0);
 
-  const seedHex = toHex(seed);
   const address = wasm.deriveAddressFromSeed(
     seedHex,
     toHex(sub.viewPublic),
@@ -106,22 +112,37 @@ export function walletFromMnemonic(mnemonic: string): SnapWallet {
 }
 
 let cachedWallet: SnapWallet | null = null;
-let cachedMnemonic: string | null = null;
 
-/** Fetch the SIP-6 entropy and turn it into the 24-word Botho mnemonic. */
+/**
+ * Fetch the SIP-6 entropy and turn it into the 24-word Botho mnemonic.
+ *
+ * DELIBERATELY NOT CACHED (#1096, F1): the raw 24-word phrase is full spending
+ * authority, so it is derived on demand and allowed to go out of scope after each
+ * use rather than being pinned at module scope for the whole execution context.
+ * `deriveWallet` consumes it once to build (and cache) the derived `SignerKeys`
+ * the signer actually needs; `revealMnemonic` re-derives it for the rare backup-
+ * export path. `snap_getEntropy` is deterministic in (SRP, snap id, salt), so
+ * re-derivation always yields the identical phrase — no functional change. The
+ * transient raw-entropy bytes are zeroized after use; the intermediate
+ * `entropyHex` string is immutable and cannot be wiped (inherent JS limitation,
+ * see audits/2026-07-20-snap-keyhandling.md).
+ */
 async function deriveMnemonic(): Promise<string> {
-  if (cachedMnemonic) return cachedMnemonic;
   // SIP-6 entropy: deterministic in (SRP, snap id, salt). 32 bytes.
   const entropyHex = (await snap.request({
     method: 'snap_getEntropy',
     params: { version: 1, salt: ENTROPY_SALT },
   })) as string;
   const entropy = hexToBytes(entropyHex);
-  if (entropy.length !== 32) {
-    throw new Error(`snap_getEntropy returned ${entropy.length} bytes, expected 32`);
+  try {
+    if (entropy.length !== 32) {
+      throw new Error(`snap_getEntropy returned ${entropy.length} bytes, expected 32`);
+    }
+    return entropyToMnemonic(entropy, wordlist);
+  } finally {
+    // Defense-in-depth: wipe the transient entropy bytes once consumed.
+    entropy.fill(0);
   }
-  cachedMnemonic = entropyToMnemonic(entropy, wordlist);
-  return cachedMnemonic;
 }
 
 /**

--- a/web/packages/snap/test/keyhandling.snap.ts
+++ b/web/packages/snap/test/keyhandling.snap.ts
@@ -1,0 +1,370 @@
+/**
+ * Key-handling security regression tests (#1096).
+ *
+ * The Botho Snap's key-handling surface was designed carefully — the doc-comments
+ * across `derivation.ts` / `claim.ts` / `state.ts` promise "keys never leave the
+ * sandbox", "the bearer secret is never surfaced", and "no secret is written to
+ * persisted state". Those were *prose promises*, not *enforced invariants*: a
+ * later refactor could silently add a secret to an error message, a debug field to
+ * an RPC result, or a key to the `snap_manageState` blob and nothing would catch
+ * it. This suite turns each promise into an ASSERTED invariant, mirroring the
+ * closed web-wallet at-rest audit (#474 claim-link bearer secrets in plaintext /
+ * #475 seed-at-rest). See `audits/2026-07-20-snap-keyhandling.md`.
+ *
+ * Two layers, matching `state.snap.ts`:
+ *
+ *  A. WRITE-BOUNDARY capture (no `installSnap`): a `snap_manageState`-capturing
+ *     stub proves that the persisted blob produced by `incrementalScan` /
+ *     `writeContacts` carries only public/derived data — the private `SignerKeys`
+ *     passed IN never appear in what is written OUT (the #475/#476 class). This is
+ *     the direct proof of the "no secret in state" invariant: the SES simulation
+ *     harness (snaps-simulation 4.x) exposes no state getter, so the blob is
+ *     inspected at the write boundary instead (documented in the audit).
+ *
+ *  B. SES-HARNESS behaviour (`@metamask/snaps-jest`): drives the real RPC methods
+ *     inside the SES executor against a mocked node and asserts no secret material
+ *     (a known bearer mnemonic, the derived wallet's phrase, its private-key/seed
+ *     hex) appears in any RPC RESULT, any `snap_dialog` CONTENT, or any thrown
+ *     ERROR — including after a persisted round-trip.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+import {
+  deriveKeypairs,
+  createClaimLinkMnemonic,
+  encodeClaimLinkFragment,
+} from '@botho/core';
+import {
+  mnemonicToSeedHex,
+  type ChainOutputWithMeta,
+  type SignerKeys,
+  type WasmSigner,
+} from '@botho/wasm-signer';
+
+import { incrementalScan } from '../src/state';
+import { writeContacts } from '../src/contacts';
+import { startMockNode, type MockNode } from './mock-node';
+
+const toHex = (b: Uint8Array): string =>
+  Array.from(b)
+    .map((x) => x.toString(16).padStart(2, '0'))
+    .join('');
+
+function unwrap<T>(response: { response: unknown }): T {
+  const res = response.response as { result?: T; error?: { message?: string } };
+  if (res.error) {
+    throw new Error(`snap returned error: ${JSON.stringify(res.error)}`);
+  }
+  return res.result as T;
+}
+
+function errorOf(response: { response: unknown }): { message?: string } | undefined {
+  return (response.response as { error?: { message?: string } }).error;
+}
+
+/** Recursively collect every `Copyable`/field `value` string in a dialog tree. */
+function collectValues(node: unknown, acc: string[] = []): string[] {
+  if (!node || typeof node !== 'object') return acc;
+  const n = node as { value?: unknown; props?: { value?: unknown; children?: unknown }; children?: unknown };
+  const value = n.props?.value ?? n.value;
+  if (typeof value === 'string') acc.push(value);
+  const children = n.props?.children ?? n.children;
+  if (Array.isArray(children)) children.forEach((c) => collectValues(c, acc));
+  else if (children) collectValues(children, acc);
+  return acc;
+}
+
+/** The 24-word phrase rendered in a mnemonic-backup alert (the sensitive Copyable). */
+function extractPhrase(content: unknown): string {
+  const phrase = collectValues(content).find((v) => v.trim().split(/\s+/).length === 24);
+  if (!phrase) throw new Error('no 24-word phrase found in dialog content');
+  return phrase;
+}
+
+/** A fixed, KNOWN wallet whose secrets we search the persisted blob for. */
+const KNOWN_MNEMONIC = createClaimLinkMnemonic();
+const KNOWN_KP = deriveKeypairs(KNOWN_MNEMONIC, 0);
+const KNOWN_KEYS: SignerKeys = {
+  spendPrivateKey: toHex(KNOWN_KP.spendPrivate),
+  viewPrivateKey: toHex(KNOWN_KP.viewPrivate),
+  seed: mnemonicToSeedHex(KNOWN_MNEMONIC),
+};
+const KNOWN_SECRETS = [
+  KNOWN_MNEMONIC,
+  KNOWN_KEYS.spendPrivateKey,
+  KNOWN_KEYS.viewPrivateKey,
+  KNOWN_KEYS.seed as string,
+];
+
+/* ================================================================== */
+/* A. Write-boundary: no secret is ever written to persisted state    */
+/*    (#475/#476 class — proven at the snap_manageState boundary)      */
+/* ================================================================== */
+
+describe('key-handling: persisted-state write boundary (#1096, F4)', () => {
+  afterEach(() => {
+    delete (globalThis as unknown as { snap?: unknown }).snap;
+  });
+
+  /** Install a capturing `snap_manageState` stub; returns the write log. */
+  function stubManageState(): { updates: Record<string, unknown>[]; current(): unknown } {
+    let stored: Record<string, unknown> | null = null;
+    const updates: Record<string, unknown>[] = [];
+    (globalThis as unknown as { snap: unknown }).snap = {
+      request: async ({
+        method,
+        params,
+      }: {
+        method: string;
+        params?: { operation?: string; newState?: Record<string, unknown> };
+      }) => {
+        if (method !== 'snap_manageState') {
+          throw new Error(`unexpected snap.request in capture stub: ${method}`);
+        }
+        switch (params?.operation) {
+          case 'get':
+            return stored;
+          case 'update':
+            stored = params.newState ?? null;
+            if (stored) updates.push(stored);
+            return null;
+          case 'clear':
+            stored = null;
+            return null;
+          default:
+            return null;
+        }
+      },
+    };
+    return { updates, current: () => stored };
+  }
+
+  it('incrementalScan persists owned outputs (public) but NEVER the private keys it scans with', async () => {
+    const captured = stubManageState();
+
+    // A single owned output the fake signer "discovers" in the scanned window.
+    const raw: ChainOutputWithMeta = {
+      targetKey: 'aa'.repeat(32),
+      publicKey: 'bb'.repeat(32),
+      amount: 1_000_000_000_000n,
+      outputIndex: 0,
+      kemCiphertext: null,
+      txHash: 'cc'.repeat(32),
+      height: 5,
+    };
+    const fakeSigner = {
+      scanOwnedOutputs: ({ outputs }: { outputs: Array<Record<string, unknown>> }) =>
+        outputs.map((o) => ({
+          targetKey: o.targetKey,
+          publicKey: o.publicKey,
+          amount: o.amount,
+          subaddressIndex: 0n,
+          outputIndex: o.outputIndex,
+          kemCiphertext: o.kemCiphertext ?? null,
+        })),
+      computeOwnedOutputKeyImages: ({ outputs }: { outputs: Array<Record<string, unknown>> }) =>
+        outputs.map((o, i) => ({ ...o, keyImage: `ki${i}` })),
+    } as unknown as WasmSigner;
+
+    await incrementalScan({
+      signer: fakeSigner,
+      keys: KNOWN_KEYS,
+      network: 'botho-testnet',
+      tip: 10,
+      fetchWindow: async (lo, hi) => (lo <= 5 && hi >= 5 ? [raw] : []),
+      sendRpc: {
+        getChainHeight: async () => 10,
+        getOutputs: async () => [],
+        areKeyImagesSpent: async (keyImages) =>
+          keyImages.map((keyImage) => ({ keyImage, spent: false, spentHeight: null, pending: false })),
+      },
+    });
+
+    const blob = JSON.stringify(captured.current());
+    // Non-vacuous: the write really happened and persisted the PUBLIC receive facts.
+    expect(blob).toContain(raw.targetKey);
+    expect(blob).toContain('botho-testnet');
+    // The wallet keys were an INPUT to the scan but must never be written out.
+    for (const secret of KNOWN_SECRETS) expect(blob.includes(secret)).toBe(false);
+  });
+
+  it('writeContacts persists only the (public) address book, no key material', async () => {
+    const captured = stubManageState();
+    await writeContacts([
+      { id: 'deadbeef', label: 'My other wallet', address: 'tbotho://2/public-address' },
+    ]);
+
+    const blob = JSON.stringify(captured.current());
+    expect(blob).toContain('My other wallet'); // non-vacuous: contact persisted
+    expect(blob).toContain('tbotho://2/public-address');
+    for (const secret of KNOWN_SECRETS) expect(blob.includes(secret)).toBe(false);
+  });
+
+  it('src/ contains no console.* sink (secrets can never reach a log)', () => {
+    const srcDir = join(__dirname, '..', 'src');
+    const offenders: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, entry.name);
+        if (entry.isDirectory()) walk(p);
+        else if (entry.name.endsWith('.ts') && /\bconsole\s*\./.test(readFileSync(p, 'utf8'))) {
+          offenders.push(p);
+        }
+      }
+    };
+    walk(srcDir);
+    expect(offenders).toEqual([]);
+  });
+});
+
+/* ================================================================== */
+/* B. SES harness: no secret in any result / dialog / error           */
+/* ================================================================== */
+
+describe('key-handling: no secret in RPC result / dialog / error (#1096, F2/F3)', () => {
+  let node: MockNode | undefined;
+
+  afterEach(async () => {
+    if (node) {
+      await node.close();
+      node = undefined; // don't re-close in a later test that starts no node
+    }
+  });
+
+  it('claim link: the ephemeral bearer mnemonic never appears in a result, dialog, or error (F2)', async () => {
+    node = await startMockNode();
+    const mnemonic = createClaimLinkMnemonic();
+    const fragment = encodeClaimLinkFragment(mnemonic);
+
+    // Dialog/error templates legitimately share a few English tokens with the
+    // BIP39 wordlist; exclude those so a random mnemonic that happens to contain
+    // one does not false-fail. We then assert no remaining secret word appears as
+    // a standalone token, and the whole phrase never appears verbatim.
+    const templateVocab =
+      'claim link nothing to this is empty already claimed or not yet confirmed holds ' +
+      'funds that will be swept into your wallet the sweep fee is paid from claimable ' +
+      'you receive hint cosmetic scanned amount above authoritative node confirm invalid ' +
+      'bth does cover reject user rejected the';
+    const templateTokens = new Set(templateVocab.match(/[a-z]+/g));
+    const secretWords = mnemonic.split(' ').filter((w) => !templateTokens.has(w));
+    expect(secretWords.length).toBeGreaterThan(0); // filtering did not empty it
+
+    const assertNoLeak = (blob: string): void => {
+      const tokens = new Set(blob.toLowerCase().match(/[a-z]+/g) ?? []);
+      for (const w of secretWords) expect(tokens.has(w)).toBe(false);
+      expect(blob.includes(mnemonic)).toBe(false);
+    };
+
+    const { request } = await installSnap();
+
+    // Preview: dialog content + returned result.
+    const preview = request({ method: 'botho_previewClaimLink', params: { rpcUrl: node.url, link: fragment } });
+    const previewUi = await preview.getInterface();
+    assertNoLeak(JSON.stringify(previewUi.content));
+    await (previewUi as { ok(): Promise<void> }).ok();
+    assertNoLeak(JSON.stringify((await preview).response));
+
+    // Claim (approve → "nothing to claim" error on the empty mock): dialog + error.
+    const claim = request({ method: 'botho_claimLink', params: { rpcUrl: node.url, link: fragment } });
+    const claimUi = await claim.getInterface();
+    assertNoLeak(JSON.stringify(claimUi.content));
+    await (claimUi as { ok(): Promise<void> }).ok();
+    const claimed = await claim;
+    expect(errorOf(claimed)?.message).toBeTruthy();
+    assertNoLeak(JSON.stringify(claimed.response));
+  });
+
+  it('botho_showMnemonic: masked before confirm, phrase only in a sensitive Copyable after, never in the result (F3)', async () => {
+    const { request } = await installSnap();
+    const response = request({ method: 'botho_showMnemonic' });
+
+    // Pre-confirm dialog: the masked placeholder, not the real words.
+    const confirmUi = await response.getInterface();
+    expect(confirmUi.type).toBe('confirmation');
+    const preConfirm = JSON.stringify(confirmUi.content);
+    expect(preConfirm).toContain('••••');
+    await (confirmUi as { ok(): Promise<void> }).ok();
+
+    // Post-confirm alert: the real phrase, flagged sensitive.
+    const alertUi = await response.getInterface();
+    const revealed = JSON.stringify(alertUi.content);
+    expect(revealed).toContain('"sensitive":true');
+    const phrase = extractPhrase(alertUi.content);
+    expect(phrase.split(/\s+/)).toHaveLength(24);
+    await (alertUi as { ok(): Promise<void> }).ok();
+
+    // The pre-confirm dialog must NOT render the real phrase (it shows the mask).
+    // A per-word token check would false-positive on the backup body copy, which
+    // legitimately shares common English words with the BIP39 wordlist ("them",
+    // "your", …); the verbatim-phrase check is what precisely guards the mask.
+    expect(preConfirm.includes(phrase)).toBe(false);
+    // And no run of the real ordered words (defeats a reordered/partial render).
+    const orderedWords = phrase.split(/\s+/);
+    for (let i = 0; i + 3 < orderedWords.length; i++) {
+      const window = orderedWords.slice(i, i + 4).join(' ');
+      expect(preConfirm.toLowerCase().includes(window)).toBe(false);
+    }
+
+    // The RPC result is just {revealed:true} — never the phrase.
+    const result = unwrap<{ revealed: boolean }>(await response);
+    expect(result).toEqual({ revealed: true });
+    expect(JSON.stringify(result).includes(phrase)).toBe(false);
+  });
+
+  it('botho_showMnemonic: rejecting reveals nothing (fixed decline error, no phrase) (F3)', async () => {
+    const { request } = await installSnap();
+    const response = request({ method: 'botho_showMnemonic' });
+    const ui = await response.getInterface();
+    await (ui as { cancel(): Promise<void> }).cancel();
+
+    const rejected = await response;
+    const message = errorOf(rejected)?.message ?? '';
+    expect(message).toMatch(/declined to reveal/i);
+    // A fixed i18n decline string — no 24-word phrase can hide in it.
+    expect(message.split(/\s+/).length).toBeLessThan(12);
+  });
+
+  it('no derived wallet secret appears in any silent-read RPC result, even after a persisted round-trip (F2/F4)', async () => {
+    node = await startMockNode();
+    const { request } = await installSnap();
+
+    // Learn the wallet's real secret material by revealing the mnemonic once,
+    // then derive its private keys / seed in-test to search results for.
+    const reveal = request({ method: 'botho_showMnemonic' });
+    const confirmUi = await reveal.getInterface();
+    await (confirmUi as { ok(): Promise<void> }).ok();
+    const alertUi = await reveal.getInterface();
+    const phrase = extractPhrase(alertUi.content);
+    await (alertUi as { ok(): Promise<void> }).ok();
+    await reveal;
+
+    const kp = deriveKeypairs(phrase, 0);
+    const secrets = [phrase, toHex(kp.spendPrivate), toHex(kp.viewPrivate), mnemonicToSeedHex(phrase)];
+    const assertNoSecret = (blob: string): void => {
+      for (const s of secrets) expect(blob.includes(s)).toBe(false);
+    };
+
+    // getAddress gives us a real (public) address to save as a contact.
+    const { address } = unwrap<{ address: string }>(await request({ method: 'botho_getAddress' }));
+    assertNoSecret(JSON.stringify(address));
+
+    // Balance read persists scan state; addContact persists the contacts book.
+    assertNoSecret(
+      JSON.stringify(unwrap(await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }))),
+    );
+    unwrap(await request({ method: 'botho_addContact', params: { label: 'Self', address } }));
+
+    // Read everything back through the persisted-state-backed paths.
+    assertNoSecret(
+      JSON.stringify(unwrap(await request({ method: 'botho_getBalance', params: { rpcUrl: node.url } }))),
+    );
+    assertNoSecret(
+      JSON.stringify(unwrap(await request({ method: 'botho_getHistory', params: { rpcUrl: node.url } }))),
+    );
+    assertNoSecret(JSON.stringify(unwrap(await request({ method: 'botho_listContacts' }))));
+  });
+});


### PR DESCRIPTION
## Summary

Dedicated key-handling security pass for the Botho MetaMask Snap (`web/packages/snap`). The design was already sound — the **#474** (claim-link bearer secrets in plaintext) and **#475/#476** (seed / address-book at rest) classes structurally **cannot recur**: claim secrets are transient in-memory only, and the Snap never writes seed/keys to `snap_manageState` (MetaMask holds the SRP; the Snap re-derives via `snap_getEntropy`). The real gaps were that the invariants were *prose promises* with no test enforcement, plus minor defense-in-depth. Both are addressed here.

## Changes

- **Audit doc** `audits/2026-07-20-snap-keyhandling.md` — 7-locus surface enumeration, findings **F1–F6** with disposition, and the #474/#475/#476 comparison (per `audits/TEMPLATE.md`).
- **Regression tests** `web/packages/snap/test/keyhandling.snap.ts` — assert no secret material (bearer mnemonic, derived recovery phrase, private-key/seed hex) appears in any RPC **result**, any `snap_dialog` **content**, any thrown **error**, or the `snap_manageState` **write**; plus a `console.*`-free source guard. The persisted-state invariant is proven at the **write boundary** because the SES simulation harness (`@metamask/snaps-simulation` 4.x) exposes no state getter.
- **F1 hardening** `web/packages/snap/src/derivation.ts` — zeroize the transient `entropy`/`seed` `Uint8Array`s after use; stop caching the raw 24-word phrase at module scope (re-derived on demand — deterministic in `(SRP, snap id, salt)`, so the **derived wallet is unchanged**; only `cachedWallet` is kept). Residual limits (immutable JS hex strings, required in-memory keys) documented in the audit.
- **README** — "Key-handling & at-rest" subsection linking the audit + the enforced invariants. `snap.manifest.json` shasum refreshed by the bundle rebuild.
- **F5 (least-privilege)** — reviewed `snap.manifest.json`; every permission maps to a live consumer (incl. `snap_getPreferences` added by #1095). **No change** (removing a used permission would break i18n).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Audit doc (F1–F6, template) | ✅ | `audits/2026-07-20-snap-keyhandling.md` |
| No secret in results | ✅ | `botho_showMnemonic` → `{revealed:true}`; claim + silent-read results asserted secret-free |
| No secret in dialogs | ✅ | bearer mnemonic never rendered; phrase only in `sensitive` Copyable after confirm; masked pre-confirm |
| No secret in errors | ✅ | claim/reveal reject + parse errors asserted secret-free |
| No secret in persisted state | ✅ | `snap_manageState` write captured; owned-output/contact (public) present, `SignerKeys` absent |
| No logging | ✅ | `src/` `console.*` guard test |
| F1 hardening, wallet unchanged | ✅ | `derivation.ts` zeroize + no phrase cache; `derivation.snap.ts` green |
| README note | ✅ | "Key-handling & at-rest" subsection |
| Least-privilege check | ✅ | audit F5 — no unused permission |

## Test Plan

`pnpm --filter @botho/snap typecheck && pnpm --filter @botho/snap build:snap && pnpm --filter @botho/snap test:snap`

- typecheck: PASS
- build:snap: PASS (bundle evaluated; 3 pre-existing webpack warnings)
- test:snap: **76 passed, 10 suites** (incl. new `keyhandling.snap.ts` 7/7; `derivation.snap.ts` regression green)

Findings needing larger work remain deferred under umbrella #1089 (F6 production snap-id pinning; live-send/claim on betanet #1051; Rust-side wasm zeroization) — not scoped into this PR.

Closes #1096