### PR TITLE
infra(seed): add reprovision-relay.sh to re-sync one relay after a reset

### DIFF
--- a/infra/seed/README.md
+++ b/infra/seed/README.md
@@ -19,6 +19,9 @@ infra/seed/
 ├── botho-seed.service        # Systemd service file
 ├── reset-chain.sh            # Wipe chain data over SSH (--dry-run / --help)
 ├── reset-to-testnet.sh       # Local on-host reset to testnet (--dry-run / --help)
+├── reprovision-relay.sh      # Re-provision ONE relay after a consensus-breaking reset:
+│                             #   stop → wipe ledger → deploy pinned release → restart →
+│                             #   verify re-peering + tip convergence (--dry-run / --help)
 ├── deploy-botho.sh           # Build + deploy node binary to host
 ├── deploy-web.sh             # Deploy web files to server
 ├── seed-nginx.conf           # Nginx configuration

--- a/infra/seed/TESTNET_RESET.md
+++ b/infra/seed/TESTNET_RESET.md
@@ -84,6 +84,57 @@ via RPC on `localhost:17101`.
 ./reset-to-testnet.sh
 ```
 
+### `reprovision-relay.sh` — re-provision ONE relay after a consensus-breaking reset
+
+The composed operator command for the failure that stranded the eu/ap relays in
+**#1114**: after a coordinated, consensus-breaking reset, a single regional
+relay is left behind on the **old** chain. Its on-disk ledger is incompatible
+with the new protocol, so the freshly deployed binary boots against a chain it
+can never reconcile. `deploy-botho.sh` alone swaps the binary but never wipes
+the ledger; `reset-chain.sh` alone wipes the ledger but never upgrades/pins the
+binary. Neither verifies the relay actually re-peers and converges on the
+fleet's tip. This script does all of it, in the only order that works:
+
+1. stops the service,
+2. wipes **only** `ledger/` + `wallet/` (preserving `config.toml` **and**
+   `node_key` — see below),
+3. deploys the pinned release (delegates to `deploy-botho.sh`),
+4. restarts onto the fresh, empty ledger,
+5. polls the relay's **LOCAL** RPC (§7) until `peerCount > 0` **and** its
+   `tipHash` matches a known-good validator, with a bounded timeout.
+
+```bash
+./reprovision-relay.sh --dry-run ubuntu@eu.seed.botho.io          # preview, no SSH
+RELEASE_TAG=v0.6.0 ./reprovision-relay.sh ubuntu@eu.seed.botho.io
+RELEASE_TAG=v0.6.0 ./reprovision-relay.sh --service botho \
+    --validator-rpc https://seed.botho.io/rpc ubuntu@ap.seed.botho.io
+```
+
+> **`node_key` survives the wipe automatically.** The stable peer identity lives
+> at `~/.botho/<network>/node_key`, a **sibling** of `ledger/` and `wallet/`
+> (`botho/src/config.rs` `node_key_path_from_config`), so removing `ledger/` +
+> `wallet/` never touches it. The relay keeps its `PEER_ID` across the
+> re-provision — no acceptance-criterion code change was needed for this, only
+> verification.
+
+> **Service-name drift (verify before running).** `deploy-botho.sh` historically
+> hardcoded the `botho` unit, `reset-chain.sh` defaults to `botho-seed`, and
+> `reset-to-testnet.sh` installs `botho-seed.service` — yet the live regional
+> relays in #1114 were running under a `botho` unit. `reprovision-relay.sh`
+> defaults `--service` to `botho` but **preflights the unit's existence and
+> fails loudly** if the named unit is not installed (printing the actual
+> `botho*` units present), so it can never silently restart the wrong service.
+> Confirm the real unit first: `systemctl list-unit-files | grep botho`.
+
+> **Firewall prerequisite (#1117).** A relay cannot re-peer if the validators'
+> gossip port (`17100`) is dropping its IP. The validators carry an
+> **un-persisted** iptables lockdown on `:17100` (VPC-only) even while the
+> security group shows `0.0.0.0/0` — the SG lies, iptables is the real gate, and
+> it silently strands external relays. On a `peerCount == 0` timeout the script
+> explicitly points at #1117 as the most likely cause. Confirm the relay's
+> public IP is `ACCEPT`ed on **every** validator's `:17100` before blaming the
+> relay.
+
 ## 3. Deploy from the published release artifact (do NOT build on the seeds)
 
 The seeds are **t4g.small** (1.8 GiB RAM, 0 swap) and a release build **OOMs**
@@ -311,10 +362,21 @@ while all artifacts still publish (#996) — non-blocking for a testnet deploy.
 
 ## Operator steps remaining (NOT in this PR — require AWS/DNS/credentials)
 
+> **The fleet node list — enumerate EVERY host, including the regional relays.**
+> A coordinated reset must touch **all five** live nodes, not just "the seeds":
+> the two SCP validators/faucet **and** the two regional relays
+> `eu.seed.botho.io` and `ap.seed.botho.io`. In #1114 the eu/ap relays were left
+> behind on the old chain because the runbook spoke generically of "the fleet" /
+> "every host" without naming them — do not repeat that. If you only need to
+> bring a **single** stranded relay back onto the current chain (rather than
+> resetting the whole fleet), use `reprovision-relay.sh` (§2) instead of the
+> full sequence below.
+
 1. **Decommission any old-protocol nodes from the prior testnet BEFORE the
    reset** (§5). If you cannot, prepare the gossip firewall to apply on every
    fleet node at reset time — old zombies will otherwise wedge the fresh chain.
-2. **Deploy the current release binary** to every host from the published
+2. **Deploy the current release binary** to every host — the validators/faucet
+   **and** `eu.seed.botho.io` / `ap.seed.botho.io` — from the published
    artifact: `RELEASE_TAG=v0.6.0 ./infra/seed/deploy-botho.sh ubuntu@<host>`
    (§3). Do NOT `--build-on-host` on the t4g.small seeds (OOM).
 3. **Reset the chain** to fresh genesis on the current protocol version

--- a/infra/seed/deploy-botho.sh
+++ b/infra/seed/deploy-botho.sh
@@ -11,8 +11,11 @@
 #   ./deploy-botho.sh [user@host] [--build-on-host]
 #
 # Environment:
-#   SSH_KEY      SSH key path (default: ~/.ssh/botho-nodes.pem)
-#   RELEASE_TAG  Release tag to deploy (default: latest GitHub release)
+#   SSH_KEY       SSH key path (default: ~/.ssh/botho-nodes.pem)
+#   RELEASE_TAG   Release tag to deploy (default: latest GitHub release)
+#   SERVICE_NAME  systemd unit to stop/restart (default: botho). Override when
+#                 the host runs the node under a different unit (e.g. a relay
+#                 installed as botho-seed). reprovision-relay.sh sets this.
 #
 # Example:
 #   ./deploy-botho.sh ubuntu@seed.botho.io
@@ -39,7 +42,10 @@ REPO="botho-project/botho"
 SSH_KEY="${SSH_KEY:-$HOME/.ssh/botho-nodes.pem}"
 BUILD_DIR="/tmp/botho-build"
 INSTALL_DIR="/usr/local/bin"
-SERVICE_NAME="botho"
+# SERVICE_NAME is overridable via the environment so this deploy path can be
+# shared by reprovision-relay.sh (which may target a botho-seed unit). Defaults
+# to "botho" to preserve the original behavior.
+SERVICE_NAME="${SERVICE_NAME:-botho}"
 
 # Parse arguments: optional host, optional --build-on-host
 HOST="$DEFAULT_HOST"

--- a/infra/seed/reprovision-relay.sh
+++ b/infra/seed/reprovision-relay.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+#
+# Re-provision a single relay after a consensus-breaking reset
+#
+# Composes the existing deploy + wipe steps into ONE operator command for the
+# case that has bitten us twice (#1114): a single regional relay is left behind
+# on a stale chain after a coordinated, consensus-breaking testnet reset. The
+# relay's on-disk ledger is incompatible with the new protocol, so the new
+# binary boots against a chain it can never reconcile. deploy-botho.sh alone
+# swaps the binary but never wipes the ledger; reset-chain.sh alone wipes the
+# ledger but never pins/upgrades the binary. Neither verifies the relay
+# actually re-peers and converges on the fleet's tip.
+#
+# This script does all of it, in the only order that works:
+#   1. stop the service
+#   2. wipe ONLY the ledger + wallet (config.toml and node_key are preserved)
+#   3. deploy the pinned release binary (delegates to deploy-botho.sh)
+#   4. restart onto the fresh, empty ledger
+#   5. poll the relay's LOCAL RPC until peerCount > 0 AND its tipHash matches a
+#      known-good validator, with a bounded timeout
+#
+# node_key is preserved automatically: it lives at ~/.botho/<network>/node_key,
+# a SIBLING of ledger/ and wallet/ (see botho/src/config.rs
+# node_key_path_from_config), so wiping ledger/ + wallet/ never touches it. The
+# relay keeps its stable peer identity across the re-provision.
+#
+# Usage:
+#   ./reprovision-relay.sh [user@host]
+#
+# Options:
+#   --service NAME        systemd unit to control (default: botho). MUST match
+#                         the unit actually installed on the host — the script
+#                         verifies it exists and fails loudly otherwise, so it
+#                         cannot silently restart the wrong unit.
+#   --network NAME        network data dir to wipe (default: testnet)
+#   --validator-rpc URL   known-good validator RPC to compare tipHash against
+#                         (default: https://seed.botho.io/rpc)
+#   --rpc-port PORT       relay's LOCAL RPC port for verification
+#                         (default: 17101, the testnet RPC port)
+#   --timeout SECONDS     max seconds to wait for re-peering + convergence
+#                         (default: 180)
+#   --force               skip the confirmation prompt
+#   --dry-run             print every remote command without contacting a host
+#   --help, -h            show this help and exit
+#
+# Environment:
+#   SSH_KEY      SSH key path (default: ~/.ssh/botho-nodes.pem)
+#   RELEASE_TAG  release tag to deploy (default: latest GitHub release).
+#                Pin it (e.g. RELEASE_TAG=v0.6.0) for a reproducible reset.
+#
+# Example:
+#   ./reprovision-relay.sh --dry-run ubuntu@eu.seed.botho.io
+#   RELEASE_TAG=v0.6.0 ./reprovision-relay.sh ubuntu@eu.seed.botho.io
+#   RELEASE_TAG=v0.6.0 ./reprovision-relay.sh --service botho \
+#       --validator-rpc https://seed.botho.io/rpc ubuntu@ap.seed.botho.io
+#
+# Data layout (must match botho/src/config.rs::data_dir / Network::dir_name):
+#   ~/.botho/<network>/            base data dir (network = "testnet"|"mainnet")
+#   ~/.botho/<network>/ledger/     chain database        (WIPED)
+#   ~/.botho/<network>/wallet/     minting/relay wallet  (WIPED — relays carry
+#                                  no wallet; see TESTNET_RESET.md §2/§4)
+#   ~/.botho/<network>/config.toml node config           (PRESERVED)
+#   ~/.botho/<network>/node_key    stable peer identity  (PRESERVED — sibling)
+#
+# NOTE: This is an OPERATOR script that connects to a live host over SSH.
+# It is intentionally never invoked by CI. --dry-run requires no credentials
+# and is safe to run anywhere for validation.
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_step() { echo -e "${BLUE}[STEP]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+usage() {
+    # Print the leading comment block (up to the blank line before `set -e`).
+    sed -n '2,67p' "$0" | sed 's/^#\s\{0,1\}//'
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Configuration
+DEFAULT_HOST="ubuntu@seed.botho.io"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/botho-nodes.pem}"
+SERVICE_NAME="botho"
+NETWORK="testnet"
+VALIDATOR_RPC="https://seed.botho.io/rpc"
+RPC_PORT="17101"
+TIMEOUT="180"
+FORCE=false
+DRY_RUN=false
+
+# Parse arguments
+HOST="$DEFAULT_HOST"
+host_set=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --service)
+            SERVICE_NAME="$2"
+            shift
+            ;;
+        --network)
+            NETWORK="$2"
+            shift
+            ;;
+        --validator-rpc)
+            VALIDATOR_RPC="$2"
+            shift
+            ;;
+        --rpc-port)
+            RPC_PORT="$2"
+            shift
+            ;;
+        --timeout)
+            TIMEOUT="$2"
+            shift
+            ;;
+        --force)
+            FORCE=true
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            log_error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+        *)
+            HOST="$1"
+            host_set=true
+            ;;
+    esac
+    shift
+done
+
+DATA_DIR=".botho/$NETWORK"
+
+SSH_OPTS_DISPLAY="-i $SSH_KEY -o StrictHostKeyChecking=accept-new"
+SSH_OPTS="$SSH_OPTS_DISPLAY"
+
+# run_remote: execute (or, in dry-run mode, just print) a command on $HOST.
+run_remote() {
+    local cmd="$1"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    ssh $SSH_OPTS_DISPLAY $HOST \"$cmd\""
+    else
+        # SC2086: word-split SSH_OPTS intentionally. SC2029: $cmd is a fixed,
+        # script-controlled string (no untrusted input), so client-side
+        # expansion is fine.
+        # shellcheck disable=SC2086,SC2029
+        ssh $SSH_OPTS "$HOST" "$cmd"
+    fi
+}
+
+# run_remote_capture: like run_remote but returns stdout (for preflight checks
+# and RPC polling). In dry-run mode it prints the command and returns empty.
+run_remote_capture() {
+    local cmd="$1"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    ssh $SSH_OPTS_DISPLAY $HOST \"$cmd\"" >&2
+        echo ""
+    else
+        # shellcheck disable=SC2086,SC2029
+        ssh $SSH_OPTS "$HOST" "$cmd"
+    fi
+}
+
+# rpc_field: POST node_getStatus to an RPC endpoint and extract a .result field.
+# Usage: rpc_field <curl-target-command> <field>
+# where <curl-target-command> is the full curl invocation printing raw JSON.
+NODE_STATUS_REQ='{"jsonrpc":"2.0","method":"node_getStatus","params":{},"id":1}'
+
+# Validate SSH key exists (skip in dry-run so it works without credentials)
+if [[ "$DRY_RUN" != "true" ]]; then
+    if [[ ! -f "$SSH_KEY" ]]; then
+        log_error "SSH key not found: $SSH_KEY"
+        log_info "Set SSH_KEY environment variable or ensure key exists at default location"
+        exit 1
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        log_error "jq is required for the verification step but was not found on PATH"
+        exit 1
+    fi
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_warn "DRY RUN: no SSH connection will be made; commands are printed only."
+fi
+
+log_info "Re-provisioning relay on $HOST"
+log_info "  service:        $SERVICE_NAME"
+log_info "  network:        $NETWORK (data dir ~/$DATA_DIR)"
+log_info "  release tag:    ${RELEASE_TAG:-<latest>}"
+log_info "  validator RPC:  $VALIDATOR_RPC"
+
+# Confirmation
+if [[ "$FORCE" != "true" && "$DRY_RUN" != "true" ]]; then
+    log_warn "This will STOP $SERVICE_NAME, WIPE ~/$DATA_DIR/{ledger,wallet}, deploy"
+    log_warn "${RELEASE_TAG:-the latest release}, and restart onto a fresh chain."
+    log_warn "config.toml and node_key are preserved."
+    echo ""
+    read -r -p "Are you sure? Type 'yes' to confirm: " confirm
+    if [[ "$confirm" != "yes" ]]; then
+        log_info "Aborted."
+        exit 0
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 0: Preflight — confirm the target systemd unit actually exists so we
+# never silently restart the wrong unit. (deploy-botho.sh / reset-chain.sh /
+# reset-to-testnet.sh disagree on botho vs botho-seed; this is that drift.)
+# ---------------------------------------------------------------------------
+log_step "Preflight: verifying systemd unit '$SERVICE_NAME' exists on host..."
+if [[ "$DRY_RUN" == "true" ]]; then
+    run_remote "systemctl list-unit-files '${SERVICE_NAME}.service' | grep -q '${SERVICE_NAME}.service'"
+else
+    if ! run_remote_capture "systemctl list-unit-files '${SERVICE_NAME}.service' 2>/dev/null | grep -q '${SERVICE_NAME}.service'"; then
+        log_error "systemd unit '${SERVICE_NAME}.service' not found on $HOST."
+        log_error "Installed botho units are:"
+        run_remote_capture "systemctl list-unit-files | grep -i botho || echo '  (none found)'"
+        log_error "Re-run with the correct --service NAME (e.g. --service botho-seed)."
+        exit 1
+    fi
+    log_info "Unit '${SERVICE_NAME}.service' confirmed present."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1: Stop the service (idempotent — || true tolerates already-stopped)
+# ---------------------------------------------------------------------------
+log_step "Stopping $SERVICE_NAME..."
+run_remote "sudo systemctl stop $SERVICE_NAME || true"
+
+# ---------------------------------------------------------------------------
+# Step 2: Wipe ONLY ledger + wallet. config.toml and node_key are siblings and
+# are left untouched (see the data-layout note in the header). We back up
+# config.toml first, mirroring reset-chain.sh, in case the dir is recreated.
+# ---------------------------------------------------------------------------
+log_step "Backing up config.toml..."
+run_remote "cp ~/$DATA_DIR/config.toml /tmp/botho-config-backup.toml 2>/dev/null || true"
+
+log_step "Wiping stale chain data (ledger + wallet; config.toml + node_key preserved)..."
+run_remote "rm -rf ~/$DATA_DIR/ledger ~/$DATA_DIR/wallet"
+
+log_step "Ensuring config.toml is in place..."
+run_remote "mkdir -p ~/$DATA_DIR && cp /tmp/botho-config-backup.toml ~/$DATA_DIR/config.toml 2>/dev/null || true"
+
+# ---------------------------------------------------------------------------
+# Step 3: Deploy the pinned release binary. We delegate to deploy-botho.sh
+# rather than duplicating its checksum-verify flow — passing SERVICE_NAME and
+# RELEASE_TAG through the environment. deploy-botho.sh will stop (already
+# stopped), install the binary, and start the service onto the now-empty
+# ledger, which is exactly the ordering we need.
+# ---------------------------------------------------------------------------
+log_step "Deploying release binary via deploy-botho.sh..."
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "    SSH_KEY=$SSH_KEY SERVICE_NAME=$SERVICE_NAME RELEASE_TAG=${RELEASE_TAG:-<latest>} \\"
+    echo "        $SCRIPT_DIR/deploy-botho.sh $HOST"
+else
+    SSH_KEY="$SSH_KEY" SERVICE_NAME="$SERVICE_NAME" ${RELEASE_TAG:+RELEASE_TAG="$RELEASE_TAG"} \
+        "$SCRIPT_DIR/deploy-botho.sh" "$HOST"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Verify re-peering + convergence via the relay's LOCAL RPC. We poll
+# the LOCAL RPC (not public HTTPS) per TESTNET_RESET.md §7 so nginx/DNS caching
+# can't mask a wedge. Success = peerCount > 0 AND the relay's tipHash matches
+# the validator's tipHash.
+# ---------------------------------------------------------------------------
+log_step "Verifying re-peering + tip convergence (timeout ${TIMEOUT}s)..."
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_info "Would poll relay LOCAL RPC and compare to validator until convergence:"
+    run_remote "curl -s localhost:$RPC_PORT/rpc -H 'content-type: application/json' -d '$NODE_STATUS_REQ'"
+    echo "    curl -s $VALIDATOR_RPC -H 'content-type: application/json' -d '$NODE_STATUS_REQ'"
+    log_info "Dry run complete. No changes were made."
+    : "${host_set}"
+    exit 0
+fi
+
+deadline=$(( $(date +%s) + TIMEOUT ))
+last_local_peers="?"
+last_local_tip="?"
+last_val_tip="?"
+converged=false
+while [[ "$(date +%s)" -lt "$deadline" ]]; do
+    local_json="$(run_remote_capture "curl -s localhost:$RPC_PORT/rpc -H 'content-type: application/json' -d '$NODE_STATUS_REQ'" || true)"
+    val_json="$(curl -s "$VALIDATOR_RPC" -H 'content-type: application/json' -d "$NODE_STATUS_REQ" || true)"
+
+    last_local_peers="$(echo "$local_json" | jq -r '.result.peerCount // "?"' 2>/dev/null || echo "?")"
+    last_local_tip="$(echo "$local_json"  | jq -r '.result.tipHash // "?"'   2>/dev/null || echo "?")"
+    local_height="$(echo "$local_json"    | jq -r '.result.chainHeight // "?"' 2>/dev/null || echo "?")"
+    last_val_tip="$(echo "$val_json"      | jq -r '.result.tipHash // "?"'   2>/dev/null || echo "?")"
+    val_height="$(echo "$val_json"        | jq -r '.result.chainHeight // "?"' 2>/dev/null || echo "?")"
+
+    log_info "relay: peers=$last_local_peers height=$local_height tip=${last_local_tip:0:12}… | validator: height=$val_height tip=${last_val_tip:0:12}…"
+
+    if [[ "$last_local_peers" =~ ^[0-9]+$ && "$last_local_peers" -gt 0 \
+          && "$last_local_tip" != "?" && "$last_local_tip" == "$last_val_tip" ]]; then
+        converged=true
+        break
+    fi
+    sleep 10
+done
+
+if [[ "$converged" == "true" ]]; then
+    log_info "Relay re-peered and converged on the validator's tip. Re-provision complete!"
+else
+    log_error "Relay did not converge within ${TIMEOUT}s."
+    log_error "  last relay peerCount: $last_local_peers"
+    log_error "  last relay tipHash:   $last_local_tip"
+    log_error "  validator tipHash:    $last_val_tip"
+    if [[ "$last_local_peers" == "0" ]]; then
+        log_error "peerCount is 0 — the relay cannot find peers. The MOST LIKELY cause is"
+        log_error "the validator gossip firewall dropping this relay's IP (see #1117): the"
+        log_error "validators' iptables lockdown on gossip :17100 is un-persisted and can"
+        log_error "silently strand external relays even when the security group looks open."
+        log_error "Confirm the relay's public IP is ACCEPTed on every validator's :17100."
+    fi
+    exit 1
+fi


### PR DESCRIPTION
## Summary

After a consensus-breaking testnet reset, there was **no scripted path** to
bring a single stranded relay back onto the current chain — exactly the gap
that left the eu/ap regional relays on the old chain in #1114. The existing
scripts each do half the job: `deploy-botho.sh` swaps the binary but never
wipes the ledger (so the new binary boots against an incompatible on-disk
chain), and `reset-chain.sh` wipes the ledger but never pins/upgrades the
binary. Neither verifies the relay actually re-peers and converges on the
fleet's tip. This PR adds `infra/seed/reprovision-relay.sh`, which composes
both in the only order that works and adds the missing verification step.

## Changes

- **New `infra/seed/reprovision-relay.sh`** — stop service → wipe only
  `ledger/` + `wallet/` → deploy pinned release (delegates to
  `deploy-botho.sh`) → restart onto empty ledger → poll the relay's **LOCAL**
  RPC until `peerCount > 0` **and** its `tipHash` matches a known-good
  validator, with a bounded `--timeout`. Follows sibling-script conventions
  (`--help`, `--dry-run`, `--force`, `--service`, `--network`, colored
  `log_*` helpers, SSH via `$SSH_KEY`, `RELEASE_TAG` env).
- **Service-name drift reconciled** — the script defaults `--service` to
  `botho` (the unit the #1114 relays actually ran under) but **preflights the
  unit's existence and fails loudly** on a mismatch, printing the installed
  `botho*` units. No more silently restarting the wrong unit.
- **`node_key` preservation documented** — it is a sibling of `ledger/` /
  `wallet/`, so the existing wipe already preserves it; verified, no code
  change needed.
- **`#1117` firewall pointer** — on a `peerCount == 0` timeout the script
  explicitly names the validator gossip-firewall as the likely cause.
- **`deploy-botho.sh`** — `SERVICE_NAME` is now env-overridable (default
  `botho`) so the deploy path is shared, not duplicated.
- **`TESTNET_RESET.md`** — new "single-relay re-provision" subsection; the
  operator node list now explicitly enumerates `eu.seed` / `ap.seed`.
- **`README.md`** — new script added to the directory-structure listing.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Scripted single-relay re-provision: stop → wipe ledger (preserve config.toml + node_key) → deploy pinned release → restart → verify tipHash match + peerCount > 0 | ✅ | `reprovision-relay.sh` implements this exact sequence; `--dry-run` prints every step |
| node_key preserved | ✅ | Sibling of `ledger/`/`wallet/`; wipe targets only those two dirs. Documented in header + TESTNET_RESET.md |
| Coordinated-reset runbook includes eu/ap relays | ✅ | Operator node list in TESTNET_RESET.md now names `eu.seed.botho.io` / `ap.seed.botho.io` |
| Cross-reference firewall prerequisite (#1117) | ✅ | Script's `peerCount == 0` failure message + a TESTNET_RESET.md note both point at #1117 |
| `--dry-run` makes no SSH connection | ✅ | Verified — dry-run only prints the remote command sequence |
| Mismatched `--service` fails loudly | ✅ | Preflight `systemctl list-unit-files` check exits 1 with the installed units listed |

## Test Plan

Operator/infra tooling intentionally excluded from CI (matches the header
comments in the sibling scripts). Verified locally:

- `bash -n reprovision-relay.sh` → OK; `bash -n deploy-botho.sh` → OK
- `shellcheck reprovision-relay.sh` → clean (the `deploy-botho.sh`
  `SC2086/SC2029` infos are pre-existing on its SSH lines, untouched by this PR)
- `./reprovision-relay.sh --help` → prints the header block cleanly
- `./reprovision-relay.sh --dry-run --service botho-seed ubuntu@eu.seed.botho.io`
  → prints the full stop/wipe/deploy/restart/verify sequence, **no SSH made**

Closes #1119