### PR TITLE
docs: add orienting READMEs to nine top-level source dirs

### DIFF
--- a/address-codec/README.md
+++ b/address-codec/README.md
@@ -1,0 +1,24 @@
+## bth-address-codec
+
+The single shared base58 codec for Botho address strings (address format v2,
+ADR 0008).
+
+### Role
+
+Historically the `botho://…` address string was encoded and decoded by four
+independent hand-rolled base58 implementations (node, browser wasm-signer,
+mobile FFI, and the CLI wallet / desktop shell), which risked byte-for-byte
+drift between encoders. This crate consolidates that into one implementation so
+every encoder agrees on the wire format.
+
+### Key API (`src/lib.rs`)
+
+- `encode_address(&PublicAddress, Network) -> String` — encode an address.
+- `decode_address(&str) -> (PublicAddress, Network)` — decode and validate.
+- `Network::v2_prefix` — the per-network address string prefix.
+
+### Workspace fit
+
+A small foundational crate depended on by every component that needs to render
+or parse Botho address strings (node, wallet, mobile, wasm-signer), keeping them
+from drifting.

--- a/botho-exchange-scanner/README.md
+++ b/botho-exchange-scanner/README.md
@@ -1,0 +1,20 @@
+## botho-exchange-scanner
+
+A client-side deposit detection tool for exchanges integrating with the Botho
+blockchain. It scans chain outputs against precomputed subaddress lookup tables
+to detect deposits, with resumable sync state.
+
+### Key modules (`src/`)
+
+- `scanner` — the core output-scanning engine.
+- `subaddress` — precomputed subaddress lookup tables (0 to 2^64 range).
+- `deposit` — detected-deposit representation.
+- `output` — output parsing/handling.
+- `sync` — sync-state persistence for resumable scanning.
+- `config` — scanner configuration (`main.rs` is the CLI entry point).
+
+### Workspace fit
+
+A standalone integration binary. It consumes the workspace's transaction and
+crypto primitives to recognize outputs belonging to an exchange's subaddress
+ranges, without running a full node.

--- a/botho-wallet/README.md
+++ b/botho-wallet/README.md
@@ -1,0 +1,23 @@
+## botho-wallet
+
+A standalone thin wallet client for Botho. It manages its own keys locally and
+communicates with untrusted Botho nodes over JSON-RPC — private keys never leave
+the wallet.
+
+### Key modules (`src/`)
+
+- `keys` — key management.
+- `storage` — encrypted local wallet storage.
+- `secmem` — secure (zeroizing) in-memory secret handling.
+- `transaction`, `transaction_legacy` — transaction construction.
+- `ring_builder`, `decoy_selection` — ring-signature assembly and decoy choice.
+- `fee_estimation` — fee estimation.
+- `discovery`, `rpc_pool` — node discovery and pooled JSON-RPC connections to
+  untrusted nodes.
+- `commands` — CLI subcommands (`main.rs` is the entry point).
+
+### Workspace fit
+
+A client-facing binary crate. It talks to a `botho` node's RPC interface rather
+than embedding node logic, and reuses the workspace's transaction and crypto
+crates for constructing spends.

--- a/botho/README.md
+++ b/botho/README.md
@@ -1,0 +1,36 @@
+## botho
+
+The main Botho node — a privacy-preserving, mined cryptocurrency. This crate
+provides the core node library plus the binaries that run and simulate a node.
+
+### Role
+
+Ties the workspace together into a running node: it assembles blockchain types,
+networking, consensus, the ledger, and wallet support into the `botho` daemon.
+
+### Key modules (`src/`)
+
+- `block`, `transaction`, `monetary` — block, transaction, and unit primitives.
+- `ledger` — chain state and block application.
+- `consensus` — SCP-based consensus integration.
+- `network` — peer networking and message handling.
+- `node` — node lifecycle and orchestration.
+- `mempool` — pending-transaction pool.
+- `pow` — proof-of-work / mining logic.
+- `rpc` — JSON-RPC interface used by wallets and tools.
+- `decoy_selection` — ring-signature decoy selection.
+- `operator_action`, `operator_key`, `operator_nonce` — operator-signed actions.
+- `config`, `telemetry`, `address`, `wallet` — node config, metrics, address
+  handling, and embedded wallet support.
+
+### Binaries
+
+- `botho` — the node daemon (`main.rs`).
+- `botho-testnet` — helper for spinning up local testnets.
+- `scp_sim` — SCP consensus simulator.
+
+### Workspace fit
+
+The top-level application crate. It depends on the workspace's component crates
+(`consensus`, `ledger`, `transaction/*`, `gossip`, `crypto`, `common`, and
+others) and is the primary consumer of them.

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,18 @@
+## bridge
+
+The BTH bridge, which moves value between BTH and external chains (Ethereum and
+Solana) via wrapped BTH (wBTH). This directory groups two workspace-member
+sub-crates.
+
+### Sub-crates
+
+- [`core`](./core/) — `bth-bridge-core`: core types and logic for the bridge
+  (order records, peg accounting, and shared primitives).
+- [`service`](./service/) — `bth-bridge-service`: the runnable bridge service
+  that relays between BTH and Ethereum / Solana.
+
+### Workspace fit
+
+`service` builds on `core` to produce the bridge relayer binary. Related
+on-chain contracts live under [`../contracts`](../contracts/) (Ethereum, Solana,
+and the Wormhole NTT deployment for wBTH).

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,20 @@
+## contracts
+
+On-chain contracts and deployment tooling for wrapped BTH (wBTH) — the
+external-chain leg of the [BTH bridge](../bridge/). These are not Rust workspace
+members (this directory is excluded from the Cargo workspace); each sub-dir has
+its own README with build and deployment detail.
+
+### Sub-directories
+
+- [`ethereum`](./ethereum/README.md) — `WrappedBTH.sol`, the ERC-20 wBTH token
+  minted 1:1 against BTH locked in the bridge.
+- [`solana`](./solana/README.md) — the `wbth` Anchor program that mints the wBTH
+  SPL token 1:1.
+- [`wbth-ntt`](./wbth-ntt/README.md) — Wormhole NTT deployment config for
+  bridging wBTH (Sepolia ↔ HyperEVM).
+
+### Workspace fit
+
+These contracts are the counterpart to the [`bridge`](../bridge/) service, which
+relays lock/mint and burn/unlock events between BTH and these chains.

--- a/discover/README.md
+++ b/discover/README.md
@@ -1,0 +1,21 @@
+## bth-discover
+
+A CLI tool for discovering Botho network topology and generating node
+configurations.
+
+### Role
+
+Connects to the gossip network, discovers peers, and helps operators configure
+their nodes — suggesting quorum sets based on observed trust patterns.
+
+### Structure
+
+A single-binary crate (`bth-discover`, entry point `src/main.rs`). It drives the
+`bth-gossip` service (`GossipService`, `TopologyAnalyzer`, `QuorumStrategy`) to
+observe the live topology and emit configuration.
+
+### Workspace fit
+
+An operator-facing tool built on top of `gossip` (`bth-gossip`) and the
+consensus quorum-set types. It complements the `botho` node by helping new nodes
+join and configure themselves.

--- a/gossip/README.md
+++ b/gossip/README.md
@@ -1,0 +1,27 @@
+## bth-gossip
+
+A gossip protocol layer for Botho that provides peer discovery and topology
+sharing.
+
+### Role
+
+Enables nodes to find each other without static configuration, share their
+quorum sets so new nodes can learn the network structure, and stay in sync via a
+hybrid push-pull approach (gossipsub for real-time updates plus periodic pulls).
+
+### Key modules (`src/`)
+
+- `service` — the top-level `GossipService`.
+- `behaviour` — the libp2p network behaviour.
+- `messages` — gossip message types.
+- `store` — peer/topology store.
+- `analyzer` — `TopologyAnalyzer` for reasoning about observed topology.
+- `consensus_integration` — bridges gossiped topology into consensus quorum
+  strategy.
+- `rate_limit` — inbound message rate limiting.
+- `config`, `error` — configuration and error types.
+
+### Workspace fit
+
+A networking crate consumed by the `botho` node and by the `bth-discover` tool
+to observe and configure network topology.

--- a/transaction/README.md
+++ b/transaction/README.md
@@ -1,0 +1,19 @@
+## transaction
+
+The Botho transaction stack, split into focused sub-crates. This directory is an
+index; see each sub-crate's own README (where present) for detail.
+
+### Sub-crates
+
+- [`clsag`](./clsag/) — `bth-transaction-clsag`: self-contained CLSAG
+  ring-signature transaction types (stealth addresses + ring signatures).
+- [`core`](./core/README.md) — `bth-transaction-core`: core transaction logic.
+- [`signer`](./signer/README.md) — `bth-transaction-signer`: transaction
+  signing.
+- [`types`](./types/README.md) — `bth-transaction-types`: shared transaction
+  data types.
+
+### Workspace fit
+
+These crates provide the transaction primitives consumed by the `botho` node,
+`botho-wallet`, and other clients that build or verify spends.


### PR DESCRIPTION
## Summary
Adds a short, accurate `README.md` to nine undocumented significant top-level source dirs, lowering onboarding friction for anyone browsing into a crate. Docs-only; no code paths touched.

## Changes
- New crate READMEs (role, key modules, workspace fit), grounded in each dir's `Cargo.toml` and top-level `src/` module tree:
  - `botho/` — main node binary/library (block/ledger/consensus/network/mempool/pow/rpc/…, binaries `botho`, `botho-testnet`, `scp_sim`)
  - `botho-wallet/` — standalone thin wallet client
  - `botho-exchange-scanner/` — exchange deposit scanner
  - `address-codec/` — `bth-address-codec`, shared base58 address codec (ADR 0008)
  - `discover/` — `bth-discover` topology/config CLI
  - `gossip/` — `bth-gossip` peer discovery + topology sharing
- New thin index READMEs for group dirs, pointing to sub-crate READMEs instead of duplicating them:
  - `bridge/` — indexes `core` (`bth-bridge-core`) + `service` (`bth-bridge-service`)
  - `transaction/` — indexes `clsag`/`core`/`signer`/`types`
  - `contracts/` — index pointing to existing `ethereum`/`solana`/`wbth-ntt` READMEs

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| README exists for each of the nine in-scope dirs | ✅ | `git status` shows exactly 9 new `README.md` files |
| Each states role, key modules/sub-crates, workspace fit (< ~40 lines) | ✅ | All under 40 lines; each has Role/Key modules/Workspace fit |
| Group READMEs point to sub-crate READMEs, no duplication | ✅ | `bridge`/`transaction`/`contracts` link to sub-crates |
| No READMEs for out-of-scope dirs; no existing README modified | ✅ | `git status` shows only 9 additions, no modifications (root README untouched) |
| Descriptions accurate to actual Cargo.toml/module layout | ✅ | Module lists derived from each crate's `Cargo.toml` and `src/lib.rs`/`main.rs` — no invented modules |

## Test Plan
- `git status --porcelain` shows only the nine new `README.md` files (no edits to root or sub-crate READMEs).
- Docs-only change — no Rust code paths touched, `cargo build` unaffected.
- Module/sub-crate lists were cross-checked against each dir's `Cargo.toml` `[package]` and `src/` listing.

Closes #1109