### PR TITLE
fix(snap): prune reorged-out owned outputs by reconciling the rescanned range

### DIFF
--- a/web/packages/snap/snap.manifest.json
+++ b/web/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Manage a privacy-by-default Botho wallet from inside MetaMask. Keys are derived from your MetaMask Secret Recovery Phrase and never leave the Snap sandbox.",
   "proposedName": "Botho Wallet",
   "source": {
-    "shasum": "YkefLNaYb+2JC9kP21c9IPU9yweFTbRSbaMlE9mp+nM=",
+    "shasum": "8Iva7ztrgdLBlQ5RbwCA9P8GlgAEkJbXu8A5VMZKW/8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/web/packages/snap/src/state.ts
+++ b/web/packages/snap/src/state.ts
@@ -36,8 +36,15 @@
  *
  *  - **Reorg safety.** betanet can reorg. On resume we conservatively re-scan a
  *    small trailing `REORG_BUFFER` of blocks below the checkpoint so a shallow
- *    reorg near the tip is picked up; merges dedupe by one-time target key so the
- *    overlap never double-counts.
+ *    reorg near the tip is picked up. Rather than only *adding* what the re-scan
+ *    finds (which can never remove a receive that was reorged out), we
+ *    **reconcile** the re-fetched range: the persisted contents of `[start, tip]`
+ *    are REPLACED wholesale by what the node currently reports, while everything
+ *    strictly below `start` (treated as final — never re-fetched) is retained
+ *    unchanged, and anything stranded above the reported `tip` is pruned. Pruning
+ *    is bounded to the range the node was authoritatively queried for, so a
+ *    still-returned output is never dropped (the dangerous under-report
+ *    direction). See {@link reconcileOwnedOutputs} for the safety invariant.
  */
 
 import type {
@@ -240,6 +247,12 @@ export function toOwnedOutput(p: PersistedOwnedOutput): OwnedOutput {
  * one-time target key (which is globally unique per output). Existing records
  * win, so a re-scanned reorg-buffer block never appends a duplicate. Returns a
  * new array (does not mutate `existing`).
+ *
+ * NOTE: this is **add-only** (monotonic) — it can never PRUNE a persisted output
+ * that has since been reorged out. The incremental scan therefore does NOT use it
+ * as the persist step; it reconciles the re-fetched range via
+ * {@link reconcileOwnedOutputs}. Retained only for its within-`discovered` /
+ * against-`existing` dedupe semantics and its historical unit contract.
  */
 export function mergeOwnedOutputs(
   existing: PersistedOwnedOutput[],
@@ -248,6 +261,63 @@ export function mergeOwnedOutputs(
   const byKey = new Map<string, PersistedOwnedOutput>();
   for (const o of existing) byKey.set(o.targetKey, o);
   for (const o of discovered) if (!byKey.has(o.targetKey)) byKey.set(o.targetKey, o);
+  return Array.from(byKey.values());
+}
+
+/**
+ * Reconcile the persisted owned set against a **rescanned** height range, so a
+ * reorged-out output is PRUNED instead of lingering forever (the add-only
+ * {@link mergeOwnedOutputs} can never remove one). Returns a new array (does not
+ * mutate `existing`).
+ *
+ * `start` is `scanStartHeight(lastScannedHeight)` and `tip` is the node's
+ * reported chain tip this scan; `[start, tip]` is exactly the range the scan
+ * re-fetched (window by window) and `discovered` is every owned output the node
+ * returned across ALL those windows. The re-fetched range is treated as
+ * AUTHORITATIVE: its persisted contents are replaced wholesale by `discovered`,
+ * while everything strictly below `start` (never re-fetched — assumed final) is
+ * retained unchanged. Anything stranded ABOVE the reported `tip` (a chain that
+ * shrank below an output's receive height) is provably gone and is pruned too.
+ *
+ * SAFETY INVARIANT — after every scan, for the re-fetched range `R = [start, tip]`
+ * (`R = ∅` when `tip < start`):
+ *
+ *   1. No phantom:  no persisted output with `blockHeight ∈ R` survives unless the
+ *      node returned it this scan; nor does any with `blockHeight > tip`.
+ *   2. No dropped:  every owned output the node returned in `R` is present.
+ *   3. No collateral prune:  every persisted output with `blockHeight < start`
+ *      (and `≤ tip`) is retained unchanged — a range NOT re-fetched is NEVER pruned.
+ *
+ * Equivalently `persisted ∩ R == node-reported-owned ∩ R` (exactly) and
+ * `persisted \ R` is untouched. Because pruning is bounded to a range the node
+ * was authoritatively queried for (plus the provably-empty region above the tip),
+ * a still-returned output is NEVER dropped — the dangerous under-report direction
+ * that would make funds appear lost.
+ *
+ * Prune keys on ON-CHAIN PRESENCE (membership in the node's `chain_getOutputs`
+ * response, i.e. `discovered`), NOT on live spent status. Spending an output does
+ * not remove it from `chain_getOutputs` — a spent output stays a mined output, so
+ * it is re-returned, RETAINED here, then split out of `spendable` by the live
+ * `chain_areKeyImagesSpent` check and rendered `direction: 'spent'`. Only a
+ * genuinely reorged-out output (absent from `discovered`, or above `tip`) is
+ * pruned.
+ */
+export function reconcileOwnedOutputs(
+  existing: PersistedOwnedOutput[],
+  discovered: PersistedOwnedOutput[],
+  start: number,
+  tip: number,
+): PersistedOwnedOutput[] {
+  const byKey = new Map<string, PersistedOwnedOutput>();
+  // Retain only outputs strictly BELOW the re-fetched range AND at/below the tip.
+  // `< start`  : not re-fetched, treated as final -> never pruned.
+  // `<= tip`   : guards the chain-shrank case (tip < start): anything above the
+  //              node's reported tip is provably gone and must not survive.
+  for (const o of existing) {
+    if (o.blockHeight < start && o.blockHeight <= tip) byKey.set(o.targetKey, o);
+  }
+  // The re-fetched range [start, tip] is replaced wholesale by node truth.
+  for (const o of discovered) byKey.set(o.targetKey, o);
   return Array.from(byKey.values());
 }
 
@@ -301,9 +371,15 @@ export async function incrementalScan(args: IncrementalScanArgs): Promise<Increm
 
   const persisted = await readState();
   const usable = usableScanState(persisted, network);
-  let ownedOutputs = usable ? usable.ownedOutputs : [];
+  const priorOwned = usable ? usable.ownedOutputs : [];
   const start = usable ? scanStartHeight(usable.lastScannedHeight) : 0;
 
+  // Accumulate every owned output the node reports across ALL windows of this
+  // scan's re-fetched range, then reconcile ONCE against `[start, tip]`. A single
+  // whole-range reconcile (rather than a per-window merge) is what makes the prune
+  // exact: an output at a low window boundary is never dropped by a later window's
+  // reconcile, because the whole `[start, tip]` set is compared together.
+  const allDiscovered: PersistedOwnedOutput[] = [];
   for (const [lo, hi] of windows(start, tip)) {
     const raw = await fetchWindow(lo, hi);
     if (raw.length === 0) continue;
@@ -324,15 +400,21 @@ export async function incrementalScan(args: IncrementalScanArgs): Promise<Increm
       })),
     });
 
-    const persistedDiscovered = discovered.map((o) => {
+    for (const o of discovered) {
       const meta = metaByTargetKey.get(o.targetKey);
-      return toPersistedOwnedOutput(o, {
-        blockHeight: meta?.height ?? 0,
-        txHash: meta?.txHash ?? o.targetKey,
-      });
-    });
-    ownedOutputs = mergeOwnedOutputs(ownedOutputs, persistedDiscovered);
+      allDiscovered.push(
+        toPersistedOwnedOutput(o, {
+          blockHeight: meta?.height ?? 0,
+          txHash: meta?.txHash ?? o.targetKey,
+        }),
+      );
+    }
   }
+
+  // Reconcile: replace the re-fetched `[start, tip]` range wholesale with node
+  // truth (dropping reorged-out receives), retaining everything below `start` and
+  // pruning anything stranded above `tip`. See `reconcileOwnedOutputs`.
+  const ownedOutputs = reconcileOwnedOutputs(priorOwned, allDiscovered, start, tip);
 
   await writeState({
     version: STATE_VERSION,

--- a/web/packages/snap/test/state.snap.ts
+++ b/web/packages/snap/test/state.snap.ts
@@ -31,6 +31,9 @@ import {
   scanStartHeight,
   windows,
   mergeOwnedOutputs,
+  reconcileOwnedOutputs,
+  spentTargetKeys,
+  deriveHistory,
   toPersistedOwnedOutput,
   toOwnedOutput,
   type PersistedOwnedOutput,
@@ -144,6 +147,130 @@ describe('persisted scan-state helpers (#1091)', () => {
     expect(state.version).toBe(1);
     expect(state.scan?.ownedOutputs).toEqual([]);
     expect(state.scan?.lastScannedHeight).toBe(0);
+  });
+});
+
+/* ================================================================== */
+/* 1b. reconcile-on-rescan: the reorg-staleness prune (#1099)         */
+/* ================================================================== */
+
+describe('reconcileOwnedOutputs — prune-on-rescan safety invariant (#1099)', () => {
+  /** Build a persisted owned output with a distinct target key at a given height. */
+  function out(tag: string, blockHeight: number, amount = '1000'): PersistedOwnedOutput {
+    // 64-hex target key from the tag so keys are unique + deterministic.
+    const targetKey = (tag.charCodeAt(0).toString(16).padStart(2, '0')).repeat(32);
+    return {
+      targetKey,
+      publicKey: 'bb'.repeat(32),
+      amount,
+      subaddressIndex: '0',
+      outputIndex: 0,
+      kemCiphertext: null,
+      blockHeight,
+      txHash: `${tag}${tag}`.repeat(16).slice(0, 64),
+    };
+  }
+  const keys = (xs: PersistedOwnedOutput[]) => xs.map((o) => o.targetKey).sort();
+  /** Sum owned amounts the way `incrementalScanBalance` would (all unspent). */
+  const sum = (xs: PersistedOwnedOutput[]) => xs.reduce((s, o) => s + BigInt(o.amount), 0n);
+
+  it('prunes a stale (reorged-out) output inside the re-fetched range', () => {
+    const A = out('A', 95); // in [90,100], node no longer returns it
+    const B = out('B', 50); // below the re-fetched range
+    const result = reconcileOwnedOutputs([A, B], /* discovered */ [], 90, 100);
+
+    // A pruned (reorged out of its window); B (below start) retained.
+    expect(keys(result)).toEqual(keys([B]));
+    // It drops out of the balance sum...
+    expect(sum(result)).toBe(BigInt(B.amount));
+    // ...and out of history entirely (no live-spent set needed — it's gone).
+    const history = deriveHistory(result, new Set<string>(), 100);
+    expect(history.map((h) => h.txHash)).not.toContain(A.txHash);
+    expect(history.map((h) => h.txHash)).toContain(B.txHash);
+  });
+
+  it('NEVER prunes a still-returned output in the re-fetched range (funds-safety)', () => {
+    const A = out('A', 95);
+    // Node re-returns A unchanged this scan.
+    const result = reconcileOwnedOutputs([A], /* discovered */ [A], 90, 100);
+    expect(keys(result)).toEqual(keys([A])); // retained
+    expect(result).toHaveLength(1); // and not duplicated
+    expect(sum(result)).toBe(BigInt(A.amount)); // balance intact
+  });
+
+  it('never prunes an output below the re-fetched range even when absent from discovered', () => {
+    const B = out('B', 50);
+    const result = reconcileOwnedOutputs([B], /* discovered */ [], 90, 100);
+    expect(keys(result)).toEqual(keys([B])); // below start -> never re-fetched -> retained
+  });
+
+  it('prunes an output stranded above the tip when the chain shrank', () => {
+    const A = out('A', 98); // above the reported tip
+    const B = out('B', 50);
+    const result = reconcileOwnedOutputs([A, B], /* discovered */ [], 90, 93);
+    expect(keys(result)).toEqual(keys([B])); // A (>tip) pruned, B retained
+  });
+
+  it('deep shrink (tip < start): prunes everything above tip, prunes nothing at/below it, queries nothing extra', () => {
+    const h5 = out('a', 5);
+    const h6 = out('b', 6);
+    const h50 = out('c', 50);
+    const h95 = out('d', 95);
+    // start=90, tip=5 -> windows(90,5) is empty -> discovered is necessarily empty.
+    expect(windows(90, 5)).toEqual([]);
+    const result = reconcileOwnedOutputs([h5, h6, h50, h95], [], 90, 5);
+    // Only h=5 (<= tip) survives; h6/h50/h95 are all > tip -> provably gone.
+    expect(keys(result)).toEqual(keys([h5]));
+  });
+
+  it('retains a spent-but-still-mined output (present in discovered) and renders it direction:spent', () => {
+    const A = out('A', 95, '2000');
+    // The node still MINES A (spending does not remove it from chain_getOutputs),
+    // so it is re-returned in discovered and must be retained...
+    const reconciled = reconcileOwnedOutputs([A], /* discovered */ [A], 90, 100);
+    expect(keys(reconciled)).toEqual(keys([A]));
+
+    // ...even though the LIVE spent-check reports A as spent (spendable excludes it).
+    const spendable: OwnedOutput[] = []; // A has been spent -> not spendable
+    const spent = spentTargetKeys(reconciled, spendable);
+    expect(spent.has(A.targetKey)).toBe(true);
+
+    const history = deriveHistory(reconciled, spent, 100);
+    const entry = history.find((h) => h.txHash === A.txHash);
+    expect(entry).toBeDefined();
+    expect(entry?.direction).toBe('spent'); // rendered spent, NOT pruned
+  });
+
+  it('is idempotent on the happy path (re-returned unchanged, no duplicates)', () => {
+    const A = out('A', 95);
+    const B = out('B', 50);
+    const result = reconcileOwnedOutputs([A, B], /* discovered */ [A], 90, 100);
+    expect(keys(result)).toEqual(keys([A, B])); // order-insensitive set equality
+    expect(result).toHaveLength(2); // no duplicate of A
+  });
+
+  it('reconciles correctly across multiple windows (low-boundary output not pruned by a later window)', () => {
+    // A big range spans >1 window; A sits at the low window boundary, C near the tip.
+    const start = 0;
+    const tip = WINDOW_SIZE + 500; // two windows: [0, WINDOW_SIZE-1], [WINDOW_SIZE, tip]
+    expect(windows(start, tip).length).toBeGreaterThan(1);
+
+    const A = out('A', 0); // low window boundary, discovered in window 1
+    const C = out('C', WINDOW_SIZE + 100); // discovered in window 2
+    const stale = out('S', 5); // persisted but reorged out -> not in discovered
+    // discovered accumulates across BOTH windows before the single reconcile.
+    const allDiscovered = [A, C];
+    const result = reconcileOwnedOutputs([A, stale], allDiscovered, start, tip);
+
+    expect(keys(result)).toEqual(keys([A, C])); // A kept, C added, stale pruned
+  });
+
+  it('reorg-buffer boundary: blockHeight === start is in-range; start-1 is retained', () => {
+    const atStart = out('A', 90); // exactly at start -> in the re-fetched range
+    const belowStart = out('B', 89); // one below -> out of range -> retained
+    // Neither is re-returned this scan.
+    const result = reconcileOwnedOutputs([atStart, belowStart], [], 90, 100);
+    expect(keys(result)).toEqual(keys([belowStart])); // atStart pruned, belowStart retained
   });
 });
 


### PR DESCRIPTION
## Summary

`mergeOwnedOutputs` in `web/packages/snap/src/state.ts` was **add-only** (existing-wins union). `incrementalScan` re-fetches the trailing reorg-buffer range `[start, tip]` (`start = max(0, lastScannedHeight - REORG_BUFFER)`) on every read and only *added* what it found, so an owned output reorged out of that window was **never removed** — over-reporting both the balance sum (`incrementalScanBalance` → `spendable`) and the transaction history (`deriveHistory`). This is the write-layer half of the #1091 Judge's reorg-staleness flag (the non-destructive `confirmations` read-layer half shipped in #1092).

Balance-critical, so implemented exactly to the curator's prune-on-rescan design with the funds-safety invariant preserved.

## Changes

- **New pure `reconcileOwnedOutputs(existing, discovered, start, tip)`** replaces the add-only merge at the scan call-site. It treats the re-fetched range as authoritative:
  - Retains every existing output **strictly below `start`** (never re-fetched → assumed final) **and at/below `tip`**.
  - Replaces `[start, tip]` **wholesale** with what the node currently reports (`discovered`).
  - Prunes anything **stranded above `tip`** (a chain that shrank below an output's receive height).
- **`incrementalScan` rewired** to accumulate `discovered` across **all** windows into one array and reconcile **once** against `[start, tip]` (not a per-window merge) — so a low-window-boundary output is never pruned before a later window rediscovers it.
- **Prune keys on on-chain presence (`chain_getOutputs`), NOT live spent status.** A spent-but-still-mined output is re-returned by the node → retained → split out of `spendable` by the live `chain_areKeyImagesSpent` check → rendered `direction: 'spent'`. Only a genuinely reorged-out output is pruned.
- `mergeOwnedOutputs` kept (no longer on the scan path) for its dedupe unit contract; documented as add-only/monotonic.
- Module-header "Reorg safety" paragraph updated from "merges dedupe" to "reconciles the re-fetched range"; full safety invariant documented on `reconcileOwnedOutputs`.
- No `STATE_VERSION` bump, no schema change, no new RPC (persisted `PersistedOwnedOutput` shape unchanged — only the reconciliation rule changed).
- `snap.manifest.json` shasum updated by `mm-snap build` (bundle changed), per repo convention for snap-src PRs.

### Safety invariant (holds after every scan, `R = [start, tip]`, `R = ∅` when `tip < start`)

`persisted ∩ R == node-reported-owned ∩ R` exactly (no phantom, no dropped); `persisted \ R` untouched; nothing above `tip` survives. Pruning is bounded to a range the node was authoritatively queried for, so a still-valid output is **never** dropped — the dangerous under-report direction that would make funds appear lost.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| New pure reconcile replaces add-only merge at call-site; discovered accumulated across all windows, reconciled once against `[start, tip]` | ✅ | `reconcileOwnedOutputs` + rewired `incrementalScan` (single `allDiscovered` array, one reconcile after the window loop) |
| Reorged-out output in `[start, tip]` removed → drops from balance and history | ✅ | Test "prunes a stale (reorged-out) output…" asserts removal + excluded from sum + `deriveHistory` |
| Output with `blockHeight > tip` (chain shrank) pruned | ✅ | Test "prunes an output stranded above the tip…" |
| Still-returned output retained, not duplicated (No dropped / No collateral prune) | ✅ | Test "NEVER prunes a still-returned output… (funds-safety)" |
| Output `blockHeight < start` never pruned even if absent from discovered | ✅ | Test "never prunes an output below the re-fetched range…" |
| Empty range (`tip < start`, deep shrink): at/below tip retained, only above-tip pruned, nothing un-queried pruned | ✅ | Test "deep shrink (tip < start)…" (`windows(90,5) === []`) |
| Spent-but-still-mined output retained + `direction:'spent'`, never pruned | ✅ | Test "retains a spent-but-still-mined output…" (in `discovered`, excluded from `spendable`, `spentTargetKeys` has it, history `direction:'spent'`) |
| Happy-path incremental resume unchanged (idempotent; still fetches only reorg-buffer window) | ✅ | Test "is idempotent on the happy path…"; behavioural "resumes from the checkpoint…" still green |
| Invariant documented on the fn + module header | ✅ | Doc comment on `reconcileOwnedOutputs` + updated "Reorg safety" paragraph |

## Test Plan

`pnpm typecheck && pnpm build:snap && pnpm test:snap` — all green (**85/85**, exit 0; wasm bundler artifact built first). New pure-logic matrix in `test/state.snap.ts` (8 reconcile cases + boundary case), all passing, including the two funds-safety guarantees:
- **still-valid never pruned** (retained, not duplicated, balance intact)
- **spent-but-present retained** (retained despite live-spent, rendered `direction:'spent'`)

Closes #1099