### PR TITLE
infra(seed): add persisted peer-allowlist gossip firewall for :17100

### DIFF
--- a/infra/seed/README.md
+++ b/infra/seed/README.md
@@ -19,6 +19,8 @@ infra/seed/
 ├── botho-seed.service        # Systemd service file
 ├── reset-chain.sh            # Wipe chain data over SSH (--dry-run / --help)
 ├── reset-to-testnet.sh       # Local on-host reset to testnet (--dry-run / --help)
+├── gossip-firewall.sh        # Peer-allowlist :17100 firewall, persisted (--dry-run / --help)
+├── gossip-peers.conf         # Editable :17100 gossip allowlist (data for gossip-firewall.sh)
 ├── deploy-botho.sh           # Build + deploy node binary to host
 ├── deploy-web.sh             # Deploy web files to server
 ├── seed-nginx.conf           # Nginx configuration

--- a/infra/seed/TESTNET_RESET.md
+++ b/infra/seed/TESTNET_RESET.md
@@ -173,27 +173,58 @@ major mismatch), but their **connect-churn + height gossip stalls SCP first**,
 before the disconnect takes effect. Every reconnect (~every 5s) also churns a
 quorum reconfiguration.
 
-**Best practice: decommission the old nodes BEFORE the reset.** If you cannot
-(they are outside your control), firewall gossip (port `17100`) to the fleet's
-own IPs only, on **ALL** nodes, until #1000 lands:
+**Best practice: decommission the old nodes BEFORE the reset.** As a
+belt-and-suspenders measure, firewall gossip (port `17100`) to an explicit
+peer allowlist on **ALL** validators. This is now scripted and persisted —
+run `gossip-firewall.sh apply` on each validator host instead of hand-typing
+`iptables` commands (the old copy-paste block was never persisted and never
+updated for the eu/ap relays, which silently stranded them in #1114):
 
 ```bash
-# Run on EVERY fleet node. Replace <fleet-internal-IPs> with the space-
-# separated internal IPs of the other fleet nodes.
-for ip in <fleet-internal-IPs> 127.0.0.1; do
-  sudo iptables -A INPUT -p tcp --dport 17100 -s "$ip" -j ACCEPT
-done
-sudo iptables -A INPUT -p tcp --dport 17100 -j DROP
+# ON each validator host (seed / seed2 / faucet), as an OPERATOR with sudo.
+# Edit the allowlist first (see gossip-peers.conf), then apply + persist:
+sudo ./gossip-firewall.sh apply
+
+# Preview without touching iptables (no root needed, safe anywhere):
+./gossip-firewall.sh --dry-run apply
+
+# Is :17100 locked down AND durable across reboot?
+./gossip-firewall.sh status
+
+# Revert :17100 to the SG default (open), e.g. when decommissioning:
+sudo ./gossip-firewall.sh remove
 ```
 
-This drops all gossip from non-fleet peers so the zombies can no longer
-connect, churn, or gossip their stale height. Leave RPC (`17101`) alone.
+The allowlist lives in [`gossip-peers.conf`](./gossip-peers.conf) (edit that
+one file when topology changes) and currently covers:
 
-> **Tracking.** #998 is the wedge incident + operational root cause; #1000 is
-> the propose-gate hardening follow-up (exclude a consensus-incompatible peer's
-> height advertisement from the sync-complete / propose-gate determination).
-> Once #1000 ships, the firewall workaround is no longer required — the
-> zombies' height advertisements will simply be ignored.
+| Peer | IP | Notes |
+|------|----|----|
+| eu.seed.botho.io | `3.77.150.19` (public) | EU relay (Frankfurt), #613 — on a separate host, cannot reach the US validators over the VPC, so must be allowlisted by public IP |
+| ap.seed.botho.io | `3.0.209.59` (public) | AP relay (Singapore), #613 — same reasoning |
+| seed / seed2 / faucet | `172.31.x.y` (internal VPC) | The three US validators — internal IPs are VPC-private and rotation-prone, so they are **not** committed; the operator fills them into `gossip-peers.conf` before applying (see the file's comments) |
+
+`127.0.0.1` is always allowed by the script. This drops all gossip from
+non-allowlisted peers so zombies can no longer connect, churn, or gossip their
+stale height. Leave RPC (`17101`) alone.
+
+> **Scope.** Editing `gossip-peers.conf` and the script itself is repo work;
+> running `apply`/`remove` against a live validator mutates the kernel firewall
+> and is an **operator** action (SSH + sudo on the host), never done by CI —
+> the same split this runbook's header calls out for the reset scripts.
+
+> **Tracking / why keep it now that #1000 shipped.** #998 was the original
+> wedge incident; #1000 (the propose-gate hardening that excludes a
+> consensus-incompatible peer's height advertisement from the sync/propose
+> determination) **shipped on 2026-07-16**, so the *specific* propose-gate
+> wedge this firewall once mitigated is fixed in the node itself. The firewall
+> is **retained deliberately** as defense-in-depth: the validators are private
+> consensus infrastructure, so peer-allowlisting `:17100` keeps hostile/zombie
+> gossip and connect-churn off the fleet in general (not just the #998 bug),
+> and makes the iptables gate declarative + reboot-durable so it can no longer
+> silently drift from the AWS SG (the #1114 / #1117 failure mode). Do **not**
+> read "#1000 shipped" as "remove the firewall" — the policy is now
+> peer-allowlist by design.
 
 ## 6. Wedge recovery (chain stops producing after a reset)
 
@@ -209,7 +240,8 @@ producing blocks after a reset:
    `journalctl -u botho-seed | grep -i "peer_version=4.0.0"`; the tell is
    `peer_version=4.0.0 ... disconnecting` (consensus-incompatible) repeating
    every few seconds.
-3. **Firewall the zombies off on ALL nodes** using the §5 gossip firewall.
+3. **Firewall the zombies off on ALL validators** with the §5 gossip firewall
+   (`sudo ./gossip-firewall.sh apply` on each host).
 4. **Confirm no degenerate quorum** — verify no node has
    `[network.quorum] mode=explicit threshold=1 members=[]` (§4). A degenerate
    quorum wedges identically and will NOT be fixed by the firewall.

--- a/infra/seed/gossip-firewall.sh
+++ b/infra/seed/gossip-firewall.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+#
+# Validator Gossip Firewall (port 17100)
+#
+# Renders + loads a peer-allowlist iptables ruleset for the Botho consensus
+# gossip port (17100) from a single editable allowlist (gossip-peers.conf), and
+# persists it so it survives a reboot. This replaces the hand-typed `iptables`
+# commands that TESTNET_RESET.md section 5 used to document — those were never
+# persisted and never updated for the eu/ap regional relays, which silently
+# stranded the relays in #1114.
+#
+# Policy: :17100 is PEER-ALLOWLISTED (not open). Only the peers in
+# gossip-peers.conf (the US validators' internal VPC IPs + the eu/ap relays'
+# public IPs) plus 127.0.0.1 may gossip; everything else is DROPped. The AWS
+# security group shows :17100 open to the world, so iptables is the real gate.
+#
+# Usage:
+#   ./gossip-firewall.sh apply    # render + load the ruleset, persist to disk
+#   ./gossip-firewall.sh status   # show live :17100 rules + whether persisted
+#   ./gossip-firewall.sh remove   # drop our ruleset (revert :17100 to SG-open)
+#
+# Options:
+#   --dry-run          Print every iptables/apt/netfilter command, change nothing
+#   --peers FILE       Allowlist file (default: gossip-peers.conf next to script)
+#   --help, -h         Show this help and exit
+#
+# Examples:
+#   ./gossip-firewall.sh --dry-run apply    # preview, no changes, no root needed
+#   sudo ./gossip-firewall.sh apply         # load + persist on a validator host
+#   ./gossip-firewall.sh status             # is :17100 locked down and durable?
+#
+# OPERATOR SCOPE: running `apply`/`remove` for real mutates the live kernel
+# firewall and requires sudo/root ON the validator host (seed / seed2 /
+# faucet.botho.io). Like reset-chain.sh / reset-to-testnet.sh, this is an
+# OPERATOR action and is intentionally never invoked by CI. `--dry-run` and
+# `--help` need no root and are safe to run anywhere (e.g. on a laptop or in
+# CI as a lint/preview) — they never touch iptables.
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_step() { echo -e "${BLUE}[STEP]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+usage() { sed -n '2,37p' "$0" | sed 's/^#\s\{0,1\}//'; }
+
+# Configuration
+PORT=17100
+# iptables comment tag marking rules this script owns. Used to flush our own
+# rules idempotently on re-apply without disturbing unrelated INPUT rules.
+TAG="botho-gossip-allowlist"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PEERS_FILE="${GOSSIP_PEERS_FILE:-$SCRIPT_DIR/gossip-peers.conf}"
+PERSIST_FILE="/etc/iptables/rules.v4"
+
+DRY_RUN=false
+COMMAND=""
+
+# Parse arguments (subcommand + flags, in any order)
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        apply|status|remove)
+            COMMAND="$1"
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        --peers)
+            PEERS_FILE="$2"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            log_error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+        *)
+            log_error "Unknown command: $1 (expected apply|status|remove)"
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [[ -z "$COMMAND" ]]; then
+    log_error "No command given (expected apply|status|remove)"
+    usage
+    exit 1
+fi
+
+# run: execute a privileged command, or just print it in dry-run mode.
+run() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    $*"
+    else
+        "$@"
+    fi
+}
+
+# load_peers: read PEERS_FILE into the PEERS array. Strips inline `#` comments
+# and blank lines; validates each entry looks like an IPv4 address or CIDR.
+PEERS=()
+load_peers() {
+    if [[ ! -f "$PEERS_FILE" ]]; then
+        log_error "Allowlist file not found: $PEERS_FILE"
+        exit 1
+    fi
+    local line ip
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Strip inline comments and surrounding whitespace.
+        ip="${line%%#*}"
+        ip="${ip//[[:space:]]/}"
+        [[ -z "$ip" ]] && continue
+        if [[ ! "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(/[0-9]{1,2})?$ ]]; then
+            log_warn "Skipping malformed allowlist entry: '$ip'"
+            continue
+        fi
+        PEERS+=("$ip")
+    done < "$PEERS_FILE"
+
+    if [[ ${#PEERS[@]} -eq 0 ]]; then
+        log_warn "Allowlist '$PEERS_FILE' has no usable peer IPs."
+        log_warn "On a validator this DROPs every remote peer on :$PORT and breaks consensus."
+        log_warn "Fill in the fleet's IPs (see the file's comments) before applying for real."
+    fi
+}
+
+# flush_our_rules: delete every INPUT rule this script previously added, matched
+# by our comment TAG, so `apply` is idempotent and `remove` fully reverts.
+flush_our_rules() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    # delete every INPUT rule tagged '$TAG' (repeat until none remain):"
+        echo "    while n=\$(sudo iptables -L INPUT --line-numbers -n | awk '/$TAG/{print \$1; exit}'); [ -n \"\$n\" ]; do sudo iptables -D INPUT \"\$n\"; done"
+        return
+    fi
+    local num
+    while num="$(sudo iptables -L INPUT --line-numbers -n 2>/dev/null | awk -v t="$TAG" '$0 ~ t {print $1; exit}')"; do
+        [[ -z "$num" ]] && break
+        sudo iptables -D INPUT "$num"
+    done
+}
+
+# ensure_persistence: make sure netfilter-persistent is installed (Ubuntu 24.04
+# on the seeds) so `netfilter-persistent save` can write /etc/iptables/rules.v4.
+ensure_persistence() {
+    if [[ "$DRY_RUN" == "true" ]]; then
+        run sudo apt-get update
+        run sudo apt-get install -y netfilter-persistent iptables-persistent
+        return
+    fi
+    if ! command -v netfilter-persistent >/dev/null 2>&1; then
+        log_step "Installing netfilter-persistent / iptables-persistent..."
+        run sudo apt-get update
+        run sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            netfilter-persistent iptables-persistent
+    else
+        log_info "netfilter-persistent already installed."
+    fi
+}
+
+# persist: write the current in-kernel ruleset to disk so it survives reboot.
+persist() {
+    log_step "Persisting ruleset to $PERSIST_FILE (netfilter-persistent save)..."
+    run sudo netfilter-persistent save
+}
+
+cmd_apply() {
+    load_peers
+    ensure_persistence
+
+    log_step "Flushing any previously-applied '$TAG' rules (idempotent re-apply)..."
+    flush_our_rules
+
+    log_step "Allowlisting :$PORT for ${#PEERS[@]} peer(s) + localhost, DROP the rest..."
+    local ip
+    for ip in "${PEERS[@]}" 127.0.0.1; do
+        run sudo iptables -A INPUT -p tcp --dport "$PORT" -s "$ip" \
+            -m comment --comment "$TAG" -j ACCEPT
+    done
+    # Final catch-all DROP for :17100 (added last so it sits after the ACCEPTs).
+    run sudo iptables -A INPUT -p tcp --dport "$PORT" \
+        -m comment --comment "$TAG" -j DROP
+
+    persist
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "Dry run complete. No changes were made."
+    else
+        log_info "Applied gossip firewall for :$PORT and persisted it."
+        log_info "Verify with: $0 status"
+    fi
+}
+
+cmd_status() {
+    log_step "Live in-kernel INPUT rules for :$PORT:"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    sudo iptables -L INPUT -n --line-numbers | grep -E '$PORT|$TAG'"
+    else
+        sudo iptables -L INPUT -n --line-numbers | grep -E "$PORT|$TAG" \
+            || log_warn "No :$PORT rules in the running kernel (port is OPEN per the SG)."
+    fi
+
+    log_step "Persisted ruleset ($PERSIST_FILE):"
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "    sudo grep -E '$PORT|$TAG' $PERSIST_FILE"
+        return
+    fi
+    if [[ ! -f "$PERSIST_FILE" ]]; then
+        log_warn "$PERSIST_FILE does not exist — the live rules are NOT durable."
+        log_warn "A reboot will lose them (this is the #1114 failure mode). Run: $0 apply"
+        return
+    fi
+    if sudo grep -qE "$TAG" "$PERSIST_FILE"; then
+        log_info "Our '$TAG' rules are present in $PERSIST_FILE (durable across reboot)."
+    else
+        log_warn "$PERSIST_FILE exists but has no '$TAG' rules — live rules are NOT persisted."
+        log_warn "Run '$0 apply' to persist them."
+    fi
+}
+
+cmd_remove() {
+    log_step "Removing all '$TAG' rules from :$PORT (reverts to SG default = open)..."
+    flush_our_rules
+    persist
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "Dry run complete. No changes were made."
+    else
+        log_info "Removed gossip firewall for :$PORT and persisted the cleared state."
+    fi
+}
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    log_warn "DRY RUN: printing commands only; iptables is not touched."
+fi
+
+case "$COMMAND" in
+    apply)  cmd_apply ;;
+    status) cmd_status ;;
+    remove) cmd_remove ;;
+esac

--- a/infra/seed/gossip-peers.conf
+++ b/infra/seed/gossip-peers.conf
@@ -1,0 +1,37 @@
+# Botho testnet gossip peer allowlist (port 17100)
+#
+# Single source of truth for which peers the validator gossip firewall
+# (gossip-firewall.sh) ACCEPTs on the consensus port 17100. Everything NOT
+# listed here (and not 127.0.0.1, which the script always allows) is DROPped.
+#
+# Format: one IPv4 address (or CIDR) per line. Blank lines and everything
+# after a `#` are ignored, so inline comments are fine.
+#
+# WHY a firewall at all: see infra/seed/TESTNET_RESET.md section 5. Briefly,
+# gossip from stale/hostile nodes can churn SCP and (historically) wedge the
+# propose-gate; keeping :17100 peer-allowlisted is defense-in-depth for the
+# private consensus fleet. The AWS security group shows :17100 open to the
+# world, so iptables is the *real* gate — keep this list current or peers get
+# silently stranded (this is exactly what happened in #1114).
+#
+# Update this file (not the script) whenever the fleet topology changes:
+# a new relay, a new validator, or an IP rotation.
+
+# --- Regional relay seeds (#613) ---
+# PUBLIC IPs. These relays live on separate hosts in other regions and cannot
+# reach the US validators over the VPC, so they must be allowlisted by their
+# public IP. Source: web/packages/web-wallet/src/config/networks.ts (eu/ap).
+3.77.150.19    # eu.seed.botho.io  — EU relay seed (Frankfurt)
+3.0.209.59     # ap.seed.botho.io  — AP relay seed (Singapore)
+
+# --- US SCP validators (seed / seed2 / faucet) ---
+# INTERNAL VPC IPs (172.31.x.y). These are deliberately NOT committed: they are
+# VPC-private and subject to rotation. The OPERATOR must fill in the current
+# internal IPs of the three US validators below before running
+# `gossip-firewall.sh apply` on a validator host — otherwise the two other US
+# validators are DROPped over the VPC and consensus breaks. Find them with
+# `ip -4 addr show` on each host, or in the AWS console.
+#
+# 172.31.x.y   # seed   (US seed 1, Oregon)
+# 172.31.x.y   # seed2  (US seed 2, Oregon)
+# 172.31.x.y   # faucet (US faucet 1 + faucet RPC, Oregon)


### PR DESCRIPTION
## Summary

The testnet validators carried a live-only iptables lockdown on the consensus
gossip port `:17100` — the hand-typed workaround from `TESTNET_RESET.md` §5.
It was never persisted (a reboot loses it) and was never updated for the eu/ap
regional relays, so it silently stranded them in #1114 while the AWS security
group still showed `:17100` open to the world. Its documented justification
(#998 propose-gate wedge) also expired when #1000 shipped on 2026-07-16, yet
the rule was never removed or re-scoped.

This PR codifies the intended firewall as a scripted, reboot-durable,
peer-allowlist ruleset, and corrects the stale docs. Scope is **scripts + docs
in the repo only** — actually applying the ruleset to the live validators is
operator work (SSH/sudo), called out explicitly in the script header and docs.

## Changes

- **`infra/seed/gossip-firewall.sh`** (new): `apply` / `status` / `remove`
  subcommands driven by a single editable allowlist. `apply` is idempotent
  (flushes its own comment-tagged rules before re-adding, so re-runs never
  stack duplicates) and persists via `netfilter-persistent`
  (`/etc/iptables/rules.v4`) so the ruleset survives reboot. `status` reports
  both the live in-kernel rules and whether they match what's persisted to
  disk. `--dry-run` / `--help` match `reset-chain.sh` / `reset-to-testnet.sh`
  conventions (colored `log_*` helpers, header-comment `usage()`, no live
  changes under `--dry-run`).
- **`infra/seed/gossip-peers.conf`** (new): the allowlist as data. eu/ap relay
  public IPs (`3.77.150.19` / `3.0.209.59`, #613) enumerated; the US
  validators' internal VPC IPs left as operator-filled placeholders
  (VPC-private, rotation-prone, deliberately not committed).
- **`infra/seed/TESTNET_RESET.md`** §5: points to the script instead of raw
  `iptables` commands, adds the eu/ap public IPs to the documented allowlist,
  and corrects the stale "no longer required once #1000 ships" framing (#1000
  shipped; states the current defense-in-depth rationale for keeping it). §6
  recovery step updated to invoke the script.
- **`infra/seed/README.md`**: lists the new script + conf in the directory
  structure.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Script renders `:17100` ruleset from one editable allowlist, `apply`/`status`/`remove` | ✅ | `gossip-firewall.sh` + `gossip-peers.conf`; dry-run shows all three subcommands |
| `apply` idempotent + persisted via netfilter-persistent | ✅ | Container test: 2nd `apply` stays at 6 rules (no stacking); `persist()` runs `netfilter-persistent save` |
| `status` reports live vs persisted state | ✅ | Container run showed live rules + accurate "not durable" warning when `rules.v4` absent |
| `--dry-run` / `--help` match sibling scripts, no live changes under dry-run | ✅ | `--dry-run apply/status/remove` print commands only; `--help` prints header block |
| §5 updated: points to script, corrects #1000 framing, eu/ap IPs documented | ✅ | See TESTNET_RESET.md diff |
| README directory listing includes new script | ✅ | See README.md diff |
| Operator-scope (SSH/sudo, not Builder/CI) documented | ✅ | Script header "OPERATOR SCOPE" + TESTNET_RESET.md §5 scope note |

## Test Plan

- `bash -n` clean; `shellcheck` clean.
- `--dry-run apply/status/remove` print the full `iptables`/`apt`/
  `netfilter-persistent` sequence with no state mutated.
- Real behavior verified in a disposable `ubuntu:24.04` container with
  `NET_ADMIN` + real `iptables` (netfilter-persistent stubbed): `apply`
  installs 4 peer + localhost ACCEPTs and a trailing DROP (6 rules); a second
  `apply` stays at 6 (idempotent); `status` reports live rules; `remove`
  clears to 0.
- Doc verification: §5 no longer instructs hand-typing `iptables -A`, and
  eu (`3.77.150.19`) / ap (`3.0.209.59`) appear in the documented allowlist.
- Operator/infra tooling intentionally excluded from CI (same convention as
  `reset-chain.sh` / `deploy-botho.sh`).

Note: sibling issue #1119's builder is concurrently touching `infra/seed/`
(reprovision-relay.sh + TESTNET_RESET.md/README.md); these edits are kept
tightly scoped to the firewall sections to minimize merge overlap.

Closes #1117