### PR TITLE
ci(web): run the MetaMask Snap suite (@metamask/snaps-jest) in web-ci

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -6,6 +6,13 @@ name: Web CI
 # change to the BaaS provisioner/webhook/checkout/status code (or the wallet)
 # could ship a broken test suite with no red signal (#530).
 #
+# Also runs the MetaMask Snap suite (`web/packages/snap`, 76 `*.snap.ts` tests
+# via @metamask/snaps-jest). Those are NOT `*.test.ts` so the root vitest run
+# never collects them — without this job the whole Snap package ships with zero
+# CI coverage (#1105). The snap tests need the wasm-signer bundler artifact
+# built first (the snap bundle inlines `bth_wasm_signer` from pkg-bundler), so
+# this job installs a wasm Rust toolchain + wasm-pack and builds it in-job.
+#
 # Path-filtered so Rust-only PRs don't pay the pnpm install/test cost.
 # Everything here is offline/mocked and `--dry-run` only: NO secrets required.
 
@@ -32,9 +39,9 @@ permissions:
 
 jobs:
   web-ci:
-    name: typecheck + vitest + worker dry-run
+    name: typecheck + vitest + snap + worker dry-run
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     # The pnpm workspace is rooted at web/, not the repo root.
     defaults:
@@ -71,6 +78,42 @@ jobs:
       # ~195 @botho/baas-worker tests in a single run.
       - name: Run web + baas-worker tests
         run: pnpm test:run
+
+      # --- MetaMask Snap suite (@metamask/snaps-jest, web/packages/snap) --------
+      # These `*.snap.ts` tests are invisible to the root vitest run above, so
+      # they need their own step (#1105). The snap bundle inlines the
+      # `bth-wasm-signer` wasm, so we build a wasm Rust toolchain + wasm-pack and
+      # produce the bundler-target artifact (`pkg-bundler/`) before running them.
+      # Toolchain pin matches rust-toolchain.toml; the wasm32 target is not in
+      # that file's `targets`, so request it explicitly here.
+      - name: Install Rust (wasm32 target for the snap wasm-signer)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-12-03
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo (snap wasm build)
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: web-ci-wasm-signer
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: v0.13.1
+
+      # Bundler-target build: emits web/packages/wasm-signer/pkg-bundler, which
+      # the snap's `mm-snap build` inlines. Runs headless on ubuntu-latest — no
+      # browser, no network beyond crate/wasm-bindgen fetches.
+      - name: Build wasm-signer bundler artifact (prereq for snap tests)
+        run: pnpm --filter @botho/wasm-signer build:wasm:bundler
+
+      # test:snap = `mm-snap build && jest`; runs the 76 `*.snap.ts` tests inside
+      # the real Snaps SES executor with an in-process mocked node (no secrets,
+      # no live betanet).
+      - name: Run Snap tests (@metamask/snaps-jest)
+        run: pnpm --filter @botho/snap test:snap
+      # -------------------------------------------------------------------------
 
       # Validate the worker still bundles/deploys without actually shipping it.
       # --dry-run needs no Cloudflare token and contacts no network.


### PR DESCRIPTION
## Summary
The `@botho/snap` package's tests are `*.snap.ts` files run by `@metamask/snaps-jest` (`test:snap`), not `*.test.ts`. The root vitest run in `web-ci.yml` (`pnpm test:run`) only collects `packages/**/*.test.ts(x)`, so the entire 76-test Snap suite had **zero CI coverage** — every Snap PR in the Phase-2 sweep was validated only by the reviewer locally.

This wires the Snap suite into the existing path-filtered `web-ci` job so a Snap regression turns CI red.

## Changes
- `.github/workflows/web-ci.yml`:
  - Add a wasm Rust toolchain step (`dtolnay/rust-toolchain@master`, `nightly-2025-12-03` + `wasm32-unknown-unknown`). The pin matches `rust-toolchain.toml`; that file does **not** list the wasm32 target, so it is requested explicitly.
  - Add `Swatinem/rust-cache@v2` (key `web-ci-wasm-signer`) so the crypto-stack compile is cached across runs.
  - Add `jetli/wasm-pack-action@v0.4.0` (pinned `v0.13.1`) — stock ubuntu-latest has neither wasm-pack nor the wasm32 target.
  - Build the wasm-signer bundler artifact (`pnpm --filter @botho/wasm-signer build:wasm:bundler`) that `mm-snap build` inlines into the snap bundle (`src/signer.ts` imports `@botho/wasm-signer/pkg-bundler/bth_wasm_signer.js`).
  - Run the suite: `pnpm --filter @botho/snap test:snap`.
  - Bump `timeout-minutes` 15 -> 25 to cover the first (uncached) Rust compile; update the job name and header comment.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `web-ci.yml` runs the Snap `*.snap.ts` suite on PRs touching `web/**` | ✅ | New `Run Snap tests` step; job stays under the existing `web/**` path filter |
| The wasm bundler prereq is built in-job (SES harness needs it) | ✅ | `build:wasm:bundler` step emits `pkg-bundler/` before `test:snap`; confirmed the snap imports `@botho/wasm-signer/pkg-bundler/bth_wasm_signer.js` |
| A deliberately-broken snap test turns CI red | ✅ | Temporarily changed a `balance.snap.ts` assertion → `test:snap` exited **1** (`1 failed, 75 passed`); reverted (not committed) |
| No secrets/network needed | ✅ | Snap tests use an in-process mocked node; wasm build is headless (crate/wasm-bindgen fetches only) |

## Test Plan
Ran the exact CI commands locally from `web/` in the worktree:
1. `pnpm install --frozen-lockfile`
2. `pnpm --filter @botho/wasm-signer build:wasm:bundler` → `pkg-bundler` produced
3. `pnpm --filter @botho/snap test:snap` → **76 passed, 10 suites, ~13s**

Sanity check: broke one `balance.snap.ts` assertion → exit code 1; reverted.

Verified package/script names against source:
- `web/packages/snap/package.json`: name `@botho/snap`, script `test:snap` = `mm-snap build && jest`
- `web/packages/wasm-signer/package.json`: name `@botho/wasm-signer`, script `build:wasm:bundler` = `wasm-pack build --target bundler`

Closes #1105