### PR TITLE
feat(snap): payment-request (pull payment /pay#…) preview + prefill-send

### DIFF
--- a/web/packages/core/src/wallet/index.ts
+++ b/web/packages/core/src/wallet/index.ts
@@ -25,6 +25,14 @@ export {
   type ClaimLinkSecret,
 } from './claim-link'
 
+// Payment-request (pull payment link) helpers (#470, promoted for the Snap #1108)
+export {
+  buildPaymentRequestFragment,
+  buildPaymentRequestLink,
+  parsePaymentRequestFragment,
+  type PaymentRequest,
+} from './payment-request'
+
 // Re-export address utilities
 export {
   deriveKeypairs,

--- a/web/packages/core/src/wallet/payment-request.test.ts
+++ b/web/packages/core/src/wallet/payment-request.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildPaymentRequestFragment,
+  buildPaymentRequestLink,
+  parsePaymentRequestFragment,
+  type PaymentRequest,
+} from './payment-request'
+
+const ADDR = 'tbotho://2/abcdef0123456789'
+
+/**
+ * The PREVIOUS `btoa`/`TextEncoder`-based encoder, reproduced verbatim so we can
+ * assert the SES-safe `@scure/base` + pure-UTF-8 encoder (#1108) produces
+ * byte-for-byte identical fragments. This is the regression guard that keeps
+ * `/pay#…` links minted before the SES swap round-tripping. `btoa`/`TextEncoder`
+ * are fine HERE (the test runs under jsdom/Node) — the point is the PROMOTED
+ * encoder must match this legacy output without touching those globals.
+ */
+function legacyEncodeFragment(req: PaymentRequest): string {
+  const wire: { to: string; amount?: string; memo?: string } = { to: req.to.trim() }
+  if (req.amount !== undefined && req.amount > 0n) wire.amount = req.amount.toString()
+  const memo = req.memo?.trim()
+  if (memo) wire.memo = memo
+  const json = JSON.stringify(wire)
+  const bytes = new TextEncoder().encode(json)
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/** base64url-encode a JSON value the same way the lib does, for crafting fixtures. */
+function encodeWire(value: unknown): string {
+  const json = JSON.stringify(value)
+  const bytes = new TextEncoder().encode(json)
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+describe('payment-request fragment helpers (@botho/core, #1108)', () => {
+  describe('build / parse round-trip', () => {
+    it('round-trips an address with amount and memo', () => {
+      const req: PaymentRequest = { to: ADDR, amount: 5_000_000_000_000n, memo: 'Lunch' }
+      const parsed = parsePaymentRequestFragment(buildPaymentRequestFragment(req))
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBe(5_000_000_000_000n)
+      expect(parsed.memo).toBe('Lunch')
+    })
+
+    it('round-trips with no amount (payer chooses)', () => {
+      const parsed = parsePaymentRequestFragment(buildPaymentRequestFragment({ to: ADDR }))
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBeUndefined()
+      expect(parsed.memo).toBeUndefined()
+    })
+
+    it('round-trips with amount but no memo', () => {
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, amount: 1n }),
+      )
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBe(1n)
+      expect(parsed.memo).toBeUndefined()
+    })
+
+    it('round-trips with memo but no amount', () => {
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, memo: 'Invoice #42' }),
+      )
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBeUndefined()
+      expect(parsed.memo).toBe('Invoice #42')
+    })
+
+    it('treats a zero amount as "no amount"', () => {
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, amount: 0n }),
+      )
+      expect(parsed.amount).toBeUndefined()
+    })
+
+    it('preserves a large bigint amount exactly', () => {
+      const big = 123_456_789_012_345_678_901n
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, amount: big }),
+      )
+      expect(parsed.amount).toBe(big)
+    })
+
+    it('preserves unicode in the memo', () => {
+      const memo = 'Café ☕ — 支払い'
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, memo }),
+      )
+      expect(parsed.memo).toBe(memo)
+    })
+
+    it('preserves an astral (emoji) code point in the memo', () => {
+      // 💸 (U+1F4B8) is a surrogate pair — exercises the pure-UTF-8 codec's
+      // 4-byte path in BOTH directions.
+      const memo = 'thanks 💸'
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: ADDR, memo }),
+      )
+      expect(parsed.memo).toBe(memo)
+    })
+
+    it('parses a fragment carrying a leading #', () => {
+      const frag = buildPaymentRequestFragment({ to: ADDR, amount: 7n })
+      expect(parsePaymentRequestFragment('#' + frag).amount).toBe(7n)
+    })
+
+    it('parses a whole URL, using only the fragment portion', () => {
+      const url = buildPaymentRequestLink('https://wallet.botho.io', { to: ADDR, amount: 7n })
+      const parsed = parsePaymentRequestFragment(url)
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBe(7n)
+    })
+  })
+
+  describe('SES-safe encoder is byte-identical to the legacy btoa encoder (#1108)', () => {
+    // Guards the base64url swap: fragments minted before the SES-safe change must
+    // still parse, and freshly minted fragments must equal the legacy output.
+    const cases: PaymentRequest[] = [
+      { to: ADDR },
+      { to: ADDR, amount: 5_000_000_000_000n },
+      { to: ADDR, amount: 1n, memo: 'Invoice #42' },
+      { to: ADDR, memo: 'Café ☕ — 支払い' },
+      { to: ADDR, memo: 'thanks 💸' },
+      { to: ADDR, amount: 123_456_789_012_345_678_901n, memo: 'big' },
+    ]
+    it.each(cases.map((c, i) => [i, c] as const))(
+      'case %#: fragment matches legacy byte-for-byte',
+      (_i, req) => {
+        expect(buildPaymentRequestFragment(req)).toBe(legacyEncodeFragment(req))
+      },
+    )
+
+    it('parses a fragment produced by the legacy btoa encoder', () => {
+      const legacy = legacyEncodeFragment({ to: ADDR, amount: 42n, memo: 'legacy 支払い' })
+      const parsed = parsePaymentRequestFragment(legacy)
+      expect(parsed.to).toBe(ADDR)
+      expect(parsed.amount).toBe(42n)
+      expect(parsed.memo).toBe('legacy 支払い')
+    })
+  })
+
+  describe('buildPaymentRequestFragment validation', () => {
+    it('rejects a missing recipient', () => {
+      expect(() => buildPaymentRequestFragment({ to: '' })).toThrow()
+      expect(() => buildPaymentRequestFragment({ to: '   ' })).toThrow()
+    })
+
+    it('rejects a negative amount', () => {
+      expect(() => buildPaymentRequestFragment({ to: ADDR, amount: -1n })).toThrow()
+    })
+
+    it('trims the recipient address', () => {
+      const parsed = parsePaymentRequestFragment(
+        buildPaymentRequestFragment({ to: `  ${ADDR}  ` }),
+      )
+      expect(parsed.to).toBe(ADDR)
+    })
+  })
+
+  describe('buildPaymentRequestLink', () => {
+    it('targets /pay and carries the payload in the fragment', () => {
+      const url = buildPaymentRequestLink('https://wallet.botho.io', { to: ADDR })
+      expect(url.startsWith('https://wallet.botho.io/pay#')).toBe(true)
+      // The address must NOT appear in the query string portion.
+      const [beforeHash] = url.split('#')
+      expect(beforeHash).not.toContain('?')
+    })
+
+    it('tolerates a trailing slash on the origin', () => {
+      const url = buildPaymentRequestLink('https://wallet.botho.io/', { to: ADDR })
+      expect(url.startsWith('https://wallet.botho.io/pay#')).toBe(true)
+    })
+  })
+
+  describe('parsePaymentRequestFragment malformed input', () => {
+    it('rejects an empty fragment', () => {
+      expect(() => parsePaymentRequestFragment('')).toThrow()
+      expect(() => parsePaymentRequestFragment('#')).toThrow()
+    })
+
+    it('rejects non-base64 / non-JSON garbage', () => {
+      expect(() => parsePaymentRequestFragment('!!!not-base64!!!')).toThrow()
+    })
+
+    it('rejects valid base64 that is not JSON', () => {
+      // "hello" base64url'd is "aGVsbG8" — decodes fine but is not JSON.
+      expect(() => parsePaymentRequestFragment('aGVsbG8')).toThrow()
+    })
+
+    it('rejects JSON without a recipient', () => {
+      expect(() => parsePaymentRequestFragment(encodeWire({ amount: '5' }))).toThrow()
+    })
+
+    it('rejects a non-numeric amount', () => {
+      expect(() => parsePaymentRequestFragment(encodeWire({ to: ADDR, amount: 'abc' }))).toThrow()
+    })
+
+    it('rejects a JSON array payload', () => {
+      expect(() => parsePaymentRequestFragment(encodeWire([ADDR]))).toThrow()
+    })
+  })
+})

--- a/web/packages/core/src/wallet/payment-request.ts
+++ b/web/packages/core/src/wallet/payment-request.ts
@@ -1,0 +1,252 @@
+/**
+ * Payment-request links — the *pull* complement to claimable send-links (#460).
+ *
+ * A claim link PUSHES money: it carries a bearer secret, and whoever holds it
+ * can sweep the funds (#460, `claim-link.ts`). A payment-request link PULLS
+ * money instead: it carries the requester's PUBLIC address plus an (optional)
+ * amount and memo. The payer opens it, the wallet pre-fills a send, they
+ * confirm, and they pay via the normal send path. There is NO secret — the link
+ * reveals nothing the requester wouldn't already hand out (their address).
+ *
+ * Link format (#470):
+ *
+ *   https://botho.io/pay#<base64url(JSON)>
+ *
+ * where the JSON is `{ to, amount?, memo? }`:
+ *   - `to`     the requester's public address (tbotho://… / botho://…).
+ *   - `amount` OPTIONAL requested amount in PICOCREDITS, serialized as a decimal
+ *              string (bigint-safe). Omitted/blank means "payer chooses".
+ *   - `memo`   OPTIONAL human label / note for the request.
+ *
+ * Why the FRAGMENT (after `#`) and not the query string: browsers never transmit
+ * the fragment to a server, so the requester's address stays out of
+ * Cloudflare/CDN/server access logs — exactly as claim links carry their payload.
+ * The pay page strips the fragment (`history.replaceState`) after reading it.
+ *
+ * Encoding is plain base64url'd JSON (not the claim link's `v1.<base58>` form):
+ * a payment request has no fixed-width secret, just a small structured record,
+ * so base64'd JSON keeps it readable, versionable, and trivially round-trippable.
+ *
+ * SES SAFETY (#1108): this module lives in `@botho/core` so the Botho MetaMask
+ * Snap can import it. The Snap bundle runs inside MetaMask's SES (hardened)
+ * executor, where browser globals like `btoa` / `atob` / `TextEncoder` /
+ * `TextDecoder` are NOT reliably endowed (the same casualty `snap/src/format.ts`
+ * documents for `Intl`). So the base64url step uses `@scure/base`'s
+ * `base64urlnopad` (already a `@botho/core` dependency — see `claim-link.ts`'s
+ * `base58`) and the string↔bytes step uses a tiny pure-JS UTF-8 codec instead of
+ * `TextEncoder` / `TextDecoder`. The `base64urlnopad` alphabet output is
+ * byte-for-byte identical to the previous `btoa`-based encoder, so `/pay#…` links
+ * minted before this change keep round-tripping (asserted in the test).
+ */
+
+import { base64urlnopad } from '@scure/base'
+
+/** A payment request: who to pay, optionally how much, optionally why. */
+export interface PaymentRequest {
+  /** The requester's PUBLIC address (tbotho://… / botho://…). */
+  to: string
+  /**
+   * OPTIONAL requested amount in picocredits. When omitted the payer enters the
+   * amount themselves on the pay page.
+   */
+  amount?: bigint
+  /** OPTIONAL human-readable label / note for the request. */
+  memo?: string
+}
+
+/** The shape we actually serialize to JSON (bigint -> decimal string). */
+interface PaymentRequestWire {
+  to: string
+  amount?: string
+  memo?: string
+}
+
+/**
+ * Encode a JS string as UTF-8 bytes WITHOUT `TextEncoder` (not reliably endowed
+ * under the Snaps SES executor — see the module header). Handles the full BMP
+ * plus astral code points via surrogate-pair recombination, so unicode memos
+ * (emoji, CJK) survive the round-trip.
+ */
+function utf8Encode(input: string): Uint8Array {
+  const out: number[] = []
+  for (let i = 0; i < input.length; i++) {
+    let code = input.charCodeAt(i)
+    // Recombine a high/low surrogate pair into a single astral code point.
+    if (code >= 0xd800 && code <= 0xdbff && i + 1 < input.length) {
+      const next = input.charCodeAt(i + 1)
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        code = 0x10000 + ((code - 0xd800) << 10) + (next - 0xdc00)
+        i++
+      }
+    }
+    if (code < 0x80) {
+      out.push(code)
+    } else if (code < 0x800) {
+      out.push(0xc0 | (code >> 6), 0x80 | (code & 0x3f))
+    } else if (code < 0x10000) {
+      out.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f))
+    } else {
+      out.push(
+        0xf0 | (code >> 18),
+        0x80 | ((code >> 12) & 0x3f),
+        0x80 | ((code >> 6) & 0x3f),
+        0x80 | (code & 0x3f),
+      )
+    }
+  }
+  return Uint8Array.from(out)
+}
+
+/**
+ * Decode UTF-8 bytes back to a JS string WITHOUT `TextDecoder` (see the module
+ * header). Inverse of {@link utf8Encode}. Throws on a truncated multi-byte
+ * sequence so malformed payloads fail loudly (the caller maps that to a
+ * "not a valid link" error).
+ */
+function utf8Decode(bytes: Uint8Array): string {
+  let out = ''
+  let i = 0
+  while (i < bytes.length) {
+    const b0 = bytes[i++]
+    let code: number
+    if (b0 < 0x80) {
+      code = b0
+    } else if ((b0 & 0xe0) === 0xc0) {
+      if (i >= bytes.length) throw new Error('truncated UTF-8 sequence')
+      code = ((b0 & 0x1f) << 6) | (bytes[i++] & 0x3f)
+    } else if ((b0 & 0xf0) === 0xe0) {
+      if (i + 1 >= bytes.length) throw new Error('truncated UTF-8 sequence')
+      code = ((b0 & 0x0f) << 12) | ((bytes[i++] & 0x3f) << 6) | (bytes[i++] & 0x3f)
+    } else {
+      if (i + 2 >= bytes.length) throw new Error('truncated UTF-8 sequence')
+      code =
+        ((b0 & 0x07) << 18) |
+        ((bytes[i++] & 0x3f) << 12) |
+        ((bytes[i++] & 0x3f) << 6) |
+        (bytes[i++] & 0x3f)
+    }
+    if (code > 0xffff) {
+      code -= 0x10000
+      out += String.fromCharCode(0xd800 + (code >> 10), 0xdc00 + (code & 0x3ff))
+    } else {
+      out += String.fromCharCode(code)
+    }
+  }
+  return out
+}
+
+/**
+ * base64url-encode a UTF-8 string (no padding), SES-safely.
+ *
+ * Uses a pure-JS UTF-8 codec + `@scure/base` `base64urlnopad` so it never
+ * touches `btoa` / `TextEncoder` (not reliably endowed under the Snaps SES
+ * executor). The output is byte-for-byte identical to the previous `btoa`-based
+ * encoder (verified in the test), so existing `/pay#…` links keep round-tripping.
+ */
+function base64UrlEncode(input: string): string {
+  return base64urlnopad.encode(utf8Encode(input))
+}
+
+/** Decode a base64url string back into its UTF-8 source. Throws if malformed. */
+function base64UrlDecode(input: string): string {
+  return utf8Decode(base64urlnopad.decode(input))
+}
+
+/**
+ * Encode a payment request into a URL fragment payload.
+ *
+ * Returns the fragment WITHOUT the leading `#`, i.e. the base64url'd JSON.
+ *
+ * @throws if `to` is missing/blank, or `amount` is negative.
+ */
+export function buildPaymentRequestFragment(req: PaymentRequest): string {
+  const to = (req.to ?? '').trim()
+  if (!to) throw new Error('A payment request needs a recipient address')
+
+  const wire: PaymentRequestWire = { to }
+  if (req.amount !== undefined) {
+    if (req.amount < 0n) throw new Error('amount must be non-negative')
+    // A zero amount is treated the same as "no amount" (payer chooses).
+    if (req.amount > 0n) wire.amount = req.amount.toString()
+  }
+  const memo = req.memo?.trim()
+  if (memo) wire.memo = memo
+
+  return base64UrlEncode(JSON.stringify(wire))
+}
+
+/**
+ * Build the full shareable payment-request URL.
+ *
+ * @param origin e.g. `https://botho.io` (trailing slash tolerated)
+ * @param req    the payment request
+ */
+export function buildPaymentRequestLink(origin: string, req: PaymentRequest): string {
+  const base = origin.replace(/\/$/, '')
+  return `${base}/pay#${buildPaymentRequestFragment(req)}`
+}
+
+/**
+ * Parse a payment-request fragment back into a {@link PaymentRequest}.
+ *
+ * Accepts the fragment with or without a leading `#`, and accepts a full URL
+ * (only the part after `#` is used). Throws on a malformed/unsupported payload.
+ *
+ * NOTE: this validates only that `to` is a non-empty string — it does NOT
+ * validate the address FORMAT. Callers that act on the address (e.g. the Snap's
+ * prefill-send path) must additionally validate it via `parseAddress` /
+ * `isValidAddress` before use.
+ */
+export function parsePaymentRequestFragment(fragment: string): PaymentRequest {
+  let raw = (fragment ?? '').trim()
+  // Allow passing a whole URL — take only the fragment portion.
+  const hashIdx = raw.indexOf('#')
+  if (hashIdx >= 0) raw = raw.slice(hashIdx + 1)
+  if (raw.startsWith('#')) raw = raw.slice(1)
+  if (!raw) throw new Error('Empty payment-request link')
+
+  let json: string
+  try {
+    json = base64UrlDecode(raw)
+  } catch {
+    throw new Error('This payment-request link is not valid.')
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch {
+    throw new Error('This payment-request link is not valid.')
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('This payment-request link is not valid.')
+  }
+  const wire = parsed as Record<string, unknown>
+
+  const to = typeof wire.to === 'string' ? wire.to.trim() : ''
+  if (!to) throw new Error('This payment-request link is missing a recipient address.')
+
+  const req: PaymentRequest = { to }
+
+  if (wire.amount !== undefined && wire.amount !== null && wire.amount !== '') {
+    if (typeof wire.amount !== 'string' && typeof wire.amount !== 'number') {
+      throw new Error('This payment-request link has an invalid amount.')
+    }
+    let amount: bigint
+    try {
+      amount = BigInt(wire.amount)
+    } catch {
+      throw new Error('This payment-request link has an invalid amount.')
+    }
+    if (amount < 0n) throw new Error('This payment-request link has an invalid amount.')
+    if (amount > 0n) req.amount = amount
+  }
+
+  if (typeof wire.memo === 'string') {
+    const memo = wire.memo.trim()
+    if (memo) req.memo = memo
+  }
+
+  return req
+}

--- a/web/packages/snap/README.md
+++ b/web/packages/snap/README.md
@@ -32,6 +32,8 @@ All params/results are JSON-safe; amounts are string-encoded `u64` picocredits
 | `botho_send` | `{ rpcUrl, recipientAddress, amountPicocredits, feePicocredits? }` | confirmation | `{ txHash, txBytes }` |
 | `botho_previewClaimLink` | `{ rpcUrl, link }` | alert (claim) | `{ grossPicocredits, feePicocredits, netPicocredits }` |
 | `botho_claimLink` | `{ rpcUrl, link }` | confirmation | `{ txHash, netPicocredits }` |
+| `botho_previewPaymentRequest` | `{ link }` | none | `{ to, amountPicocredits?, memo? }` |
+| `botho_showPaymentRequest` | `{ link }` | alert (request) | `{ to, amountPicocredits?, memo? }` |
 | `botho_showReceive` | — | alert (address) | `{ address }` |
 | `botho_showBalance` | `{ rpcUrl }` | alert (balance) | `{ spendablePicocredits }` |
 | `botho_showHistory` | `{ rpcUrl }` | alert (history) | `{ entries, count }` |
@@ -219,14 +221,55 @@ result / error message**, and never logged. `snap.manifest.json` needs **no**
 permission change (`endowment:network-access` + `snap_dialog` + `snap_getEntropy`
 already cover it).
 
-> **Not built here (deferred siblings).** The **request-link / pull** flow
-> (`/pay#…`, where the payer keeps custody until they approve) is a *request*
-> feature, not receive ingress; its encoder lives in the web wallet
-> (`web-wallet/src/lib/payment-request.ts`), not `@botho/core`, and would need
-> promotion + an SES-safe base64 pass — filed as a separate follow-up. An
-> **address QR** is **infeasible**: Botho v2 post-quantum stealth addresses
+> **Note.** The **request-link / pull** flow (`/pay#…`) is now built — see
+> [Payment-request (pull payment) ingress](#payment-request-pull-payment-ingress-1108)
+> below. An **address QR** is **infeasible**: Botho v2 post-quantum stealth addresses
 > (`tbotho://2/…`) are too large for a scannable QR (see the web wallet's
 > `ReceiveModal.tsx`) — the `Copyable` field is the correct affordance.
+
+## Payment-request (pull payment) ingress (#1108)
+
+A Botho **payment-request link** (`/pay#…`) is the *pull* complement to the
+claim-link *push* flow above. Where a claim link is a **bearer instrument** (the
+fragment IS an ephemeral spending secret), a request link carries only the
+requester's **PUBLIC address** plus an optional amount and memo — it asks the
+holder to **pay** the requester, and the payer keeps custody until they approve a
+normal send.
+
+The encoder/parser was **promoted into `@botho/core`**
+(`wallet/payment-request.ts`) so the Snap can import it; the web wallet's
+`web-wallet/src/lib/payment-request.ts` is now a thin re-export, so `/pay#…` links
+minted by `RequestModal.tsx` keep working. The base64url step is **SES-safe**:
+`@scure/base` `base64urlnopad` + a pure-JS UTF-8 codec (no `btoa` / `atob` /
+`TextEncoder` / `TextDecoder`, which are not reliably endowed in the Snaps SES
+executor — the same casualty `src/format.ts` documents for `Intl`), with output
+**byte-identical** to the previous `btoa`-based encoder (regression-tested in
+`@botho/core`).
+
+Two methods surface it (`src/request.ts` + `src/ui.ts`):
+
+- `botho_previewPaymentRequest` — a **pure parse** (no node RPC): it parses the
+  link (full URL, bare fragment, or leading-`#`), **validates the recipient
+  address format** at the boundary via `@botho/core` `isValidAddress` (the same
+  gate `botho_send` applies), and returns `{ to, amountPicocredits?, memo? }`. A
+  malformed fragment or a malformed address fails with a typed
+  `InvalidParamsError` before any dialog. Because there is no node round-trip, it
+  is **fully deterministic and not gated on betanet**.
+- `botho_showPaymentRequest` — the same parse behind an informational **alert
+  dialog** showing who to pay, the requested amount (or "any amount" when the link
+  leaves it open), and the memo.
+
+**Security — push vs pull.** A request link carries **nothing secret** (the
+address is public), so — unlike the claim dialogs — every field is shown in the
+clear; the payer must *see* `to` / `amount` / `memo` to verify who they are
+paying. There is deliberately **no bearer-secret redaction** here.
+
+**Paying.** There is **no new payer RPC**: to complete the payment the caller
+threads the previewed `{ to, amountPicocredits?, memo? }` straight into the
+existing param-driven `botho_send` (supplying the amount itself when the link left
+it open). The live send therefore inherits the existing **`#1051`** betanet gate
+unchanged — parse/preview is not blocked by it. `snap.manifest.json` needs **no**
+permission change (preview touches neither the network nor state).
 
 ## Internationalization (i18n, #1095)
 

--- a/web/packages/snap/snap.manifest.json
+++ b/web/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Manage a privacy-by-default Botho wallet from inside MetaMask. Keys are derived from your MetaMask Secret Recovery Phrase and never leave the Snap sandbox.",
   "proposedName": "Botho Wallet",
   "source": {
-    "shasum": "8Iva7ztrgdLBlQ5RbwCA9P8GlgAEkJbXu8A5VMZKW/8=",
+    "shasum": "Yof7rxE91HKVU8peCBpaHASH3fh9jD1dAs+0Zx1BduU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/web/packages/snap/src/index.ts
+++ b/web/packages/snap/src/index.ts
@@ -25,6 +25,8 @@
  *   - botho_send        — build + sign + submit, behind a confirmation dialog
  *   - botho_previewClaimLink — scan a claim link (parse → derive → scan → alert), pure read (#1094)
  *   - botho_claimLink   — sweep a claim link into this wallet, behind a confirmation (#1094)
+ *   - botho_previewPaymentRequest — parse + validate a /pay#… request link, pure read, no RPC (#1108)
+ *   - botho_showPaymentRequest — same parse behind an informational preview dialog (#1108)
  *   - botho_showReceive — receive dialog (stealth address, copyable)
  *   - botho_showBalance — balance dialog
  *   - botho_showHistory — transaction-history dialog (#1092)
@@ -75,9 +77,11 @@ import {
   sendConfirmContent,
   claimPreviewContent,
   claimConfirmContent,
+  paymentRequestContent,
   mnemonicBackupContent,
 } from './ui';
 import { parseClaimLink, scanClaimLink, buildSweep } from './claim';
+import { parsePaymentRequest, type ParsedPaymentRequest } from './request';
 import { resolveLocale, t } from './i18n';
 
 declare const snap: {
@@ -188,6 +192,24 @@ async function scanHistory(rpcUrl: string): Promise<HistoryEntry[]> {
     sendRpc: makeSendRpc(call),
   });
   return deriveHistory(ownedOutputs, spentTargetKeys(ownedOutputs, spendable), tip);
+}
+
+/**
+ * Shape a parsed payment request into a JSON-safe RPC result. `amountPicocredits`
+ * is a string-encoded picocredit amount (matching the rest of the Snap surface)
+ * and is OMITTED entirely when the link left the amount open, so the caller knows
+ * to prompt for it before threading the fields into `botho_send`. `memo` is
+ * likewise omitted when absent.
+ */
+function paymentRequestResult(parsed: ParsedPaymentRequest): Json {
+  const out: Record<string, Json> = { to: parsed.to };
+  if (parsed.amountPicocredits !== undefined) {
+    out.amountPicocredits = parsed.amountPicocredits.toString();
+  }
+  if (parsed.memo !== undefined) {
+    out.memo = parsed.memo;
+  }
+  return out;
 }
 
 /** Ask the user to approve/reject a confirmation dialog. */
@@ -404,6 +426,35 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request }) => {
 
       const { txHash } = await call<{ txHash: string }>('tx_submit', { tx_hex: txHex });
       return { txHash, netPicocredits: sweptScan.netPicocredits.toString() } as Json;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Payment-request (pull payment) ingress (#1108): parse -> validate.  */
+    /* A request link carries only the requester's PUBLIC address (+ an     */
+    /* optional amount/memo) — nothing secret — so the fields are echoed    */
+    /* freely (the payer must verify them). Preview is a PURE parse with no  */
+    /* node RPC, so it is not gated on betanet. To actually pay, the caller  */
+    /* threads the returned { to, amountPicocredits?, memo? } straight into  */
+    /* the existing param-driven `botho_send` — there is no new payer RPC,   */
+    /* and the live send inherits the #1051 gap unchanged.                  */
+    /* ------------------------------------------------------------------ */
+    case 'botho_previewPaymentRequest': {
+      const link = requireString(params, 'link');
+      // Pure parse + address-format validation. A malformed link / address fails
+      // with a typed InvalidParamsError; no node round-trip, no dialog.
+      return paymentRequestResult(parsePaymentRequest(link));
+    }
+
+    case 'botho_showPaymentRequest': {
+      const link = requireString(params, 'link');
+      const parsed = parsePaymentRequest(link);
+      await alert(
+        paymentRequestContent(
+          { to: parsed.to, amountPicocredits: parsed.amountPicocredits, memo: parsed.memo },
+          locale,
+        ),
+      );
+      return paymentRequestResult(parsed);
     }
 
     default:

--- a/web/packages/snap/src/locales/en.ts
+++ b/web/packages/snap/src/locales/en.ts
@@ -59,6 +59,16 @@ export const en = {
   'claim.youReceive': 'You receive',
   'claim.hint': 'Link hint: {amount} (cosmetic — the scanned amount above is authoritative)',
 
+  // Payment-request (pull payment) dialog (#1108)
+  'request.heading': 'Payment request',
+  'request.body':
+    'Someone is requesting a payment. Check the amount and the recipient below, ' +
+    'then confirm to pay from your wallet.',
+  'request.amount': 'Requested amount',
+  'request.amountAny': 'Any amount (you choose)',
+  'request.memo': 'Note',
+  'request.payTo': 'Pay to',
+
   // Mnemonic-backup dialog
   'mnemonic.heading': 'Botho recovery phrase',
   'mnemonic.body':

--- a/web/packages/snap/src/locales/es.ts
+++ b/web/packages/snap/src/locales/es.ts
@@ -57,6 +57,15 @@ export const es: Record<keyof typeof en, string> = {
   'claim.youReceive': 'Recibes',
   'claim.hint': 'Pista del enlace: {amount} (cosmética: el importe escaneado de arriba es el que manda)',
 
+  'request.heading': 'Solicitud de pago',
+  'request.body':
+    'Alguien está solicitando un pago. Revisa el importe y el destinatario a ' +
+    'continuación y confirma para pagar desde tu monedero.',
+  'request.amount': 'Importe solicitado',
+  'request.amountAny': 'Cualquier importe (tú eliges)',
+  'request.memo': 'Nota',
+  'request.payTo': 'Pagar a',
+
   'mnemonic.heading': 'Frase de recuperación de Botho',
   'mnemonic.body':
     'Estas 24 palabras se derivan de tu Frase de Recuperación Secreta de ' +

--- a/web/packages/snap/src/locales/zh.ts
+++ b/web/packages/snap/src/locales/zh.ts
@@ -50,6 +50,13 @@ export const zh: Record<keyof typeof en, string> = {
   'claim.youReceive': '你将收到',
   'claim.hint': '链接提示：{amount}（仅供参考——以上方扫描到的金额为准）',
 
+  'request.heading': '付款请求',
+  'request.body': '有人正在请求付款。请核对下方的金额和收款人，然后确认以从你的钱包付款。',
+  'request.amount': '请求金额',
+  'request.amountAny': '任意金额（由你决定）',
+  'request.memo': '备注',
+  'request.payTo': '付款至',
+
   'mnemonic.heading': 'Botho 恢复助记词',
   'mnemonic.body':
     '这 24 个单词由你的 MetaMask 秘密恢复助记词派生而来，拥有此 Botho 钱包的全部支配权。' +

--- a/web/packages/snap/src/request.ts
+++ b/web/packages/snap/src/request.ts
@@ -1,0 +1,70 @@
+/**
+ * Payment-request (pull payment) ingress for the Botho Snap (phase 2, #1108).
+ *
+ * A Botho **payment-request link** (`/pay#…`) is the *pull* complement to the
+ * claim-link *push* flow shipped in #1094 (`claim.ts`). Where a claim link is a
+ * BEARER instrument (the fragment IS an ephemeral spending secret), a payment
+ * request carries only the requester's PUBLIC address plus an optional amount and
+ * memo. It asks the holder to PAY the requester; the payer keeps custody until
+ * they approve a normal send.
+ *
+ * SECURITY — push vs pull (why this file is NOT a copy of `claim.ts`): a claim
+ * link's mnemonic is a bearer secret, so `claim.ts` is meticulous never to
+ * surface it. A request link is the opposite: `to`/`amount`/`memo` are the exact
+ * fields the payer must SEE to verify who they are paying. So this module freely
+ * echoes them in dialogs and results — there is deliberately NO redaction.
+ *
+ * Preview is a PURE parse (no node RPC), so it is trivially "not gated on
+ * betanet" (#1051). The actual send reuses the existing param-driven `botho_send`
+ * (the caller threads the previewed `{ to, amountPicocredits?, memo? }` straight
+ * into it); there is no new payer RPC, and the live send inherits the existing
+ * #1051 gap unchanged.
+ */
+
+import { InvalidParamsError } from '@metamask/snaps-sdk';
+import { parsePaymentRequestFragment, isValidAddress } from '@botho/core';
+
+/**
+ * A parsed payment request: the requester's PUBLIC address plus the optional
+ * requested amount (picocredits) and memo. Nothing here is secret.
+ */
+export interface ParsedPaymentRequest {
+  /** The requester's PUBLIC Botho address (format-validated). */
+  to: string;
+  /**
+   * The requested amount in picocredits, if the link carried one. Absent means
+   * the payer chooses the amount (the caller supplies it to `botho_send`).
+   */
+  amountPicocredits?: bigint;
+  /** Optional human-readable note attached to the request. */
+  memo?: string;
+}
+
+/**
+ * Parse a payment-request link (full URL, bare fragment, or leading-`#` fragment
+ * — all accepted by `parsePaymentRequestFragment`) and VALIDATE the recipient
+ * address format at the boundary.
+ *
+ * `parsePaymentRequestFragment` only checks that `to` is a non-empty string; a
+ * pull payment acts on that address, so we additionally require it to be a valid
+ * Botho address (`isValidAddress`, the same gate `botho_send`'s `decodeRecipient`
+ * applies) BEFORE any dialog or send. Both a malformed fragment and a malformed
+ * address fail with a typed {@link InvalidParamsError}, mirroring how `claim.ts`
+ * wraps `parseClaimLinkFragment`.
+ */
+export function parsePaymentRequest(link: string): ParsedPaymentRequest {
+  let req;
+  try {
+    req = parsePaymentRequestFragment(link);
+  } catch (err) {
+    throw new InvalidParamsError(
+      `Invalid payment request: ${err instanceof Error ? err.message : 'unparseable fragment'}`,
+    );
+  }
+  if (!isValidAddress(req.to)) {
+    throw new InvalidParamsError(
+      'Invalid payment request: the recipient is not a valid Botho address.',
+    );
+  }
+  return { to: req.to, amountPicocredits: req.amount, memo: req.memo };
+}

--- a/web/packages/snap/src/ui.ts
+++ b/web/packages/snap/src/ui.ts
@@ -263,6 +263,48 @@ export function claimConfirmContent(view: ClaimView, locale: Locale): JSXElement
   });
 }
 
+/** Fields rendered in the payment-request (pull payment) preview dialog. */
+export interface PaymentRequestView {
+  /** The requester's PUBLIC address to pay — echoed in full for verification. */
+  to: string;
+  /** Requested amount in picocredits, if the link carried one (payer chooses if absent). */
+  amountPicocredits?: bigint;
+  /** Optional human-readable note attached to the request. */
+  memo?: string;
+}
+
+/**
+ * Payment-request PREVIEW dialog (alert): shows who a `/pay#…` link asks the user
+ * to pay, the requested amount (or "any amount" when the link leaves it open),
+ * and an optional memo (`botho_showPaymentRequest`). A request link carries only
+ * the requester's PUBLIC address — nothing secret — so, unlike the claim dialogs,
+ * every field is shown in the clear (the payer must verify the address). The
+ * actual payment is a separate, param-driven `botho_send` prefilled from these
+ * fields; this dialog does not submit anything.
+ */
+export function paymentRequestContent(view: PaymentRequestView, locale: Locale): JSXElement {
+  const rows: JSXElement[] = [
+    Heading({ children: t('request.heading', locale) }),
+    Text({ children: t('request.body', locale) }),
+    Row({
+      label: t('request.amount', locale),
+      children: Text({
+        children:
+          view.amountPicocredits !== undefined
+            ? formatBTHWithUnit(view.amountPicocredits)
+            : t('request.amountAny', locale),
+      }),
+    }),
+  ];
+  if (view.memo !== undefined) {
+    rows.push(Row({ label: t('request.memo', locale), children: Text({ children: view.memo }) }));
+  }
+  rows.push(Divider({}));
+  rows.push(Text({ children: t('request.payTo', locale) }));
+  rows.push(Copyable({ value: view.to }));
+  return Box({ children: rows });
+}
+
 /** Mnemonic-backup dialog: the derived 24-word Botho recovery phrase. */
 export function mnemonicBackupContent(mnemonic: string, locale: Locale): JSXElement {
   return Box({

--- a/web/packages/snap/test/request.snap.ts
+++ b/web/packages/snap/test/request.snap.ts
@@ -1,0 +1,248 @@
+/**
+ * Payment-request (pull payment) ingress through the `@metamask/snaps-jest` SES
+ * harness (issue #1108).
+ *
+ * A payment-request link (`/pay#…`) is the *pull* complement to the claim-link
+ * *push* flow (#1094). It carries only the requester's PUBLIC address plus an
+ * optional amount and memo — nothing secret. `botho_previewPaymentRequest` is a
+ * PURE parse (no node RPC), so unlike the claim/send sweeps it is fully
+ * deterministic against the SES harness with NO funded fixtures and NO #1051
+ * caveat: these tests cover the real preview surface end-to-end.
+ *
+ * The address in every well-formed fixture is the Snap's OWN derived stealth
+ * address (fetched once via `botho_getAddress`) so it is a guaranteed-valid v2
+ * address — the boundary address-format validation (`isValidAddress`) is what we
+ * assert rejects a malformed `to`.
+ *
+ * The prefill-send test demonstrates the intended "no new payer RPC" path: the
+ * previewed `{ to, amountPicocredits }` is threaded straight into the existing
+ * param-driven `botho_send`, whose confirmation dialog then renders those fields.
+ * We cancel before submit (a live send inherits the #1051 gap), so this needs no
+ * funded output.
+ */
+
+import { beforeAll, describe, expect, it } from '@jest/globals';
+import { installSnap } from '@metamask/snaps-jest';
+import { buildPaymentRequestFragment, buildPaymentRequestLink } from '@botho/core';
+
+import { startMockNode, type MockNode } from './mock-node';
+
+function unwrap<T>(response: { response: unknown }): T {
+  const res = response.response as { result?: T; error?: { message?: string } };
+  if (res.error) {
+    throw new Error(`snap returned error: ${JSON.stringify(res.error)}`);
+  }
+  return res.result as T;
+}
+
+function errorOf(response: { response: unknown }): { message?: string } | undefined {
+  return (response.response as { error?: { message?: string } }).error;
+}
+
+/** Craft a raw base64url'd wire payload directly (for malformed-input fixtures). */
+function encodeWire(value: unknown): string {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+interface PreviewResult {
+  to: string;
+  amountPicocredits?: string;
+  memo?: string;
+}
+
+describe('botho snap: payment-request (pull) ingress (#1108)', () => {
+  // One install + one derived address, reused across the pure-parse cases (SES
+  // lockdown + wasm is slow, and preview persists nothing).
+  let request: Awaited<ReturnType<typeof installSnap>>['request'];
+  let addr: string;
+
+  beforeAll(async () => {
+    const installed = await installSnap();
+    request = installed.request;
+    const { address } = unwrap<{ address: string }>(
+      await request({ method: 'botho_getAddress' }),
+    );
+    addr = address;
+  });
+
+  /* ================================================================== */
+  /* botho_previewPaymentRequest — pure parse, zero node RPC             */
+  /* ================================================================== */
+
+  it('parses a well-formed link with amount + memo (no dialog, no node call)', async () => {
+    const fragment = buildPaymentRequestFragment({
+      to: addr,
+      amount: 5_000_000_000_000n,
+      memo: 'Lunch',
+    });
+    const result = unwrap<PreviewResult>(
+      await request({ method: 'botho_previewPaymentRequest', params: { link: fragment } }),
+    );
+    expect(result.to).toBe(addr);
+    expect(result.amountPicocredits).toBe('5000000000000');
+    expect(result.memo).toBe('Lunch');
+  });
+
+  it('omits amountPicocredits when the link leaves the amount open', async () => {
+    const fragment = buildPaymentRequestFragment({ to: addr });
+    const result = unwrap<PreviewResult>(
+      await request({ method: 'botho_previewPaymentRequest', params: { link: fragment } }),
+    );
+    expect(result.to).toBe(addr);
+    expect(result.amountPicocredits).toBeUndefined();
+    expect(result.memo).toBeUndefined();
+  });
+
+  it('passes a unicode memo through verbatim (SES-safe UTF-8 codec)', async () => {
+    const memo = 'Café ☕ — 支払い 💸';
+    const fragment = buildPaymentRequestFragment({ to: addr, memo });
+    const result = unwrap<PreviewResult>(
+      await request({ method: 'botho_previewPaymentRequest', params: { link: fragment } }),
+    );
+    expect(result.memo).toBe(memo);
+  });
+
+  it('accepts a bare fragment, a leading-# fragment, and a full URL alike', async () => {
+    const fragment = buildPaymentRequestFragment({ to: addr, amount: 7n });
+    const url = buildPaymentRequestLink('https://botho.io', { to: addr, amount: 7n });
+    for (const link of [fragment, `#${fragment}`, url]) {
+      const result = unwrap<PreviewResult>(
+        await request({ method: 'botho_previewPaymentRequest', params: { link } }),
+      );
+      expect(result.to).toBe(addr);
+      expect(result.amountPicocredits).toBe('7');
+    }
+  });
+
+  /* ================================================================== */
+  /* Error branches — all typed InvalidParamsError, all pre-dialog      */
+  /* ================================================================== */
+
+  it('rejects malformed base64 / non-JSON garbage with InvalidParamsError', async () => {
+    const response = await request({
+      method: 'botho_previewPaymentRequest',
+      params: { link: '!!!not-a-valid-link!!!' },
+    });
+    expect(errorOf(response)?.message).toMatch(/invalid payment request/i);
+  });
+
+  it('rejects valid base64 that is not JSON', async () => {
+    // "hello" base64url'd decodes fine but is not JSON.
+    const response = await request({
+      method: 'botho_previewPaymentRequest',
+      params: { link: 'aGVsbG8' },
+    });
+    expect(errorOf(response)?.message).toMatch(/invalid payment request/i);
+  });
+
+  it('rejects a payload missing the recipient', async () => {
+    const response = await request({
+      method: 'botho_previewPaymentRequest',
+      params: { link: encodeWire({ amount: '5' }) },
+    });
+    expect(errorOf(response)?.message).toMatch(/invalid payment request/i);
+  });
+
+  it('rejects a syntactically-fine but format-invalid recipient address', async () => {
+    // parsePaymentRequestFragment accepts any non-empty `to`; the Snap boundary
+    // rejects it because it is not a valid Botho address.
+    const fragment = buildPaymentRequestFragment({ to: 'tbotho://2/not-a-real-address' });
+    const response = await request({
+      method: 'botho_previewPaymentRequest',
+      params: { link: fragment },
+    });
+    expect(errorOf(response)?.message).toMatch(/not a valid botho address/i);
+  });
+
+  it('rejects an empty link param', async () => {
+    const response = await request({
+      method: 'botho_previewPaymentRequest',
+      params: { link: '' },
+    });
+    expect(errorOf(response)?.message).toBeTruthy();
+  });
+
+  /* ================================================================== */
+  /* botho_showPaymentRequest — informational alert dialog              */
+  /* ================================================================== */
+
+  it('renders an alert dialog echoing the address, amount, and memo', async () => {
+    const fragment = buildPaymentRequestFragment({
+      to: addr,
+      amount: 2_500_000_000_000n,
+      memo: 'Invoice #42',
+    });
+    const response = request({
+      method: 'botho_showPaymentRequest',
+      params: { link: fragment },
+    });
+    const ui = await response.getInterface();
+    expect(ui.type).toBe('alert');
+    const rendered = JSON.stringify(ui.content);
+    expect(rendered).toContain('Payment request');
+    expect(rendered).toContain(addr); // public address echoed in the clear
+    expect(rendered).toContain('2.5 BTH'); // requested amount rendered
+    expect(rendered).toContain('Invoice #42'); // memo passthrough
+
+    await (ui as { ok(): Promise<void> }).ok();
+    const result = unwrap<PreviewResult>(await response);
+    expect(result.to).toBe(addr);
+    expect(result.amountPicocredits).toBe('2500000000000');
+  });
+
+  it('shows "any amount" copy when the request leaves the amount open', async () => {
+    const fragment = buildPaymentRequestFragment({ to: addr });
+    const response = request({
+      method: 'botho_showPaymentRequest',
+      params: { link: fragment },
+    });
+    const ui = await response.getInterface();
+    expect(JSON.stringify(ui.content)).toContain('Any amount');
+    await (ui as { ok(): Promise<void> }).ok();
+    const result = unwrap<PreviewResult>(await response);
+    expect(result.amountPicocredits).toBeUndefined();
+  });
+
+  /* ================================================================== */
+  /* Prefill-send: preview -> feed the fields into the existing         */
+  /* param-driven botho_send (no new payer RPC). Cancel before submit   */
+  /* (a live send inherits the #1051 gap).                              */
+  /* ================================================================== */
+
+  it('prefills botho_send from the preview and shows the requested figures', async () => {
+    const node: MockNode = await startMockNode();
+    try {
+      const fragment = buildPaymentRequestFragment({ to: addr, amount: 3_000_000_000_000n });
+
+      // 1. Preview the request link (pure parse, no node call).
+      const preview = unwrap<PreviewResult>(
+        await request({ method: 'botho_previewPaymentRequest', params: { link: fragment } }),
+      );
+      const amountPicocredits = preview.amountPicocredits ?? '';
+      expect(amountPicocredits).toBe('3000000000000');
+
+      // 2. Thread the previewed fields straight into the existing botho_send.
+      const send = request({
+        method: 'botho_send',
+        params: {
+          rpcUrl: node.url,
+          recipientAddress: preview.to,
+          amountPicocredits,
+        },
+      });
+      const ui = await send.getInterface();
+      expect(ui.type).toBe('confirmation');
+      const rendered = JSON.stringify(ui.content);
+      expect(rendered).toContain(preview.to); // prefilled recipient
+      expect(rendered).toContain('3 BTH'); // prefilled amount
+
+      // Cancel before any on-chain submit (live send is #1051-gated).
+      await (ui as { cancel(): Promise<void> }).cancel();
+      const rejected = await send;
+      expect(errorOf(rejected)?.message).toMatch(/reject/i);
+      expect(node.calls.map((c) => c.method)).not.toContain('tx_submit');
+    } finally {
+      await node.close();
+    }
+  });
+});

--- a/web/packages/web-wallet/src/lib/payment-request.ts
+++ b/web/packages/web-wallet/src/lib/payment-request.ts
@@ -1,167 +1,20 @@
 /**
  * Payment-request links — the *pull* complement to claimable send-links (#460).
  *
- * A claim link PUSHES money: it carries a bearer secret, and whoever holds it
- * can sweep the funds (#460, `@botho/core` `claim-link.ts`). A payment-request
- * link PULLS money instead: it carries the requester's PUBLIC address plus an
- * (optional) amount and memo. The payer opens it, the wallet pre-fills a send,
- * they confirm, and they pay via the normal send path. There is NO secret — the
- * link reveals nothing the requester wouldn't already hand out (their address).
+ * The implementation was PROMOTED into `@botho/core` (`wallet/payment-request.ts`)
+ * so the Botho MetaMask Snap can import it too (#1108). That move also swapped the
+ * base64url step to an SES-safe codec (`@scure/base` `base64urlnopad` + a pure-JS
+ * UTF-8 codec) with byte-identical output, so existing `/pay#…` links keep
+ * round-tripping. This module is now a thin re-export to keep the web wallet's
+ * consumers (`RequestModal.tsx`, `pay.tsx`) importing from the same local path.
  *
- * Link format (#470):
- *
- *   https://botho.io/pay#<base64url(JSON)>
- *
- * where the JSON is `{ to, amount?, memo? }`:
- *   - `to`     the requester's public address (tbotho://… / botho://…).
- *   - `amount` OPTIONAL requested amount in PICOCREDITS, serialized as a decimal
- *              string (bigint-safe). Omitted/blank means "payer chooses".
- *   - `memo`   OPTIONAL human label / note for the request.
- *
- * Why the FRAGMENT (after `#`) and not the query string: browsers never transmit
- * the fragment to a server, so the requester's address stays out of
- * Cloudflare/CDN/server access logs — exactly as claim links carry their payload.
- * The pay page strips the fragment (`history.replaceState`) after reading it.
- *
- * Encoding is plain base64url'd JSON (not the claim link's `v1.<base58>` form):
- * a payment request has no fixed-width secret, just a small structured record,
- * so base64'd JSON keeps it readable, versionable, and trivially round-trippable.
+ * See `@botho/core` `wallet/payment-request.ts` for the full documentation and
+ * link-format details.
  */
 
-/** A payment request: who to pay, optionally how much, optionally why. */
-export interface PaymentRequest {
-  /** The requester's PUBLIC address (tbotho://… / botho://…). */
-  to: string
-  /**
-   * OPTIONAL requested amount in picocredits. When omitted the payer enters the
-   * amount themselves on the pay page.
-   */
-  amount?: bigint
-  /** OPTIONAL human-readable label / note for the request. */
-  memo?: string
-}
-
-/** The shape we actually serialize to JSON (bigint -> decimal string). */
-interface PaymentRequestWire {
-  to: string
-  amount?: string
-  memo?: string
-}
-
-/**
- * base64url-encode a UTF-8 string (no padding).
- *
- * `btoa`/`atob` are globals in every environment this wallet runs in (browsers,
- * jsdom, and Node 16+), so we rely on them directly. `btoa` is latin1-only, so
- * we UTF-8 encode first to preserve unicode in memos.
- */
-function base64UrlEncode(input: string): string {
-  const bytes = new TextEncoder().encode(input)
-  let binary = ''
-  for (const b of bytes) binary += String.fromCharCode(b)
-  const b64 = btoa(binary)
-  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
-}
-
-/** Decode a base64url string back into its UTF-8 source. Throws if malformed. */
-function base64UrlDecode(input: string): string {
-  const b64 = input.replace(/-/g, '+').replace(/_/g, '/')
-  const binary = atob(b64)
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
-  return new TextDecoder().decode(bytes)
-}
-
-/**
- * Encode a payment request into a URL fragment payload.
- *
- * Returns the fragment WITHOUT the leading `#`, i.e. the base64url'd JSON.
- *
- * @throws if `to` is missing/blank, or `amount` is negative.
- */
-export function buildPaymentRequestFragment(req: PaymentRequest): string {
-  const to = (req.to ?? '').trim()
-  if (!to) throw new Error('A payment request needs a recipient address')
-
-  const wire: PaymentRequestWire = { to }
-  if (req.amount !== undefined) {
-    if (req.amount < 0n) throw new Error('amount must be non-negative')
-    // A zero amount is treated the same as "no amount" (payer chooses).
-    if (req.amount > 0n) wire.amount = req.amount.toString()
-  }
-  const memo = req.memo?.trim()
-  if (memo) wire.memo = memo
-
-  return base64UrlEncode(JSON.stringify(wire))
-}
-
-/**
- * Build the full shareable payment-request URL.
- *
- * @param origin e.g. `https://botho.io` (trailing slash tolerated)
- * @param req    the payment request
- */
-export function buildPaymentRequestLink(origin: string, req: PaymentRequest): string {
-  const base = origin.replace(/\/$/, '')
-  return `${base}/pay#${buildPaymentRequestFragment(req)}`
-}
-
-/**
- * Parse a payment-request fragment back into a {@link PaymentRequest}.
- *
- * Accepts the fragment with or without a leading `#`, and accepts a full URL
- * (only the part after `#` is used). Throws on a malformed/unsupported payload.
- */
-export function parsePaymentRequestFragment(fragment: string): PaymentRequest {
-  let raw = (fragment ?? '').trim()
-  // Allow passing a whole URL — take only the fragment portion.
-  const hashIdx = raw.indexOf('#')
-  if (hashIdx >= 0) raw = raw.slice(hashIdx + 1)
-  if (raw.startsWith('#')) raw = raw.slice(1)
-  if (!raw) throw new Error('Empty payment-request link')
-
-  let json: string
-  try {
-    json = base64UrlDecode(raw)
-  } catch {
-    throw new Error('This payment-request link is not valid.')
-  }
-
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(json)
-  } catch {
-    throw new Error('This payment-request link is not valid.')
-  }
-
-  if (typeof parsed !== 'object' || parsed === null) {
-    throw new Error('This payment-request link is not valid.')
-  }
-  const wire = parsed as Record<string, unknown>
-
-  const to = typeof wire.to === 'string' ? wire.to.trim() : ''
-  if (!to) throw new Error('This payment-request link is missing a recipient address.')
-
-  const req: PaymentRequest = { to }
-
-  if (wire.amount !== undefined && wire.amount !== null && wire.amount !== '') {
-    if (typeof wire.amount !== 'string' && typeof wire.amount !== 'number') {
-      throw new Error('This payment-request link has an invalid amount.')
-    }
-    let amount: bigint
-    try {
-      amount = BigInt(wire.amount)
-    } catch {
-      throw new Error('This payment-request link has an invalid amount.')
-    }
-    if (amount < 0n) throw new Error('This payment-request link has an invalid amount.')
-    if (amount > 0n) req.amount = amount
-  }
-
-  if (typeof wire.memo === 'string') {
-    const memo = wire.memo.trim()
-    if (memo) req.memo = memo
-  }
-
-  return req
-}
+export {
+  buildPaymentRequestFragment,
+  buildPaymentRequestLink,
+  parsePaymentRequestFragment,
+  type PaymentRequest,
+} from '@botho/core'


### PR DESCRIPTION
## Summary

Adds the in-Snap **payment-request (pull payment) flow** — the deferred sibling of the claim-link *push* flow shipped in #1094/PR #1102. Where a claim link is a bearer instrument, a request link (`/pay#…`) carries only the requester's PUBLIC address plus an optional amount and memo, and asks the holder to pay.

The blocker was packaging: the encoder lived in `web-wallet/src/lib/payment-request.ts`, not `@botho/core`, so the Snap could not import it. This PR promotes it into `@botho/core` (SES-safe) and wires up the Snap RPC surface.

## Changes

**Core**
- `wallet/payment-request.ts` (NEW): promoted encoder/parser, made SES-safe — base64url via `@scure/base` `base64urlnopad` + a pure-JS UTF-8 codec instead of `btoa`/`atob`/`TextEncoder`/`TextDecoder` (not reliably endowed under the Snaps SES executor). Output is **byte-identical** to the old `btoa` encoder, so existing `/pay#…` links keep round-tripping.
- `wallet/index.ts`: export the new helpers.
- `wallet/payment-request.test.ts` (NEW): round-trip + validation + a byte-identical-fragment regression guard vs the legacy encoder (incl. astral/emoji memos).
- `web-wallet/src/lib/payment-request.ts`: reduced to a thin re-export from `@botho/core` — `RequestModal.tsx` / `pay.tsx` and their tests are unchanged.

**Snap**
- `src/request.ts` (NEW): parse a request link and validate the recipient **address format** at the boundary (`isValidAddress`), failing with a typed `InvalidParamsError`. No bearer-secret redaction — a request link carries only a PUBLIC address.
- `src/index.ts`: `botho_previewPaymentRequest` (pure parse, no node RPC) and `botho_showPaymentRequest` (informational alert). Paying reuses the existing param-driven `botho_send` — no new payer RPC.
- `src/ui.ts`: `paymentRequestContent` dialog builder. `src/locales/{en,es,zh}.ts`: `request.*` i18n keys.
- `test/request.snap.ts` (NEW): `@metamask/snaps-jest` coverage.
- `snap.manifest.json`: shasum reflects the rebuilt bundle.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Expose a request-link parser/encoder in a Snap-consumable package, SES-safe | ✅ | `@botho/core` `wallet/payment-request.ts`; no `btoa`/`atob`/`Text{En,De}coder`/`Intl` — `@scure/base` + pure UTF-8 codec |
| `botho_previewPaymentRequest` (parse + display) and a prefill-send path | ✅ | `botho_previewPaymentRequest` + `botho_showPaymentRequest`; prefill threads preview → existing `botho_send` |
| `@metamask/snaps-jest` tests against the mocked node | ✅ | `test/request.snap.ts` — 12 tests, incl. prefill into `botho_send` against `mock-node.ts` |
| Not gated on betanet | ✅ | preview is a pure parse (no node RPC); live send inherits the #1051 gap only |
| Address validated at the boundary | ✅ | `parsePaymentRequest` rejects a format-invalid `to` with `InvalidParamsError` |
| No bearer-secret redaction (public address) | ✅ | `to`/`amount`/`memo` echoed in dialog + result |
| Byte-identical fragments (regression guard) | ✅ | core test asserts new encoder == legacy `btoa` output |

## Test Plan

- Core: `vitest run packages/core/src/wallet` → 150 passed (28 in `payment-request.test.ts`, incl. byte-identical + legacy-fragment parse).
- Web wallet re-export: `payment-request.test.ts` → 20 passed; `pnpm --filter @botho/web-wallet typecheck` clean.
- Snap: `mm-snap build && jest` → **97 passed across 11 suites** (12 in `request.snap.ts`; i18n key-parity + units green). `pnpm --filter @botho/snap typecheck` clean.

Closes #1108