### PR TITLE
chore(deps): migrate dalek family to curve25519-dalek 5 / ed25519-dalek 3 / ed25519 3 / signature 3 / x25519-dalek 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,16 +33,13 @@ updates:
       # bumps are guaranteed-red (two trait-incompatible majors in-tree) and
       # each family upgrade is a deliberate migration through
       # consensus-critical code, tracked as an issue:
-      # dalek-5 family (#1153): CLSAG / key code
-      - dependency-name: "ed25519"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "ed25519-dalek"
-        update-types: ["version-update:semver-major"]
+      # The dalek-5 family migrated in #1153, but the workspace keeps a
+      # deliberate curve25519-dalek 4 pin (`curve25519-dalek-v4`) for the
+      # bulletproofs-og interop boundary in transaction/core/src/range_proofs.
+      # A major bump of that pin is guaranteed-red until a bulletproofs
+      # release supports curve25519-dalek 5; remove this ignore when the
+      # v4 pin is retired.
       - dependency-name: "curve25519-dalek"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "signature"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "x25519-dalek"
         update-types: ["version-update:semver-major"]
       # rand family (#1154): deterministic key derivation. Pre-1.0, so 0.x
       # "minors" are the breaking axis — ignore those too; patches flow.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1503,6 +1503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base256emoji"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,7 +1776,7 @@ dependencies = [
  "dashmap",
  "digest 0.10.7",
  "dirs 5.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "futures",
  "getrandom 0.2.17",
  "heed",
@@ -1805,7 +1811,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "siphasher",
  "statrs",
  "tempfile",
@@ -1947,7 +1953,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tiny-bip39",
  "tokio",
@@ -2009,7 +2015,7 @@ dependencies = [
  "bth-util-serial",
  "bth-util-test-helper",
  "criterion",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "displaydoc",
  "hkdf",
  "prost 0.12.6",
@@ -2017,7 +2023,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rand_hc",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "tiny-bip39",
  "zeroize",
 ]
@@ -2048,11 +2054,11 @@ version = "0.6.0"
 dependencies = [
  "bs58 0.4.0",
  "chrono",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "hex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "uuid",
@@ -2078,7 +2084,7 @@ dependencies = [
  "bth-transaction-types",
  "chrono",
  "clap",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "hex",
  "proptest",
  "rand 0.8.7",
@@ -2087,7 +2093,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tracing",
@@ -2103,7 +2109,7 @@ dependencies = [
  "bth-transaction-types",
  "clap",
  "criterion",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "indicatif",
  "rand 0.8.7",
  "rand_chacha 0.3.1",
@@ -2111,7 +2117,7 @@ dependencies = [
  "rand_distr",
  "rayon",
  "serde",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2205,13 +2211,13 @@ dependencies = [
  "bth-crypto-keys",
  "bth-util-from-random",
  "clap",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "hex",
  "hkdf",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "slip10_ed25519",
  "tiny-bip39",
  "zeroize",
@@ -2224,7 +2230,7 @@ dependencies = [
  "bth-crypto-keys",
  "bth-util-from-random",
  "bth-util-test-helper",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "prost 0.12.6",
  "rand_core 0.6.4",
  "rand_hc",
@@ -2255,11 +2261,11 @@ version = "7.1.0"
 dependencies = [
  "bth-crypto-digestible-derive",
  "cfg-if",
- "curve25519-dalek",
- "ed25519-dalek",
+ "curve25519-dalek 5.0.0",
+ "ed25519-dalek 3.0.0",
  "generic-array",
  "merlin",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
 ]
 
 [[package]]
@@ -2276,7 +2282,7 @@ name = "bth-crypto-digestible-signature"
 version = "7.1.0"
 dependencies = [
  "bth-crypto-digestible",
- "signature 2.2.0",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -2300,26 +2306,28 @@ dependencies = [
  "bth-util-repr-bytes",
  "bth-util-serial",
  "bth-util-test-helper",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
  "digest 0.10.7",
+ "digest 0.11.3",
  "displaydoc",
- "ed25519",
- "ed25519-dalek",
+ "ed25519 3.0.0",
+ "ed25519-dalek 3.0.0",
  "hex",
  "hex_fmt",
  "pem",
+ "rand_core 0.10.1",
  "rand_core 0.6.4",
  "rand_hc",
  "schnorrkel-og",
  "semver 1.0.28",
  "serde",
  "serde_json",
- "sha2",
- "signature 2.2.0",
+ "sha2 0.10.9",
+ "signature 3.0.0",
  "static_assertions",
  "subtle",
  "tempfile",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
  "zeroize",
 ]
 
@@ -2353,7 +2361,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.20",
  "zeroize",
 ]
@@ -2373,7 +2381,8 @@ dependencies = [
  "bth-util-serial",
  "bth-util-test-helper",
  "criterion",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0",
+ "digest 0.10.7",
  "displaydoc",
  "proptest",
  "prost 0.12.6",
@@ -2410,7 +2419,7 @@ dependencies = [
  "hmac",
  "k256",
  "rand 0.8.7",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.9",
  "thiserror 2.0.20",
  "tiny-bip39",
@@ -2502,7 +2511,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2530,7 +2539,8 @@ dependencies = [
  "bulletproofs-og",
  "criterion",
  "ctr",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
+ "curve25519-dalek 5.0.0",
  "displaydoc",
  "generic-array",
  "hex_fmt",
@@ -2542,7 +2552,7 @@ dependencies = [
  "rand 0.8.7",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2586,7 +2596,7 @@ dependencies = [
  "proptest",
  "prost 0.12.6",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2704,7 +2714,7 @@ source = "git+https://github.com/mobilecoinfoundation/bulletproofs.git?rev=9abfd
 dependencies = [
  "byteorder",
  "clear_on_drop",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "merlin",
  "rand_core 0.6.4",
  "serde",
@@ -2825,7 +2835,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3502,8 +3512,25 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rand_core 0.6.4",
+ "rustc_version 0.4.1",
+ "serde",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version 0.4.1",
  "serde",
  "subtle",
@@ -3895,11 +3922,11 @@ dependencies = [
  "sec1",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "webrtc-util",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "x509-parser 0.16.0",
 ]
 
@@ -3955,7 +3982,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "serdect",
+ "serdect 0.2.0",
  "signature 2.2.0",
  "spki 0.7.3",
 ]
@@ -3967,8 +3994,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8 0.10.2",
- "serde",
  "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "serdect 0.4.3",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -3977,12 +4014,25 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
- "sha2",
- "signature 2.2.0",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -4014,7 +4064,7 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
@@ -4025,7 +4075,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -4249,6 +4299,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "field-offset"
@@ -5852,8 +5908,8 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "serdect",
- "sha2",
+ "serdect 0.2.0",
+ "sha2 0.10.9",
  "signature 2.2.0",
 ]
 
@@ -6108,7 +6164,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.7",
  "regex",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "web-time 1.1.0",
 ]
@@ -6141,12 +6197,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "bs58 0.5.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hkdf",
  "multihash",
  "prost 0.14.4",
  "rand 0.8.7",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.20",
  "tracing",
  "zeroize",
@@ -6171,7 +6227,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.7",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.20",
  "tracing",
@@ -6235,7 +6291,7 @@ dependencies = [
  "static_assertions",
  "thiserror 2.0.20",
  "tracing",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -7452,7 +7508,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7464,7 +7520,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -9162,10 +9218,10 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cfg-if",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "merlin",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -9214,11 +9270,11 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -9599,7 +9655,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -9679,6 +9745,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -9856,11 +9933,11 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "ring",
  "rustc_version 0.4.1",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
 ]
 
@@ -10335,7 +10412,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.118",
  "tauri-utils",
  "thiserror 2.0.20",
@@ -10635,7 +10712,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.8.7",
  "rustc-hash 1.1.0",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "unicode-normalization",
  "wasm-bindgen",
@@ -11872,7 +11949,7 @@ dependencies = [
  "sdp",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smol_str",
  "stun",
  "thiserror 1.0.69",
@@ -12724,7 +12801,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.20",
@@ -12774,10 +12851,20 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,15 +88,23 @@ crc = { version = "3", default-features = false }
 criterion = "0.5"
 crossbeam-channel = "0.5"
 ctr = "0.9"
-curve25519-dalek = { version = "4", default-features = false, features = ["precomputed-tables"] }
+curve25519-dalek = { version = "5", default-features = false, features = ["precomputed-tables", "zeroize"] }
+# Dalek-4 line kept ONLY for the bulletproofs-og interop boundary in
+# transaction/core/src/range_proofs (no bulletproofs release supports
+# curve25519-dalek 5 yet); conversions are canonical 32-byte roundtrips.
+curve25519-dalek-v4 = { package = "curve25519-dalek", version = "4", default-features = false }
 der = { version = "0.7", default-features = false }
 digest = { version = "0.10", default-features = false }
+# digest 0.11 generation, used only to bridge digest-0.10 hashers into
+# ed25519-dalek 3's prehashed (Ed25519ph) API; the workspace hash stack
+# remains on digest 0.10.
+digest-v011 = { package = "digest", version = "0.11", default-features = false }
 dashmap = "6"
 dirs = "5"
 displaydoc = { version = "0.2", default-features = false }
 dyn-clone = "1"
-ed25519 = { version = "2", default-features = false }
-ed25519-dalek = { version = "2", default-features = false }
+ed25519 = { version = "3", default-features = false }
+ed25519-dalek = { version = "3", default-features = false }
 futures = "0.3"
 generic-array = { version = "0.14", default-features = false }
 getrandom = "0.2"
@@ -138,6 +146,10 @@ quote = "1"
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }
 rand_chacha = "0.3"
 rand_core = { version = "0.6", default-features = false }
+# rand_core 0.10 generation, used only to bridge workspace rand_core 0.6
+# CSPRNGs into dalek-5-family APIs that have no byte-level constructor
+# (x25519 ephemeral secrets). The full rand-family migration is #1154.
+rand-core-v010 = { package = "rand_core", version = "0.10", default-features = false }
 rand_hc = { version = "0.3", default-features = false }
 rand_distr = { version = "0.4", default-features = false }
 randomx-rs = "1.3"
@@ -157,7 +169,7 @@ serial_test = "3"
 sha2 = { version = "0.10", default-features = false }
 sha3 = { version = "0.10", default-features = false }
 signal-hook = "0.3"
-signature = { version = "2", default-features = false }
+signature = { version = "3", default-features = false }
 siphasher = "1"
 slip10_ed25519 = "0.1"
 static_assertions = "1"
@@ -175,7 +187,7 @@ url = "2"
 walkdir = "2"
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"
-x25519-dalek = { version = "2", default-features = false }
+x25519-dalek = { version = "3", default-features = false }
 x509-cert = { version = "0.2", default-features = false }
 x509-signature = "0.5"
 yare = "2"

--- a/account-keys/src/burn_address.rs
+++ b/account-keys/src/burn_address.rs
@@ -76,7 +76,13 @@ pub fn burn_address() -> PublicAddress {
 fn burn_address_spend_public() -> RistrettoPoint {
     let mut hasher = Blake2b512::new();
     hasher.update(BURN_ADDRESS_DOMAIN_SEPARATOR);
-    RistrettoPoint::from_hash(hasher)
+    // Byte-identical replacement for curve25519-dalek 4's
+    // `RistrettoPoint::from_hash` (finalize the 64-byte digest, apply the
+    // one-way uniform map); dalek 5's version requires digest 0.11 hashers
+    // while this workspace remains on digest 0.10.
+    let mut output = [0u8; 64];
+    output.copy_from_slice(hasher.finalize().as_slice());
+    RistrettoPoint::from_uniform_bytes(&output)
 }
 
 // The burn address view public key, in the curve25519-dalek ristretto point

--- a/botho/Cargo.toml
+++ b/botho/Cargo.toml
@@ -121,7 +121,7 @@ chacha20poly1305 = { workspace = true }
 # Argon2id + ChaCha20-Poly1305 to encrypt the private key at rest under a
 # mandatory passphrase (the same at-rest recipe botho-wallet uses); blake2 for
 # the shared `blake2b-256(pubkey)[..8]` signerKeyId fingerprint.
-ed25519-dalek = { workspace = true, features = ["std", "rand_core"] }
+ed25519-dalek = { workspace = true }
 blake2 = { workspace = true, features = ["std"] }
 digest = { workspace = true }
 argon2 = "0.5"

--- a/botho/src/operator_key.rs
+++ b/botho/src/operator_key.rs
@@ -144,7 +144,15 @@ impl OperatorKeyFile {
 
         // Fresh Ed25519 keypair. `to_bytes()` is the 32-byte secret scalar;
         // wrap it in Zeroizing so it is wiped from memory after encryption.
-        let signing_key = SigningKey::generate(&mut rand::thread_rng());
+        // (ed25519-dalek 3's `generate` requires rand_core 0.10 traits; draw
+        // the 32 secret bytes directly — exactly what `generate` does — to
+        // stay on the workspace rand 0.8 stack until #1154.)
+        let signing_key = {
+            use rand::RngCore as _;
+            let mut secret = [0u8; 32];
+            rand::thread_rng().fill_bytes(&mut secret);
+            SigningKey::from_bytes(&secret)
+        };
         let secret = Zeroizing::new(signing_key.to_bytes());
         let public_key = signing_key.verifying_key().to_bytes();
 

--- a/bridge/core/Cargo.toml
+++ b/bridge/core/Cargo.toml
@@ -26,7 +26,7 @@ sha2 = { workspace = true, features = ["std"] }
 # Attestation envelope protocol (#824): federation Ed25519 signatures and
 # canonical-JSON envelope parsing, mirroring the operator-signed-action
 # machinery.
-ed25519-dalek = { workspace = true, features = ["std"] }
+ed25519-dalek = { workspace = true, features = ["alloc"] }
 serde_json = { workspace = true, features = ["std"] }
 
 # The deterministic bridge-election tally CLI (ADR 0010 option C / A1). A thin,

--- a/bridge/service/Cargo.toml
+++ b/bridge/service/Cargo.toml
@@ -43,7 +43,7 @@ alloy = { workspace = true, features = [
 
 # BTH release attestation verification (ADR 0002: federation Ed25519
 # signatures, mirroring the operator-signed-action machinery)
-ed25519-dalek = { workspace = true, features = ["std"] }
+ed25519-dalek = { workspace = true, features = ["alloc"] }
 
 # Live BTH node transports (#856): deposit view-key scan + release tx
 # construction / CLSAG signing. We REUSE the node-identical crypto and wire

--- a/cluster-tax/Cargo.toml
+++ b/cluster-tax/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/bin/sim.rs"
 
 [dependencies]
 # Cryptographic primitives for committed tags
-curve25519-dalek = { workspace = true, features = ["alloc", "rand_core", "digest"] }
+curve25519-dalek = { workspace = true, features = ["alloc"] }
 sha2 = { workspace = true }
 rand_core = { workspace = true }
 

--- a/cluster-tax/benches/committed_tags_benchmarks.rs
+++ b/cluster-tax/benches/committed_tags_benchmarks.rs
@@ -44,6 +44,14 @@ use curve25519_dalek::scalar::Scalar;
 use rand_core::OsRng;
 use std::collections::HashMap;
 
+/// Byte-identical replacement for curve25519-dalek 4's `Scalar::random`
+/// (dalek 5's version requires rand_core 0.10 traits; see #1154).
+fn random_scalar<R: rand_core::RngCore + rand_core::CryptoRng>(rng: &mut R) -> Scalar {
+    let mut bytes = [0u8; 64];
+    rng.fill_bytes(&mut bytes);
+    Scalar::from_bytes_mod_order_wide(&bytes)
+}
+
 /// Create a test secret for a given number of clusters.
 fn create_test_secret(num_clusters: usize, value: u64) -> CommittedTagVectorSecret {
     let mut tags = HashMap::new();
@@ -272,7 +280,7 @@ fn bench_commitment_creation(c: &mut Criterion) {
 
     c.bench_function("commitment_create", |b| {
         b.iter(|| {
-            let blinding = Scalar::random(&mut OsRng);
+            let blinding = random_scalar(&mut OsRng);
             black_box(CommittedTagMass::new(cluster, mass, blinding))
         })
     });
@@ -306,7 +314,7 @@ fn bench_vector_creation(c: &mut Criterion) {
 
 /// Benchmark Schnorr proof generation.
 fn bench_schnorr_prove(c: &mut Criterion) {
-    let x = Scalar::random(&mut OsRng);
+    let x = random_scalar(&mut OsRng);
 
     c.bench_function("schnorr_prove", |b| {
         b.iter(|| black_box(SchnorrProof::prove(x, b"test_context", &mut OsRng)))
@@ -315,7 +323,7 @@ fn bench_schnorr_prove(c: &mut Criterion) {
 
 /// Benchmark Schnorr proof verification.
 fn bench_schnorr_verify(c: &mut Criterion) {
-    let x = Scalar::random(&mut OsRng);
+    let x = random_scalar(&mut OsRng);
     let p = (x * blinding_generator()).compress();
     let proof = SchnorrProof::prove(x, b"test_context", &mut OsRng);
 

--- a/cluster-tax/src/crypto/committed_tags.rs
+++ b/cluster-tax/src/crypto/committed_tags.rs
@@ -33,14 +33,14 @@ pub fn cluster_generator(cluster_id: ClusterId) -> RistrettoPoint {
     let mut hasher = Sha512::new();
     hasher.update(CLUSTER_GENERATOR_DOMAIN_TAG);
     hasher.update(cluster_id.0.to_le_bytes());
-    RistrettoPoint::from_hash(hasher)
+    crate::crypto::dalek_compat::point_from_hash(hasher)
 }
 
 /// Derive the generator for total mass commitments.
 pub fn total_mass_generator() -> RistrettoPoint {
     let mut hasher = Sha512::new();
     hasher.update(TOTAL_MASS_GENERATOR_DOMAIN_TAG);
-    RistrettoPoint::from_hash(hasher)
+    crate::crypto::dalek_compat::point_from_hash(hasher)
 }
 
 /// A Pedersen commitment to tag mass for a single cluster.
@@ -213,7 +213,7 @@ impl CommittedTagVectorSecret {
             // We keep mass in millionths for precision
             let mass = (value as u128 * weight as u128 / TAG_WEIGHT_SCALE as u128) as u64;
 
-            let blinding = Scalar::random(rng);
+            let blinding = crate::crypto::dalek_compat::random_scalar(rng);
 
             entries.push(TagMassSecret {
                 cluster_id,
@@ -256,7 +256,7 @@ impl CommittedTagVectorSecret {
                 TagMassSecret {
                     cluster_id: e.cluster_id,
                     mass: decayed_mass,
-                    blinding: Scalar::random(rng),
+                    blinding: crate::crypto::dalek_compat::random_scalar(rng),
                 }
             })
             .collect();
@@ -267,7 +267,7 @@ impl CommittedTagVectorSecret {
         Self {
             entries,
             total_mass,
-            total_blinding: Scalar::random(rng),
+            total_blinding: crate::crypto::dalek_compat::random_scalar(rng),
         }
     }
 
@@ -291,7 +291,7 @@ impl CommittedTagVectorSecret {
             .map(|(cluster_id, mass)| TagMassSecret {
                 cluster_id,
                 mass,
-                blinding: Scalar::random(rng),
+                blinding: crate::crypto::dalek_compat::random_scalar(rng),
             })
             .collect();
 
@@ -300,7 +300,7 @@ impl CommittedTagVectorSecret {
         Self {
             entries,
             total_mass,
-            total_blinding: Scalar::random(rng),
+            total_blinding: crate::crypto::dalek_compat::random_scalar(rng),
         }
     }
 }
@@ -753,7 +753,7 @@ impl CommittedFeeProver {
 
         for (i, challenge) in challenges.iter_mut().enumerate() {
             if i != real_segment {
-                *challenge = Scalar::random(rng);
+                *challenge = crate::crypto::dalek_compat::random_scalar(rng);
                 simulated_challenges_sum += *challenge;
             }
         }
@@ -802,8 +802,8 @@ impl CommittedFeeProver {
             .saturating_sub(self.wealth as u128 + 1)
             .min(u64::MAX as u128) as u64;
 
-        let lower_blinding = Scalar::random(rng);
-        let upper_blinding = Scalar::random(rng);
+        let lower_blinding = crate::crypto::dalek_compat::random_scalar(rng);
+        let upper_blinding = crate::crypto::dalek_compat::random_scalar(rng);
 
         let lower_commitment = (Scalar::from(lower_diff) * g + lower_blinding * g).compress();
         let upper_commitment = (Scalar::from(upper_diff) * g + upper_blinding * g).compress();
@@ -827,7 +827,7 @@ impl CommittedFeeProver {
         let required = (self.base_fee as u128 * expected_factor as u128) as u64;
         let excess = self.fee_paid.saturating_sub(required);
 
-        let excess_blinding = Scalar::random(rng);
+        let excess_blinding = crate::crypto::dalek_compat::random_scalar(rng);
         let excess_commitment = (Scalar::from(excess) * g + excess_blinding * g).compress();
 
         let linear_proof = LinearRelationProof {
@@ -852,19 +852,19 @@ impl CommittedFeeProver {
         // the OR-composition verification equation
         let g = blinding_generator();
 
-        let lower_blinding = Scalar::random(rng);
-        let upper_blinding = Scalar::random(rng);
+        let lower_blinding = crate::crypto::dalek_compat::random_scalar(rng);
+        let upper_blinding = crate::crypto::dalek_compat::random_scalar(rng);
 
         let range_proof = RangeProof {
-            lower_commitment: (Scalar::random(rng) * g).compress(),
-            upper_commitment: (Scalar::random(rng) * g).compress(),
+            lower_commitment: (crate::crypto::dalek_compat::random_scalar(rng) * g).compress(),
+            upper_commitment: (crate::crypto::dalek_compat::random_scalar(rng) * g).compress(),
             lower_proof: SchnorrProof::prove(lower_blinding, b"range_lower", rng),
             upper_proof: SchnorrProof::prove(upper_blinding, b"range_upper", rng),
         };
 
-        let excess_blinding = Scalar::random(rng);
+        let excess_blinding = crate::crypto::dalek_compat::random_scalar(rng);
         let linear_proof = LinearRelationProof {
-            excess_commitment: (Scalar::random(rng) * g).compress(),
+            excess_commitment: (crate::crypto::dalek_compat::random_scalar(rng) * g).compress(),
             excess_proof: SchnorrProof::prove(excess_blinding, b"linear_excess", rng),
         };
 
@@ -886,7 +886,7 @@ impl CommittedFeeProver {
             hasher.update(proof.linear_proof.excess_commitment.as_bytes());
         }
 
-        Scalar::from_hash(hasher)
+        crate::crypto::dalek_compat::scalar_from_hash(hasher)
     }
 }
 
@@ -975,7 +975,7 @@ impl CommittedFeeVerifier {
             hasher.update(segment_proof.linear_proof.excess_commitment.as_bytes());
         }
 
-        Scalar::from_hash(hasher)
+        crate::crypto::dalek_compat::scalar_from_hash(hasher)
     }
 }
 
@@ -1139,7 +1139,7 @@ impl SchnorrProof {
         let p = x * g;
 
         // Random nonce
-        let k = Scalar::random(rng);
+        let k = crate::crypto::dalek_compat::random_scalar(rng);
         let r = k * g;
 
         // Challenge (Fiat-Shamir)
@@ -1187,7 +1187,7 @@ impl SchnorrProof {
         hasher.update(context);
         hasher.update(r.as_bytes());
         hasher.update(p.as_bytes());
-        Scalar::from_hash(hasher)
+        crate::crypto::dalek_compat::scalar_from_hash(hasher)
     }
 }
 
@@ -1205,14 +1205,14 @@ const FEE_GENERATOR_DOMAIN_TAG: &[u8] = b"mc_zk_fee_fee_generator";
 pub fn wealth_generator() -> RistrettoPoint {
     let mut hasher = Sha512::new();
     hasher.update(WEALTH_GENERATOR_DOMAIN_TAG);
-    RistrettoPoint::from_hash(hasher)
+    crate::crypto::dalek_compat::point_from_hash(hasher)
 }
 
 /// Derive the generator for fee commitments in fee proofs.
 pub fn fee_generator() -> RistrettoPoint {
     let mut hasher = Sha512::new();
     hasher.update(FEE_GENERATOR_DOMAIN_TAG);
-    RistrettoPoint::from_hash(hasher)
+    crate::crypto::dalek_compat::point_from_hash(hasher)
 }
 
 #[cfg(test)]
@@ -1237,7 +1237,7 @@ mod tests {
     fn test_committed_tag_mass_creation() {
         let cluster = ClusterId(42);
         let mass = 500_000u64; // 50% weight on 1 unit value
-        let blinding = Scalar::random(&mut OsRng);
+        let blinding = crate::crypto::dalek_compat::random_scalar(&mut OsRng);
 
         let committed = CommittedTagMass::new(cluster, mass, blinding);
         assert_eq!(committed.cluster_id, cluster);
@@ -1249,8 +1249,8 @@ mod tests {
         let cluster = ClusterId(1);
         let mass1 = 300_000u64;
         let mass2 = 200_000u64;
-        let blinding1 = Scalar::random(&mut OsRng);
-        let blinding2 = Scalar::random(&mut OsRng);
+        let blinding1 = crate::crypto::dalek_compat::random_scalar(&mut OsRng);
+        let blinding2 = crate::crypto::dalek_compat::random_scalar(&mut OsRng);
 
         let c1 = CommittedTagMass::new(cluster, mass1, blinding1);
         let c2 = CommittedTagMass::new(cluster, mass2, blinding2);
@@ -1297,7 +1297,7 @@ mod tests {
 
     #[test]
     fn test_schnorr_proof() {
-        let x = Scalar::random(&mut OsRng);
+        let x = crate::crypto::dalek_compat::random_scalar(&mut OsRng);
         let p = (x * blinding_generator()).compress();
 
         let proof = SchnorrProof::prove(x, b"test_context", &mut OsRng);
@@ -1307,7 +1307,9 @@ mod tests {
         assert!(!proof.verify(&p, b"wrong_context"));
 
         // Wrong point should fail
-        let wrong_p = (Scalar::random(&mut OsRng) * blinding_generator()).compress();
+        let wrong_p = (crate::crypto::dalek_compat::random_scalar(&mut OsRng)
+            * blinding_generator())
+        .compress();
         assert!(!proof.verify(&wrong_p, b"test_context"));
     }
 
@@ -1430,7 +1432,7 @@ mod tests {
 
     #[test]
     fn test_schnorr_proof_size() {
-        let x = Scalar::random(&mut OsRng);
+        let x = crate::crypto::dalek_compat::random_scalar(&mut OsRng);
         let proof = SchnorrProof::prove(x, b"test", &mut OsRng);
         let bytes = proof.to_bytes();
 

--- a/cluster-tax/src/crypto/dalek_compat.rs
+++ b/cluster-tax/src/crypto/dalek_compat.rs
@@ -1,0 +1,38 @@
+// Copyright (c) 2018-2026 The Botho Foundation
+
+//! Byte-level replacements for curve25519-dalek convenience constructors
+//! whose trait generations changed in dalek 5.
+//!
+//! curve25519-dalek 5 moved `Scalar::random` behind rand_core 0.10 traits and
+//! `Scalar::from_hash` / `RistrettoPoint::from_hash` behind digest 0.11
+//! traits. This workspace remains on rand_core 0.6 (the rand-family migration
+//! is tracked in #1154) and digest 0.10, so these helpers re-implement the
+//! exact upstream algorithms at the byte level. Outputs are bit-identical to
+//! the dalek 4 era.
+
+use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
+use rand_core::CryptoRngCore;
+use sha2::{Digest, Sha512};
+
+/// Hash to a `Scalar` from a `Sha512` digest (replaces `Scalar::from_hash`).
+pub(crate) fn scalar_from_hash(hasher: Sha512) -> Scalar {
+    let mut output = [0u8; 64];
+    output.copy_from_slice(hasher.finalize().as_slice());
+    Scalar::from_bytes_mod_order_wide(&output)
+}
+
+/// Hash to a `RistrettoPoint` from a `Sha512` digest (replaces
+/// `RistrettoPoint::from_hash`).
+pub(crate) fn point_from_hash(hasher: Sha512) -> RistrettoPoint {
+    let mut output = [0u8; 64];
+    output.copy_from_slice(hasher.finalize().as_slice());
+    RistrettoPoint::from_uniform_bytes(&output)
+}
+
+/// Draw a uniformly random `Scalar` from a rand_core 0.6 CSPRNG (replaces
+/// `Scalar::random`).
+pub(crate) fn random_scalar<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Scalar {
+    let mut bytes = [0u8; 64];
+    rng.as_rngcore().fill_bytes(&mut bytes);
+    Scalar::from_bytes_mod_order_wide(&bytes)
+}

--- a/cluster-tax/src/crypto/entropy_proof.rs
+++ b/cluster-tax/src/crypto/entropy_proof.rs
@@ -52,7 +52,7 @@ pub const ENTROPY_SCALE: u64 = 1_000_000;
 pub fn entropy_generator() -> RistrettoPoint {
     let mut hasher = Sha512::new();
     hasher.update(ENTROPY_GENERATOR_DOMAIN_TAG);
-    RistrettoPoint::from_hash(hasher)
+    crate::crypto::dalek_compat::point_from_hash(hasher)
 }
 
 // ============================================================================
@@ -243,15 +243,15 @@ impl EntropyProofBuilder {
         let h_e = entropy_generator();
         let g = blinding_generator();
 
-        let r_before = Scalar::random(rng);
-        let r_after = Scalar::random(rng);
+        let r_before = crate::crypto::dalek_compat::random_scalar(rng);
+        let r_after = crate::crypto::dalek_compat::random_scalar(rng);
 
         let c_before = Scalar::from(entropy_before) * h_e + r_before * g;
         let c_after = Scalar::from(entropy_after) * h_e + r_after * g;
 
         // Generate threshold range proof
         let excess = entropy_delta - self.threshold;
-        let r_excess = Scalar::random(rng);
+        let r_excess = crate::crypto::dalek_compat::random_scalar(rng);
         let c_excess = Scalar::from(excess) * h_e + r_excess * g;
 
         // Schnorr proof for excess commitment blinding
@@ -259,7 +259,7 @@ impl EntropyProofBuilder {
 
         // Proof that excess is non-negative (simplified)
         // In production, this would be a Bulletproof range proof
-        let r_nn = Scalar::random(rng);
+        let r_nn = crate::crypto::dalek_compat::random_scalar(rng);
         let non_negative_proof = SchnorrProof::prove(r_nn, b"mc_entropy_non_negative", rng);
 
         let threshold_range_proof = EntropyRangeProof {
@@ -319,7 +319,7 @@ impl EntropyProofBuilder {
             };
 
             // Commit to contribution
-            let r_step = Scalar::random(rng);
+            let r_step = crate::crypto::dalek_compat::random_scalar(rng);
             let c_step = Scalar::from(contribution) * h_e + r_step * g;
             intermediate_commitments.push(c_step.compress());
 
@@ -331,7 +331,7 @@ impl EntropyProofBuilder {
 
         // Final aggregation proof
         // Links sum of intermediates to the entropy commitment
-        let r_agg = Scalar::random(rng);
+        let r_agg = crate::crypto::dalek_compat::random_scalar(rng);
         let aggregation_proof = SchnorrProof::prove(r_agg, b"mc_entropy_aggregation", rng);
 
         Some(EntropyLinkageProof {
@@ -857,7 +857,7 @@ mod tests {
     #[test]
     fn test_entropy_range_proof_serialization() {
         let g = blinding_generator();
-        let r = Scalar::random(&mut OsRng);
+        let r = crate::crypto::dalek_compat::random_scalar(&mut OsRng);
         let c = r * g;
 
         let range_proof = EntropyRangeProof {

--- a/cluster-tax/src/crypto/extended_signature.rs
+++ b/cluster-tax/src/crypto/extended_signature.rs
@@ -38,7 +38,6 @@ use super::{
     entropy_validation::TransactionVersion,
 };
 use crate::{ClusterId, TagWeight};
-use curve25519_dalek::scalar::Scalar;
 
 // TAG_WEIGHT_SCALE is used in tests
 #[cfg(test)]
@@ -260,7 +259,7 @@ impl ExtendedSignatureBuilder {
 
         for entry in &real_secret.entries {
             // New blinding for pseudo-output
-            let pseudo_blinding = Scalar::random(rng);
+            let pseudo_blinding = crate::crypto::dalek_compat::random_scalar(rng);
 
             // Create pseudo commitment
             let pseudo_commitment =
@@ -287,7 +286,7 @@ impl ExtendedSignatureBuilder {
         }
 
         // Create pseudo total commitment
-        let pseudo_total_blinding = Scalar::random(rng);
+        let pseudo_total_blinding = crate::crypto::dalek_compat::random_scalar(rng);
 
         // Note: We could add a total inheritance proof here too, but since we
         // prove each cluster individually and the total is just a sum, it's

--- a/cluster-tax/src/crypto/mod.rs
+++ b/cluster-tax/src/crypto/mod.rs
@@ -21,6 +21,7 @@
 //! - Threshold range proofs for minimum entropy delta
 
 mod committed_tags;
+mod dalek_compat;
 mod entropy_proof;
 mod entropy_validation;
 mod extended_signature;

--- a/core/src/subaddress.rs
+++ b/core/src/subaddress.rs
@@ -16,6 +16,18 @@ use crate::{
     keys::*,
 };
 
+/// Hash to a `Scalar` from a 512-bit digest.
+///
+/// Byte-identical replacement for curve25519-dalek 4's `Scalar::from_hash`
+/// (finalize the 64-byte digest, reduce mod the group order); dalek 5's
+/// version requires digest 0.11 hashers while this workspace remains on
+/// digest 0.10.
+fn scalar_from_hash(digest: Blake2b512) -> Scalar {
+    let mut output = [0u8; 64];
+    output.copy_from_slice(digest.finalize().as_slice());
+    Scalar::from_bytes_mod_order_wide(&output)
+}
+
 /// Generate a subaddress for a given input key set
 pub trait Subaddress {
     /// Subaddress type
@@ -41,7 +53,7 @@ impl Subaddress for (&RootViewPrivate, &RootSpendPrivate) {
             digest.update(SUBADDRESS_DOMAIN_TAG);
             digest.update(a.as_bytes());
             digest.update(n.as_bytes());
-            Scalar::from_hash(digest)
+            scalar_from_hash(digest)
         };
 
         // Return private subaddress keys
@@ -70,7 +82,7 @@ impl Subaddress for (&RootViewPrivate, &RootSpendPublic) {
             digest.update(SUBADDRESS_DOMAIN_TAG);
             digest.update(a.as_bytes());
             digest.update(n.as_bytes());
-            Scalar::from_hash(digest)
+            scalar_from_hash(digest)
         };
 
         let b = RistrettoPrivate::from(Hs);

--- a/crypto/keys/Cargo.toml
+++ b/crypto/keys/Cargo.toml
@@ -39,11 +39,13 @@ default = [
 [dependencies]
 
 base64 = { workspace = true }
-curve25519-dalek = { workspace = true, features = ["rand_core"] }
+curve25519-dalek = { workspace = true }
 digest = { workspace = true }
+# digest 0.11 bridge for ed25519-dalek 3's prehashed (Ed25519ph) API only.
+digest-v011 = { workspace = true }
 displaydoc = { workspace = true }
 ed25519 = { workspace = true }
-ed25519-dalek = { workspace = true, features = ["rand_core", "digest"] }
+ed25519-dalek = { workspace = true, features = ["digest"] }
 hex = { workspace = true }
 hex_fmt = { workspace = true }
 
@@ -53,11 +55,14 @@ bth-util-from-random = { workspace = true }
 bth-util-repr-bytes = { workspace = true }
 bth-util-serial = { workspace = true, optional = true }
 rand_core = { workspace = true }
+# rand_core 0.10 bridge for x25519-dalek 3 secret generation only (#1154
+# tracks the full rand-family migration).
+rand-core-v010 = { workspace = true }
 rand_hc = { workspace = true }
 schnorrkel-og = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 sha2 = { workspace = true }
-signature = { workspace = true, features = ["digest"] }
+signature = { workspace = true }
 static_assertions = { workspace = true }
 subtle = { workspace = true }
 x25519-dalek = { workspace = true, features = ["static_secrets"] }

--- a/crypto/keys/src/ed25519.rs
+++ b/crypto/keys/src/ed25519.rs
@@ -25,6 +25,38 @@ use ed25519_dalek::{
 use rand_core::{CryptoRng, RngCore};
 use zeroize::Zeroize;
 
+/// Bridges a workspace (`digest` 0.10) hasher into the `digest` 0.11 `Digest`
+/// trait that ed25519-dalek 3's prehashed (Ed25519ph) API expects.
+///
+/// The wrapper only forwards `update` calls and copies the finalized 64-byte
+/// output, so signatures produced/verified through it are bit-identical to
+/// the ed25519-dalek 2.x era.
+struct DigestCompat<D>(D);
+
+impl<D: Digest<OutputSize = U64>> digest_v011::Update for DigestCompat<D> {
+    fn update(&mut self, data: &[u8]) {
+        Digest::update(&mut self.0, data)
+    }
+}
+
+impl<D: Digest<OutputSize = U64>> digest_v011::OutputSizeUser for DigestCompat<D> {
+    type OutputSize = digest_v011::consts::U64;
+}
+
+impl<D: Digest<OutputSize = U64>> digest_v011::FixedOutput for DigestCompat<D> {
+    fn finalize_into(self, out: &mut digest_v011::Output<Self>) {
+        out.copy_from_slice(self.0.finalize().as_slice())
+    }
+}
+
+impl<D: Digest<OutputSize = U64>> digest_v011::HashMarker for DigestCompat<D> {}
+
+impl<D: Digest<OutputSize = U64>> Default for DigestCompat<D> {
+    fn default() -> Self {
+        Self(D::new())
+    }
+}
+
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
@@ -211,7 +243,7 @@ impl<D: Digest<OutputSize = U64>> DigestVerifier<D, Ed25519Signature> for Ed2551
     fn verify_digest(&self, digest: D, signature: &Ed25519Signature) -> Result<(), SignatureError> {
         let sig = DalekSignature::from(&signature.to_bytes());
         self.0
-            .verify_prehashed(digest, None, &sig)
+            .verify_prehashed(DigestCompat(digest), None, &sig)
             .map_err(|_e| SignatureError::new())
     }
 }
@@ -310,8 +342,13 @@ impl PrivateKey for Ed25519Private {
 
 impl FromRandom for Ed25519Private {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> Self {
-        let signing_key = SigningKey::generate(csprng);
-        Self(signing_key.to_bytes())
+        // ed25519-dalek 3's `SigningKey::generate` requires rand_core 0.10
+        // traits; draw the 32 secret bytes directly instead (exactly what
+        // `generate` does internally) to keep the workspace on rand_core 0.6
+        // until the rand-family migration (#1154).
+        let mut secret = SecretKey::default();
+        csprng.fill_bytes(&mut secret);
+        Self(secret)
     }
 }
 
@@ -350,7 +387,7 @@ impl Ed25519Pair {
 
 impl<D: Digest<OutputSize = U64>> DigestSigner<D, Ed25519Signature> for Ed25519Pair {
     fn try_sign_digest(&self, digest: D) -> Result<Ed25519Signature, SignatureError> {
-        let sig = self.0.sign_prehashed(digest, None)?;
+        let sig = self.0.sign_prehashed(DigestCompat(digest), None)?;
         Ok(Ed25519Signature::new(sig.to_bytes()))
     }
 }
@@ -359,7 +396,7 @@ impl<D: Digest<OutputSize = U64>> DigestVerifier<D, Ed25519Signature> for Ed2551
     fn verify_digest(&self, digest: D, signature: &Ed25519Signature) -> Result<(), SignatureError> {
         let sig = DalekSignature::from(&signature.to_bytes());
         self.0
-            .verify_prehashed(digest, None, &sig)
+            .verify_prehashed(DigestCompat(digest), None, &sig)
             .map_err(|_e| SignatureError::new())
     }
 }
@@ -373,7 +410,11 @@ impl From<Ed25519Private> for Ed25519Pair {
 
 impl FromRandom for Ed25519Pair {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> Self {
-        Self(SigningKey::generate(csprng))
+        // See `Ed25519Private::from_random` for why this draws bytes directly
+        // instead of calling `SigningKey::generate`.
+        let mut secret = SecretKey::default();
+        csprng.fill_bytes(&mut secret);
+        Self(SigningKey::from_bytes(&secret))
     }
 }
 

--- a/crypto/keys/src/lib.rs
+++ b/crypto/keys/src/lib.rs
@@ -65,8 +65,9 @@ pub use crate::{
         RistrettoPublic, RistrettoSecret, RistrettoSignature,
     },
     traits::{
-        DistinguishedEncoding, Fingerprintable, Kex, KexEphemeralPrivate, KexPrivate, KexPublic,
-        KexReusablePrivate, KexSecret, KeyError, PrivateKey, PublicKey,
+        DigestSigner, DigestVerifier, DistinguishedEncoding, Fingerprintable, Kex,
+        KexEphemeralPrivate, KexPrivate, KexPublic, KexReusablePrivate, KexSecret, KeyError,
+        PrivateKey, PublicKey,
     },
     x25519::{
         X25519EphemeralPrivate, X25519Private, X25519Public, X25519Secret, X25519, X25519_LEN,
@@ -79,8 +80,6 @@ pub(crate) use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
 pub use bth_util_repr_bytes::{typenum::Unsigned, GenericArray, LengthMismatch, ReprBytes};
 pub use digest::Digest;
 pub use schnorrkel_og::SignatureError as SchnorrkelError;
-pub use signature::{
-    DigestSigner, DigestVerifier, Error as SignatureError, SignatureEncoding, Signer, Verifier,
-};
+pub use signature::{Error as SignatureError, SignatureEncoding, Signer, Verifier};
 
 pub use traits::DER_MAX_LEN;

--- a/crypto/keys/src/ristretto.rs
+++ b/crypto/keys/src/ristretto.rs
@@ -47,6 +47,28 @@ use bth_util_repr_bytes::derive_prost_message_from_repr_bytes;
 use subtle::{Choice, ConstantTimeEq};
 use zeroize::Zeroize;
 
+/// Draw a uniformly random `Scalar` from a rand_core 0.6 CSPRNG.
+///
+/// This is exactly what curve25519-dalek's `Scalar::random` does (64 bytes,
+/// reduced mod the group order); dalek 5's version requires rand_core 0.10
+/// traits, which the workspace does not use yet (#1154).
+fn random_scalar<R: CryptoRng + RngCore>(csprng: &mut R) -> Scalar {
+    let mut bytes = [0u8; 64];
+    csprng.fill_bytes(&mut bytes);
+    Scalar::from_bytes_mod_order_wide(&bytes)
+}
+
+/// Draw a uniformly random `RistrettoPoint` from a rand_core 0.6 CSPRNG.
+///
+/// This is exactly what curve25519-dalek's `RistrettoPoint::random` does
+/// (64 bytes through the one-way uniform map); dalek 5's version requires
+/// rand_core 0.10 traits, which the workspace does not use yet (#1154).
+fn random_ristretto_point<R: CryptoRng + RngCore>(csprng: &mut R) -> RistrettoPoint {
+    let mut bytes = [0u8; 64];
+    csprng.fill_bytes(&mut bytes);
+    RistrettoPoint::from_uniform_bytes(&bytes)
+}
+
 /// A Ristretto-format private scalar
 #[derive(Clone, Copy, Default, Digestible, Zeroize)]
 #[digestible(transparent)]
@@ -190,7 +212,7 @@ impl<T: Digestible> DigestibleSigner<RistrettoSignature, T> for RistrettoPrivate
 
 impl FromRandom for RistrettoPrivate {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> RistrettoPrivate {
-        Self(Scalar::random(csprng))
+        Self(random_scalar(csprng))
     }
 }
 
@@ -251,7 +273,7 @@ impl KexEphemeralPrivate for RistrettoEphemeralPrivate {
 
 impl FromRandom for RistrettoEphemeralPrivate {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> Self {
-        Self(Scalar::random(csprng))
+        Self(random_scalar(csprng))
     }
 }
 
@@ -278,7 +300,7 @@ impl AsRef<RistrettoPoint> for RistrettoPublic {
 
 impl FromRandom for RistrettoPublic {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> RistrettoPublic {
-        Self(RistrettoPoint::random(csprng))
+        Self(random_ristretto_point(csprng))
     }
 }
 
@@ -342,7 +364,11 @@ impl RistrettoPublic {
         signature: &RistrettoSignature,
     ) -> Result<(), SchnorrkelError> {
         let ctx = schnorrkel_og::signing_context(context);
-        let pubkey = SchnorrkelPublic::from_point(*self.as_ref());
+        // schnorrkel-og is still on curve25519-dalek 4, so its `from_point`
+        // constructor no longer accepts our (dalek 5) `RistrettoPoint`.
+        // Round-trip through the canonical compressed encoding instead; this
+        // is the same point, at the cost of one decompression.
+        let pubkey = SchnorrkelPublic::from_bytes(&self.to_bytes())?;
         pubkey.verify(ctx.bytes(message), &signature.try_into()?)
     }
 }
@@ -551,7 +577,7 @@ impl From<CompressedRistretto> for CompressedRistrettoPublic {
 
 impl FromRandom for CompressedRistrettoPublic {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> CompressedRistrettoPublic {
-        Self::from(RistrettoPoint::random(csprng))
+        Self::from(random_ristretto_point(csprng))
     }
 }
 

--- a/crypto/keys/src/traits.rs
+++ b/crypto/keys/src/traits.rs
@@ -17,6 +17,39 @@ use alloc::vec::Vec;
 #[cfg(feature = "serde")]
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
+/// Sign the given prehashed message [`Digest`], returning a signature.
+///
+/// This is the `signature` 2.x shape of `DigestSigner`, kept locally because
+/// `signature` 3 changed `DigestSigner` to a closure-based API generic over
+/// `digest` 0.11, while this workspace's hash stack remains on `digest` 0.10.
+/// Implementations bridge into the dalek 3.x prehashed APIs internally; the
+/// produced signatures are bit-identical to the `signature` 2.x era.
+pub trait DigestSigner<D: Digest, S> {
+    /// Sign the given prehashed message [`Digest`], returning a signature.
+    ///
+    /// # Panics
+    ///
+    /// Panics in the event of a signing error.
+    fn sign_digest(&self, digest: D) -> S {
+        self.try_sign_digest(digest)
+            .expect("signature operation failed")
+    }
+
+    /// Attempt to sign the given prehashed message [`Digest`], returning a
+    /// digital signature on success, or an error if something went wrong.
+    fn try_sign_digest(&self, digest: D) -> Result<S, signature::Error>;
+}
+
+/// Verify the provided signature for the given prehashed message [`Digest`]
+/// is authentic.
+///
+/// This is the `signature` 2.x shape of `DigestVerifier`, kept locally for the
+/// same reason as [`DigestSigner`] above.
+pub trait DigestVerifier<D: Digest, S> {
+    /// Verify the signature against the given [`Digest`] output.
+    fn verify_digest(&self, digest: D, signature: &S) -> Result<(), signature::Error>;
+}
+
 /// Marker trait for serialization when `serde` feature is enabled
 #[cfg(feature = "serde")]
 pub trait MaybeSerde: DeserializeOwned + Serialize {}

--- a/crypto/keys/src/x25519.rs
+++ b/crypto/keys/src/x25519.rs
@@ -34,6 +34,35 @@ use sha2::Sha256;
 use x25519_dalek::{EphemeralSecret, PublicKey as DalekPublicKey, SharedSecret, StaticSecret};
 use zeroize::Zeroize;
 
+/// Bridges a workspace (rand_core 0.6) CSPRNG into the rand_core 0.10 traits
+/// that x25519-dalek 3's `random_from_rng` constructors expect.
+///
+/// `EphemeralSecret` deliberately has no byte-level constructor, so this is
+/// the only way to seed it from the workspace RNG generation. All methods
+/// forward directly, so the byte stream consumed (32 bytes via `fill_bytes`)
+/// is identical to the x25519-dalek 2.x era. The full rand-family migration
+/// is tracked in #1154.
+struct RngCompat<'a, R: RngCore + CryptoRng>(&'a mut R);
+
+impl<R: RngCore + CryptoRng> rand_core_v010::TryRng for RngCompat<'_, R> {
+    type Error = core::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.0.next_u32())
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(self.0.next_u64())
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        self.0.fill_bytes(dst);
+        Ok(())
+    }
+}
+
+impl<R: RngCore + CryptoRng> rand_core_v010::TryCryptoRng for RngCompat<'_, R> {}
+
 /// The length in bytes of canonical representation of x25519 (public and
 /// private keys)
 pub const X25519_LEN: usize = 32;
@@ -379,7 +408,7 @@ impl KexEphemeralPrivate for X25519EphemeralPrivate {
 
 impl FromRandom for X25519EphemeralPrivate {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> X25519EphemeralPrivate {
-        X25519EphemeralPrivate(EphemeralSecret::random_from_rng(csprng))
+        X25519EphemeralPrivate(EphemeralSecret::random_from_rng(&mut RngCompat(csprng)))
     }
 }
 
@@ -402,7 +431,7 @@ impl PrivateKey for X25519Private {
 
 impl FromRandom for X25519Private {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> X25519Private {
-        X25519Private(StaticSecret::random_from_rng(csprng))
+        X25519Private(StaticSecret::random_from_rng(&mut RngCompat(csprng)))
     }
 }
 

--- a/crypto/ring-signature/Cargo.toml
+++ b/crypto/ring-signature/Cargo.toml
@@ -41,6 +41,7 @@ proptest = ["dep:proptest", "default"]
 curve25519-dalek = { workspace = true }
 
 # External dependencies
+digest = { workspace = true }
 displaydoc = { workspace = true }
 
 # Botho dependencies

--- a/crypto/ring-signature/benches/ring_signature_benchmarks.rs
+++ b/crypto/ring-signature/benches/ring_signature_benchmarks.rs
@@ -34,7 +34,7 @@ impl TestRingParams {
 
         // Use the generators function with a deterministic index
         let generator = generators(seed);
-        let pseudo_output_blinding = Scalar::random(&mut rng);
+        let pseudo_output_blinding = bth_crypto_ring_signature::compat::random_scalar(&mut rng);
 
         // Create mixin ring members
         let mut ring: Vec<ReducedTxOut> = Vec::with_capacity(num_mixins + 1);
@@ -43,7 +43,7 @@ impl TestRingParams {
             let target_key = CompressedRistrettoPublic::from_random(&mut rng);
             let commitment = {
                 let value = rng.next_u64();
-                let blinding = Scalar::random(&mut rng);
+                let blinding = bth_crypto_ring_signature::compat::random_scalar(&mut rng);
                 CompressedCommitment::new(value, blinding, &generator)
             };
             ring.push(ReducedTxOut {
@@ -56,7 +56,7 @@ impl TestRingParams {
         // The real input
         let onetime_private_key = RistrettoPrivate::from_random(&mut rng);
         let value = rng.next_u64();
-        let blinding = Scalar::random(&mut rng);
+        let blinding = bth_crypto_ring_signature::compat::random_scalar(&mut rng);
         let commitment = CompressedCommitment::new(value, blinding, &generator);
 
         let real_index = num_mixins; // Put real input at the end

--- a/crypto/ring-signature/src/amount/commitment.rs
+++ b/crypto/ring-signature/src/amount/commitment.rs
@@ -95,7 +95,7 @@ mod commitment_tests {
     fn test_new() {
         run_with_several_seeds(|mut rng| {
             let value = rng.next_u64();
-            let blinding = Scalar::random(&mut rng);
+            let blinding = crate::compat::random_scalar(&mut rng);
             let gens = generators(rng.next_u64());
 
             let commitment = Commitment::new(value, blinding, &gens);

--- a/crypto/ring-signature/src/amount/compressed_commitment.rs
+++ b/crypto/ring-signature/src/amount/compressed_commitment.rs
@@ -103,7 +103,7 @@ mod compressed_commitment_tests {
     fn test_new() {
         run_with_several_seeds(|mut rng| {
             let value = rng.next_u64();
-            let blinding = Scalar::random(&mut rng);
+            let blinding = crate::compat::random_scalar(&mut rng);
             let generator = generators(0);
 
             let commitment = CompressedCommitment::new(value, blinding, &generator);

--- a/crypto/ring-signature/src/compat.rs
+++ b/crypto/ring-signature/src/compat.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2018-2026 The Botho Foundation
+
+//! Byte-level replacements for curve25519-dalek convenience constructors
+//! whose trait generations changed in dalek 5.
+//!
+//! curve25519-dalek 5 moved `Scalar::random` / `RistrettoPoint::random`
+//! behind rand_core 0.10 traits and `Scalar::from_hash` /
+//! `RistrettoPoint::from_hash` behind digest 0.11 traits. This workspace
+//! remains on rand_core 0.6 (the rand-family migration is tracked in #1154)
+//! and digest 0.10, so these helpers re-implement the exact upstream
+//! algorithms at the byte level:
+//!
+//! * `random`: draw 64 uniform bytes, then reduce (scalars) or apply the
+//!   one-way uniform map (points) — identical to dalek 4 and dalek 5.
+//! * `from_hash`: finalize the 64-byte digest, then reduce / map — identical to
+//!   dalek 4 and dalek 5.
+//!
+//! Because the byte streams and reductions are unchanged, all derived keys,
+//! signatures, and digests are bit-identical to the dalek 4 era.
+
+use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
+use digest::{generic_array::typenum::U64, Digest};
+use rand_core::CryptoRngCore;
+
+/// Hash to a `Scalar` from a 512-bit digest (replaces `Scalar::from_hash`).
+pub fn scalar_from_hash<D: Digest<OutputSize = U64>>(hasher: D) -> Scalar {
+    let mut output = [0u8; 64];
+    output.copy_from_slice(hasher.finalize().as_slice());
+    Scalar::from_bytes_mod_order_wide(&output)
+}
+
+/// Hash to a `RistrettoPoint` from a 512-bit digest (replaces
+/// `RistrettoPoint::from_hash`).
+pub fn point_from_hash<D: Digest<OutputSize = U64>>(hasher: D) -> RistrettoPoint {
+    let mut output = [0u8; 64];
+    output.copy_from_slice(hasher.finalize().as_slice());
+    RistrettoPoint::from_uniform_bytes(&output)
+}
+
+/// Draw a uniformly random `Scalar` from a rand_core 0.6 CSPRNG (replaces
+/// `Scalar::random`).
+pub fn random_scalar<R: CryptoRngCore + ?Sized>(rng: &mut R) -> Scalar {
+    let mut bytes = [0u8; 64];
+    rng.as_rngcore().fill_bytes(&mut bytes);
+    Scalar::from_bytes_mod_order_wide(&bytes)
+}
+
+/// Draw a uniformly random `RistrettoPoint` from a rand_core 0.6 CSPRNG
+/// (replaces `RistrettoPoint::random`).
+pub fn random_point<R: CryptoRngCore + ?Sized>(rng: &mut R) -> RistrettoPoint {
+    let mut bytes = [0u8; 64];
+    rng.as_rngcore().fill_bytes(&mut bytes);
+    RistrettoPoint::from_uniform_bytes(&bytes)
+}

--- a/crypto/ring-signature/src/lib.rs
+++ b/crypto/ring-signature/src/lib.rs
@@ -18,6 +18,8 @@ mod amount;
 mod domain_separators;
 mod ring_signature;
 
+pub mod compat;
+
 pub mod onetime_keys;
 #[cfg(feature = "pq")]
 pub mod pq_onetime_keys;

--- a/crypto/ring-signature/src/onetime_keys.rs
+++ b/crypto/ring-signature/src/onetime_keys.rs
@@ -86,7 +86,7 @@ fn hash_to_scalar(point: RistrettoPoint) -> Scalar {
     let mut hasher = Blake2b512::new();
     hasher.update(HASH_TO_SCALAR_DOMAIN_TAG);
     hasher.update(point.compress().as_bytes());
-    Scalar::from_hash(hasher)
+    crate::compat::scalar_from_hash(hasher)
 }
 
 /// Creates target_key `Hs( r * C ) * G + D` for an output sent to
@@ -254,7 +254,7 @@ fn hybrid_stealth_scalar(
     hasher.update(dh_secret.compress().as_bytes());
     hasher.update(kem_shared_secret);
     hasher.update(output_index.to_le_bytes());
-    Scalar::from_hash(hasher)
+    crate::compat::scalar_from_hash(hasher)
 }
 
 /// Creates the hybrid `target_key = Hs(r * C || K || i) * G + D` for an output
@@ -419,8 +419,8 @@ mod tests {
     // Should return `r * D`.
     fn test_create_tx_public_key() {
         run_with_several_seeds(|mut rng| {
-            let r = Scalar::random(&mut rng);
-            let D = RistrettoPoint::random(&mut rng);
+            let r = crate::compat::random_scalar(&mut rng);
+            let D = crate::compat::random_point(&mut rng);
 
             let expected = RistrettoPublic::from(r * D);
 
@@ -691,7 +691,7 @@ mod tests {
     // The hybrid scalar is deterministic in its inputs.
     fn test_hybrid_scalar_deterministic() {
         run_with_several_seeds(|mut rng| {
-            let dh = RistrettoPoint::random(&mut rng);
+            let dh = crate::compat::random_point(&mut rng);
             let kem_secret = [0x44u8; KEM_SHARED_SECRET_LEN];
             let s1 = hybrid_stealth_scalar(dh, &kem_secret, 7);
             let s2 = hybrid_stealth_scalar(dh, &kem_secret, 7);

--- a/crypto/ring-signature/src/pq_onetime_keys.rs
+++ b/crypto/ring-signature/src/pq_onetime_keys.rs
@@ -57,7 +57,7 @@ fn hash_shared_secret_to_scalar(shared_secret: &MlKem768SharedSecret, output_ind
     hasher.update(PQ_STEALTH_DOMAIN_TAG);
     hasher.update(shared_secret.as_bytes());
     hasher.update(output_index.to_le_bytes());
-    Scalar::from_hash(hasher)
+    crate::compat::scalar_from_hash(hasher)
 }
 
 /// Result of encapsulating a shared secret for a PQ stealth address output.

--- a/crypto/ring-signature/src/ring_signature/clsag.rs
+++ b/crypto/ring-signature/src/ring_signature/clsag.rs
@@ -182,12 +182,12 @@ impl Clsag {
             alloc::vec![CurveScalar::from(Scalar::ZERO); ring_size];
         for i in 0..ring_size {
             if i != real_index {
-                responses[i] = CurveScalar::from(Scalar::random(rng));
+                responses[i] = CurveScalar::from(crate::compat::random_scalar(rng));
             }
         }
 
         // Random nonce for the real signer
-        let alpha = Scalar::random(rng);
+        let alpha = crate::compat::random_scalar(rng);
 
         // Compute initial L and R at real_index
         // L = alpha * G
@@ -350,7 +350,7 @@ fn compute_aggregation_coefficients(
     }
     hasher_p.update(key_image.as_bytes());
     hasher_p.update(commitment_key_image.as_bytes());
-    let mu_P = Scalar::from_hash(hasher_p);
+    let mu_P = crate::compat::scalar_from_hash(hasher_p);
 
     // mu_C = H("bth_clsag_agg_c" || ring || I || D)
     let mut hasher_c = Blake2b512::new();
@@ -361,7 +361,7 @@ fn compute_aggregation_coefficients(
     }
     hasher_c.update(key_image.as_bytes());
     hasher_c.update(commitment_key_image.as_bytes());
-    let mu_C = Scalar::from_hash(hasher_c);
+    let mu_C = crate::compat::scalar_from_hash(hasher_c);
 
     (mu_P, mu_C)
 }
@@ -381,7 +381,7 @@ fn compute_round_hash(
     hasher.update(commitment_key_image.as_bytes());
     hasher.update(L.compress().as_bytes());
     hasher.update(R.compress().as_bytes());
-    Scalar::from_hash(hasher)
+    crate::compat::scalar_from_hash(hasher)
 }
 
 #[cfg(test)]
@@ -423,7 +423,7 @@ mod clsag_tests {
                 let target_key = CompressedRistrettoPublic::from_random(rng);
                 let commitment = {
                     let value = rng.next_u64();
-                    let blinding = Scalar::random(rng);
+                    let blinding = crate::compat::random_scalar(rng);
                     CompressedCommitment::new(value, blinding, &generator)
                 };
                 ring.push(ReducedTxOut {
@@ -436,7 +436,7 @@ mod clsag_tests {
             // The real input
             let onetime_private_key = RistrettoPrivate::from_random(rng);
             let value = rng.next_u64();
-            let blinding = Scalar::random(rng);
+            let blinding = crate::compat::random_scalar(rng);
             let commitment = CompressedCommitment::new(value, blinding, &generator);
 
             let reduced_tx_out = ReducedTxOut {
@@ -487,7 +487,7 @@ mod clsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = ClsagTestParams::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -508,7 +508,7 @@ mod clsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = ClsagTestParams::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -522,7 +522,7 @@ mod clsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = ClsagTestParams::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -542,7 +542,7 @@ mod clsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = ClsagTestParams::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -568,7 +568,7 @@ mod clsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = ClsagTestParams::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let mut signature = params.sign(&mut rng).unwrap();
@@ -592,7 +592,7 @@ mod clsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = ClsagTestParams::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -616,7 +616,7 @@ mod clsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = ClsagTestParams::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -634,7 +634,7 @@ mod clsag_tests {
     #[test]
     fn test_clsag_value_not_conserved() {
         let mut rng = rand_core::OsRng;
-        let pseudo_output_blinding = Scalar::random(&mut rng);
+        let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
         let mut params = ClsagTestParams::random(5, pseudo_output_blinding, &mut rng);
 
         // Change the value so it doesn't match
@@ -649,7 +649,7 @@ mod clsag_tests {
     #[test]
     fn test_clsag_index_out_of_bounds() {
         let mut rng = rand_core::OsRng;
-        let pseudo_output_blinding = Scalar::random(&mut rng);
+        let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
         let mut params = ClsagTestParams::random(5, pseudo_output_blinding, &mut rng);
 
         params.real_index = 100; // Out of bounds

--- a/crypto/ring-signature/src/ring_signature/curve_scalar.rs
+++ b/crypto/ring-signature/src/ring_signature/curve_scalar.rs
@@ -49,7 +49,7 @@ impl CurveScalar {
 impl FromRandom for CurveScalar {
     fn from_random<R: CryptoRng + RngCore>(csprng: &mut R) -> Self {
         Self {
-            scalar: Scalar::random(csprng),
+            scalar: crate::compat::random_scalar(csprng),
         }
     }
 }

--- a/crypto/ring-signature/src/ring_signature/mlsag.rs
+++ b/crypto/ring-signature/src/ring_signature/mlsag.rs
@@ -244,7 +244,7 @@ mod mlsag_tests {
                 let target_key = CompressedRistrettoPublic::from_random(rng);
                 let commitment = {
                     let value = rng.next_u64();
-                    let blinding = Scalar::random(rng);
+                    let blinding = crate::compat::random_scalar(rng);
                     CompressedCommitment::new(value, blinding, &generator)
                 };
                 ring.push(ReducedTxOut {
@@ -258,7 +258,7 @@ mod mlsag_tests {
             let onetime_private_key = RistrettoPrivate::from_random(rng);
 
             let value = rng.next_u64();
-            let blinding = Scalar::random(rng);
+            let blinding = crate::compat::random_scalar(rng);
             let commitment = CompressedCommitment::new(value, blinding, &generator);
 
             let reduced_tx_out = ReducedTxOut {
@@ -328,7 +328,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
 
             let params =
                 RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
@@ -351,7 +351,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -367,7 +367,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let mut params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
             let wrong_value = rng.next_u64();
             params.value = wrong_value;
@@ -386,7 +386,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let mut params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
             // The ring contains num_mixins + 1 elements, with indices 0..num_mixins.
             // This is the smallest out of bounds index.
@@ -409,7 +409,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -428,7 +428,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let mut params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
             let wrong_onetime_private_key = RistrettoPrivate::from_random(&mut rng);
             params.onetime_private_key = wrong_onetime_private_key;
@@ -450,7 +450,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             // Sign with an input value that differs from the real input's amount commitment.
@@ -475,7 +475,7 @@ mod mlsag_tests {
             // Sign with an input blinding that differs from the real input's amount commitment.
             {
                 let mut params = params;
-                let wrong_blinding = Scalar::random(&mut rng);
+                let wrong_blinding = crate::compat::random_scalar(&mut rng);
 
                 params.blinding = wrong_blinding;
 
@@ -501,7 +501,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let mut signature = params.sign(&mut rng).unwrap();
@@ -531,7 +531,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let mut signature = params.sign(&mut rng).unwrap();
@@ -555,7 +555,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -581,7 +581,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let mut params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -605,7 +605,7 @@ mod mlsag_tests {
             {
                 let index = (rng.next_u64() as usize) % num_mixins;
                 let value = rng.next_u64();
-                let blinding = Scalar::random(&mut rng);
+                let blinding = crate::compat::random_scalar(&mut rng);
                 params.ring[index].commitment = CompressedCommitment::new(value, blinding, &params.generator);
 
                 let result = signature.verify(&params.message, &params.ring, &output_commitment);
@@ -624,7 +624,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
            let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();
@@ -647,7 +647,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
 
             let params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
 
@@ -692,7 +692,7 @@ mod mlsag_tests {
             seed in any::<[u8; 32]>(),
         ) {
             let mut rng: RngType = SeedableRng::from_seed(seed);
-            let pseudo_output_blinding = Scalar::random(&mut rng);
+            let pseudo_output_blinding = crate::compat::random_scalar(&mut rng);
             let params = RingMLSAGParameters::random(num_mixins, pseudo_output_blinding, &mut rng);
 
             let signature = params.sign(&mut rng).unwrap();

--- a/crypto/ring-signature/src/ring_signature/mlsag_sign.rs
+++ b/crypto/ring-signature/src/ring_signature/mlsag_sign.rs
@@ -164,8 +164,8 @@ impl<R: AsRef<[CurveScalar]> + AsMut<[CurveScalar]>> MlsagSignCtx<R> {
             if i == params.real_index {
                 continue;
             }
-            r[2 * i].scalar = Scalar::random(&mut rng);
-            r[2 * i + 1].scalar = Scalar::random(&mut rng);
+            r[2 * i].scalar = crate::compat::random_scalar(&mut rng);
+            r[2 * i + 1].scalar = crate::compat::random_scalar(&mut rng);
         }
 
         Ok(Self {
@@ -173,8 +173,8 @@ impl<R: AsRef<[CurveScalar]> + AsMut<[CurveScalar]>> MlsagSignCtx<R> {
             I,
             key_image,
             output_commitment,
-            alpha_0: Scalar::random(&mut rng),
-            alpha_1: Scalar::random(&mut rng),
+            alpha_0: crate::compat::random_scalar(&mut rng),
+            alpha_1: crate::compat::random_scalar(&mut rng),
             ring_count: 0,
             real_input: None,
             real_challenge: None,

--- a/crypto/ring-signature/src/ring_signature/mod.rs
+++ b/crypto/ring-signature/src/ring_signature/mod.rs
@@ -112,7 +112,7 @@ pub fn generators(token_id: u64) -> PedersenGens {
     }
 
     PedersenGens {
-        B: RistrettoPoint::from_hash(hasher),
+        B: crate::compat::point_from_hash(hasher),
         B_blinding: B_BLINDING,
     }
 }
@@ -122,7 +122,7 @@ pub fn hash_to_point(ristretto_public: &RistrettoPublic) -> RistrettoPoint {
     let mut hasher = Blake2b512::new();
     hasher.update(HASH_TO_POINT_DOMAIN_TAG);
     hasher.update(ristretto_public.to_bytes());
-    RistrettoPoint::from_hash(hasher)
+    crate::compat::point_from_hash(hasher)
 }
 
 // Compute the ring "challenge" H( message | key_image | L0 | R0 | L1 ).
@@ -140,7 +140,7 @@ pub(crate) fn challenge(
     hasher.update(L0.compress().as_bytes());
     hasher.update(R0.compress().as_bytes());
     hasher.update(L1.compress().as_bytes());
-    Scalar::from_hash(hasher)
+    crate::compat::scalar_from_hash(hasher)
 }
 
 /// A reduced representation of a TxOut, appropriate for making MLSAG

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -82,7 +82,7 @@ uuid = { version = "1", features = ["v4"] }
 rand = "0.8"
 rand_chacha = "0.3"
 subtle = "2"
-curve25519-dalek = "4"
+curve25519-dalek = "5"
 tempfile = "3"
 
 # Native-smoke driver (#920): NOT a libFuzzer target. Runs the shared harness

--- a/fuzz/fuzz_targets/fuzz_clsag.rs
+++ b/fuzz/fuzz_targets/fuzz_clsag.rs
@@ -142,7 +142,7 @@ fn create_test_ring(
         let public_key = CompressedRistrettoPublic::from_random(rng);
         let target_key = CompressedRistrettoPublic::from_random(rng);
         let mixin_value = rng.next_u64();
-        let mixin_blinding = Scalar::random(rng);
+        let mixin_blinding = bth_crypto_ring_signature::compat::random_scalar(rng);
         let commitment = CompressedCommitment::new(mixin_value, mixin_blinding, &generator);
         ring.push(ReducedTxOut {
             public_key,
@@ -154,7 +154,7 @@ fn create_test_ring(
     // Create the real input
     let onetime_private_key = RistrettoPrivate::from_random(rng);
     let value = rng.next_u64();
-    let blinding = Scalar::random(rng);
+    let blinding = bth_crypto_ring_signature::compat::random_scalar(rng);
     let commitment = CompressedCommitment::new(value, blinding, &generator);
 
     let reduced_tx_out = ReducedTxOut {
@@ -166,7 +166,7 @@ fn create_test_ring(
     let real_index = rng.next_u64() as usize % (num_mixins + 1);
     ring.insert(real_index, reduced_tx_out);
 
-    let pseudo_output_blinding = Scalar::random(rng);
+    let pseudo_output_blinding = bth_crypto_ring_signature::compat::random_scalar(rng);
 
     (
         ring,

--- a/transaction/core/Cargo.toml
+++ b/transaction/core/Cargo.toml
@@ -17,6 +17,7 @@ aes = { workspace = true }
 bulletproofs-og = { workspace = true }
 ctr = { workspace = true }
 curve25519-dalek = { workspace = true }
+curve25519-dalek-v4 = { workspace = true }
 displaydoc = { workspace = true }
 generic-array = { workspace = true, features = ["serde", "more_lengths"] }
 hex_fmt = { workspace = true }

--- a/transaction/core/benches/transaction_benchmarks.rs
+++ b/transaction/core/benches/transaction_benchmarks.rs
@@ -66,7 +66,7 @@ impl SignatureParams {
                 let target_key = CompressedRistrettoPublic::from_random(&mut rng);
                 let commitment = {
                     let value = rng.next_u64();
-                    let blinding = Scalar::random(&mut rng);
+                    let blinding = bth_crypto_ring_signature::compat::random_scalar(&mut rng);
                     CompressedCommitment::new(value, blinding, &generator)
                 };
                 ring_members.push(ReducedTxOut {
@@ -79,7 +79,7 @@ impl SignatureParams {
             // The real input
             let onetime_private_key = RistrettoPrivate::from_random(&mut rng);
             let value = rng.next_u64();
-            let blinding = Scalar::random(&mut rng);
+            let blinding = bth_crypto_ring_signature::compat::random_scalar(&mut rng);
             let commitment = CompressedCommitment::new(value, blinding, &generator);
 
             let reduced_tx_out = ReducedTxOut {
@@ -112,7 +112,7 @@ impl SignatureParams {
         let output_secrets: Vec<_> = rings
             .iter()
             .map(|ring| {
-                let blinding = Scalar::random(&mut rng);
+                let blinding = bth_crypto_ring_signature::compat::random_scalar(&mut rng);
                 OutputSecret {
                     amount: ring.input_secret.amount,
                     blinding,
@@ -184,7 +184,9 @@ fn bench_range_proof_generate(c: &mut Criterion) {
         let generator = generators(0);
 
         let values: Vec<u64> = (0..num_outputs).map(|_| rng.next_u64()).collect();
-        let blindings: Vec<Scalar> = (0..num_outputs).map(|_| Scalar::random(&mut rng)).collect();
+        let blindings: Vec<Scalar> = (0..num_outputs)
+            .map(|_| bth_crypto_ring_signature::compat::random_scalar(&mut rng))
+            .collect();
 
         group.bench_with_input(
             BenchmarkId::new("num_outputs", num_outputs),
@@ -212,7 +214,9 @@ fn bench_range_proof_verify(c: &mut Criterion) {
         let generator = generators(0);
 
         let values: Vec<u64> = (0..num_outputs).map(|_| rng.next_u64()).collect();
-        let blindings: Vec<Scalar> = (0..num_outputs).map(|_| Scalar::random(&mut rng)).collect();
+        let blindings: Vec<Scalar> = (0..num_outputs)
+            .map(|_| bth_crypto_ring_signature::compat::random_scalar(&mut rng))
+            .collect();
 
         let (proof, commitments) =
             generate_range_proofs(&values, &blindings, &generator, &mut rng).unwrap();

--- a/transaction/core/src/range_proofs/mod.rs
+++ b/transaction/core/src/range_proofs/mod.rs
@@ -12,6 +12,14 @@ use alloc::vec::Vec;
 use bth_crypto_ring_signature::PedersenGens;
 use bulletproofs_og::{BulletproofGens, PedersenGens as BPPedersenGens, RangeProof};
 use curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar};
+// bulletproofs-og is still built against curve25519-dalek 4, so scalars,
+// compressed points, and generators must be converted across the dalek 4/5
+// boundary. All conversions round-trip the canonical 32-byte encodings, so
+// they are bit-exact (proofs and commitments are unchanged).
+use curve25519_dalek_v4::{
+    ristretto::{CompressedRistretto as CompressedRistrettoV4, RistrettoPoint as RistrettoPointV4},
+    scalar::Scalar as ScalarV4,
+};
 use merlin::Transcript;
 use rand_core::{CryptoRng, RngCore};
 
@@ -52,10 +60,13 @@ pub fn generate_range_proofs<T: RngCore + CryptoRng>(
     // Aggregated rangeproofs operate on sets of `m` values, where `m` must be a
     // power of 2. If the number of inputs is not a power of 2, pad them.
     let values_padded: Vec<u64> = resize_slice_to_pow2::<u64>(values)?;
-    let blindings_padded: Vec<Scalar> = resize_slice_to_pow2::<Scalar>(blindings)?;
+    let blindings_padded: Vec<ScalarV4> = resize_slice_to_pow2::<Scalar>(blindings)?
+        .iter()
+        .map(scalar_to_v4)
+        .collect();
 
     // Create a 64-bit RangeProof and corresponding commitments.
-    RangeProof::prove_multiple_with_rng(
+    let (proof, commitments) = RangeProof::prove_multiple_with_rng(
         &BP_GENERATORS,
         &convert_gens(pedersen_generators),
         &mut Transcript::new(BULLETPROOF_DOMAIN_TAG.as_ref()),
@@ -63,8 +74,12 @@ pub fn generate_range_proofs<T: RngCore + CryptoRng>(
         &blindings_padded,
         64,
         rng,
-    )
-    .map_err(Error::from)
+    )?;
+    let commitments = commitments
+        .into_iter()
+        .map(|c| CompressedRistretto(c.to_bytes()))
+        .collect();
+    Ok((proof, commitments))
 }
 
 /// Verifies an aggregated 64-bit RangeProof for the given value commitments.
@@ -83,7 +98,11 @@ pub fn check_range_proofs<T: RngCore + CryptoRng>(
     rng: &mut T,
 ) -> Result<(), Error> {
     // The length of `commitments` must be a power of 2. If not, resize it.
-    let resized_commitments = resize_slice_to_pow2::<CompressedRistretto>(commitments)?;
+    let resized_commitments: Vec<CompressedRistrettoV4> =
+        resize_slice_to_pow2::<CompressedRistretto>(commitments)?
+            .iter()
+            .map(|c| CompressedRistrettoV4(c.to_bytes()))
+            .collect();
     range_proof
         .verify_multiple_with_rng(
             &BP_GENERATORS,
@@ -120,12 +139,29 @@ fn resize_slice_to_pow2<T: Clone>(slice: &[T]) -> Result<Vec<T>, Error> {
 
 /// Convert from the bth_crypto_ring_signature::PedersenGens to BPPedersenGens.
 /// These types are identical, but we need a version of it in the lower-level
-/// crate to break dependency on the bulletproofs crate.
+/// crate to break dependency on the bulletproofs crate. The base points cross
+/// the dalek 4/5 boundary through their canonical compressed encodings.
 fn convert_gens(src: &PedersenGens) -> BPPedersenGens {
     BPPedersenGens {
-        B: src.B,
-        B_blinding: src.B_blinding,
+        B: point_to_v4(&src.B),
+        B_blinding: point_to_v4(&src.B_blinding),
     }
+}
+
+/// Convert a (dalek 5) `RistrettoPoint` into the dalek 4 equivalent that
+/// bulletproofs-og expects, via the canonical compressed encoding.
+fn point_to_v4(src: &curve25519_dalek::ristretto::RistrettoPoint) -> RistrettoPointV4 {
+    CompressedRistrettoV4(src.compress().to_bytes())
+        .decompress()
+        .expect("compressing a valid point always yields a decompressible encoding")
+}
+
+/// Convert a (dalek 5) `Scalar` into the dalek 4 equivalent that
+/// bulletproofs-og expects. The encoding of a `Scalar` is always canonical,
+/// so this conversion is infallible and bit-exact.
+fn scalar_to_v4(src: &Scalar) -> ScalarV4 {
+    Option::from(ScalarV4::from_canonical_bytes(src.to_bytes()))
+        .expect("Scalar encodings are always canonical")
 }
 
 /// Tests for the range_proofs module.
@@ -151,7 +187,10 @@ pub mod tests {
     fn test_pow2_number_of_inputs() {
         let mut rng = get_seeded_rng();
         let vals: Vec<u64> = (0..2).map(|_| rng.next_u64()).collect();
-        let blindings: Vec<Scalar> = vals.iter().map(|_| Scalar::random(&mut rng)).collect();
+        let blindings: Vec<Scalar> = vals
+            .iter()
+            .map(|_| bth_crypto_ring_signature::compat::random_scalar(&mut rng))
+            .collect();
         generate_and_check(vals, blindings);
     }
 
@@ -159,7 +198,10 @@ pub mod tests {
     fn test_not_pow2_number_of_inputs() {
         let mut rng = get_seeded_rng();
         let vals: Vec<u64> = (0..9).map(|_| rng.next_u64()).collect();
-        let blindings: Vec<Scalar> = vals.iter().map(|_| Scalar::random(&mut rng)).collect();
+        let blindings: Vec<Scalar> = vals
+            .iter()
+            .map(|_| bth_crypto_ring_signature::compat::random_scalar(&mut rng))
+            .collect();
         generate_and_check(vals, blindings);
     }
 
@@ -171,13 +213,15 @@ pub mod tests {
 
         let num_values: usize = 4;
         let values: Vec<u64> = (0..num_values).map(|_| rng.next_u64()).collect();
-        let blindings: Vec<Scalar> = (0..num_values).map(|_| Scalar::random(&mut rng)).collect();
+        let blindings: Vec<Scalar> = (0..num_values)
+            .map(|_| bth_crypto_ring_signature::compat::random_scalar(&mut rng))
+            .collect();
         let (proof, commitments) =
             generate_range_proofs(&values, &blindings, &generators(0), &mut rng).unwrap();
 
         // Modify a commitment.
         let mut wrong_commitments = commitments;
-        wrong_commitments[0] = RistrettoPoint::random(&mut rng).compress();
+        wrong_commitments[0] = bth_crypto_ring_signature::compat::random_point(&mut rng).compress();
 
         match check_range_proofs(&proof, &wrong_commitments, &generators(0), &mut rng) {
             Ok(_) => panic!(),

--- a/transaction/core/src/ring_ct/rct_bulletproofs.rs
+++ b/transaction/core/src/ring_ct/rct_bulletproofs.rs
@@ -1135,7 +1135,7 @@ fn compute_pseudo_output_blindings<CSPRNG: RngCore + CryptoRng>(
                         // except this one.
                         sum_of_output_blindings - running_sum
                     } else {
-                        let random = Scalar::random(rng);
+                        let random = bth_crypto_ring_signature::compat::random_scalar(rng);
                         running_sum += random;
                         random
                     }
@@ -1240,7 +1240,7 @@ mod rct_bulletproofs_tests {
                     let generator = generator_cache.get(tx_prefix.fee_token_id.into());
                     let commitment = {
                         let value = rng.next_u64();
-                        let blinding = Scalar::random(rng);
+                        let blinding = bth_crypto_ring_signature::compat::random_scalar(rng);
                         CompressedCommitment::new(value, blinding, generator)
                     };
                     ring_members.push(ReducedTxOut {
@@ -1253,7 +1253,7 @@ mod rct_bulletproofs_tests {
                 let onetime_private_key = RistrettoPrivate::from_random(rng);
 
                 let value = rng.next_u64();
-                let blinding = Scalar::random(rng);
+                let blinding = bth_crypto_ring_signature::compat::random_scalar(rng);
 
                 let token_id = TokenId::from(token_ids[i % token_ids.len()]);
                 let generator = generator_cache.get(token_id);
@@ -1293,7 +1293,7 @@ mod rct_bulletproofs_tests {
             let output_secrets: Vec<_> = rings
                 .iter()
                 .map(|ring| {
-                    let blinding = Scalar::random(rng);
+                    let blinding = bth_crypto_ring_signature::compat::random_scalar(rng);
                     OutputSecret {
                         amount: ring.input_secret.amount,
                         blinding,
@@ -1578,7 +1578,7 @@ mod rct_bulletproofs_tests {
                 let values = [13; 6];
                 let blindings: Vec<Scalar> = values
                     .iter()
-                    .map(|_value| Scalar::random(&mut rng))
+                    .map(|_value| bth_crypto_ring_signature::compat::random_scalar(&mut rng))
                     .collect();
                 let (range_proof, _commitments) =
                     generate_range_proofs(&values, &blindings, &params.generator(), &mut rng).unwrap();
@@ -1617,7 +1617,7 @@ mod rct_bulletproofs_tests {
                 let values = [13; 6];
                 let blindings: Vec<Scalar> = values
                     .iter()
-                    .map(|_value| Scalar::random(&mut rng))
+                    .map(|_value| bth_crypto_ring_signature::compat::random_scalar(&mut rng))
                     .collect();
                 let (range_proof, _commitments) =
                     generate_range_proofs(&values, &blindings, &params.generator(), &mut rng).unwrap();

--- a/transaction/types/src/masked_amount/v1.rs
+++ b/transaction/types/src/masked_amount/v1.rs
@@ -18,7 +18,9 @@ use crate::{
 use bth_crypto_digestible::Digestible;
 use bth_crypto_hashes::{Blake2b512, Digest};
 use bth_crypto_keys::RistrettoPublic;
-use bth_crypto_ring_signature::{generators, CompressedCommitment, Scalar};
+use bth_crypto_ring_signature::{
+    compat::scalar_from_hash, generators, CompressedCommitment, Scalar,
+};
 
 use crc::Crc;
 #[cfg(feature = "prost")]
@@ -218,7 +220,7 @@ fn get_value_mask(shared_secret: &RistrettoPublic) -> u64 {
     let mut hasher = Blake2b512::new();
     hasher.update(AMOUNT_VALUE_DOMAIN_TAG);
     hasher.update(shared_secret.to_bytes());
-    let scalar = Scalar::from_hash(hasher);
+    let scalar = scalar_from_hash(hasher);
     let mut temp = [0u8; 8];
     temp.copy_from_slice(&scalar.as_bytes()[0..8]);
     u64::from_le_bytes(temp)
@@ -245,7 +247,7 @@ fn get_blinding(shared_secret: &RistrettoPublic) -> Scalar {
     let mut hasher = Blake2b512::new();
     hasher.update(AMOUNT_BLINDING_DOMAIN_TAG);
     hasher.update(shared_secret.to_bytes());
-    Scalar::from_hash(hasher)
+    scalar_from_hash(hasher)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

One lockstep migration of the dalek-5 family — curve25519-dalek 4→5, ed25519-dalek 2→3, ed25519 2→3, signature 2→3, x25519-dalek 2→3 — with a hard bit-identical-behavior bar: **no golden vectors, fixtures, or snapshot values were regenerated, updated, or deleted**, and every affected test suite passes unchanged.

The family cannot move one crate at a time (ed25519-dalek 3 requires curve25519-dalek ^5 and signature ^3), which is why Dependabot PR #1152 was closed in favor of this issue.

## Changes

**Workspace manifest (`Cargo.toml`)**
- Bump the five family crates; add `zeroize` to curve25519-dalek features (previously enabled transitively by dalek-4-era dependents).
- Add two narrow bridge deps: `curve25519-dalek-v4` (renamed v4 pin, bulletproofs boundary only) and `rand-core-v010` / `digest-v011` (trait-generation bridges, crypto/keys only).
- The `[profile.release.package.curve25519-dalek]` overflow-checks exemption is **unchanged and still correct for v5**: the default serial/simd backends keep the constant-time limb arithmetic in-crate; `fiat-crypto` only compiles under an explicit `curve25519_dalek_backend="fiat"` cfg override (verified against the v5 build.rs and CHANGELOG).

**Byte-level compat shims (the core of the migration).** dalek 5 moved its convenience constructors behind rand_core 0.10 / digest 0.11 traits; the workspace stays on rand_core 0.6 (rand family is #1154) and digest 0.10. Each call site now uses the exact upstream algorithm at the byte level (verified against the vendored dalek 4 and 5 sources — both fill 64/32 bytes via `fill_bytes` and reduce/map identically):
- `bth-crypto-ring-signature::compat` — `scalar_from_hash`, `point_from_hash`, `random_scalar`, `random_point`; used by CLSAG/MLSAG signing+challenge code, one-time keys, generators, transaction/core, transaction/types.
- Local equivalents in `core/subaddress.rs`, `account-keys/burn_address.rs`, `cluster-tax` (crates that do not depend on ring-signature).
- `crypto/keys`: byte-draw `SigningKey`/scalar/point generation; `RngCompat` (rand_core 0.6→0.10 pass-through) for x25519 secrets (`EphemeralSecret` has no byte-level constructor by design); `DigestCompat` (digest 0.10→0.11 forwarding wrapper) for Ed25519ph prehashed sign/verify; the `signature`-2-shaped `DigestSigner`/`DigestVerifier` traits are now defined locally in `traits.rs` (signature 3 changed them to closure-based APIs over digest 0.11) — same shape, so downstream callers are unchanged.
- `SchnorrkelPublic::from_point` → `from_bytes` over the canonical compressed encoding (schnorrkel-og is still on dalek 4; same point, one extra decompression per schnorrkel verify).

**bulletproofs-og boundary (`transaction/core/src/range_proofs`)**: no bulletproofs release supports dalek 5 (upstream max 5.0.0 pins dalek ^4.1.1), so scalars, compressed points, and Pedersen generators cross the dalek 4/5 boundary via canonical 32-byte encodings — bit-exact, infallible for values originating from valid points/scalars. The module's public API keeps dalek-5 types.

**Dependabot (`.github/dependabot.yml`)**: removed the now-obsolete family ignores for `ed25519`, `ed25519-dalek`, `signature`, `x25519-dalek`. The `curve25519-dalek` major ignore is deliberately **kept** with an updated comment: the workspace now carries an intentional v4 pin for the bulletproofs boundary, and a Dependabot major bump of it would be guaranteed-red until bulletproofs supports dalek 5. Rand-family ignores untouched (#1154).

**Misc**: ed25519-dalek 3 dropped its `std` feature — botho/bridge manifests now use default/`alloc`; `botho/src/operator_key.rs` key generation byte-draws from `thread_rng` (identical to the old `generate`); fuzz crate bumped to dalek 5 and its `fuzz_clsag` harness updated.

## Acceptance Criteria Verification

- [x] Lockstep bump of all five family crates in the workspace `Cargo.toml` — no crate left on a mixed major within the workspace's own dependency edges (remaining v4/v2 lock entries belong to third-party crates: bulletproofs-og/schnorrkel-og/snow/libp2p-identity, which never exchange dalek types with our code except at the two bridged boundaries above).
- [x] Constant-time limb exemption reviewed against the v5 backend selection — still applies as written (fiat backend is opt-in via cfg, not default).
- [x] Byte-identical signatures/derivations against existing golden vectors — **no fixture regeneration**; see Test Plan. The seeded-RNG doctests (e.g. the x25519 fingerprint goldens over `Hc128Rng::seed_from_u64(0)`) prove the RNG byte-stream consumption is unchanged.
- [x] Dependabot ignore updates (see above for the one deliberate retention).

## Test Plan

All run locally in the worktree; **no fixtures/goldens/snapshots were modified** (diff touches only `.rs`, `.toml`, `.yml`, `Cargo.lock`).

- `cargo build --workspace` — passes.
- `cargo check --workspace` — passes (no new warnings from this change).
- Hard-bar suites, all green:
  - `bth-crypto-keys`: 30 passed (+2 ignored openssl-nightly) + 12 doctests (incl. seeded x25519 fingerprint goldens)
  - `bth-crypto-ring-signature`: 51 passed (CLSAG/MLSAG sign+verify, one-time keys)
  - `bth-crypto-digestible`: 10 passed (tests/basic.rs)
  - `bth-account-keys`: 69 passed (with dev-deps run) / 9 lib
  - `bth-transaction-core`: 99 passed; `--all-features`: 120 passed (CI-parity job)
  - `bth-transaction-types`: 69 passed
- Consensus + neighbors: `bth-consensus-scp` 101, `bth-core` 24, `bth-core-types` 46, `bth-crypto-box` 30, `bth-crypto-multisig` 8, `bth-crypto-sig` 8, `bth-crypto-hashes` ok.
- `bth-cluster-tax`: 504 passed + 5 doctests.
- `cargo test --workspace --exclude bth-cluster-tax --no-fail-fast`: 136 suites ok; 4 failing targets (`compact_block_integration`, `e2e_consensus_integration`, `e2e_progressive_fees`, `e2e_transfer_patterns`) were **each re-run against unmodified main (5cc9a715) and fail identically there** — pre-existing, not a regression (matches the known stale fee-e2e history, #1080). The compact-block estimate drift is now tracked as #1187.
- `cargo deny check` — advisories/bans/licenses/sources ok (`multiple-versions = "warn"`).
- `cargo fmt --check` — clean (workspace + fuzz crate); fuzz crate resolves and `fuzz_clsag` type-checks on the pinned nightly.

TDD: N/A — dependency migration with a bit-identical-behavior requirement; correctness is gated on the pre-existing golden/seeded suites passing unchanged rather than new tests.

Closes #1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)