### PR TITLE
fix(web/network): don't let peer-isolated nodes poison fleet consensus height (#1115)

### DIFF
--- a/web/packages/features/src/network/components/fleet-summary.tsx
+++ b/web/packages/features/src/network/components/fleet-summary.tsx
@@ -33,12 +33,12 @@ export function FleetSummaryStrip({
           }
           label="Nodes in sync"
           value={`${summary.nodesInSync}/${summary.nodesTotal}`}
-          sub={
-            summary.nodesReachable < summary.nodesTotal
-              ? `${summary.nodesTotal - summary.nodesReachable} unreachable`
-              : undefined
+          sub={syncSub(summary)}
+          warn={
+            summary.nodesInSync < summary.nodesReachable ||
+            summary.nodesIsolated > 0 ||
+            summary.anySlotStalled
           }
-          warn={summary.nodesInSync < summary.nodesReachable || summary.anySlotStalled}
         />
         <Metric
           icon={<Layers className="h-4 w-4" />}
@@ -59,6 +59,19 @@ export function FleetSummaryStrip({
       </CardContent>
     </Card>
   )
+}
+
+/**
+ * Sub-label for the "Nodes in sync" metric: call out unreachable and
+ * peer-isolated (off-consensus) nodes so a stale/forked relay is visible
+ * rather than silently green.
+ */
+function syncSub(summary: FleetSummary): string | undefined {
+  const parts: string[] = []
+  const unreachable = summary.nodesTotal - summary.nodesReachable
+  if (unreachable > 0) parts.push(`${unreachable} unreachable`)
+  if (summary.nodesIsolated > 0) parts.push(`${summary.nodesIsolated} isolated`)
+  return parts.length > 0 ? parts.join(', ') : undefined
 }
 
 /**

--- a/web/packages/features/src/network/components/network-dashboard.test.tsx
+++ b/web/packages/features/src/network/components/network-dashboard.test.tsx
@@ -76,6 +76,23 @@ describe('NetworkDashboard', () => {
     expect(screen.getByText('2/3')).toBeDefined()
   })
 
+  it('flags peer-isolated relays and does not let their stale height poison consensus', () => {
+    // The live eu/ap drift: one connected validator at 202, two isolated
+    // relays stuck on the old pre-reset chain at 3233 with zero peers.
+    renderDash({
+      seed: live('seed', { chainHeight: 202, peerCount: 2 }),
+      eu: live('eu', { chainHeight: 3233, peerCount: 0 }),
+      ap: live('ap', { chainHeight: 3233, peerCount: 0 }),
+    })
+    // Consensus is the connected validator's height, not the isolated relays'.
+    expect(screen.getAllByText('202')).toHaveLength(2) // summary + seed card
+    // Both isolated relays are called out; the validator is NOT "behind".
+    expect(screen.getAllByText(/isolated — 0 peers/)).toHaveLength(2)
+    expect(screen.queryByText(/blocks behind/)).toBeNull()
+    expect(screen.getByText(/2 isolated/)).toBeDefined()
+    expect(screen.getByText('1/3')).toBeDefined() // only the validator in sync
+  })
+
   it('surfaces a stalled SCP slot as a warning badge', () => {
     renderDash({
       seed: live('seed', { slotStalled: true }),

--- a/web/packages/features/src/network/components/node-card.tsx
+++ b/web/packages/features/src/network/components/node-card.tsx
@@ -39,12 +39,19 @@ export function NodeCard({ node, status, consensusHeight, className }: NodeCardP
   }
 
   const height = status?.chainHeight
+  // A reachable node with zero peers is off the mesh: its height is a singleton
+  // view (possibly a stale/forked chain), so the "N blocks behind consensus"
+  // comparison is meaningless and misleading — surface isolation instead.
+  const isolated = status?.reachable === true && status.peerCount === 0
   const lagging =
-    consensusHeight !== null && typeof height === 'number' && consensusHeight - height > 1
+    !isolated &&
+    consensusHeight !== null &&
+    typeof height === 'number' &&
+    consensusHeight - height > 1
 
   return (
     <Card
-      className={`${lagging ? 'border-[--color-warning]/50' : ''} ${className ?? ''}`}
+      className={`${isolated ? 'border-[--color-danger]/40' : lagging ? 'border-[--color-warning]/50' : ''} ${className ?? ''}`}
       data-testid={`node-card-${node.id}`}
     >
       <CardContent className="p-4">
@@ -61,11 +68,20 @@ export function NodeCard({ node, status, consensusHeight, className }: NodeCardP
                 warn={lagging}
               />
               <Stat label="Mempool" value={status.mempoolSize?.toLocaleString() ?? '—'} />
-              <Stat label="Peers" value={status.peerCount?.toLocaleString() ?? '—'} />
+              <Stat
+                label="Peers"
+                value={status.peerCount?.toLocaleString() ?? '—'}
+                warn={isolated}
+              />
               <Stat label="SCP peers" value={status.scpPeerCount?.toLocaleString() ?? '—'} />
             </div>
 
             <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+              {isolated && (
+                <span className="inline-flex items-center gap-1 rounded bg-[--color-danger]/15 px-1.5 py-0.5 text-[--color-danger]">
+                  <WifiOff className="h-3 w-3" /> isolated — 0 peers, off consensus
+                </span>
+              )}
               {status.mintingActive && (
                 <span className="inline-flex items-center gap-1 rounded bg-[--color-pulse]/15 px-1.5 py-0.5 text-[--color-pulse]">
                   <Pickaxe className="h-3 w-3" /> minting

--- a/web/packages/features/src/network/fleet.test.ts
+++ b/web/packages/features/src/network/fleet.test.ts
@@ -21,6 +21,38 @@ describe('deriveFleetSummary', () => {
     expect(s.totalMempool).toBe(3)
   })
 
+  it('excludes peer-isolated nodes from consensus so a stale fork cannot poison the tip', () => {
+    // The live eu/ap relay drift: two isolated relays stuck on the old
+    // pre-reset chain at height 3233, three connected validators at 202.
+    const s = deriveFleetSummary([
+      status({ nodeId: 'seed', chainHeight: 202, peerCount: 2 }),
+      status({ nodeId: 'seed2', chainHeight: 202, peerCount: 2 }),
+      status({ nodeId: 'faucet', chainHeight: 202, peerCount: 2 }),
+      status({ nodeId: 'eu', chainHeight: 3233, peerCount: 0 }),
+      status({ nodeId: 'ap', chainHeight: 3233, peerCount: 0 }),
+    ])
+    expect(s.consensusHeight).toBe(202) // NOT 3233
+    expect(s.nodesInSync).toBe(3) // the validators, not the isolated relays
+    expect(s.nodesReachable).toBe(5)
+    expect(s.nodesIsolated).toBe(2)
+  })
+
+  it('falls back to reachable heights when no node has peers (lone dev node)', () => {
+    const s = deriveFleetSummary([status({ chainHeight: 10, peerCount: 0 })])
+    expect(s.consensusHeight).toBe(10)
+    expect(s.nodesIsolated).toBe(1)
+  })
+
+  it('treats an undefined peerCount as participating (back-compat with older nodes)', () => {
+    const s = deriveFleetSummary([
+      status({ chainHeight: 220 }), // no peerCount field
+      status({ chainHeight: 219 }),
+    ])
+    expect(s.consensusHeight).toBe(220)
+    expect(s.nodesInSync).toBe(2)
+    expect(s.nodesIsolated).toBe(0)
+  })
+
   it('reports null consensus height when nothing is reachable', () => {
     const s = deriveFleetSummary([status({ reachable: false }), status({ reachable: false })])
     expect(s.consensusHeight).toBeNull()

--- a/web/packages/features/src/network/fleet.ts
+++ b/web/packages/features/src/network/fleet.ts
@@ -65,7 +65,21 @@ export async function fetchFleetStatus(nodes: FleetNode[]): Promise<FleetNodeSta
 /** Derive fleet-level facts from live snapshots. Pure. */
 export function deriveFleetSummary(statuses: FleetNodeStatus[]): FleetSummary {
   const reachable = statuses.filter((s) => s.reachable)
-  const heights = reachable
+
+  // A node reporting zero peers is not participating in the mesh: its height is
+  // a singleton view (possibly a stale pre-reset fork) and must neither define
+  // consensus nor count as in-sync. Without this, an isolated relay stuck on an
+  // old chain at a far-higher height wins `Math.max` and paints the real,
+  // connected validators as thousands of blocks behind. `peerCount === undefined`
+  // (a node predating the field) is given the benefit of the doubt and kept.
+  const participating = reachable.filter((s) => s.peerCount !== 0)
+  const nodesIsolated = reachable.length - participating.length
+
+  // Consensus comes from participating nodes; fall back to all reachable only
+  // when none are participating (e.g. a lone dev node with no peers) so the
+  // strip still shows a height rather than an em-dash.
+  const heightPool = participating.length > 0 ? participating : reachable
+  const heights = heightPool
     .map((s) => s.chainHeight)
     .filter((h): h is number => typeof h === 'number')
   const consensusHeight = heights.length > 0 ? Math.max(...heights) : null
@@ -75,10 +89,11 @@ export function deriveFleetSummary(statuses: FleetNodeStatus[]): FleetSummary {
     nodesInSync:
       consensusHeight === null
         ? 0
-        : reachable.filter(
+        : heightPool.filter(
             (s) => typeof s.chainHeight === 'number' && consensusHeight - s.chainHeight <= 1,
           ).length,
     nodesReachable: reachable.length,
+    nodesIsolated,
     nodesTotal: statuses.length,
     totalMempool: reachable.reduce((acc, s) => acc + (s.mempoolSize ?? 0), 0),
     anySlotStalled: reachable.some((s) => s.slotStalled === true),

--- a/web/packages/features/src/network/types.ts
+++ b/web/packages/features/src/network/types.ts
@@ -43,12 +43,22 @@ export interface FleetNodeStatus {
 
 /** Fleet-level facts derived from the live snapshots (pure function). */
 export interface FleetSummary {
-  /** Highest height any reachable node reports (consensus tip). */
+  /**
+   * Consensus tip: the highest height among *connected* nodes (peerCount > 0).
+   * Peer-isolated nodes are excluded so a stale/forked singleton cannot define
+   * the tip. `null` when nothing reachable.
+   */
   consensusHeight: number | null
-  /** Reachable nodes at the consensus height (within 1 block). */
+  /** Connected nodes at the consensus height (within 1 block). */
   nodesInSync: number
   /** Reachable node count. */
   nodesReachable: number
+  /**
+   * Reachable but peer-isolated nodes (peerCount === 0). Not participating in
+   * the mesh — their height is a singleton view (possibly a stale pre-reset
+   * fork), so they are excluded from `consensusHeight`/`nodesInSync`.
+   */
+  nodesIsolated: number
   /** Total nodes watched. */
   nodesTotal: number
   /** Sum of mempool sizes across reachable nodes. */


### PR DESCRIPTION
Closes #1115. Related: #1114 (the live operator fix for the eu/ap relays that surfaced this).

## Problem

`deriveFleetSummary` computed `consensusHeight = Math.max(...allReachableHeights)`. A reachable-but-**isolated** node (0 peers) stuck on a stale/forked chain at a far-higher height wins that max and becomes the reported fleet tip.

Live trigger: the eu/ap regional relays are stranded on the pre-6.0.0 chain (v0.3.2, **height 3233, 0 peers**) while the three validators are on v0.6.0 at **height 202**. Result on the network tab:
- Consensus height shows **3233** (the dead fork), not 202.
- The three *real* validators render as **3031 blocks behind** (warning border) — backwards.
- Both relays report `synced: true` (their own singleton view) → **green cards** (the #541 hardcoded-observability trap).

## Fix

A node with `peerCount === 0` isn't in the mesh; its height is a singleton view and must not define or count toward consensus.

- **`deriveFleetSummary`** — consensus/in-sync derived from connected nodes (`peerCount !== 0`); fall back to all-reachable only when none are connected (lone dev node); `undefined` peerCount kept (back-compat). New `nodesIsolated` field.
- **`NodeCard`** — explicit `isolated — 0 peers, off consensus` badge for reachable 0-peer nodes; the misleading "N blocks behind" is suppressed for them.
- **`FleetSummaryStrip`** — surfaces the isolated count ("N isolated") and warns when any node is isolated.

The discriminator is **peer connectivity, not network id** — all five nodes report `network: "botho-testnet"`, so the name can't distinguish the fork; `peerCount` can.

## Tests
`pnpm vitest run` on the two touched suites: **22 pass** (4 new: the 202-vs-3233 poisoning case, lone-dev fallback, undefined-peerCount back-compat, and a dashboard render test asserting the isolated badge + un-poisoned consensus). `@botho/features` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)